### PR TITLE
feat(subagent): stop inheriting conversation-pinned profiles; verify tool support

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -4,15 +4,26 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "./helpers/set-config.js";
 
-// Seed the two non-catalog inference profiles these tests exercise: `disabled`
-// drives the "profile is disabled" spawn error, and `frontier` is the advisor
-// consult's default `advisorProfile`. The catalog profiles (balanced,
+// Seed the non-catalog inference profiles these tests exercise: `disabled`
+// drives the "profile is disabled" spawn error, `frontier` is the advisor
+// consult's default `advisorProfile`, and the two model-pinned profiles stand
+// on either side of the catalog's tool-use verdict (`no-tool-model` is a
+// catalog model declared `supportsToolUse: false`, `byok-unknown-model` is a
+// model the catalog has never heard of). The catalog profiles (balanced,
 // cost-optimized, quality-optimized) always resolve through the code catalog,
 // so they need no seeding.
 setConfig("llm", {
   profiles: {
     disabled: { status: "disabled" },
     frontier: {},
+    "no-tool-model": {
+      provider: "openrouter",
+      model: "minimax/minimax-01",
+    },
+    "byok-unknown-model": {
+      provider: "openrouter",
+      model: "acme/private-llm-9",
+    },
   },
   advisorProfile: "frontier",
 });
