### PR TITLE
refactor(util): extract short-title hygiene helpers from the conversation title service

### DIFF
--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -19,6 +19,11 @@ import { publishConversationTitleChanged } from "../runtime/sync/resource-sync-e
 import { getLogger } from "../util/logger.js";
 import { Mutex } from "../util/mutex.js";
 import {
+  normalizeTitle,
+  stripThinkingTags,
+  truncateTitle,
+} from "../util/short-title.js";
+import {
   getConversation,
   getMessages,
   type MessageRow,
@@ -575,176 +580,6 @@ function logRetryableFallback(
     retryableFallbackLogFields(params, reason),
     "Conversation title generation used retryable fallback",
   );
-}
-
-const META_FAILURE_TITLES = new Set([
-  "missing context",
-  "no context",
-  "insufficient context",
-  "unclear context",
-  "empty context",
-  "no topic",
-  "unclear topic",
-  "unclear request",
-  "unclear message",
-  "empty conversation",
-  "empty message",
-  "no content",
-]);
-
-const MAX_TITLE_LENGTH = 40;
-const MAX_TITLE_WORDS = 7;
-
-function truncateTitle(title: string): string {
-  if (title.length <= MAX_TITLE_LENGTH) {
-    return title;
-  }
-  const words = title.split(/\s+/);
-  if (words.length <= MAX_TITLE_WORDS) {
-    // Long words but few of them — truncate to char limit at word boundary
-    let result = "";
-    for (const word of words) {
-      const candidate = result ? result + " " + word : word;
-      if (candidate.length > MAX_TITLE_LENGTH) {
-        break;
-      }
-      result = candidate;
-    }
-    return result || title.slice(0, MAX_TITLE_LENGTH);
-  }
-  // Too many words — trim to 5 words
-  return words.slice(0, 5).join(" ");
-}
-
-function normalizeTitle(raw: string): string {
-  let title = raw.trim().replace(/^["']|["']$/g, "");
-  title = stripMarkdown(title);
-  title = stripThinkingTags(title).trim();
-  if (!title) {
-    return "";
-  }
-  // Reject outputs that are the model reasoning aloud or continuing the
-  // conversation instead of naming it (e.g. "I need to generate a…", "I'll
-  // work through these files…"). Callers fall back to a deterministic title.
-  if (looksLikeLeakedProse(title)) {
-    return "";
-  }
-  if (META_FAILURE_TITLES.has(title.toLowerCase())) {
-    return "";
-  }
-  return truncateTitle(title);
-}
-
-/** Reasoning/sentence openers that never start a legitimate topic title. */
-const LEAKED_PROSE_PREFIXES = [
-  "i need to",
-  "i needed to",
-  "i should",
-  "i will",
-  "i'll",
-  "i can ",
-  "i can't",
-  "i cannot",
-  "i'm ",
-  "i am ",
-  "i've ",
-  "i have ",
-  "i'd ",
-  "i would",
-  "let me",
-  "looking at",
-  "based on",
-  "given the",
-  "to generate",
-  "to summarize",
-  "to title",
-  // Subject-led reasoning openers. A bare noun phrase ("The User Interface
-  // Redesign", "The Conversation API") is a valid title, so each subject only
-  // counts as leaked prose when a verb or possessive follows it — marking the
-  // output as a sentence rather than a topic.
-  "the user wants",
-  "the user asked",
-  "the user is",
-  "the user wanted",
-  "the user needs",
-  "the user said",
-  "the user has",
-  "the user would",
-  "the user's request",
-  "the conversation is",
-  "this conversation is",
-  "the conversation appears",
-  "the conversation seems",
-  "the conversation covers",
-  "the conversation discusses",
-  "the assistant should",
-  "the assistant is",
-  "the assistant wants",
-  "the assistant needs",
-  "the title should",
-  "the title is",
-  "the title would",
-  "the title for",
-  "here's ",
-  "here is ",
-  "here are ",
-  "sure,",
-  "okay,",
-  "ok,",
-];
-
-/**
- * Heuristic guard for title outputs that are clearly prose — the model
- * reasoning aloud or replying to the conversation rather than naming it. A real
- * title is a single-line short noun phrase, so we reject multi-line output,
- * embedded transcript markers, leading reasoning openers, and sentence-shaped
- * clauses. Deliberately tight: a false reject only costs a deterministic
- * fallback title, while a false accept persists a broken one.
- */
-function looksLikeLeakedProse(title: string): boolean {
-  if (/\n/.test(title)) {
-    return true;
-  }
-  if (/\b(?:user|assistant)\s*:/i.test(title)) {
-    return true;
-  }
-  const lower = title.toLowerCase();
-  if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
-    return true;
-  }
-  // Sentence-shaped: terminal punctuation on a multi-word clause.
-  if (/[.?!]$/.test(title) && title.split(/\s+/).length > 5) {
-    return true;
-  }
-  return false;
-}
-
-/** Strip thinking tags so they don't bleed into generated titles. */
-function stripThinkingTags(text: string): string {
-  return text
-    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
-    .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
-    .replace(/<think>[\s\S]*?<\/think>/gi, "")
-    .replace(/<thought>/gi, "")
-    .replace(/<\/thought>/gi, "")
-    .replace(/<thinking>/gi, "")
-    .replace(/<\/thinking>/gi, "")
-    .replace(/<think>/gi, "")
-    .replace(/<\/think>/gi, "")
-    .replace(/<:[^>]*>/gi, "");
-}
-
-/** Strip common markdown formatting so titles render as plain text. */
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, "$1") // **bold**
-    .replace(/__(.+?)__/g, "$1") // __bold__
-    .replace(/\*(.+?)\*/g, "$1") // *italic*
-    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1") // _italic_ (word-boundary-aware to preserve snake_case)
-    .replace(/~~(.+?)~~/g, "$1") // ~~strikethrough~~
-    .replace(/`(.+?)`/g, "$1") // `code`
-    .replace(/\[(.+?)\]\(.+?\)/g, "$1") // [link](url)
-    .replace(/^#{1,6}\s+/gm, ""); // # headings
 }
 
 function deriveFallbackTitle(context?: TitleContext): string | null {

--- a/assistant/src/util/__tests__/short-title.test.ts
+++ b/assistant/src/util/__tests__/short-title.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LEAKED_PROSE_PREFIXES,
+  looksLikeLeakedProse,
+  MAX_TITLE_LENGTH,
+  MAX_TITLE_WORDS,
+  META_FAILURE_TITLES,
+  normalizeTitle,
+  stripMarkdown,
+  stripThinkingTags,
+  truncateTitle,
+} from "../short-title.js";
+
+describe("stripMarkdown", () => {
+  test("unwraps bold, italic, strikethrough, and code spans", () => {
+    expect(stripMarkdown("**Auth** Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("__Auth__ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("*Auth* Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("_Auth_ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("~~Auth~~ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("`Auth` Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("keeps link text and drops the target", () => {
+    expect(stripMarkdown("[Auth Rewrite](https://example.com)")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("removes heading markers", () => {
+    expect(stripMarkdown("## Auth Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("preserves snake_case identifiers", () => {
+    expect(stripMarkdown("record_conversation_title")).toBe(
+      "record_conversation_title",
+    );
+  });
+});
+
+describe("stripThinkingTags", () => {
+  test("removes paired thinking blocks and their contents", () => {
+    expect(stripThinkingTags("<thinking>hmm</thinking>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+    expect(stripThinkingTags("<thought>hmm</thought>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+    expect(stripThinkingTags("<think>hmm</think>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("removes unpaired tags but keeps the surrounding text", () => {
+    expect(stripThinkingTags("<thinking>Auth Rewrite")).toBe("Auth Rewrite");
+    expect(stripThinkingTags("Auth Rewrite</think>")).toBe("Auth Rewrite");
+  });
+
+  test("removes colon-prefixed pseudo tags", () => {
+    expect(stripThinkingTags("<:anything>Auth Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("leaves plain text untouched", () => {
+    expect(stripThinkingTags("Auth Rewrite")).toBe("Auth Rewrite");
+  });
+});
+
+describe("truncateTitle", () => {
+  test("leaves titles within the character limit untouched", () => {
+    const title = "Auth Middleware Rewrite";
+    expect(title.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(truncateTitle(title)).toBe(title);
+  });
+
+  test("trims at a word boundary when few but long words exceed the char limit", () => {
+    const title = "Supercalifragilistic Authentication Middleware Rewrite";
+    expect(title.split(" ").length).toBeLessThanOrEqual(MAX_TITLE_WORDS);
+    expect(truncateTitle(title)).toBe("Supercalifragilistic Authentication");
+  });
+
+  test("hard-slices a single word longer than the char limit", () => {
+    const title = "a".repeat(MAX_TITLE_LENGTH + 5);
+    expect(truncateTitle(title)).toBe("a".repeat(MAX_TITLE_LENGTH));
+  });
+
+  test("keeps the first five words when the word limit is exceeded", () => {
+    const title =
+      "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+    expect(title.length).toBeGreaterThan(MAX_TITLE_LENGTH);
+    expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
+    expect(truncateTitle(title)).toBe("alpha bravo charlie delta echo");
+  });
+});
+
+describe("looksLikeLeakedProse", () => {
+  test("rejects multi-line output", () => {
+    expect(looksLikeLeakedProse("Auth Rewrite\nand more")).toBe(true);
+  });
+
+  test("rejects embedded transcript markers", () => {
+    expect(looksLikeLeakedProse("User: how do I log in")).toBe(true);
+    expect(looksLikeLeakedProse("Assistant : here you go")).toBe(true);
+  });
+
+  test("rejects sentence-shaped clauses ending in terminal punctuation", () => {
+    expect(looksLikeLeakedProse("This is a topic about authentication.")).toBe(
+      true,
+    );
+    expect(looksLikeLeakedProse("What did they want to build here?")).toBe(
+      true,
+    );
+  });
+
+  test("keeps short phrases that end in punctuation", () => {
+    expect(looksLikeLeakedProse("Auth Rewrite?")).toBe(false);
+  });
+
+  test("rejects first-person reasoning openers", () => {
+    expect(looksLikeLeakedProse("I need to generate a title")).toBe(true);
+    expect(looksLikeLeakedProse("I'll work through these files")).toBe(true);
+    expect(looksLikeLeakedProse("I cannot title this")).toBe(true);
+  });
+
+  test("rejects imperative and deferral openers", () => {
+    expect(looksLikeLeakedProse("Let me summarize the request")).toBe(true);
+    expect(looksLikeLeakedProse("Looking at the conversation")).toBe(true);
+    expect(looksLikeLeakedProse("Based on the messages")).toBe(true);
+    expect(looksLikeLeakedProse("Given the context")).toBe(true);
+  });
+
+  test("rejects infinitive openers", () => {
+    expect(looksLikeLeakedProse("To generate a good title")).toBe(true);
+    expect(looksLikeLeakedProse("To summarize the discussion")).toBe(true);
+    expect(looksLikeLeakedProse("To title this thread")).toBe(true);
+  });
+
+  test("rejects subject-led reasoning openers", () => {
+    expect(looksLikeLeakedProse("The user wants a summary")).toBe(true);
+    expect(looksLikeLeakedProse("The conversation is about Docker")).toBe(true);
+    expect(looksLikeLeakedProse("The assistant should reply")).toBe(true);
+    expect(looksLikeLeakedProse("The title should be short")).toBe(true);
+  });
+
+  test("rejects preamble openers", () => {
+    expect(looksLikeLeakedProse("Here's a title")).toBe(true);
+    expect(looksLikeLeakedProse("Here is a title")).toBe(true);
+    expect(looksLikeLeakedProse("Sure, Auth Rewrite")).toBe(true);
+    expect(looksLikeLeakedProse("Okay, Auth Rewrite")).toBe(true);
+  });
+
+  test("accepts bare noun-phrase titles that share a subject word", () => {
+    expect(looksLikeLeakedProse("The Conversation API")).toBe(false);
+    expect(looksLikeLeakedProse("The User Interface Redesign")).toBe(false);
+    expect(looksLikeLeakedProse("Auth Middleware Rewrite")).toBe(false);
+  });
+
+  test("every configured prefix is treated as prose", () => {
+    for (const prefix of LEAKED_PROSE_PREFIXES) {
+      expect(looksLikeLeakedProse(`${prefix} something`)).toBe(true);
+    }
+  });
+});
+
+describe("normalizeTitle", () => {
+  test("strips surrounding quotes", () => {
+    expect(normalizeTitle('"Auth Rewrite"')).toBe("Auth Rewrite");
+    expect(normalizeTitle("'Auth Rewrite'")).toBe("Auth Rewrite");
+  });
+
+  test("strips markdown and thinking tags together", () => {
+    expect(normalizeTitle("<thinking>hmm</thinking> **Auth Rewrite**")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("returns empty for blank input", () => {
+    expect(normalizeTitle("")).toBe("");
+    expect(normalizeTitle("   ")).toBe("");
+    expect(normalizeTitle("<thinking>hmm</thinking>")).toBe("");
+  });
+
+  test("returns empty for leaked prose", () => {
+    expect(normalizeTitle("I need to generate a title for this")).toBe("");
+    expect(normalizeTitle("User: how do I log in")).toBe("");
+    expect(normalizeTitle("Auth Rewrite\nand more")).toBe("");
+  });
+
+  test("returns empty for meta-failure titles regardless of case", () => {
+    for (const meta of META_FAILURE_TITLES) {
+      expect(normalizeTitle(meta)).toBe("");
+    }
+    expect(normalizeTitle("Missing Context")).toBe("");
+    expect(normalizeTitle('"No Topic"')).toBe("");
+  });
+
+  test("truncates an over-long accepted title", () => {
+    expect(
+      normalizeTitle("alpha bravo charlie delta echo foxtrot golf hotel india"),
+    ).toBe("alpha bravo charlie delta echo");
+  });
+});

--- a/assistant/src/util/short-title.ts
+++ b/assistant/src/util/short-title.ts
@@ -1,0 +1,180 @@
+/**
+ * Title hygiene helpers shared by every surface that renders a short,
+ * scannable conversation title: markdown/thinking-tag stripping, prose and
+ * meta-failure rejection, and length truncation.
+ */
+
+export const MAX_TITLE_LENGTH = 40;
+export const MAX_TITLE_WORDS = 7;
+
+export const META_FAILURE_TITLES = new Set([
+  "missing context",
+  "no context",
+  "insufficient context",
+  "unclear context",
+  "empty context",
+  "no topic",
+  "unclear topic",
+  "unclear request",
+  "unclear message",
+  "empty conversation",
+  "empty message",
+  "no content",
+]);
+
+/** Reasoning/sentence openers that never start a legitimate topic title. */
+export const LEAKED_PROSE_PREFIXES = [
+  "i need to",
+  "i needed to",
+  "i should",
+  "i will",
+  "i'll",
+  "i can ",
+  "i can't",
+  "i cannot",
+  "i'm ",
+  "i am ",
+  "i've ",
+  "i have ",
+  "i'd ",
+  "i would",
+  "let me",
+  "looking at",
+  "based on",
+  "given the",
+  "to generate",
+  "to summarize",
+  "to title",
+  // Subject-led reasoning openers. A bare noun phrase ("The User Interface
+  // Redesign", "The Conversation API") is a valid title, so each subject only
+  // counts as leaked prose when a verb or possessive follows it, marking the
+  // output as a sentence rather than a topic.
+  "the user wants",
+  "the user asked",
+  "the user is",
+  "the user wanted",
+  "the user needs",
+  "the user said",
+  "the user has",
+  "the user would",
+  "the user's request",
+  "the conversation is",
+  "this conversation is",
+  "the conversation appears",
+  "the conversation seems",
+  "the conversation covers",
+  "the conversation discusses",
+  "the assistant should",
+  "the assistant is",
+  "the assistant wants",
+  "the assistant needs",
+  "the title should",
+  "the title is",
+  "the title would",
+  "the title for",
+  "here's ",
+  "here is ",
+  "here are ",
+  "sure,",
+  "okay,",
+  "ok,",
+];
+
+/** Strip common markdown formatting so titles render as plain text. */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "$1") // **bold**
+    .replace(/__(.+?)__/g, "$1") // __bold__
+    .replace(/\*(.+?)\*/g, "$1") // *italic*
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1") // _italic_ (word-boundary-aware to preserve snake_case)
+    .replace(/~~(.+?)~~/g, "$1") // ~~strikethrough~~
+    .replace(/`(.+?)`/g, "$1") // `code`
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1") // [link](url)
+    .replace(/^#{1,6}\s+/gm, ""); // # headings
+}
+
+/** Strip thinking tags so they don't bleed into generated titles. */
+export function stripThinkingTags(text: string): string {
+  return text
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
+    .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .replace(/<thought>/gi, "")
+    .replace(/<\/thought>/gi, "")
+    .replace(/<thinking>/gi, "")
+    .replace(/<\/thinking>/gi, "")
+    .replace(/<think>/gi, "")
+    .replace(/<\/think>/gi, "")
+    .replace(/<:[^>]*>/gi, "");
+}
+
+export function truncateTitle(title: string): string {
+  if (title.length <= MAX_TITLE_LENGTH) {
+    return title;
+  }
+  const words = title.split(/\s+/);
+  if (words.length <= MAX_TITLE_WORDS) {
+    // Long words but few of them: truncate to char limit at word boundary
+    let result = "";
+    for (const word of words) {
+      const candidate = result ? result + " " + word : word;
+      if (candidate.length > MAX_TITLE_LENGTH) {
+        break;
+      }
+      result = candidate;
+    }
+    return result || title.slice(0, MAX_TITLE_LENGTH);
+  }
+  // Too many words: trim to 5 words
+  return words.slice(0, 5).join(" ");
+}
+
+/**
+ * Heuristic guard for title outputs that are clearly prose: the model
+ * reasoning aloud or replying to the conversation rather than naming it. A real
+ * title is a single-line short noun phrase, so we reject multi-line output,
+ * embedded transcript markers, leading reasoning openers, and sentence-shaped
+ * clauses. Deliberately tight: a false reject only costs a deterministic
+ * fallback title, while a false accept persists a broken one.
+ */
+export function looksLikeLeakedProse(title: string): boolean {
+  if (/\n/.test(title)) {
+    return true;
+  }
+  if (/\b(?:user|assistant)\s*:/i.test(title)) {
+    return true;
+  }
+  const lower = title.toLowerCase();
+  if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return true;
+  }
+  // Sentence-shaped: terminal punctuation on a multi-word clause.
+  if (/[.?!]$/.test(title) && title.split(/\s+/).length > 5) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Clean a raw title into a short, scannable label. Returns "" when the input is
+ * empty, reads as leaked prose, or is a meta-failure title, signalling that
+ * callers should fall back to a deterministic title.
+ */
+export function normalizeTitle(raw: string): string {
+  let title = raw.trim().replace(/^["']|["']$/g, "");
+  title = stripMarkdown(title);
+  title = stripThinkingTags(title).trim();
+  if (!title) {
+    return "";
+  }
+  // Reject outputs that are the model reasoning aloud or continuing the
+  // conversation instead of naming it (e.g. "I need to generate a…", "I'll
+  // work through these files…"). Callers fall back to a deterministic title.
+  if (looksLikeLeakedProse(title)) {
+    return "";
+  }
+  if (META_FAILURE_TITLES.has(title.toLowerCase())) {
+    return "";
+  }
+  return truncateTitle(title);
+}


### PR DESCRIPTION
## Summary
- Move the title normalization, truncation, and prose-rejection helpers into a shared util module
- Pure move: the conversation title service imports them and its existing tests pass unmodified
- Adds direct unit coverage for helpers that were previously only tested indirectly

Part of plan: home-feed-required-titles.md (PR 2 of 8)