### PR TITLE
fix(memory): make embed worker death diagnosable and its recall loss visible (JARVIS-1410)

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/dimension-probe-worker-death.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/dimension-probe-worker-death.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The dimension probe runs before a read lane's real embed, so a worker that
+ * dies during the probe degrades the turn without the lane's own failure
+ * classification ever running. The probe therefore carries the same
+ * visibility contract itself: a dead worker logs at error with
+ * `cause: "embed_worker_died"`, while any other probe failure stays an
+ * ordinary degraded-probe warning (JARVIS-1410).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/** Log calls captured from the module under test, keyed by level. */
+const logCalls: { level: string; fields: unknown; message: string }[] = [];
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    error: (fields: unknown, message: string) =>
+      logCalls.push({ level: "error", fields, message }),
+    warn: (fields: unknown, message: string) =>
+      logCalls.push({ level: "warn", fields, message }),
+    info: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { resolveBackendDimension } = await import("../embedding-backend.js");
+const { EmbeddingWorkerDiedError } = await import("../embedding-types.js");
+
+/** A backend whose probe embed fails the way the caller programs. */
+let backendCounter = 0;
+function failingBackend(err: unknown) {
+  backendCounter += 1;
+  return {
+    provider: "local" as const,
+    // Distinct per test so the per-model dimension cache cannot short-circuit.
+    model: `probe-death-${backendCounter}`,
+    embed: async () => {
+      throw err;
+    },
+  };
+}
+
+describe("dimension probe worker-death visibility", () => {
+  beforeEach(() => {
+    logCalls.length = 0;
+  });
+
+  test("a worker death during the probe logs at error with the cause tag", async () => {
+    const dim = await resolveBackendDimension(
+      failingBackend(
+        new EmbeddingWorkerDiedError(
+          "Embedding worker error: Embedding worker process exited unexpectedly",
+        ),
+      ) as never,
+    );
+
+    expect(dim).toBeNull();
+    const errors = logCalls.filter((c) => c.level === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.fields).toMatchObject({ cause: "embed_worker_died" });
+    expect(errors[0]!.message).toContain("dense recall degrades");
+  });
+
+  test("an untyped worker-death message classifies the same way", async () => {
+    const dim = await resolveBackendDimension(
+      failingBackend(
+        new Error("worker pipe write failed: EPIPE: broken pipe, write"),
+      ) as never,
+    );
+
+    expect(dim).toBeNull();
+    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(1);
+  });
+
+  test("any other probe failure stays a warning", async () => {
+    const dim = await resolveBackendDimension(
+      failingBackend(new Error("connect ECONNREFUSED 127.0.0.1:6333")) as never,
+    );
+
+    expect(dim).toBeNull();
+    expect(logCalls.filter((c) => c.level === "error")).toHaveLength(0);
+    expect(logCalls.filter((c) => c.level === "warn")).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -29,6 +29,7 @@ import {
   listWorkerProcesses,
   LocalEmbeddingBackend,
 } from "../embedding-local.js";
+import { EmbeddingWorkerDiedError } from "../embedding-types.js";
 
 /** Reach past `private`, which is compile-time only, so tests drive real state. */
 type Internals = any;
@@ -261,6 +262,21 @@ describe("broken worker pipe", () => {
 
     await expect(backend.embed(["hello"])).rejects.toThrow(
       /worker pipe write failed/,
+    );
+  });
+
+  /**
+   * The fault is typed at its origin: the backend knows the child is gone, so
+   * `embed()` throws {@link EmbeddingWorkerDiedError} rather than encoding the
+   * fact only as message text for consumers to parse back out.
+   */
+  test("a dead-worker embed rejects with the typed error", async () => {
+    const backend = new LocalEmbeddingBackend("test-model") as Internals;
+    backend.workerProc = brokenPipeProc();
+    backend.ensureInitialized = async () => {};
+
+    await expect(backend.embed(["hello"])).rejects.toBeInstanceOf(
+      EmbeddingWorkerDiedError,
     );
   });
 

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -9,12 +9,21 @@
  *   4. Shutdown reaps process-owned workers deterministically.
  */
 
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { getEmbedWorkerPidPath } from "../../../util/platform.js";
+import {
+  getEmbeddingModelsDir,
+  getEmbedWorkerPidPath,
+} from "../../../util/platform.js";
 import {
   classifyWorkerOwnership,
   listWorkerProcesses,
@@ -462,6 +471,10 @@ describe("reclaiming before spawning a replacement", () => {
     spawned.push(proc);
     await Bun.sleep(400);
 
+    // `startWorker` spawns with `cwd: getEmbeddingModelsDir()`; posix_spawn
+    // fails with ENOENT when that directory is absent.
+    mkdirSync(getEmbeddingModelsDir(), { recursive: true });
+
     const backend = new LocalEmbeddingBackend("test-model") as Internals;
     backend.terminateGraceMs = 300;
     await backend.reclaimOwnedWorkers(scriptPath);
@@ -494,6 +507,10 @@ setTimeout(() => {}, 60_000);\n`,
     const workers = listWorkerProcesses(scriptPath);
     expect(workers.length).toBe(1);
     expect(workers[0].ppid).toBe(parent.pid);
+
+    // `startWorker` spawns with `cwd: getEmbeddingModelsDir()`; posix_spawn
+    // fails with ENOENT when that directory is absent.
+    mkdirSync(getEmbeddingModelsDir(), { recursive: true });
 
     const backend = new LocalEmbeddingBackend("test-model") as Internals;
     backend.terminateGraceMs = 300;
@@ -751,5 +768,74 @@ describe("model matching", () => {
     expect(
       listWorkerProcesses(scriptPath, "foo/bar-small-v2").map((w) => w.pid),
     ).toEqual([proc.pid]);
+  });
+});
+
+describe("stderr capture across worker startup", () => {
+  /**
+   * Discriminating test for drain ordering. The worker prints to stderr, waits,
+   * and only then signals ready. While readiness is still pending, the tail
+   * must already hold that line, which is true only if draining began at spawn.
+   * A drain started after readiness sees an empty tail at this point, so this
+   * fails on the pre-fix ordering rather than passing either way.
+   */
+  test("stderr is captured while readiness is still pending", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "embed-worker-drain-order-"));
+    const scriptPath = join(dir, "embed-worker.mjs");
+    writeFileSync(
+      scriptPath,
+      [
+        `process.stderr.write("EARLY: emitted before ready\\n");`,
+        `setTimeout(() => {`,
+        `  process.stdout.write(JSON.stringify({ type: "ready" }) + "\\n");`,
+        `}, 700);`,
+        `setTimeout(() => {}, 60_000);`,
+        ``,
+      ].join("\n"),
+    );
+
+    mkdirSync(getEmbeddingModelsDir(), { recursive: true });
+
+    const backend = new LocalEmbeddingBackend("test-model") as Internals;
+    backend.terminateGraceMs = 300;
+
+    // Not awaited: it cannot resolve until the worker signals ready at 700ms.
+    const starting = backend.startWorker(process.execPath, scriptPath);
+    await Bun.sleep(300);
+
+    const tailDuringStartup = [...(backend.stderrTail ?? [])].join("\n");
+    expect(tailDuringStartup).toContain("EARLY: emitted before ready");
+
+    await starting;
+    backend.terminateNow();
+  });
+
+  /**
+   * The drain owns `proc.stderr`, so the startup-failure path must read the
+   * tail rather than the stream. A worker that never signals ready and dies
+   * with output must still surface that output in the thrown error.
+   */
+  test("a worker that dies before ready surfaces its stderr in the startup error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "embed-worker-prefatal-"));
+    const scriptPath = join(dir, "embed-worker.mjs");
+    writeFileSync(
+      scriptPath,
+      [
+        `process.stderr.write("FATAL: died before ready\\n");`,
+        `process.exit(4);`,
+        ``,
+      ].join("\n"),
+    );
+
+    // `startWorker` spawns with `cwd: getEmbeddingModelsDir()`; posix_spawn
+    // fails with ENOENT when that directory is absent.
+    mkdirSync(getEmbeddingModelsDir(), { recursive: true });
+
+    const backend = new LocalEmbeddingBackend("test-model") as Internals;
+    backend.terminateGraceMs = 300;
+
+    await expect(
+      backend.startWorker(process.execPath, scriptPath),
+    ).rejects.toThrow(/died before ready/);
   });
 });

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -789,11 +789,10 @@ describe("model matching", () => {
 
 describe("stderr capture across worker startup", () => {
   /**
-   * Discriminating test for drain ordering. The worker prints to stderr, waits,
-   * and only then signals ready. While readiness is still pending, the tail
-   * must already hold that line, which is true only if draining began at spawn.
-   * A drain started after readiness sees an empty tail at this point, so this
-   * fails on the pre-fix ordering rather than passing either way.
+   * Drain ordering. The worker prints to stderr, waits, and only then signals
+   * ready. While readiness is still pending the tail must already hold that
+   * line, which holds only if draining begins at spawn: a drain that starts
+   * after the readiness handshake sees an empty tail at this point.
    */
   test("stderr is captured while readiness is still pending", async () => {
     const dir = mkdtempSync(join(tmpdir(), "embed-worker-drain-order-"));
@@ -853,5 +852,36 @@ describe("stderr capture across worker startup", () => {
     await expect(
       backend.startWorker(process.execPath, scriptPath),
     ).rejects.toThrow(/died before ready/);
+  });
+});
+
+describe("startup failure diagnostics", () => {
+  /**
+   * `initialize` classifies a startup failure by pattern-matching the thrown
+   * message to decide whether to clear the model cache and retry. The retained
+   * stderr tail is bounded, so a corruption signature must survive independently
+   * of it: a worker that keeps printing after the signature would otherwise
+   * evict it and silently disable the self-healing retry.
+   */
+  test("a corruption signature survives a worker that keeps printing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "embed-worker-corrupt-"));
+    const scriptPath = join(dir, "embed-worker.mjs");
+    writeFileSync(
+      scriptPath,
+      [
+        `process.stderr.write("Error: protobuf parsing failed\\n");`,
+        `for (let i = 0; i < 60; i++) process.stderr.write("noise line " + i + "\\n");`,
+        `process.exit(1);`,
+        ``,
+      ].join("\n"),
+    );
+
+    mkdirSync(getEmbeddingModelsDir(), { recursive: true });
+    const backend = new LocalEmbeddingBackend("test-model") as Internals;
+    backend.terminateGraceMs = 300;
+
+    await expect(
+      backend.startWorker(process.execPath, scriptPath),
+    ).rejects.toThrow(/protobuf parsing/);
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -26,6 +26,7 @@ import {
   embeddingInputContentHash,
   type EmbeddingProviderName,
   type EmbeddingRequestOptions,
+  isEmbeddingWorkerDeath,
   type MultimodalEmbeddingInput,
   normalizeEmbeddingInput,
   type SparseEmbedding,
@@ -764,10 +765,27 @@ export async function resolveBackendDimension(
     if (extractHttpStatus(err) === 402) {
       recordBillingBlock();
     }
-    log.warn(
-      { err, provider: backend.provider, model: backend.model },
-      "Embedding-dimension availability probe failed; treating as degraded",
-    );
+    // The probe runs before the lane's real embed, so a worker that dies here
+    // degrades the turn without ever reaching the lane's own classification.
+    // Preserve the visibility contract at this earlier failure point: a dead
+    // worker is a fault and logs at error with the same cause tag; anything
+    // else stays an ordinary degraded-probe warning.
+    if (isEmbeddingWorkerDeath(err)) {
+      log.error(
+        {
+          err,
+          provider: backend.provider,
+          model: backend.model,
+          cause: "embed_worker_died",
+        },
+        "embedding worker died during the dimension probe; dense recall degrades this turn",
+      );
+    } else {
+      log.warn(
+        { err, provider: backend.provider, model: backend.model },
+        "Embedding-dimension availability probe failed; treating as degraded",
+      );
+    }
     return null;
   }
 }

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -900,6 +900,11 @@ export async function embedWithBackend(
   const backends = await assembleEmbeddingBackends(config, selection.backend);
 
   let lastErr: unknown;
+  // The first worker death seen while walking the chain. Only the last
+  // backend's failure is rethrown, so without this a fallback that also fails
+  // would mask a dead local worker and the fault would classify as an ordinary
+  // query failure on multi-backend setups.
+  let workerDeath: unknown;
   let anyBackendAttempted = false;
   for (const backend of backends) {
     const isPrimary = backend === selection.backend;
@@ -965,6 +970,9 @@ export async function embedWithBackend(
       return { provider: backend.provider, model: backend.model, vectors };
     } catch (err) {
       lastErr = err;
+      if (workerDeath === undefined && isEmbeddingWorkerDeath(err)) {
+        workerDeath = err;
+      }
       // If ANY backend in the chain returns 402, trip the billing breaker
       // immediately — fallbacks will hit the same depleted balance.
       if (extractHttpStatus(err) === 402) {
@@ -988,6 +996,14 @@ export async function embedWithBackend(
       throw new Error(
         "No available embedding backend supports multimodal inputs. Gemini API key is required for image/audio/video embeddings.",
       );
+    }
+  }
+  // Surface the last backend's failure as before, but carry the worker death
+  // as its cause so `isEmbeddingWorkerDeath` still recognises it. Attaching
+  // rather than substituting keeps the message the caller sees unchanged.
+  if (workerDeath !== undefined && workerDeath !== lastErr) {
+    if (lastErr instanceof Error && lastErr.cause === undefined) {
+      lastErr.cause = workerDeath;
     }
   }
   throw lastErr;

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -78,6 +78,13 @@ const WORKER_EXIT_POLL_MS = 50;
  */
 const WORKER_STDERR_TAIL_LINES = 20;
 
+/**
+ * How long the unexpected-exit report waits for the worker's stderr stream to
+ * close. Short enough that a stream which never closes cannot stall teardown,
+ * long enough for the final chunk of an exiting child to arrive.
+ */
+const WORKER_STDERR_DRAIN_MS = 250;
+
 /** Whether `promise` settles within `timeoutMs`. */
 async function didSettle(
   promise: Promise<unknown>,
@@ -312,14 +319,15 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   /** Path of the worker script, retained so liveness can be re-probed. */
   private workerPath: string | null = null;
   /**
-   * Tail of the worker's stderr, kept so an unexpected exit can say why.
+   * Tail of the current worker's stderr, so an unexpected exit can say why.
    *
-   * Streaming stderr stays at `debug` because a healthy worker is chatty, but
-   * that means production logs hold nothing at the moment it matters. Retaining
-   * the tail lets the exit path report the cause at `warn` without turning on
-   * debug logging for everyone (JARVIS-1410).
+   * Streaming stderr stays at `debug` because a healthy worker is chatty. The
+   * tail is what the exit path reports at `warn`, so the cause of a death is
+   * available without debug logging enabled.
    */
   private recentStderr: string[] = [];
+  /** Settles when the current worker's stderr stream closes. */
+  private stderrDrained: Promise<void> | null = null;
   /** Overridable so tests can exercise the escalation path without the wait. */
   private terminateGraceMs = WORKER_TERMINATE_GRACE_MS;
 
@@ -572,8 +580,12 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       );
     }
 
-    // Worker is running — drain stderr in background for ongoing logging
-    this.drainStderr(proc.stderr);
+    // The tail belongs to this worker alone. Clearing at spawn, rather than on
+    // a teardown path, is what keeps that true: several teardowns null
+    // `workerProc` themselves, and the previous worker's drain loop is not
+    // cancelled, so a late chunk can still arrive after it was let go.
+    this.recentStderr = [];
+    this.stderrDrained = this.drainStderr(proc.stderr);
 
     // Write PID file so `vellum ps` can see the embed worker
     this.writePidFile(proc.pid);
@@ -586,31 +598,59 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     this.disposeIfIdle();
   }
 
-  private drainStderr(stderr: ReadableStream<Uint8Array>): void {
+  /**
+   * Stream the worker's stderr to the debug log and retain its tail.
+   *
+   * A read returns an arbitrary slice of the pipe, which may hold many lines or
+   * half of one, so chunks are split on newlines and a trailing partial line is
+   * carried to the next read. The retained tail is therefore the last
+   * {@link WORKER_STDERR_TAIL_LINES} lines rather than that many chunks, which
+   * bounds both the entry count and the size of the death report.
+   *
+   * Returns a promise that settles when the stream closes. The unexpected-exit
+   * report awaits it briefly: stdout and stderr close independently, so a
+   * worker's final stderr can still be in flight when the stdout reader ends.
+   */
+  private drainStderr(stderr: ReadableStream<Uint8Array>): Promise<void> {
     const reader = stderr.getReader();
     const decoder = new TextDecoder();
-    (async () => {
+    return (async () => {
+      let carry = "";
+      const retain = (line: string): void => {
+        const text = line.trim();
+        if (!text) {
+          return;
+        }
+        log.debug({ workerStderr: text }, "Embedding worker stderr");
+        this.recentStderr.push(text);
+        if (this.recentStderr.length > WORKER_STDERR_TAIL_LINES) {
+          this.recentStderr.splice(
+            0,
+            this.recentStderr.length - WORKER_STDERR_TAIL_LINES,
+          );
+        }
+      };
+
       try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) {
             break;
           }
-          const text = decoder.decode(value, { stream: true }).trim();
-          if (text) {
-            log.debug({ workerStderr: text }, "Embedding worker stderr");
-            this.recentStderr.push(text);
-            if (this.recentStderr.length > WORKER_STDERR_TAIL_LINES) {
-              this.recentStderr.splice(
-                0,
-                this.recentStderr.length - WORKER_STDERR_TAIL_LINES,
-              );
-            }
+          carry += decoder.decode(value, { stream: true });
+          const lines = carry.split("\n");
+          // The last element is whatever followed the final newline: either an
+          // incomplete line or an empty string. Either way it waits for more.
+          carry = lines.pop() ?? "";
+          for (const line of lines) {
+            retain(line);
           }
         }
       } catch {
         // Reader cancelled or stream errored — expected on shutdown
       }
+      // A worker killed mid-line still emitted that text; keep it.
+      retain(carry);
     })();
   }
 
@@ -658,11 +698,17 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         return;
       }
 
-      // Report the death where production logging will actually keep it. The
-      // pending requests below each surface as an ordinary embed failure the
-      // backend chain falls back from, so without this line the only trace of
-      // a worker dying is a downstream "degraded to no hits" with no cause
-      // attached, which is what made these undiagnosable (JARVIS-1410).
+      // stdout and stderr close independently, so a worker that printed its
+      // cause and exited can still have that text in flight here. Wait briefly
+      // for the stderr stream to close so the tail carries the fatal message,
+      // bounded so a stream that never closes cannot stall the teardown.
+      if (this.stderrDrained) {
+        await didSettle(this.stderrDrained, WORKER_STDERR_DRAIN_MS);
+      }
+
+      // The pending requests below each resolve as an ordinary embed failure
+      // the backend chain falls back from, so this is the only record that
+      // names the worker and why it went away.
       log.warn(
         {
           pid: proc.pid,
@@ -682,7 +728,6 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         });
       }
       this.pendingRequests.clear();
-      this.recentStderr = [];
       this.workerProc = null;
       this.stdoutReaderActive = false;
       this.stdoutBuffer = "";

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -323,9 +323,10 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
    *
    * Streaming stderr stays at `debug` because a healthy worker is chatty. The
    * tail is what the exit path reports at `warn`, so the cause of a death is
-   * available without debug logging enabled.
+   * available without debug logging enabled. Points at the array owned by the
+   * current worker's drain; a previous worker's drain keeps its own.
    */
-  private recentStderr: string[] = [];
+  private stderrTail: string[] = [];
   /** Settles when the current worker's stderr stream closes. */
   private stderrDrained: Promise<void> | null = null;
   /** Overridable so tests can exercise the escalation path without the wait. */
@@ -580,12 +581,12 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       );
     }
 
-    // The tail belongs to this worker alone. Clearing at spawn, rather than on
-    // a teardown path, is what keeps that true: several teardowns null
-    // `workerProc` themselves, and the previous worker's drain loop is not
-    // cancelled, so a late chunk can still arrive after it was let go.
-    this.recentStderr = [];
-    this.stderrDrained = this.drainStderr(proc.stderr);
+    // Each drain owns its own tail array, so this points at the new worker's
+    // buffer while any still-running drain from a previous worker keeps
+    // appending to its own. The report can only ever read one worker's output.
+    const { drained, tail } = this.drainStderr(proc.stderr);
+    this.stderrDrained = drained;
+    this.stderrTail = tail;
 
     // Write PID file so `vellum ps` can see the embed worker
     this.writePidFile(proc.pid);
@@ -607,14 +608,23 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
    * {@link WORKER_STDERR_TAIL_LINES} lines rather than that many chunks, which
    * bounds both the entry count and the size of the death report.
    *
-   * Returns a promise that settles when the stream closes. The unexpected-exit
-   * report awaits it briefly: stdout and stderr close independently, so a
-   * worker's final stderr can still be in flight when the stdout reader ends.
+   * The returned `tail` array belongs to this drain alone. A drain is never
+   * cancelled, so one whose worker has already died can still resume and append
+   * after a replacement was spawned; owning its own array means those late
+   * lines land where nothing reads them instead of in the live worker's report.
+   *
+   * `drained` settles when the stream closes. The unexpected-exit report awaits
+   * it briefly: stdout and stderr close independently, so a worker's final
+   * stderr can still be in flight when the stdout reader ends.
    */
-  private drainStderr(stderr: ReadableStream<Uint8Array>): Promise<void> {
+  private drainStderr(stderr: ReadableStream<Uint8Array>): {
+    drained: Promise<void>;
+    tail: string[];
+  } {
     const reader = stderr.getReader();
     const decoder = new TextDecoder();
-    return (async () => {
+    const tail: string[] = [];
+    const drained = (async () => {
       let carry = "";
       const retain = (line: string): void => {
         const text = line.trim();
@@ -622,12 +632,9 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
           return;
         }
         log.debug({ workerStderr: text }, "Embedding worker stderr");
-        this.recentStderr.push(text);
-        if (this.recentStderr.length > WORKER_STDERR_TAIL_LINES) {
-          this.recentStderr.splice(
-            0,
-            this.recentStderr.length - WORKER_STDERR_TAIL_LINES,
-          );
+        tail.push(text);
+        if (tail.length > WORKER_STDERR_TAIL_LINES) {
+          tail.splice(0, tail.length - WORKER_STDERR_TAIL_LINES);
         }
       };
 
@@ -652,6 +659,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       // A worker killed mid-line still emitted that text; keep it.
       retain(carry);
     })();
+    return { drained, tail };
   }
 
   private startStdoutReader(): void {
@@ -717,7 +725,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
           signal: proc.signalCode ?? null,
           confirmedTerminated: confirmed,
           abandonedRequests: this.pendingRequests.size,
-          workerStderrTail: this.recentStderr.slice(-WORKER_STDERR_TAIL_LINES),
+          workerStderrTail: this.stderrTail.slice(-WORKER_STDERR_TAIL_LINES),
         },
         "Embedding worker exited unexpectedly",
       );

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -71,6 +71,13 @@ const WORKER_TERMINATE_GRACE_MS = 2_000;
 /** Poll interval while waiting for a worker we hold no handle for to exit. */
 const WORKER_EXIT_POLL_MS = 50;
 
+/**
+ * Stderr lines retained per worker for the unexpected-exit report. Bounded so a
+ * worker looping on a warning cannot grow the buffer without limit; the tail is
+ * what carries the fatal message.
+ */
+const WORKER_STDERR_TAIL_LINES = 20;
+
 /** Whether `promise` settles within `timeoutMs`. */
 async function didSettle(
   promise: Promise<unknown>,
@@ -304,6 +311,15 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   private unconfirmedWorker: number | null = null;
   /** Path of the worker script, retained so liveness can be re-probed. */
   private workerPath: string | null = null;
+  /**
+   * Tail of the worker's stderr, kept so an unexpected exit can say why.
+   *
+   * Streaming stderr stays at `debug` because a healthy worker is chatty, but
+   * that means production logs hold nothing at the moment it matters. Retaining
+   * the tail lets the exit path report the cause at `warn` without turning on
+   * debug logging for everyone (JARVIS-1410).
+   */
+  private recentStderr: string[] = [];
   /** Overridable so tests can exercise the escalation path without the wait. */
   private terminateGraceMs = WORKER_TERMINATE_GRACE_MS;
 
@@ -583,6 +599,13 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
           const text = decoder.decode(value, { stream: true }).trim();
           if (text) {
             log.debug({ workerStderr: text }, "Embedding worker stderr");
+            this.recentStderr.push(text);
+            if (this.recentStderr.length > WORKER_STDERR_TAIL_LINES) {
+              this.recentStderr.splice(
+                0,
+                this.recentStderr.length - WORKER_STDERR_TAIL_LINES,
+              );
+            }
           }
         }
       } catch {
@@ -635,12 +658,31 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         return;
       }
 
+      // Report the death where production logging will actually keep it. The
+      // pending requests below each surface as an ordinary embed failure the
+      // backend chain falls back from, so without this line the only trace of
+      // a worker dying is a downstream "degraded to no hits" with no cause
+      // attached, which is what made these undiagnosable (JARVIS-1410).
+      log.warn(
+        {
+          pid: proc.pid,
+          model: this.model,
+          exitCode: proc.exitCode ?? null,
+          signal: proc.signalCode ?? null,
+          confirmedTerminated: confirmed,
+          abandonedRequests: this.pendingRequests.size,
+          workerStderrTail: this.recentStderr.slice(-WORKER_STDERR_TAIL_LINES),
+        },
+        "Embedding worker exited unexpectedly",
+      );
+
       for (const [, pending] of this.pendingRequests) {
         pending.resolve({
           error: "Embedding worker process exited unexpectedly",
         });
       }
       this.pendingRequests.clear();
+      this.recentStderr = [];
       this.workerProc = null;
       this.stdoutReaderActive = false;
       this.stdoutBuffer = "";

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -42,20 +42,26 @@ interface WorkerResponse {
 }
 
 /**
- * Detect model loading errors (corrupted cache, incompatible ONNX format, etc.)
- * that can be resolved by clearing the model cache and re-downloading.
+ * Whether a line of worker output signals a corrupted or incompatible model
+ * cache. Single source of the patterns, so the per-line scan during startup and
+ * the error-level check below cannot drift apart.
  */
-function isModelCorruptionError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const msg = err.message.toLowerCase();
+function isModelCorruptionMessage(text: string): boolean {
+  const msg = text.toLowerCase();
   return (
     msg.includes("protobuf parsing") ||
     (msg.includes("load model") && msg.includes("failed")) ||
     msg.includes("invalid model") ||
     msg.includes("corrupt")
   );
+}
+
+/**
+ * Detect model loading errors (corrupted cache, incompatible ONNX format, etc.)
+ * that can be resolved by clearing the model cache and re-downloading.
+ */
+function isModelCorruptionError(err: unknown): boolean {
+  return err instanceof Error && isModelCorruptionMessage(err.message);
 }
 
 /** Remove the cached model files so they are re-downloaded on next attempt. */
@@ -84,6 +90,13 @@ const WORKER_EXIT_POLL_MS = 50;
  * what carries the fatal message.
  */
 const WORKER_STDERR_TAIL_LINES = 20;
+
+/**
+ * Corruption signatures retained from a worker's startup output, independent of
+ * the bounded tail. One line is enough to classify; the small allowance covers
+ * a runtime that reports the same fault across a couple of lines.
+ */
+const WORKER_CORRUPTION_LINES = 5;
 
 /**
  * How long the unexpected-exit report waits for the worker's stderr stream to
@@ -568,7 +581,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     //
     // Each drain owns its tail array, so this points at the new worker's buffer
     // while a still-running drain from a previous worker appends to its own.
-    const { drained, tail } = this.drainStderr(proc.stderr);
+    const { drained, tail, corruption } = this.drainStderr(proc.stderr);
     this.stderrDrained = drained;
     this.stderrTail = tail;
 
@@ -594,7 +607,10 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       // than the stream itself. Bounded for the same reason the drain is: a
       // live child never closes stderr.
       await didSettle(drained, this.terminateGraceMs);
-      const stderr = tail.join("\n");
+      // Corruption lines are prepended rather than left to the tail: the tail
+      // is bounded, so a signature followed by enough further output would be
+      // evicted and the clear-cache-and-retry recovery would stop firing.
+      const stderr = [...corruption, ...tail].join("\n");
       if (stderr.trim()) {
         log.warn(
           { stderr: stderr.trim(), exitCode, bunPath },
@@ -640,10 +656,16 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   private drainStderr(stderr: ReadableStream<Uint8Array>): {
     drained: Promise<void>;
     tail: string[];
+    corruption: string[];
   } {
     const reader = stderr.getReader();
     const decoder = new TextDecoder();
     const tail: string[] = [];
+    // Corruption signatures are captured as they stream, because the bounded
+    // tail evicts them when a worker keeps printing afterwards, and the
+    // startup-failure path classifies on this text to decide whether to clear
+    // the model cache and retry.
+    const corruption: string[] = [];
     const drained = (async () => {
       let carry = "";
       const retain = (line: string): void => {
@@ -652,6 +674,12 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
           return;
         }
         log.debug({ workerStderr: text }, "Embedding worker stderr");
+        if (
+          corruption.length < WORKER_CORRUPTION_LINES &&
+          isModelCorruptionMessage(text)
+        ) {
+          corruption.push(text);
+        }
         tail.push(text);
         if (tail.length > WORKER_STDERR_TAIL_LINES) {
           tail.splice(0, tail.length - WORKER_STDERR_TAIL_LINES);
@@ -679,7 +707,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       // A worker killed mid-line still emitted that text; keep it.
       retain(carry);
     })();
-    return { drained, tail };
+    return { drained, tail, corruption };
   }
 
   private startStdoutReader(): void {

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -22,6 +22,7 @@ import {
   type EmbeddingBackend,
   type EmbeddingInput,
   type EmbeddingRequestOptions,
+  EmbeddingWorkerDiedError,
   normalizeEmbeddingInput,
 } from "./embedding-types.js";
 
@@ -32,6 +33,12 @@ interface WorkerResponse {
   type?: string;
   vectors?: number[][];
   error?: string;
+  /**
+   * Set on the two resolution sites that know the child is gone (observed
+   * exit, and a failed pipe write), so `embed()` can throw the typed
+   * {@link EmbeddingWorkerDiedError} instead of encoding the fault as text.
+   */
+  workerDied?: boolean;
 }
 
 /**
@@ -371,7 +378,10 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         const batch = texts.slice(i, i + batchSize);
         const response = await this.sendRequest(batch);
         if (response.error) {
-          throw new Error(`Embedding worker error: ${response.error}`);
+          const message = `Embedding worker error: ${response.error}`;
+          throw response.workerDied
+            ? new EmbeddingWorkerDiedError(message)
+            : new Error(message);
         }
         if (!response.vectors) {
           throw new Error("Embedding worker returned no vectors");
@@ -424,7 +434,11 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     this.pendingRequests.delete(id);
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err, model: this.model }, "Embedding worker pipe write failed");
-    pending.resolve({ id, error: `worker pipe write failed: ${message}` });
+    pending.resolve({
+      id,
+      error: `worker pipe write failed: ${message}`,
+      workerDied: true,
+    });
     this.disposeIfIdle();
   }
 
@@ -739,6 +753,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       for (const [, pending] of this.pendingRequests) {
         pending.resolve({
           error: "Embedding worker process exited unexpectedly",
+          workerDied: true,
         });
       }
       this.pendingRequests.clear();

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -545,6 +545,19 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
     // Type-compatible assignment
     this.workerProc = proc;
 
+    // Drain stderr from the moment the child exists. A worker can signal ready,
+    // print why it is about to die, and exit before any later setup runs, so a
+    // drain started after readiness can find the stream already closed and
+    // report the death with nothing attached. This is also the only reader of
+    // `proc.stderr`: a stream admits one, so the startup-failure path below
+    // reads the tail rather than the stream.
+    //
+    // Each drain owns its tail array, so this points at the new worker's buffer
+    // while a still-running drain from a previous worker appends to its own.
+    const { drained, tail } = this.drainStderr(proc.stderr);
+    this.stderrDrained = drained;
+    this.stderrTail = tail;
+
     // Start reading stdout for responses (needed for waitForReady)
     this.startStdoutReader();
 
@@ -563,11 +576,11 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
       this.stdoutBuffer = "";
       const confirmed = await this.terminateWorker(proc);
       const exitCode = confirmed ? proc.exitCode : undefined;
-      // Bounded for the same reason: a live child never closes stderr.
-      const stderr = await Promise.race([
-        new Response(proc.stderr).text().catch(() => ""),
-        Bun.sleep(this.terminateGraceMs).then(() => ""),
-      ]);
+      // The drain started at spawn owns the stream, so read its tail rather
+      // than the stream itself. Bounded for the same reason the drain is: a
+      // live child never closes stderr.
+      await didSettle(drained, this.terminateGraceMs);
+      const stderr = tail.join("\n");
       if (stderr.trim()) {
         log.warn(
           { stderr: stderr.trim(), exitCode, bunPath },
@@ -580,13 +593,6 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         }`,
       );
     }
-
-    // Each drain owns its own tail array, so this points at the new worker's
-    // buffer while any still-running drain from a previous worker keeps
-    // appending to its own. The report can only ever read one worker's output.
-    const { drained, tail } = this.drainStderr(proc.stderr);
-    this.stderrDrained = drained;
-    this.stderrTail = tail;
 
     // Write PID file so `vellum ps` can see the embed worker
     this.writePidFile(proc.pid);

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -116,3 +116,44 @@ export interface EmbeddingBackend {
  * input (and therefore the in-memory vector cache identity).
  */
 export const EMBEDDING_DIMENSION_PROBE_TEXT = "embedding dimension probe";
+
+/**
+ * Thrown by an embedding backend when its worker subprocess is gone: either
+ * the child exited while a request was in flight, or it was already dead when
+ * the next request hit the pipe. Typed at the origin so consumers that need to
+ * distinguish a dead worker from an ordinary backend failure check the type
+ * rather than parsing message text.
+ */
+export class EmbeddingWorkerDiedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmbeddingWorkerDiedError";
+  }
+}
+
+/**
+ * Message fragments a worker-owning backend emits when its child is gone. The
+ * fallback for errors that are not {@link EmbeddingWorkerDiedError}: the rerank
+ * worker reports its deaths with the same phrasing but does not yet throw the
+ * typed error, and an error that crossed a serialization boundary arrives as a
+ * plain object. Both shapes describe the same fault, distinguished only by
+ * whether the death beat the write.
+ */
+const WORKER_DEATH_MESSAGE_FRAGMENTS = [
+  "worker process exited unexpectedly",
+  "worker pipe write failed",
+];
+
+/**
+ * Whether an error means a worker subprocess died, as opposed to any other
+ * embedding failure. The two need different responses: a dead worker is a
+ * fault to investigate, while most other failures are transient backend
+ * conditions.
+ */
+export function isEmbeddingWorkerDeath(err: unknown): boolean {
+  if (err instanceof EmbeddingWorkerDiedError) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return WORKER_DEATH_MESSAGE_FRAGMENTS.some((m) => message.includes(m));
+}

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -1,5 +1,7 @@
 import { createHash } from "crypto";
 
+import { EmbeddingWorkerDiedError } from "../../util/errors.js";
+
 export type EmbeddingTaskType =
   | "SEMANTIC_SIMILARITY"
   | "CLASSIFICATION"
@@ -118,26 +120,21 @@ export interface EmbeddingBackend {
 export const EMBEDDING_DIMENSION_PROBE_TEXT = "embedding dimension probe";
 
 /**
- * Thrown by an embedding backend when its worker subprocess is gone: either
- * the child exited while a request was in flight, or it was already dead when
- * the next request hit the pipe. Typed at the origin so consumers that need to
- * distinguish a dead worker from an ordinary backend failure check the type
- * rather than parsing message text.
+ * The typed worker-death error is part of the shared `VellumError` hierarchy
+ * (`util/errors.ts`), where structured errors propagate to logging and
+ * monitoring. Re-exported here because this module is the embedding domain's
+ * public surface: backends throw it and consumers import it from the same
+ * place as the other embedding types.
  */
-export class EmbeddingWorkerDiedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "EmbeddingWorkerDiedError";
-  }
-}
+export { EmbeddingWorkerDiedError } from "../../util/errors.js";
 
 /**
  * Message fragments a worker-owning backend emits when its child is gone. The
  * fallback for errors that are not {@link EmbeddingWorkerDiedError}: the rerank
- * worker reports its deaths with the same phrasing but does not yet throw the
- * typed error, and an error that crossed a serialization boundary arrives as a
- * plain object. Both shapes describe the same fault, distinguished only by
- * whether the death beat the write.
+ * worker reports its deaths with the same phrasing as plain errors, and an
+ * error that crossed a serialization boundary arrives untyped. Both fragments
+ * describe the same fault, distinguished only by whether the death beat the
+ * write.
  */
 const WORKER_DEATH_MESSAGE_FRAGMENTS = [
   "worker process exited unexpectedly",

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -148,9 +148,18 @@ const WORKER_DEATH_MESSAGE_FRAGMENTS = [
  * conditions.
  */
 export function isEmbeddingWorkerDeath(err: unknown): boolean {
-  if (err instanceof EmbeddingWorkerDiedError) {
-    return true;
+  // Walk the cause chain: a backend chain that falls back past a dead worker
+  // rethrows the last backend's failure, attaching the worker death as its
+  // cause, so the fault stays detectable on multi-backend setups.
+  for (let cur = err, depth = 0; cur != null && depth < 8; depth++) {
+    if (cur instanceof EmbeddingWorkerDiedError) {
+      return true;
+    }
+    const message = cur instanceof Error ? cur.message : String(cur);
+    if (WORKER_DEATH_MESSAGE_FRAGMENTS.some((m) => message.includes(m))) {
+      return true;
+    }
+    cur = cur instanceof Error ? cur.cause : undefined;
   }
-  const message = err instanceof Error ? err.message : String(err);
-  return WORKER_DEATH_MESSAGE_FRAGMENTS.some((m) => message.includes(m));
+  return false;
 }

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -352,6 +352,20 @@ describe("classifyDenseLaneFailure", () => {
     ).toBe("embed_worker_died");
   });
 
+  /**
+   * A worker already gone when the next request is written fails the pipe
+   * before any exit is observed, so `failPendingRequest` resolves with a
+   * different message for the same underlying fault. Classifying only the
+   * exit shape under-counts worker deaths in exactly the alerting this feeds.
+   */
+  test("recognizes a worker that died before the pipe write", () => {
+    expect(
+      classifyDenseLaneFailure(
+        new Error("worker pipe write failed: EPIPE: broken pipe, write"),
+      ),
+    ).toBe("embed_worker_died");
+  });
+
   test("treats any other failure as a query failure", () => {
     expect(classifyDenseLaneFailure(new Error("embed backend down"))).toBe(
       "dense_query_failed",

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -88,7 +88,8 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
-const { denseLane, denseLaneScored, OVERSAMPLE } = await import("../dense.js");
+const { classifyDenseLaneFailure, denseLane, denseLaneScored, OVERSAMPLE } =
+  await import("../dense.js");
 const { SECTION_COLLECTION, _resetSectionDenseStoreForTests } =
   await import("../section-dense-store.js");
 
@@ -222,6 +223,22 @@ describe("memory v3 dense lane", () => {
     expect(state.queryCalls).toHaveLength(0);
   });
 
+  /**
+   * A dead embed worker degrades the turn the same way, so the `[]` contract
+   * must hold for it too: the orchestrator calls this lane inside an unguarded
+   * Promise.all and one throw would discard the sibling lanes (JARVIS-1410).
+   */
+  test("a dead embed worker still degrades to [] rather than throwing", async () => {
+    embedState.throws = new Error(
+      "Embedding worker error: Embedding worker process exited unexpectedly",
+    );
+
+    const hits = await denseLane(CONFIG, "query", 5);
+
+    expect(hits).toEqual([]);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
   test("non-positive k short-circuits without a search", async () => {
     const hits = await denseLane(CONFIG, "query", 0);
 
@@ -313,5 +330,41 @@ describe("denseLaneScored", () => {
     expect(plain).toEqual(
       scored.map(({ article, section }) => ({ article, section })),
     );
+  });
+});
+
+describe("classifyDenseLaneFailure", () => {
+  test("recognizes a dead embed worker from the backend's message", () => {
+    expect(
+      classifyDenseLaneFailure(
+        new Error(
+          "Embedding worker error: Embedding worker process exited unexpectedly",
+        ),
+      ),
+    ).toBe("embed_worker_died");
+  });
+
+  test("recognizes a dead rerank worker the same way", () => {
+    expect(
+      classifyDenseLaneFailure(
+        new Error("Rerank worker process exited unexpectedly"),
+      ),
+    ).toBe("embed_worker_died");
+  });
+
+  test("treats any other failure as a query failure", () => {
+    expect(classifyDenseLaneFailure(new Error("embed backend down"))).toBe(
+      "dense_query_failed",
+    );
+    expect(classifyDenseLaneFailure(new Error("Qdrant timeout"))).toBe(
+      "dense_query_failed",
+    );
+  });
+
+  test("handles a non-Error throw without losing the classification", () => {
+    expect(classifyDenseLaneFailure("worker process exited unexpectedly")).toBe(
+      "embed_worker_died",
+    );
+    expect(classifyDenseLaneFailure(undefined)).toBe("dense_query_failed");
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -90,6 +90,8 @@ mock.module("@qdrant/js-client-rest", () => ({
 
 const { classifyDenseLaneFailure, denseLane, denseLaneScored, OVERSAMPLE } =
   await import("../dense.js");
+const { EmbeddingWorkerDiedError } =
+  await import("../../../../../persistence/embeddings/embedding-types.js");
 const { SECTION_COLLECTION, _resetSectionDenseStoreForTests } =
   await import("../section-dense-store.js");
 
@@ -373,6 +375,17 @@ describe("classifyDenseLaneFailure", () => {
     expect(classifyDenseLaneFailure(new Error("Qdrant timeout"))).toBe(
       "dense_query_failed",
     );
+  });
+
+  /**
+   * The typed error is the origin signal; the message fallback exists for the
+   * rerank worker and serialized errors. A typed error with an arbitrary
+   * message must classify as a worker death on the type alone.
+   */
+  test("classifies the typed error without relying on message text", () => {
+    expect(
+      classifyDenseLaneFailure(new EmbeddingWorkerDiedError("anything")),
+    ).toBe("embed_worker_died");
   });
 
   test("handles a non-Error throw without losing the classification", () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -395,3 +395,27 @@ describe("classifyDenseLaneFailure", () => {
     expect(classifyDenseLaneFailure(undefined)).toBe("dense_query_failed");
   });
 });
+
+describe("worker death through a backend fallback chain", () => {
+  /**
+   * A chain that falls back past a dead local worker rethrows the last
+   * backend's failure and attaches the worker death as its cause. The lane must
+   * still classify the fault, or worker deaths go uncounted wherever a fallback
+   * backend is configured.
+   */
+  test("classifies a worker death carried as the cause of another error", () => {
+    const chainFailure = new Error("openai embeddings: 500 Internal Error", {
+      cause: new EmbeddingWorkerDiedError(
+        "Embedding worker error: Embedding worker process exited unexpectedly",
+      ),
+    });
+
+    expect(classifyDenseLaneFailure(chainFailure)).toBe("embed_worker_died");
+  });
+
+  test("an unrelated cause chain still classifies as a query failure", () => {
+    const nested = new Error("outer", { cause: new Error("qdrant timeout") });
+
+    expect(classifyDenseLaneFailure(nested)).toBe("dense_query_failed");
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -27,6 +27,26 @@ import type { Slug } from "./types.js";
 
 const log = getLogger("memory-v3-dense-lane");
 
+/** Why the dense lane produced nothing, for the degraded-turn record. */
+export type DenseLaneFailureCause = "embed_worker_died" | "dense_query_failed";
+
+/**
+ * Distinguish a dead embed worker from any other dense-lane failure.
+ *
+ * Both degrade the turn to zero semantic recall, but they need different
+ * responses: a dead worker is a fault to investigate, while a query failure is
+ * usually a transient backend condition. Matching on the message is what the
+ * backend gives us. A worker death arrives as the string `embed()` resolves
+ * pending requests with when the child exits (`embedding-local.ts`), not as a
+ * typed error, so this is deliberately coupled to that text and tested here.
+ */
+export function classifyDenseLaneFailure(err: unknown): DenseLaneFailureCause {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("worker process exited unexpectedly")
+    ? "embed_worker_died"
+    : "dense_query_failed";
+}
+
 /**
  * Multiplier applied to `k` when fetching section points from Qdrant. Several
  * sections can belong to the same article, so we oversample the section hits to
@@ -95,7 +115,22 @@ export async function denseLaneScored(
     });
     points = result.points;
   } catch (err) {
-    log.warn({ err }, "memory v3 dense lane failed; degrading to no hits");
+    // Degrading open is right for availability, but it silently changes what
+    // the model sees, so the record has to carry enough to recognise the cause
+    // later. A dead embed worker is a fault, not an expected miss: it logs at
+    // `error` and is flagged so it can be alerted on separately from the
+    // ordinary "backend unavailable" case (JARVIS-1410).
+    const cause = classifyDenseLaneFailure(err);
+    const workerDied = cause === "embed_worker_died";
+    const fields = { err, cause, degradedTo: "no_hits" };
+    if (workerDied) {
+      log.error(
+        fields,
+        "memory v3 dense lane lost its embed worker; this turn runs with no semantic recall",
+      );
+    } else {
+      log.warn(fields, "memory v3 dense lane failed; degrading to no hits");
+    }
     return [];
   }
 

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -31,18 +31,33 @@ const log = getLogger("memory-v3-dense-lane");
 export type DenseLaneFailureCause = "embed_worker_died" | "dense_query_failed";
 
 /**
+ * Message fragments an embedding backend produces when its worker is gone.
+ *
+ * A dead worker reaches the lane in two shapes, and both must classify the
+ * same way or alerting under-counts the fault. The child exiting while a
+ * request is in flight resolves it with "worker process exited unexpectedly";
+ * a child already gone when the next request is written fails the pipe first
+ * and resolves with "worker pipe write failed". Both are the same underlying
+ * fault, distinguished only by whether the death beat the write.
+ */
+const WORKER_DEATH_MESSAGES = [
+  "worker process exited unexpectedly",
+  "worker pipe write failed",
+];
+
+/**
  * Distinguish a dead embed worker from any other dense-lane failure.
  *
- * Both degrade the turn to zero semantic recall, but they need different
+ * Both degrade the turn to zero semantic recall, but they warrant different
  * responses: a dead worker is a fault to investigate, while a query failure is
- * usually a transient backend condition. Matching on the message is what the
- * backend gives us. A worker death arrives as the string `embed()` resolves
- * pending requests with when the child exits (`embedding-local.ts`), not as a
- * typed error, so this is deliberately coupled to that text and tested here.
+ * usually a transient backend condition. The match is on message text because
+ * the backend resolves these as strings rather than typed errors
+ * (`embedding-local.ts`), so the coupling is deliberate and pinned by tests
+ * that use the exact messages the backend emits.
  */
 export function classifyDenseLaneFailure(err: unknown): DenseLaneFailureCause {
   const message = err instanceof Error ? err.message : String(err);
-  return message.includes("worker process exited unexpectedly")
+  return WORKER_DEATH_MESSAGES.some((m) => message.includes(m))
     ? "embed_worker_died"
     : "dense_query_failed";
 }

--- a/assistant/src/plugins/defaults/memory/v3/dense.ts
+++ b/assistant/src/plugins/defaults/memory/v3/dense.ts
@@ -17,6 +17,7 @@
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { isEmbeddingDimensionAvailable } from "../../../../persistence/embeddings/embedding-backend.js";
+import { isEmbeddingWorkerDeath } from "../../../../persistence/embeddings/embedding-types.js";
 import { embedWithBackend } from "../embeddings.js";
 import { getLogger } from "../logging.js";
 import {
@@ -31,33 +32,17 @@ const log = getLogger("memory-v3-dense-lane");
 export type DenseLaneFailureCause = "embed_worker_died" | "dense_query_failed";
 
 /**
- * Message fragments an embedding backend produces when its worker is gone.
- *
- * A dead worker reaches the lane in two shapes, and both must classify the
- * same way or alerting under-counts the fault. The child exiting while a
- * request is in flight resolves it with "worker process exited unexpectedly";
- * a child already gone when the next request is written fails the pipe first
- * and resolves with "worker pipe write failed". Both are the same underlying
- * fault, distinguished only by whether the death beat the write.
- */
-const WORKER_DEATH_MESSAGES = [
-  "worker process exited unexpectedly",
-  "worker pipe write failed",
-];
-
-/**
  * Distinguish a dead embed worker from any other dense-lane failure.
  *
  * Both degrade the turn to zero semantic recall, but they warrant different
  * responses: a dead worker is a fault to investigate, while a query failure is
- * usually a transient backend condition. The match is on message text because
- * the backend resolves these as strings rather than typed errors
- * (`embedding-local.ts`), so the coupling is deliberate and pinned by tests
- * that use the exact messages the backend emits.
+ * usually a transient backend condition. The knowledge of what a worker death
+ * looks like lives with the backend that produces it
+ * ({@link isEmbeddingWorkerDeath}); this maps that answer onto the lane's
+ * cause vocabulary.
  */
 export function classifyDenseLaneFailure(err: unknown): DenseLaneFailureCause {
-  const message = err instanceof Error ? err.message : String(err);
-  return WORKER_DEATH_MESSAGES.some((m) => message.includes(m))
+  return isEmbeddingWorkerDeath(err)
     ? "embed_worker_died"
     : "dense_query_failed";
 }

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -59,6 +59,22 @@ export class BackendUnavailableError extends BackendError {
 }
 
 /**
+ * An embedding worker subprocess died while an operation was in flight: the
+ * child exited with a request pending, or was already gone when the request
+ * hit the pipe. Distinct from {@link BackendUnavailableError}, which is thrown
+ * before attempting an operation; this is discovered during one. Consumers
+ * that must tell a dead worker apart from an ordinary backend failure check
+ * this type (via `isEmbeddingWorkerDeath` in
+ * `persistence/embeddings/embedding-types.ts`) rather than parsing messages.
+ */
+export class EmbeddingWorkerDiedError extends BackendError {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmbeddingWorkerDiedError";
+  }
+}
+
+/**
  * A request or token-budget quota was exceeded.
  * Thrown by the provider rate-limiter and by domain-specific clients (e.g. DoorDash).
  */


### PR DESCRIPTION
## TL;DR

When the local embedding worker subprocess dies, memory v3 silently loses semantic recall for the turn and nothing records why. This change types the worker's death as a first-class error, reports it at error level with a stable cause tag on every path that can hit it, and captures the evidence (stderr tail, exit code, signal) needed to diagnose the death itself.

Closes JARVIS-1410.

## Why it's needed

Observed on a dogfood instance, twice in one afternoon: the embed worker died mid-turn, the dense retrieval lane degraded to zero hits, and the injection gate passed open. The turn ran without semantic memory recall.

Two properties made this worse than an ordinary degradation:

- **It is invisible.** From the outside, a turn with no recall is indistinguishable from the assistant having nothing relevant to remember. This failure gets reported as "the assistant forgot", not as a dead subprocess.
- **It is undiagnosable after the fact.** Worker stderr streams at `debug` and is not retained in production, so the log held zero stderr lines, no exit code, and no signal across both deaths. There was nothing to investigate.

## What changes for a user

| | Before | After |
|---|---|---|
| A turn where the worker dies | Runs with no semantic recall, silently | Same behavior (degrade open is correct) — but the loss is recorded as a fault, not a shrug |
| "The assistant forgot something" reports | Untraceable | The log names a dead worker, with the evidence attached |
| Diagnosing why the worker died | Impossible without debug logging pre-enabled on the affected machine | Exit code, signal, and the worker's last 20 stderr lines are captured automatically |
| Operator alerting | Worker deaths blend into generic backend warnings | `error` level with `cause: "embed_worker_died"` distinguishes a fault from a transient blip |

No behavior a user can see changes: retrieval still degrades open, fallback chains are untouched, and no new failure modes are introduced.

## Design

**The fault is typed where it is known.** The embedding backend (`embedding-local.ts`) is the one component that observes the worker's death: it resolves the in-flight requests when the child exits or a pipe write fails. Both sites mark the fault, and `embed()` throws `EmbeddingWorkerDiedError` instead of encoding the fact only as message text. The class lives on the `BackendError` branch of the shared `VellumError` hierarchy (`util/errors.ts`), per `docs/error-handling.md` — the in-flight sibling of `BackendUnavailableError` — so structured errors propagate to logging and monitoring the same way as every other backend fault.

**Consumers check the type, not the prose.** `isEmbeddingWorkerDeath` (exported beside the embedding types) is the single shared answer to "did a worker die". It checks the type first and falls back to the two known message shapes, which covers the rerank worker (same phrasing, plain errors) and errors that crossed a serialization boundary.

**Every dense-lane entry path carries the same contract.** `denseLaneScored` can hit the backend twice: the dimension preflight (`resolveBackendDimension`, which probes via a real embed) and the query embed. Both classify a worker death at `error` with `cause: "embed_worker_died"`; every other failure stays a `warn`, so a legitimate dimension mismatch or a transient outage never alerts as a fault. Without the probe-side handling, a worker dying during the preflight would degrade the turn with only a generic warning — one entry path would honor the contract and the other would bypass it.

**A worker death survives the backend fallback chain.** `embedWithBackend` rethrows only the last backend's failure, so a dead local worker followed by a fallback failing for its own reason would classify as an ordinary query failure on any multi-backend setup. The chain records the first worker death and attaches it as the rethrown error's `cause`; `isEmbeddingWorkerDeath` walks that chain. Attaching rather than substituting keeps the message the caller sees unchanged — the fallback's failure is what actually blocked the embed — while the underlying fault stays detectable.

**The death is diagnosable.** The backend retains a bounded 20-line tail of worker stderr, split on newlines with partial-line carry. Draining starts at spawn, because stdout and stderr close independently and a worker that signals ready, prints its reason, and exits must already have a reader attached. Each drain owns its tail array, so output from a replaced worker's still-running drain lands where nothing reads it rather than in the next worker's report. The unexpected-exit report awaits the drain (bounded at 250 ms so a never-closing stream cannot stall teardown) and logs exit code, signal, whether termination was confirmed, and how many in-flight requests were abandoned.

## Why this is the right way

- **Origin typing over string parsing.** Before, every consumer re-derived "the worker died" by matching message fragments — which is exactly how one entry path (the dimension probe) ended up with no visibility at all: nobody had added the string match there. A typed error makes the fact available to any path by construction; new call sites cannot silently miss it.
- **It follows the repo's own conventions.** `docs/error-handling.md` prescribes the `VellumError` hierarchy over bare `Error` for structured propagation, and the throw-then-fall-back shape of `embed()` is the documented pattern for this layer (the caller's backend chain handles recovery).
- **Degrade-open is preserved deliberately.** The dense lane returns `[]` on any failure because the orchestrator runs it inside an unguarded `Promise.all` — a throw would discard the sibling needle and edge lanes. Availability behavior and observability are changed independently: only the latter.
- **Warn/error separation is load-bearing.** A dead worker is a fault to investigate; a dimension mismatch or provider hiccup is routine. Collapsing them would either page on noise or bury the fault — the split is what makes `cause: "embed_worker_died"` alertable.

## Why it's safe

- No control-flow changes: same fallbacks, same `[]` contract, same probe results, same degrade-open behavior. Only error types, log levels, and retained diagnostics differ.
- `EmbeddingWorkerDiedError` carries a message identical to the previous bare `Error`, so any message-based handling elsewhere keeps working; the type is additive.
- Model-cache corruption recovery is preserved: `initialize` classifies startup failures by matching the thrown message, so corruption signatures are captured per line as stderr streams and prepended to that message, independent of the bounded tail's eviction. One shared predicate backs both the per-line scan and the error-level check.
- The stderr tail is bounded by line count and owned per drain — it cannot grow without limit or leak one worker's output into another's report.
- The single added wait is bounded at 250 ms through the existing `didSettle` helper; exit code and signal are read synchronously off the subprocess, so no teardown path can hang.
- Verified: typecheck and lint clean; 41 lifecycle, 25 dense, 71 orchestrate, 3 probe-path, and 5 plugin-boundary tests pass. Every new behavioral test was additionally checked to **fail against the pre-change source**, so the coverage discriminates rather than passing vacuously.

## Deferred, with reasons

- **Typing the rerank worker's death the same way.** Same fix shape, but it lives in the memory plugin behind an off-by-default feature; the message fallback in `isEmbeddingWorkerDeath` covers it meanwhile.
- **Carrying the cause into the injection-gate record.** The gate currently records `reason: "dense_unavailable"`; threading `embed_worker_died` into that vocabulary would put the cause in the selection log, not just the log stream — but that vocabulary feeds an API-response surface and deserves its own reviewed change.
- **Surfacing the degradation to telemetry or the user.** Telemetry event types come from a platform-generated wire contract (per `assistant/CLAUDE.md`); the stable `cause` tag here is the in-repo hook for that follow-up.
- **Fixing the underlying death.** This change is deliberately the instrument, not the cure: the death was undiagnosable, and diagnosis is part 3 of JARVIS-1410. A resident worker measured at 1774 MB RSS is the leading suspect, recorded on JARVIS-888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

