### PR TITLE
fix: decode file URLs when deriving script directories

### DIFF
--- a/assistant/src/cli/lib/list-installed-plugins.ts
+++ b/assistant/src/cli/lib/list-installed-plugins.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { parsePluginIcon } from "./plugin-artifact.js";
@@ -27,7 +28,7 @@ import { readValidatedPluginIcon } from "./plugin-icon-file.js";
  * dependencies in test environments).
  */
 const DEFAULT_PLUGINS_DIR = join(
-  dirname(new URL(import.meta.url).pathname),
+  dirname(fileURLToPath(import.meta.url)),
   "..",
   "..",
   "plugins",

--- a/clients/web/scripts/transform-daemon-spec.ts
+++ b/clients/web/scripts/transform-daemon-spec.ts
@@ -15,9 +15,10 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import YAML from "js-yaml";
 
-const SCRIPT_DIR = dirname(new URL(import.meta.url).pathname);
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const WEB_ROOT = resolve(SCRIPT_DIR, "..");
 const DAEMON_SPEC_PATH = resolve(WEB_ROOT, "../../assistant/openapi.yaml");
 const OUTPUT_PATH = resolve(WEB_ROOT, "openapi-schemas/daemon.json");

--- a/clients/web/scripts/transform-gateway-spec.ts
+++ b/clients/web/scripts/transform-gateway-spec.ts
@@ -15,8 +15,9 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const SCRIPT_DIR = dirname(new URL(import.meta.url).pathname);
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const WEB_ROOT = resolve(SCRIPT_DIR, "..");
 const GATEWAY_SPEC_PATH = resolve(WEB_ROOT, "../../gateway/openapi.json");
 const OUTPUT_PATH = resolve(WEB_ROOT, "openapi-schemas/gateway.json");

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 
 const setDeviceBool = mock((_name: string, _value: boolean) => {});
 const syncDiagnosticsToMain = mock((_enabled: boolean) => {});
@@ -324,7 +325,7 @@ describe("single-writer invariant", () => {
     // through this module's chokepoints. Reads (`getDeviceSetting`/
     // `getDeviceBool`/`watchDeviceSetting`) and the device-settings registry
     // entry are fine anywhere.
-    const srcRoot = new URL("../..", import.meta.url).pathname;
+    const srcRoot = fileURLToPath(new URL("../..", import.meta.url));
     const writePatterns = [
       /\bset(?:DeviceBool|DeviceSetting)\(\s*["']diagnosticsReporting["']/,
       /\bset(?:LocalBool|LocalSetting)\(\s*["']device:diagnostics_reporting["']/,

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("feature-flag-defaults");
@@ -44,7 +45,8 @@ function getRegistryCandidates(): string[] {
     candidates.push(...registryCandidateOverrides);
   }
 
-  const srcDir = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
+  const srcDir =
+    import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
 
   // 1. Bundled gateway-local copy
   candidates.push(join(srcDir, REGISTRY_FILENAME));


### PR DESCRIPTION
new URL(import.meta.url).pathname leaves percent-encoding intact (e.g. a space becomes %20), so any checkout path containing a space breaks these scripts with ENOENT. Switch to fileURLToPath, which decodes correctly.


Claude-Session: https://claude.ai/code/session_01NB4BX4hGBWm3ehN497j9ho

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
