### PR TITLE
refactor(web): move subagent panel controls onto design-library buttons

### DIFF
--- a/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
+++ b/clients/web/src/domains/chat/components/detail-panel-stop-button.tsx
@@ -4,11 +4,19 @@
  * shared right-aligned header control, distinct from the inline cards'
  * `dangerGhost` icon-only stop. Keeping both panels on this one component stops
  * their headers from drifting apart.
+ *
+ * `rounded-lg` matches the sibling Back/Close buttons in the same header, which
+ * override the design-library default the same way.
+ *
+ * The hover override keeps this button's weak-fill hover instead of
+ * `dangerOutline`'s text/border recolor. Letting the recolor land on top of the
+ * fill drops the label to ~2.4:1 in light and ~2.0:1 in dark; holding the
+ * foreground at `--system-negative-strong` keeps it at ~3.2:1 / ~2.9:1.
  */
 
 import { Square } from "lucide-react";
 
-import { Typography } from "@vellumai/design-library";
+import { Button, Typography } from "@vellumai/design-library";
 
 export interface DetailPanelStopButtonProps {
   onStop: () => void;
@@ -24,15 +32,15 @@ export function DetailPanelStopButton({
   disabled,
 }: DetailPanelStopButtonProps) {
   return (
-    <button
-      type="button"
+    <Button
+      variant="dangerOutline"
+      leftIcon={<Square className="h-3 w-3" fill="currentColor" />}
       aria-label={ariaLabel}
       onClick={onStop}
       disabled={disabled}
-      className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--system-negative-strong)] bg-transparent px-2.5 py-1.5 text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)] disabled:cursor-not-allowed disabled:opacity-50"
+      className="shrink-0 rounded-lg hover:border-[var(--system-negative-strong)] hover:bg-[var(--system-negative-weak)] hover:[--vbtn-fg:var(--system-negative-strong)]"
     >
-      <Square className="h-3 w-3" fill="currentColor" />
       <Typography variant="label-small-default">Stop</Typography>
