### PR TITLE
Disable gateway backup worker in platform mode

### DIFF
--- a/gateway/src/__tests__/backup-worker-platform-mode.test.ts
+++ b/gateway/src/__tests__/backup-worker-platform-mode.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, mock, test } from "bun:test";
+
+let exportRequested = false;
+const originalIsPlatform = process.env.IS_PLATFORM;
+
+mock.module("../config-file-utils.js", () => ({
+  readConfigFileOrEmpty: () => ({
+    backup: {
+      enabled: true,
+      intervalHours: 1,
+      retention: 3,
+      offsite: { enabled: false },
+    },
+  }),
+}));
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: async () => {
+    exportRequested = true;
+    throw new Error("Platform backup export must not be requested");
+  },
+}));
+
+afterEach(() => {
+  if (originalIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = originalIsPlatform;
+  }
+  mock.restore();
+});
+
+test("platform mode disables the backup worker", async () => {
+  process.env.IS_PLATFORM = "true";
+  const { startBackupWorker } = await import("../backup/backup-worker.js");
+
+  const worker = startBackupWorker({
+    assistantRuntimeBaseUrl: "http://127.0.0.1:7821",
+  });
+  await worker.runOnce();
+  worker.stop();
+
+  expect(exportRequested).toBeFalse();
+});

--- a/gateway/src/backup/backup-worker.ts
+++ b/gateway/src/backup/backup-worker.ts
@@ -25,6 +25,7 @@ import { pipeline } from "node:stream/promises";
 import { mintServiceToken } from "../auth/token-exchange.js";
 import { readConfigFileOrEmpty } from "../config-file-utils.js";
 import { fetchImpl } from "../fetch.js";
+import { isPlatformMode } from "../feature-flag-resolver.js";
 import { getLogger } from "../logger.js";
 import { getGatewaySecurityDir } from "../paths.js";
 import { ensureBackupKey } from "./backup-key.js";
@@ -380,11 +381,23 @@ export interface BackupWorkerHandle {
   runOnce(): Promise<void>;
 }
 
+function createDisabledBackupWorkerHandle(): BackupWorkerHandle {
+  return {
+    stop: () => {},
+    runOnce: () => Promise.resolve(),
+  };
+}
+
 /**
  * Start the periodic backup worker. Returns a handle with stop() and
  * runOnce() methods.
  */
 export function startBackupWorker(deps: BackupDeps): BackupWorkerHandle {
+  if (isPlatformMode()) {
+    log.info("Backup worker disabled in platform mode");
+    return createDisabledBackupWorkerHandle();
+  }
+
   try {
     const timer = setInterval(async () => {
       try {
@@ -402,9 +415,6 @@ export function startBackupWorker(deps: BackupDeps): BackupWorkerHandle {
     };
   } catch (err) {
     log.warn({ err }, "Failed to start backup worker — continuing without it");
-    return {
-      stop: () => {},
-      runOnce: () => Promise.resolve(),
-    };
+    return createDisabledBackupWorkerHandle();
   }
 }


### PR DESCRIPTION
## Summary

- prevent the periodic gateway backup worker from starting when `IS_PLATFORM` identifies a cloud-managed assistant
- reuse the canonical platform-mode predicate and return an inert lifecycle handle
- add regression coverage proving enabled backup config cannot trigger an export through the platform worker

## Original prompt

The gateway backup worker periodically exports assistant workspaces and manages local and offsite snapshots. Disable these worker-driven backups for platform and cloud-based assistants while preserving the self-hosted worker behavior. This gates the periodic worker lifecycle only; manual gateway snapshot requests remain available.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->