### PR TITLE
feat(web): add the message-files overlay view to the viewer store

### DIFF
--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -4,8 +4,10 @@ import {
   isAppNotFoundError,
   useViewerStore,
   type ActivityStepsPayload,
+  type MessageFilesPayload,
   type ToolDetailPayload,
 } from "@/stores/viewer-store";
+import type { DisplayAttachment } from "@/types/attachment-types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -562,6 +564,14 @@ describe("closeActiveOverlay", () => {
     expect(getState().activeWorkflowRunId).toBeNull();
   });
 
+  it("closes the message-files overlay and restores its prior view", () => {
+    getState().openMessageFiles({ messageId: "m1", attachments: [] });
+
+    expect(getState().closeActiveOverlay()).toBe(true);
+    expect(getState().mainView).toBe("chat");
+    expect(getState().activeMessageFiles).toBeNull();
+  });
+
   it("returns false without changing a non-overlay view", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1" });
 
@@ -758,6 +768,68 @@ describe("openActivitySteps / toggleActivitySteps / closeActivitySteps", () => {
     expect(getState().viewBeforeActivitySteps).toBe("app");
     getState().closeActivitySteps();
     expect(getState().mainView).toBe("app");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message files panel
+// ---------------------------------------------------------------------------
+
+function makeAttachment(id: string): DisplayAttachment {
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1024,
+    previewUrl: null,
+  };
+}
+
+const SAMPLE_FILES: MessageFilesPayload = {
+  messageId: "m1",
+  attachments: [makeAttachment("a1"), makeAttachment("a2")],
+  assistantId: "asst-1",
+};
+
+describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
+  it("opens the panel with the payload and records the prior view", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    const state = getState();
+    expect(state.mainView).toBe("message-files");
+    expect(state.activeMessageFiles).toBe(SAMPLE_FILES);
+    expect(state.viewBeforeMessageFiles).toBe("chat");
+  });
+
+  it("close restores the prior view and clears the payload", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openMessageFiles(SAMPLE_FILES);
+    expect(getState().viewBeforeMessageFiles).toBe("app");
+    getState().closeMessageFiles();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeMessageFiles).toBeNull();
+  });
+
+  it("toggle closes the panel when targeting the SAME message", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().toggleMessageFiles({ ...SAMPLE_FILES });
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeMessageFiles).toBeNull();
+  });
+
+  it("toggle switches to a DIFFERENT message instead of closing", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().toggleMessageFiles({ ...SAMPLE_FILES, messageId: "m2" });
+    const state = getState();
+    expect(state.mainView).toBe("message-files");
+    expect(state.activeMessageFiles?.messageId).toBe("m2");
+  });
+
+  it("identity-less payloads match on the first attachment id", () => {
+    getState().openMessageFiles({ attachments: [makeAttachment("a1")] });
+    getState().toggleMessageFiles({ attachments: [makeAttachment("a1")] });
+    expect(getState().mainView).toBe("chat");
   });
 });
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -15,6 +15,7 @@
  * - `activeSubagentId` — subagent detail panel
  * - `activeToolDetail` — tool-call detail drawer payload
  * - `activeActivitySteps` — activity-steps side panel payload (a group's full timeline)
+ * - `activeMessageFiles` - message-files side panel payload (one message's attachments)
  * - `activeWorkflowRunId` — workflow detail panel
  * - `activeAcpRunId` — ACP run detail panel
  * - `activeBackgroundTaskId` — background-task detail panel
@@ -32,6 +33,7 @@ import type { SetupChannelId } from "@/types/channel-types";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
+import type { DisplayAttachment } from "@/types/attachment-types";
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
@@ -44,6 +46,7 @@ type OverlayView =
   | "subagent-detail"
   | "tool-detail"
   | "activity-steps"
+  | "message-files"
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
@@ -115,6 +118,7 @@ function resolveViewBefore(
     | "viewBeforeSubagentDetail"
     | "viewBeforeToolDetail"
     | "viewBeforeActivitySteps"
+    | "viewBeforeMessageFiles"
     | "viewBeforeWorkflowDetail"
     | "viewBeforeAcpRunDetail"
     | "viewBeforeBackgroundTaskDetail"
@@ -127,6 +131,7 @@ function resolveViewBefore(
     mv === "subagent-detail" ||
     mv === "tool-detail" ||
     mv === "activity-steps" ||
+    mv === "message-files" ||
     mv === "workflow-detail" ||
     mv === "acp-run-detail" ||
     mv === "background-task-detail" ||
@@ -150,6 +155,7 @@ export type MainView =
   | "subagent-detail"
   | "tool-detail"
   | "activity-steps"
+  | "message-files"
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
@@ -275,6 +281,34 @@ export function sameActivityStepsTarget(
   return a.toolCalls[0]?.id === b.toolCalls[0]?.id;
 }
 
+/**
+ * Payload for the message-files side panel: every attachment on one
+ * transcript message. The open panel re-derives live attachments from the
+ * transcript by `messageId`; the embedded `attachments` array is the
+ * open-time snapshot, used when the message cannot be resolved (paged out,
+ * or identity-less callers like stories).
+ */
+export interface MessageFilesPayload {
+  messageId?: string;
+  attachments: DisplayAttachment[];
+  assistantId?: string | null;
+}
+
+/**
+ * Whether two message-files payloads address the same transcript message.
+ * Keys on `messageId` when present, falling back to the first attachment id
+ * for identity-less callers.
+ */
+export function sameMessageFilesTarget(
+  a: MessageFilesPayload,
+  b: MessageFilesPayload,
+): boolean {
+  if (a.messageId != null || b.messageId != null) {
+    return a.messageId === b.messageId;
+  }
+  return a.attachments[0]?.id === b.attachments[0]?.id;
+}
+
 /** The identity fields a thinking drawer target is matched on. */
 type ThinkingTarget = Pick<
   ToolDetailPayload,
@@ -324,6 +358,8 @@ export interface ViewerState {
   viewBeforeToolDetail: Exclude<MainView, OverlayView>;
   activeActivitySteps: ActivityStepsPayload | null;
   viewBeforeActivitySteps: Exclude<MainView, OverlayView>;
+  activeMessageFiles: MessageFilesPayload | null;
+  viewBeforeMessageFiles: Exclude<MainView, OverlayView>;
   activeWorkflowRunId: string | null;
   viewBeforeWorkflowDetail: Exclude<MainView, OverlayView>;
   activeAcpRunId: string | null;
@@ -423,6 +459,16 @@ export interface ViewerActions {
   toggleActivitySteps: (payload: ActivityStepsPayload) => void;
   closeActivitySteps: () => void;
 
+  // --- Message files panel ---
+  openMessageFiles: (payload: MessageFilesPayload) => void;
+  /**
+   * Open the files panel for `payload`, or close it when the panel is already
+   * showing the SAME message. Powers the overflow tile, where clicking the
+   * already-open tile dismisses the panel.
+   */
+  toggleMessageFiles: (payload: MessageFilesPayload) => void;
+  closeMessageFiles: () => void;
+
   // --- Channel setup ---
   openChannelSetup: (payload: ChannelSetupPayload) => void;
   closeChannelSetup: () => void;
@@ -471,6 +517,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeToolDetail: "chat",
   activeActivitySteps: null,
   viewBeforeActivitySteps: "chat",
+  activeMessageFiles: null,
+  viewBeforeMessageFiles: "chat",
   activeWorkflowRunId: null,
   viewBeforeWorkflowDetail: "chat",
   activeAcpRunId: null,
@@ -741,6 +789,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       case "activity-steps":
         get().closeActivitySteps();
         return true;
+      case "message-files":
+        get().closeMessageFiles();
+        return true;
       case "workflow-detail":
         get().closeWorkflowDetail();
         return true;
@@ -856,6 +907,40 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeActivitySteps,
       activeActivitySteps: null,
+    });
+  },
+
+  // --- Message files panel ---
+
+  openMessageFiles: (payload) => {
+    set({
+      mainView: "message-files",
+      activeMessageFiles: payload,
+      viewBeforeMessageFiles: resolveViewBefore(
+        get(),
+        "viewBeforeMessageFiles",
+      ),
+    });
+  },
+
+  toggleMessageFiles: (payload) => {
+    const state = get();
+    const active = state.activeMessageFiles;
+    const isSameTarget =
+      state.mainView === "message-files" &&
+      active != null &&
+      sameMessageFilesTarget(active, payload);
+    if (isSameTarget) {
+      get().closeMessageFiles();
+    } else {
+      get().openMessageFiles(payload);
+    }
+  },
+
+  closeMessageFiles: () => {
+    set({
+      mainView: get().viewBeforeMessageFiles,
+      activeMessageFiles: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Add a `message-files` overlay view to the viewer store, mirroring the existing `activity-steps` block.
- Adds `MessageFilesPayload`, `sameMessageFilesTarget`, and open/toggle/close actions.
- Wires `closeActiveOverlay` so Escape and stacked-panel unwinding work once the panel lands.

Part of plan: message-attachment-overflow.md (PR 2 of 3)