### PR TITLE
fix(web): stop a long process name overlapping the step count in the activity popover

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-activity-pill.tsx
@@ -324,14 +324,17 @@ export function ConversationActivityPill({
         </Button>
       </Popover.Trigger>
       {/* `align="end"`, unlike the Assets pill's centred panel: Activity sits
-          further right in the cluster, so a centred 320px panel resolves flush
+          further right in the cluster, so a centred panel resolves flush
           against the window edge. Anchoring the panel's trailing edge to the
-          trigger matches the notification bell, its neighbour on that side. */}
+          trigger matches the notification bell, its neighbour on that side,
+          whose 384px width the rows here borrow too: a generated process name
+          plus its status metadata needs the room, and `max-w` still yields to
+          a narrow viewport. */}
       <Popover.Content
         side="bottom"
         align="end"
         sideOffset={8}
-        className="w-80 max-w-[calc(100vw-2rem)] p-0"
+        className="w-96 max-w-[calc(100vw-2rem)] p-0"
       >
         <div className="max-h-[280px] overflow-y-auto">{panel}</div>
       </Popover.Content>

--- a/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.test.tsx
@@ -2,11 +2,17 @@
  * Tests for `HeaderStepCarousel` — the animated (title, info) tuple rendered
  * inside a `ToolProgressCardShell`'s collapsed header.
  *
- * Focus: the title-less rendering path. Some tools (e.g. bash) intentionally
- * carry no collapsed-header title; the carousel must then drop both the title
- * element and the leading pipe separator and promote the info subtext into the
- * primary (emphasised) slot. The component seeds its throttle state with the
- * initial value, so the first render shows the supplied tuple synchronously.
+ * Focus: which of the two labels renders where, and how each is bounded.
+ *
+ * Some tools (e.g. bash) intentionally carry no collapsed-header title; the
+ * carousel must then drop both the title element and the leading pipe
+ * separator and promote the info subtext into the primary (emphasised) slot.
+ * Both labels stay bounded in every combination so neither can overflow the
+ * header and paint over the trailing step count, with the info giving up its
+ * space first.
+ *
+ * The component seeds its throttle state with the initial value, so the first
+ * render shows the supplied tuple synchronously.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -62,7 +68,28 @@ describe("HeaderStepCarousel — with title", () => {
     expect(info.className).not.toContain("content-emphasised");
   });
 
-  test("keeps the title a non-shrinking anchor when info is present", () => {
+  test("bounds the title so a long one can't overflow past the trailing controls", () => {
+    // Titles are not always short activity verbs: the process-registry rows
+    // pass a generated process name (a subagent's task label). A `shrink-0`
+    // title would push past the row and paint over the step count, so the
+    // title stays bounded (min-w-0 + truncate) even with info beside it.
+    const { getByText } = render(
+      <HeaderStepCarousel
+        currentStepTitle="skillsmith-method-audit"
+        currentStepInfo="Working"
+      />,
+    );
+
+    const title = getByText("skillsmith-method-audit");
+    expect(title.className).toContain("truncate");
+    expect(title.className).toContain("min-w-0");
+    expect(title.className).not.toContain("shrink-0");
+  });
+
+  test("leaves the info the grower so it yields its space before the title", () => {
+    // The info's `flex-1` basis of 0 gives it a scaled shrink factor of 0, so
+    // an over-long row shrinks the title (which has a real basis) and leaves a
+    // short title like "Reading" whole.
     const { getByText } = render(
       <HeaderStepCarousel
         currentStepTitle="Reading"
@@ -70,9 +97,10 @@ describe("HeaderStepCarousel — with title", () => {
       />,
     );
 
-    const title = getByText("Reading");
-    expect(title.className).toContain("shrink-0");
-    expect(title.className).not.toContain("truncate");
+    const info = getByText("foo.ts");
+    expect(info.className).toContain("flex-1");
+    expect(info.className).toContain("truncate");
+    expect(getByText("Reading").className).not.toContain("flex-1");
   });
 
   test("truncates a title-only label so a long one can't overflow the row", () => {

--- a/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/header-step-carousel.tsx
@@ -211,6 +211,11 @@ export function HeaderStepCarousel({
   // primary (emphasised) slot so it doesn't read as de-emphasised subtext.
   const hasTitle = displayed.title.trim() !== "";
 
+  // The sole label grows into the whole row; with info present the info is the
+  // grower and the title takes its natural width. Either way the title is
+  // bounded, so it ellipsizes rather than running past the trailing controls.
+  const titleSizing = hasInfo ? "block min-w-0" : "block min-w-0 flex-1";
+
   return (
     <AnimatePresence initial={false} mode="popLayout">
       <motion.span
@@ -219,11 +224,14 @@ export function HeaderStepCarousel({
         animate={animate}
         exit={exit}
         transition={transition}
-        // Header layout — flex row. With info present the title is a
-        // non-shrinking anchor (shrink-0 + nowrap) and the info truncates in
-        // the remaining space; when the title is the sole label it truncates
-        // itself so a long one (e.g. an ACP command) can't overflow the row
-        // and overlap the trailing controls.
+        // Header layout: a flex row. Both labels are bounded (min-w-0 +
+        // truncate) so neither can overflow the row and overlap the trailing
+        // controls, whether the title is a short activity verb ("Reading") or
+        // a caller-supplied name (a subagent's task label, an ACP command).
+        // The info yields its space first: its `flex-1` basis of 0 gives it a
+        // scaled shrink factor of 0, so a deficit falls entirely on the title,
+        // which therefore ellipsizes only once the info has nothing left to
+        // give.
         className="flex min-w-0 flex-1 items-center gap-1"
       >
         {hasTitle ? (
@@ -235,11 +243,7 @@ export function HeaderStepCarousel({
             // line-height of 1, which clips descenders (the "g" in
             // "Working") behind the shimmer/truncate overflow clipping.
             <span
-              className={
-                hasInfo
-                  ? "shrink-0 whitespace-nowrap text-[13px] font-medium leading-[16px] text-[var(--content-secondary)]"
-                  : "block min-w-0 flex-1 truncate text-left text-[13px] font-medium leading-[16px] text-[var(--content-secondary)]"
-              }
+              className={`${titleSizing} truncate text-left text-[13px] font-medium leading-[16px] text-[var(--content-secondary)]`}
             >
               {shimmer ? (
                 <StreamingShimmerText>{displayed.title}</StreamingShimmerText>
@@ -250,11 +254,7 @@ export function HeaderStepCarousel({
           ) : (
             <Typography
               variant="body-medium-default"
-              className={
-                hasInfo
-                  ? "ml-1 shrink-0 whitespace-nowrap text-[var(--content-emphasised)]"
-                  : "ml-1 block min-w-0 flex-1 truncate text-left text-[var(--content-emphasised)]"
-              }
+              className={`ml-1 ${titleSizing} truncate text-left text-[var(--content-emphasised)]`}
             >
               {shimmer ? (
                 <StreamingShimmerText>{displayed.title}</StreamingShimmerText>


### PR DESCRIPTION
## TL;DR

A long running-job name in the chat header's activity popover painted straight over the trailing "N steps" count. The shared `HeaderStepCarousel` pinned its title at `shrink-0` + `whitespace-nowrap` whenever an info subtext sat beside it, so an over-long title could not shrink and nothing on that path clipped it. Both labels are now bounded, and the popover widens from 320px to 384px to match the notification bell it already aligns with.

Fixes LUM-2986

## Root cause

The popover lists each agent session as a generic `InlineProcessCard` row: a leading status cluster, the shared `HeaderStepCarousel`, then a trailing count and Stop button.

`HeaderStepCarousel` treated the title as a fixed anchor and the info as the variable part that truncates. That is right for the tool-progress card it was written for, where the title is a short activity verb ("Reading") and the info is a long file path. It is wrong for the process-registry rows, where the roles are **inverted**: [`SUBAGENT_DESCRIPTOR.useCardSummary`](clients/web/src/domains/chat/process-registry/descriptors/subagent.tsx#L43-L60) maps the subagent's `label` onto the title, so the title is a model-generated task name of arbitrary length and the info is the short verb ("Working", "Loading").

The overlap itself is a flexbox dead end. A `flex-shrink: 0` item is frozen immediately, and the info's `flex-1` basis of `0` gives it a scaled shrink factor of `0`, so when the title exceeded the carousel width no item could absorb the deficit. The line overflowed its box, and since nothing on the path sets `overflow: hidden`, the name painted over the trailing cluster.

## The fix

The title keeps `min-w-0` + `truncate` in every combination, so it ellipsizes rather than escaping the row.

The priority order between the two labels is deliberately unchanged: the info still yields its space first, because its zero flex basis keeps its scaled shrink factor at `0` and sends the whole deficit to the title. The title therefore truncates only once the info has nothing left to give, and a short verb title beside a long path stays whole exactly as it does today.

`overflow: hidden` on the carousel span would also have stopped the bleed, but it would clip the `mode="popLayout"` enter/exit slide (the labels animate ±16px vertically), so the flex sizing is the right seam.

## What changes for the user

| | Before | After |
|---|---|---|
| Long job name + step count | Name runs over the count; both unreadable | Name ellipsizes and clears the count |
| Short verb title ("Reading") + long path | Title whole, path truncates | Unchanged |
| Title-only row (e.g. an ACP command) | Truncates | Unchanged |
| Activity popover width (desktop) | 320px | 384px, same as the notification bell |
| Narrow viewport | `max-w-[calc(100vw-2rem)]` | Unchanged |
| Mobile | Bottom sheet, full width | Unchanged |

## Why it's safe

- **Blast radius is the two title branches of one component.** No props, no API, no store, no descriptor changes. Every other consumer of `HeaderStepCarousel` (the tool-progress card shell, the subagent phase timeline) passes either a short verb title or an empty title, and neither path changes behavior.
- **The one behavioral change is bounded by construction.** Flexbox can only shrink the title once the info is at its floor, so the case that regresses is exactly the case that was broken.
- **Verified in a real engine**, not just jsdom. Reproducing the reported row in Chrome: with the old classes the name ran **249px past** the count's left edge with no ellipsis; with the new ones the same name clears it by **80px**, a pathologically long name ellipsizes and stays 25px clear, and a "Reading" title beside a long file path still renders at its full natural width (52.4px).
- Tests updated for the new contract; `header-step-carousel`, `tool-progress-card-shell`, `inline-process-card`, `conversation-activity-pill`, and `subagent-phase-timeline` suites all pass. `tsc --noEmit` and `bun run lint` clean.

## Deferred

Three things spotted in this area, all pre-existing and none blocking the overlap fix:

1. **`StreamingShimmerText` cannot ellipsize.** It renders `display: inline-block`, and `text-overflow: ellipsis` does not apply to an atomic inline-level box, so a shimmering title hard-clips instead of showing "…". This already applied to the title-only branch and now also reaches the title+info branch. Worth fixing (it needs the ellipsis moved onto the shimmer span, which changes how the gradient tile is measured) but it is a separate change to a separate component. **Worth doing.**
2. **A dangling divider when the info is squeezed to zero.** With a very long title the vertical rule still renders with nothing after it. Cosmetic, and it is the same as today's behavior when the info truncates away. **Backlog.**
3. **`WorkflowSubagentRow` hand-rolls this same layout.** It reimplements the title / divider / activity row with its own `max-w-[60%] shrink-0 truncate` recipe rather than using `HeaderStepCarousel`; its own docstring already calls itself "the seam" for when per-leaf progress data arrives. Consolidating now would mean changing a surface this ticket does not cover. **Worth doing when per-leaf progress lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->