### PR TITLE
fix(notifications): validate model-authored titles instead of accepting them raw

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -66,6 +66,10 @@ let providerSendMessage: (
   );
 };
 
+// Tool block the engine reads back from a provider response. Null drives the
+// deterministic fallback, so LLM-path tests set it before calling in.
+let toolUseBlock: { input: Record<string, unknown> } | null = null;
+
 mock.module("../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => ({
     sendMessage: (messages: unknown[], opts: ProviderSendOptions) =>
@@ -75,7 +79,7 @@ mock.module("../../providers/provider-send-message.js", () => ({
     signal: new AbortController().signal,
     cleanup: () => {},
   }),
-  extractToolUse: () => null,
+  extractToolUse: () => toolUseBlock,
   userMessage: (text: string) => ({ role: "user", content: text }),
 }));
 
@@ -575,5 +579,87 @@ describe("decision tool title field specification", () => {
     expect(description).toContain("no markdown");
     expect(description).toContain("Missing Context");
     expect(description.match(/NOT '/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("title normalization", () => {
+  /** Run the LLM path with the given channel copy and return the kept title. */
+  async function titleFromModelCopy(
+    title: string,
+    body: string,
+  ): Promise<string | undefined> {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+    const previousSendMessage = providerSendMessage;
+    providerSendMessage = async () => ({});
+    toolUseBlock = {
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "model decision",
+        dedupeKey: "title-normalization-test",
+        renderedCopy: { vellum: { title, body } },
+      },
+    };
+
+    try {
+      const decision = await evaluateSignal(makeLlmSignal(), [
+        "vellum",
+      ] as NotificationChannel[]);
+      return decision.renderedCopy.vellum?.title;
+    } finally {
+      toolUseBlock = null;
+      providerSendMessage = previousSendMessage;
+    }
+  }
+
+  test("replaces a model title that restates the body with a derived one", async () => {
+    const title = "The staging deploy finished and the build is live.";
+    const body = `Deploy complete. ${title}`;
+
+    expect(await titleFromModelCopy(title, body)).toBe("Deploy complete.");
+  });
+
+  test("keeps a clean model title verbatim", async () => {
+    expect(
+      await titleFromModelCopy(
+        "Staging Deploy Status",
+        "The staging deploy finished.",
+      ),
+    ).toBe("Staging Deploy Status");
+  });
+
+  test("truncates a model title longer than 40 characters", async () => {
+    const kept = await titleFromModelCopy(
+      "Quarterly Infrastructure Migration Status Report",
+      "The migration is on track for the quarter.",
+    );
+
+    expect(kept).toBe("Quarterly Infrastructure Migration");
+    expect(kept?.length).toBeLessThanOrEqual(40);
+  });
+
+  test("strips markdown from a model title", async () => {
+    expect(
+      await titleFromModelCopy(
+        "**Deploy Status**",
+        "The staging deploy finished.",
+      ),
+    ).toBe("Deploy Status");
+  });
+
+  test("replaces a pass-through requestedTitle that stutters against the body", async () => {
+    const requestedTitle = "The nightly backup finished without any errors.";
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: `Backup finished. ${requestedTitle}`,
+        requestedTitle,
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+    ] as NotificationChannel[]);
+
+    expect(decision.renderedCopy.vellum?.title).toBe("Backup finished.");
   });
 });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -26,6 +26,7 @@ import {
 } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { normalizeTitle } from "../util/short-title.js";
 import { truncate } from "../util/truncate.js";
 import {
   buildAccessRequestContractText,
@@ -416,6 +417,19 @@ function buildFallbackDecision(
 
 const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
 
+/**
+ * Clean a title authored elsewhere (the decision model, or a producer payload),
+ * falling back to one derived from the body when `normalizeTitle` returns its
+ * empty-string rejection signal.
+ *
+ * `normalizeTitle` is the last clamp a title passes through, so its 40-char
+ * budget is the effective one. `NOTIFICATION_TITLE_MAX_LENGTH` (60) still bounds
+ * `deriveTitle` and the control-character stripping in `notification-utils.ts`.
+ */
+function resolveTitle(raw: string | undefined, body: string): string {
+  return normalizeTitle(raw ?? "") || deriveTitle(body);
+}
+
 function validateDecisionOutput(
   input: Record<string, unknown>,
   availableChannels: NotificationChannel[],
@@ -465,7 +479,7 @@ function validateDecisionOutput(
             );
           }
           renderedCopy[ch] = {
-            title: c.title,
+            title: resolveTitle(c.title, c.body),
             body: c.body,
             deliveryText:
               typeof c.deliveryText === "string" ? c.deliveryText : undefined,
@@ -894,7 +908,8 @@ function ensureInviteFlowDirectiveInCopy(
 /**
  * Build, guard, and persist a decision whose copy came verbatim from the
  * producer, bypassing the LLM classifier. The title falls back to one derived
- * from the body when the producer supplies none.
+ * from the body when the producer supplies none or supplies one that fails
+ * normalization.
  *
  * `renderedCopy` and `conversationActions` are populated for every available
  * channel, not just `selectedChannels`: downstream guards (routing-intent
@@ -911,9 +926,10 @@ function buildPassThroughDecision(params: {
   reasoningSummary: string;
 }): NotificationDecision {
   const { availableChannels, body, signal } = params;
-  const title =
-    nonEmpty(readPayloadString(signal.contextPayload, "requestedTitle")) ??
-    deriveTitle(body);
+  const title = resolveTitle(
+    readPayloadString(signal.contextPayload, "requestedTitle"),
+    body,
+  );
   const deepLinkTarget = readPayloadObject(
     signal.contextPayload,
     "deepLinkMetadata",


### PR DESCRIPTION
## Summary
- Run model-authored and payload-supplied titles through the shared normalizer before they reach renderedCopy
- Rejected titles fall back to deriveTitle(body) rather than persisting prose or an echoed body
- No change to model, profile, or token budget

Part of plan: home-feed-required-titles.md (PR 4 of 8)