### PR TITLE
feat(assistant): config gate + manual force/retention mode for workspace git history compaction

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -699,6 +699,52 @@ paths:
                 required:
                   - ok
                 additionalProperties: false
+  /v1/admin/workspace-compact-history:
+    post:
+      operationId: admin_workspacecompacthistory_post
+      summary: Compact workspace git history
+      description:
+        Squash workspace git history older than the retention window into a single base commit and prune reclaimed
+        objects. By default acts only when an oversized blob is reclaimable; with force, the squash runs
+        unconditionally.
+      tags:
+        - admin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force:
+                  description: Squash aged history even when no oversized blob is reclaimable
+                  type: boolean
+                retentionDays:
+                  description: Retention window override in days (default 7)
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rewrote:
+                    type: boolean
+                  squashedCommits:
+                    type: number
+                  keptCommits:
+                    type: number
+                  retryAfterMs:
+                    type: number
+                required:
+                  - rewrote
+                  - squashedCommits
+                  - keptCommits
+                additionalProperties: false
   /v1/apps:
     get:
       operationId: apps_get

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -747,6 +747,7 @@ describe("AssistantConfigSchema", () => {
       failureBackoffBaseMs: 2000,
       failureBackoffMaxMs: 60000,
       maxFileSizeBytes: 256000,
+      historyCompaction: { enabled: true },
       interactiveGitTimeoutMs: 10000,
       enrichmentQueueSize: 50,
       enrichmentConcurrency: 1,

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -10,9 +10,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { getWorkspaceConfigPath } from "../util/platform.js";
 import {
   _getConsecutiveFailures,
   _getInitConsecutiveFailures,
@@ -1685,6 +1686,17 @@ describe("WorkspaceGitService", () => {
         .trim()
         .split("\n");
 
+    // Author/committer env for backdated commits when building history
+    // externally.
+    const gitEnvAt = (daysAgo: number) => {
+      const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
+      return {
+        ...process.env,
+        GIT_AUTHOR_DATE: date,
+        GIT_COMMITTER_DATE: date,
+      };
+    };
+
     test("commitChanges skips oversized files but commits the rest", async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
@@ -1904,14 +1916,6 @@ describe("WorkspaceGitService", () => {
     });
 
     test("history compaction purges oversized blobs from aged history", async () => {
-      const gitEnvAt = (daysAgo: number) => {
-        const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
-        return {
-          ...process.env,
-          GIT_AUTHOR_DATE: date,
-          GIT_COMMITTER_DATE: date,
-        };
-      };
       // Build history externally: a big blob committed 30 days ago,
       // untracked 20 days ago, plus a recent commit inside retention.
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
@@ -1987,14 +1991,6 @@ describe("WorkspaceGitService", () => {
     });
 
     test("history compaction reschedules when kept commits still hold blobs", async () => {
-      const gitEnvAt = (daysAgo: number) => {
-        const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
-        return {
-          ...process.env,
-          GIT_AUTHOR_DATE: date,
-          GIT_COMMITTER_DATE: date,
-        };
-      };
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
       execFileSync("git", ["config", "user.email", "user@example.com"], {
@@ -2122,14 +2118,6 @@ describe("WorkspaceGitService", () => {
     });
 
     test("loose blobs in a repo with old history are pruned without a rewrite", async () => {
-      const gitEnvAt = (daysAgo: number) => {
-        const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
-        return {
-          ...process.env,
-          GIT_AUTHOR_DATE: date,
-          GIT_COMMITTER_DATE: date,
-        };
-      };
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
       execFileSync("git", ["config", "user.email", "user@example.com"], {
@@ -2171,14 +2159,6 @@ describe("WorkspaceGitService", () => {
     });
 
     test("history compaction converges when a legacy branch retains the blob", async () => {
-      const gitEnvAt = (daysAgo: number) => {
-        const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
-        return {
-          ...process.env,
-          GIT_AUTHOR_DATE: date,
-          GIT_COMMITTER_DATE: date,
-        };
-      };
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
       execFileSync("git", ["config", "user.email", "user@example.com"], {
@@ -2265,6 +2245,166 @@ describe("WorkspaceGitService", () => {
       await service.commitChanges("Remove legacy");
 
       expect(trackedFiles()).not.toContain("legacy.bin");
+    });
+
+    // Overrides the process workspace config (what getConfig() reads) for
+    // the duration of `fn`, restoring the previous contents afterwards.
+    const withHistoryCompactionDisabled = async (fn: () => Promise<void>) => {
+      const configPath = getWorkspaceConfigPath();
+      mkdirSync(dirname(configPath), { recursive: true });
+      const previous = existsSync(configPath)
+        ? readFileSync(configPath, "utf-8")
+        : null;
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          workspaceGit: { historyCompaction: { enabled: false } },
+        }),
+      );
+      try {
+        await fn();
+      } finally {
+        if (previous === null) {
+          rmSync(configPath, { force: true });
+        } else {
+          writeFileSync(configPath, previous);
+        }
+      }
+    };
+
+    test("background compaction scheduling is disabled by config", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      await withHistoryCompactionDisabled(async () => {
+        const internal = service as unknown as {
+          scheduleHistoryCompaction: (delayMs?: number) => void;
+        };
+        internal.scheduleHistoryCompaction(60_000);
+        expect(_hasPendingHistoryCompaction(service)).toBe(false);
+      });
+    });
+
+    test("a pending compaction timer honors a config flip to disabled", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // A loose oversized blob that a scheduled run would prune.
+      const blobSha = execFileSync("git", ["hash-object", "-w", "--stdin"], {
+        cwd: testDir,
+        input: bigContent(),
+        encoding: "utf-8",
+      }).trim();
+
+      const internal = service as unknown as {
+        scheduleHistoryCompaction: (delayMs?: number) => void;
+      };
+      // Enabled at schedule time, disabled by the time the timer fires.
+      internal.scheduleHistoryCompaction(150);
+      await withHistoryCompactionDisabled(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        expect(_hasPendingHistoryCompaction(service)).toBe(false);
+        execFileSync("git", ["cat-file", "-e", blobSha], { cwd: testDir });
+      });
+    });
+
+    test("forced compaction squashes aged history without oversized blobs", async () => {
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
+      execFileSync("git", ["config", "user.email", "user@example.com"], {
+        cwd: testDir,
+      });
+      writeFileSync(join(testDir, "one.txt"), "v1");
+      execFileSync("git", ["add", "one.txt"], { cwd: testDir });
+      execFileSync("git", ["commit", "--no-verify", "-m", "old change one"], {
+        cwd: testDir,
+        env: gitEnvAt(30),
+      });
+      writeFileSync(join(testDir, "two.txt"), "v2");
+      execFileSync("git", ["add", "two.txt"], { cwd: testDir });
+      execFileSync("git", ["commit", "--no-verify", "-m", "old change two"], {
+        cwd: testDir,
+        env: gitEnvAt(20),
+      });
+      writeFileSync(join(testDir, "recent.txt"), "recent");
+      execFileSync("git", ["add", "recent.txt"], { cwd: testDir });
+      execFileSync("git", ["commit", "--no-verify", "-m", "recent change"], {
+        cwd: testDir,
+      });
+      const tipTreeBefore = execFileSync("git", ["rev-parse", "HEAD^{tree}"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      }).trim();
+
+      const service = new WorkspaceGitService(testDir);
+      const result = await service.compactHistoryNow({ force: true });
+
+      expect(result.rewrote).toBe(true);
+      expect(result.squashedCommits).toBe(2);
+      expect(result.keptCommits).toBe(1);
+      expect(result.retryAfterMs).toBeUndefined();
+
+      const subjects = execFileSync("git", ["log", "--format=%s"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(subjects).toContain("Compacted workspace history");
+      expect(subjects).toContain("recent change");
+      expect(subjects).not.toContain("old change one");
+      expect(subjects).not.toContain("old change two");
+
+      // The tip tree is preserved exactly — no scrub without oversized blobs
+      const tipTreeAfter = execFileSync("git", ["rev-parse", "HEAD^{tree}"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      }).trim();
+      expect(tipTreeAfter).toBe(tipTreeBefore);
+    });
+
+    test("retentionDays override moves the forced squash cutoff", async () => {
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: testDir });
+      execFileSync("git", ["config", "user.email", "user@example.com"], {
+        cwd: testDir,
+      });
+      writeFileSync(join(testDir, "aging.txt"), "v1");
+      execFileSync("git", ["add", "aging.txt"], { cwd: testDir });
+      execFileSync("git", ["commit", "--no-verify", "-m", "aging change"], {
+        cwd: testDir,
+        env: gitEnvAt(3),
+      });
+      writeFileSync(join(testDir, "current.txt"), "v2");
+      execFileSync("git", ["add", "current.txt"], { cwd: testDir });
+      execFileSync("git", ["commit", "--no-verify", "-m", "current change"], {
+        cwd: testDir,
+      });
+
+      const service = new WorkspaceGitService(testDir);
+
+      // Default window keeps everything: the forced run has nothing to
+      // squash and nothing to reclaim, so it is a no-op.
+      const withDefault = await service.compactHistoryNow({ force: true });
+      expect(withDefault.rewrote).toBe(false);
+      expect(withDefault.squashedCommits).toBe(0);
+      expect(withDefault.keptCommits).toBe(2);
+      expect(withDefault.retryAfterMs).toBeUndefined();
+
+      // A one-day window squashes the three-day-old commit.
+      const withOverride = await service.compactHistoryNow({
+        force: true,
+        retentionDays: 1,
+      });
+      expect(withOverride.rewrote).toBe(true);
+      expect(withOverride.squashedCommits).toBe(1);
+      expect(withOverride.keptCommits).toBe(1);
+
+      const subjects = execFileSync("git", ["log", "--format=%s"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(subjects).toContain("Compacted workspace history");
+      expect(subjects).toContain("current change");
+      expect(subjects).not.toContain("aging change");
     });
   });
 });

--- a/assistant/src/config/schemas/workspace-git.ts
+++ b/assistant/src/config/schemas/workspace-git.ts
@@ -34,6 +34,21 @@ export const WorkspaceGitConfigSchema = z
       .describe(
         "Files larger than this (bytes) are excluded from workspace auto-commits",
       ),
+    historyCompaction: z
+      .object({
+        enabled: z
+          .boolean({
+            error: "workspaceGit.historyCompaction.enabled must be a boolean",
+          })
+          .default(true)
+          .describe(
+            "Whether background history compaction runs automatically. Manual compaction via the admin route is unaffected.",
+          ),
+      })
+      .default({ enabled: true })
+      .describe(
+        "Background compaction of workspace git history (squashes commits older than the retention window to reclaim oversized blobs from .git)",
+      ),
     interactiveGitTimeoutMs: z
       .number({
         error: "workspaceGit.interactiveGitTimeoutMs must be a number",

--- a/assistant/src/runtime/routes/__tests__/workspace-commit-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/workspace-commit-routes.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Request-body validation for the workspace git admin routes.
+ *
+ * Each handler validates its body before touching the workspace git
+ * service, so a malformed body is rejected with a `BadRequestError`
+ * (→ 400) without running any git operation. The handlers are async,
+ * hence the `.rejects` form.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../workspace-commit-routes.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("workspace git route body validation", () => {
+  test("workspace_commit rejects a missing message", async () => {
+    await expect(
+      routeFor("workspace_commit").handler({
+        body: {} as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("workspace_commit rejects an empty message", async () => {
+    await expect(
+      routeFor("workspace_commit").handler({
+        body: { message: "" } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("workspace_compact_history rejects a non-boolean force", async () => {
+    await expect(
+      routeFor("workspace_compact_history").handler({
+        body: { force: "yes" } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("workspace_compact_history rejects a non-integer retentionDays", async () => {
+    await expect(
+      routeFor("workspace_compact_history").handler({
+        body: { retentionDays: 1.5 } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("workspace_compact_history rejects a non-positive retentionDays", async () => {
+    await expect(
+      routeFor("workspace_compact_history").handler({
+        body: { retentionDays: 0 } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/workspace-commit-routes.ts
+++ b/assistant/src/runtime/routes/workspace-commit-routes.ts
@@ -1,6 +1,6 @@
 /**
- * Workspace commit endpoint — creates a git commit in the workspace
- * directory with all pending changes.
+ * Workspace git admin endpoints — commit pending workspace changes, and
+ * compact workspace git history on demand.
  */
 
 import { z } from "zod";
@@ -9,6 +9,7 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import { getWorkspaceGitService } from "../../workspace/git-service.js";
 import { GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 async function handleWorkspaceCommit({ body }: RouteHandlerArgs) {
@@ -22,6 +23,30 @@ async function handleWorkspaceCommit({ body }: RouteHandlerArgs) {
 
   await getWorkspaceGitService(getWorkspaceDir()).commitChanges(message);
   return { ok: true };
+}
+
+const compactHistoryBodySchema = z.object({
+  force: z
+    .boolean()
+    .optional()
+    .describe("Squash aged history even when no oversized blob is reclaimable"),
+  retentionDays: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Retention window override in days (default 7)"),
+});
+
+async function handleWorkspaceCompactHistory({ body }: RouteHandlerArgs) {
+  const { force, retentionDays } = parseBody(
+    compactHistoryBodySchema,
+    body ?? {},
+  );
+  return getWorkspaceGitService(getWorkspaceDir()).compactHistoryNow({
+    force,
+    retentionDays,
+  });
 }
 
 export const ROUTES: RouteDefinition[] = [
@@ -44,5 +69,27 @@ export const ROUTES: RouteDefinition[] = [
       ok: z.boolean(),
     }),
     handler: handleWorkspaceCommit,
+  },
+  {
+    operationId: "workspace_compact_history",
+    endpoint: "admin/workspace-compact-history",
+    method: "POST",
+    policy: {
+      requiredScopes: ["internal.write"],
+      allowedPrincipalTypes: GATEWAY_PRINCIPALS,
+    },
+    summary: "Compact workspace git history",
+    description:
+      "Squash workspace git history older than the retention window into a single base commit and prune reclaimed objects. " +
+      "By default acts only when an oversized blob is reclaimable; with force, the squash runs unconditionally.",
+    tags: ["admin"],
+    requestBody: compactHistoryBodySchema,
+    responseBody: z.object({
+      rewrote: z.boolean(),
+      squashedCommits: z.number(),
+      keptCommits: z.number(),
+      retryAfterMs: z.number().optional(),
+    }),
+    handler: handleWorkspaceCompactHistory,
   },
 ];

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -916,6 +916,15 @@ export class WorkspaceGitService {
   }
 
   /**
+   * Whether background history compaction is enabled for this workspace.
+   * Gates only the scheduler — {@link compactHistoryNow} stays callable so
+   * operators can compact manually while automatic runs are off.
+   */
+  private isHistoryCompactionEnabled(): boolean {
+    return getConfig().workspaceGit?.historyCompaction?.enabled ?? true;
+  }
+
+  /**
    * Working-tree size check for a repo-relative path. Uses lstat so a
    * symlink is measured by the link itself, not its target. Missing or
    * unreadable paths (deletions, races) are treated as not oversized.
@@ -1003,10 +1012,21 @@ export class WorkspaceGitService {
    * history is still within retention, the attempt reschedules itself for
    * when the oldest commit ages past the cutoff. Best-effort like the
    * untrack sweeps: failures are logged and never affect commits.
+   *
+   * Gated by workspaceGit.historyCompaction.enabled, checked both here and
+   * when the timer fires (config hot-reloads, so a pending timer must honor
+   * a flip to disabled).
    */
   private scheduleHistoryCompaction(
     delayMs = HISTORY_COMPACTION_INITIAL_DELAY_MS,
   ): void {
+    if (!this.isHistoryCompactionEnabled()) {
+      log.debug(
+        { workspaceDir: this.workspaceDir },
+        "Background history compaction disabled by config; not scheduling",
+      );
+      return;
+    }
     const dueAtMs = Date.now() + delayMs;
     if (this.historyCompactionTimer) {
       if (dueAtMs >= this.historyCompactionDueAtMs) {
@@ -1020,6 +1040,14 @@ export class WorkspaceGitService {
     }
     const timer = setTimeout(() => {
       void (async () => {
+        if (!this.isHistoryCompactionEnabled()) {
+          log.debug(
+            { workspaceDir: this.workspaceDir },
+            "Background history compaction disabled by config; skipping scheduled run",
+          );
+          this.historyCompactionTimer = null;
+          return;
+        }
         let retryAfterMs: number | undefined;
         try {
           const result = await this.compactHistoryNow();
@@ -1044,14 +1072,19 @@ export class WorkspaceGitService {
 
   /**
    * Rewrite workspace history so blobs over workspaceGit.maxFileSizeBytes
-   * stop occupying .git. Commits older than HISTORY_RETENTION_DAYS are
+   * stop occupying .git. Commits older than the retention window
+   * (HISTORY_RETENTION_DAYS unless `retentionDays` overrides it) are
    * squashed into a single base commit whose tree is scrubbed of oversized
    * entries; younger commits are replayed verbatim (trees, messages,
    * authors, and dates preserved); reflogs are then expired and unreachable
-   * objects pruned. Runs only when the object store contains an oversized
-   * blob that is actionable — unreachable, or reachable at a non-exempt
-   * path (see SIZE_GUARD_EXEMPT_PATTERNS) — so the steady state is a cheap
-   * detection scan and exempt canonical state never triggers rewrites.
+   * objects pruned. By default runs only when the object store contains an
+   * oversized blob that is actionable — unreachable, or reachable at a
+   * non-exempt path (see SIZE_GUARD_EXEMPT_PATTERNS) — so the steady state
+   * is a cheap detection scan and exempt canonical state never triggers
+   * rewrites. With `force`, the squash runs unconditionally whenever any
+   * commit is older than the cutoff — the manual path for reclaiming bulk
+   * history (including old versions of exempt canonical state referenced
+   * only by squashed commits).
    *
    * Oversized blobs still referenced by replayed recent commits survive
    * until those commits age past retention — the result carries
@@ -1061,7 +1094,12 @@ export class WorkspaceGitService {
    * Git notes attached to rewritten commits are orphaned; enrichment only
    * targets commits created after the rewrite, so this is cosmetic.
    */
-  async compactHistoryNow(): Promise<{
+  async compactHistoryNow(options?: {
+    /** Squash aged history even when no oversized blob is actionable. */
+    force?: boolean;
+    /** Retention window override in days for this run. */
+    retentionDays?: number;
+  }): Promise<{
     rewrote: boolean;
     squashedCommits: number;
     keptCommits: number;
@@ -1069,7 +1107,7 @@ export class WorkspaceGitService {
     retryAfterMs?: number;
   }> {
     await this.ensureInitialized();
-    return this.mutex.withLock(() => this.compactHistoryLocked());
+    return this.mutex.withLock(() => this.compactHistoryLocked(options));
   }
 
   /**
@@ -1180,7 +1218,10 @@ export class WorkspaceGitService {
     return remaining.size > 0 ? "prunable" : "none";
   }
 
-  private async compactHistoryLocked(): Promise<{
+  private async compactHistoryLocked(options?: {
+    force?: boolean;
+    retentionDays?: number;
+  }): Promise<{
     rewrote: boolean;
     squashedCommits: number;
     keptCommits: number;
@@ -1188,11 +1229,13 @@ export class WorkspaceGitService {
   }> {
     const noop = { rewrote: false, squashedCommits: 0, keptCommits: 0 };
     const limit = this.maxFileSizeBytes();
+    const force = options?.force === true;
+    const retentionDays = options?.retentionDays ?? HISTORY_RETENTION_DAYS;
 
     // Any oversized blobs at all? Bounds the cost of every boot where there
-    // is nothing to do.
+    // is nothing to do. Forced runs squash regardless.
     const oversizedOids = await this.collectOversizedBlobOidsLocked(limit);
-    if (oversizedOids.size === 0) {
+    if (oversizedOids.size === 0 && !force) {
       return noop;
     }
 
@@ -1236,31 +1279,39 @@ export class WorkspaceGitService {
       return noop;
     }
 
-    const verdict = await this.classifyOversizedBlobsLocked(oversizedOids);
-    if (verdict === "none") {
-      // Exempt canonical state or ref-retained only — nothing to reclaim.
-      return { ...noop, keptCommits: commits.length };
-    }
-    if (verdict === "prunable") {
-      // Only unreachable blobs (e.g. an external add that stageAllLocked
-      // reset) — prune reclaims them without rewriting any history.
-      await this.expireReflogsAndPruneLocked();
-      log.info(
-        { workspaceDir: this.workspaceDir },
-        "Pruned unreachable oversized blobs from workspace git",
-      );
-      return { ...noop, keptCommits: commits.length };
+    // Forced runs skip classification: they squash whenever aged history
+    // exists, so the reachable/exempt distinction does not short-circuit.
+    if (!force) {
+      const verdict = await this.classifyOversizedBlobsLocked(oversizedOids);
+      if (verdict === "none") {
+        // Exempt canonical state or ref-retained only — nothing to reclaim.
+        return { ...noop, keptCommits: commits.length };
+      }
+      if (verdict === "prunable") {
+        // Only unreachable blobs (e.g. an external add that stageAllLocked
+        // reset) — prune reclaims them without rewriting any history.
+        await this.expireReflogsAndPruneLocked();
+        log.info(
+          { workspaceDir: this.workspaceDir },
+          "Pruned unreachable oversized blobs from workspace git",
+        );
+        return { ...noop, keptCommits: commits.length };
+      }
     }
 
     // Squash a PREFIX of the chain so replay order stays consistent even if
     // commit timestamps are not monotonic.
-    const cutoffSec =
-      Math.floor(Date.now() / 1000) - HISTORY_RETENTION_DAYS * 86400;
+    const cutoffSec = Math.floor(Date.now() / 1000) - retentionDays * 86400;
     let splitIdx = commits.findIndex((c) => c.committedAtSec >= cutoffSec);
     if (splitIdx === -1) {
       splitIdx = commits.length;
     }
     if (splitIdx === 0) {
+      if (oversizedOids.size === 0) {
+        // Forced run, but every commit is inside retention and there is
+        // nothing to reclaim — no rewrite.
+        return { ...noop, keptCommits: commits.length };
+      }
       // Main holds the blobs, but only in commits still within retention.
       // A mixed case can also carry unreachable blobs — prune those now,
       // and re-check in case they were all that remained actionable.
@@ -1279,7 +1330,7 @@ export class WorkspaceGitService {
       // bloat until restart.
       const oldestCommittedAtSec = commits[0]?.committedAtSec ?? cutoffSec;
       const oldestAgesOutMs =
-        (oldestCommittedAtSec + HISTORY_RETENTION_DAYS * 86400) * 1000 -
+        (oldestCommittedAtSec + retentionDays * 86400) * 1000 -
         Date.now() +
         60_000;
       const retryAfterMs = Math.max(
@@ -1358,9 +1409,7 @@ export class WorkspaceGitService {
       const oldestKeptSec =
         kept[0]?.committedAtSec ?? Math.floor(Date.now() / 1000);
       retryAfterMs = Math.max(
-        (oldestKeptSec + HISTORY_RETENTION_DAYS * 86400) * 1000 -
-          Date.now() +
-          60_000,
+        (oldestKeptSec + retentionDays * 86400) * 1000 - Date.now() + 60_000,
         HISTORY_COMPACTION_MIN_RETRY_MS,
       );
     }


### PR DESCRIPTION
## Summary
- Add `workspaceGit.historyCompaction.enabled` (zod, default `true`). The background scheduler checks it when arming the timer and again when the timer fires (config hot-reloads on file change), and logs when it skips. `compactHistoryNow()` is intentionally not gated: it is the manual path.
- Extend `compactHistoryNow(options?)` with `force` (squash aged history even when no oversized blob is actionable; the tree scrub degrades to a no-op so the boundary and tip trees are preserved verbatim) and `retentionDays` (per-run override of the 7-day retention window). Background scheduler behavior with no options is unchanged.
- Add POST `admin/workspace-compact-history` to the shared ROUTES array (internal.write, gateway principals), validated with `parseBody` so the declared `requestBody` schema is the single source of truth; OpenAPI regenerated. Tests cover the scheduler gate (schedule-time and fire-time), forced squash without oversized blobs, the retentionDays cutoff move, the force no-op inside retention, and route body validation.

## Original prompt
The operator wants automatic workspace git history compaction turned off for one assistant instance (via that instance's workspace config.json) so history rewrites only ever happen deliberately, after an automatic run squashed early history they cared about. They still want to compact manually when the workspace repo grows too large. Automatic compaction only acts when an oversized blob is reclaimable, so the manual path needed a force mode plus a per-run retention override to squash ordinary aged commit history on demand. Defaults keep behavior identical for every other instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)