### PR TITLE
feat(subagent): rate-limit near-identical repeat spawns behind a flag

### DIFF
--- a/assistant/src/__tests__/subagent-persistence.test.ts
+++ b/assistant/src/__tests__/subagent-persistence.test.ts
@@ -5,10 +5,12 @@ import { migrateCreateSubagentsTable } from "../persistence/migrations/311-creat
 import { migrateAddSubagentParentToolUseId } from "../persistence/migrations/356-add-subagent-parent-tool-use-id.js";
 import { resetTestTables } from "../persistence/raw-query.js";
 import {
+  countRecentSimilarSpawns,
   deleteSubagentRecordsByParent,
   getSubagentRecordById,
   getSubagentRecordByLabel,
   loadAllSubagentRecords,
+  normalizeSpawnObjective,
   type SubagentRecord,
   upsertSubagentRecord,
 } from "../persistence/subagent-store.js";
@@ -131,6 +133,85 @@ describe("subagent-store", () => {
     deleteSubagentRecordsByParent("parent-1");
 
     expect(loadAllSubagentRecords().map((r) => r.id)).toEqual(["s2"]);
+  });
+});
+
+describe("recent similar spawn tallies", () => {
+  const OBJECTIVE = "Audit the billing pipeline for drift";
+
+  /** A row for `OBJECTIVE`, spelled however the caller wants it. */
+  function spawn(
+    id: string,
+    over: Partial<SubagentRecord> = {},
+  ): SubagentRecord {
+    return record({
+      id,
+      conversationId: `conv-${id}`,
+      objective: OBJECTIVE,
+      createdAt: Date.now(),
+      estimatedCost: 0.5,
+      ...over,
+    });
+  }
+
+  function tally(parentConversationId = "parent-1") {
+    return countRecentSimilarSpawns({
+      parentConversationId,
+      normalizedObjective: normalizeSpawnObjective(OBJECTIVE),
+      sinceMs: Date.now() - 24 * 60 * 60 * 1000,
+    });
+  }
+
+  test("normalization folds case and whitespace, capped at the prefix", () => {
+    expect(normalizeSpawnObjective("  Audit   the\nBILLING pipeline ")).toBe(
+      "audit the billing pipeline",
+    );
+    expect(normalizeSpawnObjective("x".repeat(200))).toHaveLength(90);
+  });
+
+  test("counts both scopes and sums their cost", () => {
+    upsertSubagentRecord(spawn("a"));
+    upsertSubagentRecord(
+      spawn("b", { objective: "  AUDIT the Billing\tpipeline for drift  " }),
+    );
+    upsertSubagentRecord(spawn("c", { parentConversationId: "parent-2" }));
+
+    expect(tally()).toEqual({
+      conversation: { count: 2, estimatedCost: 1 },
+      assistant: { count: 3, estimatedCost: 1.5 },
+    });
+  });
+
+  test("a genuinely different objective is not a match", () => {
+    upsertSubagentRecord(spawn("a"));
+    upsertSubagentRecord(
+      spawn("b", { objective: "Audit the payouts pipeline for drift" }),
+    );
+
+    expect(tally().conversation.count).toBe(1);
+  });
+
+  test("objectives that diverge past the prefix still match", () => {
+    upsertSubagentRecord(spawn("a", { objective: `${"e".repeat(90)} first` }));
+    upsertSubagentRecord(spawn("b", { objective: `${"e".repeat(90)} second` }));
+
+    expect(
+      countRecentSimilarSpawns({
+        parentConversationId: "parent-1",
+        normalizedObjective: normalizeSpawnObjective("e".repeat(90)),
+        sinceMs: Date.now() - 24 * 60 * 60 * 1000,
+      }).conversation.count,
+    ).toBe(2);
+  });
+
+  test("spawns older than the cutoff and advisor consults are left out", () => {
+    upsertSubagentRecord(spawn("fresh"));
+    upsertSubagentRecord(
+      spawn("stale", { createdAt: Date.now() - 90_000_000 }),
+    );
+    upsertSubagentRecord(spawn("consult", { role: "advisor" }));
+
+    expect(tally().assistant.count).toBe(1);
   });
 });
 

