### PR TITLE
fix(persistence): keep SQLite planner statistics fresh

### DIFF
--- a/assistant/src/persistence/db-init.ts
+++ b/assistant/src/persistence/db-init.ts
@@ -6,6 +6,7 @@ import { runAsyncSqlite } from "./db-async-query.js";
 import { getDb, getSqliteFrom } from "./db-connection.js";
 import { runMigrationSteps } from "./migrations/run-migrations.js";
 import { validateMigrationState } from "./migrations/validate-migration-state.js";
+import { PLANNER_OPTIMIZE_PRAGMA } from "./planner-statistics.js";
 import { migrationSteps } from "./steps.js";
 
 /**
@@ -108,7 +109,7 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
   // mask bounds the scan.
   if (applied.length > 0) {
     try {
-      getSqliteFrom(database).exec("PRAGMA optimize=0x10012");
+      getSqliteFrom(database).exec(PLANNER_OPTIMIZE_PRAGMA);
     } catch (err) {
       log.warn({ err }, "Post-migration PRAGMA optimize failed (non-fatal)");
     }

--- a/assistant/src/persistence/db-init.ts
+++ b/assistant/src/persistence/db-init.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { getLogger } from "../util/logger.js";
 import { getDbPath } from "../util/platform.js";
 import { runAsyncSqlite } from "./db-async-query.js";
-import { getDb } from "./db-connection.js";
+import { getDb, getSqliteFrom } from "./db-connection.js";
 import { runMigrationSteps } from "./migrations/run-migrations.js";
 import { validateMigrationState } from "./migrations/validate-migration-state.js";
 import { migrationSteps } from "./steps.js";
@@ -100,6 +100,19 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
     },
     "DB migration steps complete",
   );
+
+  // A migration that adds an index leaves it with no sqlite_stat1 entry, so the
+  // planner works from built-in guesses until something analyzes it. SQLite
+  // recommends running optimize after a schema change for exactly this reason.
+  // Only boots that applied a step pay for it, and the analysis limit in the
+  // mask bounds the scan.
+  if (applied.length > 0) {
+    try {
+      getSqliteFrom(database).exec("PRAGMA optimize=0x10012");
+    } catch (err) {
+      log.warn({ err }, "Post-migration PRAGMA optimize failed (non-fatal)");
+    }
+  }
 
   if (failed.length > 0) {
     log.error(

--- a/assistant/src/persistence/db-init.ts
+++ b/assistant/src/persistence/db-init.ts
@@ -102,11 +102,10 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
     "DB migration steps complete",
   );
 
-  // A migration that adds an index leaves it with no sqlite_stat1 entry, so the
-  // planner works from built-in guesses until something analyzes it. SQLite
-  // recommends running optimize after a schema change for exactly this reason.
-  // Only boots that applied a step pay for it, and the analysis limit in the
-  // mask bounds the scan.
+  // An index a migration creates has no sqlite_stat1 entry until something
+  // analyzes it, which SQLite calls out as a case to handle after a schema
+  // change. Only boots that applied a step pay for it, and optimize analyzes
+  // just the tables that need it.
   if (applied.length > 0) {
     try {
       getSqliteFrom(database).exec(PLANNER_OPTIMIZE_PRAGMA);

--- a/assistant/src/persistence/db-maintenance.ts
+++ b/assistant/src/persistence/db-maintenance.ts
@@ -8,6 +8,7 @@ import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import { getLastInteractiveUserMessageTimestamp } from "./conversation-crud.js";
 import { runAsyncSqlite } from "./db-async-query.js";
 import { getSqlite } from "./db-connection.js";
+import { PLANNER_OPTIMIZE_PRAGMA } from "./planner-statistics.js";
 
 const log = getLogger("db-maintenance");
 
@@ -80,17 +81,12 @@ async function runDbMaintenance(): Promise<void> {
     log.warn({ err }, "Workflow run pruning failed (non-fatal)");
   }
 
-  // Refresh the query planner's statistics. The sweep runs on a fresh
-  // connection with no query history, so a bare `PRAGMA optimize` would only
-  // consider tables missing from sqlite_stat1 and leave every existing entry
-  // frozen at whatever size it was first analyzed at. The 0x10000 bit makes it
-  // examine all tables instead; 0x2 keeps the default "analyze where it helps"
-  // behavior and 0x10 bounds each ANALYZE with a temporary analysis_limit so
-  // the scan cost stays flat regardless of table size. It is routed through the
-  // async path for consistency and to keep it off the main thread when the
-  // sqlite3 CLI backend is available.
+  // Refresh the query planner's statistics — see PLANNER_OPTIMIZE_PRAGMA for
+  // what the mask buys on this connection. Routed through the async path for
+  // consistency and to keep it off the main thread when the sqlite3 CLI backend
+  // is available.
   const optimizeResult = await runAsyncSqlite(
-    "PRAGMA optimize=0x10012",
+    PLANNER_OPTIMIZE_PRAGMA,
     "db-maintenance:optimize",
   );
   if (!optimizeResult.ok) {

--- a/assistant/src/persistence/db-maintenance.ts
+++ b/assistant/src/persistence/db-maintenance.ts
@@ -81,10 +81,9 @@ async function runDbMaintenance(): Promise<void> {
     log.warn({ err }, "Workflow run pruning failed (non-fatal)");
   }
 
-  // Refresh the query planner's statistics — see PLANNER_OPTIMIZE_PRAGMA for
-  // what the mask buys on this connection. Routed through the async path for
-  // consistency and to keep it off the main thread when the sqlite3 CLI backend
-  // is available.
+  // Refresh the query planner's statistics (see PLANNER_OPTIMIZE_PRAGMA for
+  // what the mask buys here). Routed through the async path to keep it off the
+  // main thread when the sqlite3 CLI backend is available.
   const optimizeResult = await runAsyncSqlite(
     PLANNER_OPTIMIZE_PRAGMA,
     "db-maintenance:optimize",

--- a/assistant/src/persistence/db-maintenance.ts
+++ b/assistant/src/persistence/db-maintenance.ts
@@ -80,11 +80,17 @@ async function runDbMaintenance(): Promise<void> {
     log.warn({ err }, "Workflow run pruning failed (non-fatal)");
   }
 
-  // Refresh the query planner's statistics. PRAGMA optimize is cheap; it is
-  // routed through the async path for consistency and to keep it off the main
-  // thread when the sqlite3 CLI backend is available.
+  // Refresh the query planner's statistics. The sweep runs on a fresh
+  // connection with no query history, so a bare `PRAGMA optimize` would only
+  // consider tables missing from sqlite_stat1 and leave every existing entry
+  // frozen at whatever size it was first analyzed at. The 0x10000 bit makes it
+  // examine all tables instead; 0x2 keeps the default "analyze where it helps"
+  // behavior and 0x10 bounds each ANALYZE with a temporary analysis_limit so
+  // the scan cost stays flat regardless of table size. It is routed through the
+  // async path for consistency and to keep it off the main thread when the
+  // sqlite3 CLI backend is available.
   const optimizeResult = await runAsyncSqlite(
-    "PRAGMA optimize",
+    "PRAGMA optimize=0x10012",
     "db-maintenance:optimize",
   );
   if (!optimizeResult.ok) {

--- a/assistant/src/persistence/planner-statistics.ts
+++ b/assistant/src/persistence/planner-statistics.ts
@@ -1,17 +1,14 @@
 /**
- * The `PRAGMA optimize` mask both planner-statistics call sites run: the daily
- * maintenance sweep and the post-migration refresh in `db-init`.
+ * The `PRAGMA optimize` mask run by the daily maintenance sweep and by
+ * `db-init` after a boot that applied migrations.
  *
- * `0x10000` makes optimize examine every table rather than only those the
- * current connection has queried. Both call sites run on connections with no
- * meaningful query history, so without it optimize considers only tables
- * missing from `sqlite_stat1` and leaves every existing entry frozen at
- * whatever size it was first analyzed at. `0x2` keeps the default "analyze
- * where it would help" behavior, and `0x10` bounds each ANALYZE with a
- * temporary `analysis_limit` so scan cost stays flat regardless of table size.
+ * Both run on connections with no useful query history, so `0x10000` is what
+ * lets optimize look past tables missing from `sqlite_stat1` and reconsider
+ * ones whose entries have gone stale. `0x2` keeps the default "analyze where
+ * it helps" behavior and `0x10` bounds each ANALYZE with a temporary
+ * `analysis_limit`. Releases before 3.46 ignore bits they do not recognize
+ * rather than failing, so the mask is safe to send to any version.
  *
- * SQLite releases before 3.46 do not implement `0x10000`; they ignore the
- * unrecognized bits and fall back to their existing behavior rather than
- * failing, so the mask is safe to send to any version.
+ * https://sqlite.org/lang_analyze.html#recommended_usage_patterns
  */
 export const PLANNER_OPTIMIZE_PRAGMA = "PRAGMA optimize=0x10012";

