### PR TITLE
fix(web): realign two style assertions with the shipped components

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.test.tsx
+++ b/clients/web/src/components/collapsible-nav-section.test.tsx
@@ -96,9 +96,9 @@ describe("CollapsibleNavSection", () => {
     expect(actionButton).toBeGreaterThan(triggerClose);
   });
 
-  test("trigger carries the text-body-medium-default typography utility", () => {
+  test("trigger carries the text-body-medium-lighter typography utility", () => {
     const html = renderSingleSection({ value: "recents", label: "Recents" });
-    expect(html).toContain("text-body-medium-default");
+    expect(html).toContain("text-body-medium-lighter");
   });
 
   test("emits both leading glyphs (category icon + chevron-right) layered", () => {

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -60,7 +60,7 @@ import { NotificationsBell } from "@/domains/home/components/notifications-bell"
 // The same amber dot HomeRecapRow puts on unread rows, top-right of the bell,
 // ringed in the top-bar surface color to separate it from the bell outline.
 const UNREAD_DOT_CLASS =
-  "-right-1 -top-1 h-3 w-3 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
+  "-right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
 
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
   return {


### PR DESCRIPTION
`CI Main Web` has been red on main since #39818. Two tests pin utility strings that PR intentionally changed:

| Test | Asserts | Component now renders |
|---|---|---|
| `collapsible-nav-section` | `text-body-medium-default` | `text-body-medium-lighter` |
| `notifications-bell` | dot with `h-3 w-3` | dot with `h-2.5 w-2.5` |

Both look like deliberate visual changes from a polish PR (lighter trigger type, slightly smaller unread dot), so the tests are stale rather than the components broken. Updated the expectations to match what ships.

**Worth a sanity check from whoever shipped #39818** that the lighter type and smaller dot are the intended end state. If either was accidental, the fix belongs in the component instead and this PR should be dropped.

Verified locally: `collapsible-nav-section` 8 pass, `notifications-bell` 5 pass.

## Note on these assertions

Both pin exact Tailwind utility strings, so any restyle of the same element breaks them and they can't distinguish a regression from an intentional change. I left that shape alone rather than loosening it, since it's the tests' owner's call and worth a separate conversation.

Found while investigating CI on #39821, which inherits these failures from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)