### PR TITLE
fix(notifications): ask the decision model for a topic headline, not a popup title

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -55,9 +55,11 @@ mock.module("../../contacts/contact-store.js", () => ({
 // Provider mock. By default `sendMessage` throws so the pass-through paths
 // (which must skip the LLM) fail loudly if they reach the provider. LLM-path
 // tests override `providerSendMessage` to capture inputs.
+type ProviderSendOptions = { systemPrompt?: string; tools?: unknown[] };
+
 let providerSendMessage: (
   messages: unknown[],
-  opts: { systemPrompt?: string },
+  opts: ProviderSendOptions,
 ) => Promise<unknown> = () => {
   throw new Error(
     "provider.sendMessage should NOT be invoked for pass-through decisions",
@@ -66,7 +68,7 @@ let providerSendMessage: (
 
 mock.module("../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => ({
-    sendMessage: (messages: unknown[], opts: { systemPrompt?: string }) =>
+    sendMessage: (messages: unknown[], opts: ProviderSendOptions) =>
       providerSendMessage(messages, opts),
   }),
   createTimeout: () => ({
@@ -128,6 +130,24 @@ function makeAssistantReplySignal(
       visibleInSourceNow: false,
     },
     ...overrides,
+  };
+}
+
+/** A signal with no verbatim copy, so the engine takes the LLM path. */
+function makeLlmSignal(): NotificationSignal {
+  return {
+    signalId: "sig-llm-1",
+    createdAt: Date.now(),
+    sourceChannel: "scheduler",
+    sourceContextId: "schedule-1",
+    sourceEventName: "schedule.notify",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
   };
 }
 
@@ -485,23 +505,6 @@ describe("chat.assistant_reply pass-through in notification decision engine", ()
 });
 
 describe("recipient notes injection (ACL from gateway, notes joined locally)", () => {
-  function makeLlmSignal(): NotificationSignal {
-    return {
-      signalId: "sig-llm-notes-1",
-      createdAt: Date.now(),
-      sourceChannel: "scheduler",
-      sourceContextId: "schedule-1",
-      sourceEventName: "schedule.notify",
-      contextPayload: {},
-      attentionHints: {
-        requiresAction: false,
-        urgency: "low",
-        isAsyncBackground: false,
-        visibleInSourceNow: false,
-      },
-    };
-  }
-
   test("injects the guardian's local notes, resolved via the gateway contactId", async () => {
     guardianDeliveryFixture = [{ contactId: "contact-42" }];
     contactInfoFixture = { "contact-42": { notes: "Prefers terse updates." } };
@@ -531,5 +534,46 @@ describe("recipient notes injection (ACL from gateway, notes joined locally)", (
     await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
 
     expect(capturedSystemPrompt).not.toContain("<recipient-context>");
+  });
+});
+
+describe("decision tool title field specification", () => {
+  test("pins the length, form, and no-echo constraints in the tool schema", async () => {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+
+    let capturedTools: unknown[] | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedTools = opts.tools;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    const tool = capturedTools?.[0] as {
+      input_schema: {
+        properties: {
+          renderedCopy: {
+            properties: Record<
+              string,
+              { properties: { title: { description: string } } }
+            >;
+          };
+        };
+      };
+    };
+    const description =
+      tool.input_schema.properties.renderedCopy.properties.vellum.properties
+        .title.description;
+
+    expect(description).toContain("2 to 5 words");
+    expect(description).toContain("40 characters");
+    expect(description).toContain("noun phrase");
+    expect(description).toContain(
+      "Do NOT restate, summarize, or echo the body",
+    );
+    expect(description).toContain("no markdown");
+    expect(description).toContain("Missing Context");
+    expect(description.match(/NOT '/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -230,9 +230,9 @@ function buildUserPrompt(signal: NotificationSignal): string {
 // ── Tool definition ────────────────────────────────────────────────────
 
 /**
- * Modelled on the conversation title prompt (`persistence/conversation-title-service.ts`),
- * which reliably gets clean noun-phrase headlines out of this same model profile.
- * Without a real spec the model echoes the body back as the title.
+ * Spec for the per-channel notification title. Mirrors the conversation title
+ * prompt (`persistence/conversation-title-service.ts`), which gets clean
+ * noun-phrase headlines out of this same model profile.
  */
 const TITLE_FIELD_DESCRIPTION = [
   "Scannable headline naming the TOPIC of this notification, not a summary of it.",

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -229,6 +229,26 @@ function buildUserPrompt(signal: NotificationSignal): string {
 
 // ── Tool definition ────────────────────────────────────────────────────
 
+/**
+ * Modelled on the conversation title prompt (`persistence/conversation-title-service.ts`),
+ * which reliably gets clean noun-phrase headlines out of this same model profile.
+ * Without a real spec the model echoes the body back as the title.
+ */
+const TITLE_FIELD_DESCRIPTION = [
+  "Scannable headline naming the TOPIC of this notification, not a summary of it.",
+  "Rules:",
+  "- 2 to 5 words. Longer titles are unacceptable, ruthlessly compress",
+  "- 40 characters absolute maximum, longer titles get truncated and look broken",
+  "- A noun phrase naming the topic, never a sentence, question, or greeting (e.g. 'Platform Standup', 'Nightly Backup Failure')",
+  "- Do NOT restate, summarize, or echo the body. The title and the body must carry different information",
+  "- No quotes, no markdown, no trailing punctuation",
+  "- Never describe missing or thin context. Titles like 'Notification', 'Update', 'Missing Context' are forbidden. Extract a topic from the words that ARE present",
+  "Examples:",
+  "- Body 'Your 9am standup with the platform team starts in 5 minutes' -> 'Platform Standup', NOT 'Standup Starts In 5 Minutes'",
+  "- Body 'The nightly backup job failed on db-primary at 02:14' -> 'Nightly Backup Failure', NOT 'Nightly Backup Job Failed On db-primary'",
+  "- Body 'Dana replied about the Q3 pricing deck and wants your notes' -> 'Q3 Pricing Deck', NOT 'Dana Replied About The Pricing Deck'",
+].join("\n");
+
 function buildDecisionTool(availableChannels: NotificationChannel[]) {
   return {
     name: "record_notification_decision",
@@ -264,7 +284,7 @@ function buildDecisionTool(availableChannels: NotificationChannel[]) {
                 properties: {
                   title: {
                     type: "string",
-                    description: "Short notification popup title (≤ 8 words)",
+                    description: TITLE_FIELD_DESCRIPTION,
                   },
                   body: {
                     type: "string",

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -246,7 +246,7 @@ const TITLE_FIELD_DESCRIPTION = [
   "Examples:",
   "- Body 'Your 9am standup with the platform team starts in 5 minutes' -> 'Platform Standup', NOT 'Standup Starts In 5 Minutes'",
   "- Body 'The nightly backup job failed on db-primary at 02:14' -> 'Nightly Backup Failure', NOT 'Nightly Backup Job Failed On db-primary'",
-  "- Body 'Dana replied about the Q3 pricing deck and wants your notes' -> 'Q3 Pricing Deck', NOT 'Dana Replied About The Pricing Deck'",
+  "- Body 'Alice replied about the Q3 pricing deck and wants your notes' -> 'Q3 Pricing Deck', NOT 'Alice Replied About The Pricing Deck'",
 ].join("\n");
 
 function buildDecisionTool(availableChannels: NotificationChannel[]) {


### PR DESCRIPTION
## Summary
- Replace the one-line title field description with a real specification modelled on the conversation title prompt
- Same model, profile, and token budget: this is a prompt-only change
- Adds a test pinning the new constraints so the guidance cannot be silently dropped

Part of plan: home-feed-required-titles.md (PR 3 of 8)