### PR TITLE
fix(notifications): validate fallback-composer titles and correct migration 138

### DIFF
--- a/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
@@ -9,9 +9,12 @@
  *   1. Missing file, malformed JSON, and a non-object root are no-ops.
  *   2. Title-less items gain a first-sentence title from the summary.
  *   3. Items that already have a title are untouched.
- *   4. A long summary truncates to 40 characters with an ellipsis.
- *   5. `version`, `updatedAt`, and unrelated item fields are preserved.
- *   6. A second run writes nothing.
+ *   4. A long summary truncates to 60 characters with an ellipsis, the
+ *      same cap the notification pipeline's derivation applies.
+ *   5. Markdown-rich and multi-line summaries yield a single line of
+ *      plain text.
+ *   6. `version`, `updatedAt`, and unrelated item fields are preserved.
+ *   7. A second run writes nothing.
  */
 
 import {
@@ -169,7 +172,7 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
     expect(items[1]!.title).toBe("Needs a headline.");
   });
 
-  test("truncates a long summary to 40 characters with an ellipsis", () => {
+  test("truncates a long summary to 60 characters with an ellipsis", () => {
     const summary =
       "Bob shared a very long document that keeps going well past the limit";
     writeFeed([makeItem({ id: "long", summary })]);
@@ -177,9 +180,11 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
     backfillHomeFeedTitlesMigration.run(workspaceDir);
 
     const title = readFeedFile().items[0]!.title as string;
-    expect(title).toBe("Bob shared a very long document that kee…");
-    // The ellipsis sits past the cap, so the retained text is exactly 40.
-    expect(title.slice(0, -1).length).toBe(40);
+    expect(title).toBe(
+      "Bob shared a very long document that keeps going well past t…",
+    );
+    // The ellipsis sits past the cap, so the retained text is exactly 60.
+    expect(title.slice(0, -1).length).toBe(60);
   });
 
   test("truncates a long first sentence rather than the whole summary", () => {
@@ -187,14 +192,64 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
       makeItem({
         id: "long-sentence",
         summary:
-          "This opening sentence runs well beyond the forty character cap. Then another.",
+          "This opening sentence runs well beyond the sixty character cap on derived titles. Then another.",
       }),
     ]);
 
     backfillHomeFeedTitlesMigration.run(workspaceDir);
 
     const title = readFeedFile().items[0]!.title as string;
-    expect(title).toBe("This opening sentence runs well beyond t…");
+    expect(title).toBe(
+      "This opening sentence runs well beyond the sixty character c…",
+    );
+  });
+
+  test("flattens a markdown-rich multi-line summary into one plain line", () => {
+    writeFeed([
+      makeItem({
+        id: "markdown",
+        summary:
+          "## Nightly run\n\n- **Deploy** finished\n- Tests passed\n\nSee the `report` for details.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe(
+      "Nightly run Deploy finished Tests passed See the report for…",
+    );
+  });
+
+  test("unwraps inline markdown before taking the first sentence", () => {
+    writeFeed([
+      makeItem({
+        id: "inline",
+        summary:
+          "**Alice** shared the [design doc](https://example.com/doc). Review it soon.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe("Alice shared the design doc.");
+  });
+
+  test("collapses a newline-only summary run into single spaces", () => {
+    writeFeed([
+      makeItem({ id: "newlines", summary: "Backup complete\n\nNo errors" }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe("Backup complete No errors");
+  });
+
+  test("skips an item whose summary is markdown structure only", () => {
+    writeFeed([makeItem({ id: "structure-only", summary: "##\n\n- \n\n> " })]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBeUndefined();
   });
 
   test("preserves version, updatedAt, and unrelated item fields", () => {

--- a/assistant/src/notifications/__tests__/copy-composer.test.ts
+++ b/assistant/src/notifications/__tests__/copy-composer.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for the notification copy-composer — specifically the fallback
- * path that composeFallbackCopy uses when the LLM is unavailable, and
- * the shared deriveTitle utility.
+ * Tests for the notification copy-composer: the fallback path that
+ * composeFallbackCopy uses when the LLM is unavailable, the normalization
+ * it applies to producer-supplied titles, and the shared deriveTitle
+ * utility.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -188,6 +189,55 @@ describe("composeFallbackCopy honors requestedMessage / requestedTitle", () => {
 
     expect(copy.vellum?.body).toBe("User-supplied content");
     expect(copy.vellum?.title).toBe("User Title");
+  });
+
+  test("strips markdown and quotes from a producer-supplied title", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "The deploy finished cleanly.",
+        requestedTitle: '"**Deploy** finished"',
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Deploy finished");
+  });
+
+  test("derives the title when requestedTitle reads as leaked prose", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "Backup finished. Nothing needs your attention.",
+        requestedTitle: "I need to generate a title for this notification",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Backup finished.");
+  });
+
+  test("derives the title when requestedTitle spans multiple lines", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "The nightly job is done.",
+        requestedTitle: "Nightly job\nsecond line",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("The nightly job is done.");
+  });
+
+  test("truncates an over-long requestedTitle to the shared title budget", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "Body text",
+        requestedTitle:
+          "Alpha bravo charlie delta echo foxtrot golf hotel india juliett",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Alpha bravo charlie delta echo");
   });
 
   test("works with non-assistant_tool source channels", () => {

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -480,6 +480,29 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(item?.summary).toBe(seed);
   });
 
+  test("strips tilde fences and indented headings, matching migration 138", async () => {
+    // Workspace migration 138 backfills titles with its own self-contained copy
+    // of these rules. A backfilled title and a freshly written one must match
+    // for the same summary, so both accept CommonMark's 3-space indent and both
+    // fence styles.
+    conversationRow = { conversationType: "background" };
+    const seed = "   ## Indented heading\n\n~~~\ntilde fence\n~~~\nBody text.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "Body text.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Indented heading tilde fence Body text.");
+  });
+
   test("derives a single-line plain title from a markdown-list conversation seed", async () => {
     conversationRow = { conversationType: "background" };
     const seed = "- Ran 12 checks\n- 3 failed\n\nSee the log for details.";

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -9,6 +9,7 @@
  * values from the context payload.
  */
 
+import { normalizeTitle } from "../util/short-title.js";
 import {
   accessRequestCardTitle,
   buildAccessRequestContractText,
@@ -58,6 +59,18 @@ export function deriveTitle(body: string): string {
   return candidate.length > NOTIFICATION_TITLE_MAX_LENGTH
     ? candidate.slice(0, NOTIFICATION_TITLE_MAX_LENGTH).trim() + "\u2026"
     : candidate.trim();
+}
+
+/**
+ * Clean a producer-authored title, falling back to one derived from the body
+ * when `normalizeTitle` returns its empty-string rejection signal.
+ *
+ * The decision engine's pass-through path applies the same clamp, so a signal
+ * carrying `requestedTitle` renders the same headline whether or not the LLM
+ * classifier was reachable.
+ */
+function resolveTitle(raw: string | undefined, body: string): string {
+  return normalizeTitle(raw ?? "") || deriveTitle(body);
 }
 
 /**
@@ -291,9 +304,10 @@ export function composeFallbackCopy(
     readPayloadString(signal.contextPayload, "requestedMessage"),
   );
   if (msg) {
-    const title =
-      nonEmpty(readPayloadString(signal.contextPayload, "requestedTitle")) ??
-      deriveTitle(msg);
+    const title = resolveTitle(
+      readPayloadString(signal.contextPayload, "requestedTitle"),
+      msg,
+    );
     const baseCopy: RenderedChannelCopy = {
       title,
       body: msg,

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -68,8 +68,14 @@ export function deriveTitle(body: string): string {
  * The decision engine's pass-through path applies the same clamp, so a signal
  * carrying `requestedTitle` renders the same headline whether or not the LLM
  * classifier was reachable.
+ *
+ * The two branches carry different budgets. An accepted authored title is
+ * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
+ * `deriveTitle`, which never sees the normalizer and applies
+ * `NOTIFICATION_TITLE_MAX_LENGTH` (60) plus a trailing ellipsis, so a derived
+ * title can reach 61 characters.
  */
-function resolveTitle(raw: string | undefined, body: string): string {
+export function resolveTitle(raw: string | undefined, body: string): string {
   return normalizeTitle(raw ?? "") || deriveTitle(body);
 }
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -26,7 +26,6 @@ import {
 } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
-import { normalizeTitle } from "../util/short-title.js";
 import { truncate } from "../util/truncate.js";
 import {
   buildAccessRequestContractText,
@@ -45,7 +44,7 @@ import {
   type ConversationCandidateSet,
   serializeCandidatesForPrompt,
 } from "./conversation-candidates.js";
-import { composeFallbackCopy, deriveTitle } from "./copy-composer.js";
+import { composeFallbackCopy, resolveTitle } from "./copy-composer.js";
 import { createDecision } from "./decisions-store.js";
 import {
   buildGuardianRequestCodeInstruction,
@@ -416,21 +415,6 @@ function buildFallbackDecision(
 // ── Validation ─────────────────────────────────────────────────────────
 
 const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
-
-/**
- * Clean a title authored elsewhere (the decision model, or a producer payload),
- * falling back to one derived from the body when `normalizeTitle` returns its
- * empty-string rejection signal.
- *
- * The two branches carry different budgets. An accepted authored title is
- * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
- * `deriveTitle`, which never sees the normalizer and applies the composer's own
- * `NOTIFICATION_TITLE_MAX_LENGTH` (60) cap plus a trailing ellipsis, so a
- * derived title can reach 61 characters.
- */
-function resolveTitle(raw: string | undefined, body: string): string {
-  return normalizeTitle(raw ?? "") || deriveTitle(body);
-}
 
 function validateDecisionOutput(
   input: Record<string, unknown>,

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -170,10 +170,14 @@ function deriveFallbackTitle(summary: string): string {
   // fence into a stray backtick). Ordered markers matter most: the seed prompt
   // asks the model for numbered lists, and a leading `1.` also reads as a
   // sentence terminator, which would truncate the title to the first digit.
+  // The leading-space allowance and rule set mirror `flattenToPlainText` in
+  // workspace migration 138, which must stay self-contained and so cannot share
+  // this code. A backfilled title and a freshly written one have to match.
   const deblocked = summary
-    .replace(/^[ \t]*```.*$/gm, "")
-    .replace(/^[ \t]*>[ \t]?/gm, "")
-    .replace(/^[ \t]*(?:[-*+]|\d+[.)])[ \t]+/gm, "");
+    .replace(/^\s{0,3}(?:```|~~~).*$/gm, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm, "");
   const plain = flattenWhitespace(stripMarkdown(deblocked));
   return deriveTitle(plain || flattenWhitespace(summary));
 }

--- a/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
+++ b/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
@@ -2,15 +2,16 @@
  * Workspace migration `138-backfill-home-feed-titles`.
  *
  * Gives every item in `<workspace>/data/home-feed.json` a non-empty
- * `title`. The wire schema requires the field, and an item on disk that
- * lacks it is dropped when the feed is read, so the title is derived
- * from the item's own `summary` instead.
+ * `title`. The feed writer sets one on every item it appends; stored
+ * items that lack the field get a headline derived from their own
+ * `summary`, so the field is uniformly present across the file.
  *
  * Behaviour:
  *   - Missing file, unparseable JSON, or a non-object root: no-op.
  *   - Item that already has a non-empty `title`: untouched.
- *   - Item without one: title derived from `summary` (first sentence,
- *     capped at 40 characters with an ellipsis).
+ *   - Item without one: title derived from `summary` (markdown and
+ *     newlines flattened, first sentence, capped at 60 characters with
+ *     an ellipsis).
  *   - `version`, `updatedAt`, and every other item field are preserved.
  *
  * Idempotent: a second run finds every item titled, so it writes
@@ -27,7 +28,14 @@ import type { WorkspaceMigration } from "./types.js";
 const log = getLogger("workspace-migration-138-backfill-home-feed-titles");
 
 const HOME_FEED_RELATIVE_PATH = join("data", "home-feed.json");
-const MAX_TITLE_LENGTH = 40;
+
+/**
+ * Matches `NOTIFICATION_TITLE_MAX_LENGTH` in
+ * `notifications/notification-utils.ts`, the cap on the headline the feed
+ * writer derives from a summary, so a backfilled item and a freshly
+ * written one with the same summary carry the same title.
+ */
+const MAX_TITLE_LENGTH = 60;
 
 /**
  * The persisted item fields this migration touches. Inlined rather than
@@ -125,18 +133,45 @@ export const backfillHomeFeedTitlesMigration: WorkspaceMigration = {
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a short headline from a summary: the first sentence when the
- * text has a terminator, capped at `MAX_TITLE_LENGTH` characters with an
- * ellipsis. Mirrors the notification copy composer's derivation, inlined
- * rather than imported so the migration stays self-contained.
+ * Derive a short headline from a summary: the markdown is flattened to a
+ * single line of plain text, the first sentence is taken when the text
+ * has a terminator, and the result is capped at `MAX_TITLE_LENGTH`
+ * characters with an ellipsis. Returns "" when nothing usable survives.
+ *
+ * Inlined rather than imported from the notification pipeline so the
+ * migration stays self-contained per the migrations AGENTS.md.
  */
 function deriveTitle(summary: string): string {
-  const firstSentenceEnd = summary.search(/[.!?](\s|$)/);
+  const text = flattenToPlainText(summary);
+  const firstSentenceEnd = text.search(/[.!?](\s|$)/);
   const candidate =
-    firstSentenceEnd > 0 ? summary.slice(0, firstSentenceEnd + 1) : summary;
+    firstSentenceEnd > 0 ? text.slice(0, firstSentenceEnd + 1) : text;
   return candidate.length > MAX_TITLE_LENGTH
     ? candidate.slice(0, MAX_TITLE_LENGTH).trim() + "…"
     : candidate.trim();
+}
+
+/**
+ * Reduce markdown-rich summary text to a single line of plain prose:
+ * block structure (code fences, headings, blockquotes, list markers) is
+ * dropped, inline formatting is unwrapped, and every run of whitespace,
+ * newlines included, collapses to one space.
+ */
+function flattenToPlainText(text: string): string {
+  return text
+    .replace(/^\s{0,3}(?:```|~~~).*$/gm, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1")
+    .replace(/~~(.+?)~~/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\[(.+?)\]\(.*?\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- composeFallbackCopy now normalizes producer titles, so channel copy no longer depends on classifier availability and unvalidated titles stop reaching notification_deliveries.rendered_title
- Migration 138's docblock no longer claims a schema constraint that does not exist on this branch
- The migration's length cap and derivation now genuinely mirror the runtime path, including markdown and newline handling

Fixes gaps found during plan self-review for home-feed-required-titles.md