### PR TITLE
fix(assistant): repair main CI fallout from the retrospective user-activity gate

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-store-enqueue-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-store-enqueue-gate.test.ts
@@ -38,6 +38,15 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
+// Stub the user-activity gate probe open. Its real logic is covered by
+// memory-retrospective-accounting.test.ts and
+// memory-retrospective-enqueue.test.ts; against this file's empty stub db it
+// would report no activity and close the gate, masking the memory.enabled
+// gate under test.
+mock.module("../memory-retrospective-accounting.js", () => ({
+  hasQualifyingUserMessageAfter: () => true,
+}));
+
 // Stub the qdrant breaker so `enqueueMemoryJob` doesn't trip on it.
 mock.module(
   "../../../../persistence/embeddings/qdrant-circuit-breaker.js",
@@ -94,6 +103,8 @@ const stubDb = makeStubDb();
 mock.module("../../../../persistence/db-connection.js", () => ({
   getDb: () => stubDb,
   getMemoryDb: () => stubDb,
+  // Truthy handle: consulted only as memory-db's availability gate.
+  getMemorySqlite: () => ({}),
 }));
 
 // Now load the real modules under test.

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -87,13 +87,17 @@ export function countRetrospectiveMessagesAfter(
 
 /**
  * True when any block in a parsed content array is something other than a
- * tool_result. Bare tool-result carriers are transport rows for tool output,
- * not user-authored activity; an empty array carries nothing.
+ * tool result (`tool_result` / `web_search_tool_result`). Both are transport
+ * blocks for tool output riding on user-role rows, not user-authored
+ * activity; an empty array carries nothing.
  */
 function blocksCarryNonToolResult(
   blocks: ReadonlyArray<{ type?: unknown }>,
 ): boolean {
-  return blocks.some((block) => block.type !== "tool_result");
+  return blocks.some(
+    (block) =>
+      block.type !== "tool_result" && block.type !== "web_search_tool_result",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Exclude `web_search_tool_result` blocks from the retrospective user-activity check in `memory-retrospective-accounting.ts`: they are tool-output transport riding user-role rows, same as `tool_result`, so a web-search-only tail no longer counts as user activity (and the web-search structural guard passes again).
- Fix `jobs-store-enqueue-gate.test.ts`, which crashed at import time after #39815 pulled the accounting/state modules into the enqueue funnel: the user-activity gate probe is stubbed open (its real logic is covered by `memory-retrospective-accounting.test.ts` and `memory-retrospective-enqueue.test.ts`), and the db-connection mock now provides the `getMemorySqlite` availability handle.
- Verified the two failing files plus the five neighboring retrospective suites green, each run solo.

## Original prompt
Fix the specific CI issue in the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/30791303042/job/91615210063 (and only that job). The job is the assistant Test shard on main at ff10e008e1, red since #39815 merged: the web-search structural guard flags the new raw `tool_result` check, and `jobs-store-enqueue-gate.test.ts` fails to load against the module graph the PR introduced.