--- a/assistant/src/__tests__/subagent-persistence.test.ts
+++ b/assistant/src/__tests__/subagent-persistence.test.ts
@@ -139,7 +139,7 @@ describe("subagent-store", () => {
 describe("recent similar spawn tallies", () => {
   const OBJECTIVE = "Audit the billing pipeline for drift";
 
-  /** A row for `OBJECTIVE`, spelled however the caller wants it. */
+  /** A completed row for `OBJECTIVE`, spelled however the caller wants it. */
   function spawn(
     id: string,
     over: Partial<SubagentRecord> = {},
@@ -148,7 +148,9 @@ describe("recent similar spawn tallies", () => {
       id,
       conversationId: `conv-${id}`,
       objective: OBJECTIVE,
+      status: "completed",
       createdAt: Date.now(),
+      completedAt: Date.now(),
       estimatedCost: 0.5,
       ...over,
     });
@@ -162,11 +164,11 @@ describe("recent similar spawn tallies", () => {
     });
   }
 
-  test("normalization folds case and whitespace, capped at the prefix", () => {
+  test("normalization folds case and whitespace over the whole objective", () => {
     expect(normalizeSpawnObjective("  Audit   the\nBILLING pipeline ")).toBe(
       "audit the billing pipeline",
     );
-    expect(normalizeSpawnObjective("x".repeat(200))).toHaveLength(90);
+    expect(normalizeSpawnObjective("x".repeat(200))).toHaveLength(200);
   });
 
   test("counts both scopes and sums their cost", () => {
@@ -191,14 +193,36 @@ describe("recent similar spawn tallies", () => {
     expect(tally().conversation.count).toBe(1);
   });
 
-  test("objectives that diverge past the prefix still match", () => {
-    upsertSubagentRecord(spawn("a", { objective: `${"e".repeat(90)} first` }));
-    upsertSubagentRecord(spawn("b", { objective: `${"e".repeat(90)} second` }));
+  test("a shared boilerplate prefix does not fold distinct objectives together", () => {
+    const preamble =
+      "Follow the audit checklist to the letter and report ".repeat(3);
+    upsertSubagentRecord(
+      spawn("a", { objective: `${preamble} on the billing service` }),
+    );
+    upsertSubagentRecord(
+      spawn("b", { objective: `${preamble} on the payouts service` }),
+    );
+
+    const forBilling = countRecentSimilarSpawns({
+      parentConversationId: "parent-1",
+      normalizedObjective: normalizeSpawnObjective(
+        `${preamble} on the billing service`,
+      ),
+      sinceMs: Date.now() - 24 * 60 * 60 * 1000,
+    });
+
+    expect(forBilling.conversation.count).toBe(1);
+  });
+
+  test("the same objective still matches however long its preamble", () => {
+    const objective = `${"e".repeat(200)} tail`;
+    upsertSubagentRecord(spawn("a", { objective }));
+    upsertSubagentRecord(spawn("b", { objective: `  ${objective}  ` }));
 
     expect(
       countRecentSimilarSpawns({
         parentConversationId: "parent-1",
-        normalizedObjective: normalizeSpawnObjective("e".repeat(90)),
+        normalizedObjective: normalizeSpawnObjective(objective),
         sinceMs: Date.now() - 24 * 60 * 60 * 1000,
       }).conversation.count,
     ).toBe(2);
@@ -212,6 +236,22 @@ describe("recent similar spawn tallies", () => {
     upsertSubagentRecord(spawn("consult", { role: "advisor" }));
 
     expect(tally().assistant.count).toBe(1);
+  });
+
+  test("runs that produced no answer are left out of both scopes", () => {
+    upsertSubagentRecord(spawn("done"));
+    for (const status of ["failed", "aborted", "interrupted"]) {
+      upsertSubagentRecord(
+        spawn(`ended-${status}`, { status, completedAt: Date.now() }),
+      );
+    }
+    upsertSubagentRecord(spawn("in-flight", { status: "running" }));
+    upsertSubagentRecord(spawn("queued", { status: "pending" }));
+
+    expect(tally()).toEqual({
+      conversation: { count: 1, estimatedCost: 0.5 },
+      assistant: { count: 1, estimatedCost: 0.5 },
+    });
   });
 });
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1054,7 +1054,7 @@ describe("Subagent spawn repeat-loop guard", () => {
     expect(spawned).toBe(false);
     expect(result.isError).toBe(false);
     expect(result.content).toContain(
-      "3 near-identical subagents already ran in this conversation in the last 24 hours",
+      "3 near-identical subagents already completed in this conversation in the last 24 hours",
     );
     expect(result.content).toContain("about $3.75");
     expect(result.content).toContain("confirm_repeat: true");
@@ -1076,7 +1076,7 @@ describe("Subagent spawn repeat-loop guard", () => {
 
     expect(spawned).toBe(false);
     expect(result.content).toContain(
-      "10 near-identical subagents already ran across this assistant in the last 24 hours",
+      "10 near-identical subagents already completed across this assistant in the last 24 hours",
     );
   });
 
@@ -1136,6 +1136,71 @@ describe("Subagent spawn repeat-loop guard", () => {
     });
 
     expect(spawned).toBe(true);
+  });
+
+  test("a retry after runs that produced no answer spawns normally", async () => {
+    const objective = "Audit the flaky pipeline for drift";
+    const unfinished = ["failed", "aborted", "interrupted"];
+    unfinished.forEach((status, i) => {
+      seedSpawn(`guard-retry-${i}`, objective, { status });
+    });
+    // Well past the assistant-wide limit too, so neither scope may count them.
+    for (let i = 0; i < 12; i++) {
+      seedSpawn(`guard-retry-wide-${i}`, objective, {
+        parentConversationId: `guard-retry-parent-${i}`,
+        status: unfinished[i % unfinished.length],
+      });
+    }
+
+    const { spawned } = await spawnWithGuard(true, {
+      label: "Retry",
+      objective,
+    });
+
+    expect(spawned).toBe(true);
+  });
+
+  test("runs still in flight do not count as answers already produced", async () => {
+    const objective = "Audit the in-flight pipeline for drift";
+    seedSpawn("guard-inflight-0", objective, { status: "running" });
+    seedSpawn("guard-inflight-1", objective, { status: "pending" });
+    seedSpawn("guard-inflight-2", objective, { status: "awaiting_input" });
+
+    const { spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(true);
+  });
+
+  test("objectives sharing a boilerplate prefix are distinct tasks", async () => {
+    const preamble =
+      "Review the module against every item in the team checklist, then write up " +
+      "what you found and what should change, focusing on ";
+    seedSpawns("guard-batch", `${preamble}the billing service`, 5);
+
+    const { spawned } = await spawnWithGuard(true, {
+      label: "Next in batch",
+      objective: `${preamble}the payouts service`,
+    });
+
+    expect(spawned).toBe(true);
+  });
+
+  test("the same long objective is still caught however long its preamble", async () => {
+    const objective =
+      "Review the module against every item in the team checklist, then write up " +
+      "what you found and what should change, focusing on the ledger service";
+    seedSpawns("guard-long", objective, 3);
+
+    const { result, spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(false);
+    expect(result.content).toContain("3 near-identical subagents");
   });
 });
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -305,6 +305,7 @@ describe("Subagent tool definitions", () => {
     expect(def).toBeDefined();
     expect(def.input_schema.required).toEqual(["label", "objective"]);
     expect(def.input_schema.properties.inference_profile).toBeDefined();
+    expect(def.input_schema.properties.confirm_repeat.type).toBe("boolean");
   });
 
   test("abort tool has correct definition", () => {
@@ -940,6 +941,201 @@ describe("Subagent spawn profile isolation", () => {
     });
     expect(config.overrideProfile).toBe("no-tool-model");
     expect(JSON.parse(result.content).note).toBeUndefined();
+  });
+});
+
+// ── Repeat-spawn guard ──────────────────────────────────────────────
+
+describe("Subagent spawn repeat-loop guard", () => {
+  const guardParent = "guard-parent";
+
+  /** Seed a finished spawn of `objective`, the way the manager records one. */
+  function seedSpawn(
+    id: string,
+    objective: string,
+    over: Partial<SubagentRecord> = {},
+  ): void {
+    upsertSubagentRecord({
+      id,
+      parentConversationId: guardParent,
+      conversationId: `conv-${id}`,
+      label: id,
+      objective,
+      role: "general",
+      isFork: false,
+      sendResultToUser: true,
+      parentToolUseId: null,
+      status: "completed",
+      error: null,
+      createdAt: Date.now(),
+      startedAt: null,
+      completedAt: Date.now(),
+      inputTokens: 10,
+      outputTokens: 20,
+      estimatedCost: 1.25,
+      ...over,
+    });
+  }
+
+  /** Seed `count` finished spawns of one objective. */
+  function seedSpawns(
+    idPrefix: string,
+    objective: string,
+    count: number,
+  ): void {
+    for (let i = 0; i < count; i++) {
+      seedSpawn(`${idPrefix}-${i}`, objective);
+    }
+  }
+
+  /**
+   * Run the spawn tool with `subagent-loop-guard` seeded on or off, reporting
+   * whether the manager was actually asked to spawn.
+   */
+  async function spawnWithGuard(
+    enabled: boolean,
+    input: Record<string, unknown>,
+    conversationId = guardParent,
+  ) {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let spawned = false;
+    manager.spawn = async () => {
+      spawned = true;
+      return "guard-subagent-id";
+    };
+    setOverridesForTesting({ "subagent-loop-guard": enabled });
+    try {
+      const result = await executeSubagentSpawn(
+        input,
+        makeContext(conversationId, { sendToClient: () => {} }),
+      );
+      return { result, spawned };
+    } finally {
+      setOverridesForTesting({});
+      manager.spawn = originalSpawn;
+    }
+  }
+
+  test("flag off spawns however often the objective has already run", async () => {
+    const objective = "Audit the flag-off pipeline for drift";
+    seedSpawns("guard-off", objective, 6);
+
+    const { result, spawned } = await spawnWithGuard(false, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(true);
+    expect(JSON.parse(result.content).subagentId).toBe("guard-subagent-id");
+  });
+
+  test("a conversation under the threshold spawns normally", async () => {
+    const objective = "Audit the under-threshold pipeline for drift";
+    seedSpawns("guard-under", objective, 2);
+
+    const { spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(true);
+  });
+
+  test("a fourth repeat in one conversation is held for confirmation", async () => {
+    const objective = "Audit the retention pipeline for drift";
+    seedSpawns("guard-conv", objective, 3);
+
+    const { result, spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(false);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(
+      "3 near-identical subagents already ran in this conversation in the last 24 hours",
+    );
+    expect(result.content).toContain("about $3.75");
+    expect(result.content).toContain("confirm_repeat: true");
+  });
+
+  test("the assistant-wide threshold catches a repeat spread across conversations", async () => {
+    const objective = "Audit the fleet-wide pipeline for drift";
+    for (let i = 0; i < 10; i++) {
+      seedSpawn(`guard-wide-${i}`, objective, {
+        parentConversationId: `guard-wide-parent-${i}`,
+      });
+    }
+
+    const { result, spawned } = await spawnWithGuard(
+      true,
+      { label: "Repeat", objective },
+      "guard-fresh-conversation",
+    );
+
+    expect(spawned).toBe(false);
+    expect(result.content).toContain(
+      "10 near-identical subagents already ran across this assistant in the last 24 hours",
+    );
+  });
+
+  test("confirm_repeat spawns past the guard", async () => {
+    const objective = "Audit the confirmed pipeline for drift";
+    seedSpawns("guard-confirm", objective, 5);
+
+    const { result, spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+      confirm_repeat: true,
+    });
+
+    expect(spawned).toBe(true);
+    expect(JSON.parse(result.content).status).toBe("pending");
+  });
+
+  test("advisor consults are never guarded", async () => {
+    const objective = "Audit the advisor pipeline for drift";
+    seedSpawns("guard-advisor", objective, 6);
+
+    const { result } = await spawnWithGuard(true, {
+      label: "Consult",
+      objective,
+      role: "advisor",
+    });
+
+    // The advisor branch runs and reports its own missing-parent notice, so the
+    // guard never saw the repetition.
+    expect(result.content).toContain("advisor unavailable");
+    expect(result.content).not.toContain("confirm_repeat");
+  });
+
+  test("case and spacing differences count as the same objective", async () => {
+    const objective = "Audit the normalized pipeline for drift";
+    seedSpawn("guard-norm-0", objective.toUpperCase());
+    seedSpawn("guard-norm-1", `  ${objective}  `);
+    seedSpawn("guard-norm-2", objective.replace(/ /gu, "\n"));
+    seedSpawn("guard-norm-3", objective.replace(/ /gu, "   "));
+
+    const { result, spawned } = await spawnWithGuard(true, {
+      label: "Repeat",
+      objective,
+    });
+
+    expect(spawned).toBe(false);
+    expect(result.content).toContain("4 near-identical subagents");
+  });
+
+  test("a genuinely different objective is not a repeat", async () => {
+    const objective = "Audit the distinct pipeline for drift";
+    seedSpawns("guard-distinct", objective, 5);
+
+    const { spawned } = await spawnWithGuard(true, {
+      label: "Different",
+      objective: "Audit the payouts ledger for drift",
+    });
+
+    expect(spawned).toBe(true);
   });
 });
 

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -44,6 +44,10 @@
           "inference_profile": {
             "type": "string",
             "description": "Optional llm.profiles key this subagent should run under. When omitted, the subagent inherits the parent turn's profile when one is active; otherwise it uses the subagentSpawn call site's default model selection."
+          },
+          "confirm_repeat": {
+            "type": "boolean",
+            "description": "Set true to spawn anyway when the repeat-spawn guard reports that this objective already ran several times in the last day."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -47,7 +47,7 @@
           },
           "confirm_repeat": {
             "type": "boolean",
-            "description": "Set true to spawn anyway when the repeat-spawn guard reports that this objective already ran several times in the last day."
+            "description": "Set true to spawn anyway when the repeat-spawn guard reports that this objective already completed several times in the last day."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -300,6 +300,104 @@ export function getSubagentRecordsByParent(
 }
 
 /**
+ * How much of an objective decides that two spawns are near-identical. Long
+ * objectives share a preamble and diverge in their tail, so a prefix comparison
+ * catches the re-run of an audit whose closing sentence was reworded while
+ * leaving two genuinely different tasks apart.
+ */
+const SIMILAR_OBJECTIVE_PREFIX_CHARS = 90;
+
+/**
+ * Rows the similarity scan reads before it stops. The scan is bounded so a
+ * long-lived assistant cannot turn every spawn into a full-table read; a
+ * truncated window can only under-count, which is the safe direction for a
+ * caller that rate-limits on the count.
+ */
+const RECENT_SPAWN_SCAN_LIMIT = 500;
+
+/**
+ * Fold an objective to the form two spawns are compared in: lowercased,
+ * whitespace-collapsed, and cut to {@link SIMILAR_OBJECTIVE_PREFIX_CHARS}.
+ * Callers normalize the incoming objective with this same function, so both
+ * sides of the comparison are folded by one implementation.
+ */
+export function normalizeSpawnObjective(objective: string): string {
+  return objective
+    .toLowerCase()
+    .replace(/\s+/gu, " ")
+    .trim()
+    .slice(0, SIMILAR_OBJECTIVE_PREFIX_CHARS);
+}
+
+/** How many spawns matched one normalized objective, and what they cost. */
+export interface SimilarSpawnTally {
+  count: number;
+  /** Summed `estimated_cost` of the matched rows. */
+  estimatedCost: number;
+}
+
+/** The two scopes a repeat spawn is judged against. */
+export interface RecentSimilarSpawns {
+  /** Matches spawned under the same parent conversation. */
+  conversation: SimilarSpawnTally;
+  /** Matches anywhere in this assistant; the table holds one assistant's rows. */
+  assistant: SimilarSpawnTally;
+}
+
+/**
+ * Tally the spawns since `sinceMs` (an epoch cutoff) whose objective folds to
+ * `normalizedObjective`, both under `parentConversationId` and assistant-wide.
+ * Advisor rows are left out: an advisor consult blocks its caller and is not
+ * rate-limited, so its history must not count against a background spawn.
+ *
+ * Both scopes come from one bounded scan because the assistant-wide set
+ * contains the conversation's, so a second query would read the same rows
+ * twice.
+ *
+ * Rows hold the raw objective, so the fold has to happen on the column too.
+ * It runs in JS rather than SQL: SQLite's `lower()` folds ASCII only and has no
+ * whitespace-collapsing function, so a SQL predicate would disagree with
+ * {@link normalizeSpawnObjective} on exactly the objectives (accented, oddly
+ * spaced) a re-run is most likely to differ by.
+ */
+export function countRecentSimilarSpawns(args: {
+  parentConversationId: string;
+  normalizedObjective: string;
+  sinceMs: number;
+}): RecentSimilarSpawns {
+  const rows = rawAll<{
+    parent_conversation_id: string;
+    objective: string;
+    estimated_cost: number;
+  }>(
+    "subagent:countRecentSimilar",
+    `SELECT parent_conversation_id, objective, estimated_cost FROM subagents
+       WHERE created_at >= ? AND role <> 'advisor'
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    args.sinceMs,
+    RECENT_SPAWN_SCAN_LIMIT,
+  );
+
+  const tally: RecentSimilarSpawns = {
+    conversation: { count: 0, estimatedCost: 0 },
+    assistant: { count: 0, estimatedCost: 0 },
+  };
+  for (const row of rows) {
+    if (normalizeSpawnObjective(row.objective) !== args.normalizedObjective) {
+      continue;
+    }
+    tally.assistant.count += 1;
+    tally.assistant.estimatedCost += row.estimated_cost;
+    if (row.parent_conversation_id === args.parentConversationId) {
+      tally.conversation.count += 1;
+      tally.conversation.estimatedCost += row.estimated_cost;
+    }
+  }
+  return tally;
+}
+
+/**
  * Delete every subagent record spawned under `parentConversationId`. A row
  * lives as long as its parent conversation, and the TTL sweep drops a child's
  * in-memory entry while keeping the row, so deleting by id alone strands the

--- a/assistant/src/persistence/subagent-store.ts
+++ b/assistant/src/persistence/subagent-store.ts
@@ -300,14 +300,6 @@ export function getSubagentRecordsByParent(
 }
 
 /**
- * How much of an objective decides that two spawns are near-identical. Long
- * objectives share a preamble and diverge in their tail, so a prefix comparison
- * catches the re-run of an audit whose closing sentence was reworded while
- * leaving two genuinely different tasks apart.
- */
-const SIMILAR_OBJECTIVE_PREFIX_CHARS = 90;
-
-/**
  * Rows the similarity scan reads before it stops. The scan is bounded so a
  * long-lived assistant cannot turn every spawn into a full-table read; a
  * truncated window can only under-count, which is the safe direction for a
@@ -316,20 +308,36 @@ const SIMILAR_OBJECTIVE_PREFIX_CHARS = 90;
 const RECENT_SPAWN_SCAN_LIMIT = 500;
 
 /**
- * Fold an objective to the form two spawns are compared in: lowercased,
- * whitespace-collapsed, and cut to {@link SIMILAR_OBJECTIVE_PREFIX_CHARS}.
- * Callers normalize the incoming objective with this same function, so both
- * sides of the comparison are folded by one implementation.
+ * The status a run has to hold to count as a repeat of already-done work. A
+ * failed, aborted, or interrupted run left no answer behind, so spawning its
+ * objective again is recovery rather than repetition, and counting those runs
+ * would hold the retry that is exactly the right move.
+ */
+const REUSABLE_SPAWN_STATUS = "completed";
+
+/**
+ * Fold an objective to the form two spawns are compared in: lowercased and
+ * whitespace-collapsed. Callers normalize the incoming objective with this same
+ * function, so both sides of the comparison are folded by one implementation.
+ *
+ * The whole objective is compared, never a prefix. Batch work routinely shares
+ * a long instruction preamble and diverges only in its tail (the file,
+ * component, or ticket each run targets), and comparing prefixes reads that
+ * batch as one objective repeated. Comparing in full costs only the re-run
+ * whose wording changed, which is a missed catch by an advisory guard, while a
+ * batch folded together holds work the caller genuinely meant to run.
+ *
+ * The separate `context` spawn argument is not part of the key: a subagent row
+ * does not carry it (context, prompts, and trust are deliberately left off the
+ * durable record), so two spawns with one objective and different contexts
+ * still fold together. That residue is bounded by the guard being advisory:
+ * the caller is told what already ran and spawns anyway if it meant to.
  */
 export function normalizeSpawnObjective(objective: string): string {
-  return objective
-    .toLowerCase()
-    .replace(/\s+/gu, " ")
-    .trim()
-    .slice(0, SIMILAR_OBJECTIVE_PREFIX_CHARS);
+  return objective.toLowerCase().replace(/\s+/gu, " ").trim();
 }
 
-/** How many spawns matched one normalized objective, and what they cost. */
+/** How many completed runs matched one normalized objective, and their cost. */
 export interface SimilarSpawnTally {
   count: number;
   /** Summed `estimated_cost` of the matched rows. */
@@ -345,10 +353,14 @@ export interface RecentSimilarSpawns {
 }
 
 /**
- * Tally the spawns since `sinceMs` (an epoch cutoff) whose objective folds to
- * `normalizedObjective`, both under `parentConversationId` and assistant-wide.
- * Advisor rows are left out: an advisor consult blocks its caller and is not
- * rate-limited, so its history must not count against a background spawn.
+ * Tally the runs since `sinceMs` (an epoch cutoff) that completed and whose
+ * objective folds to `normalizedObjective`, both under `parentConversationId`
+ * and assistant-wide.
+ *
+ * Only {@link REUSABLE_SPAWN_STATUS} rows are counted, so a run that is still
+ * in flight or that ended without an answer never reads as work already done.
+ * Advisor rows are left out too: an advisor consult blocks its caller and is
+ * not rate-limited, so its history must not count against a background spawn.
  *
  * Both scopes come from one bounded scan because the assistant-wide set
  * contains the conversation's, so a second query would read the same rows
@@ -372,10 +384,11 @@ export function countRecentSimilarSpawns(args: {
   }>(
     "subagent:countRecentSimilar",
     `SELECT parent_conversation_id, objective, estimated_cost FROM subagents
-       WHERE created_at >= ? AND role <> 'advisor'
+       WHERE created_at >= ? AND role <> 'advisor' AND status = ?
        ORDER BY created_at DESC
        LIMIT ?`,
     args.sinceMs,
+    REUSABLE_SPAWN_STATUS,
     RECENT_SPAWN_SCAN_LIMIT,
   );
 

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -11,6 +11,12 @@ import {
   getConversationOverrideProfile,
   getMessages,
 } from "../../persistence/conversation-crud.js";
+import {
+  countRecentSimilarSpawns,
+  normalizeSpawnObjective,
+  type RecentSimilarSpawns,
+  type SimilarSpawnTally,
+} from "../../persistence/subagent-store.js";
 import type { ContentBlock, Message } from "../../providers/types.js";
 import { buildAdvisorContext } from "../../subagent/consult-context.js";
 import {
@@ -51,6 +57,25 @@ const ADVISOR_IDLE_TIMEOUT_MS = 60_000;
  */
 const ADVISOR_MAX_TIMEOUT_MS = 300_000;
 
+/** How far back the repeat-spawn guard looks for near-identical spawns. */
+const LOOP_GUARD_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Near-identical spawns one conversation may run inside the window, the pending
+ * spawn included: the fourth is the one held for confirmation. A couple of
+ * retries is normal work; a fourth run of one objective in a single
+ * conversation is a loop.
+ */
+const LOOP_GUARD_CONVERSATION_LIMIT = 3;
+
+/**
+ * Near-identical spawns the whole assistant may run inside the window, counted
+ * the same way. Higher than the per-conversation limit so the same audit asked
+ * for in a few separate chats still goes through, while a standing re-run of
+ * one objective does not.
+ */
+const LOOP_GUARD_ASSISTANT_LIMIT = 10;
+
 /**
  * Model-input schema, `safeParse`d at the top of {@link executeSubagentSpawn}.
  * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
@@ -67,6 +92,7 @@ export const subagentSpawnInputSchema = z.looseObject({
   objective: nullAsOmitted(z.string()),
   context: nullAsOmitted(z.string()),
   inference_profile: z.string().optional(),
+  confirm_repeat: nullAsOmitted(z.boolean()),
 });
 
 export async function executeSubagentSpawn(
@@ -135,6 +161,24 @@ export async function executeSubagentSpawn(
       sendToClient: sendToClient as (msg: AssistantEvent) => void,
       requestedOverrideProfile,
     });
+  }
+
+  // ── Repeat-spawn guard ───────────────────────────────────────────
+  // Re-running an objective that already ran several times in the last day
+  // buys the same answer twice, so the guard hands the repetition back to the
+  // caller with what it has already cost. It never blocks: `confirm_repeat`
+  // always spawns, and the advisor consult returned above is never guarded.
+  if (
+    isAssistantFeatureFlagEnabled("subagent-loop-guard") &&
+    parsed.confirm_repeat !== true
+  ) {
+    const guardResult = repeatSpawnGuardResult(
+      context.conversationId,
+      objective,
+    );
+    if (guardResult) {
+      return guardResult;
+    }
   }
 
   // ── Fork mode: resolve parent context ────────────────────────────
@@ -278,6 +322,65 @@ export async function executeSubagentSpawn(
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Failed to spawn subagent: ${msg}`, isError: true };
   }
+}
+
+// ── Repeat-spawn guard ───────────────────────────────────────────────
+
+/**
+ * The result to return instead of spawning when this objective has already run
+ * too often inside {@link LOOP_GUARD_WINDOW_MS}, or `undefined` when the spawn
+ * should proceed.
+ *
+ * Not an error: the caller is being handed what its earlier runs produced and
+ * cost, and can still spawn by passing `confirm_repeat: true`. The spawn
+ * history can only advise, so a failed read lets the spawn through.
+ */
+function repeatSpawnGuardResult(
+  parentConversationId: string,
+  objective: string,
+): ToolExecutionResult | undefined {
+  let recent: RecentSimilarSpawns;
+  try {
+    recent = countRecentSimilarSpawns({
+      parentConversationId,
+      normalizedObjective: normalizeSpawnObjective(objective),
+      sinceMs: Date.now() - LOOP_GUARD_WINDOW_MS,
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId: parentConversationId },
+      "Repeat-spawn guard could not read spawn history",
+    );
+    return undefined;
+  }
+
+  // The spawn being asked for is itself part of the limit, so a window already
+  // holding the full allowance is what trips the guard.
+  let scope: string;
+  let tally: SimilarSpawnTally;
+  if (recent.conversation.count >= LOOP_GUARD_CONVERSATION_LIMIT) {
+    scope = "in this conversation";
+    tally = recent.conversation;
+  } else if (recent.assistant.count >= LOOP_GUARD_ASSISTANT_LIMIT) {
+    scope = "across this assistant";
+    tally = recent.assistant;
+  } else {
+    return undefined;
+  }
+
+  const hours = LOOP_GUARD_WINDOW_MS / 3_600_000;
+  const cost =
+    tally.estimatedCost > 0
+      ? `, at a total cost of about $${tally.estimatedCost.toFixed(2)}`
+      : "";
+  return {
+    content:
+      `${tally.count} near-identical subagents already ran ${scope} in the last ${hours} hours${cost}. ` +
+      "Repeating an objective rarely returns a different answer: read what the earlier run produced with subagent_read, " +
+      "or narrow the objective to what is actually still missing. " +
+      "If the repetition is intentional, call subagent_spawn again with confirm_repeat: true.",
+    isError: false,
+  };
 }
 
 // ── Advisor consult ──────────────────────────────────────────────────

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -57,22 +57,23 @@ const ADVISOR_IDLE_TIMEOUT_MS = 60_000;
  */
 const ADVISOR_MAX_TIMEOUT_MS = 300_000;
 
-/** How far back the repeat-spawn guard looks for near-identical spawns. */
+/** How far back the repeat-spawn guard looks for near-identical runs. */
 const LOOP_GUARD_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Near-identical spawns one conversation may run inside the window, the pending
- * spawn included: the fourth is the one held for confirmation. A couple of
- * retries is normal work; a fourth run of one objective in a single
- * conversation is a loop.
+ * Near-identical runs one conversation may complete inside the window before
+ * the next spawn is held for confirmation. A couple of repeats is normal work;
+ * a fourth completed run of one objective in a single conversation is a loop.
+ * Runs that failed, were aborted, or were interrupted never count, so a retry
+ * after a bad run is not what trips this.
  */
 const LOOP_GUARD_CONVERSATION_LIMIT = 3;
 
 /**
- * Near-identical spawns the whole assistant may run inside the window, counted
- * the same way. Higher than the per-conversation limit so the same audit asked
- * for in a few separate chats still goes through, while a standing re-run of
- * one objective does not.
+ * Near-identical runs the whole assistant may complete inside the window,
+ * counted the same way. Higher than the per-conversation limit so the same
+ * audit asked for in a few separate chats still goes through, while a standing
+ * re-run of one objective does not.
  */
 const LOOP_GUARD_ASSISTANT_LIMIT = 10;
 
@@ -164,9 +165,9 @@ export async function executeSubagentSpawn(
   }
 
   // ── Repeat-spawn guard ───────────────────────────────────────────
-  // Re-running an objective that already ran several times in the last day
-  // buys the same answer twice, so the guard hands the repetition back to the
-  // caller with what it has already cost. It never blocks: `confirm_repeat`
+  // Re-running an objective that already completed several times in the last
+  // day buys the same answer twice, so the guard hands the repetition back to
+  // the caller with what it has already cost. It never blocks: `confirm_repeat`
   // always spawns, and the advisor consult returned above is never guarded.
   if (
     isAssistantFeatureFlagEnabled("subagent-loop-guard") &&
@@ -327,9 +328,12 @@ export async function executeSubagentSpawn(
 // ── Repeat-spawn guard ───────────────────────────────────────────────
 
 /**
- * The result to return instead of spawning when this objective has already run
- * too often inside {@link LOOP_GUARD_WINDOW_MS}, or `undefined` when the spawn
- * should proceed.
+ * The result to return instead of spawning when this objective has already
+ * completed too often inside {@link LOOP_GUARD_WINDOW_MS}, or `undefined` when
+ * the spawn should proceed.
+ *
+ * Only completed runs are counted, so the message can point the caller at an
+ * answer that exists and a re-spawn after failures is never held.
  *
  * Not an error: the caller is being handed what its earlier runs produced and
  * cost, and can still spawn by passing `confirm_repeat: true`. The spawn
@@ -354,8 +358,8 @@ function repeatSpawnGuardResult(
     return undefined;
   }
 
-  // The spawn being asked for is itself part of the limit, so a window already
-  // holding the full allowance is what trips the guard.
+  // The spawn being asked for is itself part of the limit, so a window whose
+  // completed runs already fill the allowance is what trips the guard.
   let scope: string;
   let tally: SimilarSpawnTally;
   if (recent.conversation.count >= LOOP_GUARD_CONVERSATION_LIMIT) {
@@ -375,7 +379,7 @@ function repeatSpawnGuardResult(
       : "";
   return {
     content:
-      `${tally.count} near-identical subagents already ran ${scope} in the last ${hours} hours${cost}. ` +
+      `${tally.count} near-identical subagents already completed ${scope} in the last ${hours} hours${cost}. ` +
       "Repeating an objective rarely returns a different answer: read what the earlier run produced with subagent_read, " +
       "or narrow the objective to what is actually still missing. " +
       "If the repetition is intentional, call subagent_spawn again with confirm_repeat: true.",


### PR DESCRIPTION
## Summary

- Adds `countRecentSimilarSpawns` / `normalizeSpawnObjective` to the subagent store: one bounded scan tallies count and summed `estimated_cost` for near-identical spawns in the window, both per parent conversation and assistant-wide (advisor rows excluded, since an advisor consult blocks its caller and is never rate-limited). Objectives are folded in TS rather than SQL because SQLite's `lower()` is ASCII-only and has no whitespace collapse.
- Gates a repeat-spawn guard in `executeSubagentSpawn` on `subagent-loop-guard` (default false). The 4th near-identical spawn in a conversation, or the 11th assistant-wide, within 24 hours returns a non-error result stating the observed count, the window, and the spend so far, and asks the caller to pass `confirm_repeat: true` if the repetition is intentional. It never hard-blocks: `confirm_repeat: true` always spawns, advisor consults return before the guard, and a failed history read fails open.
- Declares `confirm_repeat` on the spawn zod schema and in TOOLS.json (the bundled-skill layer rejects undeclared keys), plus tests for flag-off parity, under/over threshold in both scopes, the confirm bypass, the advisor exemption, and objective normalization.

Part of plan: subagent-type-consolidation.md (PR 6 of 9)