### PR TITLE
fix(errors): classify ChatGPT OAuth rate limits correctly

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -190,6 +190,29 @@ describe("classifyConversationError", () => {
       expect(result.userMessage).toContain("AI provider");
       expect(result.errorCategory).toBe("rate_limit");
     });
+
+    it("does not apply a managed LLM route to a plain rate-limit error", () => {
+      const result = classifyConversationError(
+        new Error("429 Too Many Requests from a tool API"),
+        {
+          ...baseCtx,
+          isManagedRoute: true,
+        },
+      );
+
+      expect(result.code).toBe("PROVIDER_RATE_LIMIT");
+      expect(result.errorCategory).toBe("rate_limit");
+    });
+
+    it("still recognizes a rewrapped Vellum quota body", () => {
+      const result = classifyConversationError(
+        new Error('429 {"code":"daily_quota_exceeded"}'),
+        baseCtx,
+      );
+
+      expect(result.code).toBe("MANAGED_USAGE_LIMIT");
+      expect(result.errorCategory).toBe("managed_usage_limit");
+    });
   });
 
   describe("provider overloaded errors", () => {

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -170,6 +170,26 @@ describe("classifyConversationError", () => {
       expect(result.userMessage).toContain("AI provider");
       expect(result.errorCategory).toBe("rate_limit");
     });
+
+    it("uses the ChatGPT OAuth route instead of the OpenAI registry default", () => {
+      providerRoutingSources.openai = "managed-proxy";
+      const err = new ProviderError(
+        "OpenAI API error (429): Too many requests",
+        "openai",
+        429,
+        { reason: "rate_limited" },
+      );
+
+      const result = classifyConversationError(err, {
+        ...baseCtx,
+        connectionName: "chatgpt-subscription",
+        isManagedRoute: false,
+      });
+
+      expect(result.code).toBe("PROVIDER_RATE_LIMIT");
+      expect(result.userMessage).toContain("AI provider");
+      expect(result.errorCategory).toBe("rate_limit");
+    });
   });
 
   describe("provider overloaded errors", () => {

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -254,6 +254,19 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("rate_limit");
     });
 
