### PR TITLE
fix(gateway): wake on Slack replies under the assistant's own top-level posts (LUM-2941)

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -74,7 +74,8 @@ function createSlackStore(): { rawDb: Database; store: SlackStore } {
       channel_id TEXT,
       tracked_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL,
-      detached_at INTEGER
+      detached_at INTEGER,
+      speculative_root_at INTEGER
     );
     CREATE TABLE slack_seen_events (
       event_id TEXT PRIMARY KEY,
@@ -698,6 +699,99 @@ describe("replayMissedEvents", () => {
       const raw = emitted[0].event.raw as { type?: string };
       expect(raw.type).toBe("app_mention");
       expect(emitted[0].threadTs).toBe(parentTs);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not fan out over a speculative root until a human replies (LUM-2941)", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    // The assistant posts top-level into an unrouted channel (a heartbeat
+    // turn). The echo arms the post's ts as a speculative thread root.
+    const rootTs = "1700000020.000000";
+    const post = (eventId: string) =>
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: `env-${eventId}`,
+          type: "events_api",
+          payload: {
+            event_id: eventId,
+            event: {
+              type: "message",
+              user: "UBOT",
+              text: "three PRs are waiting on review",
+              ts: rootTs,
+              channel: "CUNROUTED1",
+              channel_type: "channel",
+            },
+          },
+        }),
+        ws,
+      );
+
+    post("Ev-bot-top-level");
+    await flushAsyncEventEmission();
+    expect(emitted).toHaveLength(0);
+    expect(store.hasThread(rootTs)).toBe(true);
+
+    const calls: string[] = [];
+    fetchMock = mock(async (input) => {
+      calls.push(String(input));
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+
+      // The assistant posts continuously; one tier-3 conversations.replies
+      // call per never-engaged root on every reconnect would burn the rate
+      // limit that recovery of genuinely missed messages depends on.
+      expect(calls.some((u) => u.includes("conversations.replies"))).toBe(
+        false,
+      );
+
+      // A human replies live, which promotes the root to a tracked thread.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-human-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-human-reply",
+            event: {
+              type: "message",
+              user: "U-human",
+              text: "which one is blocking the release?",
+              ts: "1700000040.000000",
+              channel: "CUNROUTED1",
+              channel_type: "channel",
+              thread_ts: rootTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+
+      calls.length = 0;
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+
+      expect(
+        calls.some(
+          (u) =>
+            u.includes("conversations.replies") &&
+            u.includes(encodeURIComponent(rootTs)),
+        ),
+      ).toBe(true);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
@@ -134,7 +134,8 @@ function createSlackStore(): { rawDb: Database; store: SlackStore } {
       channel_id TEXT,
       tracked_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL,
-      detached_at INTEGER
+      detached_at INTEGER,
+      speculative_root_at INTEGER
     );
     CREATE TABLE slack_seen_events (
       event_id TEXT PRIMARY KEY,

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -410,6 +410,32 @@ describe("LUM-2941: arming the assistant's own top-level posts", () => {
     }
   });
 
+  test("arms a root without spending any Slack API call", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+    const calls: string[] = [];
+
+    try {
+      fetchMock = mock(async (input) => {
+        calls.push(String(input));
+        return makeSlackUserResponse();
+      });
+
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(true);
+      // The direct-like guard reads the payload's own `channel_type`. Routing
+      // it through the observed-kind cache instead would fire a background
+      // `conversations.info` per channel per cache TTL, on a path whose whole
+      // point is not to spend Slack's rate limit.
+      expect(calls).toEqual([]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("does not arm a root for a bot-authored system subtype", async () => {
     const { rawDb, store } = createSlackStore();
     const client = createHarness(store, () => {});

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -337,8 +337,10 @@ describe("LUM-2941: arming the assistant's own top-level posts", () => {
       const armed = threadRow(rawDb, BOT_POST_TS);
       expect(armed?.channel_id).toBe(CHANNEL);
       expect(armed?.speculative_root_at).not.toBeNull();
-      // Four hours, not the 24h an inbound thread gets.
-      expect(armed?.expires_at).toBeLessThanOrEqual(armedAt + FOUR_HOURS_MS);
+      // Four hours, not the 24h an inbound thread gets. The ceiling is read
+      // after delivery so the bound holds however long the write took.
+      expect(armed?.expires_at).toBeLessThanOrEqual(Date.now() + FOUR_HOURS_MS);
+      expect(armed?.expires_at).toBeGreaterThan(armedAt);
 
       deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
       await flushAsyncEventEmission();
@@ -404,6 +406,52 @@ describe("LUM-2941: arming the assistant's own top-level posts", () => {
       expect(row?.expires_at).toBeGreaterThan(armedAt + FOUR_HOURS_MS);
       expect(store.listActiveThreadsWithChannel()).toEqual([
         { threadTs, channelId: CHANNEL },
+      ]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("the assistant threading under its own root does not promote it into catch-up", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      const armedAt = Date.now();
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      // The assistant follows up in the thread under its own post (chunked
+      // output, a progress update). Nobody has replied to it yet.
+      deliver(client, ws, "Ev-bot-followup", {
+        type: "message",
+        user: "UBOT",
+        text: "and here is the detail",
+        ts: "1785437330.000100",
+        channel: CHANNEL,
+        channel_type: "channel",
+        thread_ts: BOT_POST_TS,
+      });
+      await flushAsyncEventEmission();
+
+      // Talking to itself is not engagement: the row stays speculative and out
+      // of the fan-out, but its window is refreshed so admission survives for
+      // as long as the assistant keeps posting.
+      const row = threadRow(rawDb, BOT_POST_TS);
+      expect(row?.speculative_root_at).not.toBeNull();
+      expect(row?.expires_at).toBeLessThanOrEqual(Date.now() + FOUR_HOURS_MS);
+      expect(row?.expires_at).toBeGreaterThanOrEqual(armedAt);
+      expect(store.hasThread(BOT_POST_TS)).toBe(true);
+      expect(store.listActiveThreadsWithChannel()).toEqual([]);
+
+      // A human reply still promotes it.
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      expect(threadRow(rawDb, BOT_POST_TS)?.speculative_root_at).toBeNull();
+      expect(store.listActiveThreadsWithChannel()).toEqual([
+        { threadTs: BOT_POST_TS, channelId: CHANNEL },
       ]);
     } finally {
       rawDb.close();

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -1,0 +1,695 @@
+/**
+ * LUM-2941: wake on replies under the assistant's own top-level posts.
+ *
+ * When the assistant posted a top-level message into a channel (a heartbeat or
+ * triage turn, via the Slack skill's raw `chat.postMessage`), nothing was
+ * armed: `maybeTrackBotOwnPost` only tracked echoes that carried a
+ * `thread_ts`. A human replying in the thread under that post then failed the
+ * active-thread filter and was dropped before the daemon saw it.
+ *
+ * A top-level echo now arms the post's own `ts` as a *speculative* thread
+ * root. Pinned below with the four properties that make that safe to ship:
+ * roots are armed only where they buy admission, only for real posts, at a
+ * shorter TTL than an inbound thread, and excluded from reconnect catch-up
+ * enumeration until a human actually replies.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { GatewayConfig } from "../config.js";
+import { SlackStore } from "../db/slack-store.js";
+import * as schema from "../db/schema.js";
+import type { RuntimeInboundPayload } from "../runtime/client.js";
+import type { NormalizedSlackEvent } from "../slack/message-schemas.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function makeSlackUserResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      user: {
+        name: "example-user",
+        profile: { display_name: "Example User" },
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () =>
+  makeSlackUserResponse(),
+);
+const runtimePayloads: RuntimeInboundPayload[] = [];
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+mock.module("../runtime/client.js", () => ({
+  CircuitBreakerOpenError: class CircuitBreakerOpenError extends Error {
+    readonly retryAfterSecs: number;
+
+    constructor(retryAfterSecs: number) {
+      super("Circuit breaker is open");
+      this.name = "CircuitBreakerOpenError";
+      this.retryAfterSecs = retryAfterSecs;
+    }
+  },
+  forwardToRuntime: mock(
+    async (_config: GatewayConfig, payload: RuntimeInboundPayload) => {
+      runtimePayloads.push(payload);
+      return { accepted: true, duplicate: false, eventId: "runtime-event-1" };
+    },
+  ),
+}));
+
+mock.module("../logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  }),
+}));
+
+mock.module("../verification/text-verification.js", () => ({
+  tryTextVerificationIntercept: mock(async () => ({ intercepted: false })),
+}));
+
+const { SlackSocketModeClient } = await import("../slack/socket-mode.js");
+const { clearChannelInfoCache, clearUserInfoCache, clearInFlightFetches } =
+  await import("../slack/user-directory.js");
+const { initGatewayDb, resetGatewayDb } = await import("../db/connection.js");
+const { initAdmissionPolicyCache, resetAdmissionPolicyCache } =
+  await import("../risk/admission-policy-cache.js");
+import type { SlackSocketModeConfig } from "../slack/socket-mode.js";
+
+type SocketModeHarness = {
+  config: SlackSocketModeConfig;
+  onEvent: (event: NormalizedSlackEvent) => void;
+  store: SlackStore;
+  handleMessage(raw: string, originWs: WebSocket): void;
+};
+
+/** An ordinary channel the assistant posts into. Deliberately unsubscribed. */
+const CHANNEL = "C0000000CH1";
+/** A 1:1 DM, where every message is admitted without a tracked thread. */
+const DM = "D0000000DM1";
+/** A group DM. `C`-prefixed, as real workspaces mint MPIMs. */
+const MPIM = "C0000000MP1";
+
+/** The assistant's top-level post, from the LUM-2935 live report. */
+const BOT_POST_TS = "1785437318.595479";
+
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1_000;
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    // Intentionally empty: no conversation_id entry for CHANNEL, so
+    // `isChannelSubscribed` cannot mask the arming behaviour under test.
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    trustProxy: false,
+  };
+}
+
+function createSlackStore(): { rawDb: Database; store: SlackStore } {
+  const rawDb = new Database(":memory:");
+  rawDb.exec(`
+    CREATE TABLE slack_active_threads (
+      thread_ts TEXT PRIMARY KEY,
+      channel_id TEXT,
+      tracked_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      detached_at INTEGER,
+      speculative_root_at INTEGER
+    );
+    CREATE TABLE slack_seen_events (
+      event_id TEXT PRIMARY KEY,
+      seen_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
+    CREATE TABLE slack_last_seen_ts (
+      key TEXT PRIMARY KEY,
+      ts TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      last_interaction INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE channel_bot_identity (
+      channel_type TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      username TEXT,
+      metadata TEXT,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return { rawDb, store: new SlackStore(drizzle(rawDb, { schema })) };
+}
+
+type ThreadRow = {
+  channel_id: string | null;
+  expires_at: number;
+  speculative_root_at: number | null;
+};
+
+/** Raw row read, so the TTL and the speculative marker are both observable. */
+function threadRow(rawDb: Database, threadTs: string): ThreadRow | undefined {
+  return rawDb
+    .prepare(
+      "SELECT channel_id, expires_at, speculative_root_at FROM slack_active_threads WHERE thread_ts = ?",
+    )
+    .get(threadTs) as ThreadRow | undefined;
+}
+
+function createHarness(
+  store: SlackStore,
+  onEvent: (event: NormalizedSlackEvent) => void,
+  threadMode: SlackSocketModeConfig["threadMode"] = "mention_then_thread",
+): SocketModeHarness {
+  const harness = Object.create(
+    SlackSocketModeClient.prototype,
+  ) as SocketModeHarness;
+  harness.config = {
+    appToken: "xapp-test",
+    botToken: "xoxb-test",
+    botUserId: "UBOT",
+    botUsername: "assistant",
+    teamName: "Example Team",
+    gatewayConfig: makeConfig(),
+    threadMode,
+  };
+  harness.onEvent = onEvent;
+  harness.store = store;
+  return harness;
+}
+
+function makeOpenSocket(): WebSocket {
+  return {
+    readyState: WebSocket.OPEN,
+    send: mock(() => {}),
+  } as unknown as WebSocket;
+}
+
+function flushAsyncEventEmission(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Feed one synthetic events_api envelope through the live ingress path. */
+function deliver(
+  client: SocketModeHarness,
+  ws: WebSocket,
+  eventId: string,
+  event: Record<string, unknown>,
+): void {
+  client.handleMessage(
+    JSON.stringify({
+      envelope_id: `env-${eventId}`,
+      type: "events_api",
+      payload: { event_id: eventId, event },
+    }),
+    ws,
+  );
+}
+
+/** The Socket Mode echo of a top-level `chat.postMessage` by the assistant. */
+function botTopLevelPost(
+  channel: string,
+  channelType: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    type: "message",
+    user: "UBOT",
+    text: "heartbeat: three PRs are waiting on review",
+    ts: BOT_POST_TS,
+    channel,
+    channel_type: channelType,
+    ...extra,
+  };
+}
+
+/** A human's unmentioned reply in the thread under the assistant's post. */
+function humanReply(
+  channel: string,
+  ts = "1785437359.111100",
+): Record<string, unknown> {
+  return {
+    type: "message",
+    user: "U0000000AL1",
+    text: "which one is blocking the release?",
+    ts,
+    channel,
+    channel_type: "channel",
+    thread_ts: BOT_POST_TS,
+  };
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  resetAdmissionPolicyCache();
+  await initGatewayDb();
+  initAdmissionPolicyCache();
+  runtimePayloads.length = 0;
+  clearUserInfoCache();
+  clearChannelInfoCache();
+  clearInFlightFetches();
+  fetchMock = mock(async () => makeSlackUserResponse());
+});
+
+afterEach(() => {
+  resetAdmissionPolicyCache();
+  resetGatewayDb();
+});
+
+describe("LUM-2941: arming the assistant's own top-level posts", () => {
+  test("admits a human reply under a top-level post the assistant made", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      // The echo itself is never forwarded, but it arms the root.
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(BOT_POST_TS)).toBe(true);
+
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.source.updateId).toBe("Ev-human-reply");
+      expect(emitted[0]?.threadTs).toBe(BOT_POST_TS);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("arms the root at the speculative TTL, then promotes it on the first human reply", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      const armedAt = Date.now();
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      const armed = threadRow(rawDb, BOT_POST_TS);
+      expect(armed?.channel_id).toBe(CHANNEL);
+      expect(armed?.speculative_root_at).not.toBeNull();
+      // Four hours, not the 24h an inbound thread gets.
+      expect(armed?.expires_at).toBeLessThanOrEqual(armedAt + FOUR_HOURS_MS);
+
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      // The reply is real engagement: the row is no longer speculative and
+      // carries the full inbound TTL.
+      const promoted = threadRow(rawDb, BOT_POST_TS);
+      expect(promoted?.speculative_root_at).toBeNull();
+      expect(promoted?.expires_at).toBeGreaterThan(armedAt + FOUR_HOURS_MS);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("keeps speculative roots out of reconnect catch-up enumeration until a human replies", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      // Every row here costs one tier-3 conversations.replies call on every
+      // reconnect. The assistant posts continuously, so roots nobody replied
+      // to must not enter the fan-out.
+      expect(store.listActiveThreadsWithChannel()).toEqual([]);
+
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      expect(store.listActiveThreadsWithChannel()).toEqual([
+        { threadTs: BOT_POST_TS, channelId: CHANNEL },
+      ]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("arms the assistant's own thread reply at the full TTL, not as a root", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+    const threadTs = "1785437000.000100";
+
+    try {
+      const armedAt = Date.now();
+      deliver(client, ws, "Ev-bot-thread-reply", {
+        type: "message",
+        user: "UBOT",
+        text: "picking up this thread",
+        ts: "1785437010.000200",
+        channel: CHANNEL,
+        channel_type: "channel",
+        thread_ts: threadTs,
+      });
+      await flushAsyncEventEmission();
+
+      // The bot joining an existing thread is a participation signal as strong
+      // as an inbound one: full TTL, and covered by catch-up.
+      const row = threadRow(rawDb, threadTs);
+      expect(row?.speculative_root_at).toBeNull();
+      expect(row?.expires_at).toBeGreaterThan(armedAt + FOUR_HOURS_MS);
+      expect(store.listActiveThreadsWithChannel()).toEqual([
+        { threadTs, channelId: CHANNEL },
+      ]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not arm a root for a bot-authored system subtype", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      // `classifySlackEvent` reports kind "message" for system subtypes too.
+      // The assistant being added to a channel opens no conversation.
+      deliver(
+        client,
+        ws,
+        "Ev-bot-join",
+        botTopLevelPost(CHANNEL, "channel", {
+          subtype: "channel_join",
+          text: "<@UBOT> has joined the channel",
+        }),
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("arms a root for a top-level file_share the assistant posted", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      // A file post is still the assistant saying something repliable.
+      deliver(
+        client,
+        ws,
+        "Ev-bot-file",
+        botTopLevelPost(CHANNEL, "channel", { subtype: "file_share" }),
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(true);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not arm a root in a DM", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-bot-dm", botTopLevelPost(DM, "im"));
+      await flushAsyncEventEmission();
+
+      // A DM admits every message without a tracked thread, so a root buys
+      // nothing and only adds a row.
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not arm a root in a group DM", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-bot-mpim", botTopLevelPost(MPIM, "mpim"));
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not arm a root when the ts carries an explicit-detach marker", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      store.detachThread(BOT_POST_TS, CHANNEL);
+
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+      expect(store.isThreadDetached(BOT_POST_TS)).toBe(true);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not arm a root in mention_only thread mode", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {}, "mention_only");
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("a re-delivered echo does not downgrade a root a human already replied into", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+
+    try {
+      const armedAt = Date.now();
+      deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+      await flushAsyncEventEmission();
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      // Reconnect catch-up can replay the assistant's own post after the reply
+      // was already admitted. Re-arming would put the promoted thread back to
+      // speculative and drop it out of catch-up again.
+      deliver(
+        client,
+        ws,
+        "Ev-bot-post-again",
+        botTopLevelPost(CHANNEL, "channel"),
+      );
+      await flushAsyncEventEmission();
+
+      const row = threadRow(rawDb, BOT_POST_TS);
+      expect(row?.speculative_root_at).toBeNull();
+      expect(row?.expires_at).toBeGreaterThan(armedAt + FOUR_HOURS_MS);
+    } finally {
+      rawDb.close();
+    }
+  });
+});
+
+/**
+ * Arming a root widens three more filters for the root's TTL, because they all
+ * consult `hasThread` on the target message's ts. In an ordinary unsubscribed
+ * channel a reaction, edit, or delete on the assistant's own post now reaches
+ * the daemon where it previously did not. That is the intended reading of
+ * "wake on responses to what the assistant said", and is pinned here so it
+ * stays a decision rather than a side effect. Each case is paired with the
+ * same event on a message the assistant did not post, which still drops.
+ */
+describe("LUM-2941: filters widened by an armed root", () => {
+  async function armRoot(client: SocketModeHarness, ws: WebSocket) {
+    deliver(client, ws, "Ev-bot-post", botTopLevelPost(CHANNEL, "channel"));
+    await flushAsyncEventEmission();
+  }
+
+  test("admits a reaction on the assistant's own top-level post", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await armRoot(client, ws);
+
+      deliver(client, ws, "Ev-reaction", {
+        type: "reaction_added",
+        user: "U0000000AL1",
+        reaction: "eyes",
+        item: { type: "message", channel: CHANNEL, ts: BOT_POST_TS },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.message.callbackData).toBe("reaction:eyes");
+
+      // Same channel, a message the assistant never posted: still dropped.
+      deliver(client, ws, "Ev-reaction-other", {
+        type: "reaction_added",
+        user: "U0000000AL1",
+        reaction: "tada",
+        item: { type: "message", channel: CHANNEL, ts: "1785430000.000900" },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits an edit of the assistant's own top-level post", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await armRoot(client, ws);
+
+      deliver(client, ws, "Ev-edit", {
+        type: "message",
+        subtype: "message_changed",
+        channel: CHANNEL,
+        channel_type: "channel",
+        message: {
+          user: "U0000000AL1",
+          text: "edited in the assistant's thread",
+          ts: BOT_POST_TS,
+        },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.message.isEdit).toBe(true);
+
+      deliver(client, ws, "Ev-edit-other", {
+        type: "message",
+        subtype: "message_changed",
+        channel: CHANNEL,
+        channel_type: "channel",
+        message: {
+          user: "U0000000AL1",
+          text: "unrelated edit",
+          ts: "1785430000.000900",
+        },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits a delete of the assistant's own top-level post", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await armRoot(client, ws);
+
+      deliver(client, ws, "Ev-del", {
+        type: "message",
+        subtype: "message_deleted",
+        channel: CHANNEL,
+        channel_type: "channel",
+        deleted_ts: BOT_POST_TS,
+        previous_message: {
+          user: "U0000000AL1",
+          text: "gone",
+          ts: BOT_POST_TS,
+        },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.message.callbackData).toBe("message_deleted");
+
+      deliver(client, ws, "Ev-del-other", {
+        type: "message",
+        subtype: "message_deleted",
+        channel: CHANNEL,
+        channel_type: "channel",
+        deleted_ts: "1785430000.000900",
+        previous_message: {
+          user: "U0000000AL1",
+          text: "unrelated",
+          ts: "1785430000.000900",
+        },
+      });
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+});

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -105,6 +105,11 @@ const MPIM = "C0000000MP1";
 /** The assistant's top-level post, from the LUM-2935 live report. */
 const BOT_POST_TS = "1785437318.595479";
 
+/** Our app's own `bot_id`, as `auth.test` reports it. */
+const OUR_BOT_ID = "B0000000SELF";
+/** Another app in the same workspace. Its posts are never ours. */
+const OTHER_BOT_ID = "B0000000OTHR";
+
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1_000;
 
 function makeConfig(): GatewayConfig {
@@ -201,7 +206,7 @@ function threadRow(rawDb: Database, threadTs: string): ThreadRow | undefined {
 function createHarness(
   store: SlackStore,
   onEvent: (event: NormalizedSlackEvent) => void,
-  threadMode: SlackSocketModeConfig["threadMode"] = "mention_then_thread",
+  overrides: Partial<SlackSocketModeConfig> = {},
 ): SocketModeHarness {
   const harness = Object.create(
     SlackSocketModeClient.prototype,
@@ -210,10 +215,12 @@ function createHarness(
     appToken: "xapp-test",
     botToken: "xoxb-test",
     botUserId: "UBOT",
+    botId: OUR_BOT_ID,
     botUsername: "assistant",
     teamName: "Example Team",
     gatewayConfig: makeConfig(),
-    threadMode,
+    threadMode: "mention_then_thread",
+    ...overrides,
   };
   harness.onEvent = onEvent;
   harness.store = store;
@@ -582,7 +589,9 @@ describe("LUM-2941: arming the assistant's own top-level posts", () => {
 
   test("does not arm a root in mention_only thread mode", async () => {
     const { rawDb, store } = createSlackStore();
-    const client = createHarness(store, () => {}, "mention_only");
+    const client = createHarness(store, () => {}, {
+      threadMode: "mention_only",
+    });
     const ws = makeOpenSocket();
 
     try {
@@ -621,6 +630,221 @@ describe("LUM-2941: arming the assistant's own top-level posts", () => {
       const row = threadRow(rawDb, BOT_POST_TS);
       expect(row?.speculative_root_at).toBeNull();
       expect(row?.expires_at).toBeGreaterThan(armedAt + FOUR_HOURS_MS);
+    } finally {
+      rawDb.close();
+    }
+  });
+});
+
+/**
+ * The other shape Slack uses for the assistant's own posts.
+ *
+ * A plain `chat.postMessage` with a bot token is attributed to the bot *user*
+ * and carries `user`. A post made with a `username` / `icon_*` override, sent
+ * through an incoming webhook, or made by a classic app arrives as
+ * `subtype: "bot_message"` with `bot_id` and **no** `user` at all. That shape
+ * matched nothing in the `user`-keyed self-filter, so it armed no root and was
+ * not even recognized as our own echo.
+ */
+describe("LUM-2941: the assistant's own bot_message echoes", () => {
+  /** The `bot_message` echo shape: `bot_id`, `username`, and no `user`. */
+  function botMessagePost(
+    channel: string,
+    channelType: string,
+    botId: string,
+    extra: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      type: "message",
+      subtype: "bot_message",
+      bot_id: botId,
+      username: "Vex",
+      text: "heartbeat: three PRs are waiting on review",
+      ts: BOT_POST_TS,
+      channel,
+      channel_type: channelType,
+      ...extra,
+    };
+  }
+
+  test("arms a root from our own bot_message post, so the human reply is admitted", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      deliver(
+        client,
+        ws,
+        "Ev-bot-message",
+        botMessagePost(CHANNEL, "channel", OUR_BOT_ID),
+      );
+      await flushAsyncEventEmission();
+
+      // Still dropped as our own echo, but now recognized as ours.
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(BOT_POST_TS)).toBe(true);
+      expect(threadRow(rawDb, BOT_POST_TS)?.speculative_root_at).not.toBeNull();
+
+      deliver(client, ws, "Ev-human-reply", humanReply(CHANNEL));
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.threadTs).toBe(BOT_POST_TS);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("arms the thread from our own bot_message thread reply", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {});
+    const ws = makeOpenSocket();
+    const threadTs = "1785437000.000100";
+
+    try {
+      deliver(
+        client,
+        ws,
+        "Ev-bot-message-reply",
+        botMessagePost(CHANNEL, "channel", OUR_BOT_ID, {
+          ts: "1785437010.000200",
+          thread_ts: threadTs,
+        }),
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(threadTs)).toBe(true);
+      expect(threadRow(rawDb, threadTs)?.speculative_root_at).toBeNull();
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("another app's bot_message is not treated as ours", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      // The match is on the exact `bot_id`. A different app posting into the
+      // same channel must not arm a root, or the assistant would start waking
+      // on threads under other bots' posts in channels it merely observes.
+      deliver(
+        client,
+        ws,
+        "Ev-other-bot",
+        botMessagePost(CHANNEL, "channel", OTHER_BOT_ID),
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+      // Unsubscribed, unmentioned, untracked: the ordinary filter drops it.
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("fails closed when our bot_id has not been resolved yet", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {}, { botId: undefined });
+    const ws = makeOpenSocket();
+
+    try {
+      // `auth.test` predating the bot_id field, or a transient resolution
+      // failure, must not turn into "every bot_message is ours".
+      deliver(
+        client,
+        ws,
+        "Ev-bot-message-no-identity",
+        botMessagePost(CHANNEL, "channel", OUR_BOT_ID),
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("treats a delete of our own bot_message post like a delete of our own user post", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      // This is a real behaviour change, made for consistency rather than as a
+      // side effect. `normalizeSlackMessageDelete` does not require an author
+      // (it falls back to "slack-system"), so a delete of a `bot_message`-shaped
+      // post used to reach the daemon while the identical delete of a
+      // user-attributed assistant post was already self-filtered on
+      // `previous_message.user`. Both shapes now behave the same way.
+      deliver(client, ws, "Ev-del-ours-botmsg", {
+        type: "message",
+        subtype: "message_deleted",
+        channel: DM,
+        channel_type: "im",
+        deleted_ts: BOT_POST_TS,
+        previous_message: {
+          bot_id: OUR_BOT_ID,
+          text: "heartbeat",
+          ts: BOT_POST_TS,
+        },
+      });
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(0);
+
+      // A delete of someone else's message in the same DM still forwards, so
+      // the filter narrowed to our own posts and nothing wider.
+      deliver(client, ws, "Ev-del-theirs", {
+        type: "message",
+        subtype: "message_deleted",
+        channel: DM,
+        channel_type: "im",
+        deleted_ts: "1785430000.000900",
+        previous_message: {
+          user: "U0000000AL1",
+          text: "their message",
+          ts: "1785430000.000900",
+        },
+      });
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]?.event.message.callbackData).toBe("message_deleted");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not forward our own bot_message DM echo back to the daemon", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      // This one held before the bot_id arm too, but only by luck of a later
+      // guard: a DM admits every message unconditionally, so the echo passed
+      // the admission filter and was caught downstream by
+      // `normalizeSlackDirectMessage`, which returns null for both a non
+      // `file_share` subtype and a missing `user`. It is now recognized as
+      // ours at the self-filter, where every other echo is handled. Pinned so
+      // a change to either normalizer guard cannot quietly start feeding the
+      // assistant its own posts.
+      deliver(
+        client,
+        ws,
+        "Ev-bot-message-dm",
+        botMessagePost(DM, "im", OUR_BOT_ID),
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(BOT_POST_TS)).toBe(false);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -93,6 +93,7 @@ type SocketModeHarness = {
   onEvent: (event: NormalizedSlackEvent) => void;
   store: SlackStore;
   handleMessage(raw: string, originWs: WebSocket): void;
+  resolveBotIdentity(): Promise<void>;
 };
 
 /** An ordinary channel the assistant posts into. Deliberately unsubscribed. */
@@ -743,6 +744,78 @@ describe("LUM-2941: the assistant's own bot_message echoes", () => {
       expect(store.hasThread(BOT_POST_TS)).toBe(false);
       // Unsubscribed, unmentioned, untracked: the ordinary filter drops it.
       expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("keeps retrying auth.test until bot_id lands, so a bad upgrade self-heals", async () => {
+    const { rawDb, store } = createSlackStore();
+    const client = createHarness(store, () => {}, {
+      botUserId: undefined,
+      botId: undefined,
+      botUsername: undefined,
+    });
+
+    try {
+      // The pre-upgrade persisted identity: user id and username, written
+      // before `botId` existed.
+      store.setBotIdentity({
+        userId: "UBOT",
+        username: "assistant",
+        metadata: { teamName: "Example Team" },
+      });
+
+      // First resolution happens during a Slack blip, so it falls back to that
+      // persisted row and comes up without a bot_id.
+      let authCalls = 0;
+      fetchMock = mock(async (input) => {
+        if (String(input).includes("auth.test")) {
+          authCalls++;
+          return new Response(
+            JSON.stringify({ ok: false, error: "internal_error" }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return makeSlackUserResponse();
+      });
+      await client.resolveBotIdentity();
+
+      expect(authCalls).toBe(1);
+      expect(client.config.botUserId).toBe("UBOT");
+      expect(client.config.botId).toBeUndefined();
+
+      // Slack recovers. The next reconnect must retry rather than short-circuit
+      // on the populated user fields, or the bot_message self-filter would stay
+      // disabled until a full restart.
+      fetchMock = mock(async (input) => {
+        if (String(input).includes("auth.test")) {
+          authCalls++;
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              user_id: "UBOT",
+              user: "assistant",
+              team: "Example Team",
+              bot_id: OUR_BOT_ID,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return makeSlackUserResponse();
+      });
+      await client.resolveBotIdentity();
+
+      expect(authCalls).toBe(2);
+      expect(client.config.botId).toBe(OUR_BOT_ID);
+      // Persisted, so the next process starts with it.
+      expect(
+        (store.getBotIdentity("slack")?.metadata as { botId?: string })?.botId,
+      ).toBe(OUR_BOT_ID);
+
+      // Now that the answer is authoritative, further reconnects short-circuit.
+      await client.resolveBotIdentity();
+      expect(authCalls).toBe(2);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -134,7 +134,8 @@ function createSlackStore(): { rawDb: Database; store: SlackStore } {
       channel_id TEXT,
       tracked_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL,
-      detached_at INTEGER
+      detached_at INTEGER,
+      speculative_root_at INTEGER
     );
     CREATE TABLE slack_seen_events (
       event_id TEXT PRIMARY KEY,

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -35,6 +35,16 @@ export const slackActiveThreads = sqliteTable("slack_active_threads", {
   // the bot's own mute confirmation cannot silently re-arm the thread it
   // just muted. An explicit human re-engagement (trackThread) clears it.
   detachedAt: integer("detached_at"),
+  // Set when the row was armed speculatively from the assistant's own
+  // top-level post: a thread root nobody has replied into yet. NULL = a
+  // thread with real human engagement behind it. Speculative roots still
+  // admit inbound events (`hasThread`), but are excluded from reconnect
+  // catch-up enumeration (`listActiveThreadsWithChannel`), which spends one
+  // tier-3 `conversations.replies` call per row. The assistant posts
+  // continuously, so fanning out over every never-engaged root could burn
+  // the rate limit that genuinely missed messages need. The first human
+  // reply promotes the row via `trackThread`, which clears this.
+  speculativeRootAt: integer("speculative_root_at"),
 });
 
 export const slackSeenEvents = sqliteTable("slack_seen_events", {

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -133,6 +133,50 @@ export class SlackStore {
       .run();
   }
 
+  /**
+   * Track a thread from the assistant's own reply echo into it.
+   *
+   * Differs from `trackThread` in exactly one way: it must not promote a
+   * speculative root. The assistant threading follow-ups under its own
+   * never-answered post is not human engagement, and promoting would move a
+   * row nobody replied to into the reconnect catch-up fan-out
+   * (`listActiveThreadsWithChannel`), which is the cost this split exists to
+   * avoid. A still-speculative root keeps its marker and has its shorter
+   * window refreshed instead, so admission stays alive for as long as the
+   * assistant keeps talking.
+   *
+   * Every other thread is tracked at the full TTL exactly as before: one a
+   * human already promoted, and one the assistant is joining for the first
+   * time (JARVIS-1086), which is a real thread it did not originate.
+   */
+  trackThreadAfterBotReply(
+    threadTs: string,
+    channelId: string,
+    ttlMs: number,
+    speculativeTtlMs: number,
+  ): void {
+    const speculative = this.db
+      .select({ threadTs: slackActiveThreads.threadTs })
+      .from(slackActiveThreads)
+      .where(
+        and(
+          eq(slackActiveThreads.threadTs, threadTs),
+          isNotNull(slackActiveThreads.speculativeRootAt),
+        ),
+      )
+      .get();
+    if (!speculative) {
+      this.trackThread(threadTs, channelId, ttlMs);
+      return;
+    }
+    const now = Date.now();
+    this.db
+      .update(slackActiveThreads)
+      .set({ channelId, trackedAt: now, expiresAt: now + speculativeTtlMs })
+      .where(eq(slackActiveThreads.threadTs, threadTs))
+      .run();
+  }
+
   hasThread(threadTs: string): boolean {
     const now = Date.now();
     const row = this.db

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -66,7 +66,11 @@ export class SlackStore {
    * human re-engagement signal (an @-mention, or a reply already admitted
    * by the active-thread filter), which re-arms a muted thread. The bot's
    * own thread-reply echoes must check `isThreadDetached` before calling
-   * this — they are not a re-engagement signal.
+   * this: they are not a re-engagement signal.
+   *
+   * Also clears the speculative-root marker, promoting a root the assistant
+   * armed from its own top-level post into a fully tracked thread once a
+   * human actually engages with it. See `armSpeculativeThreadRoot`.
    */
   trackThread(threadTs: string, channelId: string, ttlMs: number): void {
     const now = Date.now();
@@ -78,6 +82,7 @@ export class SlackStore {
         trackedAt: now,
         expiresAt: now + ttlMs,
         detachedAt: null,
+        speculativeRootAt: null,
       })
       .onConflictDoUpdate({
         target: slackActiveThreads.threadTs,
@@ -86,8 +91,45 @@ export class SlackStore {
           trackedAt: now,
           expiresAt: now + ttlMs,
           detachedAt: null,
+          speculativeRootAt: null,
         },
       })
+      .run();
+  }
+
+  /**
+   * Arm the assistant's own top-level post as a speculative thread root, so
+   * a human replying under it passes the active-thread filter.
+   *
+   * "Speculative" because nothing yet says this post will become a
+   * conversation: the assistant opens one on every heartbeat or triage turn,
+   * and most are never replied to. The marker separates those from threads
+   * with real engagement so reconnect catch-up can skip them
+   * (`listActiveThreadsWithChannel`), and callers pass a shorter TTL than the
+   * inbound one. The first human reply calls `trackThread`, which clears the
+   * marker and extends the row to the full TTL.
+   *
+   * Insert-only: an existing row is left alone. A re-delivered echo of the
+   * same post must not downgrade a root a human has since replied into back
+   * to speculative, nor stomp an explicit-detach marker.
+   */
+  armSpeculativeThreadRoot(
+    threadTs: string,
+    channelId: string,
+    ttlMs: number,
+  ): void {
+    const now = Date.now();
+    this.db
+      .insert(slackActiveThreads)
+      .values({
+        threadTs,
+        channelId,
+        trackedAt: now,
+        expiresAt: now + ttlMs,
+        detachedAt: null,
+        speculativeRootAt: now,
+      })
+      .onConflictDoNothing()
       .run();
   }
 
@@ -178,9 +220,19 @@ export class SlackStore {
 
   /**
    * Returns all unexpired active threads with a known channel for reconnect
-   * catch-up. Rows with a NULL `channel_id` (legacy rows from before the
-   * column was introduced) and explicit-detach markers are filtered out —
-   * a muted thread must not be fanned out during catch-up.
+   * catch-up. Three kinds of row are filtered out:
+   *
+   *   - NULL `channel_id` (legacy rows from before the column existed):
+   *     `conversations.replies` cannot be scoped without a channel.
+   *   - explicit-detach markers: a muted thread must not be fanned out.
+   *   - speculative roots (`armSpeculativeThreadRoot`): every row here costs
+   *     one tier-3 `conversations.replies` call on every reconnect, and the
+   *     assistant arms a root for each of its own top-level posts. Fanning
+   *     out over roots nobody replied to would spend the rate limit that
+   *     recovery of genuinely missed messages depends on. The trade-off is
+   *     that a reply arriving under a never-engaged root while the socket is
+   *     down is not recovered by catch-up; once any reply is admitted live,
+   *     `trackThread` promotes the row and later reconnects do cover it.
    */
   listActiveThreadsWithChannel(): ActiveThreadRow[] {
     const now = Date.now();
@@ -195,6 +247,7 @@ export class SlackStore {
           gt(slackActiveThreads.expiresAt, now),
           isNotNull(slackActiveThreads.channelId),
           isNull(slackActiveThreads.detachedAt),
+          isNull(slackActiveThreads.speculativeRootAt),
         ),
       )
       .all();

--- a/gateway/src/slack/message-schemas.ts
+++ b/gateway/src/slack/message-schemas.ts
@@ -57,10 +57,17 @@ const slackEditedSchema = z
 const slackMessageChannelType = () =>
   z.enum(["im", "channel", "group", "mpim"]).optional().catch(undefined);
 
-/** The edited message body carried in a `message_changed` event's `message`. */
+/**
+ * The edited message body carried in a `message_changed` event's `message`.
+ *
+ * `bot_id` is modeled because it is the only author field an app-attributed
+ * post carries: a `bot_message`-shaped message has no `user`, so without this
+ * the self-filter cannot tell our own edited post from an inbound one.
+ */
 const slackChangedMessageSchema = z
   .object({
     user: optionalString(),
+    bot_id: optionalString(),
     text: optionalString(),
     ts: optionalString(),
     client_msg_id: optionalString(),
@@ -74,6 +81,7 @@ const slackChangedMessageSchema = z
 const slackChangedPreviousMessageSchema = z
   .object({
     user: optionalString(),
+    bot_id: optionalString(),
     text: optionalString(),
     ts: optionalString(),
     edited: slackEditedSchema,
@@ -104,6 +112,7 @@ export type SlackMessageChangedEvent = z.infer<
 const slackDeletedPreviousMessageSchema = z
   .object({
     user: optionalString(),
+    bot_id: optionalString(),
     text: optionalString(),
     ts: optionalString(),
     thread_ts: optionalString(),

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -85,6 +85,34 @@ const MAX_BACKOFF_MS = 30_000;
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
 const ACTIVE_THREAD_TTL_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * TTL for a thread root armed from the assistant's own top-level post.
+ *
+ * Deliberately shorter than {@link ACTIVE_THREAD_TTL_MS} because these roots
+ * are speculative: the assistant opens one on every heartbeat or triage turn
+ * and most are never replied to. Four hours covers a same-session or
+ * after-lunch reply while letting untouched roots lapse before the next day's
+ * posts compound on them.
+ *
+ * This bounds only roots nobody engaged with. The moment a human reply is
+ * admitted, `normalizeAndEmit` re-arms the thread through `trackThread` at the
+ * full inbound TTL, so a root that becomes a real conversation immediately
+ * gets the normal lifetime.
+ */
+const OUTBOUND_ROOT_THREAD_TTL_MS = 4 * 60 * 60 * 1_000;
+
+/**
+ * Message subtypes that still count as the assistant saying something a human
+ * can reply to, and so may arm a thread root.
+ *
+ * `classifySlackEvent` reports `kind: "message"` for bot-authored system
+ * subtypes too (`channel_join`, `channel_topic`, ...); those open no
+ * conversation and must not arm anything. `thread_broadcast` is absent because
+ * it always carries a `thread_ts` and therefore takes the thread-reply arm.
+ */
+const ROOT_ARMING_SUBTYPES = new Set(["file_share"]);
+
 const SLACK_RESOLVE_TIMEOUT_MS = 3_000;
 
 /**
@@ -630,39 +658,102 @@ export class SlackSocketModeClient {
   }
 
   /**
-   * Side-effect-only handler for the bot's own thread replies. The event
-   * itself is always dropped (the caller returns after this), but thread
-   * tracking is armed so follow-up human replies pass the active-thread
-   * filter.
+   * Side-effect-only handler for the bot's own posts. The event itself is
+   * always dropped (the caller returns after this), but thread tracking is
+   * armed so follow-up human replies pass the active-thread filter.
+   *
+   * Two cases, because both open a conversation a human can reply into:
+   *
+   *   - **Thread reply** (`thread_ts` present): arms that thread at the full
+   *     TTL. The bot joining a thread is a participation signal as strong as
+   *     an inbound one.
+   *   - **Top-level post** (no `thread_ts`): arms the post's own `ts` as a
+   *     speculative thread root, at the shorter
+   *     {@link OUTBOUND_ROOT_THREAD_TTL_MS}. Without this a bot-initiated
+   *     conversation arms nothing at all and every reply under it is dropped
+   *     by the active-thread filter (LUM-2941).
+   *
+   * Keyed on the echo rather than on the sending code path, so it holds for
+   * every outbound route: the Slack skill's raw `chat.postMessage`, the
+   * messaging adapter, and the gateway's own posts alike. The flip side is
+   * that a post Slack attributes to a bot identity rather than to the bot
+   * *user* (subtype `bot_message`, no `user` field) never reaches here,
+   * because the self-filter that calls this matches on `user`. Routing
+   * outbound through the gateway (LUM-2942) removes the inference entirely.
    */
-  private maybeTrackBotOwnThreadReply(event: SlackInboundEvent): void {
+  private maybeTrackBotOwnPost(event: SlackInboundEvent): void {
     if (this.config.threadMode !== "mention_then_thread") {
       return;
     }
 
-    // Only a plain thread reply arms tracking. app_mentions, edits, deletes,
+    // Only a plain message arms tracking. app_mentions, edits, deletes,
     // and reactions do not.
     const classified = classifySlackEvent(event);
     if (!classified || classified.kind !== "message") {
       return;
     }
-    const { channel, thread_ts: threadTs } = classified.event;
-    if (!threadTs || !channel) {
+    const {
+      channel,
+      thread_ts: threadTs,
+      ts,
+      channel_type: channelType,
+      subtype,
+    } = classified.event;
+    if (!channel) {
       return;
     }
 
-    if (this.store.isThreadDetached(threadTs)) {
+    if (threadTs) {
+      if (this.store.isThreadDetached(threadTs)) {
+        log.info(
+          { channel, threadTs },
+          "Skipped tracking bot's own reply in explicitly muted thread",
+        );
+        return;
+      }
+      this.store.trackThread(threadTs, channel, ACTIVE_THREAD_TTL_MS);
       log.info(
         { channel, threadTs },
-        "Skipped tracking bot's own reply in explicitly muted thread",
+        "Tracked thread after bot's own thread reply",
       );
       return;
     }
 
-    this.store.trackThread(threadTs, channel, ACTIVE_THREAD_TTL_MS);
+    if (!ts) {
+      return;
+    }
+
+    // A system subtype (`channel_join` and friends) still classifies as
+    // `kind: "message"`, but the bot did not say anything repliable.
+    if (subtype !== undefined && !ROOT_ARMING_SUBTYPES.has(subtype)) {
+      return;
+    }
+
+    // A root buys admission only where admission is otherwise gated. DMs and
+    // group DMs already admit every message without a tracked thread, so a
+    // root there would add a row and change nothing. Message echoes carry
+    // `channel_type`, so the direct-like cases resolve from the payload
+    // without a `conversations.info` warm.
+    if (this.isDirectLikeChannel(channel, channelType)) {
+      return;
+    }
+
+    if (this.store.isThreadDetached(ts)) {
+      log.info(
+        { channel, threadTs: ts },
+        "Skipped arming bot's own post as a root in an explicitly muted thread",
+      );
+      return;
+    }
+
+    this.store.armSpeculativeThreadRoot(
+      ts,
+      channel,
+      OUTBOUND_ROOT_THREAD_TTL_MS,
+    );
     log.info(
-      { channel, threadTs },
-      "Tracked thread after bot's own thread reply",
+      { channel, threadTs: ts },
+      "Armed thread root after bot's own top-level post",
     );
   }
 
@@ -899,10 +990,10 @@ export class SlackSocketModeClient {
     // is dropped here, before any normalization or routing.
     const eventUser = this.extractEventUser(event);
     if (eventUser === botUserId) {
-      // Exception: the bot's own thread replies are used to arm thread
-      // tracking (so follow-up human replies are forwarded). This is a
-      // side effect only, the event itself is still dropped.
-      this.maybeTrackBotOwnThreadReply(event);
+      // Exception: the bot's own posts are used to arm thread tracking (so
+      // follow-up human replies are forwarded). This is a side effect only,
+      // the event itself is still dropped.
+      this.maybeTrackBotOwnPost(event);
       return;
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -731,10 +731,21 @@ export class SlackSocketModeClient {
 
     // A root buys admission only where admission is otherwise gated. DMs and
     // group DMs already admit every message without a tracked thread, so a
-    // root there would add a row and change nothing. Message echoes carry
-    // `channel_type`, so the direct-like cases resolve from the payload
-    // without a `conversations.info` warm.
-    if (this.isDirectLikeChannel(channel, channelType)) {
+    // root there would add a row and change nothing.
+    //
+    // Read the payload's own discriminators rather than calling
+    // `isDirectLikeChannel`: its observed-kind cache fallback fires a
+    // background `conversations.info` for any channel whose kind is not
+    // cached, and `recordSlackChannelKind` only learns `im` / `mpim`, so an
+    // ordinary channel would warm on every post the assistant makes. Message
+    // events always carry `channel_type`, so the fallback buys nothing on this
+    // path. If one ever arrives without it, the worst case is one useless root
+    // row in a group DM until the TTL lapses, which admits nothing that was
+    // not already admitted there.
+    if (
+      isSlackDmChannel(channel, channelType) ||
+      isSlackMpimChannel(channelType)
+    ) {
       return;
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -711,7 +711,15 @@ export class SlackSocketModeClient {
         );
         return;
       }
-      this.store.trackThread(threadTs, channel, ACTIVE_THREAD_TTL_MS);
+      // Not `trackThread`: the assistant replying to itself is not human
+      // engagement, so it must not promote one of its own speculative roots
+      // into the catch-up fan-out. See `trackThreadAfterBotReply`.
+      this.store.trackThreadAfterBotReply(
+        threadTs,
+        channel,
+        ACTIVE_THREAD_TTL_MS,
+        OUTBOUND_ROOT_THREAD_TTL_MS,
+      );
       log.info(
         { channel, threadTs },
         "Tracked thread after bot's own thread reply",

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -231,6 +231,11 @@ export class SlackSocketModeClient {
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private store: SlackStore;
   private emitQueues: Map<string, Promise<void>> | undefined = new Map();
+  /**
+   * Whether `auth.test` has answered authoritatively in this process. Gates
+   * the identity short-circuit: see `resolveBotIdentity`.
+   */
+  private identityResolvedFromApi = false;
 
   constructor(
     config: SlackSocketModeConfig,
@@ -271,7 +276,17 @@ export class SlackSocketModeClient {
    * are treated as transient and fall through to persistence.
    */
   private async resolveBotIdentity(): Promise<void> {
-    if (this.config.botUserId && this.config.botUsername) {
+    // Short-circuit on having had an authoritative answer, not on the fields
+    // being populated. Those differ exactly once: an install that upgrades
+    // during a Slack blip falls back to a persisted identity written before
+    // `botId` existed, so `botUserId` / `botUsername` are set while `botId` is
+    // not. Keying on presence would return here on every later reconnect and
+    // leave the `bot_message` self-filter disabled until a full restart, which
+    // reopens the echo gap for precisely the installs that hit a bad upgrade.
+    if (this.identityResolvedFromApi) {
+      return;
+    }
+    if (this.config.botUserId && this.config.botUsername && this.config.botId) {
       return;
     }
 
@@ -337,6 +352,13 @@ export class SlackSocketModeClient {
             username: data.user ?? null,
             metadata: Object.keys(metadata).length > 0 ? metadata : null,
           });
+        }
+
+        // Only a resolution that actually yielded an identity counts as
+        // authoritative; an `ok` response without `user_id` taught us nothing
+        // and must not disable the retry.
+        if (data.user_id) {
+          this.identityResolvedFromApi = true;
         }
 
         log.info(
@@ -764,11 +786,14 @@ export class SlackSocketModeClient {
    *
    * Keyed on the echo rather than on the sending code path, so it holds for
    * every outbound route: the Slack skill's raw `chat.postMessage`, the
-   * messaging adapter, and the gateway's own posts alike. The flip side is
-   * that a post Slack attributes to a bot identity rather than to the bot
-   * *user* (subtype `bot_message`, no `user` field) never reaches here,
-   * because the self-filter that calls this matches on `user`. Routing
-   * outbound through the gateway (LUM-2942) removes the inference entirely.
+   * messaging adapter, and the gateway's own posts alike. Both of Slack's
+   * attribution shapes reach here, because `isOwnBotEvent` matches our bot
+   * user *and* our `bot_id`.
+   *
+   * What remains is the inference itself: this reads the gateway's own
+   * outbound echo to decide that the assistant opened a conversation. Routing
+   * outbound through the gateway (LUM-2942) replaces it with registration at
+   * send time and makes this handler deletable.
    */
   private maybeTrackBotOwnPost(event: SlackInboundEvent): void {
     if (this.config.threadMode !== "mention_then_thread") {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -118,6 +118,21 @@ const OUTBOUND_ROOT_THREAD_TTL_MS = 4 * 60 * 60 * 1_000;
  */
 const ROOT_ARMING_SUBTYPES = new Set(["file_share", "bot_message"]);
 
+/**
+ * How often to retry `auth.test` while the bot identity is still incomplete.
+ *
+ * Identity is otherwise refreshed only when a WebSocket opens, and Slack
+ * Socket Mode holds a connection for around an hour, so an install that starts
+ * during a Slack blip would run that long on a persisted identity. That is
+ * survivable for the `user`-attributed shape (`botUserId` comes from the same
+ * persisted row) but leaves `botId` unresolved, and an own `bot_message` echo
+ * arriving in that window is not recognized as ours, so it arms no root. This
+ * bounds that window to roughly a minute without gating ingestion on identity,
+ * which would trade a narrow arming gap for a total Slack outage during any
+ * `auth.test` blip.
+ */
+const IDENTITY_RETRY_INTERVAL_MS = 60_000;
+
 const SLACK_RESOLVE_TIMEOUT_MS = 3_000;
 
 /**
@@ -236,6 +251,7 @@ export class SlackSocketModeClient {
    * the identity short-circuit: see `resolveBotIdentity`.
    */
   private identityResolvedFromApi = false;
+  private identityRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     config: SlackSocketModeConfig,
@@ -252,6 +268,10 @@ export class SlackSocketModeClient {
     this.startDedupCleanup();
 
     await this.resolveBotIdentity();
+    // A transient auth.test failure leaves identity incomplete; keep retrying
+    // on a timer so the gap is bounded by a minute rather than by the life of
+    // the Socket Mode connection.
+    this.scheduleIdentityRetry();
     await this.connect();
   }
 
@@ -275,6 +295,50 @@ export class SlackSocketModeClient {
    * token cannot self-heal. Server-side errors (internal_error, fatal_error)
    * are treated as transient and fall through to persistence.
    */
+  /**
+   * True while `auth.test` still has something to tell us. False once it has
+   * answered authoritatively in this process, or when the config already
+   * carries every identity field.
+   */
+  private identityNeedsResolution(): boolean {
+    if (this.identityResolvedFromApi) return false;
+    return !(
+      this.config.botUserId &&
+      this.config.botUsername &&
+      this.config.botId
+    );
+  }
+
+  /**
+   * Keep retrying identity resolution on a timer while it is incomplete.
+   *
+   * Without this the only retry is a WebSocket open, so a persisted-identity
+   * fallback survives for the life of a Socket Mode connection. See
+   * {@link IDENTITY_RETRY_INTERVAL_MS} for why this bounds the window rather
+   * than gating event processing on it.
+   */
+  private scheduleIdentityRetry(): void {
+    if (this.identityRetryTimer) {
+      clearTimeout(this.identityRetryTimer);
+      this.identityRetryTimer = null;
+    }
+    if (!this.running || !this.identityNeedsResolution()) {
+      return;
+    }
+    this.identityRetryTimer = setTimeout(() => {
+      this.identityRetryTimer = null;
+      void this.resolveBotIdentity()
+        .catch((err: unknown) => {
+          log.warn({ err }, "Slack identity retry failed");
+        })
+        .finally(() => {
+          this.scheduleIdentityRetry();
+        });
+    }, IDENTITY_RETRY_INTERVAL_MS);
+    // Never hold the process open for a retry.
+    this.identityRetryTimer.unref?.();
+  }
+
   private async resolveBotIdentity(): Promise<void> {
     // Short-circuit on having had an authoritative answer, not on the fields
     // being populated. Those differ exactly once: an install that upgrades
@@ -283,10 +347,7 @@ export class SlackSocketModeClient {
     // not. Keying on presence would return here on every later reconnect and
     // leave the `bot_message` self-filter disabled until a full restart, which
     // reopens the echo gap for precisely the installs that hit a bad upgrade.
-    if (this.identityResolvedFromApi) {
-      return;
-    }
-    if (this.config.botUserId && this.config.botUsername && this.config.botId) {
+    if (!this.identityNeedsResolution()) {
       return;
     }
 
@@ -420,6 +481,10 @@ export class SlackSocketModeClient {
     this.running = false;
     this.connecting = false;
     this.stopDedupCleanup();
+    if (this.identityRetryTimer) {
+      clearTimeout(this.identityRetryTimer);
+      this.identityRetryTimer = null;
+    }
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -110,8 +110,13 @@ const OUTBOUND_ROOT_THREAD_TTL_MS = 4 * 60 * 60 * 1_000;
  * subtypes too (`channel_join`, `channel_topic`, ...); those open no
  * conversation and must not arm anything. `thread_broadcast` is absent because
  * it always carries a `thread_ts` and therefore takes the thread-reply arm.
+ *
+ * `bot_message` is here because it is a real post, just attributed to an app
+ * rather than a user. Reaching this set at all means the self-filter already
+ * matched the event to our own `bot_id`, so another app's `bot_message` never
+ * gets this far.
  */
-const ROOT_ARMING_SUBTYPES = new Set(["file_share"]);
+const ROOT_ARMING_SUBTYPES = new Set(["file_share", "bot_message"]);
 
 const SLACK_RESOLVE_TIMEOUT_MS = 3_000;
 
@@ -150,6 +155,21 @@ export type SlackSocketModeConfig = {
    * startups load it without depending on a successful API call.
    */
   botUserId?: string;
+  /**
+   * Bot's own Slack `bot_id` (a `B…` app identity, distinct from the `U…`
+   * user id above). Slack attributes a post to one or the other depending on
+   * how it was sent: a plain `chat.postMessage` carries `user`, while a post
+   * with a `username` / `icon_*` override, or through an incoming webhook,
+   * arrives as `subtype: "bot_message"` with `bot_id` and no `user` at all.
+   * Holding both is what lets the self-filter recognize every shape of our
+   * own echo, and matching the exact id is what keeps *other* bots' posts
+   * from being mistaken for ours.
+   *
+   * Resolved alongside `botUserId` via `auth.test` and persisted with it.
+   * Optional: absent for a token whose `auth.test` predates this field, in
+   * which case the `bot_message` arm simply never matches (fail-closed).
+   */
+  botId?: string;
   /** Bot's display name, resolved at startup via auth.test. */
   botUsername?: string;
   /** Slack workspace/team name, resolved at startup via auth.test. */
@@ -267,6 +287,7 @@ export class SlackSocketModeClient {
         user_id?: string;
         user?: string;
         team?: string;
+        bot_id?: string;
       };
 
       if (!data.ok) {
@@ -301,14 +322,20 @@ export class SlackSocketModeClient {
         if (data.team) {
           this.config.teamName = data.team;
         }
+        if (data.bot_id) {
+          this.config.botId = data.bot_id;
+        }
         warnOnMissingSlackScopes(resp.headers.get("x-oauth-scopes") ?? "");
 
         // Persist for future startups.
         if (data.user_id) {
+          const metadata: Record<string, unknown> = {};
+          if (data.team) metadata.teamName = data.team;
+          if (data.bot_id) metadata.botId = data.bot_id;
           this.store.setBotIdentity({
             userId: data.user_id,
             username: data.user ?? null,
-            metadata: data.team ? { teamName: data.team } : null,
+            metadata: Object.keys(metadata).length > 0 ? metadata : null,
           });
         }
 
@@ -317,6 +344,7 @@ export class SlackSocketModeClient {
             botUserId: data.user_id,
             botUsername: data.user,
             teamName: data.team,
+            botId: data.bot_id,
           },
           "Resolved Slack bot identity via auth.test",
         );
@@ -341,8 +369,12 @@ export class SlackSocketModeClient {
     if (persisted) {
       this.config.botUserId = persisted.userId;
       this.config.botUsername = persisted.username ?? this.config.botUsername;
-      const meta = persisted.metadata as { teamName?: string } | null;
+      const meta = persisted.metadata as {
+        teamName?: string;
+        botId?: string;
+      } | null;
       this.config.teamName = meta?.teamName ?? this.config.teamName;
+      this.config.botId = meta?.botId ?? this.config.botId;
       log.info(
         {
           botUserId: persisted.userId,
@@ -655,6 +687,63 @@ export class SlackSocketModeClient {
       default:
         return classified.event.user;
     }
+  }
+
+  /**
+   * Extract the Slack `bot_id` an event is attributed to, mirroring
+   * `extractEventUser`'s per-kind field locations.
+   *
+   * Only messages carry one. A reaction is always attributed to a user even
+   * when an app adds it, so the reaction kinds have no `bot_id` to read.
+   */
+  private extractEventBotId(event: SlackInboundEvent): string | undefined {
+    const classified = classifySlackEvent(event);
+    if (!classified) {
+      return undefined;
+    }
+    switch (classified.kind) {
+      case "message_changed":
+        return classified.event.message?.bot_id;
+      case "message_deleted":
+        return classified.event.previous_message?.bot_id;
+      case "reaction_added":
+      case "reaction_removed":
+        return undefined;
+      default:
+        return classified.event.bot_id;
+    }
+  }
+
+  /**
+   * True when an event is the echo of something this assistant itself posted.
+   *
+   * Slack attributes a post to a user or to an app depending on how it was
+   * sent, and both shapes are ours:
+   *
+   *   - **`user` matches our bot user**: a plain `chat.postMessage` with a
+   *     bot token, which is what every current outbound path produces.
+   *   - **`bot_id` matches our app, with no `user`**: the `bot_message`
+   *     shape Slack emits for a post carrying a `username` / `icon_*`
+   *     override, sent through an incoming webhook, or made by a classic
+   *     app. Slack's own reference points current apps at `bot_id` /
+   *     `bot_profile` rather than this subtype, so it is the uncommon shape,
+   *     but it is the one that silently bypassed every self-filter.
+   *
+   * The `bot_id` arm is deliberately narrow. It requires an exact match
+   * against our resolved id and the absence of a `user`, so another app's
+   * posts are never mistaken for ours (which would arm roots in channels the
+   * assistant merely observes), and an unresolved `botId` matches nothing.
+   */
+  private isOwnBotEvent(event: SlackInboundEvent): boolean {
+    const eventUser = this.extractEventUser(event);
+    if (eventUser) {
+      return eventUser === this.config.botUserId;
+    }
+    const botId = this.config.botId;
+    if (!botId) {
+      return false;
+    }
+    return this.extractEventBotId(event) === botId;
   }
 
   /**
@@ -1007,8 +1096,7 @@ export class SlackSocketModeClient {
     // as inbound events (DM echoes, thread reply echoes, etc.). This is
     // the one structural filter point — every event with the bot as author
     // is dropped here, before any normalization or routing.
-    const eventUser = this.extractEventUser(event);
-    if (eventUser === botUserId) {
+    if (this.isOwnBotEvent(event)) {
       // Exception: the bot's own posts are used to arm thread tracking (so
       // follow-up human replies are forwarded). This is a side effect only,
       // the event itself is still dropped.


### PR DESCRIPTION
## TL;DR

If the assistant posted a **top-level** message into a Slack channel and a human replied in the thread under it, the reply was silently dropped at the gateway and the assistant never woke. It now wakes. The post's own `ts` is armed as a **speculative thread root**, marked distinctly so it never enters the reconnect catch-up fan-out until a human actually replies.

Closes LUM-2941. The group-DM half of LUM-2935 shipped in #39643; this is the other half.

## What was happening before

The assistant posts into a channel from a heartbeat or triage turn. A human reads it and replies in the thread. Nothing happens. No wake, no reply, no error, nothing in the channel to suggest the message went anywhere.

From the original report: the assistant posted at ts `1785437318.595479`, a human replied 41 seconds later, and the daemon never saw it.

The gateway tracks which Slack threads are "live" so it can admit unmentioned replies in them. Thread tracking was armed from the assistant's own outbound echo, but only when that echo carried a `thread_ts` — that is, only when the assistant had replied *inside* an existing thread. A top-level post has no `thread_ts`, so nothing was armed, and the human's reply then failed `hasThread(msg.thread_ts)` and was dropped by the admission filter before reaching the daemon.

The second, narrower half of the same bug: Slack attributes a post either to a user or to an app. A plain `chat.postMessage` with a bot token carries `user`; a post made with a `username`/`icon_*` override, through an incoming webhook, or by a classic app arrives as `subtype: "bot_message"` with `bot_id` and **no** `user`. The self-filter only matched on `user`, so that shape was not recognized as the assistant's own echo at all and armed nothing either.

## What is experienced after

| Situation | Before | After |
| --- | --- | --- |
| Assistant posts top-level in a channel, human replies in the thread | Dropped at the gateway, no wake | Reply is forwarded, assistant wakes |
| Same, where Slack attributes the post to the app (`bot_message`) | Dropped, and the post wasn't even recognized as the assistant's own | Recognized and armed, reply wakes the assistant |
| Human reacts to / edits / deletes the assistant's own top-level post in an unsubscribed channel | Dropped | Forwarded for the root's TTL |
| Same events on a message the assistant did not post | Dropped | Still dropped |
| Assistant posts top-level in a DM or group DM | Everything there is already admitted | Unchanged: no root armed, it would buy nothing |
| Assistant is added to a channel (`channel_join`, other system subtypes) | Nothing armed | Nothing armed |
| Assistant replies inside an existing thread | Thread armed for 24h | Unchanged |
| Assistant threads a follow-up under its own unanswered post | n/a | Stays speculative: admission refreshed, still out of catch-up |
| Reconnect catch-up after sleep/wake | One `conversations.replies` call per tracked thread | Unchanged: roots nobody replied to are never enumerated |
| Someone deletes the assistant's own `bot_message`-shaped post | Forwarded to the daemon | Dropped, matching how a user-attributed assistant post already behaved |

## Why this is needed

Every proactive thing the assistant says in a channel is a conversation opener. Before this, the assistant could start a conversation it was structurally incapable of hearing the answer to — and the failure was silent on both sides: the human sees their reply sitting in the thread, and the assistant has no idea it was addressed. That is the worst shape a messaging bug can take, because nothing about it looks broken.

## Why this is the right fix, and where it stops

**This is a compensating mechanism, not the root fix, and it is worth being blunt about that.** The root cause is that outbound Slack posts do not go through the gateway at all: the skill posts via `assistant oauth request --provider slack_channel`, and the messaging adapter posts directly. The gateway therefore learns that the assistant said something only by watching Slack echo it back. Every awkward part of this PR descends from that one fact — the echo-sniffing, the TTL that has to *guess* how long a reply might take, the subtype question, and speculative rows existing at all.

[LUM-2942](https://linear.app/vellum/issue/LUM-2942) is the root fix: route outbound through the gateway so the conversation is registered at send time, from the send itself, with no inference.

Worth being precise about what that deletes, because it is less than it sounds. **The inference layer goes away entirely**: `maybeTrackBotOwnPost`, `isOwnBotEvent`, the `bot_id` plumbing and its retry, the subtype allowlist, and the direct-like guard all exist only to work out whether an inbound echo was ours and whether it was a real post. Registration at send time knows all of that for free.

**The storage and policy layer survives**, because it is not about inference at all. "The assistant opened a conversation and nobody has answered yet" is still true when the gateway learns it from the send: such a root still must admit replies, still must stay out of the reconnect catch-up fan-out until a human engages, still needs a shorter TTL than an answered thread, and still must not be promoted by the assistant's own follow-ups. `speculative_root_at`, `armSpeculativeThreadRoot`, the `listActiveThreadsWithChannel` exclusion, `trackThreadAfterBotReply`, and the TTL split all carry over and simply get called from the send path instead of the echo path.

Given that, the standard this PR is held to is: *be a correct and complete compensating mechanism that does not create new problems, and do not accrete more inference than the root fix will delete.* Concretely:

1. **Marked distinctly.** A new nullable `speculative_root_at` column; `listActiveThreadsWithChannel` skips those rows. This is the constraint that made the first attempt unshippable: every row in `slack_active_threads` costs one tier-3 `conversations.replies` call on **every** reconnect, and the assistant posts continuously, so fanning out over never-answered roots would burn the Slack rate limit that recovery of genuinely missed messages depends on. A laptop sleep/wake is the case that matters.
2. **Only a human promotes.** A human reply clears the marker via `trackThread` and moves the row into the catch-up set. The assistant threading follow-ups under its own unanswered post explicitly does **not** (`trackThreadAfterBotReply`) — otherwise it could manufacture a catch-up row with nobody on the other end.
3. **Shorter TTL** (4h, vs 24h for an inbound thread). This bounds only roots nobody engaged with; a promoted root immediately gets the full lifetime.
4. **Only where it buys admission.** DMs and group DMs already admit every message without a tracked thread, so no root is armed there.
5. **Only for real posts.** `classifySlackEvent` reports `kind: "message"` for bot-authored system subtypes too; those open no conversation.
6. **Both attribution shapes.** `bot_id` is resolved from `auth.test`, persisted alongside `user_id`, and matched exactly (and only when `user` is absent), so the app-attributed shape is recognized while other apps' posts are never mistaken for ours.

## Why this is safe

- **Additive migration.** A nullable column applied by the existing declarative schema push (`schema.ts` is the source of truth; the gateway has no migration files). Existing rows read NULL — non-speculative — which is correct: they were armed by real engagement and keep their catch-up coverage.
- **No new Slack API traffic.** Roots are armed from an echo the gateway already receives and already drops. The direct-like guard reads the payload's own `channel_type` rather than the observed-kind cache, which would fire a background `conversations.info` per channel per cache TTL. A test asserts the echo path issues **zero** Slack API calls.
- **Catch-up budget unchanged by construction**, pinned end to end: `replayMissedEvents` issues no `conversations.replies` for a speculative root, and does issue one once a human reply promotes it.
- **Bounded growth.** Speculative rows are reaped by the existing hourly `cleanupExpiredThreads` sweep once the 4h TTL lapses.
- **Insert-only arming.** A re-delivered echo cannot downgrade a root a human has since replied into, nor stomp an explicit-detach (mute) marker. Muted threads stay muted.
- **Fail-closed identity.** An unresolved `bot_id` matches nothing rather than matching everything.
- **The widened surface is deliberate and tested.** An armed root also lets a reaction, edit, or delete on the assistant's own post through in an unsubscribed channel, because all three consult `hasThread` on the target's `ts`. That is the intended reading of "wake on responses to what the assistant said"; each case is paired with a test of the same event on a message the assistant did **not** post, which still drops.
- Every behavioural test here was verified to fail without its change and pass with it.

## Known limitations

- **The inference itself**, as above: the gateway infers "the assistant opened a conversation" from an echo. LUM-2942 removes it.
- **A reply that arrives under a never-answered root while the socket is down is not recovered** by reconnect catch-up. That is the deliberate trade for not fanning out over speculative rows. Once any reply is admitted live, the row is promoted and later reconnects cover it.
- **A delete of the assistant's own post is not forwarded to the daemon**, for either attribution shape. That was already true for user-attributed posts (the self-filter matches `previous_message.user`); this PR makes the `bot_message` shape consistent with it rather than leaving the two divergent. Worth revisiting separately: the "author" of a `message_deleted` event is the deleted message's author, not whoever deleted it, so self-filtering on it suppresses a signal the daemon might legitimately want. Changing that would widen admission and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