@@ -21,6 +32,10 @@ setConfig("llm", {
 let mockGetMessages: (
   conversationId: string,
 ) => Array<{ role: string; content: unknown }> | null = () => null;
+
+// The profile pinned on the parent conversation, as the spawn tool's
+// inheritance rung reads it.
+let mockConversationOverrideProfile: string | undefined = undefined;
 
 // Mock the conversation registry so the advisor consult can resolve a fake
 // parent conversation (snapshot messages + system prompt) without a live
@@ -60,6 +75,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
   getMessages: (conversationId: string) => mockGetMessages(conversationId),
+  getConversationOverrideProfile: () => mockConversationOverrideProfile,
   createConversation: () => ({ id: "mock-conv" }),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
@@ -83,6 +99,7 @@ import { executeSubagentMessage } from "../tools/subagent/message.js";
 import { executeSubagentRead } from "../tools/subagent/read.js";
 import { executeSubagentSpawn } from "../tools/subagent/spawn.js";
 import { executeSubagentStatus } from "../tools/subagent/status.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
 // The tools fall back to the durable table for a subagent the manager does not
 // hold, so every executor here reaches it. Idempotent; the table may already
@@ -804,6 +821,125 @@ describe("Subagent spawn success and failure", () => {
     } finally {
       manager.spawn = originalSpawn;
     }
+  });
+});
+
+// ── Profile isolation ───────────────────────────────────────────────
+
+describe("Subagent spawn profile isolation", () => {
+  /**
+   * Capture the config `executeSubagentSpawn` hands the manager, with
+   * `subagent-profile-isolation` seeded on or off for the duration.
+   */
+  async function spawnWithFlag(
+    enabled: boolean,
+    input: Record<string, unknown>,
+    contextExtras: Record<string, unknown> = {},
+  ): Promise<{
+    result: { content: string; isError: boolean };
+    config: Record<string, unknown>;
+  }> {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> = {};
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "isolation-subagent-id";
+    };
+    setOverridesForTesting({ "subagent-profile-isolation": enabled });
+    try {
+      const result = await executeSubagentSpawn(
+        input,
+        makeContext("sess-isolation", {
+          sendToClient: () => {},
+          ...contextExtras,
+        }),
+      );
+      return { result, config: capturedConfig };
+    } finally {
+      setOverridesForTesting({});
+      mockConversationOverrideProfile = undefined;
+      manager.spawn = originalSpawn;
+    }
+  }
+
+  test("flag off keeps inheriting the conversation-pinned profile", async () => {
+    mockConversationOverrideProfile = "quality-optimized";
+    const { config } = await spawnWithFlag(false, {
+      label: "Pinned parent",
+      objective: "Do it",
+    });
+    expect(config.overrideProfile).toBe("quality-optimized");
+    expect(config.forceOverrideProfile).toBeUndefined();
+  });
+
+  test("flag on keeps the conversation-pinned profile away from the child", async () => {
+    mockConversationOverrideProfile = "quality-optimized";
+    const { config } = await spawnWithFlag(true, {
+      label: "Pinned parent",
+      objective: "Do it",
+    });
+    // The subagentSpawn call site's own default, not the parent's pin.
+    expect(config.overrideProfile).toBe("balanced");
+    expect(config.forceOverrideProfile).toBeUndefined();
+  });
+
+  test("flag on keeps the per-turn override profile away from the child", async () => {
+    const { config } = await spawnWithFlag(
+      true,
+      { label: "Override parent", objective: "Do it" },
+      { invokingCallSite: "mainAgent", overrideProfile: "quality-optimized" },
+    );
+    expect(config.overrideProfile).toBe("balanced");
+  });
+
+  test("flag on still honors an explicit inference_profile", async () => {
+    mockConversationOverrideProfile = "cost-optimized";
+    const { result, config } = await spawnWithFlag(true, {
+      label: "Explicit",
+      objective: "Do it",
+      inference_profile: "quality-optimized",
+    });
+    expect(config.overrideProfile).toBe("quality-optimized");
+    expect(config.forceOverrideProfile).toBe(true);
+    expect(JSON.parse(result.content).note).toBeUndefined();
+  });
+
+  test("flag on falls back with a note when the catalog denies tool use", async () => {
+    const { result, config } = await spawnWithFlag(true, {
+      label: "No tools",
+      objective: "Do it",
+      inference_profile: "no-tool-model",
+    });
+    expect(config.overrideProfile).toBe("balanced");
+    expect(config.forceOverrideProfile).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.subagentId).toBe("isolation-subagent-id");
+    expect(parsed.status).toBe("pending");
+    expect(parsed.note).toBe(
+      'requested profile "no-tool-model" is not verified for tool calling; ran on the default profile instead.',
+    );
+  });
+
+  test("flag on fails open for a model the catalog does not list", async () => {
+    const { result, config } = await spawnWithFlag(true, {
+      label: "BYOK",
+      objective: "Do it",
+      inference_profile: "byok-unknown-model",
+    });
+    expect(config.overrideProfile).toBe("byok-unknown-model");
+    expect(config.forceOverrideProfile).toBe(true);
+    expect(JSON.parse(result.content).note).toBeUndefined();
+  });
+
+  test("flag off leaves an unverified profile alone", async () => {
+    const { result, config } = await spawnWithFlag(false, {
+      label: "No tools",
+      objective: "Do it",
+      inference_profile: "no-tool-model",
+    });
+    expect(config.overrideProfile).toBe("no-tool-model");
+    expect(JSON.parse(result.content).note).toBeUndefined();
   });
 });
 
@@ -2241,6 +2377,29 @@ describe("Subagent advisor-role consult", () => {
       expect(captured.current!.config.forceOverrideProfile).toBe(true);
     } finally {
       restore();
+      mockFindConversation = () => undefined;
+    }
+  });
+
+  test("advisor still uses llm.advisorProfile under profile isolation", async () => {
+    mockFindConversation = () => ({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      getCurrentSystemPrompt: () => "SYS",
+    });
+    mockConversationOverrideProfile = "quality-optimized";
+    setOverridesForTesting({ "subagent-profile-isolation": true });
+    const { captured, restore } = stubAwait("advice");
+    try {
+      await executeSubagentSpawn(
+        { label: "Consult", objective: "x", role: "advisor" },
+        makeContext("advisor-sess-isolation", { sendToClient: () => {} }),
+      );
+      expect(captured.current!.config.overrideProfile).toBe("frontier");
+      expect(captured.current!.config.forceOverrideProfile).toBe(true);
+    } finally {
+      restore();
+      setOverridesForTesting({});
+      mockConversationOverrideProfile = undefined;
       mockFindConversation = () => undefined;
     }
   });

