### PR TITLE
fix(home): drop the anti-stutter heuristic and clean the derived title

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -384,39 +384,41 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.title).toBe("Payload headline");
   });
 
-  test("rejects a payload title that restates the summary in favour of the rendered title", async () => {
-    // Shape seen in real on-disk feed data: a payload title that is just the
-    // opening words of the summary.
+  test("keeps a payload title that opens the summary", async () => {
+    // A correct topic headline is usually the opening noun phrase of the body,
+    // so an authored title that overlaps the summary still wins.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
-      contextPayload: { title: "Test notifications" },
+      contextPayload: { title: "Nightly Backup Failure" },
     });
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
           title: "Reminder plumbing check",
-          body: "Test notifications reminder.",
+          body: "Nightly backup failure on db-primary at 02:14. Retry scheduled.",
         },
       },
     });
 
     const item = await writeHomeFeedItemForSignal(signal, decision);
 
-    expect(item?.title).toBe("Reminder plumbing check");
-    expect(appendCalls[0]!.summary).toBe("Test notifications reminder.");
+    expect(item?.title).toBe("Nightly Backup Failure");
+    expect(appendCalls[0]!.summary).toBe(
+      "Nightly backup failure on db-primary at 02:14. Retry scheduled.",
+    );
   });
 
-  test("derives a title from the summary when every authored candidate restates it", async () => {
+  test("keeps a payload title that matches the summary's first sentence", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
-      contextPayload: { title: "Test notifications" },
+      contextPayload: { title: "Test notifications reminder." },
     });
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
-          title: "Test notifications reminder.",
+          title: "Model headline",
           body: "Test notifications reminder. It fired on schedule.",
         },
       },
@@ -451,6 +453,51 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item?.title).toBe("Disk usage crossed 90 percent.");
     expect(appendCalls[0]!.title).toBeTruthy();
+  });
+
+  test("derives a single-line plain title from a markdown-headed conversation seed", async () => {
+    // The summary prefers `conversationSeedMessage`, which carries structured
+    // markdown and hard line breaks. The derived title must not.
+    conversationRow = { conversationType: "background" };
+    const seed =
+      "## Nightly Backup Report\n\nThe backup job on db-primary failed at 02:14.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "The backup job failed.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe(
+      "Nightly Backup Report The backup job on db-primary failed at…",
+    );
+    expect(item?.summary).toBe(seed);
+  });
+
+  test("derives a single-line plain title from a markdown-list conversation seed", async () => {
+    conversationRow = { conversationType: "background" };
+    const seed = "- Ran 12 checks\n- 3 failed\n\nSee the log for details.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "Check run finished.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Ran 12 checks 3 failed See the log for details.");
+    expect(item?.summary).toBe(seed);
   });
 
   test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -20,7 +20,7 @@ import { appendFeedItem } from "../home/feed-writer.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { getLogger } from "../util/logger.js";
-import { normalizeTitle } from "../util/short-title.js";
+import { normalizeTitle, stripMarkdown } from "../util/short-title.js";
 import { isConversationSeedSane } from "./conversation-seed-composer.js";
 import { deriveTitle } from "./copy-composer.js";
 import { readPayloadString } from "./notification-utils.js";
@@ -89,12 +89,13 @@ export async function writeHomeFeedItemForSignal(
   }
 
   // Title order: payload, then the rendered copy, then a headline derived
-  // from the summary. The derivation always yields something, so every feed
-  // item lands with a title.
+  // from the summary. `normalizeTitle` returns "" for empty, prose-shaped, and
+  // meta-failure candidates; the derivation always yields something, so every
+  // feed item lands with a title.
   const resolvedTitle =