+    it("falls back to context for fields the failed call's route omits", () => {
+      const err = new ProviderError("Unauthorized", "anthropic", 401);
+      err.attachRouteAttribution({ profileName: "direct" });
+
+      const result = classifyConversationError(err, {
+        ...baseCtx,
+        connectionName: "anthropic-key",
+      });
+
+      expect(result.connectionName).toBe("anthropic-key");
+      expect(result.profileName).toBe("direct");
+    });
+
     it("still recognizes a rewrapped Vellum quota body", () => {
       const result = classifyConversationError(
         new Error('429 {"code":"daily_quota_exceeded"}'),

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -191,6 +191,56 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("rate_limit");
     });
 
+    it("prefers the failed call's direct route over stale managed turn attribution", () => {
+      providerRoutingSources.openai = "managed-proxy";
+      const err = new ProviderError(
+        "OpenAI API error (429): Too many requests",
+        "openai",
+        429,
+        { reason: "rate_limited" },
+      );
+      err.attachRouteAttribution({
+        connectionName: "chatgpt-subscription",
+        profileName: "chatgpt",
+        isManagedRoute: false,
+      });
+
+      const result = classifyConversationError(err, {
+        ...baseCtx,
+        connectionName: "vellum",
+        profileName: "managed",
+        isManagedRoute: true,
+      });
+
+      expect(result.code).toBe("PROVIDER_RATE_LIMIT");
+      expect(result.userMessage).toContain("AI provider");
+      expect(result.errorCategory).toBe("rate_limit");
+    });
+
+    it("prefers the failed call's managed fallback over stale direct turn attribution", () => {
+      const err = new ProviderError(
+        "Anthropic API error (429): Too many requests",
+        "anthropic",
+        429,
+        { reason: "rate_limited" },
+      );
+      err.attachRouteAttribution({
+        profileName: "direct",
+        isManagedRoute: true,
+      });
+
+      const result = classifyConversationError(err, {
+        ...baseCtx,
+        connectionName: "anthropic-key",
+        profileName: "direct",
+        isManagedRoute: false,
+      });
+
+      expect(result.code).toBe("MANAGED_USAGE_LIMIT");
+      expect(result.userMessage).toContain("Vellum managed inference");
+      expect(result.errorCategory).toBe("managed_usage_limit");
+    });
+
     it("does not apply a managed LLM route to a plain rate-limit error", () => {
       const result = classifyConversationError(
         new Error("429 Too Many Requests from a tool API"),

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -6,6 +6,7 @@ import { CODE_DEFAULT_PROFILE_ENTRIES } from "../config/default-profile-catalog.
 import {
   type ResolutionFallbackReason,
   resolveCallSiteConfig,
+  resolveCallSiteConfigWithProfile,
   resolveDefaultProfileKey,
   resolveEffectiveProfileKey,
 } from "../config/llm-resolver.js";
@@ -857,6 +858,21 @@ describe("mix profiles", () => {
     } else {
       expect(first.effort).toBe("high");
     }
+  });
+
+  test("config and profile attribution share one mix selection", () => {
+    const selectedArms: string[] = [];
+    const resolved = resolveCallSiteConfigWithProfile("mainAgent", mixLlm, {
+      onMixSelected: ({ chosenProfile }) => {
+        selectedArms.push(chosenProfile);
+      },
+    });
+
+    expect(resolved.profileName).toBe("ab");
+    expect(selectedArms).toHaveLength(1);
+    expect(resolved.config.model).toBe(
+      selectedArms[0] === "a" ? "model-a" : "model-b",
+    );
   });
 
   test("all dereference spots in a turn agree for the same seed", () => {

--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -27,6 +27,7 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
 import { setConfig } from "./helpers/set-config.js";
 
 const DUMMY_MESSAGES: Message[] = [
@@ -239,6 +240,82 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     expect(response.model).toBe("openai");
   });
 
+  test("CallSiteRoutingProvider attributes provider errors to the override profile route", async () => {
+    setLlmConfig({
+      profiles: {
+        fast: {
+          provider: "openai",
+          provider_connection: "openai-conn",
+          model: "gpt-5.4",
+        },
+      },
+    });
+
+    const providerError = new ProviderError(
+      "OpenAI API error (429): Too many requests",
+      "openai",
+      429,
+      { reason: "rate_limited" },
+    );
+    const defaultProvider = makeThrowingProvider(
+      "anthropic",
+      new Error("default provider should not be called"),
+    );
+    const altProvider = makeThrowingProvider("openai", providerError);
+    const wrapped = new CallSiteRoutingProvider(
+      defaultProvider,
+      async (connectionName) =>
+        connectionName === "openai-conn" ? altProvider : null,
+      true,
+    );
+
+    await expect(
+      wrapped.sendMessage(DUMMY_MESSAGES, {
+        config: { callSite: "mainAgent", overrideProfile: "fast" },
+      }),
+    ).rejects.toBe(providerError);
+    expect(providerError.routeAttribution).toEqual({
+      connectionName: "openai-conn",
+      profileName: "fast",
+      isManagedRoute: false,
+    });
+  });
+
+  test("CallSiteRoutingProvider attributes soft fallback errors to the default route", async () => {
+    setLlmConfig({
+      profiles: {
+        fast: {
+          provider: "openai",
+          provider_connection: "openai-conn",
+          model: "gpt-5.4",
+        },
+      },
+    });
+
+    const providerError = new ProviderError(
+      "Anthropic API error (429): Too many requests",
+      "anthropic",
+      429,
+      { reason: "rate_limited" },
+    );
+    const defaultProvider = makeThrowingProvider("anthropic", providerError);
+    const wrapped = new CallSiteRoutingProvider(
+      defaultProvider,
+      async () => null,
+      true,
+    );
+
+    await expect(
+      wrapped.sendMessage(DUMMY_MESSAGES, {
+        config: { callSite: "mainAgent", overrideProfile: "fast" },
+      }),
+    ).rejects.toBe(providerError);
+    expect(providerError.routeAttribution).toEqual({
+      profileName: "fast",
+      isManagedRoute: true,
+    });
+  });
+
   test("missing overrideProfile name silently falls through to base resolution", async () => {
     setLlmConfig({
       // The call-site tweak applies last in resolution, so it pins the model
@@ -327,6 +404,15 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     expect(captured?.overrideProfile).toBeUndefined();
   });
 });
+
+function makeThrowingProvider(name: string, error: Error): Provider {
+  return {
+    name,
+    async sendMessage(): Promise<ProviderResponse> {
+      throw error;
+    },
+  };
+}
 
 describe("SendMessageOptions.config.forceOverrideProfile", () => {
   test("CallSiteConfiguredProvider forwards forceOverrideProfile into the send config", async () => {

--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -240,7 +240,7 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     expect(response.model).toBe("openai");
   });
 
-  test("CallSiteRoutingProvider attributes provider errors to the override profile route", async () => {
+  test("CallSiteRoutingProvider attributes provider errors to the actual resolved connection", async () => {
     setLlmConfig({
       profiles: {
         fast: {
@@ -262,6 +262,10 @@ describe("SendMessageOptions.config.overrideProfile", () => {
       new Error("default provider should not be called"),
     );
     const altProvider = makeThrowingProvider("openai", providerError);
+    altProvider.routeAttribution = {
+      connectionName: "openai-recovered",
+      isManagedRoute: false,
+    };
     const wrapped = new CallSiteRoutingProvider(
       defaultProvider,
       async (connectionName) =>
@@ -275,7 +279,7 @@ describe("SendMessageOptions.config.overrideProfile", () => {
       }),
     ).rejects.toBe(providerError);
     expect(providerError.routeAttribution).toEqual({
-      connectionName: "openai-conn",
+      connectionName: "openai-recovered",
       profileName: "fast",
       isManagedRoute: false,
     });

--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -266,7 +266,7 @@ describe("SendMessageOptions.config.overrideProfile", () => {
       defaultProvider,
       async (connectionName) =>
         connectionName === "openai-conn" ? altProvider : null,
-      true,
+      { connectionName: "vellum", isManagedRoute: true },
     );
 
     await expect(
@@ -281,7 +281,7 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     });
   });
 
-  test("CallSiteRoutingProvider attributes soft fallback errors to the default route", async () => {
+  test("CallSiteRoutingProvider attributes soft fallback errors to the actual default connection", async () => {
     setLlmConfig({
       profiles: {
         fast: {
@@ -299,10 +299,14 @@ describe("SendMessageOptions.config.overrideProfile", () => {
       { reason: "rate_limited" },
     );
     const defaultProvider = makeThrowingProvider("anthropic", providerError);
+    defaultProvider.routeAttribution = {
+      connectionName: "anthropic-default",
+      isManagedRoute: false,
+    };
     const wrapped = new CallSiteRoutingProvider(
       defaultProvider,
       async () => null,
-      true,
+      defaultProvider.routeAttribution,
     );
 
     await expect(
@@ -311,8 +315,9 @@ describe("SendMessageOptions.config.overrideProfile", () => {
       }),
     ).rejects.toBe(providerError);
     expect(providerError.routeAttribution).toEqual({
+      connectionName: "anthropic-default",
       profileName: "fast",
-      isManagedRoute: true,
+      isManagedRoute: false,
     });
   });
 

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -114,12 +114,29 @@ export interface ResolveCallSiteOpts {
 
 export type ResolutionFallbackReason = "missing" | "disabled" | "incomplete";
 
+export interface ResolvedCallSiteConfig {
+  config: z.infer<typeof LLMConfigBase>;
+  profileName?: string;
+}
+
+export function resolveCallSiteConfigWithProfile(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts = {},
+): ResolvedCallSiteConfig {
+  const selection = selectWinningProfile(callSite, llm, opts);
+  return {
+    config: resolveOverrideOrDefault(callSite, llm, selection),
+    ...(selection.profileName ? { profileName: selection.profileName } : {}),
+  };
+}
+
 export function resolveCallSiteConfig(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
   opts: ResolveCallSiteOpts = {},
 ): z.infer<typeof LLMConfigBase> {
-  return resolveOverrideOrDefault(callSite, llm, opts);
+  return resolveCallSiteConfigWithProfile(callSite, llm, opts).config;
 }
 
 // ─── Single-winner profile resolution ───────────────────────────────────────
@@ -358,9 +375,8 @@ const CODE_DEFAULT_BASE: z.infer<typeof LLMConfigBase> = LLMConfigBase.parse(
 function resolveOverrideOrDefault(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
-  opts: ResolveCallSiteOpts,
+  selection: ProfileWinnerSelection,
 ): z.infer<typeof LLMConfigBase> {
-  const selection = selectWinningProfile(callSite, llm, opts);
   const winnerFragment: Mergeable =
     selection.entry == null ? {} : winnerConfigFragment(selection.entry);
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -120,6 +120,7 @@ import type { AssistantSurface } from "./conversation-agent-loop.js";
 import {
   buildConversationErrorMessage,
   classifyConversationError,
+  type ConversationErrorAttribution,
   maxTokensReachedClassification,
 } from "./conversation-error.js";
 import { buildDeferredFinalizeEffect } from "./conversation-turn-finalize.js";
@@ -548,6 +549,8 @@ export interface EventHandlerDeps {
    * degrades gracefully when it's absent.
    */
   readonly latencyTracker?: TurnLatencyTracker;
+  /** Best-effort resolved route metadata for provider error classification. */
+  readonly errorAttribution?: () => ConversationErrorAttribution;
 }
 
 // ── Factory ──────────────────────────────────────────────────────────
@@ -2620,9 +2623,7 @@ function handleError(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "error" }>,
 ): void {
-  const classified = classifyConversationError(event.error, {
-    phase: "agent_loop",
-  });
+  const classified = classifyAgentLoopError(event.error, deps);
   if (classified.errorCategory === "provider_api_error") {
     log.error(
       {
@@ -3131,9 +3132,7 @@ function handleProviderError(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "provider_error" }>,
 ): void {
-  const classified = classifyConversationError(event.error, {
-    phase: "agent_loop",
-  });
+  const classified = classifyAgentLoopError(event.error, deps);
   if (!shouldPersistProviderErrorAsAssistantMessage(classified)) {
     return;
   }
@@ -3153,6 +3152,16 @@ function handleProviderError(
       "Failed to persist provider-error LLM request log (non-fatal)",
     );
   }
+}
+
+function classifyAgentLoopError(
+  error: Error,
+  deps: EventHandlerDeps,
+): ReturnType<typeof classifyConversationError> {
+  return classifyConversationError(error, {
+    phase: "agent_loop",
+    ...deps.errorAttribution?.(),
+  });
 }
 
 // ── Dispatcher ───────────────────────────────────────────────────────

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -60,13 +60,13 @@ import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import { runHook } from "../plugins/pipeline.js";
+import { isManagedConnectionRoute } from "../providers/connection-resolution.js";
 import {
   ConnectionResolutionError,
   resolveRoutingIdentity,
 } from "../providers/routing-identity.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
-import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
@@ -435,14 +435,17 @@ export async function runAgentLoopImpl(
         }
         connectionName = error.connectionName;
       }
+      // Managed-ness comes from the connection row, matching what dispatch
+      // decides. The profile's own provider can't stand in: a concrete
+      // provider tweak over a managed winner keeps the managed connection
+      // while replacing the provider (`llm-resolver.ts`).
+      const isManagedRoute = connectionName
+        ? isManagedConnectionRoute(connectionName)
+        : undefined;
       return {
         ...(connectionName ? { connectionName } : {}),
         ...(profileName ? { profileName } : {}),
-        ...(connectionName
-          ? {
-              isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
-            }
-          : {}),
+        ...(isManagedRoute !== undefined ? { isManagedRoute } : {}),
       };
     } catch {
       return {};

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -60,7 +60,10 @@ import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import { runHook } from "../plugins/pipeline.js";
-import { resolveRoutingIdentity } from "../providers/routing-identity.js";
+import {
+  ConnectionResolutionError,
+  resolveRoutingIdentity,
+} from "../providers/routing-identity.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
@@ -429,22 +432,25 @@ export async function runAgentLoopImpl(
         config.llm,
         resolveOpts,
       );
-      const routingIdentity = resolveRoutingIdentity(
-        resolved.provider,
-        resolved.model,
-      );
-      const connectionName =
-        routingIdentity?.connectionName ?? resolved.provider_connection;
-      const isManagedRoute =
-        connectionName === VELLUM_MANAGED_CONNECTION_NAME
-          ? true
-          : routingIdentity
-            ? false
-            : undefined;
+      let connectionName = resolved.provider_connection;
+      try {
+        connectionName =
+          resolveRoutingIdentity(resolved.provider, resolved.model)
+            ?.connectionName ?? connectionName;
+      } catch (error) {
+        if (!(error instanceof ConnectionResolutionError)) {
+          throw error;
+        }
+        connectionName = error.connectionName;
+      }
       return {
         ...(connectionName ? { connectionName } : {}),
         ...(profileName ? { profileName } : {}),
-        ...(isManagedRoute !== undefined ? { isManagedRoute } : {}),
+        ...(connectionName
+          ? {
+              isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+            }
+          : {}),
       };
     } catch {
       return {};

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -30,7 +30,7 @@ import {
 } from "../config/llm-context-resolution.js";
 import {
   resolveCallSiteConfig,
-  resolveEffectiveProfileKey,
+  resolveCallSiteConfigWithProfile,
   resolveProfilelessModelKey,
   selectWinningProfile,
 } from "../config/llm-resolver.js";
@@ -422,16 +422,8 @@ export async function runAgentLoopImpl(
         forceOverrideProfile,
         selectionSeed: ctx.conversationId,
       };
-      const resolved = resolveCallSiteConfig(
-        turnCallSite,
-        config.llm,
-        resolveOpts,
-      );
-      const profileName = resolveEffectiveProfileKey(
-        turnCallSite,
-        config.llm,
-        resolveOpts,
-      );
+      const { config: resolved, profileName } =
+        resolveCallSiteConfigWithProfile(turnCallSite, config.llm, resolveOpts);
       let connectionName = resolved.provider_connection;
       try {
         connectionName =

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -60,8 +60,10 @@ import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import { runHook } from "../plugins/pipeline.js";
+import { resolveRoutingIdentity } from "../providers/routing-identity.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
+import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
@@ -94,6 +96,7 @@ import {
   budgetYieldUnrecoveredClassification,
   buildConversationErrorMessage,
   classifyConversationError,
+  type ConversationErrorAttribution,
   isUserCancellation,
 } from "./conversation-error.js";
 import { raceWithTimeout } from "./conversation-media-retry.js";
@@ -408,10 +411,7 @@ export async function runAgentLoopImpl(
   // connection and profile so credential/connection errors point at the
   // exact slot to fix instead of a generic banner. Resolution can itself
   // throw on a broken config — attribution must never mask the real error.
-  const turnErrorAttribution = (): {
-    connectionName?: string;
-    profileName?: string;
-  } => {
+  const turnErrorAttribution = (): ConversationErrorAttribution => {
     try {
       const overrideProfile = readCurrentOverrideProfile();
       const resolveOpts = {
@@ -429,11 +429,22 @@ export async function runAgentLoopImpl(
         config.llm,
         resolveOpts,
       );
+      const routingIdentity = resolveRoutingIdentity(
+        resolved.provider,
+        resolved.model,
+      );
+      const connectionName =
+        routingIdentity?.connectionName ?? resolved.provider_connection;
+      const isManagedRoute =
+        connectionName === VELLUM_MANAGED_CONNECTION_NAME
+          ? true
+          : routingIdentity
+            ? false
+            : undefined;
       return {
-        ...(resolved.provider_connection
-          ? { connectionName: resolved.provider_connection }
-          : {}),
+        ...(connectionName ? { connectionName } : {}),
         ...(profileName ? { profileName } : {}),
+        ...(isManagedRoute !== undefined ? { isManagedRoute } : {}),
       };
     } catch {
       return {};
@@ -1035,6 +1046,7 @@ export async function runAgentLoopImpl(
       turnInterfaceContext: capturedTurnInterfaceContext,
       applyCompaction: applySuccessfulCompaction,
       latencyTracker,
+      errorAttribution: turnErrorAttribution,
     };
     const eventHandler = (event: AgentEvent): Promise<void> => {
       if (

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -260,22 +260,19 @@ export function classifyConversationError(
   // credential-related classifications can name the exact slot to fix.
   // A `ProviderNotConfiguredError` instance carries its own attribution
   // (from the throw site) which takes priority over context when present.
+  // The failed call's own route wins field by field — it is resolved at
+  // dispatch, while context describes the turn and can be stale for this
+  // call. Per-field, so a route carrying only some fields doesn't blank the
+  // rest.
   const providerRoute =
     error instanceof ProviderError ? error.routeAttribution : undefined;
+  const connectionName = providerRoute?.connectionName ?? ctx.connectionName;
   const profileName = providerRoute?.profileName ?? ctx.profileName;
+  const isManagedRoute = providerRoute?.isManagedRoute ?? ctx.isManagedRoute;
   const attribution: ConversationErrorAttribution = {
-    ...(providerRoute === undefined && ctx.connectionName
-      ? { connectionName: ctx.connectionName }
-      : {}),
-    ...(providerRoute?.connectionName
-      ? { connectionName: providerRoute.connectionName }
-      : {}),
+    ...(connectionName ? { connectionName } : {}),
     ...(profileName ? { profileName } : {}),
-    ...(providerRoute?.isManagedRoute !== undefined
-      ? { isManagedRoute: providerRoute.isManagedRoute }
-      : providerRoute === undefined && ctx.isManagedRoute !== undefined
-        ? { isManagedRoute: ctx.isManagedRoute }
-        : {}),
+    ...(isManagedRoute !== undefined ? { isManagedRoute } : {}),
   };
 
   // Dedicated classification for missing provider API key

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -365,8 +365,8 @@ function classifyCore(
   attribution: ConversationErrorAttribution = {},
 ): Omit<ClassifiedConversationError, "debugDetails"> {
   const isManagedRoute =
-    attribution.isManagedRoute ??
-    (error instanceof ProviderError &&
+    error instanceof ProviderError &&
+    (attribution.isManagedRoute ??
       getProviderRoutingSource(error.provider) === "managed-proxy");
 
   // Prefer the semantic reason stamped by the provider layer, regardless of

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -63,6 +63,8 @@ export interface ClassifiedConversationError {
 export interface ConversationErrorAttribution {
   connectionName?: string;
   profileName?: string;
+  /** Whether the resolved turn route uses Vellum-managed inference. */
+  isManagedRoute?: boolean;
 }
 
 // Network-level error patterns (connection refused, timeout, DNS, reset)
@@ -181,6 +183,11 @@ export interface ErrorContext {
    * underlying connection name is generic.
    */
   profileName?: string;
+  /**
+   * Whether the resolved turn route uses Vellum-managed inference. Turn routing
+   * takes precedence over the provider registry's boot-time default.
+   */
+  isManagedRoute?: boolean;
 }
 
 /**
@@ -256,6 +263,9 @@ export function classifyConversationError(
   const attribution: ConversationErrorAttribution = {
     ...(ctx.connectionName ? { connectionName: ctx.connectionName } : {}),
     ...(ctx.profileName ? { profileName: ctx.profileName } : {}),
+    ...(ctx.isManagedRoute !== undefined
+      ? { isManagedRoute: ctx.isManagedRoute }
+      : {}),
   };
 
   // Dedicated classification for missing provider API key
@@ -354,13 +364,18 @@ function classifyCore(
   message: string,
   attribution: ConversationErrorAttribution = {},
 ): Omit<ClassifiedConversationError, "debugDetails"> {
+  const isManagedRoute =
+    attribution.isManagedRoute ??
+    (error instanceof ProviderError &&
+      getProviderRoutingSource(error.provider) === "managed-proxy");
+
   // Prefer the semantic reason stamped by the provider layer, regardless of
   // HTTP status — statusless errors (e.g. SDK streaming failures) still carry a
   // reason. Reasons that map cleanly win here; `bad_request`/`unknown` (and a
   // reason-less error) fall through to the status switch + regex battery below.
   if (error instanceof ProviderError && error.reason) {
     const c = reasonToClassification(error.reason, {
-      routingSource: getProviderRoutingSource(error.provider),
+      isManagedRoute,
       attribution,
       message,
     });
@@ -382,20 +397,19 @@ function classifyCore(
       // Everything else is a user-set credential that the upstream provider
       // rejected, so emit `PROVIDER_INVALID_KEY` and let the chat banner point
       // at Settings.
-      const providerName = error.provider;
-      if (getProviderRoutingSource(providerName) === "managed-proxy") {
+      if (isManagedRoute) {
         return managedKeyInvalidClassification();
       }
       return invalidApiKeyClassification(attribution);
     }
     if (error.statusCode === 402) {
-      if (isManagedBalanceError(error)) {
+      if (isManagedRoute) {
         return managedBalanceClassification();
       }
       return providerBillingClassification();
     }
     if (error.statusCode === 429) {
-      if (isManagedUsageLimitError(error, message)) {
+      if (isManagedUsageLimitError(message, isManagedRoute)) {
         return managedUsageLimitClassification();
       }
       return rateLimitClassification();
@@ -508,7 +522,7 @@ function classifyCore(
   }
 
   // Regex fallback for non-ProviderError or ProviderError without statusCode
-  return classifyByMessage(error, message);
+  return classifyByMessage(message, isManagedRoute);
 }
 
 /**
@@ -540,12 +554,12 @@ function extractProviderDetail(message: string): string | undefined {
 function reasonToClassification(
   reason: ProviderErrorReason,
   args: {
-    routingSource?: string;
+    isManagedRoute: boolean;
     attribution?: ConversationErrorAttribution;
     message: string;
   },
 ): Omit<ClassifiedConversationError, "debugDetails"> | null {
-  const managed = args.routingSource === "managed-proxy";
+  const managed = args.isManagedRoute;
   switch (reason) {
     case "invalid_credentials":
       return managed
@@ -670,18 +684,13 @@ function isStreamingError(message: string): boolean {
   return STREAMING_ERROR_PATTERNS.some((p) => p.test(message));
 }
 
-function isManagedUsageLimitError(error: unknown, message: string): boolean {
-  if (
-    error instanceof ProviderError &&
-    getProviderRoutingSource(error.provider) === "managed-proxy"
-  ) {
-    return true;
-  }
-  return MANAGED_USAGE_LIMIT_PATTERNS.some((p) => p.test(message));
-}
-
-function isManagedBalanceError(error: ProviderError): boolean {
-  return getProviderRoutingSource(error.provider) === "managed-proxy";
+function isManagedUsageLimitError(
+  message: string,
+  isManagedRoute: boolean,
+): boolean {
+  return (
+    isManagedRoute || MANAGED_USAGE_LIMIT_PATTERNS.some((p) => p.test(message))
+  );
 }
 
 function isProviderBillingError(message: string): boolean {
@@ -906,8 +915,8 @@ function providerNotConfiguredClassification(
  * short-circuit and the status switch both decline to classify.
  */
 function classifyByMessage(
-  error: unknown,
   message: string,
+  isManagedRoute: boolean,
 ): Omit<ClassifiedConversationError, "debugDetails"> {
   // Empty-request-messages is always an internal construction failure — check
   // it before the provider/network patterns so a ProviderError that carries the
@@ -924,7 +933,7 @@ function classifyByMessage(
   // Check rate limit first (before network, since 429 could match both)
   for (const pattern of RATE_LIMIT_PATTERNS) {
     if (pattern.test(message)) {
-      if (isManagedUsageLimitError(error, message)) {
+      if (isManagedUsageLimitError(message, isManagedRoute)) {
         return managedUsageLimitClassification();
       }
       return rateLimitClassification();

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -260,12 +260,22 @@ export function classifyConversationError(
   // credential-related classifications can name the exact slot to fix.
   // A `ProviderNotConfiguredError` instance carries its own attribution
   // (from the throw site) which takes priority over context when present.
+  const providerRoute =
+    error instanceof ProviderError ? error.routeAttribution : undefined;
+  const profileName = providerRoute?.profileName ?? ctx.profileName;
   const attribution: ConversationErrorAttribution = {
-    ...(ctx.connectionName ? { connectionName: ctx.connectionName } : {}),
-    ...(ctx.profileName ? { profileName: ctx.profileName } : {}),
-    ...(ctx.isManagedRoute !== undefined
-      ? { isManagedRoute: ctx.isManagedRoute }
+    ...(providerRoute === undefined && ctx.connectionName
+      ? { connectionName: ctx.connectionName }
       : {}),
+    ...(providerRoute?.connectionName
+      ? { connectionName: providerRoute.connectionName }
+      : {}),
+    ...(profileName ? { profileName } : {}),
+    ...(providerRoute?.isManagedRoute !== undefined
+      ? { isManagedRoute: providerRoute.isManagedRoute }
+      : providerRoute === undefined && ctx.isManagedRoute !== undefined
+        ? { isManagedRoute: ctx.isManagedRoute }
+        : {}),
   };
 
   // Dedicated classification for missing provider API key

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -407,7 +407,14 @@ describe("routing identities", () => {
       "claude-opus-4-8",
     );
 
-    expect(provider).toEqual({ name: "anthropic", tag: "managed" } as never);
+    expect(provider).toEqual({
+      name: "anthropic",
+      tag: "managed",
+      routeAttribution: {
+        connectionName: "vellum",
+        isManagedRoute: true,
+      },
+    } as never);
     expect(resolveProviderCalls[0]?.name).toBe("vellum");
     expect(resolveProviderOpts[0]?.providerOverride).toBe("anthropic");
   });
@@ -433,7 +440,14 @@ describe("routing identities", () => {
       "gpt-5.5",
     );
 
-    expect(provider).toEqual({ name: "openai", tag: "subscription" } as never);
+    expect(provider).toEqual({
+      name: "openai",
+      tag: "subscription",
+      routeAttribution: {
+        connectionName: "chatgpt-subscription",
+        isManagedRoute: false,
+      },
+    } as never);
     expect(resolveProviderCalls[0]?.name).toBe("chatgpt-subscription");
     // No override needed: the subscription row itself carries provider
     // "openai", so the adapter resolves from the row.

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -454,6 +454,30 @@ describe("routing identities", () => {
     expect(resolveProviderCalls[0]?.provider).toBe("openai");
   });
 
+  test("named platform-auth connections carry managed route attribution", async () => {
+    fakeConnections.set("managed-openai", {
+      name: "managed-openai",
+      provider: "openai",
+      auth: { type: "platform" },
+    });
+    fakeProviders.set("conn:managed-openai", {
+      name: "openai",
+      tag: "managed",
+    });
+
+    const provider = await tryResolveProviderForConnectionName(
+      "managed-openai",
+      { llm: {} } as never,
+      "openai",
+      "gpt-5.5",
+    );
+
+    expect(provider?.routeAttribution).toEqual({
+      connectionName: "managed-openai",
+      isManagedRoute: true,
+    });
+  });
+
   test("chatgpt identity with no subscription row throws not_found (never a silent fallback)", async () => {
     await expect(
       tryResolveProviderForConnectionName(

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -454,10 +454,13 @@ describe("routing identities", () => {
     expect(resolveProviderCalls[0]?.provider).toBe("openai");
   });
 
-  test("named platform-auth connections carry managed route attribution", async () => {
+  // A second managed row is creatable under any non-reserved name: only the
+  // canonical name is refused at the create route, and `provider: "vellum"`
+  // derives platform auth. Managed-ness is the row, never its name.
+  test("a managed row under a non-canonical name carries managed route attribution", async () => {
     fakeConnections.set("managed-openai", {
       name: "managed-openai",
-      provider: "openai",
+      provider: "vellum",
       auth: { type: "platform" },
     });
     fakeProviders.set("conn:managed-openai", {

--- a/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-mismatch-routing.test.ts
@@ -86,6 +86,10 @@ describe("vellum connection mismatch handling", () => {
       "accounts/fireworks/models/kimi-k2p5",
     );
     expect(provider).not.toBeNull();
+    expect(provider?.routeAttribution).toEqual({
+      connectionName: "vellum",
+      isManagedRoute: true,
+    });
     expect(resolveCalls).toHaveLength(1);
     expect(resolveCalls[0].connection.name).toBe("vellum");
     expect(resolveCalls[0].opts.providerOverride).toBe("fireworks");
@@ -129,6 +133,10 @@ describe("vellum connection mismatch handling", () => {
       "anthropic/claude-fable-5",
     );
     expect(provider).not.toBeNull();
+    expect(provider?.routeAttribution).toEqual({
+      connectionName: "openrouter-personal",
+      isManagedRoute: false,
+    });
     expect(resolveCalls).toHaveLength(1);
     expect(resolveCalls[0].connection.name).toBe("openrouter-personal");
     expect(resolveCalls[0].opts.providerOverride).toBeUndefined();

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -27,7 +27,10 @@ import {
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
-import { ProviderError } from "../util/errors.js";
+import {
+  ProviderError,
+  type ProviderRouteAttribution,
+} from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
@@ -40,10 +43,7 @@ import {
 } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import type { ProvidersConfig } from "./registry.js";
-import {
-  getProviderRoutingSource,
-  shouldUseNativeWebSearch,
-} from "./registry.js";
+import { shouldUseNativeWebSearch } from "./registry.js";
 import { recordProviderRequestDiagnostics } from "./request-diagnostics.js";
 import type {
   Message,
@@ -115,7 +115,7 @@ export class CallSiteRoutingProvider implements Provider {
       expectedProvider: string,
       model: string | undefined,
     ) => Promise<Provider | null>,
-    private readonly defaultIsManagedRoute?: boolean,
+    private readonly defaultRouteAttribution?: ProviderRouteAttribution,
   ) {
     this.tokenEstimationProvider = defaultProvider.tokenEstimationProvider;
     this.supportsNativeWebSearch = defaultProvider.supportsNativeWebSearch;
@@ -366,10 +366,8 @@ export class CallSiteRoutingProvider implements Provider {
   private defaultRoute(profileName?: string): SelectedProviderRoute {
     return {
       provider: this.defaultProvider,
+      ...this.defaultRouteAttribution,
       ...(profileName ? { profileName } : {}),
-      ...(this.defaultIsManagedRoute !== undefined
-        ? { isManagedRoute: this.defaultIsManagedRoute }
-        : {}),
     };
   }
 }
@@ -387,7 +385,6 @@ export function wrapWithCallSiteRouting(
   base: Provider,
   config: ProvidersConfig,
 ): Provider {
-  const routingSource = getProviderRoutingSource(base.name);
   return new CallSiteRoutingProvider(
     base,
     (connectionName, expectedProvider, model) =>
@@ -397,6 +394,6 @@ export function wrapWithCallSiteRouting(
         expectedProvider,
         model,
       ),
-    routingSource === undefined ? undefined : routingSource === "managed-proxy",
+    base.routeAttribution,
   );
 }

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -21,9 +21,13 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  resolveCallSiteConfigWithProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
+import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
@@ -36,7 +40,10 @@ import {
 } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import type { ProvidersConfig } from "./registry.js";
-import { shouldUseNativeWebSearch } from "./registry.js";
+import {
+  getProviderRoutingSource,
+  shouldUseNativeWebSearch,
+} from "./registry.js";
 import { recordProviderRequestDiagnostics } from "./request-diagnostics.js";
 import type {
   Message,
@@ -44,8 +51,17 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "./types.js";
+import { VELLUM_MANAGED_CONNECTION_NAME } from "./vellum-model-routing.js";
 
 const log = getLogger("providers/call-site-routing");
+
+interface SelectedProviderRoute {
+  provider: Provider;
+  connectionName?: string;
+  profileName?: string;
+  isManagedRoute?: boolean;
+}
+
 export class CallSiteRoutingProvider implements Provider {
   public readonly tokenEstimationProvider?: string;
   // Forward native web-search capability so it survives the wrapper chain
@@ -99,6 +115,7 @@ export class CallSiteRoutingProvider implements Provider {
       expectedProvider: string,
       model: string | undefined,
     ) => Promise<Provider | null>,
+    private readonly defaultIsManagedRoute?: boolean,
   ) {
     this.tokenEstimationProvider = defaultProvider.tokenEstimationProvider;
     this.supportsNativeWebSearch = defaultProvider.supportsNativeWebSearch;
@@ -112,11 +129,30 @@ export class CallSiteRoutingProvider implements Provider {
     messages: Message[],
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
-    const target = await this.selectProvider(options);
+    const selectedRoute = await this.selectProvider(options);
+    const target = selectedRoute.provider;
     const isRouted = target !== this.defaultProvider;
 
     const doSend = async (): Promise<ProviderResponse> => {
-      const response = await target.sendMessage(messages, options);
+      let response: ProviderResponse;
+      try {
+        response = await target.sendMessage(messages, options);
+      } catch (error) {
+        if (error instanceof ProviderError) {
+          error.attachRouteAttribution({
+            ...(selectedRoute.connectionName
+              ? { connectionName: selectedRoute.connectionName }
+              : {}),
+            ...(selectedRoute.profileName
+              ? { profileName: selectedRoute.profileName }
+              : {}),
+            ...(selectedRoute.isManagedRoute !== undefined
+              ? { isManagedRoute: selectedRoute.isManagedRoute }
+              : {}),
+          });
+        }
+        throw error;
+      }
       // Also stamp actualProvider on the response so that handleUsage
       // (which reads event.actualProvider, not provider.name) attributes
       // the call to the right provider.
@@ -199,10 +235,10 @@ export class CallSiteRoutingProvider implements Provider {
    */
   private async selectProvider(
     options?: SendMessageOptions,
-  ): Promise<Provider> {
+  ): Promise<SelectedProviderRoute> {
     const callSite = options?.config?.callSite;
     if (!callSite) {
-      return this.defaultProvider;
+      return this.defaultRoute();
     }
 
     const overrideProfile = options?.config?.overrideProfile;
@@ -213,11 +249,15 @@ export class CallSiteRoutingProvider implements Provider {
     // request params.
     const forceOverrideProfile = options?.config?.forceOverrideProfile;
     const selectionSeed = options?.config?.selectionSeed;
-    const resolved = resolveCallSiteConfig(callSite, getConfig().llm, {
-      overrideProfile,
-      forceOverrideProfile,
-      selectionSeed,
-    });
+    const { config: resolved, profileName } = resolveCallSiteConfigWithProfile(
+      callSite,
+      getConfig().llm,
+      {
+        overrideProfile,
+        forceOverrideProfile,
+        selectionSeed,
+      },
+    );
 
     let connectionName = resolved.provider_connection;
 
@@ -273,7 +313,12 @@ export class CallSiteRoutingProvider implements Provider {
         // so a connection that fell back to the default transport is not
         // reported as the one that signed the request.
         recordProviderRequestDiagnostics({ connection_name: connectionName });
-        return connectionProvider;
+        return {
+          provider: connectionProvider,
+          connectionName,
+          ...(profileName ? { profileName } : {}),
+          isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+        };
       }
       // Soft credential failure: the routed connection yielded no usable
       // adapter and dispatch is landing on the default transport, which may
@@ -289,11 +334,11 @@ export class CallSiteRoutingProvider implements Provider {
         },
         "Routed connection yielded no adapter — falling back to the default transport",
       );
-      return this.defaultProvider;
+      return this.defaultRoute(profileName);
     }
 
     if (resolved.provider === this.defaultProvider.name) {
-      return this.defaultProvider;
+      return this.defaultRoute(profileName);
     }
 
     if (autoResolveCandidates) {
@@ -317,6 +362,16 @@ export class CallSiteRoutingProvider implements Provider {
       `call-site "${callSite}" resolves to provider "${resolved.provider}" but no provider_connection is set — alternate-provider routing requires a connection`,
     );
   }
+
+  private defaultRoute(profileName?: string): SelectedProviderRoute {
+    return {
+      provider: this.defaultProvider,
+      ...(profileName ? { profileName } : {}),
+      ...(this.defaultIsManagedRoute !== undefined
+        ? { isManagedRoute: this.defaultIsManagedRoute }
+        : {}),
+    };
+  }
 }
 
 /**
@@ -332,6 +387,7 @@ export function wrapWithCallSiteRouting(
   base: Provider,
   config: ProvidersConfig,
 ): Provider {
+  const routingSource = getProviderRoutingSource(base.name);
   return new CallSiteRoutingProvider(
     base,
     (connectionName, expectedProvider, model) =>
@@ -341,5 +397,6 @@ export function wrapWithCallSiteRouting(
         expectedProvider,
         model,
       ),
+    routingSource === undefined ? undefined : routingSource === "managed-proxy",
   );
 }

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -307,17 +307,26 @@ export class CallSiteRoutingProvider implements Provider {
         resolved.model,
       );
       if (connectionProvider) {
+        const actualRoute = {
+          connectionName:
+            connectionProvider.routeAttribution?.connectionName ??
+            connectionName,
+          isManagedRoute:
+            connectionProvider.routeAttribution?.isManagedRoute ??
+            connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+        };
         // The connection whose credential the call authenticates with is only
         // known here, and diagnostics for a failed request are unactionable
         // without it ("which key was this?"). Recorded once the adapter exists,
         // so a connection that fell back to the default transport is not
         // reported as the one that signed the request.
-        recordProviderRequestDiagnostics({ connection_name: connectionName });
+        recordProviderRequestDiagnostics({
+          connection_name: actualRoute.connectionName,
+        });
         return {
           provider: connectionProvider,
-          connectionName,
+          ...actualRoute,
           ...(profileName ? { profileName } : {}),
-          isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
         };
       }
       // Soft credential failure: the routed connection yielded no usable

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -38,6 +38,7 @@ import {
 } from "./connection-model-compat.js";
 import {
   ConnectionResolutionError,
+  isManagedConnectionRoute,
   resolveRoutingIdentity,
   tryResolveProviderForConnectionName,
 } from "./connection-resolution.js";
@@ -51,7 +52,6 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "./types.js";
-import { VELLUM_MANAGED_CONNECTION_NAME } from "./vellum-model-routing.js";
 
 const log = getLogger("providers/call-site-routing");
 
@@ -313,7 +313,7 @@ export class CallSiteRoutingProvider implements Provider {
             connectionName,
           isManagedRoute:
             connectionProvider.routeAttribution?.isManagedRoute ??
-            connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+            isManagedConnectionRoute(connectionName),
         };
         // The connection whose credential the call authenticates with is only
         // known here, and diagnostics for a failed request are unactionable

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -132,11 +132,12 @@ export async function tryResolveProviderForConnectionName(
     connectionName === VELLUM_MANAGED_CONNECTION_NAME &&
     !isVellumManagedConnection(connection)
   ) {
-    return resolveThroughPlatform(
+    const provider = await resolveThroughPlatform(
       config,
       expectedProvider ?? declaredProvider,
       model,
     );
+    return attachProviderRoute(provider, VELLUM_MANAGED_CONNECTION_NAME);
   }
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
@@ -221,10 +222,11 @@ export async function tryResolveProviderForConnectionName(
   // catch is specifically for in-flight failures that should not take
   // dispatch offline.
   try {
-    return await resolveProviderFromConnection(connection, config, {
+    const provider = await resolveProviderFromConnection(connection, config, {
       model,
       providerOverride: isVellumRoute ? expectedProvider : undefined,
     });
+    return attachProviderRoute(provider, connection.name);
   } catch (err) {
     log.warn(
       { err, connectionName },
@@ -232,6 +234,19 @@ export async function tryResolveProviderForConnectionName(
     );
     return null;
   }
+}
+
+function attachProviderRoute(
+  provider: Provider | null,
+  connectionName: string,
+): Provider | null {
+  if (provider) {
+    provider.routeAttribution = {
+      connectionName,
+      isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+    };
+  }
+  return provider;
 }
 
 /**

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -137,7 +137,7 @@ export async function tryResolveProviderForConnectionName(
       expectedProvider ?? declaredProvider,
       model,
     );
-    return attachProviderRoute(provider, VELLUM_MANAGED_CONNECTION_NAME);
+    return attachProviderRoute(provider, canonicalVellumConnection());
   }
   // The provider-agnostic Vellum-managed connection carries only the `vellum`
   // sentinel, so the usual `connection.provider === expectedProvider` equality
@@ -226,7 +226,7 @@ export async function tryResolveProviderForConnectionName(
       model,
       providerOverride: isVellumRoute ? expectedProvider : undefined,
     });
-    return attachProviderRoute(provider, connection.name);
+    return attachProviderRoute(provider, connection);
   } catch (err) {
     log.warn(
       { err, connectionName },
@@ -238,12 +238,12 @@ export async function tryResolveProviderForConnectionName(
 
 function attachProviderRoute(
   provider: Provider | null,
-  connectionName: string,
+  connection: { name: string; auth: { type: string } },
 ): Provider | null {
   if (provider) {
     provider.routeAttribution = {
-      connectionName,
-      isManagedRoute: connectionName === VELLUM_MANAGED_CONNECTION_NAME,
+      connectionName: connection.name,
+      isManagedRoute: connection.auth.type === "platform",
     };
   }
   return provider;

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -238,15 +238,40 @@ export async function tryResolveProviderForConnectionName(
 
 function attachProviderRoute(
   provider: Provider | null,
-  connection: { name: string; auth: { type: string } },
+  connection: { name: string; provider: string; auth: { type: string } },
 ): Provider | null {
   if (provider) {
     provider.routeAttribution = {
       connectionName: connection.name,
-      isManagedRoute: connection.auth.type === "platform",
+      isManagedRoute: isVellumManagedConnection(connection),
     };
   }
   return provider;
+}
+
+/**
+ * Whether a route through this connection name is Vellum-managed
+ * (platform-billed), for callers that hold only the name. Returns undefined
+ * when the row can't be read, so the caller can fall back rather than assert
+ * a BYOK route it never confirmed.
+ *
+ * The canonical name is always managed: a user-owned row claiming it is
+ * ignored and the route resolves through platform auth regardless (see
+ * `tryResolveProviderForConnectionName`).
+ */
+export function isManagedConnectionRoute(
+  connectionName: string,
+): boolean | undefined {
+  if (connectionName === VELLUM_MANAGED_CONNECTION_NAME) {
+    return true;
+  }
+  let connection;
+  try {
+    connection = getConnection(getDb(), connectionName);
+  } catch {
+    return undefined;
+  }
+  return connection ? isVellumManagedConnection(connection) : undefined;
 }
 
 /**

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -2,7 +2,11 @@ import type { ToolDefinition } from "../tools/tool-types.js";
 export type { ToolDefinition };
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
+import {
+  ProviderError,
+  type ProviderErrorReason,
+  type ProviderRouteAttribution,
+} from "../util/errors.js";
 
 export interface TextContent {
   type: "text";
@@ -359,6 +363,8 @@ export interface SendMessageOptions {
 
 export interface Provider {
   name: string;
+  /** Connection route whose credentials this provider instance uses. */
+  routeAttribution?: ProviderRouteAttribution;
   /**
    * Provider key used by the local token estimator to select model-family
    * specific rules (e.g. Anthropic's `width * height / 750` image sizing).

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -123,6 +123,12 @@ export type ProviderErrorReason =
   | "network_error"
   | "unknown";
 
+export interface ProviderRouteAttribution {
+  connectionName?: string;
+  profileName?: string;
+  isManagedRoute?: boolean;
+}
+
 export class ProviderError extends AssistantError {
   /** Delay (in ms) suggested by the server's Retry-After header, if present. */
   public readonly retryAfterMs?: number;
@@ -146,6 +152,8 @@ export class ProviderError extends AssistantError {
   public readonly abortReason?: unknown;
   /** Semantic failure classification stamped at the throw site. */
   public readonly reason?: ProviderErrorReason;
+  /** Transport route selected for the failed provider call. */
+  public routeAttribution?: ProviderRouteAttribution;
 
   constructor(
     message: string,
@@ -173,6 +181,13 @@ export class ProviderError extends AssistantError {
     this.rawBody = options?.rawBody;
     this.abortReason = options?.abortReason;
     this.reason = options?.reason;
+  }
+
+  attachRouteAttribution(attribution: ProviderRouteAttribution): void {
+    this.routeAttribution = {
+      ...attribution,
+      ...this.routeAttribution,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

- Carry resolved managed-route context into agent-loop provider error classification.
- Keep ChatGPT subscription OAuth 429s as upstream provider rate limits when the OpenAI boot default uses the managed proxy.
- Add regression coverage for the conflicting route sources.

## Original prompt

Fix the ChatGPT OAuth rate-limit misclassification found in the previous task.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->