### PR TITLE
feat(assistant): gate memory retrospectives on user activity in the unprocessed tail

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -39,6 +39,15 @@ export const MemoryRetrospectiveConfigSchema = z
         "Minimum milliseconds between attempts (success or failure). Prevents tight retry loops across trigger types. Pre-compaction bypasses this gate.",
       ),
 
+    requireUserActivity: z
+      .boolean({
+        error: "memory.retrospective.requireUserActivity must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "When true (default), a retrospective fires only when the unprocessed tail contains at least one user message carrying non-tool_result content. Tool results ride on user-role rows, so bare tool-result carriers do not count as user activity. Assistant-only stretches (proactive sends, broadcast recaps) are skipped with the cursor left in place, so the first retrospective after real user activity reviews the whole deferred stretch. Set false to run retrospectives over assistant-only activity as well.",
+      ),
+
     sweepIntervalMs: z
       .number({
         error: "memory.retrospective.sweepIntervalMs must be a number",

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createConversation,
+  type MessageRow,
+} from "../../../../persistence/conversation-crud.js";
+import { getDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { messages } from "../../../../persistence/schema/index.js";
+import {
+  hasQualifyingUserMessageAfter,
+  messagesHaveUserActivity,
+} from "../memory-retrospective-accounting.js";
+
+await initializeDb();
+
+const CONV = "conv-accounting";
+
+const TEXT = JSON.stringify([{ type: "text", text: "hello" }]);
+const TOOL_RESULT_ONLY = JSON.stringify([
+  { type: "tool_result", tool_use_id: "t1", content: "ok" },
+]);
+const MIXED = JSON.stringify([
+  { type: "tool_result", tool_use_id: "t1", content: "ok" },
+  { type: "text", text: "note" },
+]);
+
+let seq = 0;
+function insertRaw(opts: {
+  role: string;
+  content: string;
+  createdAt: number;
+  id?: string;
+}): string {
+  const id = opts.id ?? `msg-${String(++seq).padStart(4, "0")}`;
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId: CONV,
+      role: opts.role,
+      content: opts.content,
+      createdAt: opts.createdAt,
+      metadata: null,
+    })
+    .run();
+  return id;
+}
+
+describe("hasQualifyingUserMessageAfter", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+    createConversation({ id: CONV });
+  });
+
+  test("assistant-only tail does not qualify", () => {
+    insertRaw({ role: "assistant", content: TEXT, createdAt: 1_000 });
+    insertRaw({ role: "assistant", content: TEXT, createdAt: 2_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(false);
+  });
+
+  test("tool_result-only user rows do not qualify", () => {
+    insertRaw({ role: "assistant", content: TEXT, createdAt: 1_000 });
+    insertRaw({ role: "user", content: TOOL_RESULT_ONLY, createdAt: 2_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(false);
+  });
+
+  test("a user text row qualifies", () => {
+    insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+  });
+
+  test("a mixed tool_result + text user row qualifies", () => {
+    insertRaw({ role: "user", content: MIXED, createdAt: 1_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+  });
+
+  test("non-array user content qualifies (fails toward running)", () => {
+    // File-backed rows persist a `{ ref }` object; legacy rows persist a
+    // bare string. Neither shape can prove the row is a tool-result carrier.
+    insertRaw({
+      role: "user",
+      content: JSON.stringify({ ref: "deltas/abc" }),
+      createdAt: 1_000,
+    });
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+
+    getDb().run(`DELETE FROM messages`);
+    insertRaw({ role: "user", content: "plain legacy text", createdAt: 1_000 });
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+  });
+
+  test("an empty content array does not qualify", () => {
+    insertRaw({ role: "user", content: "[]", createdAt: 1_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(false);
+  });
+
+  test("only rows after the cursor count", () => {
+    const cursor = insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+    insertRaw({ role: "assistant", content: TEXT, createdAt: 2_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, cursor)).toBe(false);
+
+    insertRaw({ role: "user", content: TEXT, createdAt: 3_000 });
+    expect(hasQualifyingUserMessageAfter(CONV, cursor)).toBe(true);
+  });
+
+  test("the empty-string sentinel scans the whole conversation", () => {
+    insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, "")).toBe(true);
+  });
+
+  test("a vanished cursor reference means no new work", () => {
+    insertRaw({ role: "user", content: TEXT, createdAt: 1_000 });
+
+    expect(hasQualifyingUserMessageAfter(CONV, "msg-gone")).toBe(false);
+  });
+
+  test("rows sharing the cursor's timestamp are split by the id tie-break", () => {
+    insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 1_000,
+      id: "msg-before",
+    });
+    insertRaw({
+      role: "user",
+      content: TOOL_RESULT_ONLY,
+      createdAt: 1_000,
+      id: "msg-cursor",
+    });
+    expect(hasQualifyingUserMessageAfter(CONV, "msg-cursor")).toBe(false);
+
+    insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 1_000,
+      id: "msg-later",
+    });
+    expect(hasQualifyingUserMessageAfter(CONV, "msg-cursor")).toBe(true);
+  });
+});
+
+describe("messagesHaveUserActivity", () => {
+  function row(
+    role: string,
+    content: Array<Record<string, unknown>>,
+  ): Pick<MessageRow, "role" | "content"> {
+    return { role, content } as unknown as Pick<MessageRow, "role" | "content">;
+  }
+
+  test("a user text row counts as user activity", () => {
+    expect(
+      messagesHaveUserActivity([
+        row("assistant", [{ type: "text", text: "recap" }]),
+        row("user", [{ type: "text", text: "hey" }]),
+      ]),
+    ).toBe(true);
+  });
+
+  test("tool_result-only user rows do not count", () => {
+    expect(
+      messagesHaveUserActivity([
+        row("assistant", [{ type: "text", text: "recap" }]),
+        row("user", [
+          { type: "tool_result", tool_use_id: "t1", content: "ok" },
+        ]),
+      ]),
+    ).toBe(false);
+  });
+
+  test("a mixed tool_result + text user row counts", () => {
+    expect(
+      messagesHaveUserActivity([
+        row("user", [
+          { type: "tool_result", tool_use_id: "t1", content: "ok" },
+          { type: "text", text: "note" },
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  test("assistant rows never count, and an empty slice has no activity", () => {
+    expect(
+      messagesHaveUserActivity([
+        row("assistant", [{ type: "text", text: "hello" }]),
+      ]),
+    ).toBe(false);
+    expect(messagesHaveUserActivity([])).toBe(false);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -11,6 +11,19 @@ const upsertCalls: Array<{
   payload: { conversationId: string };
   runAfter: number;
 }> = [];
+let cfgRequireUserActivity = true;
+let mockStateRow: {
+  conversationId: string;
+  lastProcessedMessageId: string;
+  lastRunAt: number;
+  rememberedLog: string[];
+} | null = null;
+let tailQualifies = true;
+let gateProbeThrows = false;
+let gateProbeCalls: Array<{
+  conversationId: string;
+  afterMessageId: string | null;
+}> = [];
 
 mock.module("../../../../persistence/conversation-crud.js", () => ({
   getConversationSource: (_id: string) => sourceTag,
@@ -30,6 +43,29 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
   },
 }));
 
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: { retrospective: { requireUserActivity: cfgRequireUserActivity } },
+  }),
+}));
+
+mock.module("../memory-retrospective-state.js", () => ({
+  getRetrospectiveState: (_id: string) => mockStateRow,
+}));
+
+mock.module("../memory-retrospective-accounting.js", () => ({
+  hasQualifyingUserMessageAfter: (
+    conversationId: string,
+    afterMessageId: string | null,
+  ) => {
+    gateProbeCalls.push({ conversationId, afterMessageId });
+    if (gateProbeThrows) {
+      throw new Error("messages table unavailable");
+    }
+    return tailQualifies;
+  },
+}));
+
 import {
   enqueueMemoryRetrospectiveIfEnabled,
   enqueueMemoryRetrospectiveOnCompaction,
@@ -42,21 +78,79 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     convType = "standard";
     convSource = "user";
     upsertCalls.length = 0;
+    cfgRequireUserActivity = true;
+    mockStateRow = null;
+    tailQualifies = true;
+    gateProbeThrows = false;
+    gateProbeCalls = [];
   });
 
   test("standard source — interval trigger enqueues with runAfter ≈ now", () => {
     const before = Date.now();
-    enqueueMemoryRetrospectiveIfEnabled({
+    const result = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
     const after = Date.now();
 
+    expect(result).toBe(true);
     expect(upsertCalls).toHaveLength(1);
     const call = upsertCalls[0]!;
     expect(call.payload).toEqual({ conversationId: "c1" });
     expect(call.runAfter).toBeGreaterThanOrEqual(before);
     expect(call.runAfter).toBeLessThanOrEqual(after);
+  });
+
+  test("assistant-only tail — user-activity gate skips the enqueue", () => {
+    tailQualifies = false;
+    const result = enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+
+    expect(result).toBe(false);
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("requireUserActivity=false — assistant-only tail still enqueues", () => {
+    cfgRequireUserActivity = false;
+    tailQualifies = false;
+    const result = enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+
+    expect(result).toBe(true);
+    expect(upsertCalls).toHaveLength(1);
+    expect(gateProbeCalls).toHaveLength(0);
+  });
+
+  test("gate probes the tail from the state row's cursor", () => {
+    mockStateRow = {
+      conversationId: "c1",
+      lastProcessedMessageId: "m9",
+      lastRunAt: 1,
+      rememberedLog: [],
+    };
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "sweep",
+    });
+
+    expect(gateProbeCalls).toEqual([
+      { conversationId: "c1", afterMessageId: "m9" },
+    ]);
+  });
+
+  test("an unevaluable gate fails open — the enqueue proceeds", () => {
+    gateProbeThrows = true;
+    const result = enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+
+    expect(result).toBe(true);
+    expect(upsertCalls).toHaveLength(1);
   });
 
   test("compaction trigger applies the small debounce", () => {
@@ -135,6 +229,9 @@ describe("enqueueMemoryRetrospectiveOnCompaction", () => {
   beforeEach(() => {
     sourceTag = null;
     upsertCalls.length = 0;
+    cfgRequireUserActivity = true;
+    tailQualifies = true;
+    gateProbeThrows = false;
   });
 
   test("untrusted trust class — no enqueue", () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -28,7 +28,7 @@ let newMessages: Array<{
   id: string;
   createdAt: number;
   role?: string;
-  content?: string;
+  content?: string | Array<Record<string, unknown>>;
   metadata?: string | null;
 }> = [];
 
@@ -327,6 +327,7 @@ mock.module("../../../../config/memory-v3-gate.js", () => ({
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 import {
   memoryRetrospectiveJob,
+  runForkBasedRetrospective,
   SOURCE_PROCESSING_REQUEUE_DELAY_MS,
 } from "../memory-retrospective-job.js";
 
@@ -337,6 +338,7 @@ function makeConfig(
     keepSupersededRuns?: boolean;
     matchConversationProfile?: boolean;
     promptPath?: string;
+    requireUserActivity?: boolean;
   } = {},
 ): Parameters<typeof memoryRetrospectiveJob>[1] {
   return {
@@ -346,6 +348,10 @@ function makeConfig(
         keepSupersededRuns: overrides.keepSupersededRuns ?? false,
         matchConversationProfile: overrides.matchConversationProfile ?? false,
         promptPath: overrides.promptPath ?? null,
+        // Neutral in the stub (the shipped schema default is true): the
+        // default `newMessages` rows carry no roles, so the gate's own tests
+        // opt in explicitly with role-shaped slices.
+        requireUserActivity: overrides.requireUserActivity ?? false,
         sweepIntervalMs: 8 * 60 * 60 * 1000,
         sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
       },
@@ -501,6 +507,104 @@ describe("memoryRetrospectiveJob", () => {
         detail: { outcome: "no_new_messages" },
       },
     ]);
+  });
+
+  test("assistant-only slice with the user-activity gate on: completed as a no-op, both pointers untouched", async () => {
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "assistant",
+        content: [{ type: "text", text: "proactive recap" }],
+      },
+      {
+        id: "m2",
+        createdAt: Date.parse("2026-05-11T10:05:00Z"),
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ requireUserActivity: true }),
+    );
+
+    expect(outcome.kind).toBe("no_user_activity");
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(0);
+    expect(forkCalls).toHaveLength(0);
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: { outcome: "no_user_activity" },
+      },
+    ]);
+  });
+
+  test("a user text row in the slice passes the user-activity gate", async () => {
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "assistant",
+        content: [{ type: "text", text: "proactive recap" }],
+      },
+      {
+        id: "m2",
+        createdAt: Date.parse("2026-05-11T10:05:00Z"),
+        role: "user",
+        content: [{ type: "text", text: "hey" }],
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ requireUserActivity: true }),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    expect(forkCalls).toHaveLength(1);
+  });
+
+  test("requireUserActivity=false: an assistant-only slice still runs", async () => {
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "assistant",
+        content: [{ type: "text", text: "proactive recap" }],
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ requireUserActivity: false }),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+  });
+
+  test("manual runs bypass the user-activity gate: no opts means an assistant-only slice runs", async () => {
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "assistant",
+        content: [{ type: "text", text: "proactive recap" }],
+      },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      "src-conv-1",
+      makeConfig({ requireUserActivity: true }),
+    );
+
+    expect(outcome.kind).toBe("invoked");
   });
 
   test("a slice whose only row is the retrospective's own skill card is no new work", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -2,14 +2,18 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Record enqueues instead of writing job rows — the sweep's scan/gate decision
 // is the unit under test, not the jobs store's coalescing. The enqueue's own
-// recursion/low-yield guards are covered by memory-retrospective-enqueue tests.
+// recursion/low-yield/user-activity guards are covered by
+// memory-retrospective-enqueue tests; `enqueueDeclines` scripts a declined
+// conversation so the cap accounting can be asserted.
 let enqueueCalls: Array<{ conversationId: string; trigger: string }> = [];
+let enqueueDeclines = new Set<string>();
 mock.module("../memory-retrospective-enqueue.js", () => ({
   enqueueMemoryRetrospectiveIfEnabled: (args: {
     conversationId: string;
     trigger: string;
   }) => {
     enqueueCalls.push(args);
+    return !enqueueDeclines.has(args.conversationId);
   },
 }));
 
@@ -104,6 +108,7 @@ describe("runRetrospectiveSweep", () => {
   beforeEach(() => {
     resetTables();
     enqueueCalls = [];
+    enqueueDeclines = new Set();
   });
 
   test("never-run conversation with unprocessed messages is swept", async () => {
@@ -313,6 +318,23 @@ describe("runRetrospectiveSweep", () => {
       { conversationId: seen.id, trigger: "sweep" },
     ]);
     expect(result).toEqual({ scanned: 1, enqueued: 1 });
+  });
+
+  test("an enqueue the funnel declines is not counted and does not consume the cap", async () => {
+    const declined = createConversation({ id: "conv-a" });
+    insertMessage(declined.id, { createdAt: 1_000 });
+    const accepted = createConversation({ id: "conv-b" });
+    insertMessage(accepted.id, { createdAt: 1_000 });
+    enqueueDeclines.add(declined.id);
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    // Both conversations reach the funnel; only the accepted one counts.
+    expect(enqueueCalls.map((c) => c.conversationId)).toEqual([
+      declined.id,
+      accepted.id,
+    ]);
+    expect(result).toEqual({ scanned: 2, enqueued: 1 });
   });
 
   test("enqueues clamp at the per-pass cap and defer the remainder", async () => {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -23,7 +23,7 @@
 // accounting; once newer real messages arrive it is copied into the next
 // run's fork as inert prefix context.
 
-import { and, eq, like } from "drizzle-orm";
+import { and, eq, gt, like, or } from "drizzle-orm";
 
 import {
   countMessagesAfter,
@@ -83,6 +83,106 @@ export function countRetrospectiveMessagesAfter(
   }
   const cardCount = countSkillCardMessagesAfter(conversationId, afterMessageId);
   return Math.max(0, total - cardCount);
+}
+
+/**
+ * True when any block in a parsed content array is something other than a
+ * tool_result. Bare tool-result carriers are transport rows for tool output,
+ * not user-authored activity; an empty array carries nothing.
+ */
+function blocksCarryNonToolResult(
+  blocks: ReadonlyArray<{ type?: unknown }>,
+): boolean {
+  return blocks.some((block) => block.type !== "tool_result");
+}
+
+/**
+ * True when the slice contains at least one user-authored message: a
+ * user-role row whose resolved content carries a non-tool_result block. Tool
+ * results ride on user-role rows, so a bare role check would count any
+ * tool-using assistant stretch as user activity.
+ */
+export function messagesHaveUserActivity(
+  rows: ReadonlyArray<Pick<MessageRow, "role" | "content">>,
+): boolean {
+  return rows.some(
+    (row) => row.role === "user" && blocksCarryNonToolResult(row.content),
+  );
+}
+
+/**
+ * Existence probe for user-authored activity strictly after the
+ * `(createdAt, id)` cursor: at least one user-role row whose content carries
+ * a non-tool_result block. Powers the `memory.retrospective.requireUserActivity`
+ * enqueue gate, so only user rows are loaded. Cursor semantics mirror
+ * `countMessagesAfter`: a null/`""` reference scans the whole conversation,
+ * and a vanished reference means no new work.
+ *
+ * Operates on the raw `content` column: rows that do not parse to a block
+ * array (file-backed `{ ref }` rows, legacy plain strings) count as
+ * user-authored, so the gate fails toward running the retrospective.
+ */
+export function hasQualifyingUserMessageAfter(
+  conversationId: string,
+  afterMessageId: string | null,
+): boolean {
+  const cursorId =
+    afterMessageId === null || afterMessageId === "" ? null : afterMessageId;
+  const db = getDb();
+
+  let ref: { createdAt: number } | undefined;
+  if (cursorId !== null) {
+    ref = db
+      .select({ createdAt: messages.createdAt })
+      .from(messages)
+      .where(eq(messages.id, cursorId))
+      .get();
+    if (!ref) {
+      return false;
+    }
+  }
+
+  const afterCursor =
+    cursorId !== null && ref
+      ? [
+          or(
+            gt(messages.createdAt, ref.createdAt),
+            and(
+              eq(messages.createdAt, ref.createdAt),
+              gt(messages.id, cursorId),
+            ),
+          ),
+        ]
+      : [];
+  const rows = db
+    .select({ content: messages.content })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "user"),
+        ...afterCursor,
+      ),
+    )
+    .all();
+
+  return rows.some((row) => rawUserContentCarriesActivity(row.content));
+}
+
+/** Raw-column twin of the block check used by {@link messagesHaveUserActivity}. */
+function rawUserContentCarriesActivity(raw: string | null): boolean {
+  if (raw === null || raw === "") {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return true;
+    }
+    return blocksCarryNonToolResult(parsed as Array<{ type?: unknown }>);
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -8,6 +8,13 @@
 //     musings from the retrospective agent's own writes).
 //   - Source isn't a `scheduled` thread or a memory-consolidation background
 //     (low yield — see `isLowYieldRetrospectiveSource`).
+//   - The unprocessed tail contains user activity, when
+//     `memory.retrospective.requireUserActivity` is on. Assistant-only
+//     stretches (proactive sends composed by turns running elsewhere) carry
+//     no user turn, so their window anchor is undecidable and their content
+//     is a recap of work captured at its source; the gate defers them until
+//     real user activity arrives. Living here, every trigger kind funnels
+//     through one check.
 //
 // All trigger types funnel through `upsertMemoryRetrospectiveJob` which
 // coalesces rapid enqueues into a single pending row per conversation.
@@ -23,6 +30,7 @@
 // hooks ran (crash / IPC drop) and the conversation then went idle. See
 // `memory-retrospective-sweep.ts`.
 
+import { getConfig } from "../../../config/loader.js";
 import {
   getConversation,
   getConversationSource,
@@ -35,7 +43,9 @@ import {
 import { type TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../../../runtime/capabilities.js";
 import { getLogger } from "./logging.js";
+import { hasQualifyingUserMessageAfter } from "./memory-retrospective-accounting.js";
 import { isMemoryRetrospectiveSource } from "./memory-retrospective-constants.js";
+import { getRetrospectiveState } from "./memory-retrospective-state.js";
 
 const log = getLogger("memory-retrospective-enqueue");
 
@@ -47,14 +57,19 @@ export type MemoryRetrospectiveTrigger =
 
 const COMPACTION_DEBOUNCE_MS = 500;
 
+/**
+ * Returns true when a job row was upserted, false when a gate skipped the
+ * enqueue (or the upsert failed). The sweep counts only true returns toward
+ * its per-pass cap.
+ */
 export function enqueueMemoryRetrospectiveIfEnabled(args: {
   conversationId: string;
   trigger: MemoryRetrospectiveTrigger;
-}): void {
+}): boolean {
   const { conversationId, trigger } = args;
 
   if (!isMemoryEnabled()) {
-    return;
+    return false;
   }
 
   if (isMemoryRetrospectiveConversation(conversationId)) {
@@ -62,7 +77,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
       { conversationId, trigger },
       "Skipping memory-retrospective enqueue: source is a memory-retrospective conversation",
     );
-    return;
+    return false;
   }
 
   if (isLowYieldRetrospectiveSource(conversationId)) {
@@ -70,7 +85,11 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
       { conversationId, trigger },
       "Skipping memory-retrospective enqueue: scheduled or consolidation source",
     );
-    return;
+    return false;
+  }
+
+  if (!passesUserActivityGate(conversationId, trigger)) {
+    return false;
   }
 
   const runAfter =
@@ -83,6 +102,46 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
       { err, conversationId, trigger },
       "Failed to upsert memory-retrospective job",
     );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The `memory.retrospective.requireUserActivity` gate: pass when the config
+ * is off or the unprocessed tail (everything after the conversation's
+ * `lastProcessedMessageId`) contains at least one user message carrying
+ * non-tool_result content. A gate that cannot be evaluated (config or DB
+ * unavailable) passes — an unevaluable gate must not silence retrospectives.
+ */
+function passesUserActivityGate(
+  conversationId: string,
+  trigger: MemoryRetrospectiveTrigger,
+): boolean {
+  try {
+    if (!getConfig().memory.retrospective.requireUserActivity) {
+      return true;
+    }
+    const state = getRetrospectiveState(conversationId);
+    if (
+      hasQualifyingUserMessageAfter(
+        conversationId,
+        state?.lastProcessedMessageId ?? null,
+      )
+    ) {
+      return true;
+    }
+    log.debug(
+      { conversationId, trigger },
+      "Skipping memory-retrospective enqueue: no user activity in the unprocessed tail",
+    );
+    return false;
+  } catch (err) {
+    log.warn(
+      { err, conversationId, trigger },
+      "User-activity gate check failed; enqueueing anyway",
+    );
+    return true;
   }
 }
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -80,7 +80,10 @@ import { wakeAgentForOpportunity } from "../../../runtime/agent-wake.js";
 import { recordWatchdogEvent } from "../../../telemetry/watchdog-events-store.js";
 import { findMostRecentRetrospectiveFor } from "./find-most-recent-retrospective-for.js";
 import { getLogger } from "./logging.js";
-import { getRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
+import {
+  getRetrospectiveMessagesAfter,
+  messagesHaveUserActivity,
+} from "./memory-retrospective-accounting.js";
 import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
@@ -125,6 +128,7 @@ const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
   | { kind: "no_new_messages" }
+  | { kind: "no_user_activity" }
   | { kind: "source_dormant" }
   | { kind: "source_processing" }
   | { kind: "wake_failed"; reason?: string; conversationId?: string }
@@ -174,6 +178,7 @@ export async function memoryRetrospectiveJob(
   try {
     outcome = await runForkBasedRetrospective(sourceConversationId, config, {
       enforceSweepLookback: true,
+      enforceUserActivityGate: true,
     });
   } catch (err) {
     emitRunOutcome("error", err instanceof Error ? err.message : String(err));
@@ -209,6 +214,14 @@ export async function runForkBasedRetrospective(
      * window.
      */
     enforceSweepLookback?: boolean;
+    /**
+     * Apply the `memory.retrospective.requireUserActivity` gate to the loaded
+     * slice. The queue handler passes this so rows that predate the enqueue
+     * gate (or that lost their user activity to a cursor race) complete as
+     * no-ops; the CLI's manual command omits it — an operator's explicit
+     * request overrides the gate.
+     */
+    enforceUserActivityGate?: boolean;
   },
 ): Promise<MemoryRetrospectiveOutcome> {
   // Start stamp for the retrospective's end-to-end wall time, surfaced as
@@ -303,6 +316,23 @@ export async function runForkBasedRetrospective(
 
   if (newMessages.length === 0) {
     return { kind: "no_new_messages" };
+  }
+
+  // Execution-time twin of the enqueue funnel's user-activity gate. An
+  // assistant-only slice has no user turn to anchor the review window on and
+  // recaps work captured at its source, so it is deferred, not run: both
+  // state pointers stay untouched and the slice is reviewed by the first
+  // retrospective after real user activity arrives.
+  if (
+    opts?.enforceUserActivityGate === true &&
+    config.memory.retrospective.requireUserActivity &&
+    !messagesHaveUserActivity(newMessages)
+  ) {
+    log.info(
+      { sourceConversationId, newMessageCount: newMessages.length },
+      "memory-retrospective (fork): unprocessed tail has no user activity; skipping",
+    );
+    return { kind: "no_user_activity" };
   }
 
   const cutoffMessage = newMessages[newMessages.length - 1];

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -42,7 +42,9 @@
 //   - Enqueues route through `enqueueMemoryRetrospectiveIfEnabled`, whose
 //     `upsertMemoryRetrospectiveJob` coalesces against any already-pending job,
 //     so a conversation already queued by an event trigger is never
-//     double-processed.
+//     double-processed. An enqueue the funnel's gates decline (recursion,
+//     low-yield, user-activity) returns false and does not consume the
+//     per-pass cap.
 //   - Enqueues are capped at `SWEEP_MAX_ENQUEUES_PER_PASS` per pass. Inside
 //     the lookback window, organic stalled work is a handful of conversations;
 //     a pass wanting more signals an anomalous backlog. Each pass re-scans
@@ -277,7 +279,14 @@ export async function runRetrospectiveSweep(
         continue;
       }
 
-      enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
+      if (
+        !enqueueMemoryRetrospectiveIfEnabled({
+          conversationId,
+          trigger: "sweep",
+        })
+      ) {
+        continue;
+      }
       enqueued += 1;
       if (enqueued >= SWEEP_MAX_ENQUEUES_PER_PASS) {
         log.warn(


### PR DESCRIPTION
## Summary

- Add `memory.retrospective.requireUserActivity` (default true): a retrospective fires only when the unprocessed tail contains at least one user message carrying non-tool_result content. Tool results ride on user-role rows, so bare tool-result carrier rows do not count as user activity.
- Enforce the gate in the shared enqueue funnel (`enqueueMemoryRetrospectiveIfEnabled`, which now returns whether a job row was upserted) so all four trigger kinds pass one check, and the sweep counts only successful enqueues toward its per-pass cap. The job re-applies the gate to already-queued rows behind a new `enforceUserActivityGate` opt with a `no_user_activity` outcome; the CLI's manual command bypasses it, mirroring the existing sweep-lookback override.
- Skips are deferrals, not drops: both state pointers stay untouched, so the first retrospective after real user activity reviews the whole deferred stretch. Skipped conversations remain fully indexed for retrieval; only the buffer-extraction pass is deferred.

## Behavior change (intentional, default on)

Assistant-only conversations (proactive sends and broadcast recaps composed by turns running elsewhere) stop being retro-mined. On a live install, one such conversation with no real user message since May was being swept 2-3 times a day at roughly $2 and 560k input tokens per run, and on Aug 2 a sweep-triggered run wrote 32 stale entries spanning months into the memory buffer. Assistant-only windows contain no user turn, so the review-window anchor is undecidable by construction; deferring them until user activity arrives removes both the failure shape and the recurring cost. Set `memory.retrospective.requireUserActivity: false` to restore the previous behavior.

This is PR 1 of 2 for that incident. PR 2 will bottom-bound the retrospective fork so any window that does run cannot read history before its cursor.

## Original prompt

Investigated why a sweep-triggered retrospective over a messaging-channel DM conversation wrote weeks-old content into the memory buffer despite a six-message review window. Root causes: the window anchor is a wall-clock timestamp the model cannot locate in an undated transcript when the tail has no user turn, and the prompt's fail-closed fallback opens to everything after a stale compaction summary. The user proposed gating retrospectives on new user messages; investigation confirmed the gate must mean text-bearing user rows (tool results ride on user-role rows) and that heartbeat and schedule conversations keep firing because their seed prompts are user text rows. This PR implements that gate; the follow-up bounds the fork itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)