### PR TITLE
fix(subagent): make subagent_read misuse loud and premature reads self-correcting

### DIFF
--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { SkillToolEntry } from "../config/skills.js";
 import { RiskLevel } from "../permissions/types.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
-import { toolInputMisuseKeys } from "../tools/shared/input-misuse.js";
+import { bundledToolInputMisuseKeys } from "../tools/shared/input-misuse.js";
 import {
   createSkillTool,
   createSkillToolsFromManifest,
@@ -571,9 +571,51 @@ describe("createSkillTool: parameter misuse redirects", () => {
       }
     ).properties;
 
-    for (const key of toolInputMisuseKeys("subagent_read")) {
+    for (const key of bundledToolInputMisuseKeys("subagent_read")) {
       expect(properties[key]).toBeUndefined();
     }
+  });
+
+  test("a non-bundled skill reusing the name keeps the generic validation error", async () => {
+    // Tool names are not reserved, so a workspace skill can define its own
+    // `subagent_read` where `path` is a declared parameter. Its validation
+    // errors must describe its own manifest, not Vellum's file-reader redirect.
+    const tool = createSkillTool(
+      makeEntry({
+        name: "subagent_read",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+      }),
+      "/workspace/skills/notes",
+      "v1:test",
+      false,
+    );
+
+    const result = await tool.execute(
+      { path: "/tmp/notes.md", nonsense: 1 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_read"');
+    expect(result.content).toContain('Unknown parameter "nonsense"');
+  });
+
+  test("an unspecified owner keeps the generic validation error", async () => {
+    const tool = createSkillTool(
+      subagentReadEntry(),
+      "/skills/subagent",
+      "v1:test",
+    );
+
+    const result = await tool.execute({ path: "/tmp/notes.md" }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_read"');
+    expect(result.content).toContain('Unknown parameter "path"');
   });
 
   test("a tool with no rules keeps the generic validation error", async () => {

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { SkillToolEntry } from "../config/skills.js";
 import { RiskLevel } from "../permissions/types.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
+import { toolInputMisuseKeys } from "../tools/shared/input-misuse.js";
 import {
   createSkillTool,
   createSkillToolsFromManifest,
@@ -487,6 +489,110 @@ describe("createSkillTool — required/type/enum validation", () => {
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
     expect(parsed.input).toEqual({ mode: "a" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSkillTool: parameter misuse redirects
+// ---------------------------------------------------------------------------
+
+/**
+ * The subagent skill's real `subagent_read` manifest entry. Its redirect keys
+ * are absent from the advertised `properties`, so manifest validation is the
+ * layer that has to surface the redirect: nothing downstream of it runs.
+ */
+function subagentReadEntry(): SkillToolEntry {
+  const manifest = JSON.parse(
+    readFileSync(
+      join(import.meta.dir, "../config/bundled-skills/subagent/TOOLS.json"),
+      "utf-8",
+    ),
+  ) as { tools: SkillToolEntry[] };
+  const entry = manifest.tools.find((t) => t.name === "subagent_read");
+  if (!entry) {
+    throw new Error("subagent_read is missing from the subagent TOOLS.json");
+  }
+  return entry;
+}
+
+function subagentReadTool() {
+  return createSkillTool(
+    subagentReadEntry(),
+    "/skills/subagent",
+    "v1:test",
+    BUNDLED,
+  );
+}
+
+describe("createSkillTool: parameter misuse redirects", () => {
+  for (const key of ["path", "file", "filename"]) {
+    test(`subagent_read sends "${key}" to file_read`, async () => {
+      const result = await subagentReadTool().execute(
+        { [key]: "/tmp/notes.md" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(
+        "subagent_read returns a subagent's output, it does not read files. Use file_read for files. Pass subagent_id or label here.",
+      );
+    });
+  }
+
+  for (const key of ["subagentId", "agent_id"]) {
+    test(`subagent_read names "${key}" as a misspelling of subagent_id`, async () => {
+      const result = await subagentReadTool().execute(
+        { [key]: "sa-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(
+        "Unknown parameter. Use subagent_id (snake_case) or label.",
+      );
+    });
+  }
+
+  test("a key with no redirect keeps the generic validation error", async () => {
+    const result = await subagentReadTool().execute(
+      { subagent_id: "sa-1", nonsense: 1 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_read"');
+    expect(result.content).toContain('Unknown parameter "nonsense"');
+  });
+
+  test("redirect keys stay out of the advertised schema", () => {
+    const properties = (
+      subagentReadEntry().input_schema as {
+        properties: Record<string, unknown>;
+      }
+    ).properties;
+
+    for (const key of toolInputMisuseKeys("subagent_read")) {
+      expect(properties[key]).toBeUndefined();
+    }
+  });
+
+  test("a tool with no rules keeps the generic validation error", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      tempDir,
+      hash,
+      BUNDLED,
+    );
+
+    const result = await tool.execute(
+      { query: "hello", path: "/tmp/notes.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "test_tool"');
+    expect(result.content).toContain('Unknown parameter "path"');
   });
 });
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -208,8 +208,6 @@ describe("Subagent tool definitions", () => {
     expect(def.input_schema.required).toEqual([]);
     expect(def.input_schema.properties.label).toBeDefined();
     expect(def.input_schema.properties.last_n.type).toBe("integer");
-    // The description leads with what the tool is not: parents kept passing it
-    // file paths.
     expect(def.description).toContain("NOT a file reader");
     expect(def.description).toContain("file_read");
   });

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -207,6 +207,11 @@ describe("Subagent tool definitions", () => {
     expect(def).toBeDefined();
     expect(def.input_schema.required).toEqual([]);
     expect(def.input_schema.properties.label).toBeDefined();
+    expect(def.input_schema.properties.last_n.type).toBe("integer");
+    // The description leads with what the tool is not: parents kept passing it
+    // file paths.
+    expect(def.description).toContain("NOT a file reader");
+    expect(def.description).toContain("file_read");
   });
 
   test("status tool has correct definition", () => {
@@ -825,7 +830,10 @@ describe("Subagent read tool", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("still running");
-    expect(result.content).toContain("Wait");
+    expect(result.content).toContain("Do not poll");
+    expect(result.content).toContain(
+      "you will receive a message automatically when it completes",
+    );
   });
 
   test("read returns wait message for pending subagent", async () => {
@@ -2072,6 +2080,58 @@ describe("subagent tools — model-input schema validation", () => {
     );
     expect(passthrough.isError).toBe(true);
     expect(passthrough.content).toContain("required");
+  });
+});
+
+// ── Read tool misuse redirects ──────────────────────────────────────
+
+describe("Subagent read tool misuse", () => {
+  for (const key of ["path", "file", "filename"]) {
+    test(`read redirects a "${key}" param to file_read`, async () => {
+      const result = await executeSubagentRead(
+        { [key]: "/tmp/notes.md" },
+        makeContext("misuse-sess"),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("it does not read files");
+      expect(result.content).toContain("Use file_read for files");
+      expect(result.content).toContain("Pass subagent_id or label here");
+    });
+  }
+
+  for (const key of ["subagentId", "agent_id"]) {
+    test(`read names "${key}" as an unknown parameter`, async () => {
+      const result = await executeSubagentRead(
+        { [key]: "some-id" },
+        makeContext("misuse-sess"),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(
+        "Unknown parameter. Use subagent_id (snake_case) or label.",
+      );
+    });
+  }
+
+  test("a file-reader key wins over the misnamed-id message", async () => {
+    const result = await executeSubagentRead(
+      { path: "/tmp/notes.md", subagentId: "some-id" },
+      makeContext("misuse-sess"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("it does not read files");
+  });
+
+  test("a correctly named read is untouched by the misuse checks", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "misuse-untouched-1";
+    injectSubagent(manager, subagentId, "misuse-sess", "running");
+
+    const result = await executeSubagentRead(
+      { subagent_id: subagentId },
+      makeContext("misuse-sess"),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("still running");
   });
 });
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -830,8 +830,11 @@ describe("Subagent read tool", () => {
     expect(result.content).toContain("still running");
     expect(result.content).toContain("Do not poll");
     expect(result.content).toContain(
-      "you will receive a message automatically when it completes",
+      "you will be notified automatically when it completes",
     );
+    // A deferred run is announced with a read pointer rather than an inlined
+    // result, so the wait message must not promise the result itself.
+    expect(result.content).not.toContain("including its result");
   });
 
   test("read returns wait message for pending subagent", async () => {

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -123,7 +123,7 @@
     },
     {
       "name": "subagent_read",
-      "description": "Read the full conversation output from a subagent. Use this after a subagent completes to retrieve its full work product.",
+      "description": "NOT a file reader: this returns a subagent's conversation output, addressed by subagent_id or label. To read a file from disk use file_read instead. Use this after a subagent completes to retrieve its full work product; while it is still running you will be notified automatically when it finishes, so there is no need to poll.",
       "category": "orchestration",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/tools/shared/input-misuse.ts
+++ b/assistant/src/tools/shared/input-misuse.ts
@@ -10,6 +10,12 @@
  * a redirect the caller can act on in a single retry. Declaring these keys in
  * `properties` instead would advertise parameters the tool does not accept.
  *
+ * Rules describe the first-party tools that ship in `bundled-skills/`, and tool
+ * names are not reserved: a managed, workspace, extra, or plugin skill may
+ * define its own `subagent_read` with an entirely different contract. The
+ * `bundled` prefix on the exports below is the reminder that callers must
+ * establish bundled provenance before consulting the table.
+ *
  * Pure data plus a lookup, with no imports from tool executors, so both the
  * skill-tool factory (`createSkillTool`, which validates before it reaches an
  * executor) and the executors themselves can consult it.
@@ -37,11 +43,14 @@ const MISUSE_RULES: Readonly<Record<string, readonly ToolInputMisuseRule[]>> = {
 };
 
 /**
- * Return the redirect for a misused parameter shape, or `undefined` when the
- * tool has no rule for the keys present (the caller then falls back to its own
- * error message).
+ * Return the redirect for a misused parameter shape on a bundled tool, or
+ * `undefined` when the tool has no rule for the keys present (the caller then
+ * falls back to its own error message).
+ *
+ * Only call this for a tool that came from a bundled skill. `toolName` alone
+ * does not establish that.
  */
-export function toolInputMisuseMessage(
+export function bundledToolInputMisuseMessage(
   toolName: string,
   input: Record<string, unknown>,
 ): string | undefined {
@@ -57,7 +66,7 @@ export function toolInputMisuseMessage(
   return undefined;
 }
 
-/** Every key that carries a redirect for `toolName`, for drift guards. */
-export function toolInputMisuseKeys(toolName: string): string[] {
+/** Every key that carries a redirect for bundled `toolName`, for drift guards. */
+export function bundledToolInputMisuseKeys(toolName: string): string[] {
   return (MISUSE_RULES[toolName] ?? []).flatMap((rule) => [...rule.keys]);
 }

--- a/assistant/src/tools/shared/input-misuse.ts
+++ b/assistant/src/tools/shared/input-misuse.ts
@@ -1,0 +1,63 @@
+/**
+ * Targeted guidance for tool calls whose parameter names reveal that the
+ * caller wanted a different tool, or a different spelling of a parameter this
+ * tool does accept.
+ *
+ * `validateInputAgainstSchema` rejects any key a tool's `TOOLS.json`
+ * `properties` block does not declare, and its generic `Unknown parameter
+ * "path". Supported: ...` error lists the accepted keys without naming the
+ * tool the caller actually wants. A tool listed here replaces that error with
+ * a redirect the caller can act on in a single retry. Declaring these keys in
+ * `properties` instead would advertise parameters the tool does not accept.
+ *
+ * Pure data plus a lookup, with no imports from tool executors, so both the
+ * skill-tool factory (`createSkillTool`, which validates before it reaches an
+ * executor) and the executors themselves can consult it.
+ */
+
+interface ToolInputMisuseRule {
+  /** Input keys that trigger this rule. Rules are matched in array order. */
+  keys: readonly string[];
+  /** Guidance returned in place of the generic validation error. */
+  message: string;
+}
+
+const MISUSE_RULES: Readonly<Record<string, readonly ToolInputMisuseRule[]>> = {
+  subagent_read: [
+    {
+      keys: ["path", "file", "filename"],
+      message:
+        "subagent_read returns a subagent's output, it does not read files. Use file_read for files. Pass subagent_id or label here.",
+    },
+    {
+      keys: ["subagentId", "agent_id"],
+      message: "Unknown parameter. Use subagent_id (snake_case) or label.",
+    },
+  ],
+};
+
+/**
+ * Return the redirect for a misused parameter shape, or `undefined` when the
+ * tool has no rule for the keys present (the caller then falls back to its own
+ * error message).
+ */
+export function toolInputMisuseMessage(
+  toolName: string,
+  input: Record<string, unknown>,
+): string | undefined {
+  const rules = MISUSE_RULES[toolName];
+  if (!rules) {
+    return undefined;
+  }
+  for (const rule of rules) {
+    if (rule.keys.some((key) => key in input)) {
+      return rule.message;
+    }
+  }
+  return undefined;
+}
+
+/** Every key that carries a redirect for `toolName`, for drift guards. */
+export function toolInputMisuseKeys(toolName: string): string[] {
+  return (MISUSE_RULES[toolName] ?? []).flatMap((rule) => [...rule.keys]);
+}

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -5,6 +5,7 @@ import {
   coerceStringNumbers,
   validateInputAgainstSchema,
 } from "../../skills/validate-input.js";
+import { toolInputMisuseMessage } from "../shared/input-misuse.js";
 import type { ExecutionTarget } from "../tool-types.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import { runSkillToolScript } from "./skill-script-runner.js";
@@ -53,8 +54,15 @@ export function createSkillTool(
         schema,
       );
       if (!validation.ok) {
+        // A parameter shape with its own redirect (e.g. a file path passed to
+        // `subagent_read`) answers with that redirect: the generic "Unknown
+        // parameter" list names the accepted keys but not the tool the caller
+        // is actually reaching for.
+        const misuse = toolInputMisuseMessage(entry.name, coercedInput);
         return {
-          content: `Invalid input for tool "${entry.name}": ${validation.errors.join("; ")}. Fix the arguments and retry.`,
+          content:
+            misuse ??
+            `Invalid input for tool "${entry.name}": ${validation.errors.join("; ")}. Fix the arguments and retry.`,
           isError: true,
         };
       }

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -5,7 +5,7 @@ import {
   coerceStringNumbers,
   validateInputAgainstSchema,
 } from "../../skills/validate-input.js";
-import { toolInputMisuseMessage } from "../shared/input-misuse.js";
+import { bundledToolInputMisuseMessage } from "../shared/input-misuse.js";
 import type { ExecutionTarget } from "../tool-types.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import { runSkillToolScript } from "./skill-script-runner.js";
@@ -57,8 +57,13 @@ export function createSkillTool(
         // A parameter shape with its own redirect (e.g. a file path passed to
         // `subagent_read`) answers with that redirect: the generic "Unknown
         // parameter" list names the accepted keys but not the tool the caller
-        // is actually reaching for.
-        const misuse = toolInputMisuseMessage(entry.name, coercedInput);
+        // is actually reaching for. Redirects describe first-party tools, so
+        // only bundled skills consult them. A managed, workspace, extra, or
+        // plugin skill that reuses a bundled tool name keeps the generic error,
+        // which is the one that matches its own manifest.
+        const misuse = bundled
+          ? bundledToolInputMisuseMessage(entry.name, coercedInput)
+          : undefined;
         return {
           content:
             misuse ??

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -69,7 +69,7 @@ export async function executeSubagentRead(
     // message has to close the loop itself: the completion notification is
     // already coming, and re-reading only burns another turn.
     return {
-      content: `Subagent "${state.config.label}" is still ${state.status}. Do not poll: you will receive a message automatically when it completes, including its result.`,
+      content: `Subagent "${state.config.label}" is still ${state.status}. Do not poll: you will be notified automatically when it completes, and that notification tells you whether the result is inlined or waiting behind a read.`,
       isError: false,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,6 +1,7 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
 import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { TERMINAL_STATUSES } from "../../subagent/index.js";
+import { toolInputMisuseMessage } from "../shared/input-misuse.js";
 import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import {
@@ -14,33 +15,15 @@ import {
 // numbers the advertised `integer` type wouldn't admit.
 export const subagentReadInputSchema = subagentRefInputSchema;
 
-/** Keys that mean the caller wants a file reader, not a subagent's output. */
-const FILE_READER_KEYS = ["path", "file", "filename"] as const;
-
-/** Misspellings of `subagent_id` seen in production traffic. */
-const MISNAMED_ID_KEYS = ["subagentId", "agent_id"] as const;
-
-/**
- * Name the wrong-tool and wrong-parameter shapes parents actually send, rather
- * than answering them with the generic '"subagent_id" or "label" is required'.
- * The input schema is loose, so these keys reach the executor instead of
- * failing validation, which is what makes the redirect possible.
- */
-function misuseMessage(input: Record<string, unknown>): string | undefined {
-  if (FILE_READER_KEYS.some((key) => key in input)) {
-    return "subagent_read returns a subagent's output, it does not read files. Use file_read for files. Pass subagent_id or label here.";
-  }
-  if (MISNAMED_ID_KEYS.some((key) => key in input)) {
-    return "Unknown parameter. Use subagent_id (snake_case) or label.";
-  }
-  return undefined;
-}
-
 export async function executeSubagentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const misuse = misuseMessage(input);
+  // File-reader keys and misspellings of `subagent_id` name a wrong-tool or
+  // wrong-parameter call, so they get the redirect rather than the generic
+  // '"subagent_id" or "label" is required'. `createSkillTool` runs the same
+  // check for calls the manifest validator rejects before they reach here.
+  const misuse = toolInputMisuseMessage("subagent_read", input);
   if (misuse) {
     return { content: misuse, isError: true };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -14,10 +14,36 @@ import {
 // numbers the advertised `integer` type wouldn't admit.
 export const subagentReadInputSchema = subagentRefInputSchema;
 
+/** Keys that mean the caller wants a file reader, not a subagent's output. */
+const FILE_READER_KEYS = ["path", "file", "filename"] as const;
+
+/** Misspellings of `subagent_id` seen in production traffic. */
+const MISNAMED_ID_KEYS = ["subagentId", "agent_id"] as const;
+
+/**
+ * Name the wrong-tool and wrong-parameter shapes parents actually send, rather
+ * than answering them with the generic '"subagent_id" or "label" is required'.
+ * The input schema is loose, so these keys reach the executor instead of
+ * failing validation, which is what makes the redirect possible.
+ */
+function misuseMessage(input: Record<string, unknown>): string | undefined {
+  if (FILE_READER_KEYS.some((key) => key in input)) {
+    return "subagent_read returns a subagent's output, it does not read files. Use file_read for files. Pass subagent_id or label here.";
+  }
+  if (MISNAMED_ID_KEYS.some((key) => key in input)) {
+    return "Unknown parameter. Use subagent_id (snake_case) or label.";
+  }
+  return undefined;
+}
+
 export async function executeSubagentRead(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const misuse = misuseMessage(input);
+  if (misuse) {
+    return { content: misuse, isError: true };
+  }
   const parsedInput = subagentReadInputSchema.safeParse(input);
   if (!parsedInput.success) {
     return invalidToolInputResult("subagent_read", parsedInput.error);
@@ -54,8 +80,11 @@ export async function executeSubagentRead(
   }
 
   if (!TERMINAL_STATUSES.has(state.status)) {
+    // A premature read is often the only result a parent ever captures, so the
+    // message has to close the loop itself: the completion notification is
+    // already coming, and re-reading only burns another turn.
     return {
-      content: `Subagent "${state.config.label}" is still ${state.status}. Wait for it to finish.`,
+      content: `Subagent "${state.config.label}" is still ${state.status}. Do not poll: you will receive a message automatically when it completes, including its result.`,
       isError: false,
     };
   }

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,7 +1,7 @@
 import { getMessages } from "../../persistence/conversation-crud.js";
 import { extractTextFromStoredMessageContent } from "../../persistence/message-content.js";
 import { TERMINAL_STATUSES } from "../../subagent/index.js";
-import { toolInputMisuseMessage } from "../shared/input-misuse.js";
+import { bundledToolInputMisuseMessage } from "../shared/input-misuse.js";
 import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import {
@@ -23,7 +23,9 @@ export async function executeSubagentRead(
   // wrong-parameter call, so they get the redirect rather than the generic
   // '"subagent_id" or "label" is required'. `createSkillTool` runs the same
   // check for calls the manifest validator rejects before they reach here.
-  const misuse = toolInputMisuseMessage("subagent_read", input);
+  // This executor backs the bundled subagent skill, so the bundled table is
+  // the right one to consult.
+  const misuse = bundledToolInputMisuseMessage("subagent_read", input);
   if (misuse) {
     return { content: misuse, isError: true };
   }


### PR DESCRIPTION
## Summary
- `subagent_read` now redirects the wrong-tool shapes seen in production: a `path`/`file`/`filename` key returns "it does not read files, use file_read", and `subagentId`/`agent_id` returns a snake_case parameter hint, instead of the generic '"subagent_id" or "label" is required'. The loose input schema is what lets these keys reach the executor at all.
- The still-running result is self-correcting: it tells the parent not to poll and that the completion message (with the result) arrives automatically. About 14% of spawns ended with the parent's only captured result being that premature read.
- TOOLS.json `subagent_read` description now leads with what the tool is NOT. `last_n` is already declared in the advertised schema (the drift harness records it as an intentional zod passthrough), so no schema change was needed there; a test now pins both.
- SKILL.md deliberately untouched (fingerprint-guarded, and rewritten by PR 7).

Part of plan: subagent-type-consolidation.md (PR 5 of 9)
