### PR TITLE
fix(macos): Download saves the file instead of opening the Share Sheet

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -144,10 +144,12 @@ whichever Swift channel you have around.
   `View > Toggle Developer Tools` is gated to dev builds only so the
   packaged build doesn't expose devtools to end users.
 
-- **Share Sheet** (`src/main/share.ts`). The renderer's `saveFile`
+- **Share Sheet** (`src/main/share.ts`). The renderer's `shareFile`
   (`clients/web/src/runtime/native-file.ts`) hands file bytes over the
   `vellum:share:file` channel; the main process writes them to a temp file and
-  presents the native `NSSharingServicePicker` via Electron's `ShareMenu`. Two
+  presents the native `NSSharingServicePicker` via Electron's `ShareMenu`.
+  Only the *share* intent routes here — a "Download" action goes through
+  `saveFile` and the download handler below, never this sheet. Two
   gotchas here were verified against the pinned `electron@42` source and types,
   **not** the published API docs (which are wrong):
   - **Anchor with `window`, not `browserWindow`.** `ShareMenu.popup` forwards to
@@ -166,6 +168,20 @@ whichever Swift channel you have around.
     transfer), sweeping at startup and before each new share, so it never
     deletes a file still in use, including one from a second Vellum build
     sharing at the same time.
+
+- **Downloads** (`src/main/downloads.ts`). The counterpart intent to the Share
+  Sheet. The renderer downloads the browser way (`saveFile` → an `<a download>`
+  click), which Chromium raises as a `will-download` on the default session.
+  Without a handler Electron falls back to its default routine and prompts a
+  Save panel for every download, so this picks the save path itself:
+  `~/Downloads`, uniquified Finder-style (`report.pdf`, `report (1).pdf`) so a
+  repeat download never clobbers an existing file, then a Dock Downloads-stack
+  bounce via `app.dock.downloadFinished` on completion. `setSavePath` is only
+  honored while the `will-download` listener is on the stack — hence the
+  synchronous `existsSync` collision check rather than the `node:fs/promises`
+  style used elsewhere in the main process. Any failure (unwritable directory,
+  no free name) simply skips `setSavePath` and lets Electron's Save panel take
+  over.
 
 ## Scripts
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -148,7 +148,7 @@ whichever Swift channel you have around.
   (`clients/web/src/runtime/native-file.ts`) hands file bytes over the
   `vellum:share:file` channel; the main process writes them to a temp file and
   presents the native `NSSharingServicePicker` via Electron's `ShareMenu`.
-  Only the *share* intent routes here — a "Download" action goes through
+  Only the *share* intent routes here. A "Download" action goes through
   `saveFile` and the download handler below, never this sheet. Two
   gotchas here were verified against the pinned `electron@42` source and types,
   **not** the published API docs (which are wrong):
@@ -177,7 +177,7 @@ whichever Swift channel you have around.
   `~/Downloads`, uniquified Finder-style (`report.pdf`, `report (1).pdf`) so a
   repeat download never clobbers an existing file, then a Dock Downloads-stack
   bounce via `app.dock.downloadFinished` on completion. `setSavePath` is only
-  honored while the `will-download` listener is on the stack — hence the
+  honored while the `will-download` listener is on the stack, hence the
   synchronous `existsSync` collision check rather than the `node:fs/promises`
   style used elsewhere in the main process. Any failure (unwritable directory,
   no free name) simply skips `setSavePath` and lets Electron's Save panel take

--- a/clients/macos/src/main/downloads.test.ts
+++ b/clients/macos/src/main/downloads.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import path from "node:path";
 