--- a/assistant/src/persistence/planner-statistics.ts
+++ b/assistant/src/persistence/planner-statistics.ts
@@ -1,0 +1,17 @@
+/**
+ * The `PRAGMA optimize` mask both planner-statistics call sites run: the daily
+ * maintenance sweep and the post-migration refresh in `db-init`.
+ *
+ * `0x10000` makes optimize examine every table rather than only those the
+ * current connection has queried. Both call sites run on connections with no
+ * meaningful query history, so without it optimize considers only tables
+ * missing from `sqlite_stat1` and leaves every existing entry frozen at
+ * whatever size it was first analyzed at. `0x2` keeps the default "analyze
+ * where it would help" behavior, and `0x10` bounds each ANALYZE with a
+ * temporary `analysis_limit` so scan cost stays flat regardless of table size.
+ *
+ * SQLite releases before 3.46 do not implement `0x10000`; they ignore the
+ * unrecognized bits and fall back to their existing behavior rather than
+ * failing, so the mask is safe to send to any version.
+ */
+export const PLANNER_OPTIMIZE_PRAGMA = "PRAGMA optimize=0x10012";


### PR DESCRIPTION
ref ATL-1177

The daily maintenance sweep runs `PRAGMA optimize` on a fresh connection. Without query history, that only considers tables missing from `sqlite_stat1` — so every existing entry stays frozen at whatever size it was first analyzed at. One production instance has `messages` statistics recording 170k rows against an actual 305k, unchanged for three weeks.

`0x10000` makes optimize examine all tables rather than recently-used ones; `0x10` bounds each ANALYZE with a temporary `analysis_limit` so cost stays flat regardless of table size. The growth threshold still decides whether anything is analyzed at all, so most runs remain no-ops.

Also runs optimize after a boot that applied migrations: an index created by a migration has no statistics until something analyzes it, which SQLite calls out as a case worth handling explicitly.

Worth noting this can shift query plans on long-lived instances whose statistics have been stale for a while — that is the point, but it deserves a staging bake and a look at slow-query log volume before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)