-    </button>
+    </Button>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -275,8 +275,10 @@ export function SubagentDetailPanel({
             onClick={handleBack}
             title={entry.label}
             // inline-flex: the `link` variant is `display: inline`, which can't
-            // constrain the label for truncation.
-            className="inline-flex min-w-0 shrink text-left text-[color:var(--content-default)]"
+            // constrain the label for truncation. border-0: the button base
+            // carries a 1px transparent border the raw crumb never had, which
+            // would grow the breadcrumb row by 2px.
+            className="inline-flex min-w-0 shrink border-0 text-left text-[color:var(--content-default)]"
           >
             <Typography
               variant="body-small-default"
@@ -461,7 +463,8 @@ export function SubagentDetailPanel({
                         />
                       }
                       // no-underline: this is a disclosure toggle, not a link.
-                      className="mt-1.5 inline-flex gap-1 text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)] hover:no-underline"
+                      // border-0: see the breadcrumb crumb above.
+                      className="mt-1.5 inline-flex gap-1 border-0 text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)] hover:no-underline"
                     >
                       <Typography variant="label-small-default">
                         {objectiveExpanded ? "Show less" : "Show more"}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -270,16 +270,22 @@ export function SubagentDetailPanel({
           (deepest) level. */}
       {activeDetail && (
         <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hover)] px-5 py-3">
-          <button
-            type="button"
+          <Button
+            variant="link"
             onClick={handleBack}
             title={entry.label}
-            className="min-w-0 shrink cursor-pointer truncate text-left text-[var(--content-default)] hover:underline"
+            // inline-flex: the `link` variant is `display: inline`, which can't
+            // constrain the label for truncation.
+            className="inline-flex min-w-0 shrink text-left text-[color:var(--content-default)]"
           >
-            <Typography variant="body-small-default" as="span">
+            <Typography
+              variant="body-small-default"
+              as="span"
+              className="min-w-0 truncate"
+            >
               {entry.label}
             </Typography>
-          </button>
+          </Button>
           <ChevronRight
             className="h-2.5 w-2.5 shrink-0 text-[var(--content-tertiary)]"
             aria-hidden
@@ -442,21 +448,25 @@ export function SubagentDetailPanel({
                     {entry.objective}
                   </Typography>
                   {objectiveOverflows && (
-                    <button
-                      type="button"
+                    <Button
+                      variant="link"
                       onClick={() => setObjectiveExpanded((prev) => !prev)}
-                      className="mt-1.5 flex cursor-pointer items-center gap-1 text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+                      aria-expanded={objectiveExpanded}
+                      rightIcon={
+                        <ChevronDown
+                          className={`h-3.5 w-3.5 transition-transform ${
+                            objectiveExpanded ? "rotate-180" : ""
+                          }`}
+                          aria-hidden
+                        />
+                      }
+                      // no-underline: this is a disclosure toggle, not a link.
+                      className="mt-1.5 inline-flex gap-1 text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)] hover:no-underline"
                     >
                       <Typography variant="label-small-default">
                         {objectiveExpanded ? "Show less" : "Show more"}
                       </Typography>
-                      <ChevronDown
-                        className={`h-3.5 w-3.5 transition-transform ${
-                          objectiveExpanded ? "rotate-180" : ""
-                        }`}
-                        aria-hidden
-                      />
-                    </button>
+                    </Button>
                   )}
                   <div className="mt-5 h-px w-full bg-[var(--border-hover)]" />
                 </div>

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -53,13 +53,11 @@ export function SubagentAvatarRow({
         )}
       </div>
 
-      <span className="flex items-center gap-1">
-        <Typography
-          variant="body-medium-default"
-          className="text-[var(--content-tertiary)]"
-        >
-          Details
-        </Typography>
+      {/* Text style tracks the chat transcript's "Thinking" label
+          (single-activity.tsx): 13px / 500 / --content-secondary. Off the
+          typography scale, so it can't use a `Typography` variant. */}
+      <span className="flex items-center gap-1 text-[13px] font-medium text-[var(--content-secondary)]">
+        Details
         <ChevronDown className="h-3 w-3 text-[var(--content-tertiary)]" />
       </span>
     </button>

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-spawn-group.tsx
@@ -5,8 +5,6 @@ import { ChevronUp } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useState } from "react";
 
-import { Typography } from "@vellumai/design-library";
-
 import { SubagentAvatarRow } from "@/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row";
 import { SUBAGENT_DESCRIPTOR } from "@/domains/chat/process-registry/descriptors/subagent";
 import { InlineProcessCardRow } from "@/domains/chat/process-registry/inline-process-card-row";
@@ -87,14 +85,10 @@ export function SubagentSpawnGroup({
             onClick={() => setExpanded(false)}
             aria-label="Collapse subagent details"
             data-testid="subagent-spawn-group-collapse"
-            className="mt-2 flex cursor-pointer items-center gap-1"
+            // Matches the SubagentAvatarRow "Details" twin.
+            className="mt-2 flex cursor-pointer items-center gap-1 text-[13px] font-medium text-[var(--content-secondary)]"
           >
-            <Typography
-              variant="body-medium-default"
-              className="text-[var(--content-tertiary)]"
-            >
-              Collapse
-            </Typography>
+            Collapse
             <ChevronUp className="h-3 w-3 text-[var(--content-tertiary)]" />
           </button>
         </motion.div>

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.test.tsx
@@ -133,22 +133,19 @@ describe("InlineProcessCard — open affordance", () => {
     expect(opens).toBe(1);
   });
 
-  test("fires onOpen on Enter", () => {
-    let opens = 0;
+  test("is a native button, so Enter/Space activation is the browser's job", () => {
     render(
       <InlineProcessCard
         summary={summary()}
         leadingIcon={leadingIcon}
         openAriaLabel="Open thing"
-        onOpen={() => {
-          opens += 1;
-        }}
+        onOpen={() => {}}
       />,
     );
-    fireEvent.keyDown(screen.getByRole("button", { name: /open thing/i }), {
-      key: "Enter",
-    });
-    expect(opens).toBe(1);
+    const open = screen.getByRole("button", { name: /open thing/i });
+    expect(open.tagName).toBe("BUTTON");
+    // A native button is keyboard-focusable without an explicit tabindex.
+    expect(open.getAttribute("tabindex")).toBeNull();
   });
 
   test("has no role=button (inert) when onOpen is omitted", () => {

--- a/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
+++ b/clients/web/src/domains/chat/process-registry/inline-process-card.tsx
@@ -1,18 +1,13 @@
 // Generic inline progress row shared by the four background-process surfaces
 // (subagent / workflow / ACP run / background task). The leading cluster is the
-// open affordance (role="button"); the stop button stays a separate sibling so
-// it isn't nested inside an interactive element.
+// open affordance; the stop button stays a separate sibling so it isn't nested
+// inside an interactive element.
 //
 // Pure presentational: callers project their store state into a `CardSummary`
 // and supply the per-surface leading icon + handlers. No store reads here.
 
 import { Square } from "lucide-react";
-import {
-  useCallback,
-  type KeyboardEvent,
-  type MouseEvent,
-  type ReactNode,
-} from "react";
+import { useCallback, type MouseEvent, type ReactNode } from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -52,20 +47,6 @@ export function InlineProcessCard({
   countSlot,
   testId,
 }: InlineProcessCardProps) {
-  const handleOpenKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      // Ignore keydowns bubbled from children (e.g. the stop button).
-      if (e.target !== e.currentTarget) {
-        return;
-      }
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onOpen?.();
-      }
-    },
-    [onOpen],
-  );
-
   const handleStop = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
@@ -82,29 +63,37 @@ export function InlineProcessCard({
   // Without a click handler the leading cluster is inert (not a button).
   const canOpen = !!onOpen;
 
+  const leadingCluster = (
+    <>
+      <InlineCardStatusIcon state={summary.state} />
+      <span className="mx-1 flex shrink-0 items-center">{leadingIcon}</span>
+      <HeaderStepCarousel
+        currentStepTitle={summary.title}
+        currentStepInfo={summary.info}
+        bypassDwell={summary.state !== "loading"}
+      />
+    </>
+  );
+
   return (
     <div
       data-testid={testId}
       className="group flex w-full items-center justify-between gap-2 rounded-md p-2 text-left hover:bg-[var(--surface-active)]"
     >
-      <span
-        role={canOpen ? "button" : undefined}
-        tabIndex={canOpen ? 0 : undefined}
-        aria-label={canOpen ? openAriaLabel : undefined}
-        onClick={canOpen ? onOpen : undefined}
-        onKeyDown={canOpen ? handleOpenKeyDown : undefined}
-        className={`flex min-w-0 flex-1 items-center gap-1 text-left${
-          canOpen ? " cursor-pointer" : ""
-        }`}
-      >
-        <InlineCardStatusIcon state={summary.state} />
-        <span className="mx-1 flex shrink-0 items-center">{leadingIcon}</span>
-        <HeaderStepCarousel
-          currentStepTitle={summary.title}
-          currentStepInfo={summary.info}
-          bypassDwell={summary.state !== "loading"}
-        />
-      </span>
+      {canOpen ? (
+        <button
+          type="button"
+          aria-label={openAriaLabel}
+          onClick={onOpen}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-left"
+        >
+          {leadingCluster}
+        </button>
+      ) : (
+        <span className="flex min-w-0 flex-1 items-center gap-1 text-left">
+          {leadingCluster}
+        </span>
+      )}
       <div className="flex shrink-0 items-center gap-2">
         {countSlot != null ? (
           countSlot


### PR DESCRIPTION
## Summary

The subagent panel was a mix: 3 of 11 interactive controls used the design-library `Button`, the rest were hand-rolled. This moves the ones with a real equivalent onto the shared primitive and aligns the subagent group's "Details" label with the transcript's "Thinking" label, which it sits directly beneath.

No control changes appearance. Every call-site override exists to hold the current design against a variant default.

## Changes

**Button migrations**
- Panel Stop button → `Button variant="dangerOutline"` (`detail-panel-stop-button.tsx`)
- Breadcrumb crumb and objective Show more/less → `Button variant="link"` (`subagent-detail-panel.tsx`)
- Open-subagent affordance → a real `<button>`, replacing `<span role="button">` and its hand-written Enter/Space handler (`inline-process-card.tsx`)
- Show more/less gains the `aria-expanded` it was missing

**Typography**
- "Details" and its "Collapse" twin move from `body-medium-default` / `--content-tertiary` to 13px / 500 / `--content-secondary`, matching `single-activity.tsx`

**Overrides worth reviewing**
- `rounded-lg` on Stop, matching the sibling Back/Close buttons which override the same way
- Stop keeps its weak-fill hover rather than `dangerOutline`'s recolor. Letting the recolor land on the fill drops the label to ~2.4:1 in light and ~2.0:1 in dark; holding the foreground at `--system-negative-strong` keeps it at ~3.2:1 / ~2.9:1
- `hover:no-underline` on Show more, which is a disclosure toggle rather than a link
- `inline-flex` on the crumb, because the `link` variant is `display: inline` and cannot clip its own label

## Deliberately not migrated

- **Phase-timeline row** and the **avatar-stack summary** — partial matches only; the row's `h-[22px]` geometry is load-bearing
- **"Collapse"** — reaching the "Thinking" style through `variant="link"` takes ~8 overrides that each cancel part of the variant
- **`ToolStepPill` / `ChatPill`** — pill geometries the design library doesn't provide

## Testing

- 354/354 `domains/chat` tests pass via `bun scripts/run-tests.ts`; lint and typecheck clean
- One test updated: `inline-process-card.test.tsx` fired `keyDown` Enter and asserted `onOpen`, which only passed because of the hand-rolled handler. Native buttons activate on Enter via the browser, which happy-dom doesn't synthesize, so it now asserts the element is a real `BUTTON` with no explicit tabindex
- Before/after verified in a browser against the project's own Tailwind output and tokens, in both themes, including pinned hover states

## Note

`--content-link` is not defined anywhere in the repo, so the design library's `link` variant resolves `color` to an invalid value and falls back to inherit. Harmless here since both link buttons set their colour explicitly, but every other `variant="link"` call site is silently inheriting rather than rendering as a link. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)