### PR TITLE
ci(docs): dispatch the platform Helm deploy after each docs image publish

### DIFF
--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -1,12 +1,12 @@
 name: Publish Docs Image
 
 # Builds and publishes the docs-site image to each environment's Artifact
-# Registry. Pushes to main publish to dev, staging, and production so every
-# environment's registry always has the latest main build; `workflow_dispatch`
-# republishes to a single chosen environment. The image lives under the
-# existing `sandbox-images` AR repo. Publishing is inert until the platform
-# Helm chart enables the docs backend in that environment and helm-cd rolls
-# it out.
+# Registry, then dispatches the platform repo's Helm deploy so the docs
+# backend rolls to the freshly published SHA. Pushes to main publish to dev,
+# staging, and production so every environment's registry always has the
+# latest main build; `workflow_dispatch` republishes (and redeploys) a single
+# chosen environment. The image lives under the existing `sandbox-images` AR
+# repo.
 
 on:
   push:
@@ -91,3 +91,25 @@ jobs:
             ${{ steps.image.outputs.gcp }}:latest
           cache-from: type=gha,scope=docs-site
           cache-to: type=gha,mode=max,ignore-error=true,scope=docs-site
+
+      # The dispatch lives inside the matrix leg so each environment deploys
+      # only after its own publish succeeded, and a cancelled (superseded)
+      # publish never triggers a deploy. helm-cd pins the docs Deployment to
+      # this SHA and preserves every other image tag from the live release.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
+          owner: vellum-ai
+          repositories: vellum-assistant-platform
+
+      - name: Trigger platform docs deploy
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run helm-cd.yaml \
+            --repo vellum-ai/vellum-assistant-platform \
+            --field environment="${{ matrix.environment }}" \
+            --field docs_image_tag="${{ github.sha }}"


### PR DESCRIPTION
## Why

Since the docs-site migration, merging docs changes to main publishes a fresh image to each environment's Artifact Registry but does **not** deploy it — someone has to manually `kubectl rollout restart` the docs Deployment in dev, staging, and production. This closes that gap using the same cross-repo pattern as `release.yml`'s `trigger-platform-qa` job.

## What

Each matrix leg of `publish-docs-image.yaml` now, after a successful push:

1. Mints a `VELLUM_AUTOMATION` app token scoped to `vellum-assistant-platform`.
2. Runs `gh workflow run helm-cd.yaml` with `environment=<matrix env>` and `docs_image_tag=<published SHA>`.

The platform side needs **no changes**: `helm-cd.yaml` already accepts these `workflow_dispatch` inputs, preserves every other image tag from the live release, and pins the docs Deployment to the exact SHA (so there is no `:latest` drift for later Helm deploys to fight with).

## Behavior notes

- Triggers only when a docs image was actually published from main — the workflow's existing path filter (`clients/docs/**` plus the design-library/lockfile/patches inputs that bake into the image) is the definition of "docs changed". Ordinary daemon/client merges never dispatch.
- The dispatch lives inside each matrix leg, so an environment deploys only after its own publish succeeded, and a superseded (cancelled) publish never deploys.
- Manual `workflow_dispatch` republishes to a single environment now also redeploy that environment.
- `helm-cd`'s per-environment concurrency group serializes these with normal platform deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)