### PR TITLE
fix(home): drop invalid feed items individually instead of the whole file

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -257,14 +257,49 @@ describe("parseFeedFile", () => {
     ).toThrow();
   });
 
-  test("throws when an item in the file is invalid", () => {
-    expect(() =>
-      parseFeedFile({
-        version: 2,
-        items: [{ ...minimalNotification(), priority: 999 }],
-        updatedAt: NOW_ISO,
-      }),
-    ).toThrow();
+  test("throws when `items` is missing entirely", () => {
+    expect(() => parseFeedFile({ version: 2, updatedAt: NOW_ISO })).toThrow();
+  });
+
+  test("throws when `updatedAt` is missing", () => {
+    expect(() => parseFeedFile({ version: 2, items: [] })).toThrow();
+  });
+
+  test("drops an invalid item but keeps the valid ones", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [
+        minimalNotification(),
+        { ...minimalNotification(), id: "notif-bad", priority: 999 },
+      ],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]?.id).toBe("notif-1");
+    expect(parsed.droppedCount).toBe(1);
+    expect(parsed.updatedAt).toBe(NOW_ISO);
+  });
+
+  test("reports droppedCount 0 for a fully valid file", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [minimalNotification(), notificationWithActions()],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.droppedCount).toBe(0);
+  });
+
+  test("returns an empty item list when every item is invalid", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [{ ...minimalNotification(), type: "banner" }, null, "nope"],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toEqual([]);
+    expect(parsed.droppedCount).toBe(3);
+    expect(parsed.version).toBe(2);
+    expect(parsed.updatedAt).toBe(NOW_ISO);
   });
 
   test("accepts a file with a noteworthy item", () => {

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -199,6 +199,23 @@ describe("feed-writer", () => {
       const feed = readHomeFeed();
       expect(feed.items).toEqual([]);
     });
+
+    test("keeps the valid items when a single row is malformed", () => {
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      const file = {
+        version: 2,
+        updatedAt: "2026-04-14T12:00:00.000Z",
+        items: [
+          makeItem({ id: "good" }),
+          { ...makeItem({ id: "bad" }), priority: 999 },
+        ],
+      };
+      writeFileSync(getHomeFeedPath(), JSON.stringify(file, null, 2), "utf-8");
+
+      const feed = readHomeFeed();
+      expect(feed.items).toHaveLength(1);
+      expect(feed.items[0]!.id).toBe("good");
+    });
   });
 
   describe("appendFeedItem", () => {

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -53,12 +53,17 @@ export interface HomeFeedFile {
   version: 2;
   items: z.infer<typeof FeedItemSchema>[];
   updatedAt: string;
+  /** In-memory only; never persisted. Set by `parseFeedFile`. */
+  droppedCount?: number;
 }
 
-/** Schema for the on-disk `home-feed.json` file. */
-const homeFeedFileSchema = z.object({
+/**
+ * Envelope schema for the on-disk `home-feed.json` file. Items stay
+ * unvalidated here so `parseFeedFile` can validate them one at a time.
+ */
+const homeFeedEnvelopeSchema = z.object({
   version: z.literal(2),
-  items: z.array(FeedItemSchema),
+  items: z.array(z.unknown()),
   updatedAt: z.string(),
 });
 
@@ -66,9 +71,32 @@ const homeFeedFileSchema = z.object({
  * Parse and validate a raw value read from `home-feed.json`.
  *
  * Used by the writer on read-back and by the HTTP route when serving the
- * feed. Throws a `ZodError` on any validation failure — callers are
- * expected to log + recover (e.g. treat the file as empty).
+ * feed. Throws a `ZodError` when the envelope itself is invalid (wrong
+ * `version`, non-object input, missing `updatedAt`). Callers are
+ * expected to log + recover (e.g. treat the file as empty). Individual
+ * items that fail validation are dropped and counted in `droppedCount`
+ * so one malformed row cannot erase the rest of the feed.
  */
-export function parseFeedFile(raw: unknown): HomeFeedFile {
-  return homeFeedFileSchema.parse(raw) as HomeFeedFile;
+export function parseFeedFile(
+  raw: unknown,
+): HomeFeedFile & { droppedCount: number } {
+  const envelope = homeFeedEnvelopeSchema.parse(raw);
+
+  const items: z.infer<typeof FeedItemSchema>[] = [];
+  let droppedCount = 0;
+  for (const rawItem of envelope.items) {
+    const result = FeedItemSchema.safeParse(rawItem);
+    if (result.success) {
+      items.push(result.data);
+    } else {
+      droppedCount++;
+    }
+  }
+
+  return {
+    version: envelope.version,
+    items,
+    updatedAt: envelope.updatedAt,
+    droppedCount,
+  };
 }

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -68,7 +68,9 @@ export function getHomeFeedPath(): string {
  * Read the on-disk feed file, applying the stateless TTL filter.
  *
  * Returns an empty `HomeFeedFile` when the file is missing, unreadable,
- * or fails Zod validation — callers never see a throw from this path.
+ * or has an invalid envelope. Callers never see a throw from this path.
+ * Individual items that fail validation are dropped and warn-logged
+ * while the rest of the feed survives.
  * Items whose `expiresAt` is in the past are dropped from the returned
  * `items` array but are NOT rewritten to disk; the next append cycle
  * will persist the post-filter view naturally.
@@ -93,7 +95,7 @@ export function readHomeFeed(): HomeFeedFile {
     return empty;
   }
 
-  let parsed: HomeFeedFile;
+  let parsed: ReturnType<typeof parseFeedFile>;
   try {
     parsed = parseFeedFile(raw);
   } catch (err) {
@@ -102,6 +104,13 @@ export function readHomeFeed(): HomeFeedFile {
       "home-feed.json failed schema validation; returning empty",
     );
     return empty;
+  }
+
+  if (parsed.droppedCount > 0) {
+    log.warn(
+      { path, droppedCount: parsed.droppedCount },
+      "Dropped invalid items from home-feed.json",
+    );
   }
 
   const now = Date.now();


### PR DESCRIPTION
## Summary
- Validate feed items individually so one malformed row no longer empties the whole file
- Log a warning naming the dropped count so partial corruption is visible
- Removes a data-loss path: readHomeFeed returning empty causes the next write to overwrite all history

Part of plan: home-feed-required-titles.md (PR 1 of 8)