### PR TITLE
fix(web): realign two stale class assertions with the shipped sidebar polish

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.test.tsx
+++ b/clients/web/src/components/collapsible-nav-section.test.tsx
@@ -96,9 +96,10 @@ describe("CollapsibleNavSection", () => {
     expect(actionButton).toBeGreaterThan(triggerClose);
   });
 
-  test("trigger carries the text-body-medium-default typography utility", () => {
+  test("trigger carries the responsive lighter typography utilities", () => {
     const html = renderSingleSection({ value: "recents", label: "Recents" });
-    expect(html).toContain("text-body-medium-default");
+    expect(html).toContain("text-body-medium-lighter");
+    expect(html).toContain("max-md:text-body-large-lighter");
   });
 
   test("emits both leading glyphs (category icon + chevron-right) layered", () => {

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -60,7 +60,7 @@ import { NotificationsBell } from "@/domains/home/components/notifications-bell"
 // The same amber dot HomeRecapRow puts on unread rows, top-right of the bell,
 // ringed in the top-bar surface color to separate it from the bell outline.
 const UNREAD_DOT_CLASS =
-  "-right-1 -top-1 h-3 w-3 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
+  "-right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
 
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
   return {


### PR DESCRIPTION
## TL;DR

`main`'s web **Test** job has been red since [#39818](https://github.com/vellum-ai/vellum-assistant/pull/39818). Two tests pin visual constants by exact class literal, and that PR retuned both constants without updating them. This realigns the assertions. Test-only change, no production code.

## What broke

`4dda1810cc` ("polish: new-chat and sidebar UI touch-ups") changed two components deliberately:

| Component | Was | Now |
|---|---|---|
| `NotificationsBell` unread dot | `h-3 w-3` | `h-2.5 w-2.5` |
| `CollapsibleNavSection` trigger | `text-body-medium-default` | `text-body-medium-lighter` + `max-md:text-body-large-lighter` |

Both tests assert the old literal against the rendered markup, so both fail. The component changes are the intended design; the assertions are what lagged.

## What changes for the user

Nothing. No production code is touched. The only user-visible effect is indirect: `main` goes green again, so PRs stop inheriting a red Test job.

## Why it's safe

- The diff is two test files. `git diff --stat` touches nothing under a component or hook.
- Each new literal was read off the actual rendered output, not guessed.
- The nav-section assertion is widened to cover **both** halves of the responsive pair, so a future change to either the base or the `max-md:` variant is still caught rather than silently passing on one.
- Verified locally against `origin/main` HEAD: `collapsible-nav-section` 8/8, `notifications-bell` 5/5, both previously failing.

## Note

These two tests pin design tokens by string match, which is why a deliberate polish change reads as a test failure. That tradeoff is intentional (it is what makes an accidental token change visible), so this PR keeps the approach and just re-syncs the values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->