### PR TITLE
test(web): sync nav-section typography and unread-dot assertions with the shipped polish

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.test.tsx
+++ b/clients/web/src/components/collapsible-nav-section.test.tsx
@@ -96,9 +96,9 @@ describe("CollapsibleNavSection", () => {
     expect(actionButton).toBeGreaterThan(triggerClose);
   });
 
-  test("trigger carries the text-body-medium-default typography utility", () => {
+  test("trigger carries the text-body-medium-lighter typography utility", () => {
     const html = renderSingleSection({ value: "recents", label: "Recents" });
-    expect(html).toContain("text-body-medium-default");
+    expect(html).toContain("text-body-medium-lighter");
   });
 
   test("emits both leading glyphs (category icon + chevron-right) layered", () => {

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -60,7 +60,7 @@ import { NotificationsBell } from "@/domains/home/components/notifications-bell"
 // The same amber dot HomeRecapRow puts on unread rows, top-right of the bell,
 // ringed in the top-bar surface color to separate it from the bell outline.
 const UNREAD_DOT_CLASS =
-  "-right-1 -top-1 h-3 w-3 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
+  "-right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
 
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
   return {


### PR DESCRIPTION
## Summary
- #39818/#39819 changed the CollapsibleNavSection trigger typography (text-body-medium-lighter) and shrank the NotificationsBell unread dot (h-2.5 w-2.5) without updating the tests, leaving CI Main Web red since Friday
- Update the two stale assertions to match the shipped markup; no production code changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->