### PR TITLE
feat(web): cap assistant-message attachments at 5 with a "+N" overflow tile

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -1,5 +1,3 @@
-import type { FC } from "react";
-
 import { Typography } from "@vellumai/design-library";
 
 interface AttachmentOverflowSquareProps {
@@ -12,10 +10,10 @@ interface AttachmentOverflowSquareProps {
  * Terminal tile of a truncated attachment strip. Stands in for the
  * attachments past the inline limit.
  */
-export const AttachmentOverflowSquare: FC<AttachmentOverflowSquareProps> = ({
+export function AttachmentOverflowSquare({
   count,
   onClick,
-}) => {
+}: AttachmentOverflowSquareProps) {
   return (
     <button
       type="button"
@@ -32,4 +30,4 @@ export const AttachmentOverflowSquare: FC<AttachmentOverflowSquareProps> = ({
       </Typography>
     </button>
   );
-};
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -5,18 +5,15 @@ import { Typography } from "@vellumai/design-library";
 interface AttachmentOverflowSquareProps {
   /** How many attachments are hidden behind this tile. */
   count: number;
-  /** Whether this tile's files panel is currently open. */
-  active?: boolean;
   onClick: () => void;
 }
 
 /**
  * Terminal tile of a truncated attachment strip. Stands in for the
- * attachments past the inline limit and opens the message's files panel.
+ * attachments past the inline limit.
  */
 export const AttachmentOverflowSquare: FC<AttachmentOverflowSquareProps> = ({
   count,
-  active = false,
   onClick,
 }) => {
   return (
@@ -25,11 +22,7 @@ export const AttachmentOverflowSquare: FC<AttachmentOverflowSquareProps> = ({
       onClick={onClick}
       aria-label={`Show all files (${count} more)`}
       title={`${count} more`}
-      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
-        active
-          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
-          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
-      }`}
+      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--border-base)] transition-colors hover:bg-[var(--surface-lift)]"
     >
       <Typography
         variant="body-small-default"

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -1,0 +1,42 @@
+import type { FC } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+interface AttachmentOverflowSquareProps {
+  /** How many attachments are hidden behind this tile. */
+  count: number;
+  /** Whether this tile's files panel is currently open. */
+  active?: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Terminal tile of a truncated attachment strip. Stands in for the
+ * attachments past the inline limit and opens the message's files panel.
+ */
+export const AttachmentOverflowSquare: FC<AttachmentOverflowSquareProps> = ({
+  count,
+  active = false,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Show all files (${count} more)`}
+      title={`${count} more`}
+      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
+        active
+          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
+      }`}
+    >
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+      >
+        +{count}
+      </Typography>
+    </button>
+  );
+};

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -1,0 +1,149 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+      siblingAttachments,
+    }: {
+      attachment: { id: string };
+      siblingAttachments?: Array<{ id: string }>;
+    }) => (
+      <div
+        data-testid="preview-modal"
+        data-attachment-id={attachment.id}
+        data-sibling-count={String((siblingAttachments ?? []).length)}
+      />
+    ),
+  }),
+);
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+function image(index: number): DisplayAttachment {
+  return {
+    id: `img-${index}`,
+    filename: `photo-${index}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: `https://example.com/photo-${index}.png`,
+  };
+}
+
+function images(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) => image(index));
+}
+
+/** The squares are divs with `role="button"`; the download and overflow
+ *  affordances are real `<button>` elements, so this selector counts only
+ *  attachment squares. */
+function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}
+
+describe("MessageAttachments", () => {
+  test("renders every square and no overflow tile at the visible limit", () => {
+    const { container, queryByRole } = render(
+      <MessageAttachments attachments={images(5)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(queryByRole("button", { name: /Show all files/ })).toBeNull();
+  });
+
+  test("renders five squares plus a +1 tile for six attachments", () => {
+    const { container, getByText, getByRole } = render(
+      <MessageAttachments attachments={images(6)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(getByText("+1")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Show all files (1 more)" }),
+    ).toBeTruthy();
+  });
+
+  test("renders five squares plus a +36 tile for forty-one attachments", () => {
+    const { container, getByText } = render(
+      <MessageAttachments attachments={images(41)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(getByText("+36")).toBeTruthy();
+  });
+
+  test("counts non-media attachments toward the limit and keeps source order", () => {
+    const mixed: DisplayAttachment[] = [
+      image(0),
+      {
+        id: "deck-1",
+        filename: "deck.pptx",
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        sizeBytes: 4_096,
+        previewUrl: null,
+      },
+      image(1),
+      {
+        id: "report-1",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 2_048,
+        previewUrl: null,
+      },
+      {
+        id: "bundle-1",
+        filename: "bundle.zip",
+        mimeType: "application/zip",
+        sizeBytes: 8_192,
+        previewUrl: null,
+      },
+      image(2),
+      image(3),
+      image(4),
+    ];
+
+    const { container, getByText } = render(
+      <MessageAttachments attachments={mixed} />,
+    );
+
+    expect(squareLabels(container)).toEqual([
+      "photo-0.png",
+      "deck.pptx",
+      "photo-1.png",
+      "report.pdf",
+      "bundle.zip",
+    ]);
+    expect(getByText("+3")).toBeTruthy();
+  });
+
+  test("opens the preview on the first hidden attachment with the full gallery", () => {
+    const { getByRole, getByTestId } = render(
+      <MessageAttachments attachments={images(8)} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("img-5");
+    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+  });
+
+  test("returns null for an empty attachments array", () => {
+    const { container } = render(<MessageAttachments attachments={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -13,8 +13,6 @@ interface MessageAttachmentsProps {
   /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
-  /** Transcript message identity, forwarded to the files panel payload. */
-  messageId?: string;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
+import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
@@ -12,7 +13,16 @@ interface MessageAttachmentsProps {
   /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
+  /** Transcript message identity, forwarded to the files panel payload. */
+  messageId?: string;
 }
+
+/**
+ * How many attachment squares render inline before the strip collapses.
+ * A message with more than this many attachments shows the first
+ * VISIBLE_LIMIT squares plus one overflow tile.
+ */
+const VISIBLE_LIMIT = 5;
 
 /**
  * Read-only strip of attachment thumbnails rendered as a separate strip for
@@ -43,10 +53,13 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
     return null;
   }
 
+  const visible = attachments.slice(0, VISIBLE_LIMIT);
+  const overflowCount = attachments.length - visible.length;
+
   return (
     <>
-      <div className="flex flex-wrap gap-2">
-        {attachments.map((att) => (
+      <div className="flex flex-wrap items-start gap-2">
+        {visible.map((att) => (
           <MessageAttachmentSquare
             key={att.id}
             filename={att.filename}
@@ -58,6 +71,12 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
             onDownload={() => handleDownload(att)}
           />
         ))}
+        {overflowCount > 0 && (
+          <AttachmentOverflowSquare
+            count={overflowCount}
+            onClick={() => openPreview(attachments[VISIBLE_LIMIT]!)}
+          />
+        )}
       </div>
       {previewModal}
     </>

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1103,6 +1103,7 @@ export function TranscriptMessageBody({
           <MessageAttachments
             attachments={message.attachments ?? []}
             assistantId={assistantId}
+            messageId={message.id}
           />
         )}
         {trailer}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1103,7 +1103,6 @@ export function TranscriptMessageBody({
           <MessageAttachments
             attachments={message.attachments ?? []}
             assistantId={assistantId}
-            messageId={message.id}
           />
         )}
         {trailer}


### PR DESCRIPTION
## Summary
- Cap the assistant-message attachment strip at 5 inline squares, with a dashed "+N" tile standing in for the rest.
- The cap is type-blind: images, videos, PDFs, PowerPoints and zips all count toward the limit.
- New `AttachmentOverflowSquare` is a custom component; the design library has no 64px dashed-square affordance, so it reuses DL `Typography` plus design tokens for the surface.

Part of plan: message-attachment-overflow.md (PR 1 of 3)