### PR TITLE
feat(home): give feed items a real headline instead of falling back to the body

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -320,11 +320,9 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls).toHaveLength(0);
   });
 
-  test("writes a feed item with undefined title when only the body is available", async () => {
-    // Regression: when `notifications send` is called without `--title`, the
-    // notification pipeline must not manufacture a title (the LLM's rendered
-    // copy echoes the body into `renderedCopy.title`). Leave `title`
-    // undefined so renderers fall back to `summary` instead of stuttering.
+  test("derives a title from the summary when only the body is available", async () => {
+    // With no authored candidate at all, the title is derived from the
+    // summary rather than left off: every row carries a headline.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
@@ -335,14 +333,14 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
-    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.title).toBe("Real body");
     expect(appendCalls[0]!.summary).toBe("Real body");
   });
 
-  test("ignores LLM-rendered title when no payload title was supplied", async () => {
-    // The LLM often echoes the body verbatim into `renderedCopy.title` when
-    // the source didn't pass one. The home-feed writer must NOT promote that
-    // echo into the feed item — only an explicit source title is honored.
+  test("uses the LLM-rendered title when no payload title was supplied", async () => {
+    // The model authors `renderedCopy.title` as a topic headline, and the
+    // decision engine validates it before it gets here, so it is the second
+    // candidate after the payload title.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
@@ -351,7 +349,7 @@ describe("writeHomeFeedItemForSignal", () => {
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
-          title: "Real body",
+          title: "Nightly sync finished",
           body: "Real body",
         },
       },
@@ -361,8 +359,98 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
-    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.title).toBe("Nightly sync finished");
     expect(appendCalls[0]!.summary).toBe("Real body");
+  });
+
+  test("payload title wins over the rendered title when it is clean", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Payload headline" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Model headline",
+          body: "A description of what the run did.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Payload headline");
+    expect(appendCalls[0]!.title).toBe("Payload headline");
+  });
+
+  test("rejects a payload title that restates the summary in favour of the rendered title", async () => {
+    // Shape seen in real on-disk feed data: a payload title that is just the
+    // opening words of the summary.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Test notifications" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Reminder plumbing check",
+          body: "Test notifications reminder.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Reminder plumbing check");
+    expect(appendCalls[0]!.summary).toBe("Test notifications reminder.");
+  });
+
+  test("derives a title from the summary when every authored candidate restates it", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Test notifications" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Test notifications reminder.",
+          body: "Test notifications reminder. It fired on schedule.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Test notifications reminder.");
+    expect(appendCalls[0]!.summary).toBe(
+      "Test notifications reminder. It fired on schedule.",
+    );
+  });
+
+  test("always writes a non-empty title even when the copy is unusable", async () => {
+    // `normalizeTitle` rejects prose-shaped candidates, so both authored
+    // titles drop out and the derivation carries the row.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "I need to name this notification somehow" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Let me summarize what happened",
+          body: "Disk usage crossed 90 percent. Cleanup ran.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Disk usage crossed 90 percent.");
+    expect(appendCalls[0]!.title).toBeTruthy();
   });
 
   test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -20,7 +20,9 @@ import { appendFeedItem } from "../home/feed-writer.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { getLogger } from "../util/logger.js";
+import { normalizeTitle } from "../util/short-title.js";
 import { isConversationSeedSane } from "./conversation-seed-composer.js";
+import { deriveTitle } from "./copy-composer.js";
 import { readPayloadString } from "./notification-utils.js";
 import type { NotificationSignal } from "./signal.js";
 import type { NotificationDecision, RenderedChannelCopy } from "./types.js";
@@ -66,11 +68,6 @@ export async function writeHomeFeedItemForSignal(
     readPayloadString(signal.contextPayload, "body") ??
     readPayloadString(signal.contextPayload, "requestedMessage");
 
-  // Source the title from the payload only. The LLM's `renderedCopy.title`
-  // often echoes the body when no explicit title was passed, which stutters
-  // against `summary` in the row. Leave undefined when absent; renderers
-  // fall back to `summary`.
-  const resolvedTitle = payloadTitle?.trim() || undefined;
   // Prefer conversationSeedMessage over body for the home feed: the seed
   // message is richer and may contain structured markdown (lists, headers,
   // bold) that the detail panel renders. The popup-oriented `body` is
@@ -90,6 +87,14 @@ export async function writeHomeFeedItemForSignal(
     );
     return null;
   }
+
+  // Title order: payload, then the rendered copy, then a headline derived
+  // from the summary. The derivation always yields something, so every feed
+  // item lands with a title.
+  const resolvedTitle =
+    acceptTitle(payloadTitle, resolvedSummary) ??
+    acceptTitle(renderedCopy?.title, resolvedSummary) ??
+    deriveTitle(resolvedSummary);
 
   const urgency = signal.attentionHints.urgency;
   const now = new Date().toISOString();
@@ -122,7 +127,7 @@ export async function writeHomeFeedItemForSignal(
     id: `notif:${signal.signalId}`,
     type: "notification",
     priority: 50,
-    ...(resolvedTitle ? { title: resolvedTitle } : {}),
+    title: resolvedTitle,
     summary: resolvedSummary,
     timestamp: now,
     createdAt: now,
@@ -148,6 +153,34 @@ export async function writeHomeFeedItemForSignal(
 
   await appendFeedItem(item);
   return item;
+}
+
+/**
+ * Clean an authored title (producer payload or model-rendered copy) and keep
+ * it only when it says something the summary does not.
+ *
+ * `normalizeTitle` returns "" for empty, prose-shaped, and meta-failure
+ * titles. On top of that, a title that is a case-insensitive prefix of the
+ * summary, or that matches the summary's first sentence, stutters against the
+ * row's own body text. Rejection returns undefined so the caller falls
+ * through to the next candidate.
+ */
+function acceptTitle(
+  raw: string | undefined,
+  summary: string,
+): string | undefined {
+  const candidate = normalizeTitle(raw ?? "");
+  if (!candidate) {
+    return undefined;
+  }
+  const lowered = candidate.toLowerCase();
+  if (summary.toLowerCase().startsWith(lowered)) {
+    return undefined;
+  }
+  if (lowered === deriveTitle(summary).toLowerCase()) {
+    return undefined;
+  }
+  return candidate;
 }
 
 // ── Category & detail-panel derivation ────────────────────────────────


### PR DESCRIPTION
## Summary
- Feed items now resolve a title from the payload, then the rendered copy, then a derivation from the summary, so every item has a headline
- An anti-stutter guard rejects any candidate that merely restates the summary
- Reverses #31063 (872c611a96), which stopped using the rendered title because it echoed the body. That is now safe: the title is normalized in decision-engine.ts and the model is given a real spec, where previously it had neither.
- The two tests that asserted an undefined title are inverted rather than deleted so the reversal is visible

Part of plan: home-feed-required-titles.md (PR 5 of 8)