### PR TITLE
fix(macos): recover installs stranded outside /Applications

### DIFF
--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -66,7 +66,10 @@ import {
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
 import { installApplicationMenu, refreshCliPathMenuState } from "./menu";
-import { relocateToApplicationsFolder } from "./move-to-applications";
+import {
+  promptToRelocateIfStranded,
+  relocateToApplicationsFolder,
+} from "./move-to-applications";
 import { markRelocationSkipped } from "./install-location";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
@@ -466,6 +469,15 @@ app
     });
     installNativeAuth();
     installMainWindow();
+
+    // Runs after the main window so the recovery dialog has a window to sit in
+    // front of, and so a user who declines lands on a working app rather than
+    // an empty screen. A packaged app outside /Applications cannot update, and
+    // the relocation at the head of this block is the only thing that would
+    // have fixed it.
+    void promptToRelocateIfStranded().catch((err: unknown) => {
+      log.error("[app] relocation prompt failed:", err);
+    });
 
     // Dock-icon click / Cmd-Tab re-activation: bring the main window
     // back to front, recreating it if it was previously closed. The

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -374,7 +374,9 @@ app
     // its own setup here. Electron's documented single-instance example puts
     // every `whenReady` side effect behind this same branch.
     // https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata
-    if (!gotSingleInstanceLock) return;
+    if (!gotSingleInstanceLock) {
+      return;
+    }
 
     // Install into /Applications before any other setup. On the first packaged
     // launch from a mounted DMG (or ~/Downloads), the app silently moves itself

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -66,10 +66,8 @@ import {
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
 import { installApplicationMenu, refreshCliPathMenuState } from "./menu";
-import {
-  markRelocationSkipped,
-  relocateToApplicationsFolder,
-} from "./move-to-applications";
+import { relocateToApplicationsFolder } from "./move-to-applications";
+import { markRelocationSkipped } from "./install-location";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
 import { installNotifications } from "./notifications";

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -66,7 +66,10 @@ import {
   toggleVisibility as toggleMainWindowVisibility,
 } from "./main-window";
 import { installApplicationMenu, refreshCliPathMenuState } from "./menu";
-import { relocateToApplicationsFolder } from "./move-to-applications";
+import {
+  markRelocationSkipped,
+  relocateToApplicationsFolder,
+} from "./move-to-applications";
 import { installNativeAuth } from "./native-auth";
 import { installConnectivityProbe } from "./connectivity-probe";
 import { installNotifications } from "./notifications";
@@ -156,9 +159,9 @@ initSentryMain();
 
 // Single-instance lock: relaunches focus the existing window instead of
 // spawning a parallel main process. The second-instance handler fires on the
-// instance that holds the lock (the primary). The instance that fails to
-// acquire calls app.quit() and never reaches whenReady.
-if (!app.requestSingleInstanceLock()) {
+// instance that holds the lock (the primary).
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
   app.quit();
 }
 
@@ -367,13 +370,23 @@ const forwardPlatformRequest = async (
 app
   .whenReady()
   .then(async () => {
+    // The instance that lost the single-instance lock is already quitting.
+    // `app.quit()` requests a shutdown rather than halting the module, and a
+    // `ready` that is already queued still fires, so the losing instance gates
+    // its own setup here. Electron's documented single-instance example puts
+    // every `whenReady` side effect behind this same branch.
+    // https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata
+    if (!gotSingleInstanceLock) return;
+
     // Install into /Applications before any other setup. On the first packaged
     // launch from a mounted DMG (or ~/Downloads), the app silently moves itself
     // there and relaunches — the "double-click to install" half of the DMG flow.
     // Skip it when a file or deep link triggered the launch: those events are
     // buffered in-process and would be lost during the relaunch.
-    if (!hasPendingFiles() && !hasPendingDeepLinks()) {
-      if (await relocateToApplicationsFolder()) return;
+    if (hasPendingFiles() || hasPendingDeepLinks()) {
+      markRelocationSkipped();
+    } else if (await relocateToApplicationsFolder()) {
+      return;
     }
 
     if (!isDev) {

--- a/clients/macos/src/main/install-location.ts
+++ b/clients/macos/src/main/install-location.ts
@@ -45,7 +45,9 @@ export const isStrandedOutsideApplications = (): boolean =>
  * that skip rather than to a failed move.
  */
 export const markRelocationSkipped = (): void => {
-  if (!app.isPackaged) return;
+  if (!app.isPackaged) {
+    return;
+  }
   installLocation = app.isInApplicationsFolder()
     ? "applications"
     : "skipped-pending-open";

--- a/clients/macos/src/main/install-location.ts
+++ b/clients/macos/src/main/install-location.ts
@@ -1,0 +1,58 @@
+import { app } from "electron";
+
+/**
+ * Where the running app ended up, and for the negative cases which branch put
+ * it there.
+ *
+ * A packaged app outside /Applications keeps running from a read-only location:
+ * a mounted DMG, a quarantined ~/Downloads copy, or the randomized
+ * `AppTranslocation` mount macOS substitutes for any quarantined bundle that
+ * was launched without a Finder move. `electron-updater` refuses every update
+ * there ("Cannot update while running on a read-only volume"), so the install
+ * can never take one.
+ *
+ * `move-to-applications.ts` records the outcome and `sentry.ts` reports it as
+ * the `install_location` tag. The branches produce an identical downstream
+ * error, so the tag is what tells them apart in the field.
+ *
+ * This is a leaf: it holds the value and touches only `app`, so the telemetry
+ * path can read it without pulling in window or installer code.
+ */
+export type InstallLocation =
+  | "unpackaged"
+  | "applications"
+  | "relocating"
+  | "skipped-pending-open"
+  | "conflict-exists-and-running"
+  | "declined"
+  | "failed";
+
+let installLocation: InstallLocation = "unpackaged";
+
+export const getInstallLocation = (): InstallLocation => installLocation;
+
+export const recordInstallLocation = (location: InstallLocation): void => {
+  installLocation = location;
+};
+
+/** Whether the app is packaged and running somewhere other than /Applications. */
+export const isStrandedOutsideApplications = (): boolean =>
+  app.isPackaged && !app.isInApplicationsFolder();
+
+/**
+ * Record that a launch carrying a `.vellum` file or a deep link bypassed the
+ * relocation, so a packaged app left outside /Applications is attributable to
+ * that skip rather than to a failed move.
+ */
+export const markRelocationSkipped = (): void => {
+  if (!app.isPackaged) return;
+  installLocation = app.isInApplicationsFolder()
+    ? "applications"
+    : "skipped-pending-open";
+};
+
+// Test seam, exported only for unit-test setup. Production code never
+// resets the recorded location.
+export const __resetForTesting = (): void => {
+  installLocation = "unpackaged";
+};

--- a/clients/macos/src/main/move-to-applications.test.ts
+++ b/clients/macos/src/main/move-to-applications.test.ts
@@ -16,6 +16,19 @@ const appState = {
   conflict: null as ConflictType | null,
 };
 
+/** Queued `showMessageBox` answers, consumed in order. */
+let dialogAnswers: { response: number; checkboxChecked?: boolean }[] = [];
+const dialogCalls: { message?: string }[] = [];
+let revealedInFinder = 0;
+let settingsStore: Record<string, unknown> = {};
+
+mock.module("./settings", () => ({
+  readSetting: (key: string) => settingsStore[key] ?? null,
+  writeSetting: (key: string, value: unknown) => {
+    settingsStore[key] = value;
+  },
+}));
+
 mock.module("electron", () => ({
   app: {
     // `./logger` pulls in electron-log, which probes these on import.
@@ -43,6 +56,21 @@ mock.module("electron", () => ({
       return appState.move === "succeeds";
     },
   },
+  dialog: {
+    showMessageBox: (options: { message?: string }) => {
+      dialogCalls.push({ ...(options.message == null ? {} : { message: options.message }) });
+      const next = dialogAnswers.shift() ?? { response: 1 };
+      return Promise.resolve({
+        response: next.response,
+        checkboxChecked: next.checkboxChecked ?? false,
+      });
+    },
+  },
+  shell: {
+    showItemInFolder: () => {
+      revealedInFinder += 1;
+    },
+  },
   // The install splash resolves through `ready-to-show`; fire it synchronously
   // so the 150ms paint delay is the only wait per case.
   BrowserWindow: class {
@@ -63,9 +91,8 @@ mock.module("electron", () => ({
   },
 }));
 
-const { relocateToApplicationsFolder } = await import(
-  "./move-to-applications"
-);
+const { relocateToApplicationsFolder, promptToRelocateIfStranded } =
+  await import("./move-to-applications");
 const { getInstallLocation, markRelocationSkipped, __resetForTesting } =
   await import("./install-location");
 
@@ -155,5 +182,89 @@ describe("markRelocationSkipped", () => {
     markRelocationSkipped();
 
     expect(getInstallLocation()).toBe("unpackaged");
+  });
+});
+
+describe("promptToRelocateIfStranded", () => {
+  beforeEach(() => {
+    __resetForTesting();
+    appState.isPackaged = true;
+    appState.inApplicationsFolder = false;
+    appState.move = "succeeds";
+    appState.conflict = null;
+    dialogAnswers = [];
+    dialogCalls.length = 0;
+    revealedInFinder = 0;
+    settingsStore = {};
+  });
+
+  test("stays quiet when the app is already in /Applications", async () => {
+    appState.inApplicationsFolder = true;
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  test("stays quiet for an unpackaged dev build", async () => {
+    appState.isPackaged = false;
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  test("stays quiet once the user has opted out", async () => {
+    settingsStore["suppressRelocationPrompt"] = true;
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  test("retries the move when the user accepts", async () => {
+    dialogAnswers = [{ response: 0 }];
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(1);
+    expect(getInstallLocation()).toBe("relocating");
+  });
+
+  test("does not move when the user declines", async () => {
+    dialogAnswers = [{ response: 1 }];
+
+    await promptToRelocateIfStranded();
+
+    expect(getInstallLocation()).toBe("unpackaged");
+    expect(settingsStore["suppressRelocationPrompt"]).toBeUndefined();
+  });
+
+  test("remembers the opt-out when the checkbox is ticked", async () => {
+    dialogAnswers = [{ response: 1, checkboxChecked: true }];
+
+    await promptToRelocateIfStranded();
+
+    expect(settingsStore["suppressRelocationPrompt"]).toBe(true);
+  });
+
+  test("falls back to Finder when the retried move also fails", async () => {
+    appState.move = "throws";
+    dialogAnswers = [{ response: 0 }, { response: 0 }];
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(2);
+    expect(revealedInFinder).toBe(1);
+    expect(getInstallLocation()).toBe("failed");
+  });
+
+  test("leaves Finder alone when the user closes the fallback", async () => {
+    appState.move = "throws";
+    dialogAnswers = [{ response: 0 }, { response: 1 }];
+
+    await promptToRelocateIfStranded();
+
+    expect(revealedInFinder).toBe(0);
   });
 });

--- a/clients/macos/src/main/move-to-applications.test.ts
+++ b/clients/macos/src/main/move-to-applications.test.ts
@@ -93,8 +93,12 @@ mock.module("electron", () => ({
 
 const { relocateToApplicationsFolder, promptToRelocateIfStranded } =
   await import("./move-to-applications");
-const { getInstallLocation, markRelocationSkipped, __resetForTesting } =
-  await import("./install-location");
+const {
+  getInstallLocation,
+  markRelocationSkipped,
+  recordInstallLocation,
+  __resetForTesting,
+} = await import("./install-location");
 
 describe("relocateToApplicationsFolder", () => {
   beforeEach(() => {
@@ -220,6 +224,37 @@ describe("promptToRelocateIfStranded", () => {
     await promptToRelocateIfStranded();
 
     expect(dialogCalls).toHaveLength(0);
+  });
+
+  // A `.vellum` file or deep-link launch defers relocation on purpose: the
+  // event lives only in this process's pending buffers, so the relaunch that
+  // accepting the offer triggers would drop it.
+  test("stays quiet on a launch that deferred relocation for a pending open", async () => {
+    markRelocationSkipped();
+    expect(getInstallLocation()).toBe("skipped-pending-open");
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  test("cannot relaunch a pending-open launch out from under the buffer", async () => {
+    markRelocationSkipped();
+    dialogAnswers = [{ response: 0 }];
+
+    await promptToRelocateIfStranded();
+
+    // Never reached the move, so the buffered file or link survives.
+    expect(getInstallLocation()).toBe("skipped-pending-open");
+  });
+
+  test("still prompts a stranded launch that carried no pending open", async () => {
+    recordInstallLocation("failed");
+    dialogAnswers = [{ response: 1 }];
+
+    await promptToRelocateIfStranded();
+
+    expect(dialogCalls).toHaveLength(1);
   });
 
   test("retries the move when the user accepts", async () => {

--- a/clients/macos/src/main/move-to-applications.test.ts
+++ b/clients/macos/src/main/move-to-applications.test.ts
@@ -33,7 +33,9 @@ mock.module("electron", () => ({
     moveToApplicationsFolder: (options: MoveOptions) => {
       if (appState.conflict) {
         const proceed = options.conflictHandler(appState.conflict);
-        if (!proceed) return false;
+        if (!proceed) {
+          return false;
+        }
       }
       if (appState.move === "throws") {
         throw new Error("Could not create a temporary directory");
@@ -45,7 +47,9 @@ mock.module("electron", () => ({
   // so the 150ms paint delay is the only wait per case.
   BrowserWindow: class {
     once(event: string, handler: () => void) {
-      if (event === "ready-to-show") handler();
+      if (event === "ready-to-show") {
+        handler();
+      }
       return this;
     }
     show() {}

--- a/clients/macos/src/main/move-to-applications.test.ts
+++ b/clients/macos/src/main/move-to-applications.test.ts
@@ -59,12 +59,11 @@ mock.module("electron", () => ({
   },
 }));
 
-const {
-  getInstallLocation,
-  markRelocationSkipped,
-  relocateToApplicationsFolder,
-  __resetForTesting,
-} = await import("./move-to-applications");
+const { relocateToApplicationsFolder } = await import(
+  "./move-to-applications"
+);
+const { getInstallLocation, markRelocationSkipped, __resetForTesting } =
+  await import("./install-location");
 
 describe("relocateToApplicationsFolder", () => {
   beforeEach(() => {

--- a/clients/macos/src/main/move-to-applications.test.ts
+++ b/clients/macos/src/main/move-to-applications.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type ConflictType = "exists" | "existsAndRunning";
+type ConflictHandler = (conflictType: ConflictType) => boolean;
+
+interface MoveOptions {
+  conflictHandler: ConflictHandler;
+}
+
+const appState = {
+  isPackaged: true,
+  inApplicationsFolder: false,
+  /** What `moveToApplicationsFolder` does: move, refuse, or throw. */
+  move: "succeeds" as "succeeds" | "declines" | "throws",
+  /** Conflict fed to the handler before the move resolves, if any. */
+  conflict: null as ConflictType | null,
+};
+
+mock.module("electron", () => ({
+  app: {
+    // `./logger` pulls in electron-log, which probes these on import.
+    isReady: () => false,
+    whenReady: () => Promise.resolve(),
+    on: () => undefined,
+    off: () => undefined,
+    getPath: () => "/tmp",
+    getName: () => "Vellum",
+    getVersion: () => "0.0.0-test",
+    get isPackaged() {
+      return appState.isPackaged;
+    },
+    isInApplicationsFolder: () => appState.inApplicationsFolder,
+    moveToApplicationsFolder: (options: MoveOptions) => {
+      if (appState.conflict) {
+        const proceed = options.conflictHandler(appState.conflict);
+        if (!proceed) return false;
+      }
+      if (appState.move === "throws") {
+        throw new Error("Could not create a temporary directory");
+      }
+      return appState.move === "succeeds";
+    },
+  },
+  // The install splash resolves through `ready-to-show`; fire it synchronously
+  // so the 150ms paint delay is the only wait per case.
+  BrowserWindow: class {
+    once(event: string, handler: () => void) {
+      if (event === "ready-to-show") handler();
+      return this;
+    }
+    show() {}
+    close() {}
+    isDestroyed() {
+      return false;
+    }
+    loadURL() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+const {
+  getInstallLocation,
+  markRelocationSkipped,
+  relocateToApplicationsFolder,
+  __resetForTesting,
+} = await import("./move-to-applications");
+
+describe("relocateToApplicationsFolder", () => {
+  beforeEach(() => {
+    __resetForTesting();
+    appState.isPackaged = true;
+    appState.inApplicationsFolder = false;
+    appState.move = "succeeds";
+    appState.conflict = null;
+  });
+
+  afterEach(() => {
+    __resetForTesting();
+  });
+
+  test("reports `relocating` and returns true when the move succeeds", async () => {
+    expect(await relocateToApplicationsFolder()).toBe(true);
+    expect(getInstallLocation()).toBe("relocating");
+  });
+
+  test("reports `applications` when already installed", async () => {
+    appState.inApplicationsFolder = true;
+
+    expect(await relocateToApplicationsFolder()).toBe(false);
+    expect(getInstallLocation()).toBe("applications");
+  });
+
+  test("reports `unpackaged` for a dev build", async () => {
+    appState.isPackaged = false;
+
+    expect(await relocateToApplicationsFolder()).toBe(false);
+    expect(getInstallLocation()).toBe("unpackaged");
+  });
+
+  test("distinguishes a running /Applications copy from a plain refusal", async () => {
+    appState.conflict = "existsAndRunning";
+
+    expect(await relocateToApplicationsFolder()).toBe(false);
+    expect(getInstallLocation()).toBe("conflict-exists-and-running");
+  });
+
+  test("overwrites a stale copy rather than refusing", async () => {
+    appState.conflict = "exists";
+
+    expect(await relocateToApplicationsFolder()).toBe(true);
+    expect(getInstallLocation()).toBe("relocating");
+  });
+
+  test("reports `declined` when the move returns false on its own", async () => {
+    appState.move = "declines";
+
+    expect(await relocateToApplicationsFolder()).toBe(false);
+    expect(getInstallLocation()).toBe("declined");
+  });
+
+  test("reports `failed` when the move throws", async () => {
+    appState.move = "throws";
+
+    expect(await relocateToApplicationsFolder()).toBe(false);
+    expect(getInstallLocation()).toBe("failed");
+  });
+});
+
+describe("markRelocationSkipped", () => {
+  beforeEach(() => {
+    __resetForTesting();
+    appState.isPackaged = true;
+    appState.inApplicationsFolder = false;
+  });
+
+  test("attributes a packaged app left outside /Applications to the skip", () => {
+    markRelocationSkipped();
+
+    expect(getInstallLocation()).toBe("skipped-pending-open");
+  });
+
+  test("reports `applications` when the skipped launch was already installed", () => {
+    appState.inApplicationsFolder = true;
+    markRelocationSkipped();
+
+    expect(getInstallLocation()).toBe("applications");
+  });
+
+  test("leaves a dev build as `unpackaged`", () => {
+    appState.isPackaged = false;
+    markRelocationSkipped();
+
+    expect(getInstallLocation()).toBe("unpackaged");
+  });
+});

--- a/clients/macos/src/main/move-to-applications.ts
+++ b/clients/macos/src/main/move-to-applications.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, shell } from "electron";
 
 import {
+  getInstallLocation,
   isStrandedOutsideApplications,
   recordInstallLocation,
 } from "./install-location";
@@ -201,9 +202,21 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
  * the first time or a copy that has since quit), and fall back to pointing at
  * Finder when even that fails. Declining is remembered so this asks at most
  * once per install for a user who wants to run from where they are.
+ *
+ * Silent on a launch that a `.vellum` file or a deep link triggered: accepting
+ * the offer relaunches, and those events live only in this process's pending
+ * buffers until the renderer drains them, so the relaunch would drop the file
+ * or link the user actually opened. Such a launch is the one case where being
+ * outside /Applications is a deliberate deferral rather than a failure, and
+ * the deferral is only good for this launch. The next plain launch runs the
+ * relocation unguarded, and this prompt follows it if the app is still
+ * stranded afterwards.
  */
 export async function promptToRelocateIfStranded(): Promise<void> {
   if (!isStrandedOutsideApplications()) {
+    return;
+  }
+  if (getInstallLocation() === "skipped-pending-open") {
     return;
   }
   if (readSetting("suppressRelocationPrompt") === true) {

--- a/clients/macos/src/main/move-to-applications.ts
+++ b/clients/macos/src/main/move-to-applications.ts
@@ -1,7 +1,11 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog, shell } from "electron";
 
-import { recordInstallLocation } from "./install-location";
+import {
+  isStrandedOutsideApplications,
+  recordInstallLocation,
+} from "./install-location";
 import log from "./logger";
+import { readSetting, writeSetting } from "./settings";
 
 // Build-time define (see electron.vite.config.ts) — the same VELLUM_ENVIRONMENT
 // that electron-builder.config.cjs derives `productName` from.
@@ -179,6 +183,75 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
     closeSplash();
     return false;
   }
+}
+
+/**
+ * Offer a way out when the app is running as a packaged build from somewhere
+ * other than /Applications.
+ *
+ * Every branch that leaves the app there converges on the same broken state:
+ * `electron-updater` refuses to run from a read-only location, so the install
+ * can never take an update, and nothing tells the user. Under macOS app
+ * translocation it cannot self-correct either, because each launch gets a
+ * fresh randomized read-only path.
+ *
+ * The remedy does not depend on which branch got us here, so this checks the
+ * state rather than the cause: offer the move again with the user present
+ * (which also clears the transient causes, an authorization prompt dismissed
+ * the first time or a copy that has since quit), and fall back to pointing at
+ * Finder when even that fails. Declining is remembered so this asks at most
+ * once per install for a user who wants to run from where they are.
+ */
+export async function promptToRelocateIfStranded(): Promise<void> {
+  if (!isStrandedOutsideApplications()) {
+    return;
+  }
+  if (readSetting("suppressRelocationPrompt") === true) {
+    return;
+  }
+
+  const name = productDisplayName();
+  const { response, checkboxChecked } = await dialog.showMessageBox({
+    type: "warning",
+    buttons: ["Move to Applications", "Not Now"],
+    defaultId: 0,
+    cancelId: 1,
+    message: `${name} can't install updates`,
+    detail:
+      `${name} is running from a read-only location, so it can't update ` +
+      `itself and will stay on this version. Moving it to your Applications ` +
+      `folder fixes that. ${name} will restart.`,
+    checkboxLabel: "Don't remind me again",
+    checkboxChecked: false,
+  });
+
+  if (checkboxChecked) {
+    writeSetting("suppressRelocationPrompt", true);
+  }
+  if (response !== 0) {
+    return;
+  }
+
+  // A second attempt with the user watching: the authorization prompt is
+  // answerable now, and a conflicting copy may have quit since launch.
+  if (await relocateToApplicationsFolder()) {
+    return;
+  }
+
+  await dialog.showMessageBox({
+    type: "error",
+    buttons: ["Show Me", "Close"],
+    defaultId: 0,
+    cancelId: 1,
+    message: `${name} couldn't move itself`,
+    detail:
+      `Drag ${name} into your Applications folder in Finder, then open it ` +
+      `from there.`,
+  }).then(({ response: fallbackResponse }) => {
+    if (fallbackResponse === 0) {
+      shell.showItemInFolder(app.getPath("exe"));
+    }
+  });
 }
 
 // Test seam, exported only for unit-test setup. Production code never

--- a/clients/macos/src/main/move-to-applications.ts
+++ b/clients/macos/src/main/move-to-applications.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from "electron";
 
+import { recordInstallLocation } from "./install-location";
 import log from "./logger";
 
 // Build-time define (see electron.vite.config.ts) — the same VELLUM_ENVIRONMENT
@@ -104,46 +105,13 @@ function createInstallSplash(): BrowserWindow {
  *
  * @see https://www.electronjs.org/docs/latest/api/app#appmovetoapplicationsfolderoptions-macos
  */
-/**
- * Where the running app ended up, and for the negative cases which branch put
- * it there. A packaged app outside /Applications keeps running from a
- * read-only location (a mounted DMG, a quarantined ~/Downloads copy), where
- * `electron-updater` refuses every update with "Cannot update while running on
- * a read-only volume". The branches are indistinguishable from the error alone,
- * so `sentry.ts` reports this as the `install_location` tag.
- */
-export type InstallLocation =
-  | "unpackaged"
-  | "applications"
-  | "relocating"
-  | "skipped-pending-open"
-  | "conflict-exists-and-running"
-  | "declined"
-  | "failed";
-
-let installLocation: InstallLocation = "unpackaged";
-
-export const getInstallLocation = (): InstallLocation => installLocation;
-
-/**
- * Record that a launch carrying a `.vellum` file or a deep link bypassed the
- * relocation, so a packaged app left outside /Applications is attributable to
- * that skip rather than to a failed move.
- */
-export const markRelocationSkipped = (): void => {
-  if (!app.isPackaged) return;
-  installLocation = app.isInApplicationsFolder()
-    ? "applications"
-    : "skipped-pending-open";
-};
-
 export async function relocateToApplicationsFolder(): Promise<boolean> {
   if (!app.isPackaged) {
-    installLocation = "unpackaged";
+    recordInstallLocation("unpackaged");
     return false;
   }
   if (app.isInApplicationsFolder()) {
-    installLocation = "applications";
+    recordInstallLocation("applications");
     return false;
   }
 
@@ -194,17 +162,19 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
     });
     // A `false` return is the user's own doing (the conflict handler above, or
     // a cancelled authorization prompt); anything else throws.
-    installLocation = moved
-      ? "relocating"
-      : conflictedWithRunningCopy
-        ? "conflict-exists-and-running"
-        : "declined";
+    recordInstallLocation(
+      moved
+        ? "relocating"
+        : conflictedWithRunningCopy
+          ? "conflict-exists-and-running"
+          : "declined",
+    );
     // On success the process is already quitting/relaunching, so the splash
     // is torn down with it; only close it if we're staying put.
     if (!moved) closeSplash();
     return moved;
   } catch (err) {
-    installLocation = "failed";
+    recordInstallLocation("failed");
     log.error("[move-to-applications] moveToApplicationsFolder failed:", err);
     closeSplash();
     return false;
@@ -214,5 +184,5 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
 // Test seam, exported only for unit-test setup. Production code never
 // resets the recorded location.
 export const __resetForTesting = (): void => {
-  installLocation = "unpackaged";
+  recordInstallLocation("unpackaged");
 };

--- a/clients/macos/src/main/move-to-applications.ts
+++ b/clients/macos/src/main/move-to-applications.ts
@@ -104,9 +104,48 @@ function createInstallSplash(): BrowserWindow {
  *
  * @see https://www.electronjs.org/docs/latest/api/app#appmovetoapplicationsfolderoptions-macos
  */
+/**
+ * Where the running app ended up, and for the negative cases which branch put
+ * it there. A packaged app outside /Applications keeps running from a
+ * read-only location (a mounted DMG, a quarantined ~/Downloads copy), where
+ * `electron-updater` refuses every update with "Cannot update while running on
+ * a read-only volume". The branches are indistinguishable from the error alone,
+ * so `sentry.ts` reports this as the `install_location` tag.
+ */
+export type InstallLocation =
+  | "unpackaged"
+  | "applications"
+  | "relocating"
+  | "skipped-pending-open"
+  | "conflict-exists-and-running"
+  | "declined"
+  | "failed";
+
+let installLocation: InstallLocation = "unpackaged";
+
+export const getInstallLocation = (): InstallLocation => installLocation;
+
+/**
+ * Record that a launch carrying a `.vellum` file or a deep link bypassed the
+ * relocation, so a packaged app left outside /Applications is attributable to
+ * that skip rather than to a failed move.
+ */
+export const markRelocationSkipped = (): void => {
+  if (!app.isPackaged) return;
+  installLocation = app.isInApplicationsFolder()
+    ? "applications"
+    : "skipped-pending-open";
+};
+
 export async function relocateToApplicationsFolder(): Promise<boolean> {
-  if (!app.isPackaged) return false;
-  if (app.isInApplicationsFolder()) return false;
+  if (!app.isPackaged) {
+    installLocation = "unpackaged";
+    return false;
+  }
+  if (app.isInApplicationsFolder()) {
+    installLocation = "applications";
+    return false;
+  }
 
   let splash: BrowserWindow | null = null;
   try {
@@ -136,12 +175,14 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
   };
 
   try {
+    let conflictedWithRunningCopy = false;
     const moved = app.moveToApplicationsFolder({
       conflictHandler: (conflictType) => {
         if (conflictType === "existsAndRunning") {
           // Another copy is already installed and running. Leave it be and
           // keep running from the current location for this session rather
           // than nagging — the user clearly already has Vellum installed.
+          conflictedWithRunningCopy = true;
           log.info(
             "[move-to-applications] /Applications copy already running; skipping move",
           );
@@ -151,13 +192,27 @@ export async function relocateToApplicationsFolder(): Promise<boolean> {
         return true;
       },
     });
+    // A `false` return is the user's own doing (the conflict handler above, or
+    // a cancelled authorization prompt); anything else throws.
+    installLocation = moved
+      ? "relocating"
+      : conflictedWithRunningCopy
+        ? "conflict-exists-and-running"
+        : "declined";
     // On success the process is already quitting/relaunching, so the splash
     // is torn down with it; only close it if we're staying put.
     if (!moved) closeSplash();
     return moved;
   } catch (err) {
+    installLocation = "failed";
     log.error("[move-to-applications] moveToApplicationsFolder failed:", err);
     closeSplash();
     return false;
   }
 }
+
+// Test seam, exported only for unit-test setup. Production code never
+// resets the recorded location.
+export const __resetForTesting = (): void => {
+  installLocation = "unpackaged";
+};

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import * as Sentry from "@sentry/electron/main";
 import { app } from "electron";
 
-import { getInstallLocation } from "./move-to-applications";
+import { getInstallLocation } from "./install-location";
 import { onSettingChange, writeSetting } from "./settings";
 
 declare const __VELLUM_BUILD_SHA__: string;

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as Sentry from "@sentry/electron/main";
 import { app } from "electron";
 
+import { getInstallLocation } from "./move-to-applications";
 import { onSettingChange, writeSetting } from "./settings";
 
 declare const __VELLUM_BUILD_SHA__: string;
@@ -55,6 +56,11 @@ function applyTags(): void {
   Sentry.setTag("arch", process.arch);
   Sentry.setTag("electron", process.versions.electron ?? "unknown");
   Sentry.setTag("packaged", String(app.isPackaged));
+  // Consent (and therefore init) arrives from the renderer well after the
+  // relocation runs at the head of `whenReady`, so the outcome is settled by
+  // the time this reads it. It names which branch left a packaged app outside
+  // /Applications, where the updater refuses to run.
+  Sentry.setTag("install_location", getInstallLocation());
 }
 
 let cachedOptions: Sentry.ElectronMainOptions | null = null;

--- a/clients/macos/src/main/settings.ts
+++ b/clients/macos/src/main/settings.ts
@@ -20,6 +20,7 @@ export interface AppSettings {
   featureFlags: Record<string, boolean>;
   launchAtLogin: boolean;
   shareDiagnostics: boolean;
+  suppressRelocationPrompt: boolean;
 }
 
 const schema: Schema<AppSettings> = {
@@ -42,6 +43,9 @@ const schema: Schema<AppSettings> = {
     type: "boolean",
   },
   shareDiagnostics: {
+    type: "boolean",
+  },
+  suppressRelocationPrompt: {
     type: "boolean",
   },
 };


### PR DESCRIPTION
## TL;DR

242 production users are running from a read-only location where **every update silently fails** ([Sentry VELLUM-ASSISTANT-MACOS-1RD](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-MACOS-1RD)). This gives them a way out, fixes a single-instance-lock defect in the same path, and adds the telemetry needed to decide the bigger question below.

Refs [LUM-3007](https://linear.app/vellum/issue/LUM-3007/macos-first-launch-app-keeps-running-from-a-read-only-volume-when-the). Follows [#39835](https://github.com/vellum-ai/vellum-assistant/pull/39835), which stopped the resulting unhandled rejection but not the cause.

## Why a packaged app is outside /Applications at all

This is the normal first-launch state, by design. Per [LUM-2356](https://linear.app/vellum/issue/LUM-2356/improve-initial-install-experience-of-electron-app) (#35001) the DMG ships a single app icon under "double-click to install" with no Applications alias, and the app relocates itself. Anyone who drags it to `~/Downloads` first is in the same position.

The harder case is **macOS app translocation**: any bundle carrying `com.apple.quarantine` that is launched without a Finder move runs from a randomized read-only mount under `/private/var/folders/.../AppTranslocation/<UUID>/d/`. That is the read-only volume electron-updater refuses on, and because each launch gets a fresh random path, the app cannot correct itself.

## 1. Give stranded installs a way out

Three branches leave the app outside `/Applications`:

| Branch | Cause |
|---|---|
| `skipped-pending-open` | A `.vellum` file or `vellum://` link launched the app, so relocation is skipped to protect the buffered event |
| `conflict-exists-and-running` | A copy in `/Applications` is already running; the conflict resolves to stay put |
| `failed` | `moveToApplicationsFolder()` threw. Per the [docs](https://www.electronjs.org/docs/latest/api/app#appmovetoapplicationsfolderoptions-macos) it "throws errors if anything other than the user causes the move to fail", so this covers permissions, disk, and translocation |

All three converge on the same broken state and the remedy is the same for all three, so the recovery keys off the **state**, not the cause. Once the main window is up, we offer the move again with the user present. That retry independently clears two of the three causes: an authorization prompt dismissed the first time, or a conflicting copy that has since quit. If the retry fails we point at Finder. Declining is remembered in a new `suppressRelocationPrompt` setting.

A launch triggered by a `.vellum` file or a `vellum://` link is the one exception. Those events live only in this process's pending buffers until the renderer drains them, so the relaunch that accepting the offer triggers would drop the file or link the user actually opened. That launch stays silent, matching the startup guard's own resolution for the same hazard in LUM-2356: the next plain launch relocates unguarded, and the prompt follows it if the app is still stranded. `skipped-pending-open` is still recorded and reported, so those launches stay visible in telemetry.

**Relationship to LUM-2356:** that PR added a move-to-Applications prompt with decline persistence, then removed it later in the same PR in favor of the silent move. This dialog is deliberately narrower: it never gates a healthy first launch, and only appears once the install is already unable to update.

## 2. Honor the single-instance lock

`index.ts` called `app.requestSingleInstanceLock()`, called `app.quit()` on failure, then fell through and registered the whole `whenReady` setup anyway. `app.quit()` requests a shutdown; it does not halt the module, and an already-queued `ready` still fires. Electron's [documented example](https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata) puts `whenReady` inside the `else` branch for this reason. The comment claiming the loser "never reaches whenReady" asserted a guarantee the docs do not make.

This bites hardest during relocation: the copy moved into `/Applications` relaunches while the original is still quitting, so the new instance can lose the lock, build windows and a tray, then be torn down by its own pending quit. **That is a plausible mechanism for the first-launch flicker in [LUM-2960](https://linear.app/vellum/issue/LUM-2960), stated explicitly as a hypothesis, not a proven cause.**

## 3. Report which branch stranded the install

Main-process Sentry is fail-closed and initializes only once the renderer pushes diagnostics consent, long after relocation ran and lost, so none of this was observable. The outcome now lives in a leaf module and is reported as the `install_location` tag from `applyTags()`.

## The bigger fix this deliberately does NOT make

Only a **Finder** move sets `QTN_FLAG_DO_NOT_TRANSLOCATE`. Drag-to-install therefore prevents translocation structurally, and a programmatic self-move cannot. [Electron's `electron_bundle_mover.mm`](https://github.com/electron/electron/blob/main/shell/browser/ui/cocoa/electron_bundle_mover.mm) also does not detect or resolve translocation at all (its `ResolvePath()` handles symlinks only) and falls back to the deprecated `AuthorizationExecuteWithPrivileges`. That argues for restoring electron-builder's default two-icon drag-to-install DMG.

**Not doing it here, on purpose.** LUM-2356 chose the single-icon installer over drag-to-Applications on direct user feedback ("I found these interactions to be delightful. Double click rather than drag to applications."). Overriding that needs measurement, and the tempting timeline argument does not survive checking: the DMG change merged 2026-06-16, Electron main Sentry landed 2026-06-17 (#35157), and the read-only error first appears 2026-06-24. There is **no pre-change visibility**, so the dates cannot distinguish "the change caused this" from "we started looking."

The `install_location` tag added here is exactly the instrument that settles it. If `failed` dominates, translocation is implicated and the DMG question reopens with evidence. Sequencing recorded on LUM-3007.

## Why it is safe

The silent first-launch relocation is untouched: same conflict policy, same overwrite-stale-copy decision, same splash, same return values, same DMG. The recovery prompt only appears in an already-broken state, only for packaged builds outside `/Applications`. The lock change makes the losing instance do *less*, not more.

## Before / after

| | Before | After |
|---|---|---|
| Packaged app stranded outside `/Applications` | Silent. Updates fail forever, user never told | Offered the move, Finder fallback, "don't remind me" opt-out |
| Cause of a stranded install | Indistinguishable in telemetry | `install_location` names the branch |
| Second instance loses the lock | Quits, but first builds windows and a tray | Quits without building anything |
| Normal launch from `/Applications` | Unchanged | Unchanged |
| First launch that relocates successfully | Unchanged | Unchanged |
| DMG layout | Single-icon double-click installer | Unchanged |

## Testing

21 tests in `move-to-applications.test.ts` cover all seven outcomes, the three `markRelocationSkipped` cases, all eight prompt paths, and three pending-open cases (silent when deferred, no relaunch even if accepted, still prompts when no open was pending).

```
bun run test:ci    # 66/66 test files pass
bunx tsc --noEmit  # clean
```

## Reviewer note

The recovery dialog is the one **user-visible** change, and its copy and cadence are my call. Given LUM-2356 removed a different prompt for friction reasons, a second opinion from that PR's authors would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)