### PR TITLE
polish: chat empty-state greeting size and suggestions panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -46,7 +46,7 @@ export function ChatEmptyState({
                Serif 32px) — larger than the old title tokens, scaled down
                a step on mobile. */
             <h1
-              className="text-center text-[24px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasized)] md:text-[32px]"
+              className="text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasized)] md:text-[36px]"
               style={{ fontFamily: "var(--font-serif)" }}
             >
               {greeting}

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -205,9 +205,9 @@ export function useChatEmptyState({
       // padding so the panel sits flush against the viewport's bottom
       // edge.
       startersSlot = (
-        <div className="-mb-3 rounded-t-2xl bg-[var(--surface-active)] px-6 pt-5 pb-6">
+        <div className="-mb-3 rounded-t-2xl px-6 pt-5 pb-6">
           <p className="mb-4 text-center text-body-medium-default text-[var(--content-tertiary)]">
-            Suggestions
+            Try some suggestions:
           </p>
           <ConversationStarterGrid
             starters={emptyStateStarters}


### PR DESCRIPTION
Bumped the greeting headline one size up (24/32px to 28/36px), dropped the suggestions panel's background fill, and reworded its caption to "Try some suggestions:".

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
