### PR TITLE
fix(home): treat an empty title edit as a no-op instead of clearing the field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21436,6 +21436,7 @@ paths:
                   minLength: 1
                   description: Feed item id (notif:<uuid>) or bare uuid
                 title:
+                  description: New title. An empty value is ignored, never cleared.
                   type: string
                 body:
                   type: string

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -263,7 +263,8 @@ Examples:
         },
         {
           flags: "--title <title>",
-          description: "New short headline (≤ 8 words).",
+          description:
+            "New short headline (≤ 8 words). An empty value is ignored, so the existing title stays put.",
         },
         {
           flags: "--urgency <urgency>",

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -50,6 +50,7 @@ const {
   bulkSetFeedItemStatus,
   clearAllConversationIds,
   getHomeFeedPath,
+  patchFeedItemContent,
   patchFeedItemStatus,
   readHomeFeed,
   stripConversationIds,
@@ -403,6 +404,47 @@ describe("feed-writer", () => {
       } finally {
         spy.mockRestore();
       }
+    });
+  });
+
+  describe("patchFeedItemContent", () => {
+    test("trims and applies a non-empty title", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const result = await patchFeedItemContent("item-1", {
+        title: "  Renamed  ",
+      });
+
+      expect(result!.title).toBe("Renamed");
+      expect(readFileJson().items[0]!.title).toBe("Renamed");
+    });
+
+    test("ignores an empty or whitespace-only title instead of clearing it", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const empty = await patchFeedItemContent("item-1", { title: "" });
+      expect(empty!.title).toBe("Original");
+
+      const blank = await patchFeedItemContent("item-1", { title: "   \t" });
+      expect(blank!.title).toBe("Original");
+
+      expect(readFileJson().items[0]!.title).toBe("Original");
+    });
+
+    test("a summary-only patch leaves the title untouched", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const result = await patchFeedItemContent("item-1", {
+        summary: "Fresh summary",
+      });
+
+      expect(result!.title).toBe("Original");
+      expect(result!.summary).toBe("Fresh summary");
+    });
+
+    test("returns null for an unknown id", async () => {
+      await appendFeedItem(makeItem({ id: "known" }));
+      expect(await patchFeedItemContent("unknown", { title: "x" })).toBeNull();
     });
   });
 

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -165,7 +165,8 @@ export async function patchFeedItemStatus(
  *
  * Only fields explicitly present on `patch` are touched. Pass an empty
  * object and the call is a no-op that returns the existing item (or
- * `null` if the id isn't on disk).
+ * `null` if the id isn't on disk). A `title` that trims to empty is
+ * ignored, so no edit path can strip a title off an existing item.
  */
 export interface FeedItemContentPatch {
   title?: string;
@@ -363,9 +364,8 @@ async function runWrite(): Promise<void> {
     const updated: FeedItem = { ...existing };
     if (patch.title !== undefined) {
       const trimmed = patch.title.trim();
-      if (trimmed.length === 0) {
-        delete updated.title;
-      } else {
+      // Blank titles are ignored: an item keeps its title once it has one.
+      if (trimmed.length > 0) {
         updated.title = trimmed;
       }
     }

--- a/assistant/src/notifications/__tests__/edit-notification.test.ts
+++ b/assistant/src/notifications/__tests__/edit-notification.test.ts
@@ -1,0 +1,330 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { FeedItem } from "../../home/feed-types.js";
+import type { NotificationDeliveryRow } from "../deliveries-store.js";
+
+// ── Module mocks ───────────────────────────────────────────────────────
+//
+// The home-feed writer is deliberately NOT mocked: these tests exercise
+// the real on-disk patch semantics through a temp workspace so the
+// "an empty title never clears the field" guarantee is covered end to
+// end. Only the sqlite-backed stores, the broadcaster, and the SSE hub
+// are intercepted.
+
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: async () => {},
+    subscribe: () => () => {},
+  },
+  broadcastMessage: () => {},
+}));
+
+let decisionRow: { id: string } | null = null;
+let deliveryRows: NotificationDeliveryRow[] = [];
+const renderedCopyPatches: Array<{
+  id: string;
+  patch: { renderedTitle?: string; renderedBody?: string };
+}> = [];
+
+mock.module("../decisions-store.js", () => ({
+  findLatestDecisionByEventId: () => decisionRow,
+}));
+
+mock.module("../deliveries-store.js", () => ({
+  findDeliveriesByDecisionId: () => deliveryRows,
+  updateDeliveryRenderedCopy: (
+    id: string,
+    patch: { renderedTitle?: string; renderedBody?: string },
+  ) => {
+    renderedCopyPatches.push({ id, patch });
+    return true;
+  },
+}));
+
+const adapterUpdates: Array<{ title?: string; body?: string }> = [];
+let adapterSupportsUpdate = true;
+
+mock.module("../emit-signal.js", () => ({
+  getBroadcaster: () => ({
+    getAdapter: () =>
+      adapterSupportsUpdate
+        ? {
+            update: async (
+              _target: unknown,
+              patch: { title?: string; body?: string },
+            ) => {
+              adapterUpdates.push(patch);
+              return { success: true };
+            },
+          }
+        : {},
+  }),
+}));
+
+const { appendFeedItem, readHomeFeed } =
+  await import("../../home/feed-writer.js");
+const { editNotification, normalizeFeedItemId, feedItemIdToSignalId } =
+  await import("../edit-notification.js");
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+const SIGNAL_ID = "sig-1";
+const FEED_ITEM_ID = `notif:${SIGNAL_ID}`;
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: FEED_ITEM_ID,
+    type: "notification",
+    priority: 50,
+    title: "Backup complete",
+    summary: "Nightly backup finished",
+    timestamp: "2026-04-14T12:00:00.000Z",
+    status: "new",
+    createdAt: "2026-04-14T12:00:00.000Z",
+    ...overrides,
+  } as FeedItem;
+}
+
+function makeDelivery(
+  overrides: Partial<NotificationDeliveryRow> = {},
+): NotificationDeliveryRow {
+  return {
+    id: "del-1",
+    notificationDecisionId: "dec-1",
+    channel: "slack",
+    destination: "C123",
+    status: "sent",
+    attempt: 1,
+    renderedTitle: "Backup complete",
+    renderedBody: "Nightly backup finished",
+    errorCode: null,
+    errorMessage: null,
+    sentAt: 1700000000000,
+    conversationId: null,
+    messageId: "1700000000.0001",
+    conversationStrategy: null,
+    conversationAction: null,
+    conversationTargetId: null,
+    conversationFallbackUsed: null,
+    clientDeliveryStatus: null,
+    clientDeliveryError: null,
+    clientDeliveryAt: null,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+function readItem(id = FEED_ITEM_ID): FeedItem | undefined {
+  return readHomeFeed().items.find((item) => item.id === id);
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-edit-notif-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  decisionRow = null;
+  deliveryRows = [];
+  renderedCopyPatches.length = 0;
+  adapterUpdates.length = 0;
+  adapterSupportsUpdate = true;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("normalizeFeedItemId", () => {
+  test("adds the notif: prefix to a bare uuid and leaves prefixed ids alone", () => {
+    expect(normalizeFeedItemId(SIGNAL_ID)).toBe(FEED_ITEM_ID);
+    expect(normalizeFeedItemId(` ${FEED_ITEM_ID} `)).toBe(FEED_ITEM_ID);
+    expect(feedItemIdToSignalId(FEED_ITEM_ID)).toBe(SIGNAL_ID);
+  });
+});
+
+describe("editNotification", () => {
+  test("applies a title edit to the feed item", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.feedItem.title).toBe("Backup finished early");
+    expect(readItem()!.title).toBe("Backup finished early");
+    expect(readItem()!.summary).toBe("Nightly backup finished");
+  });
+
+  test("accepts a bare signal uuid as the id", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: SIGNAL_ID,
+      title: "Renamed via bare id",
+    });
+
+    expect(result!.feedItem.id).toBe(FEED_ITEM_ID);
+    expect(readItem()!.title).toBe("Renamed via bare id");
+  });
+
+  test("an empty title edit leaves the previous title intact", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "" });
+
+    expect(result).not.toBeNull();
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("a whitespace-only title edit leaves the previous title intact", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "   \t" });
+
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("an empty title edit does not push a channel update", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "" });
+
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+    expect(renderedCopyPatches).toHaveLength(0);
+  });
+
+  test("a body-only edit does not disturb the title", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      body: "Nightly backup finished in 4 minutes",
+    });
+
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(result!.feedItem.summary).toBe(
+      "Nightly backup finished in 4 minutes",
+    );
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("a feed-only edit skips channel updates entirely", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      status: "dismissed",
+    });
+
+    expect(result!.feedItem.status).toBe("dismissed");
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+  });
+
+  test("returns null for an unknown id", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: "notif:does-not-exist",
+      title: "Nope",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("pushes the new copy to update-capable channel deliveries", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+      body: "Done in 4 minutes",
+    });
+
+    expect(adapterUpdates).toEqual([
+      { title: "Backup finished early", body: "Done in 4 minutes" },
+    ]);
+    expect(renderedCopyPatches).toEqual([
+      {
+        id: "del-1",
+        patch: {
+          renderedTitle: "Backup finished early",
+          renderedBody: "Done in 4 minutes",
+        },
+      },
+    ]);
+    expect(result!.channels).toEqual([
+      { channel: "slack", deliveryId: "del-1", outcome: "updated" },
+    ]);
+  });
+
+  test("reports channels whose adapter cannot edit in place as unsupported", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+    adapterSupportsUpdate = false;
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels[0]!.outcome).toBe("unsupported");
+    expect(renderedCopyPatches).toHaveLength(0);
+  });
+
+  test("skips deliveries that never reached sent", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery({ status: "failed" })];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels[0]!.outcome).toBe("skipped");
+    expect(adapterUpdates).toHaveLength(0);
+  });
+
+  test("skips channel updates when the feed item has no persisted decision", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = null;
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+  });
+});

