### PR TITLE
fix(compaction): refresh the context-window indicator after /compact

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -436,6 +436,49 @@ describe("forceCompact context-window usage push", () => {
     expect(usageEvent.maxTokens).toBe(200_000);
   });
 
+  test("pushes to the caller's sink when the conversation's own sender is dead", async () => {
+    // A `/compact` draining behind an interactive turn: `process-message.ts`
+    // resets `sendToClient` to a no-op in its `finally`, while the queued item
+    // still carries the live sink its result card streams on. The push has to
+    // follow the card, not the dead sender.
+    const stranded: AssistantEvent[] = [];
+    const cardSink: AssistantEvent[] = [];
+    mockCompactResult = {
+      messages: [],
+      compacted: true,
+      previousEstimatedInputTokens: 43_000,
+      estimatedInputTokens: 12_000,
+      maxInputTokens: 200_000,
+      thresholdTokens: 160_000,
+      compactedMessages: 10,
+      compactedPersistedMessages: 5,
+      summaryCalls: 1,
+      summaryInputTokens: 500,
+      summaryOutputTokens: 200,
+      summaryModel: "test-model",
+      summaryText: "summary text",
+    };
+
+    const conversation = makeConversation(
+      stranded,
+      "conv-compact-dead-sender",
+      [56_000, 18_000],
+    );
+    conversation.updateClient(() => {}, true);
+
+    const result = await conversation.forceCompact((msg) => cardSink.push(msg));
+
+    const usage = cardSink.filter((m) => m.type === "context_window_usage");
+    expect(usage.length).toBe(1);
+    expect(
+      (usage[0] as Extract<AssistantEvent, { type: "context_window_usage" }>)
+        .tokens,
+    ).toBe(result.estimatedInputTokens);
+    expect(
+      stranded.filter((m) => m.type === "context_window_usage").length,
+    ).toBe(0);
+  });
+
   test("pushes the current count when there was nothing to compact", async () => {
     const collected: AssistantEvent[] = [];
     mockCompactResult = {

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -7,6 +7,10 @@
  * turn. The `context_compacted` event is the single source of truth for the
  * indicator — the paired `usage_update` intentionally omits
  * `contextWindowTokens` to avoid a redundant SwiftUI invalidation.
+ *
+ * Also covers the `context_window_usage` push, which carries the provider
+ * tokenizer's post-compaction count so the web indicator matches the numbers
+ * on the `/compact` result card.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -218,7 +222,8 @@ import { Conversation } from "../daemon/conversation.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeProvider() {
+function makeProvider(counts?: number[]) {
+  const pending = counts ? [...counts] : null;
   return {
     name: "mock-provider",
     async sendMessage(): Promise<ProviderResponse> {
@@ -229,16 +234,20 @@ function makeProvider() {
         stopReason: "end_turn",
       };
     },
+    // Present only when the test supplies counts, so the other cases keep
+    // exercising the local-estimate fallback.
+    ...(pending ? { countInputTokens: async () => pending.shift() ?? 0 } : {}),
   };
 }
 
 function makeConversation(
   collected: AssistantEvent[],
   id = "conv-compact-events",
+  counts?: number[],
 ): Conversation {
   return new Conversation(
     id,
-    makeProvider(),
+    makeProvider(counts),
     "system prompt",
     (msg) => {
       collected.push(msg);
@@ -380,6 +389,91 @@ describe("forceCompact event emission", () => {
       0,
     );
     expect(collected.filter((m) => m.type === "usage_update").length).toBe(0);
+  });
+});
+
+describe("forceCompact context-window usage push", () => {
+  test("pushes the post-compaction tokenizer count the result card reports", async () => {
+    const collected: AssistantEvent[] = [];
+    mockCompactResult = {
+      messages: [],
+      compacted: true,
+      // Estimate-based figures the compaction pipeline records internally.
+      // The user-facing numbers come from the provider tokenizer instead.
+      previousEstimatedInputTokens: 43_000,
+      estimatedInputTokens: 12_000,
+      maxInputTokens: 200_000,
+      thresholdTokens: 160_000,
+      compactedMessages: 10,
+      compactedPersistedMessages: 5,
+      summaryCalls: 1,
+      summaryInputTokens: 500,
+      summaryOutputTokens: 200,
+      summaryModel: "test-model",
+      summaryText: "summary text",
+    };
+
+    const conversation = makeConversation(
+      collected,
+      "conv-compact-usage",
+      [56_000, 18_000],
+    );
+    const result = await conversation.forceCompact();
+
+    expect(result.previousEstimatedInputTokens).toBe(56_000);
+    expect(result.estimatedInputTokens).toBe(18_000);
+
+    const usage = collected.filter((m) => m.type === "context_window_usage");
+    expect(usage.length).toBe(1);
+    const usageEvent = usage[0] as Extract<
+      AssistantEvent,
+      { type: "context_window_usage" }
+    >;
+    expect(usageEvent.conversationId).toBe("conv-compact-usage");
+    // Same figures the `/compact` card renders, so the indicator and the card
+    // cannot disagree.
+    expect(usageEvent.tokens).toBe(result.estimatedInputTokens);
+    expect(usageEvent.maxTokens).toBe(200_000);
+  });
+
+  test("pushes the current count when there was nothing to compact", async () => {
+    const collected: AssistantEvent[] = [];
+    mockCompactResult = {
+      messages: [],
+      compacted: false,
+      previousEstimatedInputTokens: 0,
+      estimatedInputTokens: 0,
+      maxInputTokens: 200_000,
+      thresholdTokens: 160_000,
+      compactedMessages: 0,
+      compactedPersistedMessages: 0,
+      summaryCalls: 0,
+      summaryInputTokens: 0,
+      summaryOutputTokens: 0,
+      summaryModel: "",
+      summaryText: "",
+    };
+
+    const conversation = makeConversation(
+      collected,
+      "conv-compact-usage-noop",
+      // A no-op re-counts nothing, so the single count stands as before and
+      // after.
+      [56_000],
+    );
+    const result = await conversation.forceCompact();
+
+    expect(result.previousEstimatedInputTokens).toBe(56_000);
+    expect(result.estimatedInputTokens).toBe(56_000);
+
+    const usage = collected.filter((m) => m.type === "context_window_usage");
+    expect(usage.length).toBe(1);
+    const usageEvent = usage[0] as Extract<
+      AssistantEvent,
+      { type: "context_window_usage" }
+    >;
+    expect(usageEvent.tokens).toBe(56_000);
+    expect(usageEvent.maxTokens).toBe(200_000);
   });
 });
 

--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -257,7 +257,13 @@ describe("POST /v1/conversations/summarize", () => {
 
     await settle();
 
-    expect(ctx.summarizeUpToMessage).toHaveBeenCalledWith("msg-42");
+    // The second arg is the sink the context-window usage push rides. This
+    // route's conversation may hold the store's no-op sender, so it hands in
+    // the broadcast path its result card goes out on.
+    expect(ctx.summarizeUpToMessage).toHaveBeenCalledWith(
+      "msg-42",
+      expect.any(Function),
+    );
     expect(ctx.emitActivityState).toHaveBeenCalledWith(
       "thinking",
       "context_compacting",

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { CompactionContext } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
@@ -212,7 +213,8 @@ import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeProvider() {
+function makeProvider(counts?: number[]) {
+  const pending = counts ? [...counts] : null;
   return {
     name: "mock-provider",
     async sendMessage(): Promise<ProviderResponse> {
@@ -223,15 +225,21 @@ function makeProvider() {
         stopReason: "end_turn",
       };
     },
+    // Present only when the test supplies counts, so the other cases keep
+    // exercising the local-estimate fallback.
+    ...(pending ? { countInputTokens: async () => pending.shift() ?? 0 } : {}),
   };
 }
 
-function makeConversation(): Conversation {
+function makeConversation(options?: {
+  counts?: number[];
+  onEvent?: (msg: AssistantEvent) => void;
+}): Conversation {
   const conversation = new Conversation(
     "conv-1",
-    makeProvider(),
+    makeProvider(options?.counts),
     "system prompt",
-    () => {},
+    options?.onEvent ?? (() => {}),
     "/tmp",
     { maxTokens: 4096 },
   );
@@ -365,7 +373,10 @@ describe("Conversation.summarizeUpToMessage", () => {
 
     const result = await conversation.summarizeUpToMessage("m4");
 
-    expect(result).toBe(mockCompactResult);
+    // The compaction result passes through with its displayed token counts
+    // re-measured by the provider tokenizer, which the mocked manager reports
+    // as 0 here.
+    expect(result).toEqual(mockCompactResult);
     expect(compactCalls).toHaveLength(1);
     expect(compactCalls[0].force).toBe(true);
     // Row index 4 with no compacted prefix and no summary message → 4.
@@ -852,6 +863,39 @@ describe("Conversation.summarizeUpToMessage", () => {
 
     expect(recordOutcome).toHaveBeenCalledTimes(1);
     expect(recordOutcome).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  test("reports tokenizer counts and pushes them to the context-window indicator", async () => {
+    const collected: AssistantEvent[] = [];
+    const conversation = makeConversation({
+      counts: [56_000, 18_000],
+      onEvent: (msg) => collected.push(msg),
+    });
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      // Estimate-based figures the pipeline records internally; the card and
+      // the indicator both report the tokenizer counts instead.
+      previousEstimatedInputTokens: 43_000,
+      estimatedInputTokens: 12_000,
+      maxInputTokens: 200_000,
+      compactedPersistedMessages: 4,
+    };
+
+    const result = await conversation.summarizeUpToMessage("m4");
+
+    expect(result.previousEstimatedInputTokens).toBe(56_000);
+    expect(result.estimatedInputTokens).toBe(18_000);
+
+    const usage = collected.filter((m) => m.type === "context_window_usage");
+    expect(usage).toHaveLength(1);
+    const usageEvent = usage[0] as Extract<
+      AssistantEvent,
+      { type: "context_window_usage" }
+    >;
+    expect(usageEvent.conversationId).toBe("conv-1");
+    expect(usageEvent.tokens).toBe(result.estimatedInputTokens);
+    expect(usageEvent.maxTokens).toBe(200_000);
   });
 });
 

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -865,12 +865,12 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(recordOutcome).toHaveBeenCalledWith(true, expect.anything());
   });
 
-  test("reports tokenizer counts and pushes them to the context-window indicator", async () => {
+  test("reports tokenizer counts and pushes them to the caller's sink", async () => {
+    // The management route resolves its conversation outside the send path, so
+    // the instance keeps the store's no-op sender: the push has to ride the
+    // sink the route hands in, not `sendToClient`.
     const collected: AssistantEvent[] = [];
-    const conversation = makeConversation({
-      counts: [56_000, 18_000],
-      onEvent: (msg) => collected.push(msg),
-    });
+    const conversation = makeConversation({ counts: [56_000, 18_000] });
     mockCompactResult = {
       ...makeNoopResult(),
       compacted: true,
@@ -882,7 +882,9 @@ describe("Conversation.summarizeUpToMessage", () => {
       compactedPersistedMessages: 4,
     };
 
-    const result = await conversation.summarizeUpToMessage("m4");
+    const result = await conversation.summarizeUpToMessage("m4", (msg) =>
+      collected.push(msg),
+    );
 
     expect(result.previousEstimatedInputTokens).toBe(56_000);
     expect(result.estimatedInputTokens).toBe(18_000);
@@ -896,6 +898,26 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(usageEvent.conversationId).toBe("conv-1");
     expect(usageEvent.tokens).toBe(result.estimatedInputTokens);
     expect(usageEvent.maxTokens).toBe(200_000);
+  });
+
+  test("falls back to the conversation's own sender when no sink is passed", async () => {
+    const collected: AssistantEvent[] = [];
+    const conversation = makeConversation({
+      counts: [56_000, 18_000],
+      onEvent: (msg) => collected.push(msg),
+    });
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      maxInputTokens: 200_000,
+      compactedPersistedMessages: 4,
+    };
+
+    await conversation.summarizeUpToMessage("m4");
+
+    expect(
+      collected.filter((m) => m.type === "context_window_usage"),
+    ).toHaveLength(1);
   });
 });
 

--- a/assistant/src/api/events/context-window-usage.ts
+++ b/assistant/src/api/events/context-window-usage.ts
@@ -1,0 +1,31 @@
+/**
+ * `context_window_usage` SSE event.
+ *
+ * Server → client push of a conversation's current context-window usage,
+ * measured with the provider's own tokenizer. Emitted by user-initiated
+ * compaction (`/compact`, "summarize up to here"), which recomputes the
+ * count outside any turn and so has no `usage_update` to carry it. Clients
+ * apply it to the context-window indicator, which otherwise only refreshes
+ * on the next LLM call.
+ *
+ * `tokens` and `maxTokens` are the same figures the compaction result card
+ * reports, so the indicator and the card always agree.
+ *
+ * Canonical wire-contract source. Daemon code imports the type directly
+ * from this file; external consumers import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ContextWindowUsageEventSchema = z.object({
+  type: z.literal("context_window_usage"),
+  conversationId: z.string(),
+  /** Prompt tokens the conversation's context currently occupies. */
+  tokens: z.number(),
+  /** Input-token ceiling of the resolved context window. */
+  maxTokens: z.number(),
+});
+
+export type ContextWindowUsageEvent = z.infer<
+  typeof ContextWindowUsageEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -25,6 +25,7 @@ import { ConfirmationStateChangedEventSchema } from "./events/confirmation-state
 import { ContactRequestEventSchema } from "./events/contact-request.js";
 import { ContactsChangedEventSchema } from "./events/contacts-changed.js";
 import { ContextCompactedEventSchema } from "./events/context-compacted.js";
+import { ContextWindowUsageEventSchema } from "./events/context-window-usage.js";
 import { ConversationErrorEventSchema } from "./events/conversation-error.js";
 import { ConversationInferenceProfileUpdatedEventSchema } from "./events/conversation-inference-profile-updated.js";
 import { ConversationListInvalidatedEventSchema } from "./events/conversation-list-invalidated.js";
@@ -271,6 +272,10 @@ export {
   type ContextCompactedEvent,
   ContextCompactedEventSchema,
 } from "./events/context-compacted.js";
+export {
+  type ContextWindowUsageEvent,
+  ContextWindowUsageEventSchema,
+} from "./events/context-window-usage.js";
 export {
   type ConversationErrorCode,
   ConversationErrorCodeSchema,
@@ -902,6 +907,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   ContactRequestEventSchema,
   ContactsChangedEventSchema,
   ContextCompactedEventSchema,
+  ContextWindowUsageEventSchema,
   ConversationErrorEventSchema,
   ConversationInferenceProfileUpdatedEventSchema,
   ConversationListInvalidatedEventSchema,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -923,7 +923,11 @@ async function drainSingleMessage(
       conversation.emitActivityState("thinking", "context_compacting", {
         requestId: next.requestId,
       });
-      const result = await conversation.forceCompact();
+      // Push the usage refresh to the queued item's own sink, the one the
+      // result card below streams on. `sendToClient` is reset to a no-op once
+      // an interactive turn finishes, so a `/compact` draining behind one
+      // would otherwise refresh nothing.
+      const result = await conversation.forceCompact(next.onEvent);
       const responseText = formatCompactResult(result);
 
       const assistantMsg = createAssistantMessage(responseText);
@@ -2040,7 +2044,8 @@ export async function processMessage(
       conversation.emitActivityState("thinking", "context_compacting", {
         requestId,
       });
-      const result = await conversation.forceCompact();
+      // Same sink the result card below streams on (see the drain branch).
+      const result = await conversation.forceCompact(onEvent);
       const responseText = formatCompactResult(result);
 
       const assistantMsg = createAssistantMessage(responseText);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1963,13 +1963,18 @@ export class Conversation {
    * card reports. Turn-driven compaction needs no push: the turn's own
    * `usage_update` carries the post-compaction count.
    *
-   * Rides the conversation's own sender, the channel `emitActivityState` and
-   * `context_compacted` already use, so a queued `/compact` reaches the same
-   * client its result card does.
+   * Defaults to the conversation's own sender, the channel `emitActivityState`
+   * and `context_compacted` already use, so a queued `/compact` reaches the
+   * same client its result card does. Routes that resolve a conversation
+   * outside the send path never wire that sender and pass their own `onEvent`.
    */
-  private emitContextWindowUsage(tokens: number, maxTokens: number): void {
+  private emitContextWindowUsage(
+    tokens: number,
+    maxTokens: number,
+    onEvent?: (msg: AssistantEvent) => void,
+  ): void {
     try {
-      this.sendToClient({
+      (onEvent ?? this.sendToClient)({
         type: "context_window_usage",
         conversationId: this.conversationId,
         tokens,
@@ -1996,10 +2001,12 @@ export class Conversation {
    * figures, leaving calibration and historical logs untouched.
    *
    * `run` must leave the compacted history applied to `this.messages`, which
-   * every `runCompaction` path does.
+   * every `runCompaction` path does. `onEvent` overrides the sink the usage
+   * push goes to.
    */
   private async runUserCompaction(
     run: () => Promise<ContextWindowResult>,
+    onEvent?: (msg: AssistantEvent) => void,
   ): Promise<ContextWindowResult> {
     const before = await this.calculateTokens(this.messages);
     const result = await run();
@@ -2007,7 +2014,7 @@ export class Conversation {
     const after = result.compacted
       ? await this.calculateTokens(this.messages)
       : before;
-    this.emitContextWindowUsage(after, result.maxInputTokens);
+    this.emitContextWindowUsage(after, result.maxInputTokens, onEvent);
     return {
       ...result,
       previousEstimatedInputTokens: before,
@@ -2031,9 +2038,15 @@ export class Conversation {
    * `resolveMetaSlashCommand`. Throws {@link UserError} (messages are
    * user-facing) when the boundary cannot be resolved or the row→history
    * index mapping cannot be verified.
+   *
+   * `onEvent` is the sink for the context-window usage push. The management
+   * route that owns this action resolves its conversation outside the send
+   * path, so the instance can still hold the store's no-op sender; it passes
+   * the same broadcast path its result card goes out on.
    */
   async summarizeUpToMessage(
     beforeMessageId: string,
+    onEvent?: (msg: AssistantEvent) => void,
   ): Promise<ContextWindowResult> {
     const priorTrustContext = this.trustContext;
     if (!resolveCapabilities(priorTrustContext?.trustClass).canAccessMemory) {
@@ -2113,18 +2126,21 @@ export class Conversation {
           firstRowByHistoryIndex[historyIndex] = rowIndex;
         }
       }
-      return await this.runUserCompaction(() =>
-        this.runCompaction(true, undefined, {
-          fixedTailStartIndex: tailIndex,
-          // When repair merged preceding continuation rows into the boundary's
-          // message, the row boundary retreats to the message's first
-          // contributing row: the summary call reads messages[0..tailIndex),
-          // which excludes the merged rows' content, so the image manifest and
-          // watermarks must not treat them as summarized.
-          fixedBoundaryRowIndex:
-            firstRowByHistoryIndex[tailIndex] ?? boundaryRowIndex,
-          fixedBoundaryRowView: { rows, firstRowByHistoryIndex },
-        }),
+      return await this.runUserCompaction(
+        () =>
+          this.runCompaction(true, undefined, {
+            fixedTailStartIndex: tailIndex,
+            // When repair merged preceding continuation rows into the
+            // boundary's message, the row boundary retreats to the message's
+            // first contributing row: the summary call reads
+            // messages[0..tailIndex), which excludes the merged rows' content,
+            // so the image manifest and watermarks must not treat them as
+            // summarized.
+            fixedBoundaryRowIndex:
+              firstRowByHistoryIndex[tailIndex] ?? boundaryRowIndex,
+            fixedBoundaryRowView: { rows, firstRowByHistoryIndex },
+          }),
+        onEvent,
       );
     } finally {
       // Only undo the temporary guardian context this method installed. If

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1957,31 +1957,66 @@ export class Conversation {
     }
   }
 
-  async forceCompact(): Promise<ContextWindowResult> {
-    // Report the user-facing before/after using the provider's real tokenizer
-    // (count_tokens) so the `/compact` line matches the context-window
-    // indicator, which reflects the provider's actual reported usage — rather
-    // than the local chars/4 estimate the compaction pipeline runs internally
-    // (it under-counts by ~25% on typical histories). `calculateTokens`
-    // falls back to that estimate when the provider has no count endpoint or
-    // the count call fails, so behavior degrades gracefully.
-    //
-    // Only the *displayed* numbers are overridden — the compaction log and
-    // circuit-breaker accounting inside `runCompaction` keep the estimate-based
-    // figures, leaving calibration and historical logs untouched.
+  /**
+   * Push the conversation's current context-window usage to clients so the
+   * context-window indicator matches the numbers a user-initiated compaction
+   * card reports. Turn-driven compaction needs no push: the turn's own
+   * `usage_update` carries the post-compaction count.
+   *
+   * Rides the conversation's own sender, the channel `emitActivityState` and
+   * `context_compacted` already use, so a queued `/compact` reaches the same
+   * client its result card does.
+   */
+  private emitContextWindowUsage(tokens: number, maxTokens: number): void {
+    try {
+      this.sendToClient({
+        type: "context_window_usage",
+        conversationId: this.conversationId,
+        tokens,
+        maxTokens,
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId: this.conversationId },
+        "sendToClient threw in emitContextWindowUsage",
+      );
+    }
+  }
+
+  /**
+   * Run a user-initiated compaction (`run`), reporting its before/after with
+   * the provider's real tokenizer (count_tokens) rather than the local chars/4
+   * estimate the compaction pipeline runs internally (it under-counts by ~25%
+   * on typical histories), and pushing the resulting count to clients.
+   * `calculateTokens` falls back to that estimate when the provider has no
+   * count endpoint or the count call fails, so behavior degrades gracefully.
+   *
+   * Only the *displayed* numbers are overridden: the compaction log and
+   * circuit-breaker accounting inside `runCompaction` keep the estimate-based
+   * figures, leaving calibration and historical logs untouched.
+   *
+   * `run` must leave the compacted history applied to `this.messages`, which
+   * every `runCompaction` path does.
+   */
+  private async runUserCompaction(
+    run: () => Promise<ContextWindowResult>,
+  ): Promise<ContextWindowResult> {
     const before = await this.calculateTokens(this.messages);
-    const result = await this.runCompaction(true);
-    // `runCompaction` applies the compacted history to `this.messages` in
-    // place, so after a successful compaction this re-counts the new history;
-    // a no-op leaves the context unchanged, so before === after.
+    const result = await run();
+    // A no-op leaves the context unchanged, so before === after.
     const after = result.compacted
       ? await this.calculateTokens(this.messages)
       : before;
+    this.emitContextWindowUsage(after, result.maxInputTokens);
     return {
       ...result,
       previousEstimatedInputTokens: before,
       estimatedInputTokens: after,
     };
+  }
+
+  async forceCompact(): Promise<ContextWindowResult> {
+    return this.runUserCompaction(() => this.runCompaction(true));
   }
 
   /**
@@ -2078,17 +2113,19 @@ export class Conversation {
           firstRowByHistoryIndex[historyIndex] = rowIndex;
         }
       }
-      return await this.runCompaction(true, undefined, {
-        fixedTailStartIndex: tailIndex,
-        // When repair merged preceding continuation rows into the boundary's
-        // message, the row boundary retreats to the message's first
-        // contributing row: the summary call reads messages[0..tailIndex),
-        // which excludes the merged rows' content, so the image manifest and
-        // watermarks must not treat them as summarized.
-        fixedBoundaryRowIndex:
-          firstRowByHistoryIndex[tailIndex] ?? boundaryRowIndex,
-        fixedBoundaryRowView: { rows, firstRowByHistoryIndex },
-      });
+      return await this.runUserCompaction(() =>
+        this.runCompaction(true, undefined, {
+          fixedTailStartIndex: tailIndex,
+          // When repair merged preceding continuation rows into the boundary's
+          // message, the row boundary retreats to the message's first
+          // contributing row: the summary call reads messages[0..tailIndex),
+          // which excludes the merged rows' content, so the image manifest and
+          // watermarks must not treat them as summarized.
+          fixedBoundaryRowIndex:
+            firstRowByHistoryIndex[tailIndex] ?? boundaryRowIndex,
+          fixedBoundaryRowView: { rows, firstRowByHistoryIndex },
+        }),
+      );
     } finally {
       // Only undo the temporary guardian context this method installed. If
       // trustContext was legitimately updated at an `await` boundary, the

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2022,8 +2022,18 @@ export class Conversation {
     };
   }
 
-  async forceCompact(): Promise<ContextWindowResult> {
-    return this.runUserCompaction(() => this.runCompaction(true));
+  /**
+   * `/compact`. `onEvent` is the sink for the context-window usage push, and
+   * callers pass whatever sink they render the result card through: the queue
+   * drain carries the queued item's own `onEvent`, and `sendToClient` is reset
+   * to a no-op once an interactive turn finishes (`process-message.ts`), so a
+   * `/compact` draining behind that turn would otherwise push into nothing
+   * while its card still reaches the client.
+   */
+  async forceCompact(
+    onEvent?: (msg: AssistantEvent) => void,
+  ): Promise<ContextWindowResult> {
+    return this.runUserCompaction(() => this.runCompaction(true), onEvent);
   }
 
   /**

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -278,7 +278,14 @@ async function handleSummarizeConversation({ body = {} }: RouteHandlerArgs) {
       conversation.emitActivityState("thinking", "context_compacting", {
         statusText: "Summarizing conversation",
       });
-      const result = await conversation.summarizeUpToMessage(beforeMessageId);
+      // The context-window usage push goes out on the same broadcast path as
+      // the result card below: this route resolves its conversation outside
+      // the send path, so the instance may still hold the store's no-op
+      // sender and a `sendToClient` emit would reach nobody.
+      const result = await conversation.summarizeUpToMessage(
+        beforeMessageId,
+        broadcastMessage,
+      );
       // Stop aborted the in-flight summary: the compactor reports the aborted
       // provider call as a non-compacted result (it swallows the abort rather
       // than throwing), so detect cancellation via the signal. A cancelled

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2375,7 +2375,9 @@ export async function handleSendMessage(
         });
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.emitActivityState("thinking", "context_compacting");
-        const result = await conversation.forceCompact();
+        // Same sink the result card below goes out on, so the indicator and
+        // the card can never be delivered to different places.
+        const result = await conversation.forceCompact(broadcastMessage);
         const cardId = await persistCannedAssistantCard({
           conversation,
           conversationId,

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -52,6 +52,7 @@ import {
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
 import {
   handleUsageUpdate,
+  handleContextWindowUsage,
   handleCompactionCircuitOpen,
   handleCompactionCircuitClosed,
 } from "@/domains/chat/utils/stream-handlers/metadata-handlers";
@@ -361,6 +362,9 @@ export function useStreamEventHandler(
           break;
         case "usage_update":
           handleUsageUpdate(event, ctx);
+          break;
+        case "context_window_usage":
+          handleContextWindowUsage(event, ctx);
           break;
         // Per-call usage deltas. The top-level chat surface reads running
         // totals from `usage_update`; per-call deltas are only consumed by

--- a/clients/web/src/domains/chat/utils/stream-handlers/metadata-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/metadata-handlers.test.ts
@@ -4,6 +4,7 @@ import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 
 import {
   handleUsageUpdate,
+  handleContextWindowUsage,
   handleCompactionCircuitOpen,
   handleCompactionCircuitClosed,
 } from "@/domains/chat/utils/stream-handlers/metadata-handlers";
@@ -65,6 +66,43 @@ describe("handleUsageUpdate", () => {
     expect(ctx.setContextWindowUsageForConversation).toHaveBeenCalledWith(
       "conv-1",
       expect.objectContaining({ fillRatio: 1 }),
+    );
+  });
+});
+
+describe("handleContextWindowUsage", () => {
+  it("applies the pushed count the same way a usage_update would", () => {
+    const ctx = makeCtx();
+    handleContextWindowUsage(
+      {
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 200000,
+      },
+      ctx,
+    );
+    expect(ctx.setContextWindowUsage).toHaveBeenCalled();
+    expect(ctx.setContextWindowUsageForConversation).toHaveBeenCalledWith(
+      "conv-1",
+      { tokens: 18000, maxTokens: 200000, fillRatio: 0.09 },
+    );
+  });
+
+  it("sets fillRatio to null when the window is unknown", () => {
+    const ctx = makeCtx();
+    handleContextWindowUsage(
+      {
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 0,
+      },
+      ctx,
+    );
+    expect(ctx.setContextWindowUsageForConversation).toHaveBeenCalledWith(
+      "conv-1",
+      { tokens: 18000, maxTokens: null, fillRatio: null },
     );
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
@@ -4,16 +4,22 @@ import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/
 import type {
   CompactionCircuitClosedEvent,
   CompactionCircuitOpenEvent,
+  ContextWindowUsageEvent,
   UsageUpdateEvent,
 } from "@vellumai/assistant-api";
 
-export function handleUsageUpdate(
-  event: UsageUpdateEvent,
+/**
+ * Apply a context-window measurement to the indicator: the live conversation
+ * state, the per-conversation map, and the localStorage mirror that survives a
+ * reload. Every event that carries a fresh count routes through here so the
+ * indicator reads the same way whichever one delivered it.
+ */
+function applyContextWindowUsage(
   ctx: StreamHandlerContext,
+  tokens: number,
+  maxTokens: number | undefined,
 ): void {
-  const tokens = event.contextWindowTokens;
-  const maxTokens = event.contextWindowMaxTokens;
-  if (typeof tokens !== "number" || !Number.isFinite(tokens)) {
+  if (!Number.isFinite(tokens)) {
     return;
   }
 
@@ -38,6 +44,32 @@ export function handleUsageUpdate(
     );
   }
   ctx.setContextWindowUsage(usage);
+}
+
+export function handleUsageUpdate(
+  event: UsageUpdateEvent,
+  ctx: StreamHandlerContext,
+): void {
+  if (typeof event.contextWindowTokens !== "number") {
+    return;
+  }
+  applyContextWindowUsage(
+    ctx,
+    event.contextWindowTokens,
+    event.contextWindowMaxTokens,
+  );
+}
+
+/**
+ * Post-compaction context size, pushed by user-initiated compaction
+ * (`/compact`, "summarize up to here"). Those run outside a turn, so no
+ * `usage_update` follows to refresh the indicator.
+ */
+export function handleContextWindowUsage(
+  event: ContextWindowUsageEvent,
+  ctx: StreamHandlerContext,
+): void {
+  applyContextWindowUsage(ctx, event.tokens, event.maxTokens);
 }
 
 export function handleCompactionCircuitOpen(

--- a/clients/web/src/lib/streaming/event-parser.test.ts
+++ b/clients/web/src/lib/streaming/event-parser.test.ts
@@ -2362,6 +2362,54 @@ describe("parseAssistantEvent", () => {
     });
   });
 
+  describe("context_window_usage", () => {
+    test("parses context_window_usage with all required fields", () => {
+      const event = parseEvent({
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 200000,
+      });
+      expect(event).toEqual({
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 200000,
+      });
+    });
+
+    test("returns unknown when a required field is missing", () => {
+      const data = {
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+      };
+      const event = parseEvent(data);
+      expect(event).toEqual({
+        type: "unknown",
+        rawType: "context_window_usage",
+        data,
+        conversationId: "conv-1",
+      });
+    });
+
+    test("strips unknown top-level fields", () => {
+      const event = parseEvent({
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 200000,
+        fillRatio: 0.09,
+      });
+      expect(event).toEqual({
+        type: "context_window_usage",
+        conversationId: "conv-1",
+        tokens: 18000,
+        maxTokens: 200000,
+      });
+    });
+  });
+
   describe("usage_progress", () => {
     test("parses usage_progress with all required fields", () => {
       const event = parseEvent({


### PR DESCRIPTION
## TL;DR

`/compact` left the context-window indicator showing the pre-compaction token count. This adds a `context_window_usage` event that user-initiated compaction pushes after it recounts, carrying the exact figures its result card renders, and wires the web client to apply it.

Fixes [LUM-2477](https://linear.app/vellum/issue/LUM-2477/compact-token-counts-dont-reconcile-between-conversation-sidebar-and)

## The two symptoms in the report

**1. The conversation and the indicator disagreed on the current size (56K vs 43K).** Already fixed, in #35436 (Jun 19): `/compact` and `/clean` moved their displayed before/after onto the provider's `count_tokens` tokenizer, the same basis the indicator reads, instead of the compaction pipeline's internal chars/4 estimate (which runs ~25% off).

That fix missed one path. **"Summarize up to here" still reported estimate-basis numbers**, so its card reads low against the indicator standing next to it. This PR moves it onto the tokenizer too, so every user-initiated compaction card speaks one measurement basis.

**2. The indicator didn't refresh after compaction.** Still live, and the substance of this PR.

## Why the indicator went stale

It only learns a token count from `usage_update`, which the daemon emits per LLM call with the provider-reported prompt size. Compaction that happens *inside* a turn is fine: the turn's next call re-measures the shrunken prompt and the indicator self-heals.

`/compact` runs outside a turn. The only `usage_update` it produces is for the summary call itself, and that one deliberately carries no context-window fields, because `context_compacted` was meant to be the client's refresh signal. The web client no-ops on `context_compacted` ([use-stream-event-handler.ts:501](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts#L501)) — that contract was written for the SwiftUI macOS client the report came from. So nothing refreshed the ring at all.

Routing the fix through `context_compacted` would have re-created the original bug: that event is emitted from inside the compaction pipeline and carries the *estimate*-basis numbers, while the card the user is reading carries the tokenizer's. The indicator and the card would disagree again, just by a smaller margin. Hence a dedicated event emitted after the recount, from the one place that holds the final figures.

## What changed

- **New `context_window_usage` event** (`{conversationId, tokens, maxTokens}`) in the canonical wire contract, so it parses and types itself into every consumer.
- **`Conversation.runUserCompaction`** — one wrapper now backing both `forceCompact` and `summarizeUpToMessage`: recount with the tokenizer, emit the usage event, return the corrected figures. Previously only `forceCompact` did the recount, inline.
- **An optional event sink on `forceCompact` and `summarizeUpToMessage`**, defaulting to `sendToClient`. Every caller passes the sink it renders the result card through, so the two can never be delivered to different places: `broadcastMessage` on the HTTP routes, the queued item's own `onEvent` in the two queue-drain branches. This matters because `sendToClient` is not always live — `processMessage` resets it to a no-op in its `finally` once an interactive turn ends (`process-message.ts:728`), and the summarize route's conversation may never have had a real sender at all. The playground route keeps the default; it returns counts in its response and renders no card.
- **Web**: `handleContextWindowUsage` applies the push through the same helper `usage_update` uses (extracted, not copied), so both routes derive `fillRatio`, update the store, and mirror to localStorage identically.

## Before / after

| | Before | After |
|---|---|---|
| Indicator after `/compact` | Stuck on the pre-compaction count until the next message | Updates immediately to the post-compaction count |
| Indicator after "summarize up to here" | Same staleness | Same fix |
| "Summarize up to here" card | Estimate-basis tokens, ~25% low vs the indicator | Tokenizer counts, matching the indicator |
| `/compact` and `/clean` cards | Already tokenizer-based | Unchanged |
| Indicator during a normal turn | `usage_update` per LLM call | Unchanged |

## Why it's safe

- **Additive on the wire.** A new event type; no existing payload changed. Clients that don't know it (CLI, older builds) fall through their default case, exactly as before.
- **No new work on the turn path.** `count_tokens` is a network round-trip, so it stays where it already was: user-initiated actions only, never the per-turn auto-compaction gate. Auto-compaction is untouched.
- **Accounting untouched.** Only *displayed* numbers are overridden. The compaction log, the estimator calibration loop, and the circuit breaker keep their estimate-based figures.
- **Degrades gracefully.** No `count_tokens` endpoint, or a failed count, falls back to the local estimate, as `/compact` already did. A missing or zero `maxTokens` yields a null fill ratio and the indicator hides rather than rendering a wrong ring.
- The emit is wrapped in try/catch on the conversation's own sender, the same channel `emitActivityState` and `context_compacted` already ride, so a disconnected client can't fail the compaction.

## Deliberately not in scope

- **`/clean` doesn't emit the event.** It refreshes the acting client through its HTTP response (`contextUsage`), so the reported symptom doesn't occur there. Other connected clients do stay stale — the real fix is to drop that response field and let everything flow through the event, which changes an HTTP contract and deserves its own PR.
- **The summarize route's *other* emissions still ride the no-op sender.** Filed as [LUM-2987](https://linear.app/vellum/issue/LUM-2987). The sink above fixes the usage push, but that route's `emitActivityState("thinking")` and `context_compacted` have the same problem and are pre-existing — so summarizing a cold conversation shows no thinking indicator for the duration of the summary call. Fixing those properly means either wiring the sender on the route (the `hasNoClient` flag it also sets feeds host-tool gating and persists on the instance) or moving conversation emissions onto the hub wholesale.

  The wholesale move is the better end state, and I measured it: emitting through `broadcastMessage` from `Conversation` changes queue-drain behavior. `conversation-slash-queue.test.ts` ("passthrough batch is terminated by a /compact in the middle of the queue") fails, with the message queued behind `/compact` never starting its run. The `/compact` block itself completes normally (card persisted, `message_complete` emitted), so the interaction is somewhere in `drainQueue` after the branch returns. Not root-caused; repro in LUM-2987, and it should be understood before anyone routes conversation-level emissions through the hub.
- **The web still no-ops on `context_compacted`.** Auto-compaction's refresh already arrives via the turn's own `usage_update`, so handling it would only add a redundant invalidation.

## CI

The two failing web tests (`notifications-bell.test.tsx`, `collapsible-nav-section.test.tsx`) are **pre-existing on main**, not from this PR. Main's own `CI Main Web` run for 6c61f0642e (the commit this branch is based on) fails with the identical pair, 812 passed / 2 failed. They assert Tailwind size classes on an unread dot and a nav section, which the two "polish" UI commits ahead of this branch changed.

## Testing

- `assistant`: `compaction-events.test.ts` (push carries the tokenizer count and matches the returned card figures; no-op compaction still pushes the current count), `conversation-summarize-up-to.test.ts` (tokenizer counts + push).
- `clients/web`: `metadata-handlers.test.ts` (new handler applies identically to `usage_update`, null window handled), `event-parser.test.ts` (happy path, missing required field, unknown-field strip).
- Full typecheck on `assistant/` and `clients/web/`; `generate:openapi` produces no spec drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
