### PR TITLE
fix(calls): route below-floor inbound callers to guardian approval

### DIFF
--- a/assistant/src/calls/__tests__/call-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/call-setup-router.test.ts
@@ -29,6 +29,7 @@ import {
 import type { AdmissionPolicy, TrustVerdict } from "@vellumai/gateway-client";
 
 import type { TrustClass } from "../../runtime/actor-trust-resolver.js";
+import type { SetupOutcome } from "../call-setup-router.js";
 import type { CallSession } from "../types.js";
 
 // `resolveActorTrust` must never be consulted by the router — the gateway
@@ -376,47 +377,75 @@ describe("routeSetup — verdict session stamp gates getPendingSession", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Floor table: trustClass × policy → admit/deny
+// Floor table: trustClass × policy → setup action
+//
+// A caller at or above the floor connects directly (`normal_call`). A caller
+// BELOW a floor that a guardian approval could clear is routed into the
+// guardian access-request flow instead of hung up on: `name_capture` for an
+// unrecognized number, `unverified_caller` for a known contact who still owes
+// verification (LUM-2936). `guardian_only` / `no_one` sit above the trusted
+// contact rank an approval grants, so they stay a hard `deny`.
 // ---------------------------------------------------------------------------
 
 describe("routeSetup — admission floor table", () => {
   const cases: Array<{
     policy: AdmissionPolicy;
-    admits: TrustClass[];
-    denies: TrustClass[];
+    expected: Record<TrustClass, SetupOutcome["action"]>;
   }> = [
     {
       policy: "strangers",
-      admits: ["unknown", "unverified_contact", "trusted_contact", "guardian"],
-      denies: [],
+      expected: {
+        unknown: "normal_call",
+        unverified_contact: "normal_call",
+        trusted_contact: "normal_call",
+        guardian: "normal_call",
+      },
     },
     {
       policy: "any_contact",
-      admits: ["unverified_contact", "trusted_contact", "guardian"],
-      denies: ["unknown"],
+      expected: {
+        unknown: "name_capture",
+        unverified_contact: "normal_call",
+        trusted_contact: "normal_call",
+        guardian: "normal_call",
+      },
     },
     {
       policy: "trusted_contacts",
-      admits: ["trusted_contact", "guardian"],
-      denies: ["unknown", "unverified_contact"],
+      expected: {
+        unknown: "name_capture",
+        unverified_contact: "unverified_caller",
+        trusted_contact: "normal_call",
+        guardian: "normal_call",
+      },
     },
     {
       policy: "guardian_only",
-      admits: ["guardian"],
-      denies: ["unknown", "unverified_contact", "trusted_contact"],
+      expected: {
+        unknown: "deny",
+        unverified_contact: "deny",
+        trusted_contact: "deny",
+        guardian: "normal_call",
+      },
     },
     {
       policy: "no_one",
-      admits: [],
-      denies: ["unknown", "unverified_contact", "trusted_contact", "guardian"],
+      expected: {
+        unknown: "deny",
+        unverified_contact: "deny",
+        trusted_contact: "deny",
+        guardian: "deny",
+      },
     },
   ];
 
-  for (const { policy, admits, denies } of cases) {
-    for (const trustClass of denies) {
-      test(`${policy} denies ${trustClass}`, async () => {
+  for (const { policy, expected } of cases) {
+    for (const [trustClass, action] of Object.entries(expected) as Array<
+      [TrustClass, SetupOutcome["action"]]
+    >) {
+      test(`${policy} routes ${trustClass} to ${action}`, async () => {
         const { outcome } = await route(policy, verdictFor(trustClass));
-        expect(outcome.action).toBe("deny");
+        expect(outcome.action).toBe(action);
         if (outcome.action === "deny") {
           expect(outcome.logReason).toBe(
             `Inbound voice admission floor: ${policy}`,
@@ -424,13 +453,60 @@ describe("routeSetup — admission floor table", () => {
         }
       });
     }
-    for (const trustClass of admits) {
-      test(`${policy} admits ${trustClass}`, async () => {
-        const { outcome } = await route(policy, verdictFor(trustClass));
-        expect(outcome.action).not.toBe("deny");
-      });
-    }
   }
+});
+
+// ---------------------------------------------------------------------------
+// LUM-2936: an unrecognized caller below a clearable floor reaches the
+// guardian access-request flow instead of being hung up on. The default
+// channel policy is `trusted_contacts`, so this is the out-of-the-box path
+// for every inbound call from an unknown number.
+// ---------------------------------------------------------------------------
+
+describe("routeSetup: below-floor unknown caller reaches guardian approval", () => {
+  test("default trusted_contacts floor routes an unknown caller to name_capture", async () => {
+    const { outcome, resolved } = await route(
+      "trusted_contacts",
+      verdictFor("unknown"),
+    );
+    expect(outcome.action).toBe("name_capture");
+    if (outcome.action === "name_capture") {
+      expect(outcome.fromNumber).toBe("+12025550142");
+    }
+    expect(resolved.actorTrust.trustClass).toBe("unknown");
+  });
+
+  test("an active voice invite still takes precedence over the approval flow", async () => {
+    activeVoiceInvite = {
+      inviteId: "inv_1",
+      inviteeName: "Alice Example",
+      guardianName: "Sam",
+      codeDigits: 6,
+    };
+    const { outcome } = await route("trusted_contacts", verdictFor("unknown"));
+    expect(outcome.action).toBe("invite_redemption");
+  });
+
+  test("guardian_only keeps the hard deny (approval could not admit them)", async () => {
+    const { outcome } = await route("guardian_only", verdictFor("unknown"));
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("a blocked caller below a clearable floor is still denied", async () => {
+    const { outcome } = await route(
+      "trusted_contacts",
+      makeMemberVerdict("unknown", { status: "blocked" }),
+    );
+    expect(outcome.action).toBe("deny");
+  });
+
+  test("a revoked caller below a clearable floor is still denied", async () => {
+    const { outcome } = await route(
+      "trusted_contacts",
+      makeMemberVerdict("unknown", { status: "revoked" }),
+    );
+    expect(outcome.action).toBe("deny");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -542,14 +618,14 @@ describe("routeSetup — permissive floor admits to normal_call", () => {
     ).toBe("unverified_caller");
   });
 
-  test("trusted_contacts (default) still denies unknown and unverified", async () => {
+  test("trusted_contacts (default) keeps below-floor callers out of normal_call", async () => {
     expect(
       (await route("trusted_contacts", verdictFor("unknown"))).outcome.action,
-    ).toBe("deny");
+    ).toBe("name_capture");
     expect(
       (await route("trusted_contacts", verdictFor("unverified_contact")))
         .outcome.action,
-    ).toBe("deny");
+    ).toBe("unverified_caller");
   });
 });
 

--- a/assistant/src/calls/__tests__/call-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/call-setup-router.test.ts
@@ -383,7 +383,7 @@ describe("routeSetup — verdict session stamp gates getPendingSession", () => {
 // BELOW a floor that a guardian approval could clear is routed into the
 // guardian access-request flow instead of hung up on: `name_capture` for an
 // unrecognized number, `unverified_caller` for a known contact who still owes
-// verification (LUM-2936). `guardian_only` / `no_one` sit above the trusted
+// verification. `guardian_only` / `no_one` sit above the trusted
 // contact rank an approval grants, so they stay a hard `deny`.
 // ---------------------------------------------------------------------------
 
@@ -457,10 +457,10 @@ describe("routeSetup — admission floor table", () => {
 });
 
 // ---------------------------------------------------------------------------
-// LUM-2936: an unrecognized caller below a clearable floor reaches the
-// guardian access-request flow instead of being hung up on. The default
-// channel policy is `trusted_contacts`, so this is the out-of-the-box path
-// for every inbound call from an unknown number.
+// An unrecognized caller below a clearable floor reaches the guardian
+// access-request flow instead of being hung up on. The default channel policy
+// is `trusted_contacts`, so this is the out-of-the-box path for every inbound
+// call from an unknown number.
 // ---------------------------------------------------------------------------
 
 describe("routeSetup: below-floor unknown caller reaches guardian approval", () => {
@@ -506,6 +506,60 @@ describe("routeSetup: below-floor unknown caller reaches guardian approval", () 
       makeMemberVerdict("unknown", { status: "revoked" }),
     );
     expect(outcome.action).toBe("deny");
+  });
+
+  // Status and policy are independent governance signals: the gateway derives
+  // trust class from status alone, so a channel the guardian set to
+  // `policy: "deny"` still resolves to `unverified_contact` while status is
+  // `unverified`/`pending`. The deny gate is trust-class independent and runs
+  // ahead of the floor, so it holds whether the floor admits or denies, and it
+  // outranks an active voice invite.
+  describe("member policy deny outranks every inbound flow", () => {
+    const denyVerdict = () =>
+      makeMemberVerdict("unverified_contact", {
+        status: "unverified",
+        policy: "deny",
+      });
+
+    test("denied below a clearable floor (not sent to verification guidance)", async () => {
+      const { outcome } = await route("trusted_contacts", denyVerdict());
+      expect(outcome.action).toBe("deny");
+      if (outcome.action === "deny") {
+        expect(outcome.logReason).toBe("Inbound voice ACL: member policy deny");
+      }
+    });
+
+    test("denied even when the floor would admit them", async () => {
+      const { outcome } = await route("strangers", denyVerdict());
+      expect(outcome.action).toBe("deny");
+    });
+
+    test("denied with no floor configured", async () => {
+      const { outcome } = await route(null, denyVerdict());
+      expect(outcome.action).toBe("deny");
+    });
+
+    test("denied even with an active voice invite", async () => {
+      activeVoiceInvite = {
+        inviteId: "inv_1",
+        inviteeName: "Alice Example",
+        guardianName: "Sam",
+        codeDigits: 6,
+      };
+      const { outcome } = await route("trusted_contacts", denyVerdict());
+      expect(outcome.action).toBe("deny");
+    });
+
+    test("an active-status member with policy deny is denied", async () => {
+      const { outcome } = await route(
+        "trusted_contacts",
+        makeMemberVerdict("trusted_contact", {
+          status: "active",
+          policy: "deny",
+        }),
+      );
+      expect(outcome.action).toBe("deny");
+    });
   });
 });
 

--- a/assistant/src/calls/call-setup-router.ts
+++ b/assistant/src/calls/call-setup-router.ts
@@ -20,6 +20,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import {
   type AdmissionPolicyResult,
   enforceAdmissionPolicy,
+  trustedContactPromotionClearsFloor,
 } from "../runtime/routes/inbound-stages/admission-policy.js";
 import {
   actorTrustContextFromVerdict,
@@ -260,12 +261,19 @@ export async function routeSetup(ctx: SetupContext): Promise<{
       : await getPendingSession("phone");
 
   // An admission floor is "active" only when a policy applies and no pending
-  // verification challenge is in flight. While active, the floor IS the access
-  // decision: an admitted caller bypasses the legacy identity flows
-  // (unverified_caller / name_capture) and connects directly. When inactive
-  // (null policy, flag off, exempt channel, or a pending challenge), those
-  // legacy flows are preserved unchanged.
+  // verification challenge is in flight. While active, an admitted caller
+  // bypasses the legacy identity flows (unverified_caller / name_capture) and
+  // connects directly. When inactive (null policy, flag off, exempt channel,
+  // or a pending challenge), those legacy flows are preserved unchanged.
   const floorActive = ctx.admissionPolicy != null && !pendingChallenge;
+
+  // Whether a guardian approval could lift a below-floor caller past this
+  // floor. On floors it can clear, a floor deny routes the caller into the
+  // guardian access-request flow instead of hanging up on them (see the
+  // unknown-caller branch below).
+  const approvalCouldClearFloor =
+    ctx.admissionPolicy != null &&
+    trustedContactPromotionClearsFloor(ctx.admissionPolicy);
 
   // Inbound admission floor verdict; defaults to admitted when inactive.
   const floorVerdict = floorActive
@@ -350,19 +358,44 @@ export async function routeSetup(ctx: SetupContext): Promise<{
       };
     }
 
-    // When a floor is active it is the access decision: an admitted caller
-    // connects directly (skipping unverified_caller / name_capture), and a
-    // below-floor caller is denied. Invites (handled above) bypass the floor
-    // as an explicit grant. When the floor is inactive (null policy), fall
-    // through to the legacy identity flows below.
+    // A caller who clears the floor connects directly, skipping
+    // unverified_caller / name_capture. Invites (handled above) bypass the
+    // floor as an explicit grant.
+    //
+    // A caller BELOW the floor is not simply hung up on: when a guardian
+    // approval could admit them, fall through to the legacy identity flows
+    // below, which capture the caller's name, raise a guardian access request,
+    // and hold the line for the decision (LUM-2936). The floor still governs
+    // the outcome, because the flow only ever admits a caller the guardian
+    // approved into a trusted contact.
+    //
+    // Two cases keep the hard deny: floors a trusted-contact promotion could
+    // not clear (`guardian_only`, `no_one`), where an approval flow would
+    // promise a decision that cannot admit them; and blocked/revoked members,
+    // which are deliberate governance actions rather than an unvetted caller.
     if (floorActive) {
-      if (!floorVerdict.admitted) {
+      if (floorVerdict.admitted) {
+        return {
+          outcome: { action: "normal_call" as const, isInbound: true },
+          resolved,
+        };
+      }
+      if (
+        !approvalCouldClearFloor ||
+        floorVerdict.reason === "member_blocked" ||
+        floorVerdict.reason === "member_revoked"
+      ) {
         return floorDeny(floorVerdict);
       }
-      return {
-        outcome: { action: "normal_call" as const, isInbound: true },
-        resolved,
-      };
+      log.info(
+        {
+          callSessionId: ctx.callSessionId,
+          from: ctx.from,
+          trustClass: actorTrust.trustClass,
+          effectivePolicy: floorVerdict.effectivePolicy,
+        },
+        "Inbound voice ACL: caller below admission floor, routing to guardian access request",
+      );
     }
 
     // Known caller whose channel hasn't passed verification yet —

--- a/assistant/src/calls/call-setup-router.ts
+++ b/assistant/src/calls/call-setup-router.ts
@@ -311,6 +311,36 @@ export async function routeSetup(ctx: SetupContext): Promise<{
     };
   };
 
+  // Members whose channel the guardian set to `policy: 'deny'`. This gate is
+  // trust-class independent and runs ahead of every inbound flow below: the
+  // gateway derives trust class from channel STATUS alone, so a denied channel
+  // still resolves to `unverified_contact` (status `unverified`/`pending`) or
+  // `trusted_contact` (status `active`). Gating per class would leave the deny
+  // unenforced for whichever classes the branch order happened to exclude.
+  //
+  // It also outranks an active voice invite: an explicit channel-level deny is
+  // the guardian's standing ruling, and an invite must not redeem past it into
+  // a trusted contact.
+  if (actorTrust.memberRecord?.policy === "deny") {
+    log.info(
+      {
+        callSessionId: ctx.callSessionId,
+        from: ctx.from,
+        channelId: actorTrust.memberRecord.channel.id,
+        trustClass: actorTrust.trustClass,
+      },
+      "Inbound voice ACL: member policy deny",
+    );
+    return {
+      outcome: {
+        action: "deny",
+        message: "This number is not authorized to use this assistant.",
+        logReason: "Inbound voice ACL: member policy deny",
+      },
+      resolved,
+    };
+  }
+
   if (
     (actorTrust.trustClass === "unknown" ||
       actorTrust.trustClass === "unverified_contact") &&
@@ -365,14 +395,16 @@ export async function routeSetup(ctx: SetupContext): Promise<{
     // A caller BELOW the floor is not simply hung up on: when a guardian
     // approval could admit them, fall through to the legacy identity flows
     // below, which capture the caller's name, raise a guardian access request,
-    // and hold the line for the decision (LUM-2936). The floor still governs
-    // the outcome, because the flow only ever admits a caller the guardian
-    // approved into a trusted contact.
+    // and hold the line for the decision. The floor still governs the outcome,
+    // because the flow only ever admits a caller the guardian approved into a
+    // trusted contact.
     //
-    // Two cases keep the hard deny: floors a trusted-contact promotion could
+    // Two cases keep the hard deny. Floors a trusted-contact promotion could
     // not clear (`guardian_only`, `no_one`), where an approval flow would
-    // promise a decision that cannot admit them; and blocked/revoked members,
-    // which are deliberate governance actions rather than an unvetted caller.
+    // promise a decision that cannot admit the caller. And `blocked` /
+    // `revoked` members, who should hear the denial rather than an invitation
+    // to identify themselves. (The third governance signal, a channel
+    // `policy` of `deny`, is gated ahead of this whole branch.)
     if (floorActive) {
       if (floorVerdict.admitted) {
         return {
@@ -441,27 +473,6 @@ export async function routeSetup(ctx: SetupContext): Promise<{
         action: "name_capture",
         assistantId,
         fromNumber: ctx.from,
-      },
-      resolved,
-    };
-  }
-
-  // Members with policy: 'deny'
-  if (actorTrust.memberRecord?.policy === "deny") {
-    log.info(
-      {
-        callSessionId: ctx.callSessionId,
-        from: ctx.from,
-        channelId: actorTrust.memberRecord.channel.id,
-        trustClass: actorTrust.trustClass,
-      },
-      "Inbound voice ACL: member policy deny",
-    );
-    return {
-      outcome: {
-        action: "deny",
-        message: "This number is not authorized to use this assistant.",
-        logReason: "Inbound voice ACL: member policy deny",
       },
       resolved,
     };

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
@@ -8,8 +8,13 @@
  */
 import { describe, expect, test } from "bun:test";
 
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
+
 import type { AdmissionPolicyInput } from "./admission-policy.js";
-import { enforceAdmissionPolicy } from "./admission-policy.js";
+import {
+  enforceAdmissionPolicy,
+  trustedContactPromotionClearsFloor,
+} from "./admission-policy.js";
 
 function makeInput(
   overrides: Partial<AdmissionPolicyInput>,
@@ -175,4 +180,29 @@ describe("enforceAdmissionPolicy — rank vs floor", () => {
     );
     expect(result.admitted).toBe(true);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Guardian approval reach: which floors a trusted-contact promotion clears
+// ---------------------------------------------------------------------------
+
+describe("trustedContactPromotionClearsFloor", () => {
+  const clears: AdmissionPolicy[] = [
+    "trusted_contacts",
+    "any_contact",
+    "strangers",
+  ];
+  const doesNotClear: AdmissionPolicy[] = ["guardian_only", "no_one"];
+
+  for (const policy of clears) {
+    test(`${policy} is cleared by a trusted-contact promotion`, () => {
+      expect(trustedContactPromotionClearsFloor(policy)).toBe(true);
+    });
+  }
+
+  for (const policy of doesNotClear) {
+    test(`${policy} is not cleared by a trusted-contact promotion`, () => {
+      expect(trustedContactPromotionClearsFloor(policy)).toBe(false);
+    });
+  }
 });

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
@@ -103,6 +103,24 @@ const POLICIES_THAT_COULD_UPGRADE: ReadonlySet<AdmissionPolicy> = new Set([
 ]);
 
 /**
+ * Whether promoting a caller to a trusted contact would lift them past this
+ * floor.
+ *
+ * A guardian approving an access request activates the requester as a trusted
+ * contact (directly for voice, per `guardian-request-resolvers.ts`; via the
+ * minted verification code for text), so approval only helps on floors at or
+ * below the trusted-contact rank. `guardian_only` and `no_one` sit above it:
+ * an approved caller would still be below the floor, so callers denied by
+ * those floors must not be routed into an approval flow that cannot admit
+ * them.
+ */
+export function trustedContactPromotionClearsFloor(
+  policy: AdmissionPolicy,
+): boolean {
+  return ADMISSION_FLOOR[policy] <= TRUST_CLASS_RANK.trusted_contact;
+}
+
+/**
  * Enforce the admission policy floor against the resolved trust class.
  *
  * Pure function — all I/O happens in the caller. Returns the canned


### PR DESCRIPTION
## TL;DR

Inbound voice calls from unrecognized numbers were hung up on instead of raising a guardian access request. The phone channel's admission policy defaults to `trusted_contacts`, so this was the out-of-the-box behavior for **every** inbound call from an unknown number. This restores the name-capture → guardian-approval → continue-or-hang-up flow that already exists in the codebase but had become unreachable, and closes a related gap where an explicitly denied contact could reach the assistant.

Fixes [LUM-2936](https://linear.app/vellum/issue/LUM-2936/inbound-voice-calls-from-unknown-numbers-bypass-approval-flow).

## What broke

[#35246](https://github.com/vellum-ai/vellum-assistant/pull/35246) wired voice ingress into the channel admission policy. In [`call-setup-router.ts`](assistant/src/calls/call-setup-router.ts), an active floor became "the access decision" for unknown callers: below the floor → `deny`. That short-circuited the `name_capture` → access-request → guardian-wait flow, which had been the behavior for unknown callers and was only reachable when no policy was configured at all.

The flow itself was never removed. [`call-setup-flow.ts`](assistant/src/calls/call-setup-flow.ts) still implements every step the ticket asks for, and [`call-setup-flow-name-capture.test.ts`](assistant/src/__tests__/call-setup-flow-name-capture.test.ts) still covers it (21 tests). Nothing was calling it.

The gateway's Twilio voice webhook only enforces the `no_one` kill switch, so the runtime floor was the sole blocker.

## What changes for the caller

Assuming the default `trusted_contacts` policy and a call from a number the assistant doesn't recognize:

| | Before | After |
|---|---|---|
| What the caller hears | "This number is not authorized to reach the assistant right now." Call ends. | "Sorry, I don't recognize this number. I'll let \<guardian\> know you called and see if I have permission to speak with you. Can I get your name?" |
| Guardian | Never notified that anyone called | Gets an approve/reject access request |
| Guardian approves while the caller waits | n/a | Caller becomes a trusted contact; "Great! \<guardian\> said I can speak with you. How can I help?" and the conversation continues normally |
| Guardian rejects while the caller waits | n/a | "Sorry, \<guardian\> says I'm not allowed to speak with you. Goodbye." and hangs up |
| No answer from the guardian | n/a | Hold copy, then "Sorry, I can't get ahold of \<guardian\> right now. I'll let them know you called." |

Unchanged: `strangers` still admits unknown callers straight to a normal call; guardian and trusted-contact callers are unaffected; active voice invites still take precedence for callers the guardian hasn't ruled against.

## Second fix: member `policy: "deny"` was unenforced for two trust classes

The member-policy-deny gate sat *after* the unknown/unverified branch, so it was unreachable for the `unknown` and `unverified_contact` classes. The gateway derives trust class from channel **status** alone ([`trust-verdict-resolver.ts`](gateway/src/risk/trust-verdict-resolver.ts)), so a channel the guardian explicitly set to `deny` still resolves to `unverified_contact` while its status is `unverified`/`pending` — and never reached the gate.

This predates this branch (verified against `HEAD~1`) and had a real authorization consequence:

| | Before | After |
|---|---|---|
| `policy: "deny"` contact, floor admits (`strangers`) | **Reached the agent loop** | Denied |
| `policy: "deny"` contact, no floor configured | "Verify and call back" guidance | Denied |
| `policy: "deny"` contact, below a clearable floor | Floor-deny copy | Denied (policy-deny copy) |
| `policy: "deny"` contact holding an active invite | Redeemed into a trusted contact | Denied |

The gate is now hoisted ahead of every inbound flow, rather than enumerated per branch, so it can't be missed again by branch ordering.

**One deliberate scope expansion worth review attention:** the hoisted gate outranks an active voice invite. An explicit channel-level `deny` is the guardian's standing ruling on that channel, and letting an invite redeem past it into a trusted contact is the same bypass class. Happy to revert to invite-wins if that's the intended precedence.

## Why this is safe

The floor still governs who actually talks to the assistant. The approval flow only ever admits a caller the **guardian explicitly approved** into a trusted contact, so nobody reaches the agent loop without a human decision.

Callers who keep the hard deny:

- **`guardian_only` and `no_one` floors** sit above the trusted-contact rank an approval grants. Routing there would promise the caller a decision that could not admit them anyway. Encoded as `trustedContactPromotionClearsFloor()` in [`admission-policy.ts`](assistant/src/runtime/routes/inbound-stages/admission-policy.ts), next to the rank table it reads, rather than as a hardcoded policy list.
- **Blocked and revoked members, and channels set to `policy: "deny"`** — deliberate governance actions, not unvetted callers.

This also removes an asymmetry: the text path in [`inbound-message-handler.ts`](assistant/src/runtime/routes/inbound-message-handler.ts) already fired `notifyGuardianOfAccessRequest` on a floor deny. Voice was the outlier in dropping callers silently.

## Tests

- `call-setup-router.test.ts` — the floor table is now a full `(policy × trustClass) → setup action` matrix rather than admit/deny, plus regression blocks for the below-floor unknown caller (invite precedence, `guardian_only` hard deny, blocked/revoked hard deny) and for member policy deny across floor-admits / below-floor / no-floor / active-invite / active-status.
- `admission-policy.test.ts` — coverage for the new predicate.
- Green: router (70), admission-policy (17), acl-enforcement (49), name-capture (21), media-stream-integration (55), twilio-routes (48), inbound-trust-verdict (6), inbound-trust-reader (13). Lint and typecheck clean.

## Deferred

**An `unverified_contact` denied by a `trusted_contacts` floor gets the existing verification-guidance copy, not a guardian access request.** They are a contact the guardian already added who owes verification, so "finish verifying, then call back" is the more useful answer than asking the guardian to re-approve someone they already know. This restores the pre-floor behavior for that class and is out of scope for the ticket, which is about unrecognized numbers. Worth revisiting if the copy proves confusing in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)