--- a/assistant/src/notifications/edit-notification.ts
+++ b/assistant/src/notifications/edit-notification.ts
@@ -22,6 +22,7 @@ import {
   updateDeliveryRenderedCopy,
 } from "./deliveries-store.js";
 import { getBroadcaster } from "./emit-signal.js";
+import { nonEmpty } from "./notification-utils.js";
 import type { NotificationChannel } from "./types.js";
 
 const log = getLogger("edit-notification");
@@ -88,8 +89,12 @@ export async function editNotification(
 ): Promise<EditNotificationResult | null> {
   const feedItemId = normalizeFeedItemId(params.id);
 
+  // Titles are never cleared, so a blank one is dropped before it can
+  // reach the feed patch or a channel update.
+  const title = nonEmpty(params.title);
+
   const feedItem = await patchFeedItemContent(feedItemId, {
-    title: params.title,
+    title,
     summary: params.body,
     urgency: params.urgency,
     status: params.status,
@@ -102,8 +107,7 @@ export async function editNotification(
   // Only edit channel messages when the user-visible text changed.
   // Urgency/status are feed-only — pushing a channel update for those
   // alone would re-deliver the same body and confuse the recipient.
-  const shouldUpdateChannels =
-    params.title !== undefined || params.body !== undefined;
+  const shouldUpdateChannels = title !== undefined || params.body !== undefined;
   if (!shouldUpdateChannels) {
     return { feedItem, channels: [] };
   }
@@ -120,7 +124,7 @@ export async function editNotification(
 
   const deliveries = findDeliveriesByDecisionId(decision.id);
   const channels = await updateChannelDeliveries(deliveries, {
-    title: params.title,
+    title,
     body: params.body,
   });
 

--- a/assistant/src/runtime/routes/notification-routes.ts
+++ b/assistant/src/runtime/routes/notification-routes.ts
@@ -116,7 +116,10 @@ async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
 const EditNotificationParams = z
   .object({
     id: z.string().min(1).describe("Feed item id (notif:<uuid>) or bare uuid"),
-    title: z.string().optional(),
+    title: z
+      .string()
+      .optional()
+      .describe("New title. An empty value is ignored, never cleared."),
     body: z.string().optional(),
     urgency: UrgencySchema.optional(),
     status: z.enum(["new", "seen", "acted_on", "dismissed"]).optional(),


### PR DESCRIPTION
## Summary
- An empty title edit now leaves the existing title intact instead of deleting the field
- Adds the first test coverage for edit-notification.ts

## API contract
`assistant notifications edit --title ""` (and the equivalent `notifications/edit` route call) now silently IGNORES the empty title rather than returning a 400, matching how the other patch helpers spread-preserve fields they were not given. The empty title is dropped in `editNotification` before it reaches either the feed patch or a channel update, and `patchFeedItemContent` keeps its own guard as defense in depth for any other caller.

Part of plan: home-feed-required-titles.md (PR 6 of 8)