### PR TITLE
fix(persistence): keep listBookmarks driven by message_bookmarks

### DIFF
--- a/assistant/src/persistence/bookmark-crud.ts
+++ b/assistant/src/persistence/bookmark-crud.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, type SQL } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { DrizzleDb } from "./db-connection.js";
@@ -79,21 +79,30 @@ function rowToSummary(row: BookmarkJoinRow): BookmarkSummary {
   };
 }
 
-function selectBookmarkJoin(db: DrizzleDb) {
+/**
+ * CROSS JOIN constrains SQLite's join order to start from message_bookmarks,
+ * which the planner would otherwise skip in favor of a full messages scan
+ * because an empty table never has statistics. The join predicates live in
+ * WHERE with identical semantics; callers pass extra conditions through
+ * `filter` because chaining `.where()` would replace the predicates.
+ */
+function selectBookmarkJoin(db: DrizzleDb, filter?: SQL) {
+  const joinMatch = and(
+    eq(messages.id, messageBookmarks.messageId),
+    eq(conversations.id, messageBookmarks.conversationId),
+  );
   return db
     .select(BOOKMARK_JOIN_COLUMNS)
     .from(messageBookmarks)
-    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
-    .innerJoin(
-      conversations,
-      eq(conversations.id, messageBookmarks.conversationId),
-    );
+    .crossJoin(messages)
+    .crossJoin(conversations)
+    .where(filter ? and(joinMatch, filter) : joinMatch);
 }
 
 /**
  * List all bookmarks newest-first, joined against `messages` and
  * `conversations`. Bookmarks whose parent message or conversation has
- * been deleted are naturally excluded by the inner-join semantics; the
+ * been deleted are naturally excluded by the join predicates; the
  * `ON DELETE CASCADE` on the FKs means rows should never end up in this
  * orphan state, but the join provides a defense-in-depth guarantee.
  */
@@ -179,7 +188,7 @@ function readBookmarkSummaryOrThrow(
   db: DrizzleDb,
   id: string,
 ): BookmarkSummary {
-  const row = selectBookmarkJoin(db).where(eq(messageBookmarks.id, id)).get();
+  const row = selectBookmarkJoin(db, eq(messageBookmarks.id, id)).get();
   if (!row) {
     // Unreachable: caller just observed (or inserted) this id.
     throw new Error(`Bookmark ${id} disappeared between insert and read`);

--- a/assistant/src/plugins/defaults/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/bookmark-crud.test.ts
@@ -261,4 +261,38 @@ describe("bookmark-crud", () => {
       /Message ghost not found/,
     );
   });
+
+  test("listBookmarks drives the join from message_bookmarks even with planner stats that predate the table", () => {
+    const sqlite = new Database(":memory:");
+    sqlite.exec("PRAGMA foreign_keys = ON");
+    const captured: string[] = [];
+    const db = drizzle(sqlite, {
+      schema,
+      logger: { logQuery: (query: string) => captured.push(query) },
+    });
+    const raw = getSqliteFrom(db);
+    bootstrapMessageTables(raw);
+    migrateMessageBookmarks(db);
+    for (let i = 0; i < 30; i++) {
+      seedConversationAndMessage(raw, {
+        conversationId: `conv-${i}`,
+        messageId: `msg-${i}`,
+      });
+    }
+    // ANALYZE writes no sqlite_stat1 rows for an empty table, leaving
+    // message_bookmarks without statistics while messages gets them. This is
+    // the production state that made the planner scan messages.
+    raw.exec("ANALYZE");
+
+    listBookmarks(db);
+    const sql = captured.at(-1);
+    expect(sql).toBeDefined();
+    const plan = raw.query(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{
+      detail: string;
+    }>;
+    expect(plan[0]?.detail ?? "").toMatch(/^SCAN message_bookmarks/);
+    expect(plan.some((row) => row.detail.includes("SCAN messages"))).toBe(
+      false,
+    );
+  });
 });


### PR DESCRIPTION
ref ATL-1177

SQLite planner estimates ~1 million rows for empty tables (see https://sqlite.org/forum/forumpost/ec2773f9f6) which can throw off query plans.
- Note that running `ANALYZE` doesn't fix the estimates for empty tables! Separately, we not using `PRAGMA optimize` correctly - will follow up with fix for that
- There's a *compile* time option to change default row estimates (see https://sqlite.org/src/timeline?r=analyze-empty-tables) but I couldn't find docs on modifying this at runtime.


The `GET /v1/bookmarks` joins (an often empty) `bookmarks` table against (usually) large `messages` + `conversations` tables. The query planner will often reorder the joins to perform a full table scan on the `messages` table:
```
  QUERY PLAN
  |--SCAN messages
  |--SEARCH message_bookmarks USING INDEX message_bookmarks_message_id_uniq (message_id=?)
  |--SEARCH conversations USING INDEX sqlite_autoindex_conversations_1 (id=?)
  `--USE TEMP B-TREE FOR ORDER BY
```
which can take a couple hundred ms even for empty `message_bookmarks` tables.

We can use `CROSS JOIN` instead to control join order manually (https://www.sqlite.org/optoverview.html#crossjoin) and use `message_bookmarks` as the leftmost table.