### PR TITLE
feat(migrations): backfill titles on existing home-feed items

### DIFF
--- a/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
@@ -47,15 +47,15 @@ afterEach(() => {
 });
 
 describe("137-repair-retired-fireworks-minimax-model-id migration", () => {
-  test("has correct migration id and is registered last", () => {
+  test("has correct migration id and is registered", () => {
     expect(repairRetiredFireworksMinimaxModelIdMigration.id).toBe(
       "137-repair-retired-fireworks-minimax-model-id",
     );
-    // getLastWorkspaceMigrationId() reports the final entry as the registry
-    // ceiling, so the highest id must stay last.
-    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
-      "137-repair-retired-fireworks-minimax-model-id",
-    );
+    expect(
+      WORKSPACE_MIGRATIONS.some(
+        (m) => m.id === "137-repair-retired-fireworks-minimax-model-id",
+      ),
+    ).toBe(true);
   });
 
   test("repairs the retired ID in default, call sites, and profiles", () => {

--- a/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for workspace migration `138-backfill-home-feed-titles`.
+ *
+ * The migration gives every item in `<workspace>/data/home-feed.json` a
+ * non-empty `title`, derived from the item's own `summary` when the
+ * field is missing or blank.
+ *
+ * Cases covered:
+ *   1. Missing file, malformed JSON, and a non-object root are no-ops.
+ *   2. Title-less items gain a first-sentence title from the summary.
+ *   3. Items that already have a title are untouched.
+ *   4. A long summary truncates to 40 characters with an ellipsis.
+ *   5. `version`, `updatedAt`, and unrelated item fields are preserved.
+ *   6. A second run writes nothing.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backfillHomeFeedTitlesMigration } from "../workspace/migrations/138-backfill-home-feed-titles.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
+
+let workspaceDir: string;
+let feedPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-138-test-"));
+  feedPath = join(workspaceDir, "data", "home-feed.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeFeedFile(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data"), { recursive: true });
+  writeFileSync(feedPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readFeedFile(): {
+  version: number;
+  items: Array<Record<string, unknown>>;
+  updatedAt: string;
+} {
+  return JSON.parse(readFileSync(feedPath, "utf-8"));
+}
+
+function makeItem(
+  overrides: Record<string, unknown> & { id: string },
+): Record<string, unknown> {
+  return {
+    type: "notification",
+    priority: 50,
+    summary: "Something happened.",
+    timestamp: "2026-08-01T12:00:00.000Z",
+    status: "new",
+    createdAt: "2026-08-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function writeFeed(items: Array<Record<string, unknown>>): void {
+  writeFeedFile({
+    version: 2,
+    updatedAt: "2026-08-01T12:00:00.000Z",
+    items,
+  });
+}
+
+describe("workspace migration 138-backfill-home-feed-titles", () => {
+  test("has the expected id and description", () => {
+    expect(backfillHomeFeedTitlesMigration.id).toBe(
+      "138-backfill-home-feed-titles",
+    );
+    expect(backfillHomeFeedTitlesMigration.description).toContain("title");
+  });
+
+  // getLastWorkspaceMigrationId() reports the final array entry as the
+  // registry ceiling to the identity and rollback routes, so the
+  // highest-numbered migration must sit last in the registry.
+  test("the registry ceiling stays at the highest-numbered migration", () => {
+    const numericId = (id: string) => Number.parseInt(id, 10);
+    const highest = Math.max(
+      ...WORKSPACE_MIGRATIONS.map((m) => numericId(m.id)).filter(
+        Number.isFinite,
+      ),
+    );
+    const last = getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS);
+    expect(last).not.toBeNull();
+    expect(numericId(last!)).toBe(highest);
+  });
+
+  test("missing file is a no-op (no error, no file created)", () => {
+    expect(existsSync(feedPath)).toBe(false);
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(existsSync(feedPath)).toBe(false);
+  });
+
+  test("derives a title from the summary's first sentence", () => {
+    writeFeed([
+      makeItem({
+        id: "a-1",
+        summary: "Alice replied to your thread. She needs an answer.",
+      }),
+      makeItem({ id: "a-2", summary: "Deploy finished!" }),
+      makeItem({ id: "a-3", summary: "Ready to review? The draft is up." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const titles = readFeedFile().items.map((item) => item.title);
+    expect(titles).toEqual([
+      "Alice replied to your thread.",
+      "Deploy finished!",
+      "Ready to review?",
+    ]);
+  });
+
+  test("backfills items whose title is missing, empty, blank, or not a string", () => {
+    writeFeed([
+      makeItem({ id: "missing", summary: "First item summary." }),
+      makeItem({ id: "empty", title: "", summary: "Second item summary." }),
+      makeItem({ id: "blank", title: "   ", summary: "Third item summary." }),
+      makeItem({ id: "wrong-type", title: null, summary: "Fourth summary." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const titles = readFeedFile().items.map((item) => item.title);
+    expect(titles).toEqual([
+      "First item summary.",
+      "Second item summary.",
+      "Third item summary.",
+      "Fourth summary.",
+    ]);
+  });
+
+  test("leaves items that already have a title untouched", () => {
+    writeFeed([
+      makeItem({
+        id: "titled",
+        title: "Existing headline",
+        summary: "A completely different summary sentence.",
+      }),
+      makeItem({ id: "untitled", summary: "Needs a headline." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const items = readFeedFile().items;
+    expect(items[0]!.title).toBe("Existing headline");
+    expect(items[1]!.title).toBe("Needs a headline.");
+  });
+
+  test("truncates a long summary to 40 characters with an ellipsis", () => {
+    const summary =
+      "Bob shared a very long document that keeps going well past the limit";
+    writeFeed([makeItem({ id: "long", summary })]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const title = readFeedFile().items[0]!.title as string;
+    expect(title).toBe("Bob shared a very long document that kee…");
+    // The ellipsis sits past the cap, so the retained text is exactly 40.
+    expect(title.slice(0, -1).length).toBe(40);
+  });
+
+  test("truncates a long first sentence rather than the whole summary", () => {
+    writeFeed([
+      makeItem({
+        id: "long-sentence",
+        summary:
+          "This opening sentence runs well beyond the forty character cap. Then another.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const title = readFeedFile().items[0]!.title as string;
+    expect(title).toBe("This opening sentence runs well beyond t…");
+  });
+
+  test("preserves version, updatedAt, and unrelated item fields", () => {
+    writeFeedFile({
+      version: 2,
+      updatedAt: "2026-08-01T12:00:00.000Z",
+      items: [
+        makeItem({
+          id: "keep-fields",
+          summary: "Payment failed.",
+          urgency: "high",
+          conversationId: "conv-abc",
+          actions: [{ label: "Retry", kind: "prompt" }],
+          detailPanel: { kind: "text", body: "Details" },
+        }),
+      ],
+    });
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const out = readFeedFile();
+    expect(out.version).toBe(2);
+    expect(out.updatedAt).toBe("2026-08-01T12:00:00.000Z");
+
+    const item = out.items[0]!;
+    expect(item.title).toBe("Payment failed.");
+    expect(item.id).toBe("keep-fields");
+    expect(item.type).toBe("notification");
+    expect(item.priority).toBe(50);
+    expect(item.status).toBe("new");
+    expect(item.urgency).toBe("high");
+    expect(item.conversationId).toBe("conv-abc");
+    expect(item.actions).toEqual([{ label: "Retry", kind: "prompt" }]);
+    expect(item.detailPanel).toEqual({ kind: "text", body: "Details" });
+  });
+
+  test("idempotent: a second run writes nothing", () => {
+    writeFeed([
+      makeItem({ id: "a-1", summary: "Alice replied to your thread." }),
+      makeItem({ id: "a-2", title: "Already titled", summary: "Body text." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+    const afterFirst = readFileSync(feedPath, "utf-8");
+    const afterFirstStat = statSync(feedPath);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(afterFirst);
+    expect(statSync(feedPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  test("a fully titled feed is left byte-identical", () => {
+    writeFeed([makeItem({ id: "a-1", title: "Titled", summary: "Body." })]);
+    const before = readFileSync(feedPath, "utf-8");
+    const beforeStat = statSync(feedPath);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+    expect(statSync(feedPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  test("malformed JSON does not throw and leaves the file alone", () => {
+    mkdirSync(join(workspaceDir, "data"), { recursive: true });
+    writeFileSync(feedPath, "{not valid json", "utf-8");
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeFeedFile([1, 2, 3]);
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("items that cannot yield a title are skipped without throwing", () => {
+    writeFeedFile({
+      version: 2,
+      updatedAt: "2026-08-01T12:00:00.000Z",
+      items: [
+        "not an object",
+        makeItem({ id: "no-summary", summary: undefined }),
+        makeItem({ id: "blank-summary", summary: "   " }),
+        makeItem({ id: "ok", summary: "Has a summary." }),
+      ],
+    });
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    const items: unknown[] = readFeedFile().items;
+    expect(items[0]).toBe("not an object");
+    expect((items[1] as Record<string, unknown>).title).toBeUndefined();
+    expect((items[2] as Record<string, unknown>).title).toBeUndefined();
+    expect((items[3] as Record<string, unknown>).title).toBe("Has a summary.");
+  });
+
+  test("down() is a no-op (forward-only migration)", () => {
+    writeFeed([makeItem({ id: "a-1", summary: "Alice replied." })]);
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+    const after = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(after);
+  });
+});

--- a/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
+++ b/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
@@ -1,0 +1,144 @@
+/**
+ * Workspace migration `138-backfill-home-feed-titles`.
+ *
+ * Gives every item in `<workspace>/data/home-feed.json` a non-empty
+ * `title`. The wire schema requires the field, and an item on disk that
+ * lacks it is dropped when the feed is read, so the title is derived
+ * from the item's own `summary` instead.
+ *
+ * Behaviour:
+ *   - Missing file, unparseable JSON, or a non-object root: no-op.
+ *   - Item that already has a non-empty `title`: untouched.
+ *   - Item without one: title derived from `summary` (first sentence,
+ *     capped at 40 characters with an ellipsis).
+ *   - `version`, `updatedAt`, and every other item field are preserved.
+ *
+ * Idempotent: a second run finds every item titled, so it writes
+ * nothing. The runner's checkpoint also skips re-runs, but this in-file
+ * guard keeps the migration safe even if the checkpoint is wiped.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-138-backfill-home-feed-titles");
+
+const HOME_FEED_RELATIVE_PATH = join("data", "home-feed.json");
+const MAX_TITLE_LENGTH = 40;
+
+/**
+ * The persisted item fields this migration touches. Inlined rather than
+ * imported from `home/feed-types.ts` so the migration stays
+ * self-contained per the migrations AGENTS.md.
+ */
+interface PersistedFeedItem {
+  /** Missing, empty, or non-string on the items repaired here. */
+  title?: unknown;
+  /** Source text for the derived title. */
+  summary?: unknown;
+  /** Every other persisted field is carried through untouched. */
+  [key: string]: unknown;
+}
+
+export const backfillHomeFeedTitlesMigration: WorkspaceMigration = {
+  id: "138-backfill-home-feed-titles",
+  description:
+    "Backfill a summary-derived title on home-feed items that lack one",
+
+  run(workspaceDir: string): void {
+    const path = join(workspaceDir, HOME_FEED_RELATIVE_PATH);
+    if (!existsSync(path)) {
+      return;
+    }
+
+    // Read outside the parse catch: a transient filesystem error (EIO,
+    // EACCES) must reach the runner so the migration retries, while
+    // malformed JSON is a permanent state this migration cannot repair.
+    const rawText = readFileSync(path, "utf-8");
+
+    let feed: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawText);
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      feed = parsed;
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to parse home-feed.json; skipping title backfill",
+      );
+      return;
+    }
+
+    const rawItems = Array.isArray(feed.items) ? feed.items : [];
+    let backfilled = 0;
+    for (const entry of rawItems) {
+      if (!isPlainObject(entry)) {
+        continue;
+      }
+      const item: PersistedFeedItem = entry;
+      if (typeof item.title === "string" && item.title.trim().length > 0) {
+        continue;
+      }
+      if (typeof item.summary !== "string") {
+        continue;
+      }
+      const derived = deriveTitle(item.summary);
+      if (derived.length === 0) {
+        continue;
+      }
+      item.title = derived;
+      backfilled++;
+    }
+
+    if (backfilled === 0) {
+      return;
+    }
+
+    // Write-then-rename so an interrupted write cannot leave
+    // home-feed.json truncated: the reader treats an unparseable file as
+    // an empty feed, so a torn in-place write would discard the user's
+    // notification history outright.
+    const tmpPath = `${path}.migration-138.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(feed, null, 2), "utf-8");
+    renameSync(tmpPath, path);
+
+    log.info({ path, backfilled }, "Backfilled titles on home-feed items");
+  },
+
+  // Deriving a title from the summary is idempotent, so a transient
+  // failure (full disk, I/O error) is safe to retry on later startups.
+  retryFailedCheckpoint: true,
+
+  down(_workspaceDir: string): void {
+    // Forward-only: a derived title is indistinguishable from an
+    // authored one, so there is nothing safe to strip back out.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per the workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a short headline from a summary: the first sentence when the
+ * text has a terminator, capped at `MAX_TITLE_LENGTH` characters with an
+ * ellipsis. Mirrors the notification copy composer's derivation, inlined
+ * rather than imported so the migration stays self-contained.
+ */
+function deriveTitle(summary: string): string {
+  const firstSentenceEnd = summary.search(/[.!?](\s|$)/);
+  const candidate =
+    firstSentenceEnd > 0 ? summary.slice(0, firstSentenceEnd + 1) : summary;
+  return candidate.length > MAX_TITLE_LENGTH
+    ? candidate.slice(0, MAX_TITLE_LENGTH).trim() + "…"
+    : candidate.trim();
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -135,6 +135,7 @@ import { imageGenerationModeToProviderMigration } from "./134-image-generation-m
 import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js";
 import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fireworks-kimi-model-id.js";
 import { repairRetiredFireworksMinimaxModelIdMigration } from "./137-repair-retired-fireworks-minimax-model-id.js";
+import { backfillHomeFeedTitlesMigration } from "./138-backfill-home-feed-titles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -285,4 +286,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   copySubstrateTunablesMigration,
   repairStaleFireworksKimiModelIdMigration,
   repairRetiredFireworksMinimaxModelIdMigration,
+  backfillHomeFeedTitlesMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration 138, deriving a title from the summary for feed items that lack one
- Self-contained and idempotent per the migrations AGENTS.md
- Prepares existing on-disk feeds for the required-title schema

## Notes
- Derivation is the first sentence of `summary`, capped at 40 characters with an ellipsis, inlined per the migrations AGENTS.md rather than imported from `short-title.ts` or `copy-composer.ts`
- Items that already carry a non-empty title are untouched; `version`, `updatedAt`, and every other item field are preserved; a run that changes nothing does not write the file
- Because PR 8 keeps the reader tolerant, a downgrade-then-re-upgrade cycle that reintroduces title-less items degrades to the row-level fallback rather than data loss. That is the intended safety property and the reason the schema alone is not relied upon.
- `workspace-migration-137-*.test.ts` asserted that 137 sat last in the registry. That assertion now checks 137 is registered; the registry-ceiling invariant stays covered by the generic check in `workspace-migration-134-*.test.ts` and the new 138 test.

Part of plan: home-feed-required-titles.md (PR 7 of 8)