-    acceptTitle(payloadTitle, resolvedSummary) ??
-    acceptTitle(renderedCopy?.title, resolvedSummary) ??
-    deriveTitle(resolvedSummary);
+    normalizeTitle(payloadTitle ?? "") ||
+    normalizeTitle(renderedCopy?.title ?? "") ||
+    deriveFallbackTitle(resolvedSummary);
 
   const urgency = signal.attentionHints.urgency;
   const now = new Date().toISOString();
@@ -156,31 +157,25 @@ export async function writeHomeFeedItemForSignal(
 }
 
 /**
- * Clean an authored title (producer payload or model-rendered copy) and keep
- * it only when it says something the summary does not.
+ * Derive the terminal fallback headline from the summary.
  *
- * `normalizeTitle` returns "" for empty, prose-shaped, and meta-failure
- * titles. On top of that, a title that is a case-insensitive prefix of the
- * summary, or that matches the summary's first sentence, stutters against the
- * row's own body text. Rejection returns undefined so the caller falls
- * through to the next candidate.
+ * The summary is preferentially a conversation seed, which carries structured
+ * markdown and hard line breaks, so flatten it to plain single-line text
+ * before slicing a headline off the front. A non-empty summary always yields a
+ * non-empty title.
  */
-function acceptTitle(
-  raw: string | undefined,
-  summary: string,
-): string | undefined {
-  const candidate = normalizeTitle(raw ?? "");
-  if (!candidate) {
-    return undefined;
-  }
-  const lowered = candidate.toLowerCase();
-  if (summary.toLowerCase().startsWith(lowered)) {
-    return undefined;
-  }
-  if (lowered === deriveTitle(summary).toLowerCase()) {
-    return undefined;
-  }
-  return candidate;
+function deriveFallbackTitle(summary: string): string {
+  // `stripMarkdown` covers inline syntax and headings; list bullets only read
+  // as markers while the line breaks are still there, so drop them here.
+  const plain = flattenWhitespace(
+    stripMarkdown(summary).replace(/^[ \t]*[-*+][ \t]+/gm, ""),
+  );
+  return deriveTitle(plain || flattenWhitespace(summary));
+}
+
+/** Collapse whitespace runs, including hard line breaks, into single spaces. */
+function flattenWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
 }
 
 // ── Category & detail-panel derivation ────────────────────────────────

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -165,11 +165,16 @@ export async function writeHomeFeedItemForSignal(
  * non-empty title.
  */
 function deriveFallbackTitle(summary: string): string {
-  // `stripMarkdown` covers inline syntax and headings; list bullets only read
-  // as markers while the line breaks are still there, so drop them here.
-  const plain = flattenWhitespace(
-    stripMarkdown(summary).replace(/^[ \t]*[-*+][ \t]+/gm, ""),
-  );
+  // Block markers are line-anchored, so they have to go before the whitespace
+  // collapse, and before `stripMarkdown` (whose inline-code rule would chew a
+  // fence into a stray backtick). Ordered markers matter most: the seed prompt
+  // asks the model for numbered lists, and a leading `1.` also reads as a
+  // sentence terminator, which would truncate the title to the first digit.
+  const deblocked = summary
+    .replace(/^[ \t]*```.*$/gm, "")
+    .replace(/^[ \t]*>[ \t]?/gm, "")
+    .replace(/^[ \t]*(?:[-*+]|\d+[.)])[ \t]+/gm, "");
+  const plain = flattenWhitespace(stripMarkdown(deblocked));
   return deriveTitle(plain || flattenWhitespace(summary));
 }
 


### PR DESCRIPTION
## Summary
- Removes the prefix/equality rejection from the feed title chain. Per AGENTS.md Assistant-Driven Judgement, deciding whether a headline restates a summary belongs to the model, not a string match. The guard also rejected correct topic headlines (which usually open the body) while letting echoes offset by one word through, and its equality branch was unreachable.
- Strips markdown and flattens newlines before deriving the fallback title, so a markdown-rich conversation seed can no longer persist as a multi-line title.

Fixes gaps found during plan self-review for home-feed-required-titles.md