### PR TITLE
fix(config): stop the first-launch seed from pinning memory.v3.live

### DIFF
--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -52,6 +52,7 @@ afterAll(() => {
 });
 
 import { setStorePathForTesting } from "../../__tests__/encrypted-store-test-helpers.js";
+import { enableMemoryV3LiveForNewWorkspacesMigration } from "../../workspace/migrations/105-enable-memory-v3-live-for-new-workspaces.js";
 import { invalidateConfigCache, loadConfig } from "../loader.js";
 
 // ---------------------------------------------------------------------------
@@ -221,7 +222,7 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     expect(config.memory.qdrant.vectorSize).toBe(384);
   });
 
-  test("first launch persists nothing under memory.v3 — not even `live`", () => {
+  test("first launch persists nothing under memory.v3, not even `live`", () => {
     if (existsSync(CONFIG_PATH)) {
       rmSync(CONFIG_PATH, { force: true });
     }
@@ -235,41 +236,35 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
 
     // Nothing under memory.v3 is frozen to disk. Tuning knobs stay absent so a
     // shipped schema-default change reaches this assistant on its next load
-    // (mirrors the embedding-provider strip above).
-    //
-    // `live` stays absent for a load-bearing reason: this seed runs ~200ms
-    // BEFORE workspace migrations, and migration 105 (memory-v3-live for new
-    // workspaces) defers to any existing value — it cannot distinguish a
-    // user's deliberate choice from a schema default stamped here moments
-    // earlier. Persisting `live: false` therefore silently pinned every
-    // brand-new workspace to memory v2 forever. An absent leaf means "no
-    // decision recorded", so 105 makes one regardless of boot ordering.
+    // (mirrors the embedding-provider strip above), and `live` stays absent so
+    // migration 105 can record the initial choice: 105 bails on any value
+    // already present, and this seed runs before workspace migrations.
     const raw = readConfig();
     const v3Raw = ((raw.memory as Record<string, unknown>).v3 ?? {}) as Record<
       string,
       unknown
     >;
     expect(Object.keys(v3Raw)).toEqual([]);
-    expect("live" in v3Raw).toBe(false);
     expect(v3Raw.gate).toBeUndefined();
     expect(v3Raw.needleK).toBeUndefined();
   });
 
-  test("a seeded config leaves migration 105's guard free to enable v3", () => {
-    // The regression this fix exists for: migration 105 bails when the key is
-    // already present (`if ("live" in v3Config) return`). Assert the seed
-    // leaves it absent so that guard passes and 105 can write `live: true`.
+  test("migration 105 turns v3 on for a workspace this seed just created", () => {
     if (existsSync(CONFIG_PATH)) {
       rmSync(CONFIG_PATH, { force: true });
     }
     delete process.env.IS_PLATFORM;
 
     loadConfig();
+    enableMemoryV3LiveForNewWorkspacesMigration.run(WORKSPACE_DIR, {
+      isNewWorkspace: true,
+    });
 
     const raw = readConfig();
-    const memoryRaw = (raw.memory ?? {}) as Record<string, unknown>;
-    const v3Raw = (memoryRaw.v3 ?? {}) as Record<string, unknown>;
-    // This is the exact predicate migration 105 evaluates.
-    expect("live" in v3Raw).toBe(false);
+    const v3Raw = ((raw.memory as Record<string, unknown>).v3 ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(v3Raw.live).toBe(true);
   });
 });

--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -221,7 +221,7 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     expect(config.memory.qdrant.vectorSize).toBe(384);
   });
 
-  test("first launch seeds memory.v3 with only `live` — tuning knobs resolve from the schema, not disk", () => {
+  test("first launch persists nothing under memory.v3 — not even `live`", () => {
     if (existsSync(CONFIG_PATH)) {
       rmSync(CONFIG_PATH, { force: true });
     }
@@ -233,16 +233,43 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     expect(config.memory.v3.gate.denseThreshold).toBe(0.66);
     expect(config.memory.v3.needleK).toBe(100);
 
-    // Persisted config.json carries ONLY `live` under memory.v3 — no tuning knob
-    // is frozen to disk, so a shipped schema-default change reaches this
-    // assistant on its next load (mirrors the embedding-provider strip above).
+    // Nothing under memory.v3 is frozen to disk. Tuning knobs stay absent so a
+    // shipped schema-default change reaches this assistant on its next load
+    // (mirrors the embedding-provider strip above).
+    //
+    // `live` stays absent for a load-bearing reason: this seed runs ~200ms
+    // BEFORE workspace migrations, and migration 105 (memory-v3-live for new
+    // workspaces) defers to any existing value — it cannot distinguish a
+    // user's deliberate choice from a schema default stamped here moments
+    // earlier. Persisting `live: false` therefore silently pinned every
+    // brand-new workspace to memory v2 forever. An absent leaf means "no
+    // decision recorded", so 105 makes one regardless of boot ordering.
     const raw = readConfig();
     const v3Raw = ((raw.memory as Record<string, unknown>).v3 ?? {}) as Record<
       string,
       unknown
     >;
-    expect(Object.keys(v3Raw)).toEqual(["live"]);
+    expect(Object.keys(v3Raw)).toEqual([]);
+    expect("live" in v3Raw).toBe(false);
     expect(v3Raw.gate).toBeUndefined();
     expect(v3Raw.needleK).toBeUndefined();
+  });
+
+  test("a seeded config leaves migration 105's guard free to enable v3", () => {
+    // The regression this fix exists for: migration 105 bails when the key is
+    // already present (`if ("live" in v3Config) return`). Assert the seed
+    // leaves it absent so that guard passes and 105 can write `live: true`.
+    if (existsSync(CONFIG_PATH)) {
+      rmSync(CONFIG_PATH, { force: true });
+    }
+    delete process.env.IS_PLATFORM;
+
+    loadConfig();
+
+    const raw = readConfig();
+    const memoryRaw = (raw.memory ?? {}) as Record<string, unknown>;
+    const v3Raw = (memoryRaw.v3 ?? {}) as Record<string, unknown>;
+    // This is the exact predicate migration 105 evaluates.
+    expect("live" in v3Raw).toBe(false);
   });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1119,31 +1119,23 @@ export function loadConfig(): AssistantConfig {
         // Drop the deployment-context embedding provider so it is never
         // persisted (see above); the schema default re-applies in memory.
         delete (seed.memory.embeddings as { provider?: unknown }).provider;
-        // Memory-v3 is persisted as NOTHING here — neither the tuning knobs
-        // (globally-shipped defaults, so a shipped default change must reach
-        // every assistant; migration 119 strips already-seeded ones) nor
-        // `live`.
+        // Nothing under memory.v3 is persisted at seed time.
         //
-        // `live` used to be persisted to protect workspaces that predate the
-        // v3 migration from being flipped on. That protection was aimed at
-        // the wrong door: this block only runs when config.json does NOT
-        // exist, i.e. on a brand-new workspace — precisely the population
-        // migration 105 exists to turn v3 ON for. Pre-v3 workspaces always
-        // have a config.json and never reach this code.
+        // The tuning knobs are globally-shipped defaults: freezing them to
+        // disk would stop a shipped default change from reaching this
+        // assistant (mirrors the embedding-provider strip above; migration 119
+        // strips them from configs that already carry them).
         //
-        // Worse, writing the leaf actively broke 105. This seed runs ~200ms
-        // BEFORE workspace migrations, and 105 defers to any existing value
-        // (`if ("live" in v3Config) return`) so it cannot tell a user's
-        // deliberate choice from the schema default this seed just stamped.
-        // The result was every fresh Docker hatch — and ~8% of all new
-        // assistants — silently running memory v2 forever, with no graph, no
-        // v3 injection, and no retrospective skill authoring.
-        //
-        // Leaving the leaf absent means "no decision recorded", so 105 makes
-        // one regardless of which runs first. The schema default still
-        // applies in memory on every load; only disk stays quiet. A
-        // deliberate opt-out is still expressible via a hatch-time
-        // `memory.v3.live=false` override, which merges after migrations.
+        // `live` stays absent because an absent leaf is the only way to
+        // express "no decision recorded". This seed runs before workspace
+        // migrations, and migration 105 defers to any value already present
+        // (`if ("live" in v3Config) return`), unable to tell a deliberate
+        // choice from a schema default. Writing the leaf here would pin a
+        // brand-new workspace to the schema default; leaving it absent lets
+        // 105 decide regardless of boot ordering. The schema default still
+        // applies in memory on every load, and a hatch-time
+        // `memory.v3.live=false` override still wins by merging after
+        // migrations.
         seed.memory.v3 = {} as (typeof seed.memory)["v3"];
         // Strip dataDir (runtime-derived) from the persisted config
         const { dataDir: _, ...persistable } = seed;

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1119,17 +1119,32 @@ export function loadConfig(): AssistantConfig {
         // Drop the deployment-context embedding provider so it is never
         // persisted (see above); the schema default re-applies in memory.
         delete (seed.memory.embeddings as { provider?: unknown }).provider;
-        // Memory-v3 tuning knobs are globally-shipped defaults, not per-assistant
-        // config: persist only `live` (genuine per-assistant state — some
-        // workspaces predate the v3 migration and must not be flipped on) and let
-        // every tuning knob resolve from the schema on load. This way a shipped
-        // schema-default change reaches all assistants (mirrors the
-        // embedding-provider strip above); migration
-        // 119-strip-persisted-memory-v3-tuning-defaults handles already-seeded
-        // configs.
-        seed.memory.v3 = {
-          live: seed.memory.v3.live,
-        } as (typeof seed.memory)["v3"];
+        // Memory-v3 is persisted as NOTHING here — neither the tuning knobs
+        // (globally-shipped defaults, so a shipped default change must reach
+        // every assistant; migration 119 strips already-seeded ones) nor
+        // `live`.
+        //
+        // `live` used to be persisted to protect workspaces that predate the
+        // v3 migration from being flipped on. That protection was aimed at
+        // the wrong door: this block only runs when config.json does NOT
+        // exist, i.e. on a brand-new workspace — precisely the population
+        // migration 105 exists to turn v3 ON for. Pre-v3 workspaces always
+        // have a config.json and never reach this code.
+        //
+        // Worse, writing the leaf actively broke 105. This seed runs ~200ms
+        // BEFORE workspace migrations, and 105 defers to any existing value
+        // (`if ("live" in v3Config) return`) so it cannot tell a user's
+        // deliberate choice from the schema default this seed just stamped.
+        // The result was every fresh Docker hatch — and ~8% of all new
+        // assistants — silently running memory v2 forever, with no graph, no
+        // v3 injection, and no retrospective skill authoring.
+        //
+        // Leaving the leaf absent means "no decision recorded", so 105 makes
+        // one regardless of which runs first. The schema default still
+        // applies in memory on every load; only disk stays quiet. A
+        // deliberate opt-out is still expressible via a hatch-time
+        // `memory.v3.live=false` override, which merges after migrations.
+        seed.memory.v3 = {} as (typeof seed.memory)["v3"];
         // Strip dataDir (runtime-derived) from the persisted config
         const { dataDir: _, ...persistable } = seed;
         writeFileSync(configPath, JSON.stringify(persistable, null, 2) + "\n");


### PR DESCRIPTION
## Prompt / plan

Investigation started from an eval: `podcast-publish-procedural-memory` (vellum-ai/evals#57) scored 0 on both of its procedural-memory metrics, and the question was whether that was a real model failure or a broken environment. It was the environment — and the cause turned out to affect real users, not just evals.

**Symptom.** A brand-new workspace never gets memory v3. Every fresh Docker hatch comes up `memory.v3.live: false` (4/4 probes: bare `vellum hatch` with and without a config overlay, plus two hosted eval runs, all on published prod images).

**Mechanism.** The first-launch config seed in `loader.ts` runs ~200 ms *before* workspace migrations and persists `memory.v3 = { live: <schema default false> }`. Migration 105 (`105-enable-memory-v3-live-for-new-workspaces`) then runs with `isNewWorkspace: true` and immediately bails on its own guard:

```ts
if ("live" in v3Config) return;   // the seed just put the key there
v3Config.live = true;             // never reached
```

105 cannot distinguish a user's deliberate choice from the schema default the seed stamped 200 ms earlier, so it defers to a value that represents no decision at all. Daemon log from a probe:

```
14:28:19.588 [config] Wrote default config to /workspace/config.json
14:28:19.814 [workspace-migrations] Running workspace migrations (134 registered)
14:28:19.872 [workspace-migrations] Running workspace migration: 105-enable-memory-v3-live-for-new-workspaces
```

**Why the seed's rationale doesn't hold.** The comment justified persisting `live` as protection for "workspaces that predate the v3 migration." That guards the wrong door: the block only runs when `config.json` does **not** exist (`willSeed = !configFileExisted && …`), i.e. on a brand-new workspace — exactly the population 105 exists to turn v3 on for. Pre-v3 workspaces always have a `config.json` and never reach this code. Independently, 105 can't touch them anyway: it's checkpointed as applied, so the migration runner skips it outright, and `isNewWorkspace` is false for them.

**Fix.** Leave the leaf absent, mirroring the embedding-provider strip a few lines above (same failure mode: persisting a default gets read back as an explicit choice). "No decision recorded" becomes representable, so 105 makes the decision **regardless of boot ordering** — this fixes the race rather than one symptom of it. The schema default still applies in memory on every load; only disk stays quiet. A deliberate opt-out remains expressible via a hatch-time `memory.v3.live=false` override, which merges after migrations and still wins.

## Impact

Affected assistants silently run memory **v2**: no memory graph, no v3 injection, and no retrospective procedural-skill authoring (all gated on `isV3TierActive()`). Nothing errors and nothing warns. It does not self-heal — 105 is checkpointed as applied and never re-runs.

From `vellum-ai-prod.telemetry.config_setting_raw` (`config_key = "memory.v3.live"`):

| | assistants | median lifespan | ever recovered |
|---|---|---|---|
| boots `true` | 2,345 | 77h | — |
| **boots `false`** | **215** | **146h** | **6** |

- ~8–10% of **new** assistants every week, including the current one
- Not version-specific (5–10% across 0.10.11 / 0.10.12 / 0.11.0 / 0.11.1), so it's an ordering/timing condition rather than a release regression
- The `false` cohort has a *longer* median lifespan than the healthy one — these are real, long-lived assistants, not ephemeral test instances

**Ruled out during the investigation:** stale images, Docker copy-on-first-use, a corrupt migrations checkpoint, a post-migration clobber (a manually set `true` survives restart), and the hatch config-overlay gate (an overlay does not protect).

## Test plan

**Live verification.** Hatched a fresh assistant built from this branch (`vellum-assistant:local-v3fix`, so it exercises the change rather than a pulled image):

```
config.json → {"v3":{"live":true}}          # was {"live":false}, 4/4, before
```

Boot ordering is unchanged (seed `18:04:22.163` → migrations `.519` → 105 `.551`); the seed simply no longer leaves a key for the guard to trip on. Value survives a daemon restart.

**Unit tests.** Updated the existing seed test, which asserted the old behavior (`expect(Object.keys(v3Raw)).toEqual(["live"])`), and added one asserting migration 105's exact predicate — `expect("live" in v3Raw).toBe(false)` — so reintroducing the leaf fails loudly with the reason attached.

- `src/config/` → 408 pass / 12 fail; the 12 (audio transcription, flag-gated profiles) fail identically on a clean `origin/main` tree — verified by stashing
- `src/workspace/migrations/__tests__` → 45 pass / 0 fail
- typecheck, eslint, prettier, secret scan green

## Not in this PR

- **The 215 already-stuck assistants.** This is forward-only. A backfill can't distinguish "stuck by this bug" from "deliberately turned off," so whether to flip, notify, or leave them is a product call.
- **Why managed is ~92% healthy while Docker is 0%.** Likely platform provisioning writing a `config.json` before first boot (so the seed never fires), but that code is platform-side and unverified from this repo.
