### PR TITLE
fix(util): enforce the short-title budget and correct stale documentation

### DIFF
--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -86,7 +86,7 @@ Examples:
         {
           flags: "--title <title>",
           description:
-            "Short headline. Keep it to 5 words and 40 characters; anything longer is trimmed to fit. A title that reads like prose (a reasoning opener, or a full sentence ending in terminal punctuation) is discarded in favor of a headline derived from --message.",
+            "Short headline. Titles over 40 characters are trimmed to fit, and one over 40 characters that also runs past 7 words is cut to its first 5. A title that reads like prose (a reasoning opener, or a full sentence ending in terminal punctuation) is discarded in favor of a headline derived from --message.",
         },
         {
           flags: "--urgency <urgency>",

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -86,7 +86,7 @@ Examples:
         {
           flags: "--title <title>",
           description:
-            "Short headline (≤ 8 words). Always provide one — the auto-derived fallback just truncates --message.",
+            "Short headline. Keep it to 5 words and 40 characters; anything longer is trimmed to fit. A title that reads like prose (a reasoning opener, or a full sentence ending in terminal punctuation) is discarded in favor of a headline derived from --message.",
         },
         {
           flags: "--urgency <urgency>",

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -53,8 +53,6 @@ export interface HomeFeedFile {
   version: 2;
   items: z.infer<typeof FeedItemSchema>[];
   updatedAt: string;
-  /** In-memory only; never persisted. Set by `parseFeedFile`. */
-  droppedCount?: number;
 }
 
 /**
@@ -74,7 +72,8 @@ const homeFeedEnvelopeSchema = z.object({
  * feed. Throws a `ZodError` when the envelope itself is invalid (wrong
  * `version`, non-object input, missing `updatedAt`). Callers are
  * expected to log + recover (e.g. treat the file as empty). Individual
- * items that fail validation are dropped and counted in `droppedCount`
+ * items that fail validation are dropped and counted in `droppedCount`,
+ * an in-memory-only field on the return value that is never persisted,
  * so one malformed row cannot erase the rest of the feed.
  */
 export function parseFeedFile(

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -422,9 +422,11 @@ const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
  * falling back to one derived from the body when `normalizeTitle` returns its
  * empty-string rejection signal.
  *
- * `normalizeTitle` is the last clamp a title passes through, so its 40-char
- * budget is the effective one. `NOTIFICATION_TITLE_MAX_LENGTH` (60) still bounds
- * `deriveTitle` and the control-character stripping in `notification-utils.ts`.
+ * The two branches carry different budgets. An accepted authored title is
+ * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
+ * `deriveTitle`, which never sees the normalizer and applies the composer's own
+ * `NOTIFICATION_TITLE_MAX_LENGTH` (60) cap plus a trailing ellipsis, so a
+ * derived title can reach 61 characters.
  */
 function resolveTitle(raw: string | undefined, body: string): string {
   return normalizeTitle(raw ?? "") || deriveTitle(body);

--- a/assistant/src/notifications/notification-utils.ts
+++ b/assistant/src/notifications/notification-utils.ts
@@ -91,8 +91,14 @@ export function sanitizeMessagePreview(value: string): string {
 export const NOTIFICATION_TITLE_MAX_LENGTH = 60;
 
 /**
- * Sanitize an untrusted notification title for inclusion in notification copy.
- * Strips control characters and clamps to `NOTIFICATION_TITLE_MAX_LENGTH`.
+ * Flatten an untrusted notification title onto a single line, stripping control
+ * characters and newlines and bounding it at `NOTIFICATION_TITLE_MAX_LENGTH`.
+ *
+ * The newline flattening is the load-bearing part: downstream consumers re-run
+ * the value through `normalizeTitle`, whose prose guard discards any string
+ * containing a newline outright, so a multi-line conversation title would be
+ * thrown away wholesale instead of salvaged. The length bound is a backstop;
+ * `normalizeTitle`'s tighter 40-character budget is what callers observe.
  */
 export function sanitizeNotificationTitle(value: string): string {
   return sanitize(value, NOTIFICATION_TITLE_MAX_LENGTH);

--- a/assistant/src/util/__tests__/short-title.test.ts
+++ b/assistant/src/util/__tests__/short-title.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  LEAKED_PROSE_PREFIXES,
-  looksLikeLeakedProse,
-  MAX_TITLE_LENGTH,
-  MAX_TITLE_WORDS,
-  META_FAILURE_TITLES,
   normalizeTitle,
   stripMarkdown,
   stripThinkingTags,
   truncateTitle,
 } from "../short-title.js";
+
+/** The character and word budgets `short-title.ts` documents and enforces. */
+const MAX_TITLE_LENGTH = 40;
+const MAX_TITLE_WORDS = 7;
 
 describe("stripMarkdown", () => {
   test("unwraps bold, italic, strikethrough, and code spans", () => {
@@ -91,74 +90,80 @@ describe("truncateTitle", () => {
     expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
     expect(truncateTitle(title)).toBe("alpha bravo charlie delta echo");
   });
+
+  test("still honors the char limit when the first five words overflow it", () => {
+    const title =
+      "Authentication Infrastructure Modernization Deployment Verification Report Complete Today";
+    expect(title.length).toBeGreaterThan(MAX_TITLE_LENGTH);
+    expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
+    const result = truncateTitle(title);
+    expect(result).toBe("Authentication Infrastructure");
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+  });
 });
 
-describe("looksLikeLeakedProse", () => {
+describe("normalizeTitle prose rejection", () => {
   test("rejects multi-line output", () => {
-    expect(looksLikeLeakedProse("Auth Rewrite\nand more")).toBe(true);
+    expect(normalizeTitle("Auth Rewrite\nand more")).toBe("");
   });
 
   test("rejects embedded transcript markers", () => {
-    expect(looksLikeLeakedProse("User: how do I log in")).toBe(true);
-    expect(looksLikeLeakedProse("Assistant : here you go")).toBe(true);
+    expect(normalizeTitle("User: how do I log in")).toBe("");
+    expect(normalizeTitle("Assistant : here you go")).toBe("");
   });
 
   test("rejects sentence-shaped clauses ending in terminal punctuation", () => {
-    expect(looksLikeLeakedProse("This is a topic about authentication.")).toBe(
-      true,
-    );
-    expect(looksLikeLeakedProse("What did they want to build here?")).toBe(
-      true,
-    );
+    expect(normalizeTitle("This is a topic about authentication.")).toBe("");
+    expect(normalizeTitle("What did they want to build here?")).toBe("");
   });
 
   test("keeps short phrases that end in punctuation", () => {
-    expect(looksLikeLeakedProse("Auth Rewrite?")).toBe(false);
+    expect(normalizeTitle("Auth Rewrite?")).toBe("Auth Rewrite?");
   });
 
   test("rejects first-person reasoning openers", () => {
-    expect(looksLikeLeakedProse("I need to generate a title")).toBe(true);
-    expect(looksLikeLeakedProse("I'll work through these files")).toBe(true);
-    expect(looksLikeLeakedProse("I cannot title this")).toBe(true);
+    expect(normalizeTitle("I need to generate a title")).toBe("");
+    expect(normalizeTitle("I'll work through these files")).toBe("");
+    expect(normalizeTitle("I cannot title this")).toBe("");
   });
 
   test("rejects imperative and deferral openers", () => {
-    expect(looksLikeLeakedProse("Let me summarize the request")).toBe(true);
-    expect(looksLikeLeakedProse("Looking at the conversation")).toBe(true);
-    expect(looksLikeLeakedProse("Based on the messages")).toBe(true);
-    expect(looksLikeLeakedProse("Given the context")).toBe(true);
+    expect(normalizeTitle("Let me summarize the request")).toBe("");
+    expect(normalizeTitle("Looking at the conversation")).toBe("");
+    expect(normalizeTitle("Based on the messages")).toBe("");
+    expect(normalizeTitle("Given the context")).toBe("");
   });
 
   test("rejects infinitive openers", () => {
-    expect(looksLikeLeakedProse("To generate a good title")).toBe(true);
-    expect(looksLikeLeakedProse("To summarize the discussion")).toBe(true);
-    expect(looksLikeLeakedProse("To title this thread")).toBe(true);
+    expect(normalizeTitle("To generate a good title")).toBe("");
+    expect(normalizeTitle("To summarize the discussion")).toBe("");
+    expect(normalizeTitle("To title this thread")).toBe("");
   });
 
   test("rejects subject-led reasoning openers", () => {
-    expect(looksLikeLeakedProse("The user wants a summary")).toBe(true);
-    expect(looksLikeLeakedProse("The conversation is about Docker")).toBe(true);
-    expect(looksLikeLeakedProse("The assistant should reply")).toBe(true);
-    expect(looksLikeLeakedProse("The title should be short")).toBe(true);
+    expect(normalizeTitle("The user wants a summary")).toBe("");
+    expect(normalizeTitle("The conversation is about Docker")).toBe("");
+    expect(normalizeTitle("The assistant should reply")).toBe("");
+    expect(normalizeTitle("The title should be short")).toBe("");
   });
 
   test("rejects preamble openers", () => {
-    expect(looksLikeLeakedProse("Here's a title")).toBe(true);
-    expect(looksLikeLeakedProse("Here is a title")).toBe(true);
-    expect(looksLikeLeakedProse("Sure, Auth Rewrite")).toBe(true);
-    expect(looksLikeLeakedProse("Okay, Auth Rewrite")).toBe(true);
+    expect(normalizeTitle("Here's a title")).toBe("");
+    expect(normalizeTitle("Here is a title")).toBe("");
+    expect(normalizeTitle("Here are the options")).toBe("");
+    expect(normalizeTitle("Sure, Auth Rewrite")).toBe("");
+    expect(normalizeTitle("Okay, Auth Rewrite")).toBe("");
+    expect(normalizeTitle("Ok, Auth Rewrite")).toBe("");
   });
 
   test("accepts bare noun-phrase titles that share a subject word", () => {
-    expect(looksLikeLeakedProse("The Conversation API")).toBe(false);
-    expect(looksLikeLeakedProse("The User Interface Redesign")).toBe(false);
-    expect(looksLikeLeakedProse("Auth Middleware Rewrite")).toBe(false);
-  });
-
-  test("every configured prefix is treated as prose", () => {
-    for (const prefix of LEAKED_PROSE_PREFIXES) {
-      expect(looksLikeLeakedProse(`${prefix} something`)).toBe(true);
-    }
+    expect(normalizeTitle("The Conversation API")).toBe("The Conversation API");
+    expect(normalizeTitle("The User Interface Redesign")).toBe(
+      "The User Interface Redesign",
+    );
+    expect(normalizeTitle("Auth Middleware Rewrite")).toBe(
+      "Auth Middleware Rewrite",
+    );
   });
 });
 
@@ -187,7 +192,21 @@ describe("normalizeTitle", () => {
   });
 
   test("returns empty for meta-failure titles regardless of case", () => {
-    for (const meta of META_FAILURE_TITLES) {
+    const metaFailures = [
+      "missing context",
+      "no context",
+      "insufficient context",
+      "unclear context",
+      "empty context",
+      "no topic",
+      "unclear topic",
+      "unclear request",
+      "unclear message",
+      "empty conversation",
+      "empty message",
+      "no content",
+    ];
+    for (const meta of metaFailures) {
       expect(normalizeTitle(meta)).toBe("");
     }
     expect(normalizeTitle("Missing Context")).toBe("");
@@ -198,5 +217,13 @@ describe("normalizeTitle", () => {
     expect(
       normalizeTitle("alpha bravo charlie delta echo foxtrot golf hotel india"),
     ).toBe("alpha bravo charlie delta echo");
+  });
+
+  test("keeps a wordy title inside the character budget", () => {
+    const result = normalizeTitle(
+      "Authentication Infrastructure Modernization Deployment Verification Report Complete Today",
+    );
+    expect(result).toBe("Authentication Infrastructure");
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
   });
 });

--- a/assistant/src/util/short-title.ts
+++ b/assistant/src/util/short-title.ts
@@ -4,10 +4,13 @@
  * meta-failure rejection, and length truncation.
  */
 
-export const MAX_TITLE_LENGTH = 40;
-export const MAX_TITLE_WORDS = 7;
+const MAX_TITLE_LENGTH = 40;
+const MAX_TITLE_WORDS = 7;
 
-export const META_FAILURE_TITLES = new Set([
+/** Word count a title exceeding `MAX_TITLE_WORDS` is cut back to. */
+const TRIMMED_TITLE_WORDS = 5;
+
+const META_FAILURE_TITLES = new Set([
   "missing context",
   "no context",
   "insufficient context",
@@ -23,7 +26,7 @@ export const META_FAILURE_TITLES = new Set([
 ]);
 
 /** Reasoning/sentence openers that never start a legitimate topic title. */
-export const LEAKED_PROSE_PREFIXES = [
+const LEAKED_PROSE_PREFIXES = [
   "i need to",
   "i needed to",
   "i should",
@@ -108,25 +111,31 @@ export function stripThinkingTags(text: string): string {
     .replace(/<:[^>]*>/gi, "");
 }
 
+/**
+ * Clamp a title to `MAX_TITLE_LENGTH` characters and `MAX_TITLE_WORDS` words.
+ * Both budgets apply: a wordy title is cut back to `TRIMMED_TITLE_WORDS` words
+ * and the survivors are still trimmed at a word boundary to fit the character
+ * budget, so the returned string is never longer than `MAX_TITLE_LENGTH`.
+ */
 export function truncateTitle(title: string): string {
   if (title.length <= MAX_TITLE_LENGTH) {
     return title;
   }
   const words = title.split(/\s+/);
-  if (words.length <= MAX_TITLE_WORDS) {
-    // Long words but few of them: truncate to char limit at word boundary
-    let result = "";
-    for (const word of words) {
-      const candidate = result ? result + " " + word : word;
-      if (candidate.length > MAX_TITLE_LENGTH) {
-        break;
-      }
-      result = candidate;
+  const kept =
+    words.length > MAX_TITLE_WORDS
+      ? words.slice(0, TRIMMED_TITLE_WORDS)
+      : words;
+  let result = "";
+  for (const word of kept) {
+    const candidate = result ? result + " " + word : word;
+    if (candidate.length > MAX_TITLE_LENGTH) {
+      break;
     }
-    return result || title.slice(0, MAX_TITLE_LENGTH);
+    result = candidate;
   }
-  // Too many words: trim to 5 words
-  return words.slice(0, 5).join(" ");
+  // Empty when even the first word overflows: hard-slice rather than return "".
+  return result || title.slice(0, MAX_TITLE_LENGTH);
 }
 
 /**
@@ -137,7 +146,7 @@ export function truncateTitle(title: string): string {
  * clauses. Deliberately tight: a false reject only costs a deterministic
  * fallback title, while a false accept persists a broken one.
  */
-export function looksLikeLeakedProse(title: string): boolean {
+function looksLikeLeakedProse(title: string): boolean {
   if (/\n/.test(title)) {
     return true;
   }


### PR DESCRIPTION
## Summary
- truncateTitle's word-limit branch now respects the 40-char ceiling it documents (it could return 67 chars)
- Corrects a false claim that the normalizer is the last clamp every title passes through
- sanitizeNotificationTitle's docstring now records its load-bearing behaviour, newline flattening, rather than an unobservable length clamp
- Removes a dead optional field from the HomeFeedFile interface and un-exports helpers with no external consumer
- Corrects the notifications send --title help, which described pre-normalization behaviour

Fixes gaps found during plan self-review for home-feed-required-titles.md