--- a/assistant/src/config/__tests__/profile-tool-support.test.ts
+++ b/assistant/src/config/__tests__/profile-tool-support.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { profileSupportsTools } from "../profile-tool-support.js";
+import type { AssistantConfig } from "../schema.js";
+import { LLMSchema } from "../schemas/llm.js";
+
+/** An `AssistantConfig` carrying nothing the profile lookup does not read. */
+function configWithProfiles(
+  profiles: Record<string, Record<string, unknown>>,
+): AssistantConfig {
+  return { llm: LLMSchema.parse({ profiles }) } as AssistantConfig;
+}
+
+describe("profileSupportsTools", () => {
+  test("reports false only for a model the catalog declares tool-less", () => {
+    const config = configWithProfiles({
+      "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
+    });
+    expect(profileSupportsTools("no-tools", config)).toBe(false);
+  });
+
+  test("reports true for a catalog model declared tool-capable", () => {
+    const config = configWithProfiles({
+      "with-tools": { provider: "anthropic", model: "claude-fable-5" },
+    });
+    expect(profileSupportsTools("with-tools", config)).toBe(true);
+  });
+
+  test("fails open for a BYOK model the catalog has never seen", () => {
+    const config = configWithProfiles({
+      byok: { provider: "openrouter", model: "acme/private-llm-9" },
+    });
+    expect(profileSupportsTools("byok", config)).toBeUndefined();
+  });
+
+  test("fails open for a profile key that resolves to nothing", () => {
+    expect(profileSupportsTools("not-a-profile", configWithProfiles({}))).toBe(
+      undefined,
+    );
+  });
+
+  test("verdicts a catalog default profile through the code catalog", () => {
+    // `balanced` carries no workspace body, so the answer has to come from the
+    // resolved default-profile catalog rather than `llm.profiles`.
+    expect(profileSupportsTools("balanced", configWithProfiles({}))).toBe(true);
+  });
+
+  test("reads the arm a mix expands to", () => {
+    const config = configWithProfiles({
+      "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
+      "no-tools-too": {
+        provider: "openrouter",
+        model: "minimax/minimax-m2-her",
+      },
+      blend: {
+        mix: [
+          { profile: "no-tools", weight: 1 },
+          { profile: "no-tools-too", weight: 1 },
+        ],
+      },
+    });
+    // Either arm is tool-less, so the seeded pick cannot change the verdict.
+    expect(profileSupportsTools("blend", config)).toBe(false);
+  });
+});

--- a/assistant/src/config/__tests__/profile-tool-support.test.ts
+++ b/assistant/src/config/__tests__/profile-tool-support.test.ts
@@ -45,7 +45,7 @@ describe("profileSupportsTools", () => {
     expect(profileSupportsTools("balanced", configWithProfiles({}))).toBe(true);
   });
 
