### PR TITLE
fix(macos): stop the auto-updater leaking its download promise

### DIFF
--- a/clients/macos/src/main/auto-update.test.ts
+++ b/clients/macos/src/main/auto-update.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Regression cover for the auto-updater's leaked download promise.
+ *
+ * With `autoDownload` enabled, `checkForUpdates()` resolves with the in-flight
+ * download on `result.downloadPromise` instead of folding it into the returned
+ * promise, and electron-updater re-throws every download failure on it (see
+ * `AppUpdater.downloadUpdate`). A `.catch()` on `checkForUpdates()` alone
+ * therefore never sees a failed download, and the rejection escapes into the
+ * main process as an unhandled rejection.
+ */
+
+interface FakeUpdater {
+  checkForUpdates: () => Promise<{ downloadPromise: Promise<unknown> | null }>;
+  logger: unknown;
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  channel: string;
+  allowDowngrade: boolean;
+  setFeedURL: () => void;
+  on: () => void;
+  quitAndInstall: () => void;
+}
+
+let downloadResult: { downloadPromise: Promise<unknown> | null } = {
+  downloadPromise: null,
+};
+
+const fakeUpdater: FakeUpdater = {
+  checkForUpdates: () => Promise.resolve(downloadResult),
+  logger: undefined,
+  autoDownload: false,
+  autoInstallOnAppQuit: false,
+  channel: "",
+  allowDowngrade: false,
+  setFeedURL: () => undefined,
+  on: () => undefined,
+  quitAndInstall: () => undefined,
+};
+
+mock.module("electron-updater", () => ({ autoUpdater: fakeUpdater }));
+
+const { checkForUpdates } = await import("./auto-update");
+
+/** Collect unhandled rejections raised while `run` settles. */
+const unhandledDuring = async (run: () => void): Promise<unknown[]> => {
+  const seen: unknown[] = [];
+  const onUnhandled = (reason: unknown): void => {
+    seen.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    run();
+    // Two macrotask hops: one for `checkForUpdates()` to resolve and the
+    // handler to attach, one for the runtime to report anything still
+    // unhandled after that.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  return seen;
+};
+
+describe("checkForUpdates", () => {
+  beforeEach(() => {
+    downloadResult = { downloadPromise: null };
+  });
+
+  afterEach(() => {
+    downloadResult = { downloadPromise: null };
+  });
+
+  test("swallows a rejected downloadPromise instead of leaking it", async () => {
+    const readOnlyVolume = new Error(
+      "Cannot update while running on a read-only volume.",
+    );
+    downloadResult = { downloadPromise: Promise.reject(readOnlyVolume) };
+
+    const unhandled = await unhandledDuring(() => {
+      checkForUpdates();
+    });
+
+    expect(unhandled).toEqual([]);
+  });
+
+  test("tolerates a check that reports no download in flight", async () => {
+    downloadResult = { downloadPromise: null };
+
+    const unhandled = await unhandledDuring(() => {
+      checkForUpdates();
+    });
+
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/clients/macos/src/main/auto-update.ts
+++ b/clients/macos/src/main/auto-update.ts
@@ -30,9 +30,25 @@ const setState = (next: UpdateState): void => {
 };
 
 export const checkForUpdates = (): void => {
-  autoUpdater.checkForUpdates().catch((err: unknown) => {
-    log.error("[auto-update] checkForUpdates failed:", err);
-  });
+  autoUpdater
+    .checkForUpdates()
+    .then((result) => {
+      // With `autoDownload`, the download starts *inside* `checkForUpdates`,
+      // and electron-updater hands the in-flight download back on the
+      // resolved result rather than folding it into the returned promise
+      // (`AppUpdater.doCheckForUpdates` → `downloadPromise`). Its
+      // `downloadUpdate` re-throws every download failure after emitting
+      // `error`, so unless something attaches a handler here the rejection
+      // escapes as an unhandled promise rejection in the main process: the
+      // shape Sentry records for the "read-only volume" refusal an app
+      // launched from ~/Downloads or a mounted DMG hits on every check.
+      // The `error` listener below already owns the user-facing state and the
+      // logging, so this only has to keep the rejection from escaping.
+      result?.downloadPromise?.catch(() => undefined);
+    })
+    .catch((err: unknown) => {
+      log.error("[auto-update] checkForUpdates failed:", err);
+    });
 };
 
 export const installAutoUpdate = (): void => {

--- a/clients/macos/src/main/auto-update.ts
+++ b/clients/macos/src/main/auto-update.ts
@@ -33,17 +33,10 @@ export const checkForUpdates = (): void => {
   autoUpdater
     .checkForUpdates()
     .then((result) => {
-      // With `autoDownload`, the download starts *inside* `checkForUpdates`,
-      // and electron-updater hands the in-flight download back on the
-      // resolved result rather than folding it into the returned promise
-      // (`AppUpdater.doCheckForUpdates` → `downloadPromise`). Its
-      // `downloadUpdate` re-throws every download failure after emitting
-      // `error`, so unless something attaches a handler here the rejection
-      // escapes as an unhandled promise rejection in the main process: the
-      // shape Sentry records for the "read-only volume" refusal an app
-      // launched from ~/Downloads or a mounted DMG hits on every check.
-      // The `error` listener below already owns the user-facing state and the
-      // logging, so this only has to keep the rejection from escaping.
+      // With `autoDownload`, electron-updater returns the in-flight download
+      // on the resolved result and rethrows download failures on it after
+      // emitting `error`. The `error` listener owns state and logging, so this
+      // only keeps the rejection from escaping.
       result?.downloadPromise?.catch(() => undefined);
     })
     .catch((err: unknown) => {


### PR DESCRIPTION
## TL;DR

The Electron main process throws an unhandled promise rejection every time an auto-update download fails. [Sentry VELLUM-ASSISTANT-MACOS-1RD](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-MACOS-1RD) has recorded 242 of them in production since 2026-06-24, still firing today. One missing handler; regression test included.

Fixes [LUM-2988](https://linear.app/vellum/issue/LUM-2988/macos-auto-updater-leaks-its-download-promise-producing-unhandled).

## What was wrong

`checkForUpdates()` catches `autoUpdater.checkForUpdates()`, but that is not the promise download failures arrive on. Because we set `autoDownload = true`, electron-updater kicks the download off *inside* the check and hands it back on the resolved result:

```js
// AppUpdater.doCheckForUpdates (electron-updater 6.8.9)
return {
  isUpdateAvailable: true,
  ...
  downloadPromise: this.autoDownload ? this.downloadUpdate(cancellationToken) : null,
}
```

and `downloadUpdate` re-throws after emitting `error`:

```js
this.downloadPromise = this.doDownloadUpdate({...})
  .catch(e => { throw errorHandler(e) })   // errorHandler dispatches `error`, then rethrows
```

Nothing attached a handler to `result.downloadPromise`, so the check resolved cleanly and the rejection escaped into the main process.

## Why it is safe

The rejection was already fully reported before it escaped: `errorHandler` dispatches the `error` event first, and our `autoUpdater.on("error")` listener sets `UpdateState` to `error` and logs it. This change adds a handler on the promise and nothing else. No state, logging, retry, or update behavior moves.

## Before / after

| | Before | After |
|---|---|---|
| An update download fails | Update UI shows the error, **and** the main process takes an unhandled promise rejection | Update UI shows the error, exactly as now |
| A user on a read-only volume (DMG / `~/Downloads`) | Unhandled rejection on every update check, every 4 hours | Silent, error surfaced through the normal update state |
| Update succeeds, or no update available | Unchanged | Unchanged |

## Testing

`clients/macos/src/main/auto-update.test.ts` asserts that a rejecting `downloadPromise` produces no unhandled rejection. Verified it fails on the pre-fix code and passes after:

```
bun test src/main/auto-update.test.ts   # 2 pass
bunx tsc --noEmit                       # clean
```

## Deferred

**Why these installs are on a read-only volume at all is a separate defect, and it is the more valuable one.** `relocateToApplicationsFolder()` ([move-to-applications.ts](clients/macos/src/main/move-to-applications.ts)) runs first thing in `whenReady` precisely to move the app out of a DMG or `~/Downloads` and relaunch from `/Applications`. 242 production events say it is not taking effect for these users. Deferred rather than fixed blind: the candidate causes (the `hasPendingFiles()` / `hasPendingDeepLinks()` skip, an `existsAndRunning` conflict resolving to "stay put", or `moveToApplicationsFolder()` throwing into `return false`) are not distinguishable without a reproduction, and guessing would be a second speculative change on top of a confirmed one. Captured in the "Not covered here" section of LUM-2988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->