-// `node:fs` is mocked so the save-path resolution is asserted structurally —
-// no real disk access. `node:path` stays real (pure helper), so the asserted
-// paths match what production builds. Mirrors `share.test.ts`.
+// `node:fs` is mocked so the save-path resolution is asserted structurally,
+// with no real disk access. `node:path` stays real (pure helper), so the
+// asserted paths match what production builds. Mirrors `share.test.ts`.
 const existsSyncMock = mock((_p: string) => false);
 const mkdirSyncMock = mock((_p: string, _opts: unknown) => undefined);
 mock.module("node:fs", () => ({
@@ -25,7 +25,9 @@ mock.module("electron", () => ({
   session: {
     defaultSession: {
       on: (channel: string, listener: DownloadListener) => {
-        if (channel === "will-download") willDownloadListeners.push(listener);
+        if (channel === "will-download") {
+          willDownloadListeners.push(listener);
+        }
       },
     },
   },
@@ -44,28 +46,41 @@ class FakeItem {
     this.savePaths.push(p);
   }
   once(event: string, handler: (event: unknown, state: string) => void): void {
-    if (event === "done") this.doneHandlers.push(handler);
+    if (event === "done") {
+      this.doneHandlers.push(handler);
+    }
   }
   finish(state: string): void {
-    for (const handler of this.doneHandlers) handler({}, state);
+    for (const handler of this.doneHandlers) {
+      handler({}, state);
+    }
+  }
+  /** The single path this item was told to save to, or null if none. */
+  savePath(): string | null {
+    return this.savePaths[0] ?? null;
   }
 }
 
-const { installDownloads, uniqueDownloadPath } = await import("./downloads");
+const { installDownloads, uniqueDownloadPath, __resetForTesting } =
+  await import("./downloads");
 
-// Idempotent — a second call must not double-register (module-level flag).
+// Idempotent: a second call must not double-register (module-level flag).
 installDownloads();
 installDownloads();
 
 const DOWNLOADS = "/Users/tester/Downloads";
+const inDownloads = (name: string): string => path.join(DOWNLOADS, name);
 const fire = (item: FakeItem): void => {
   willDownloadListeners[0]!({}, item);
 };
+const free = (): boolean => false;
 
 beforeEach(() => {
+  __resetForTesting();
   existsSyncMock.mockReset();
   existsSyncMock.mockReturnValue(false);
   mkdirSyncMock.mockClear();
+  mkdirSyncMock.mockImplementation(() => undefined);
   downloadFinishedMock.mockClear();
   getPathMock.mockClear();
   getPathMock.mockReturnValue(DOWNLOADS);
@@ -79,42 +94,39 @@ describe("installDownloads wiring", () => {
 
 describe("uniqueDownloadPath", () => {
   test("uses the plain name when nothing collides", () => {
-    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", () => false)).toBe(
-      path.join(DOWNLOADS, "report.pdf"),
+    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", free)).toBe(
+      inDownloads("report.pdf"),
     );
   });
 
   test("suffixes ' (n)' before the extension on collision, Finder-style", () => {
     const taken = new Set([
-      path.join(DOWNLOADS, "report.pdf"),
-      path.join(DOWNLOADS, "report (1).pdf"),
+      inDownloads("report.pdf"),
+      inDownloads("report (1).pdf"),
     ]);
 
-    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", (c) => taken.has(c))).toBe(
-      path.join(DOWNLOADS, "report (2).pdf"),
-    );
+    expect(
+      uniqueDownloadPath(DOWNLOADS, "report.pdf", (c) => taken.has(c)),
+    ).toBe(inDownloads("report (2).pdf"));
   });
 
   test("handles extensionless and dotfile names without mangling them", () => {
-    const taken = new Set([
-      path.join(DOWNLOADS, "LICENSE"),
-      path.join(DOWNLOADS, ".env"),
-    ]);
-    const exists = (c: string): boolean => taken.has(c);
+    const taken = new Set([inDownloads("LICENSE"), inDownloads(".env")]);
+    const isTaken = (c: string): boolean => taken.has(c);
 
-    expect(uniqueDownloadPath(DOWNLOADS, "LICENSE", exists)).toBe(
-      path.join(DOWNLOADS, "LICENSE (1)"),
+    expect(uniqueDownloadPath(DOWNLOADS, "LICENSE", isTaken)).toBe(
+      inDownloads("LICENSE (1)"),
     );
     // `.env` is all "extension" to path.extname; the stem must not go empty.
-    expect(uniqueDownloadPath(DOWNLOADS, ".env", exists)).toBe(
-      path.join(DOWNLOADS, ".env (1)"),
+    expect(uniqueDownloadPath(DOWNLOADS, ".env", isTaken)).toBe(
+      inDownloads(".env (1)"),
     );
   });
 
   test("strips path components so a download can't escape the directory", () => {
-    expect(
-      uniqueDownloadPath(DOWNLOADS, "../../etc/passwd", () => false),
-    ).toBe(path.join(DOWNLOADS, "passwd"));
+    expect(uniqueDownloadPath(DOWNLOADS, "../../etc/passwd", free)).toBe(
+      inDownloads("passwd"),
+    );
   });
 
   test("returns null rather than looping forever when every name is taken", () => {
@@ -128,19 +140,19 @@ describe("will-download handling", () => {
 
     fire(item);
 
-    expect(item.savePaths).toEqual([path.join(DOWNLOADS, "report.pdf")]);
+    expect(item.savePaths).toEqual([inDownloads("report.pdf")]);
     expect(mkdirSyncMock).toHaveBeenCalledTimes(1);
   });
 
   test("uniquifies against an existing file rather than clobbering it", () => {
     existsSyncMock.mockImplementation(
-      (c: string) => c === path.join(DOWNLOADS, "report.pdf"),
+      (c: string) => c === inDownloads("report.pdf"),
     );
 
     const item = new FakeItem("report.pdf");
     fire(item);
 
-    expect(item.savePaths).toEqual([path.join(DOWNLOADS, "report (1).pdf")]);
+    expect(item.savePaths).toEqual([inDownloads("report (1).pdf")]);
   });
 
   test("bounces the Dock's Downloads stack once the download completes", () => {
@@ -150,7 +162,7 @@ describe("will-download handling", () => {
     item.finish("completed");
 
     expect(downloadFinishedMock).toHaveBeenCalledWith(
-      path.join(DOWNLOADS, "report.pdf"),
+      inDownloads("report.pdf"),
     );
   });
 
@@ -172,5 +184,51 @@ describe("will-download handling", () => {
     const item = new FakeItem("report.pdf");
     expect(() => fire(item)).not.toThrow();
     expect(item.savePaths).toEqual([]);
+  });
+});
+
+describe("concurrent downloads of the same filename", () => {
+  // Neither file exists yet at `will-download` time: Chromium creates the
+  // destination as bytes arrive, so `existsSync` sees nothing for a transfer
+  // that is already in flight.
+  test("gives each in-flight download its own destination", () => {
+    const first = new FakeItem("report.pdf");
+    const second = new FakeItem("report.pdf");
+    const third = new FakeItem("report.pdf");
+
+    fire(first);
+    fire(second);
+    fire(third);
+
+    expect(first.savePath()).toBe(inDownloads("report.pdf"));
+    expect(second.savePath()).toBe(inDownloads("report (1).pdf"));
+    expect(third.savePath()).toBe(inDownloads("report (2).pdf"));
+  });
+
+  test("frees the name once a download finishes", () => {
+    const first = new FakeItem("report.pdf");
+    fire(first);
+    first.finish("completed");
+
+    // The completed file is on disk now, so the reservation is redundant and
+    // the next download uniquifies against the filesystem instead.
+    existsSyncMock.mockImplementation(
+      (c: string) => c === inDownloads("report.pdf"),
+    );
+    const second = new FakeItem("report.pdf");
+    fire(second);
+
+    expect(second.savePath()).toBe(inDownloads("report (1).pdf"));
+  });
+
+  test("frees the name when a download is cancelled and leaves nothing on disk", () => {
+    const first = new FakeItem("report.pdf");
+    fire(first);
+    first.finish("cancelled");
+
+    const second = new FakeItem("report.pdf");
+    fire(second);
+
+    expect(second.savePath()).toBe(inDownloads("report.pdf"));
   });
 });

--- a/clients/macos/src/main/downloads.test.ts
+++ b/clients/macos/src/main/downloads.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import path from "node:path";
+
+// `node:fs` is mocked so the save-path resolution is asserted structurally —
+// no real disk access. `node:path` stays real (pure helper), so the asserted
+// paths match what production builds. Mirrors `share.test.ts`.
+const existsSyncMock = mock((_p: string) => false);
+const mkdirSyncMock = mock((_p: string, _opts: unknown) => undefined);
+mock.module("node:fs", () => ({
+  existsSync: existsSyncMock,
+  mkdirSync: mkdirSyncMock,
+}));
+
+// Capture the `will-download` listener so tests can drive it directly without
+// a real Electron session.
+type DownloadListener = (event: unknown, item: FakeItem) => void;
+const willDownloadListeners: DownloadListener[] = [];
+const downloadFinishedMock = mock((_p: string) => undefined);
+const getPathMock = mock((_name: string) => "/Users/tester/Downloads");
+mock.module("electron", () => ({
+  app: {
+    getPath: getPathMock,
+    dock: { downloadFinished: downloadFinishedMock },
+  },
+  session: {
+    defaultSession: {
+      on: (channel: string, listener: DownloadListener) => {
+        if (channel === "will-download") willDownloadListeners.push(listener);
+      },
+    },
+  },
+}));
+
+// Stand-in for Electron's `DownloadItem`: records the save path and replays
+// the `done` event on demand.
+class FakeItem {
+  savePaths: string[] = [];
+  private doneHandlers: Array<(event: unknown, state: string) => void> = [];
+  constructor(private filename: string) {}
+  getFilename(): string {
+    return this.filename;
+  }
+  setSavePath(p: string): void {
+    this.savePaths.push(p);
+  }
+  once(event: string, handler: (event: unknown, state: string) => void): void {
+    if (event === "done") this.doneHandlers.push(handler);
+  }
+  finish(state: string): void {
+    for (const handler of this.doneHandlers) handler({}, state);
+  }
+}
+
+const { installDownloads, uniqueDownloadPath } = await import("./downloads");
+
+// Idempotent — a second call must not double-register (module-level flag).
+installDownloads();
+installDownloads();
+
+const DOWNLOADS = "/Users/tester/Downloads";
+const fire = (item: FakeItem): void => {
+  willDownloadListeners[0]!({}, item);
+};
+
+beforeEach(() => {
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(false);
+  mkdirSyncMock.mockClear();
+  downloadFinishedMock.mockClear();
+  getPathMock.mockClear();
+  getPathMock.mockReturnValue(DOWNLOADS);
+});
+
+describe("installDownloads wiring", () => {
+  test("subscribes to will-download exactly once across repeat installs", () => {
+    expect(willDownloadListeners).toHaveLength(1);
+  });
+});
+
+describe("uniqueDownloadPath", () => {
+  test("uses the plain name when nothing collides", () => {
+    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", () => false)).toBe(
+      path.join(DOWNLOADS, "report.pdf"),
+    );
+  });
+
+  test("suffixes ' (n)' before the extension on collision, Finder-style", () => {
+    const taken = new Set([
+      path.join(DOWNLOADS, "report.pdf"),
+      path.join(DOWNLOADS, "report (1).pdf"),
+    ]);
+
+    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", (c) => taken.has(c))).toBe(
+      path.join(DOWNLOADS, "report (2).pdf"),
+    );
+  });
+
+  test("handles extensionless and dotfile names without mangling them", () => {
+    const taken = new Set([
+      path.join(DOWNLOADS, "LICENSE"),
+      path.join(DOWNLOADS, ".env"),
+    ]);
+    const exists = (c: string): boolean => taken.has(c);
+
+    expect(uniqueDownloadPath(DOWNLOADS, "LICENSE", exists)).toBe(
+      path.join(DOWNLOADS, "LICENSE (1)"),
+    );
+    // `.env` is all "extension" to path.extname; the stem must not go empty.
+    expect(uniqueDownloadPath(DOWNLOADS, ".env", exists)).toBe(
+      path.join(DOWNLOADS, ".env (1)"),
+    );
+  });
+
+  test("strips path components so a download can't escape the directory", () => {
+    expect(
+      uniqueDownloadPath(DOWNLOADS, "../../etc/passwd", () => false),
+    ).toBe(path.join(DOWNLOADS, "passwd"));
+  });
+
+  test("returns null rather than looping forever when every name is taken", () => {
+    expect(uniqueDownloadPath(DOWNLOADS, "report.pdf", () => true)).toBeNull();
+  });
+});
+
+describe("will-download handling", () => {
+  test("files the download into ~/Downloads instead of prompting a Save panel", () => {
+    const item = new FakeItem("report.pdf");
+
+    fire(item);
+
+    expect(item.savePaths).toEqual([path.join(DOWNLOADS, "report.pdf")]);
+    expect(mkdirSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("uniquifies against an existing file rather than clobbering it", () => {
+    existsSyncMock.mockImplementation(
+      (c: string) => c === path.join(DOWNLOADS, "report.pdf"),
+    );
+
+    const item = new FakeItem("report.pdf");
+    fire(item);
+
+    expect(item.savePaths).toEqual([path.join(DOWNLOADS, "report (1).pdf")]);
+  });
+
+  test("bounces the Dock's Downloads stack once the download completes", () => {
+    const item = new FakeItem("report.pdf");
+    fire(item);
+
+    item.finish("completed");
+
+    expect(downloadFinishedMock).toHaveBeenCalledWith(
+      path.join(DOWNLOADS, "report.pdf"),
+    );
+  });
+
+  test("stays quiet for a cancelled or interrupted download", () => {
+    const item = new FakeItem("report.pdf");
+    fire(item);
+
+    item.finish("cancelled");
+    item.finish("interrupted");
+
+    expect(downloadFinishedMock).not.toHaveBeenCalled();
+  });
+
+  test("defers to Electron's default save routine when the directory is unusable", () => {
+    mkdirSyncMock.mockImplementationOnce(() => {
+      throw new Error("EACCES");
+    });
+
+    const item = new FakeItem("report.pdf");
+    expect(() => fire(item)).not.toThrow();
+    expect(item.savePaths).toEqual([]);
+  });
+});

--- a/clients/macos/src/main/downloads.ts
+++ b/clients/macos/src/main/downloads.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
+import { app, session } from "electron";
+
+/**
+ * Downloads: file a renderer download into `~/Downloads`.
+ *
+ * The renderer's `saveFile` (clients/web/src/runtime/native-file.ts) downloads
+ * the browser way — an `<a download>` click on a blob URL — which Chromium
+ * turns into a real download item and Electron surfaces here as
+ * `will-download`. Without a handler, Electron falls back to its "original
+ * routine" and prompts a Save panel for every download; a desktop app's
+ * Download button should just put the file where downloads go, the way the
+ * browser build does. So we pick the save path ourselves.
+ *
+ * Two details this gets right, both of which Chromium normally handles and we
+ * inherit responsibility for the moment we call `setSavePath`:
+ *
+ *   - **Uniquify, don't clobber.** Downloading `report.pdf` twice writes
+ *     `report.pdf` then `report (1).pdf` — never silently overwriting a file
+ *     the user already has. This is Chromium/Finder's own naming convention.
+ *   - **Set the path synchronously.** `DownloadItem.setSavePath` is only
+ *     honored while the `will-download` listener is on the stack; deferring it
+ *     to a promise hands the item back to the default routine and the Save
+ *     panel reappears. That's why the collision check uses `existsSync` rather
+ *     than the `node:fs/promises` style used elsewhere in the main process.
+ *
+ * On completion the Dock's Downloads stack bounces (`app.dock.downloadFinished`
+ * — the same NSApplication signal a browser sends), so the download is
+ * acknowledged without an in-app toast the renderer would have to own.
+ *
+ * The share sheet is the *other* intent and lives in `share.ts`: the renderer
+ * calls `shareFile` for it, and it never reaches this path.
+ *
+ * Refs:
+ * - https://www.electronjs.org/docs/latest/api/download-item#downloaditemsetsavepathpath
+ * - https://www.electronjs.org/docs/latest/api/session#event-will-download
+ */
+
+// Chromium gives up de-duplicating a filename long before this; the bound
+// exists so a pathological directory can't spin the loop forever. On overflow
+// we hand the item back to Electron's default routine (Save panel), which is
+// the honest outcome — better than overwriting or failing silently.
+const MAX_UNIQUE_ATTEMPTS = 1000;
+
+/**
+ * Resolve a non-colliding absolute path for `filename` inside `dir`, following
+ * the Finder/Chromium convention: `report.pdf`, `report (1).pdf`, … The
+ * existence probe is injected so tests don't need a real filesystem.
+ *
+ * Returns `null` when no free name was found within `MAX_UNIQUE_ATTEMPTS`.
+ * Exported for unit tests.
+ */
+export const uniqueDownloadPath = (
+  dir: string,
+  filename: string,
+  exists: (candidate: string) => boolean = existsSync,
+): string | null => {
+  // `basename` strips any path components the download's suggested filename may
+  // carry, keeping the write inside the downloads directory.
+  const safe = path.basename(filename) || "download";
+  const ext = path.extname(safe);
+  const stem = safe.slice(0, safe.length - ext.length) || safe;
+
+  for (let n = 0; n < MAX_UNIQUE_ATTEMPTS; n++) {
+    const candidate = path.join(dir, n === 0 ? safe : `${stem} (${n})${ext}`);
+    if (!exists(candidate)) return candidate;
+  }
+  return null;
+};
+
+let installed = false;
+
+/** Wire the download handler. Call once from `whenReady`; idempotent. */
+export const installDownloads = (): void => {
+  if (installed) return;
+  installed = true;
+
+  session.defaultSession.on("will-download", (_event, item) => {
+    const dir = app.getPath("downloads");
+
+    // Everything here is best-effort: on any failure we simply don't call
+    // `setSavePath`, and Electron's default routine (the Save panel) takes
+    // over. A download that asks the user where to put it beats a download
+    // that throws out of an event listener.
+    try {
+      mkdirSync(dir, { recursive: true });
+      const savePath = uniqueDownloadPath(dir, item.getFilename());
+      if (!savePath) return;
+      item.setSavePath(savePath);
+
+      item.once("done", (_doneEvent, state) => {
+        // "cancelled" / "interrupted" leave nothing to announce.
+        if (state !== "completed") return;
+        app.dock?.downloadFinished(savePath);
+      });
+    } catch {
+      // Fall through to Electron's default save routine.
+    }
+  });
+};

--- a/clients/macos/src/main/downloads.ts
+++ b/clients/macos/src/main/downloads.ts
@@ -4,33 +4,41 @@ import path from "node:path";
 import { app, session } from "electron";
 
 /**
- * Downloads: file a renderer download into `~/Downloads`.
+ * Downloads: files a renderer download into `~/Downloads`.
  *
  * The renderer's `saveFile` (clients/web/src/runtime/native-file.ts) downloads
- * the browser way — an `<a download>` click on a blob URL — which Chromium
- * turns into a real download item and Electron surfaces here as
- * `will-download`. Without a handler, Electron falls back to its "original
- * routine" and prompts a Save panel for every download; a desktop app's
- * Download button should just put the file where downloads go, the way the
- * browser build does. So we pick the save path ourselves.
+ * the browser way, an `<a download>` click on a blob URL, which Chromium turns
+ * into a real download item and Electron surfaces here as `will-download`.
+ * Absent a handler, Electron falls back to its "original routine" and prompts a
+ * Save panel for every download; a desktop app's Download button should just
+ * put the file where downloads go, the way the browser build does. So this
+ * picks the save path itself.
  *
- * Two details this gets right, both of which Chromium normally handles and we
- * inherit responsibility for the moment we call `setSavePath`:
+ * Three details this owns the moment it calls `setSavePath`, all of which
+ * Chromium otherwise handles:
  *
  *   - **Uniquify, don't clobber.** Downloading `report.pdf` twice writes
- *     `report.pdf` then `report (1).pdf` — never silently overwriting a file
- *     the user already has. This is Chromium/Finder's own naming convention.
+ *     `report.pdf` then `report (1).pdf`, never silently overwriting a file the
+ *     user already has. This is Chromium/Finder's own naming convention.
+ *   - **Reserve the name for the whole transfer.** A download's file does not
+ *     exist on disk at `will-download` time (Chromium creates it as bytes
+ *     arrive), so `existsSync` alone cannot see a transfer that is already
+ *     heading for that name. Two same-named downloads started close together
+ *     (a double-clicked button) would both pick the same path and race for one
+ *     destination. `reserved` holds each chosen path until that item's `done`
+ *     event, so the second download picks the next free name.
  *   - **Set the path synchronously.** `DownloadItem.setSavePath` is only
  *     honored while the `will-download` listener is on the stack; deferring it
  *     to a promise hands the item back to the default routine and the Save
- *     panel reappears. That's why the collision check uses `existsSync` rather
+ *     panel appears. Hence the synchronous `existsSync` collision check rather
  *     than the `node:fs/promises` style used elsewhere in the main process.
  *
- * On completion the Dock's Downloads stack bounces (`app.dock.downloadFinished`
- * — the same NSApplication signal a browser sends), so the download is
- * acknowledged without an in-app toast the renderer would have to own.
+ * On completion the Dock's Downloads stack bounces
+ * (`app.dock.downloadFinished`, the same NSApplication signal a browser sends),
+ * so the download is acknowledged without an in-app toast the renderer would
+ * have to own.
  *
- * The share sheet is the *other* intent and lives in `share.ts`: the renderer
+ * The share sheet is the other intent and lives in `share.ts`: the renderer
  * calls `shareFile` for it, and it never reaches this path.
  *
  * Refs:
@@ -40,14 +48,21 @@ import { app, session } from "electron";
 
 // Chromium gives up de-duplicating a filename long before this; the bound
 // exists so a pathological directory can't spin the loop forever. On overflow
-// we hand the item back to Electron's default routine (Save panel), which is
-// the honest outcome — better than overwriting or failing silently.
+// the item goes back to Electron's default routine (Save panel), which is the
+// honest outcome: better than overwriting or failing silently.
 const MAX_UNIQUE_ATTEMPTS = 1000;
+
+// Save paths handed to in-flight downloads, held from `will-download` until
+// `done` so a concurrent download of the same filename can't select the same
+// destination. See the "Reserve the name" note above.
+const reserved = new Set<string>();
 
 /**
  * Resolve a non-colliding absolute path for `filename` inside `dir`, following
- * the Finder/Chromium convention: `report.pdf`, `report (1).pdf`, … The
- * existence probe is injected so tests don't need a real filesystem.
+ * the Finder/Chromium convention: `report.pdf`, `report (1).pdf`, and so on.
+ * `isTaken` decides whether a candidate is unavailable, so the caller supplies
+ * both halves of "unavailable" (on disk, or reserved by an in-flight download)
+ * and tests can run without a filesystem.
  *
  * Returns `null` when no free name was found within `MAX_UNIQUE_ATTEMPTS`.
  * Exported for unit tests.
@@ -55,7 +70,7 @@ const MAX_UNIQUE_ATTEMPTS = 1000;
 export const uniqueDownloadPath = (
   dir: string,
   filename: string,
-  exists: (candidate: string) => boolean = existsSync,
+  isTaken: (candidate: string) => boolean,
 ): string | null => {
   // `basename` strips any path components the download's suggested filename may
   // carry, keeping the write inside the downloads directory.
@@ -65,7 +80,9 @@ export const uniqueDownloadPath = (
 
   for (let n = 0; n < MAX_UNIQUE_ATTEMPTS; n++) {
     const candidate = path.join(dir, n === 0 ? safe : `${stem} (${n})${ext}`);
-    if (!exists(candidate)) return candidate;
+    if (!isTaken(candidate)) {
+      return candidate;
+    }
   }
   return null;
 };
@@ -74,29 +91,48 @@ let installed = false;
 
 /** Wire the download handler. Call once from `whenReady`; idempotent. */
 export const installDownloads = (): void => {
-  if (installed) return;
+  if (installed) {
+    return;
+  }
   installed = true;
 
   session.defaultSession.on("will-download", (_event, item) => {
     const dir = app.getPath("downloads");
 
-    // Everything here is best-effort: on any failure we simply don't call
-    // `setSavePath`, and Electron's default routine (the Save panel) takes
-    // over. A download that asks the user where to put it beats a download
-    // that throws out of an event listener.
+    // Everything here is best-effort: on any failure the handler skips
+    // `setSavePath` and Electron's default routine (the Save panel) takes over.
+    // A download that asks the user where to put it beats a download that
+    // throws out of an event listener.
     try {
       mkdirSync(dir, { recursive: true });
-      const savePath = uniqueDownloadPath(dir, item.getFilename());
-      if (!savePath) return;
+      const savePath = uniqueDownloadPath(
+        dir,
+        item.getFilename(),
+        (candidate) => reserved.has(candidate) || existsSync(candidate),
+      );
+      if (!savePath) {
+        return;
+      }
       item.setSavePath(savePath);
+      reserved.add(savePath);
 
       item.once("done", (_doneEvent, state) => {
-        // "cancelled" / "interrupted" leave nothing to announce.
-        if (state !== "completed") return;
+        // Released on every terminal state: a cancelled or interrupted
+        // download leaves the name free for the next one.
+        reserved.delete(savePath);
+        if (state !== "completed") {
+          return;
+        }
         app.dock?.downloadFinished(savePath);
       });
     } catch {
       // Fall through to Electron's default save routine.
     }
   });
+};
+
+// Test seam: clears the in-flight reservations so a test starts from a clean
+// slate. Production code never calls this.
+export const __resetForTesting = (): void => {
+  reserved.clear();
 };

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -428,7 +428,7 @@ app
     installDock();
     installShare();
     // Files renderer downloads into ~/Downloads instead of prompting a Save
-    // panel. Distinct from `installShare` — that's the "send elsewhere" intent.
+    // panel. Distinct from `installShare`, which is the "send elsewhere" intent.
     installDownloads();
     installPowerEvents();
     installNotifications();

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -38,6 +38,7 @@ import { installAvatarIpc } from "./avatar";
 import { installCommandPaletteWindow } from "./command-palette-window";
 import { installDictationOverlay } from "./dictation-overlay-window";
 import { installDock } from "./dock";
+import { installDownloads } from "./downloads";
 import { installShare } from "./share";
 import {
   installEscapeMonitor,
@@ -426,6 +427,9 @@ app
     installAvatarIpc();
     installDock();
     installShare();
+    // Files renderer downloads into ~/Downloads instead of prompting a Save
+    // panel. Distinct from `installShare` — that's the "send elsewhere" intent.
+    installDownloads();
     installPowerEvents();
     installNotifications();
     // Register the status channel before the tray installs so the tray's

--- a/clients/web/src/runtime/native-file.test.ts
+++ b/clients/web/src/runtime/native-file.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * The intent split is the contract under test: `saveFile` ("Download") must
+ * never present the macOS Share Sheet, while `shareFile` ("send elsewhere")
+ * must. A regression here is the user-visible bug where the desktop app's
+ * Download button opened a list of apps instead of saving the file.
+ */
+
+let isNative = false;
+mock.module("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => isNative },
+}));
+
+let electron = false;
+mock.module("@/runtime/is-electron", () => ({ isElectron: () => electron }));
+
+// The Electron bridge wrapper: returns true when it presented the sheet.
+let macSheetAvailable = true;
+const shareFileViaMacSheet = mock(
+  async (
+    resolveBlob: () => Promise<Blob>,
+    _filename: string,
+  ): Promise<boolean> => {
+    if (!macSheetAvailable) {
+      return false;
+    }
+    await resolveBlob();
+    return true;
+  },
+);
+mock.module("@/runtime/native-share", () => ({ shareFileViaMacSheet }));
+
+// Capacitor's share path is lazy-imported inside the function, so the plugin
+// modules are mocked rather than the wrapper.
+const writeFile = mock(async (_opts: unknown) => ({ uri: "file:///tmp/x" }));
+const deleteFile = mock(async (_opts: unknown) => undefined);
+const share = mock(async (_opts: unknown) => undefined);
+mock.module("@capacitor/filesystem", () => ({
+  Filesystem: { writeFile, deleteFile },
+  Directory: { Cache: "CACHE" },
+}));
+mock.module("@capacitor/share", () => ({ Share: { share } }));
+
+const { saveFile, shareFile } = await import("@/runtime/native-file");
+
+// Anchor clicks are the web download path; capture them instead of letting
+// jsdom/happy-dom try to navigate.
+const clicks: Array<{ download: string; href: string }> = [];
+const originalCreateElement = document.createElement.bind(document);
+document.createElement = ((tag: string) => {
+  const el = originalCreateElement(tag);
+  if (tag === "a") {
+    (el as HTMLAnchorElement).click = () => {
+      const a = el as HTMLAnchorElement;
+      clicks.push({ download: a.download, href: a.href });
+    };
+  }
+  return el;
+}) as typeof document.createElement;
+
+URL.createObjectURL = () => "blob:mock";
+URL.revokeObjectURL = () => {};
+
+const blob = new Blob(["hello"]);
+
+const fetchMock = mock(
+  async (_url: string) => new Response("bytes", { status: 200 }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+beforeEach(() => {
+  clicks.length = 0;
+  isNative = false;
+  electron = false;
+  macSheetAvailable = true;
+  mock.clearAllMocks();
+  writeFile.mockResolvedValue({ uri: "file:///tmp/x" });
+  fetchMock.mockResolvedValue(new Response("bytes", { status: 200 }));
+});
+
+describe("saveFile — the Download intent", () => {
+  test("never presents the macOS Share Sheet on Electron", async () => {
+    await saveFile(blob, "report.pdf");
+
+    expect(shareFileViaMacSheet).not.toHaveBeenCalled();
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0]!.download).toBe("report.pdf");
+  });
+
+  test("downloads via an <a download> anchor on web", async () => {
+    await saveFile("https://example.com/report.pdf", "report.pdf");
+
+    expect(clicks).toEqual([
+      { download: "report.pdf", href: "https://example.com/report.pdf" },
+    ]);
+  });
+
+  test("resolves a URL source to a blob on Electron, where a cross-origin anchor would be blocked", async () => {
+    electron = true;
+
+    await saveFile("https://cdn.example.com/report.pdf", "report.pdf");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(clicks).toEqual([{ download: "report.pdf", href: "blob:mock" }]);
+    expect(shareFileViaMacSheet).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the plain anchor when that fetch fails", async () => {
+    electron = true;
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+
+    await saveFile("https://cdn.example.com/report.pdf", "report.pdf");
+
+    expect(clicks).toEqual([
+      { download: "report.pdf", href: "https://cdn.example.com/report.pdf" },
+    ]);
+  });
+
+  test("does not re-fetch a blob source on Electron", async () => {
+    electron = true;
+
+    await saveFile(blob, "report.pdf");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clicks).toHaveLength(1);
+  });
+
+  test("still uses the Capacitor sheet on native, where blob downloads can't work", async () => {
+    isNative = true;
+
+    await saveFile(blob, "report.pdf");
+
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(clicks).toHaveLength(0);
+  });
+});
+
+describe("shareFile — the Share intent", () => {
+  test("presents the macOS Share Sheet on Electron", async () => {
+    await shareFile(blob, "App.vellum");
+
+    expect(shareFileViaMacSheet).toHaveBeenCalledTimes(1);
+    expect(shareFileViaMacSheet.mock.calls[0]![1]).toBe("App.vellum");
+    expect(clicks).toHaveLength(0);
+  });
+
+  test("falls back to a download when the desktop bridge is unavailable", async () => {
+    macSheetAvailable = false;
+
+    await shareFile(blob, "App.vellum");
+
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0]!.download).toBe("App.vellum");
+  });
+
+  test("presents the Capacitor sheet on native", async () => {
+    macSheetAvailable = false;
+    isNative = true;
+
+    await shareFile(blob, "App.vellum");
+
+    expect(share).toHaveBeenCalledTimes(1);
+  });
+
+  test("swallows a dismissed native sheet and still cleans up the temp file", async () => {
+    macSheetAvailable = false;
+    isNative = true;
+    share.mockRejectedValueOnce(new Error("Share canceled"));
+
+    await shareFile(blob, "App.vellum");
+
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/runtime/native-file.test.ts
+++ b/clients/web/src/runtime/native-file.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 /**
  * The intent split is the contract under test: `saveFile` ("Download") must
  * never present the macOS Share Sheet, while `shareFile` ("send elsewhere")
- * must. A regression here is the user-visible bug where the desktop app's
- * Download button opened a list of apps instead of saving the file.
+ * must. Breaking that leaves a user who clicked Download looking at a list of
+ * apps with no file saved.
  */
 
 let isNative = false;
@@ -79,7 +79,7 @@ beforeEach(() => {
   fetchMock.mockResolvedValue(new Response("bytes", { status: 200 }));
 });
 
-describe("saveFile — the Download intent", () => {
+describe("saveFile, the Download intent", () => {
   test("never presents the macOS Share Sheet on Electron", async () => {
     await saveFile(blob, "report.pdf");
 
@@ -137,7 +137,7 @@ describe("saveFile — the Download intent", () => {
   });
 });
 
-describe("shareFile — the Share intent", () => {
+describe("shareFile, the Share intent", () => {
   test("presents the macOS Share Sheet on Electron", async () => {
     await shareFile(blob, "App.vellum");
 

--- a/clients/web/src/runtime/native-file.ts
+++ b/clients/web/src/runtime/native-file.ts
@@ -1,21 +1,42 @@
 import { Capacitor } from "@capacitor/core";
 
+import { isElectron } from "@/runtime/is-electron";
 import { shareFileViaMacSheet } from "@/runtime/native-share";
 
 /**
- * Cross-platform file save/share utility.
+ * Cross-platform file save / share utility.
  *
- * - **Electron (macOS):** presents the native macOS Share Sheet
- *   (`NSSharingServicePicker`) via the `window.vellum.share` bridge — the
- *   desktop counterpart to the iOS sheet (Messages, Mail, AirDrop, Slack,
- *   Save to Files, …). Falls through to the browser download if the desktop
- *   bridge is unavailable.
- * - **Capacitor iOS:** the standard web pattern (`<a download>` with a blob
- *   URL) is broken — WKWebView does not support the `download` attribute on
- *   anchors with `blob:` URLs (WebKit bug 216918). Instead the blob is written
- *   to a temp file via `@capacitor/filesystem` and presented via
- *   `@capacitor/share`, which wraps `UIActivityViewController`.
- * - **Web (plain browser):** the `<a download>` pattern.
+ * Two *intents* live here, and they are deliberately separate entry points:
+ *
+ * - **`saveFile` — "Download".** The user asked for the file on their device.
+ *   It must land somewhere without further choices: `~/Downloads` on the
+ *   desktop, the browser's download location on web.
+ * - **`shareFile` — "Share / send elsewhere".** The user asked to hand the file
+ *   to another app (Messages, Mail, AirDrop, Slack, …), so the native Share
+ *   Sheet is the point.
+ *
+ * A share sheet is not a download. Routing a Download button into
+ * `NSSharingServicePicker` leaves the user staring at a list of apps with no
+ * file saved, which is exactly the macOS bug this split fixes — `saveFile` no
+ * longer presents the sheet on Electron.
+ *
+ * Per-host behavior:
+ *
+ * - **Electron (macOS):** `saveFile` uses the standard `<a download>` path
+ *   (against a blob URL — see the note in `saveFile`); Chromium's download
+ *   manager fires `will-download` in the main process, which files the download
+ *   into `~/Downloads` (`clients/macos/src/main/downloads.ts`). `shareFile`
+ *   presents the native
+ *   Share Sheet over the `window.vellum.share` bridge, falling through to a
+ *   download when the desktop bridge is unavailable (older preload).
+ * - **Capacitor iOS/Android:** the one host where a *download* still has to go
+ *   through the share sheet — WKWebView does not support the `download`
+ *   attribute on anchors with `blob:` URLs (WebKit bug 216918), so the blob is
+ *   written to a temp file via `@capacitor/filesystem` and presented via
+ *   `@capacitor/share` (`UIActivityViewController`), where "Save to Files" is
+ *   the download. That's a platform limitation, not the intent split above.
+ * - **Web (plain browser):** the `<a download>` pattern for both intents —
+ *   there is no reliable cross-browser file-share surface to prefer.
  *
  * The Capacitor plugins are lazy-imported so they are never loaded in SSR or
  * plain-browser contexts.
@@ -28,13 +49,53 @@ import { shareFileViaMacSheet } from "@/runtime/native-share";
  */
 
 /**
- * Save or share a file. On Electron (macOS) and Capacitor iOS, presents the
- * native Share Sheet; on plain web, triggers a browser download.
+ * Download a file to the user's device — the "Download" intent.
+ *
+ * Never presents the macOS Share Sheet: on Electron this is a real download
+ * that the main process files into `~/Downloads`. On Capacitor the iOS share
+ * sheet is still the only way to hand a blob to the filesystem (see the module
+ * docstring), so that host keeps its sheet.
+ *
+ * Accepts either a `Blob` or a URL string.
+ */
+export async function saveFile(
+  source: Blob | string,
+  filename: string,
+): Promise<void> {
+  if (Capacitor.isNativePlatform()) {
+    await shareFileNative(source, filename);
+    return;
+  }
+  // Electron: resolve a URL source to a blob before the anchor click. Chromium
+  // ignores the `download` attribute on a cross-origin URL and treats the click
+  // as a navigation, which the shell's deny-all navigation policy
+  // (`clients/macos/src/main/windows.ts`) then blocks — the file would simply
+  // never arrive. A blob URL is same-origin, so both the download and the
+  // filename survive. This is the same fetch the share path already paid for.
+  if (isElectron() && typeof source === "string") {
+    try {
+      saveFileWeb(await toBlob(source), filename);
+      return;
+    } catch {
+      // Unreachable for same-origin sources; fall through to the plain anchor
+      // rather than dropping the download entirely.
+    }
+  }
+  saveFileWeb(source, filename);
+}
+
+/**
+ * Share a file with another app — the "Share" intent (Messages, Mail, AirDrop,
+ * Slack, Save to Files, …).
+ *
+ * Presents the native Share Sheet where one exists (Electron/macOS, Capacitor)
+ * and falls back to a plain download on hosts that have none, so the user still
+ * ends up with the file.
  *
  * Accepts either a `Blob` or a URL string; a URL is fetched first on the
  * share-sheet paths (see `toBlob`).
  */
-export async function saveFile(
+export async function shareFile(
   source: Blob | string,
   filename: string,
 ): Promise<void> {
@@ -45,7 +106,7 @@ export async function saveFile(
     return;
   }
   if (Capacitor.isNativePlatform()) {
-    await saveFileNative(source, filename);
+    await shareFileNative(source, filename);
     return;
   }
   saveFileWeb(source, filename);
@@ -66,7 +127,7 @@ async function toBlob(source: Blob | string): Promise<Blob> {
   return response.blob();
 }
 
-async function saveFileNative(
+async function shareFileNative(
   source: Blob | string,
   filename: string,
 ): Promise<void> {

--- a/clients/web/src/runtime/native-file.ts
+++ b/clients/web/src/runtime/native-file.ts
@@ -6,37 +6,34 @@ import { shareFileViaMacSheet } from "@/runtime/native-share";
 /**
  * Cross-platform file save / share utility.
  *
- * Two *intents* live here, and they are deliberately separate entry points:
+ * Two *intents* live here as deliberately separate entry points:
  *
- * - **`saveFile` — "Download".** The user asked for the file on their device.
- *   It must land somewhere without further choices: `~/Downloads` on the
- *   desktop, the browser's download location on web.
- * - **`shareFile` — "Share / send elsewhere".** The user asked to hand the file
- *   to another app (Messages, Mail, AirDrop, Slack, …), so the native Share
- *   Sheet is the point.
- *
- * A share sheet is not a download. Routing a Download button into
- * `NSSharingServicePicker` leaves the user staring at a list of apps with no
- * file saved, which is exactly the macOS bug this split fixes — `saveFile` no
- * longer presents the sheet on Electron.
+ * - **`saveFile` ("Download").** The user asked for the file on their device.
+ *   It lands somewhere without further choices: `~/Downloads` on the desktop,
+ *   the browser's download location on web. It never presents a share sheet on
+ *   a host that can download, because a list of apps to send the file to is not
+ *   a saved file.
+ * - **`shareFile` ("Share", send elsewhere).** The user asked to hand the file
+ *   to another app (Messages, Mail, AirDrop, Slack), so the native Share Sheet
+ *   is the point.
  *
  * Per-host behavior:
  *
  * - **Electron (macOS):** `saveFile` uses the standard `<a download>` path
- *   (against a blob URL — see the note in `saveFile`); Chromium's download
+ *   against a blob URL (see the note in `saveFile`); Chromium's download
  *   manager fires `will-download` in the main process, which files the download
  *   into `~/Downloads` (`clients/macos/src/main/downloads.ts`). `shareFile`
- *   presents the native
- *   Share Sheet over the `window.vellum.share` bridge, falling through to a
- *   download when the desktop bridge is unavailable (older preload).
- * - **Capacitor iOS/Android:** the one host where a *download* still has to go
- *   through the share sheet — WKWebView does not support the `download`
+ *   presents the native Share Sheet over the `window.vellum.share` bridge,
+ *   falling through to a download when the desktop bridge is unavailable
+ *   (older preload).
+ * - **Capacitor iOS/Android:** the one host where a *download* also goes
+ *   through the share sheet. WKWebView does not support the `download`
  *   attribute on anchors with `blob:` URLs (WebKit bug 216918), so the blob is
  *   written to a temp file via `@capacitor/filesystem` and presented via
  *   `@capacitor/share` (`UIActivityViewController`), where "Save to Files" is
- *   the download. That's a platform limitation, not the intent split above.
- * - **Web (plain browser):** the `<a download>` pattern for both intents —
- *   there is no reliable cross-browser file-share surface to prefer.
+ *   the download. That is a platform limitation, not the intent split above.
+ * - **Web (plain browser):** the `<a download>` pattern for both intents, since
+ *   no reliable cross-browser file-share surface exists to prefer.
  *
  * The Capacitor plugins are lazy-imported so they are never loaded in SSR or
  * plain-browser contexts.
@@ -49,12 +46,12 @@ import { shareFileViaMacSheet } from "@/runtime/native-share";
  */
 
 /**
- * Download a file to the user's device — the "Download" intent.
+ * Download a file to the user's device: the "Download" intent.
  *
- * Never presents the macOS Share Sheet: on Electron this is a real download
+ * Never presents the macOS Share Sheet. On Electron this is a real download
  * that the main process files into `~/Downloads`. On Capacitor the iOS share
- * sheet is still the only way to hand a blob to the filesystem (see the module
- * docstring), so that host keeps its sheet.
+ * sheet is the only way to hand a blob to the filesystem (see the module
+ * docstring), so that host uses the sheet.
  *
  * Accepts either a `Blob` or a URL string.
  */
@@ -69,15 +66,14 @@ export async function saveFile(
   // Electron: resolve a URL source to a blob before the anchor click. Chromium
   // ignores the `download` attribute on a cross-origin URL and treats the click
   // as a navigation, which the shell's deny-all navigation policy
-  // (`clients/macos/src/main/windows.ts`) then blocks — the file would simply
-  // never arrive. A blob URL is same-origin, so both the download and the
-  // filename survive. This is the same fetch the share path already paid for.
+  // (`clients/macos/src/main/windows.ts`) blocks, so the file never arrives. A
+  // blob URL is same-origin, so both the download and the filename survive.
   if (isElectron() && typeof source === "string") {
     try {
       saveFileWeb(await toBlob(source), filename);
       return;
     } catch {
-      // Unreachable for same-origin sources; fall through to the plain anchor
+      // Unreachable for same-origin sources. Fall through to the plain anchor
       // rather than dropping the download entirely.
     }
   }
@@ -85,8 +81,8 @@ export async function saveFile(
 }
 
 /**
- * Share a file with another app — the "Share" intent (Messages, Mail, AirDrop,
- * Slack, Save to Files, …).
+ * Share a file with another app: the "Share" intent (Messages, Mail, AirDrop,
+ * Slack, Save to Files).
  *
  * Presents the native Share Sheet where one exists (Electron/macOS, Capacitor)
  * and falls back to a plain download on hosts that have none, so the user still

--- a/clients/web/src/runtime/native-share.ts
+++ b/clients/web/src/runtime/native-share.ts
@@ -3,8 +3,12 @@ import { isElectron } from "@/runtime/is-electron";
 /**
  * Per-capability wrapper for the Electron host's native Share Sheet. Matches
  * the pattern in `dock.ts` / `native-biometric.ts`: the renderer never touches
- * `window.vellum.*` directly — the cross-platform `saveFile` (native-file.ts)
+ * `window.vellum.*` directly — the cross-platform `shareFile` (native-file.ts)
  * calls this, and the platform branch lives here.
+ *
+ * Only the *share* intent routes here. A "Download" action goes through
+ * `saveFile`, which never presents this sheet — see the intent split documented
+ * in `native-file.ts`.
  *
  * On macOS this presents `NSSharingServicePicker` (Messages, Mail, AirDrop,
  * Slack, Save to Files, …) for the file, matching the native "export from the

--- a/clients/web/src/runtime/native-share.ts
+++ b/clients/web/src/runtime/native-share.ts
@@ -3,11 +3,11 @@ import { isElectron } from "@/runtime/is-electron";
 /**
  * Per-capability wrapper for the Electron host's native Share Sheet. Matches
  * the pattern in `dock.ts` / `native-biometric.ts`: the renderer never touches
- * `window.vellum.*` directly — the cross-platform `shareFile` (native-file.ts)
+ * `window.vellum.*` directly. The cross-platform `shareFile` (native-file.ts)
  * calls this, and the platform branch lives here.
  *
  * Only the *share* intent routes here. A "Download" action goes through
- * `saveFile`, which never presents this sheet — see the intent split documented
+ * `saveFile`, which never presents this sheet. See the intent split documented
  * in `native-file.ts`.
  *
  * On macOS this presents `NSSharingServicePicker` (Messages, Mail, AirDrop,

--- a/clients/web/src/utils/share-app.ts
+++ b/clients/web/src/utils/share-app.ts
@@ -3,14 +3,16 @@
  *
  * 1. Calls the share-cloud endpoint to package the app server-side.
  * 2. Downloads the binary bundle using the returned share token.
- * 3. Saves/shares the file via the cross-platform saveFile helper.
+ * 3. Hands the file to the cross-platform `shareFile` helper — this is the
+ *    "send it somewhere" intent, so it presents the native Share Sheet on the
+ *    hosts that have one and falls back to a download elsewhere.
  */
 
 import {
   appsByIdSharecloudPost,
   appsSharedByTokenGet,
 } from "@/generated/daemon/sdk.gen";
-import { saveFile } from "@/runtime/native-file";
+import { shareFile } from "@/runtime/native-file";
 
 export async function shareApp(
   assistantId: string,
@@ -35,5 +37,5 @@ export async function shareApp(
   }
 
   const safeName = appName.replace(/[/\\:*?"<>|]/g, "_").trim() || "App";
-  await saveFile(blob, `${safeName}.vellum`);
+  await shareFile(blob, `${safeName}.vellum`);
 }

--- a/clients/web/src/utils/share-app.ts
+++ b/clients/web/src/utils/share-app.ts
@@ -3,7 +3,7 @@
  *
  * 1. Calls the share-cloud endpoint to package the app server-side.
  * 2. Downloads the binary bundle using the returned share token.
- * 3. Hands the file to the cross-platform `shareFile` helper — this is the
+ * 3. Hands the file to the cross-platform `shareFile` helper. This is the
  *    "send it somewhere" intent, so it presents the native Share Sheet on the
  *    hosts that have one and falls back to a download elsewhere.
  */


### PR DESCRIPTION
## Prompt / plan

User report (high pri): *"When I try to download a file on the macOS app it shows the Share modal instead."* Screenshot showed the workspace file viewer's **Download** button opening `NSSharingServicePicker` (AirDrop, Messages, Notes).

**Root cause.** `saveFile` (`clients/web/src/runtime/native-file.ts`), the helper behind *every* Download affordance in the renderer, routed unconditionally through the Electron share bridge on the desktop host. So Download opened a list of apps and left no file on disk. Every download call site was affected (workspace files, chat attachments, transcript exports, inspector raw output, invoices), not just the one in the report.

The underlying problem is that one function served two different user intents. This PR separates them:

- **`saveFile` ("Download").** Never presents the sheet. On Electron it takes the normal `<a download>` path, which Chromium raises as a real download.
- **`shareFile` ("send elsewhere").** Keeps the Share Sheet. `shareApp` (the .vellum bundle export) is the one genuine share caller and uses it.

Capacitor iOS/Android still route downloads through the share sheet: WKWebView can't download `blob:` URLs ([WebKit 216918](https://bugs.webkit.org/show_bug.cgi?id=216918)), so that's a platform constraint rather than a product choice, and it's documented as such.

Two supporting changes on the desktop side:

- **New `clients/macos/src/main/downloads.ts`.** Handles `will-download` and files downloads into `~/Downloads`, uniquified Finder-style (`report.pdf` then `report (1).pdf`) so a repeat download never clobbers an existing file, plus a Dock Downloads-stack bounce on completion. Absent a handler, Electron's default routine prompts a Save panel for *every* download, so simply removing the share call would have traded one bad UX for another. Any failure (unwritable dir, no free name) falls back to that default routine. The collision check is synchronous because `setSavePath` is only honored while the listener is on the stack.

  Chosen paths are also reserved in memory until the item's `done` event ([review catch](https://github.com/vellum-ai/vellum-assistant/pull/39809#discussion_r3696215900)): a download's destination file does not exist at `will-download` time, so two same-named downloads started close together (a double-clicked button) would otherwise both pick the same path and race for one destination.

- **URL sources are resolved to a blob before the anchor click on Electron.** Chromium ignores the `download` attribute on cross-origin URLs and treats the click as a navigation, which the shell's deny-all navigation policy blocks, so the file would never arrive. Blob sources are not re-fetched.

## Test plan

- **New** `clients/web/src/runtime/native-file.test.ts` (10 tests). The intent split is the contract: `saveFile` never calls the Mac share bridge (the regression under test), uses `<a download>` on web, resolves URL sources to a blob on Electron with a fallback when that fetch fails, and still uses the Capacitor sheet on native; `shareFile` presents the sheet, falls back to a download on an older preload, and cleans up the temp file when the native sheet is dismissed.
- **New** `clients/macos/src/main/downloads.test.ts` (14 tests). Single `will-download` subscription across repeat installs; save path lands in `~/Downloads`; Finder-style uniquifying; extensionless/dotfile names not mangled; path components stripped so a download can't escape the directory; `null` rather than an infinite loop when every name is taken; Dock bounce only on `completed`; defers to Electron's Save panel when the directory is unusable. Concurrency: three overlapping downloads of the same filename get three distinct destinations, and the name is released on both completion and cancellation.
- Existing suites for every touched area pass (39 web test files plus macOS `share.test.ts`), run through each package's per-file isolating runner (`scripts/run-tests.ts`, since Bun's `mock.module` leaks across files in a shared process).
- `bunx tsc --noEmit` and `eslint` clean in both `clients/web` and `clients/macos`.
- Not manually verified in a packaged macOS build, since this environment can't run Electron. The download to `~/Downloads` path and the Dock bounce are asserted at the seam rather than end-to-end, so a quick manual check on a real build is worth doing before release.

## Docs

`clients/macos/README.md` gains a Downloads section, and the Share Sheet section states that only the share intent routes there. The renderer-side docstrings carry the same split.