-  test("reads the arm a mix expands to", () => {
+  test("reports false for a mix whose every arm is catalog-denied", () => {
     const config = configWithProfiles({
       "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
       "no-tools-too": {
@@ -59,7 +59,73 @@ describe("profileSupportsTools", () => {
         ],
       },
     });
-    // Either arm is tool-less, so the seeded pick cannot change the verdict.
+    // Whichever arm the child's seed lands on, it cannot call tools.
     expect(profileSupportsTools("blend", config)).toBe(false);
+  });
+
+  test("reports true for a mix whose every arm is catalog-capable", () => {
+    const config = configWithProfiles({
+      "tools-a": { provider: "anthropic", model: "claude-fable-5" },
+      "tools-b": {
+        provider: "anthropic",
+        model: "claude-haiku-4-5-20251001",
+      },
+      blend: {
+        mix: [
+          { profile: "tools-a", weight: 3 },
+          { profile: "tools-b", weight: 1 },
+        ],
+      },
+    });
+    expect(profileSupportsTools("blend", config)).toBe(true);
+  });
+
+  test("fails open for a mix of tool-capable and tool-less arms", () => {
+    const config = configWithProfiles({
+      "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
+      "with-tools": { provider: "anthropic", model: "claude-fable-5" },
+      blend: {
+        mix: [
+          { profile: "no-tools", weight: 1 },
+          { profile: "with-tools", weight: 1 },
+        ],
+      },
+    });
+    // The arm is picked from the child conversation's seed, and no such
+    // conversation exists yet, so neither arm's verdict speaks for the mix.
+    expect(profileSupportsTools("blend", config)).toBeUndefined();
+  });
+
+  test("fails open for a mix with an arm the catalog has never seen", () => {
+    const config = configWithProfiles({
+      "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
+      byok: { provider: "openrouter", model: "acme/private-llm-9" },
+      blend: {
+        mix: [
+          { profile: "no-tools", weight: 1 },
+          { profile: "byok", weight: 1 },
+        ],
+      },
+    });
+    expect(profileSupportsTools("blend", config)).toBeUndefined();
+  });
+
+  test("answers a mixed-capability mix identically on every call", () => {
+    const config = configWithProfiles({
+      "no-tools": { provider: "openrouter", model: "minimax/minimax-01" },
+      "with-tools": { provider: "anthropic", model: "claude-fable-5" },
+      blend: {
+        mix: [
+          { profile: "no-tools", weight: 1 },
+          { profile: "with-tools", weight: 1 },
+        ],
+      },
+    });
+    // No seed is available at probe time, so the verdict must not ride on a
+    // random arm pick.
+    const verdicts = new Set(
+      Array.from({ length: 50 }, () => profileSupportsTools("blend", config)),
+    );
+    expect([...verdicts]).toEqual([undefined]);
   });
 });

--- a/assistant/src/config/profile-tool-support.ts
+++ b/assistant/src/config/profile-tool-support.ts
@@ -1,6 +1,10 @@
+import type { z } from "zod";
+
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { resolveDefaultProfileForProvider } from "./default-profile-catalog.js";
 import { selectWinningProfile } from "./llm-resolver.js";
 import type { AssistantConfig } from "./schema.js";
+import type { LLMSchema } from "./schemas/llm.js";
 
 /**
  * Whether a named inference profile is KNOWN to support tool calling.
@@ -14,6 +18,13 @@ import type { AssistantConfig } from "./schema.js";
  *   - `undefined` the model is unknown to the catalog, or the catalog entry
  *     is silent on tool use
  *
+ * A `mix` profile is answered across ALL of its arms rather than by expanding
+ * it, because the arm a mix lands on is a function of the running
+ * conversation's `selectionSeed` and no such conversation exists at probe
+ * time. A verdict is only returned when it holds for every arm: all-denied is
+ * `false`, all-capable is `true`, and a mix of the two is `undefined` (which
+ * arm runs is unknowable here, so there is no honest verdict).
+ *
  * Callers gate on `=== false` so an unknown model is never punished (fail
  * open).
  */
@@ -21,12 +32,54 @@ export function profileSupportsTools(
   profileKey: string,
   config: AssistantConfig,
 ): boolean | undefined {
-  // Run the profile through the real resolver so a catalog default, a
-  // workspace shadow, and a mix (which expands to one concrete arm) all yield
-  // the model the child would actually run on. Feeding the key in as the
-  // override rung means a profile the resolver cannot use falls through to a
-  // different rung, and a non-`override` winner tells us the key never
-  // resolved: unknown, so no verdict.
+  const arms = mixArms(profileKey, config.llm);
+  if (arms == null) {
+    return concreteProfileSupportsTools(profileKey, config);
+  }
+  const verdicts = arms.map((arm) => concreteProfileSupportsTools(arm, config));
+  if (verdicts.length === 0) {
+    return undefined;
+  }
+  if (verdicts.every((verdict) => verdict === false)) {
+    return false;
+  }
+  if (verdicts.every((verdict) => verdict === true)) {
+    return true;
+  }
+  return undefined;
+}
+
+/** The arm profile names of a `mix` profile, or `undefined` if not a mix. */
+function mixArms(
+  profileKey: string,
+  llm: z.infer<typeof LLMSchema>,
+): string[] | undefined {
+  const entry = resolveDefaultProfileForProvider(
+    llm.profiles,
+    profileKey,
+    llm.defaultProvider ?? null,
+  );
+  return entry?.mix?.map((arm) => arm.profile);
+}
+
+/**
+ * Verdict for a profile expected to name one concrete model. A key that is
+ * itself a mix yields no verdict: `LLMSchema.superRefine` forbids nesting, so
+ * this is only reachable from a hand-written config that never went through
+ * the schema, and expanding it would reintroduce the unseeded random pick.
+ */
+function concreteProfileSupportsTools(
+  profileKey: string,
+  config: AssistantConfig,
+): boolean | undefined {
+  if (mixArms(profileKey, config.llm) != null) {
+    return undefined;
+  }
+  // Run the profile through the real resolver so a catalog default and a
+  // workspace shadow alike yield the model the child would actually run on.
+  // Feeding the key in as the override rung means a profile the resolver
+  // cannot use falls through to a different rung, and a non-`override` winner
+  // tells us the key never resolved: unknown, so no verdict.
   const winner = selectWinningProfile("subagentSpawn", config.llm, {
     overrideProfile: profileKey,
   });

--- a/assistant/src/config/profile-tool-support.ts
+++ b/assistant/src/config/profile-tool-support.ts
@@ -1,0 +1,57 @@
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { selectWinningProfile } from "./llm-resolver.js";
+import type { AssistantConfig } from "./schema.js";
+
+/**
+ * Whether a named inference profile is KNOWN to support tool calling.
+ *
+ * Tri-state on purpose. The model catalog is not exhaustive: BYOK installs
+ * point profiles at models the catalog has never heard of, and a
+ * `supportsToolUse` flag it does not carry is not evidence of anything. So
+ * only `false` is a verdict:
+ *   - `true`  the catalog states the model supports tool use
+ *   - `false` the catalog states the model does NOT support tool use
+ *   - `undefined` the model is unknown to the catalog, or the catalog entry
+ *     is silent on tool use
+ *
+ * Callers gate on `=== false` so an unknown model is never punished (fail
+ * open).
+ */
+export function profileSupportsTools(
+  profileKey: string,
+  config: AssistantConfig,
+): boolean | undefined {
+  // Run the profile through the real resolver so a catalog default, a
+  // workspace shadow, and a mix (which expands to one concrete arm) all yield
+  // the model the child would actually run on. Feeding the key in as the
+  // override rung means a profile the resolver cannot use falls through to a
+  // different rung, and a non-`override` winner tells us the key never
+  // resolved: unknown, so no verdict.
+  const winner = selectWinningProfile("subagentSpawn", config.llm, {
+    overrideProfile: profileKey,
+  });
+  if (winner.source !== "override") {
+    return undefined;
+  }
+  const model = winner.entry?.model;
+  return model == null ? undefined : modelSupportsTools(model);
+}
+
+/**
+ * Look a model id up across every catalog provider. A model offered by more
+ * than one provider (e.g. the same id direct and through OpenRouter) is
+ * matched several times; any entry claiming tool support settles it, keeping
+ * the answer on the fail-open side.
+ */
+function modelSupportsTools(modelId: string): boolean | undefined {
+  const matches = PROVIDER_CATALOG.flatMap((provider) =>
+    provider.models.filter((model) => model.id === modelId),
+  );
+  if (matches.some((model) => model.supportsToolUse === true)) {
+    return true;
+  }
+  if (matches.some((model) => model.supportsToolUse === false)) {
+    return false;
+  }
+  return undefined;
+}

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
 import type { AssistantEvent } from "../../api/index.js";
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
+import { profileSupportsTools } from "../../config/profile-tool-support.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
   getConversationOverrideProfile,
@@ -191,15 +193,46 @@ export async function executeSubagentSpawn(
   // `forceOverrideProfile` and wins outright; the row read short-circuits
   // to `undefined` for the background subagent conversation and for tool
   // calls outside an agent-loop turn.
+  //
+  // `subagent-profile-isolation` replaces the two inheritance rungs for
+  // non-advisor spawns. A profile pinned on a conversation is a choice about
+  // that conversation, not about delegated work, yet it carries the pinned
+  // model's price and its tool-calling reliability into every child the turn
+  // spawns. Under the flag a spawn that names no `inference_profile` resolves
+  // to the `subagentSpawn` call site's own default instead, and an explicit
+  // profile the catalog states cannot call tools falls back to that same
+  // default with a note on the result.
+  const config = getConfig();
+  const llm = config.llm;
+  const isolateProfile = isAssistantFeatureFlagEnabled(
+    "subagent-profile-isolation",
+  );
+  // `resolveDefaultProfileKey` already prefers an `llm.callSites.subagentSpawn`
+  // pin over the `balanced` catalog intent, and skips a pin that is disabled or
+  // incomplete, so it is the whole answer for "what does this call site run on".
+  const subagentCallSiteProfile = (): string | undefined =>
+    resolveDefaultProfileKey("subagentSpawn", llm);
+
+  let profileNote: string | undefined;
   let inheritedOverrideProfile = requestedOverrideProfile;
   if (inheritedOverrideProfile === undefined) {
-    const llm = getConfig().llm;
-    inheritedOverrideProfile =
-      context.overrideProfile ??
-      getConversationOverrideProfile(context.conversationId) ??
-      (llm.callSites?.subagentSpawn?.profile == null
-        ? resolveDefaultProfileKey(context.invokingCallSite ?? "mainAgent", llm)
-        : undefined);
+    inheritedOverrideProfile = isolateProfile
+      ? subagentCallSiteProfile()
+      : (context.overrideProfile ??
+        getConversationOverrideProfile(context.conversationId) ??
+        (llm.callSites?.subagentSpawn?.profile == null
+          ? resolveDefaultProfileKey(
+              context.invokingCallSite ?? "mainAgent",
+              llm,
+            )
+          : undefined));
+  } else if (
+    isolateProfile &&
+    profileSupportsTools(inheritedOverrideProfile, config) === false
+  ) {
+    profileNote = `requested profile "${inheritedOverrideProfile}" is not verified for tool calling; ran on the default profile instead.`;
+    inheritedOverrideProfile = subagentCallSiteProfile();
+    forceOverrideProfile = inheritedOverrideProfile !== undefined;
   }
 
   try {
@@ -234,6 +267,7 @@ export async function executeSubagentSpawn(
         label,
         status: "pending",
         ...(fork ? { isFork: true } : {}),
+        ...(profileNote ? { note: profileNote } : {}),
         message: fork
           ? `Forked subagent "${label}" spawned with full parent context. You will be notified automatically when it completes or fails - do NOT poll subagent_status. Continue the conversation normally.`
           : `Subagent "${label}" spawned. You will be notified automatically when it completes or fails - do NOT poll subagent_status. Continue the conversation normally.`,


### PR DESCRIPTION
## Summary
- Behind `subagent-profile-isolation` (default off), non-advisor spawns resolve the `subagentSpawn` call-site default instead of inheriting the per-turn override or the conversation-pinned profile.
- An explicit `inference_profile` still wins, unless the model catalog states the model cannot call tools: that request falls back to the call-site default and the spawn result carries a `note` explaining the substitution.
- New `config/profile-tool-support.ts` answers the tool-use question tri-state and fails open, so BYOK models absent from the catalog are never downgraded. Advisor consults still run on `llm.advisorProfile`.

Part of plan: subagent-type-consolidation.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)