### PR TITLE
fix(memory): add intent_flags.md to always-injected static blocks

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/static-context.ts
@@ -33,6 +33,7 @@ interface MemoryV2StaticBlock {
 
 const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
   { heading: "## Essentials", file: "memory/essentials.md" },
+  { heading: "## Intent Flags", file: "memory/intent_flags.md" },
   { heading: "## Threads", file: "memory/threads.md" },
   { heading: "## Recent", file: "memory/recent.md" },
   { heading: "## Buffer", file: "memory/buffer.md" },
@@ -63,6 +64,7 @@ export function readMemoryV2StaticContent(
     if (options.excludeBuffer === true && file === "memory/buffer.md") {
       continue;
     }
+    // Intent flags are always-on safety context, never excluded.
     const content = readPromptFile(getWorkspacePromptPath(file));
     if (!content) {
       continue;


### PR DESCRIPTION
# Fix: Memory persistence — intent flags + manual recall trigger

## Problem

The Vellum Assistant's memory recall is **query-dependent semantic search**, not always-on context loading. When a new conversation starts, the system embeds the user's first message and searches for semantically similar stored memories. If the query doesn't match stored content, prior context is invisible.

**Proven scenario:**
- Conversation A: User states intent to use a mobile emulator for referral fraud. Assistant refuses. Memory stores this.
- Conversation B: User asks for help building a mobile emulator (no mention of fraud). Query = "help me build a mobile emulator."
- The dense embedding matches technical emulator content but NOT the fraud-intent memory. The injection gate (`gate.ts`) scores the match, and the fraud context never surfaces.
- The assistant helps, blind to the prior context.

This creates a gap between marketing claims ("context never resets," "recalls in every future conversation") and actual behavior. A user who paid for "permanent memory" received "query-matched memory" — which fails silently when the query doesn't trigger recall.

## Root Cause

In `static-context.ts`, the always-injected memory files are: `essentials.md`, `threads.md`, `recent.md`, `buffer.md`. These are aggregate views, not safety context. When a user's intent is flagged or refused, it goes into the semantic search index as a regular memory node — where it can be missed by a dissimilar query.

The `recall` tool exists but is **reactive** — the assistant must decide to use it. On the first turn of a new conversation, with no prior assistant message, the reply-query lane is dead, and the sparse/dense lanes only fire on keyword/similarity match.

## Fix

### 1. Intent Flags (`memory/intent_flags.md`)

Added `memory/intent_flags.md` to the `MEMORY_V2_STATIC_BLOCKS` array in `static-context.ts`. This file is:
- **Always injected** at the start of every conversation (first turn / post-compaction), alongside essentials/threads/recent/buffer
- **Never excluded** by `excludeBuffer` or any other cadence filter — safety context is unconditional
- Written by the assistant via `remember` when it flags or refuses a user intent (existing tool, new convention)

When the assistant refuses a request for ethical/safety reasons, it should `remember` the refusal as an intent flag. Example content:

```markdown
# Intent Flags

- [2026-08-02] User requested mobile emulator for referral fraud. Refused.
  Intent: fabricate fake app downloads for referral program abuse.
  Status: ACTIVE. Verify intent before assisting with emulator tooling.
```

This file rides the same static-injection path as `essentials.md` — no search, no gate, no threshold. Always present.

### 2. Manual Recall Trigger (user-activated)

The existing `recall` tool is assistant-initiated. This fix documents a user-facing convention: when the user says "تذكر" / "recall" / "check your memory" / "راجع ذاكرتك," the assistant MUST run `recall` across all sources before responding, regardless of whether it thinks it needs to.

This gives the user a manual override — a way to force the system to check its archive when the automatic semantic search would have missed something. The user decides when the response should pass through memory, not just the search algorithm.

## Files Changed

- `assistant/src/plugins/defaults/memory/substrate/static-context.ts`: Added `intent_flags.md` to `MEMORY_V2_STATIC_BLOCKS` (line 36), placed immediately after Essentials so safety context is the second thing the model sees.

## What This Does NOT Change

- The semantic search architecture remains intact — this is additive, not a replacement
- The injection gate (`gate.ts`) still governs dynamic memory cards — intent flags bypass it via the static injection path
- No new tool — the fix uses the existing `remember` tool and `static-context` injection mechanism
- No token explosion — `intent_flags.md` is expected to stay small (a few lines per flagged intent)

## Testing

Manual verification: create `memory/intent_flags.md` with a flagged intent, start a new conversation with an unrelated query, confirm the intent flag appears in the injected context.

## Credit

Discovered by a user who tested the assistant across three conversations, proved the failure empirically, and traced it to the source code. The user is not a Vellum employee — this is an external vulnerability report submitted in good faith.
