### PR TITLE
feat(home): give home-feed items a real headline

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21436,6 +21436,7 @@ paths:
                   minLength: 1
                   description: Feed item id (notif:<uuid>) or bare uuid
                 title:
+                  description: New title. An empty value is ignored, never cleared.
                   type: string
                 body:
                   type: string

--- a/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-137-repair-retired-fireworks-minimax-model-id.test.ts
@@ -47,15 +47,15 @@ afterEach(() => {
 });
 
 describe("137-repair-retired-fireworks-minimax-model-id migration", () => {
-  test("has correct migration id and is registered last", () => {
+  test("has correct migration id and is registered", () => {
     expect(repairRetiredFireworksMinimaxModelIdMigration.id).toBe(
       "137-repair-retired-fireworks-minimax-model-id",
     );
-    // getLastWorkspaceMigrationId() reports the final entry as the registry
-    // ceiling, so the highest id must stay last.
-    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
-      "137-repair-retired-fireworks-minimax-model-id",
-    );
+    expect(
+      WORKSPACE_MIGRATIONS.some(
+        (m) => m.id === "137-repair-retired-fireworks-minimax-model-id",
+      ),
+    ).toBe(true);
   });
 
   test("repairs the retired ID in default, call sites, and profiles", () => {

--- a/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
@@ -9,9 +9,12 @@
  *   1. Missing file, malformed JSON, and a non-object root are no-ops.
  *   2. Title-less items gain a first-sentence title from the summary.
  *   3. Items that already have a title are untouched.
- *   4. A long summary truncates to 40 characters with an ellipsis.
- *   5. `version`, `updatedAt`, and unrelated item fields are preserved.
- *   6. A second run writes nothing.
+ *   4. A long summary truncates to 60 characters with an ellipsis, the
+ *      same cap the notification pipeline's derivation applies.
+ *   5. Markdown-rich and multi-line summaries yield a single line of
+ *      plain text.
+ *   6. `version`, `updatedAt`, and unrelated item fields are preserved.
+ *   7. A second run writes nothing.
  */
 
 import {
@@ -169,7 +172,7 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
     expect(items[1]!.title).toBe("Needs a headline.");
   });
 
-  test("truncates a long summary to 40 characters with an ellipsis", () => {
+  test("truncates a long summary to 60 characters with an ellipsis", () => {
     const summary =
       "Bob shared a very long document that keeps going well past the limit";
     writeFeed([makeItem({ id: "long", summary })]);
@@ -177,9 +180,11 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
     backfillHomeFeedTitlesMigration.run(workspaceDir);
 
     const title = readFeedFile().items[0]!.title as string;
-    expect(title).toBe("Bob shared a very long document that kee…");
-    // The ellipsis sits past the cap, so the retained text is exactly 40.
-    expect(title.slice(0, -1).length).toBe(40);
+    expect(title).toBe(
+      "Bob shared a very long document that keeps going well past t…",
+    );
+    // The ellipsis sits past the cap, so the retained text is exactly 60.
+    expect(title.slice(0, -1).length).toBe(60);
   });
 
   test("truncates a long first sentence rather than the whole summary", () => {
@@ -187,14 +192,64 @@ describe("workspace migration 138-backfill-home-feed-titles", () => {
       makeItem({
         id: "long-sentence",
         summary:
-          "This opening sentence runs well beyond the forty character cap. Then another.",
+          "This opening sentence runs well beyond the sixty character cap on derived titles. Then another.",
       }),
     ]);
 
     backfillHomeFeedTitlesMigration.run(workspaceDir);
 
     const title = readFeedFile().items[0]!.title as string;
-    expect(title).toBe("This opening sentence runs well beyond t…");
+    expect(title).toBe(
+      "This opening sentence runs well beyond the sixty character c…",
+    );
+  });
+
+  test("flattens a markdown-rich multi-line summary into one plain line", () => {
+    writeFeed([
+      makeItem({
+        id: "markdown",
+        summary:
+          "## Nightly run\n\n- **Deploy** finished\n- Tests passed\n\nSee the `report` for details.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe(
+      "Nightly run Deploy finished Tests passed See the report for…",
+    );
+  });
+
+  test("unwraps inline markdown before taking the first sentence", () => {
+    writeFeed([
+      makeItem({
+        id: "inline",
+        summary:
+          "**Alice** shared the [design doc](https://example.com/doc). Review it soon.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe("Alice shared the design doc.");
+  });
+
+  test("collapses a newline-only summary run into single spaces", () => {
+    writeFeed([
+      makeItem({ id: "newlines", summary: "Backup complete\n\nNo errors" }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBe("Backup complete No errors");
+  });
+
+  test("skips an item whose summary is markdown structure only", () => {
+    writeFeed([makeItem({ id: "structure-only", summary: "##\n\n- \n\n> " })]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFeedFile().items[0]!.title).toBeUndefined();
   });
 
   test("preserves version, updatedAt, and unrelated item fields", () => {

--- a/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-138-backfill-home-feed-titles.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for workspace migration `138-backfill-home-feed-titles`.
+ *
+ * The migration gives every item in `<workspace>/data/home-feed.json` a
+ * non-empty `title`, derived from the item's own `summary` when the
+ * field is missing or blank.
+ *
+ * Cases covered:
+ *   1. Missing file, malformed JSON, and a non-object root are no-ops.
+ *   2. Title-less items gain a first-sentence title from the summary.
+ *   3. Items that already have a title are untouched.
+ *   4. A long summary truncates to 40 characters with an ellipsis.
+ *   5. `version`, `updatedAt`, and unrelated item fields are preserved.
+ *   6. A second run writes nothing.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backfillHomeFeedTitlesMigration } from "../workspace/migrations/138-backfill-home-feed-titles.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
+
+let workspaceDir: string;
+let feedPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-138-test-"));
+  feedPath = join(workspaceDir, "data", "home-feed.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeFeedFile(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data"), { recursive: true });
+  writeFileSync(feedPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readFeedFile(): {
+  version: number;
+  items: Array<Record<string, unknown>>;
+  updatedAt: string;
+} {
+  return JSON.parse(readFileSync(feedPath, "utf-8"));
+}
+
+function makeItem(
+  overrides: Record<string, unknown> & { id: string },
+): Record<string, unknown> {
+  return {
+    type: "notification",
+    priority: 50,
+    summary: "Something happened.",
+    timestamp: "2026-08-01T12:00:00.000Z",
+    status: "new",
+    createdAt: "2026-08-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function writeFeed(items: Array<Record<string, unknown>>): void {
+  writeFeedFile({
+    version: 2,
+    updatedAt: "2026-08-01T12:00:00.000Z",
+    items,
+  });
+}
+
+describe("workspace migration 138-backfill-home-feed-titles", () => {
+  test("has the expected id and description", () => {
+    expect(backfillHomeFeedTitlesMigration.id).toBe(
+      "138-backfill-home-feed-titles",
+    );
+    expect(backfillHomeFeedTitlesMigration.description).toContain("title");
+  });
+
+  // getLastWorkspaceMigrationId() reports the final array entry as the
+  // registry ceiling to the identity and rollback routes, so the
+  // highest-numbered migration must sit last in the registry.
+  test("the registry ceiling stays at the highest-numbered migration", () => {
+    const numericId = (id: string) => Number.parseInt(id, 10);
+    const highest = Math.max(
+      ...WORKSPACE_MIGRATIONS.map((m) => numericId(m.id)).filter(
+        Number.isFinite,
+      ),
+    );
+    const last = getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS);
+    expect(last).not.toBeNull();
+    expect(numericId(last!)).toBe(highest);
+  });
+
+  test("missing file is a no-op (no error, no file created)", () => {
+    expect(existsSync(feedPath)).toBe(false);
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(existsSync(feedPath)).toBe(false);
+  });
+
+  test("derives a title from the summary's first sentence", () => {
+    writeFeed([
+      makeItem({
+        id: "a-1",
+        summary: "Alice replied to your thread. She needs an answer.",
+      }),
+      makeItem({ id: "a-2", summary: "Deploy finished!" }),
+      makeItem({ id: "a-3", summary: "Ready to review? The draft is up." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const titles = readFeedFile().items.map((item) => item.title);
+    expect(titles).toEqual([
+      "Alice replied to your thread.",
+      "Deploy finished!",
+      "Ready to review?",
+    ]);
+  });
+
+  test("backfills items whose title is missing, empty, blank, or not a string", () => {
+    writeFeed([
+      makeItem({ id: "missing", summary: "First item summary." }),
+      makeItem({ id: "empty", title: "", summary: "Second item summary." }),
+      makeItem({ id: "blank", title: "   ", summary: "Third item summary." }),
+      makeItem({ id: "wrong-type", title: null, summary: "Fourth summary." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const titles = readFeedFile().items.map((item) => item.title);
+    expect(titles).toEqual([
+      "First item summary.",
+      "Second item summary.",
+      "Third item summary.",
+      "Fourth summary.",
+    ]);
+  });
+
+  test("leaves items that already have a title untouched", () => {
+    writeFeed([
+      makeItem({
+        id: "titled",
+        title: "Existing headline",
+        summary: "A completely different summary sentence.",
+      }),
+      makeItem({ id: "untitled", summary: "Needs a headline." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const items = readFeedFile().items;
+    expect(items[0]!.title).toBe("Existing headline");
+    expect(items[1]!.title).toBe("Needs a headline.");
+  });
+
+  test("truncates a long summary to 40 characters with an ellipsis", () => {
+    const summary =
+      "Bob shared a very long document that keeps going well past the limit";
+    writeFeed([makeItem({ id: "long", summary })]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const title = readFeedFile().items[0]!.title as string;
+    expect(title).toBe("Bob shared a very long document that kee…");
+    // The ellipsis sits past the cap, so the retained text is exactly 40.
+    expect(title.slice(0, -1).length).toBe(40);
+  });
+
+  test("truncates a long first sentence rather than the whole summary", () => {
+    writeFeed([
+      makeItem({
+        id: "long-sentence",
+        summary:
+          "This opening sentence runs well beyond the forty character cap. Then another.",
+      }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const title = readFeedFile().items[0]!.title as string;
+    expect(title).toBe("This opening sentence runs well beyond t…");
+  });
+
+  test("preserves version, updatedAt, and unrelated item fields", () => {
+    writeFeedFile({
+      version: 2,
+      updatedAt: "2026-08-01T12:00:00.000Z",
+      items: [
+        makeItem({
+          id: "keep-fields",
+          summary: "Payment failed.",
+          urgency: "high",
+          conversationId: "conv-abc",
+          actions: [{ label: "Retry", kind: "prompt" }],
+          detailPanel: { kind: "text", body: "Details" },
+        }),
+      ],
+    });
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    const out = readFeedFile();
+    expect(out.version).toBe(2);
+    expect(out.updatedAt).toBe("2026-08-01T12:00:00.000Z");
+
+    const item = out.items[0]!;
+    expect(item.title).toBe("Payment failed.");
+    expect(item.id).toBe("keep-fields");
+    expect(item.type).toBe("notification");
+    expect(item.priority).toBe(50);
+    expect(item.status).toBe("new");
+    expect(item.urgency).toBe("high");
+    expect(item.conversationId).toBe("conv-abc");
+    expect(item.actions).toEqual([{ label: "Retry", kind: "prompt" }]);
+    expect(item.detailPanel).toEqual({ kind: "text", body: "Details" });
+  });
+
+  test("idempotent: a second run writes nothing", () => {
+    writeFeed([
+      makeItem({ id: "a-1", summary: "Alice replied to your thread." }),
+      makeItem({ id: "a-2", title: "Already titled", summary: "Body text." }),
+    ]);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+    const afterFirst = readFileSync(feedPath, "utf-8");
+    const afterFirstStat = statSync(feedPath);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(afterFirst);
+    expect(statSync(feedPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  test("a fully titled feed is left byte-identical", () => {
+    writeFeed([makeItem({ id: "a-1", title: "Titled", summary: "Body." })]);
+    const before = readFileSync(feedPath, "utf-8");
+    const beforeStat = statSync(feedPath);
+
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+    expect(statSync(feedPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  test("malformed JSON does not throw and leaves the file alone", () => {
+    mkdirSync(join(workspaceDir, "data"), { recursive: true });
+    writeFileSync(feedPath, "{not valid json", "utf-8");
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeFeedFile([1, 2, 3]);
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("items that cannot yield a title are skipped without throwing", () => {
+    writeFeedFile({
+      version: 2,
+      updatedAt: "2026-08-01T12:00:00.000Z",
+      items: [
+        "not an object",
+        makeItem({ id: "no-summary", summary: undefined }),
+        makeItem({ id: "blank-summary", summary: "   " }),
+        makeItem({ id: "ok", summary: "Has a summary." }),
+      ],
+    });
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    const items: unknown[] = readFeedFile().items;
+    expect(items[0]).toBe("not an object");
+    expect((items[1] as Record<string, unknown>).title).toBeUndefined();
+    expect((items[2] as Record<string, unknown>).title).toBeUndefined();
+    expect((items[3] as Record<string, unknown>).title).toBe("Has a summary.");
+  });
+
+  test("down() is a no-op (forward-only migration)", () => {
+    writeFeed([makeItem({ id: "a-1", summary: "Alice replied." })]);
+    backfillHomeFeedTitlesMigration.run(workspaceDir);
+    const after = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      backfillHomeFeedTitlesMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(after);
+  });
+});

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -263,7 +263,8 @@ Examples:
         },
         {
           flags: "--title <title>",
-          description: "New short headline (≤ 8 words).",
+          description:
+            "New short headline (≤ 8 words). An empty value is ignored, so the existing title stays put.",
         },
         {
           flags: "--urgency <urgency>",

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -86,7 +86,7 @@ Examples:
         {
           flags: "--title <title>",
           description:
-            "Short headline (≤ 8 words). Always provide one — the auto-derived fallback just truncates --message.",
+            "Short headline. Titles over 40 characters are trimmed to fit, and one over 40 characters that also runs past 7 words is cut to its first 5. A title that reads like prose (a reasoning opener, or a full sentence ending in terminal punctuation) is discarded in favor of a headline derived from --message.",
         },
         {
           flags: "--urgency <urgency>",

--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -257,14 +257,49 @@ describe("parseFeedFile", () => {
     ).toThrow();
   });
 
-  test("throws when an item in the file is invalid", () => {
-    expect(() =>
-      parseFeedFile({
-        version: 2,
-        items: [{ ...minimalNotification(), priority: 999 }],
-        updatedAt: NOW_ISO,
-      }),
-    ).toThrow();
+  test("throws when `items` is missing entirely", () => {
+    expect(() => parseFeedFile({ version: 2, updatedAt: NOW_ISO })).toThrow();
+  });
+
+  test("throws when `updatedAt` is missing", () => {
+    expect(() => parseFeedFile({ version: 2, items: [] })).toThrow();
+  });
+
+  test("drops an invalid item but keeps the valid ones", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [
+        minimalNotification(),
+        { ...minimalNotification(), id: "notif-bad", priority: 999 },
+      ],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]?.id).toBe("notif-1");
+    expect(parsed.droppedCount).toBe(1);
+    expect(parsed.updatedAt).toBe(NOW_ISO);
+  });
+
+  test("reports droppedCount 0 for a fully valid file", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [minimalNotification(), notificationWithActions()],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.droppedCount).toBe(0);
+  });
+
+  test("returns an empty item list when every item is invalid", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [{ ...minimalNotification(), type: "banner" }, null, "nope"],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items).toEqual([]);
+    expect(parsed.droppedCount).toBe(3);
+    expect(parsed.version).toBe(2);
+    expect(parsed.updatedAt).toBe(NOW_ISO);
   });
 
   test("accepts a file with a noteworthy item", () => {

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -50,6 +50,7 @@ const {
   bulkSetFeedItemStatus,
   clearAllConversationIds,
   getHomeFeedPath,
+  patchFeedItemContent,
   patchFeedItemStatus,
   readHomeFeed,
   stripConversationIds,
@@ -403,6 +404,47 @@ describe("feed-writer", () => {
       } finally {
         spy.mockRestore();
       }
+    });
+  });
+
+  describe("patchFeedItemContent", () => {
+    test("trims and applies a non-empty title", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const result = await patchFeedItemContent("item-1", {
+        title: "  Renamed  ",
+      });
+
+      expect(result!.title).toBe("Renamed");
+      expect(readFileJson().items[0]!.title).toBe("Renamed");
+    });
+
+    test("ignores an empty or whitespace-only title instead of clearing it", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const empty = await patchFeedItemContent("item-1", { title: "" });
+      expect(empty!.title).toBe("Original");
+
+      const blank = await patchFeedItemContent("item-1", { title: "   \t" });
+      expect(blank!.title).toBe("Original");
+
+      expect(readFileJson().items[0]!.title).toBe("Original");
+    });
+
+    test("a summary-only patch leaves the title untouched", async () => {
+      await appendFeedItem(makeItem({ id: "item-1", title: "Original" }));
+
+      const result = await patchFeedItemContent("item-1", {
+        summary: "Fresh summary",
+      });
+
+      expect(result!.title).toBe("Original");
+      expect(result!.summary).toBe("Fresh summary");
+    });
+
+    test("returns null for an unknown id", async () => {
+      await appendFeedItem(makeItem({ id: "known" }));
+      expect(await patchFeedItemContent("unknown", { title: "x" })).toBeNull();
     });
   });
 

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -200,6 +200,23 @@ describe("feed-writer", () => {
       const feed = readHomeFeed();
       expect(feed.items).toEqual([]);
     });
+
+    test("keeps the valid items when a single row is malformed", () => {
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      const file = {
+        version: 2,
+        updatedAt: "2026-04-14T12:00:00.000Z",
+        items: [
+          makeItem({ id: "good" }),
+          { ...makeItem({ id: "bad" }), priority: 999 },
+        ],
+      };
+      writeFileSync(getHomeFeedPath(), JSON.stringify(file, null, 2), "utf-8");
+
+      const feed = readHomeFeed();
+      expect(feed.items).toHaveLength(1);
+      expect(feed.items[0]!.id).toBe("good");
+    });
   });
 
   describe("appendFeedItem", () => {

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -53,8 +53,6 @@ export interface HomeFeedFile {
   version: 2;
   items: z.infer<typeof FeedItemSchema>[];
   updatedAt: string;
-  /** In-memory only; never persisted. Set by `parseFeedFile`. */
-  droppedCount?: number;
 }
 
 /**
@@ -74,7 +72,8 @@ const homeFeedEnvelopeSchema = z.object({
  * feed. Throws a `ZodError` when the envelope itself is invalid (wrong
  * `version`, non-object input, missing `updatedAt`). Callers are
  * expected to log + recover (e.g. treat the file as empty). Individual
- * items that fail validation are dropped and counted in `droppedCount`
+ * items that fail validation are dropped and counted in `droppedCount`,
+ * an in-memory-only field on the return value that is never persisted,
  * so one malformed row cannot erase the rest of the feed.
  */
 export function parseFeedFile(

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -53,12 +53,17 @@ export interface HomeFeedFile {
   version: 2;
   items: z.infer<typeof FeedItemSchema>[];
   updatedAt: string;
+  /** In-memory only; never persisted. Set by `parseFeedFile`. */
+  droppedCount?: number;
 }
 
-/** Schema for the on-disk `home-feed.json` file. */
-const homeFeedFileSchema = z.object({
+/**
+ * Envelope schema for the on-disk `home-feed.json` file. Items stay
+ * unvalidated here so `parseFeedFile` can validate them one at a time.
+ */
+const homeFeedEnvelopeSchema = z.object({
   version: z.literal(2),
-  items: z.array(FeedItemSchema),
+  items: z.array(z.unknown()),
   updatedAt: z.string(),
 });
 
@@ -66,9 +71,32 @@ const homeFeedFileSchema = z.object({
  * Parse and validate a raw value read from `home-feed.json`.
  *
  * Used by the writer on read-back and by the HTTP route when serving the
- * feed. Throws a `ZodError` on any validation failure — callers are
- * expected to log + recover (e.g. treat the file as empty).
+ * feed. Throws a `ZodError` when the envelope itself is invalid (wrong
+ * `version`, non-object input, missing `updatedAt`). Callers are
+ * expected to log + recover (e.g. treat the file as empty). Individual
+ * items that fail validation are dropped and counted in `droppedCount`
+ * so one malformed row cannot erase the rest of the feed.
  */
-export function parseFeedFile(raw: unknown): HomeFeedFile {
-  return homeFeedFileSchema.parse(raw) as HomeFeedFile;
+export function parseFeedFile(
+  raw: unknown,
+): HomeFeedFile & { droppedCount: number } {
+  const envelope = homeFeedEnvelopeSchema.parse(raw);
+
+  const items: z.infer<typeof FeedItemSchema>[] = [];
+  let droppedCount = 0;
+  for (const rawItem of envelope.items) {
+    const result = FeedItemSchema.safeParse(rawItem);
+    if (result.success) {
+      items.push(result.data);
+    } else {
+      droppedCount++;
+    }
+  }
+
+  return {
+    version: envelope.version,
+    items,
+    updatedAt: envelope.updatedAt,
+    droppedCount,
+  };
 }

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -165,7 +165,8 @@ export async function patchFeedItemStatus(
  *
  * Only fields explicitly present on `patch` are touched. Pass an empty
  * object and the call is a no-op that returns the existing item (or
- * `null` if the id isn't on disk).
+ * `null` if the id isn't on disk). A `title` that trims to empty is
+ * ignored, so no edit path can strip a title off an existing item.
  */
 export interface FeedItemContentPatch {
   title?: string;
@@ -363,9 +364,8 @@ async function runWrite(): Promise<void> {
     const updated: FeedItem = { ...existing };
     if (patch.title !== undefined) {
       const trimmed = patch.title.trim();
-      if (trimmed.length === 0) {
-        delete updated.title;
-      } else {
+      // Blank titles are ignored: an item keeps its title once it has one.
+      if (trimmed.length > 0) {
         updated.title = trimmed;
       }
     }

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -68,7 +68,9 @@ export function getHomeFeedPath(): string {
  * Read the on-disk feed file, applying the stateless TTL filter.
  *
  * Returns an empty `HomeFeedFile` when the file is missing, unreadable,
- * or fails Zod validation — callers never see a throw from this path.
+ * or has an invalid envelope. Callers never see a throw from this path.
+ * Individual items that fail validation are dropped and warn-logged
+ * while the rest of the feed survives.
  * Items whose `expiresAt` is in the past are dropped from the returned
  * `items` array but are NOT rewritten to disk; the next append cycle
  * will persist the post-filter view naturally.
@@ -93,7 +95,7 @@ export function readHomeFeed(): HomeFeedFile {
     return empty;
   }
 
-  let parsed: HomeFeedFile;
+  let parsed: ReturnType<typeof parseFeedFile>;
   try {
     parsed = parseFeedFile(raw);
   } catch (err) {
@@ -102,6 +104,13 @@ export function readHomeFeed(): HomeFeedFile {
       "home-feed.json failed schema validation; returning empty",
     );
     return empty;
+  }
+
+  if (parsed.droppedCount > 0) {
+    log.warn(
+      { path, droppedCount: parsed.droppedCount },
+      "Dropped invalid items from home-feed.json",
+    );
   }
 
   const now = Date.now();

--- a/assistant/src/notifications/__tests__/copy-composer.test.ts
+++ b/assistant/src/notifications/__tests__/copy-composer.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for the notification copy-composer — specifically the fallback
- * path that composeFallbackCopy uses when the LLM is unavailable, and
- * the shared deriveTitle utility.
+ * Tests for the notification copy-composer: the fallback path that
+ * composeFallbackCopy uses when the LLM is unavailable, the normalization
+ * it applies to producer-supplied titles, and the shared deriveTitle
+ * utility.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -188,6 +189,55 @@ describe("composeFallbackCopy honors requestedMessage / requestedTitle", () => {
 
     expect(copy.vellum?.body).toBe("User-supplied content");
     expect(copy.vellum?.title).toBe("User Title");
+  });
+
+  test("strips markdown and quotes from a producer-supplied title", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "The deploy finished cleanly.",
+        requestedTitle: '"**Deploy** finished"',
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Deploy finished");
+  });
+
+  test("derives the title when requestedTitle reads as leaked prose", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "Backup finished. Nothing needs your attention.",
+        requestedTitle: "I need to generate a title for this notification",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Backup finished.");
+  });
+
+  test("derives the title when requestedTitle spans multiple lines", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "The nightly job is done.",
+        requestedTitle: "Nightly job\nsecond line",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("The nightly job is done.");
+  });
+
+  test("truncates an over-long requestedTitle to the shared title budget", () => {
+    const signal = makeSignal({
+      contextPayload: {
+        requestedMessage: "Body text",
+        requestedTitle:
+          "Alpha bravo charlie delta echo foxtrot golf hotel india juliett",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Alpha bravo charlie delta echo");
   });
 
   test("works with non-assistant_tool source channels", () => {

--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -55,9 +55,11 @@ mock.module("../../contacts/contact-store.js", () => ({
 // Provider mock. By default `sendMessage` throws so the pass-through paths
 // (which must skip the LLM) fail loudly if they reach the provider. LLM-path
 // tests override `providerSendMessage` to capture inputs.
+type ProviderSendOptions = { systemPrompt?: string; tools?: unknown[] };
+
 let providerSendMessage: (
   messages: unknown[],
-  opts: { systemPrompt?: string },
+  opts: ProviderSendOptions,
 ) => Promise<unknown> = () => {
   throw new Error(
     "provider.sendMessage should NOT be invoked for pass-through decisions",
@@ -66,7 +68,7 @@ let providerSendMessage: (
 
 mock.module("../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => ({
-    sendMessage: (messages: unknown[], opts: { systemPrompt?: string }) =>
+    sendMessage: (messages: unknown[], opts: ProviderSendOptions) =>
       providerSendMessage(messages, opts),
   }),
   createTimeout: () => ({
@@ -128,6 +130,24 @@ function makeAssistantReplySignal(
       visibleInSourceNow: false,
     },
     ...overrides,
+  };
+}
+
+/** A signal with no verbatim copy, so the engine takes the LLM path. */
+function makeLlmSignal(): NotificationSignal {
+  return {
+    signalId: "sig-llm-1",
+    createdAt: Date.now(),
+    sourceChannel: "scheduler",
+    sourceContextId: "schedule-1",
+    sourceEventName: "schedule.notify",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
   };
 }
 
@@ -485,23 +505,6 @@ describe("chat.assistant_reply pass-through in notification decision engine", ()
 });
 
 describe("recipient notes injection (ACL from gateway, notes joined locally)", () => {
-  function makeLlmSignal(): NotificationSignal {
-    return {
-      signalId: "sig-llm-notes-1",
-      createdAt: Date.now(),
-      sourceChannel: "scheduler",
-      sourceContextId: "schedule-1",
-      sourceEventName: "schedule.notify",
-      contextPayload: {},
-      attentionHints: {
-        requiresAction: false,
-        urgency: "low",
-        isAsyncBackground: false,
-        visibleInSourceNow: false,
-      },
-    };
-  }
-
   test("injects the guardian's local notes, resolved via the gateway contactId", async () => {
     guardianDeliveryFixture = [{ contactId: "contact-42" }];
     contactInfoFixture = { "contact-42": { notes: "Prefers terse updates." } };
@@ -531,5 +534,46 @@ describe("recipient notes injection (ACL from gateway, notes joined locally)", (
     await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
 
     expect(capturedSystemPrompt).not.toContain("<recipient-context>");
+  });
+});
+
+describe("decision tool title field specification", () => {
+  test("pins the length, form, and no-echo constraints in the tool schema", async () => {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+
+    let capturedTools: unknown[] | undefined;
+    providerSendMessage = async (_messages, opts) => {
+      capturedTools = opts.tools;
+      return {};
+    };
+
+    await evaluateSignal(makeLlmSignal(), ["vellum"] as NotificationChannel[]);
+
+    const tool = capturedTools?.[0] as {
+      input_schema: {
+        properties: {
+          renderedCopy: {
+            properties: Record<
+              string,
+              { properties: { title: { description: string } } }
+            >;
+          };
+        };
+      };
+    };
+    const description =
+      tool.input_schema.properties.renderedCopy.properties.vellum.properties
+        .title.description;
+
+    expect(description).toContain("2 to 5 words");
+    expect(description).toContain("40 characters");
+    expect(description).toContain("noun phrase");
+    expect(description).toContain(
+      "Do NOT restate, summarize, or echo the body",
+    );
+    expect(description).toContain("no markdown");
+    expect(description).toContain("Missing Context");
+    expect(description.match(/NOT '/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 });

--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -66,6 +66,10 @@ let providerSendMessage: (
   );
 };
 
+// Tool block the engine reads back from a provider response. Null drives the
+// deterministic fallback, so LLM-path tests set it before calling in.
+let toolUseBlock: { input: Record<string, unknown> } | null = null;
+
 mock.module("../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => ({
     sendMessage: (messages: unknown[], opts: ProviderSendOptions) =>
@@ -75,7 +79,7 @@ mock.module("../../providers/provider-send-message.js", () => ({
     signal: new AbortController().signal,
     cleanup: () => {},
   }),
-  extractToolUse: () => null,
+  extractToolUse: () => toolUseBlock,
   userMessage: (text: string) => ({ role: "user", content: text }),
 }));
 
@@ -575,5 +579,87 @@ describe("decision tool title field specification", () => {
     expect(description).toContain("no markdown");
     expect(description).toContain("Missing Context");
     expect(description.match(/NOT '/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("title normalization", () => {
+  /** Run the LLM path with the given channel copy and return the kept title. */
+  async function titleFromModelCopy(
+    title: string,
+    body: string,
+  ): Promise<string | undefined> {
+    guardianDeliveryFixture = [];
+    contactInfoFixture = {};
+    const previousSendMessage = providerSendMessage;
+    providerSendMessage = async () => ({});
+    toolUseBlock = {
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "model decision",
+        dedupeKey: "title-normalization-test",
+        renderedCopy: { vellum: { title, body } },
+      },
+    };
+
+    try {
+      const decision = await evaluateSignal(makeLlmSignal(), [
+        "vellum",
+      ] as NotificationChannel[]);
+      return decision.renderedCopy.vellum?.title;
+    } finally {
+      toolUseBlock = null;
+      providerSendMessage = previousSendMessage;
+    }
+  }
+
+  test("replaces a model title that restates the body with a derived one", async () => {
+    const title = "The staging deploy finished and the build is live.";
+    const body = `Deploy complete. ${title}`;
+
+    expect(await titleFromModelCopy(title, body)).toBe("Deploy complete.");
+  });
+
+  test("keeps a clean model title verbatim", async () => {
+    expect(
+      await titleFromModelCopy(
+        "Staging Deploy Status",
+        "The staging deploy finished.",
+      ),
+    ).toBe("Staging Deploy Status");
+  });
+
+  test("truncates a model title longer than 40 characters", async () => {
+    const kept = await titleFromModelCopy(
+      "Quarterly Infrastructure Migration Status Report",
+      "The migration is on track for the quarter.",
+    );
+
+    expect(kept).toBe("Quarterly Infrastructure Migration");
+    expect(kept?.length).toBeLessThanOrEqual(40);
+  });
+
+  test("strips markdown from a model title", async () => {
+    expect(
+      await titleFromModelCopy(
+        "**Deploy Status**",
+        "The staging deploy finished.",
+      ),
+    ).toBe("Deploy Status");
+  });
+
+  test("replaces a pass-through requestedTitle that stutters against the body", async () => {
+    const requestedTitle = "The nightly backup finished without any errors.";
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: `Backup finished. ${requestedTitle}`,
+        requestedTitle,
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+    ] as NotificationChannel[]);
+
+    expect(decision.renderedCopy.vellum?.title).toBe("Backup finished.");
   });
 });

--- a/assistant/src/notifications/__tests__/edit-notification.test.ts
+++ b/assistant/src/notifications/__tests__/edit-notification.test.ts
@@ -1,0 +1,330 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { FeedItem } from "../../home/feed-types.js";
+import type { NotificationDeliveryRow } from "../deliveries-store.js";
+
+// ── Module mocks ───────────────────────────────────────────────────────
+//
+// The home-feed writer is deliberately NOT mocked: these tests exercise
+// the real on-disk patch semantics through a temp workspace so the
+// "an empty title never clears the field" guarantee is covered end to
+// end. Only the sqlite-backed stores, the broadcaster, and the SSE hub
+// are intercepted.
+
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: async () => {},
+    subscribe: () => () => {},
+  },
+  broadcastMessage: () => {},
+}));
+
+let decisionRow: { id: string } | null = null;
+let deliveryRows: NotificationDeliveryRow[] = [];
+const renderedCopyPatches: Array<{
+  id: string;
+  patch: { renderedTitle?: string; renderedBody?: string };
+}> = [];
+
+mock.module("../decisions-store.js", () => ({
+  findLatestDecisionByEventId: () => decisionRow,
+}));
+
+mock.module("../deliveries-store.js", () => ({
+  findDeliveriesByDecisionId: () => deliveryRows,
+  updateDeliveryRenderedCopy: (
+    id: string,
+    patch: { renderedTitle?: string; renderedBody?: string },
+  ) => {
+    renderedCopyPatches.push({ id, patch });
+    return true;
+  },
+}));
+
+const adapterUpdates: Array<{ title?: string; body?: string }> = [];
+let adapterSupportsUpdate = true;
+
+mock.module("../emit-signal.js", () => ({
+  getBroadcaster: () => ({
+    getAdapter: () =>
+      adapterSupportsUpdate
+        ? {
+            update: async (
+              _target: unknown,
+              patch: { title?: string; body?: string },
+            ) => {
+              adapterUpdates.push(patch);
+              return { success: true };
+            },
+          }
+        : {},
+  }),
+}));
+
+const { appendFeedItem, readHomeFeed } =
+  await import("../../home/feed-writer.js");
+const { editNotification, normalizeFeedItemId, feedItemIdToSignalId } =
+  await import("../edit-notification.js");
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+const SIGNAL_ID = "sig-1";
+const FEED_ITEM_ID = `notif:${SIGNAL_ID}`;
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: FEED_ITEM_ID,
+    type: "notification",
+    priority: 50,
+    title: "Backup complete",
+    summary: "Nightly backup finished",
+    timestamp: "2026-04-14T12:00:00.000Z",
+    status: "new",
+    createdAt: "2026-04-14T12:00:00.000Z",
+    ...overrides,
+  } as FeedItem;
+}
+
+function makeDelivery(
+  overrides: Partial<NotificationDeliveryRow> = {},
+): NotificationDeliveryRow {
+  return {
+    id: "del-1",
+    notificationDecisionId: "dec-1",
+    channel: "slack",
+    destination: "C123",
+    status: "sent",
+    attempt: 1,
+    renderedTitle: "Backup complete",
+    renderedBody: "Nightly backup finished",
+    errorCode: null,
+    errorMessage: null,
+    sentAt: 1700000000000,
+    conversationId: null,
+    messageId: "1700000000.0001",
+    conversationStrategy: null,
+    conversationAction: null,
+    conversationTargetId: null,
+    conversationFallbackUsed: null,
+    clientDeliveryStatus: null,
+    clientDeliveryError: null,
+    clientDeliveryAt: null,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+function readItem(id = FEED_ITEM_ID): FeedItem | undefined {
+  return readHomeFeed().items.find((item) => item.id === id);
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-edit-notif-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  decisionRow = null;
+  deliveryRows = [];
+  renderedCopyPatches.length = 0;
+  adapterUpdates.length = 0;
+  adapterSupportsUpdate = true;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("normalizeFeedItemId", () => {
+  test("adds the notif: prefix to a bare uuid and leaves prefixed ids alone", () => {
+    expect(normalizeFeedItemId(SIGNAL_ID)).toBe(FEED_ITEM_ID);
+    expect(normalizeFeedItemId(` ${FEED_ITEM_ID} `)).toBe(FEED_ITEM_ID);
+    expect(feedItemIdToSignalId(FEED_ITEM_ID)).toBe(SIGNAL_ID);
+  });
+});
+
+describe("editNotification", () => {
+  test("applies a title edit to the feed item", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.feedItem.title).toBe("Backup finished early");
+    expect(readItem()!.title).toBe("Backup finished early");
+    expect(readItem()!.summary).toBe("Nightly backup finished");
+  });
+
+  test("accepts a bare signal uuid as the id", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: SIGNAL_ID,
+      title: "Renamed via bare id",
+    });
+
+    expect(result!.feedItem.id).toBe(FEED_ITEM_ID);
+    expect(readItem()!.title).toBe("Renamed via bare id");
+  });
+
+  test("an empty title edit leaves the previous title intact", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "" });
+
+    expect(result).not.toBeNull();
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("a whitespace-only title edit leaves the previous title intact", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "   \t" });
+
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("an empty title edit does not push a channel update", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({ id: FEED_ITEM_ID, title: "" });
+
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+    expect(renderedCopyPatches).toHaveLength(0);
+  });
+
+  test("a body-only edit does not disturb the title", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      body: "Nightly backup finished in 4 minutes",
+    });
+
+    expect(result!.feedItem.title).toBe("Backup complete");
+    expect(result!.feedItem.summary).toBe(
+      "Nightly backup finished in 4 minutes",
+    );
+    expect(readItem()!.title).toBe("Backup complete");
+  });
+
+  test("a feed-only edit skips channel updates entirely", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      status: "dismissed",
+    });
+
+    expect(result!.feedItem.status).toBe("dismissed");
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+  });
+
+  test("returns null for an unknown id", async () => {
+    await appendFeedItem(makeItem());
+
+    const result = await editNotification({
+      id: "notif:does-not-exist",
+      title: "Nope",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("pushes the new copy to update-capable channel deliveries", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+      body: "Done in 4 minutes",
+    });
+
+    expect(adapterUpdates).toEqual([
+      { title: "Backup finished early", body: "Done in 4 minutes" },
+    ]);
+    expect(renderedCopyPatches).toEqual([
+      {
+        id: "del-1",
+        patch: {
+          renderedTitle: "Backup finished early",
+          renderedBody: "Done in 4 minutes",
+        },
+      },
+    ]);
+    expect(result!.channels).toEqual([
+      { channel: "slack", deliveryId: "del-1", outcome: "updated" },
+    ]);
+  });
+
+  test("reports channels whose adapter cannot edit in place as unsupported", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery()];
+    adapterSupportsUpdate = false;
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels[0]!.outcome).toBe("unsupported");
+    expect(renderedCopyPatches).toHaveLength(0);
+  });
+
+  test("skips deliveries that never reached sent", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = { id: "dec-1" };
+    deliveryRows = [makeDelivery({ status: "failed" })];
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels[0]!.outcome).toBe("skipped");
+    expect(adapterUpdates).toHaveLength(0);
+  });
+
+  test("skips channel updates when the feed item has no persisted decision", async () => {
+    await appendFeedItem(makeItem());
+    decisionRow = null;
+
+    const result = await editNotification({
+      id: FEED_ITEM_ID,
+      title: "Backup finished early",
+    });
+
+    expect(result!.channels).toEqual([]);
+    expect(adapterUpdates).toHaveLength(0);
+  });
+});

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -384,39 +384,41 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.title).toBe("Payload headline");
   });
 
-  test("rejects a payload title that restates the summary in favour of the rendered title", async () => {
-    // Shape seen in real on-disk feed data: a payload title that is just the
-    // opening words of the summary.
+  test("keeps a payload title that opens the summary", async () => {
+    // A correct topic headline is usually the opening noun phrase of the body,
+    // so an authored title that overlaps the summary still wins.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
-      contextPayload: { title: "Test notifications" },
+      contextPayload: { title: "Nightly Backup Failure" },
     });
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
           title: "Reminder plumbing check",
-          body: "Test notifications reminder.",
+          body: "Nightly backup failure on db-primary at 02:14. Retry scheduled.",
         },
       },
     });
 
     const item = await writeHomeFeedItemForSignal(signal, decision);
 
-    expect(item?.title).toBe("Reminder plumbing check");
-    expect(appendCalls[0]!.summary).toBe("Test notifications reminder.");
+    expect(item?.title).toBe("Nightly Backup Failure");
+    expect(appendCalls[0]!.summary).toBe(
+      "Nightly backup failure on db-primary at 02:14. Retry scheduled.",
+    );
   });
 
-  test("derives a title from the summary when every authored candidate restates it", async () => {
+  test("keeps a payload title that matches the summary's first sentence", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
-      contextPayload: { title: "Test notifications" },
+      contextPayload: { title: "Test notifications reminder." },
     });
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
-          title: "Test notifications reminder.",
+          title: "Model headline",
           body: "Test notifications reminder. It fired on schedule.",
         },
       },
@@ -451,6 +453,51 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item?.title).toBe("Disk usage crossed 90 percent.");
     expect(appendCalls[0]!.title).toBeTruthy();
+  });
+
+  test("derives a single-line plain title from a markdown-headed conversation seed", async () => {
+    // The summary prefers `conversationSeedMessage`, which carries structured
+    // markdown and hard line breaks. The derived title must not.
+    conversationRow = { conversationType: "background" };
+    const seed =
+      "## Nightly Backup Report\n\nThe backup job on db-primary failed at 02:14.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "The backup job failed.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe(
+      "Nightly Backup Report The backup job on db-primary failed at…",
+    );
+    expect(item?.summary).toBe(seed);
+  });
+
+  test("derives a single-line plain title from a markdown-list conversation seed", async () => {
+    conversationRow = { conversationType: "background" };
+    const seed = "- Ran 12 checks\n- 3 failed\n\nSee the log for details.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "Check run finished.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Ran 12 checks 3 failed See the log for details.");
+    expect(item?.summary).toBe(seed);
   });
 
   test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -480,6 +480,29 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(item?.summary).toBe(seed);
   });
 
+  test("strips tilde fences and indented headings, matching migration 138", async () => {
+    // Workspace migration 138 backfills titles with its own self-contained copy
+    // of these rules. A backfilled title and a freshly written one must match
+    // for the same summary, so both accept CommonMark's 3-space indent and both
+    // fence styles.
+    conversationRow = { conversationType: "background" };
+    const seed = "   ## Indented heading\n\n~~~\ntilde fence\n~~~\nBody text.";
+    const signal = makeSignal({ sourceEventName: "example.event" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "",
+          body: "Body text.",
+          conversationSeedMessage: seed,
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Indented heading tilde fence Body text.");
+  });
+
   test("derives a single-line plain title from a markdown-list conversation seed", async () => {
     conversationRow = { conversationType: "background" };
     const seed = "- Ran 12 checks\n- 3 failed\n\nSee the log for details.";

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -320,11 +320,9 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls).toHaveLength(0);
   });
 
-  test("writes a feed item with undefined title when only the body is available", async () => {
-    // Regression: when `notifications send` is called without `--title`, the
-    // notification pipeline must not manufacture a title (the LLM's rendered
-    // copy echoes the body into `renderedCopy.title`). Leave `title`
-    // undefined so renderers fall back to `summary` instead of stuttering.
+  test("derives a title from the summary when only the body is available", async () => {
+    // With no authored candidate at all, the title is derived from the
+    // summary rather than left off: every row carries a headline.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
@@ -335,14 +333,14 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
-    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.title).toBe("Real body");
     expect(appendCalls[0]!.summary).toBe("Real body");
   });
 
-  test("ignores LLM-rendered title when no payload title was supplied", async () => {
-    // The LLM often echoes the body verbatim into `renderedCopy.title` when
-    // the source didn't pass one. The home-feed writer must NOT promote that
-    // echo into the feed item — only an explicit source title is honored.
+  test("uses the LLM-rendered title when no payload title was supplied", async () => {
+    // The model authors `renderedCopy.title` as a topic headline, and the
+    // decision engine validates it before it gets here, so it is the second
+    // candidate after the payload title.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
@@ -351,7 +349,7 @@ describe("writeHomeFeedItemForSignal", () => {
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
-          title: "Real body",
+          title: "Nightly sync finished",
           body: "Real body",
         },
       },
@@ -361,8 +359,98 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
-    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.title).toBe("Nightly sync finished");
     expect(appendCalls[0]!.summary).toBe("Real body");
+  });
+
+  test("payload title wins over the rendered title when it is clean", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Payload headline" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Model headline",
+          body: "A description of what the run did.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Payload headline");
+    expect(appendCalls[0]!.title).toBe("Payload headline");
+  });
+
+  test("rejects a payload title that restates the summary in favour of the rendered title", async () => {
+    // Shape seen in real on-disk feed data: a payload title that is just the
+    // opening words of the summary.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Test notifications" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Reminder plumbing check",
+          body: "Test notifications reminder.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Reminder plumbing check");
+    expect(appendCalls[0]!.summary).toBe("Test notifications reminder.");
+  });
+
+  test("derives a title from the summary when every authored candidate restates it", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Test notifications" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Test notifications reminder.",
+          body: "Test notifications reminder. It fired on schedule.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Test notifications reminder.");
+    expect(appendCalls[0]!.summary).toBe(
+      "Test notifications reminder. It fired on schedule.",
+    );
+  });
+
+  test("always writes a non-empty title even when the copy is unusable", async () => {
+    // `normalizeTitle` rejects prose-shaped candidates, so both authored
+    // titles drop out and the derivation carries the row.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "I need to name this notification somehow" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Let me summarize what happened",
+          body: "Disk usage crossed 90 percent. Cleanup ran.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision);
+
+    expect(item?.title).toBe("Disk usage crossed 90 percent.");
+    expect(appendCalls[0]!.title).toBeTruthy();
   });
 
   test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -9,6 +9,7 @@
  * values from the context payload.
  */
 
+import { normalizeTitle } from "../util/short-title.js";
 import {
   accessRequestCardTitle,
   buildAccessRequestContractText,
@@ -58,6 +59,24 @@ export function deriveTitle(body: string): string {
   return candidate.length > NOTIFICATION_TITLE_MAX_LENGTH
     ? candidate.slice(0, NOTIFICATION_TITLE_MAX_LENGTH).trim() + "\u2026"
     : candidate.trim();
+}
+
+/**
+ * Clean a producer-authored title, falling back to one derived from the body
+ * when `normalizeTitle` returns its empty-string rejection signal.
+ *
+ * The decision engine's pass-through path applies the same clamp, so a signal
+ * carrying `requestedTitle` renders the same headline whether or not the LLM
+ * classifier was reachable.
+ *
+ * The two branches carry different budgets. An accepted authored title is
+ * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
+ * `deriveTitle`, which never sees the normalizer and applies
+ * `NOTIFICATION_TITLE_MAX_LENGTH` (60) plus a trailing ellipsis, so a derived
+ * title can reach 61 characters.
+ */
+export function resolveTitle(raw: string | undefined, body: string): string {
+  return normalizeTitle(raw ?? "") || deriveTitle(body);
 }
 
 /**
@@ -291,9 +310,10 @@ export function composeFallbackCopy(
     readPayloadString(signal.contextPayload, "requestedMessage"),
   );
   if (msg) {
-    const title =
-      nonEmpty(readPayloadString(signal.contextPayload, "requestedTitle")) ??
-      deriveTitle(msg);
+    const title = resolveTitle(
+      readPayloadString(signal.contextPayload, "requestedTitle"),
+      msg,
+    );
     const baseCopy: RenderedChannelCopy = {
       title,
       body: msg,

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -26,7 +26,6 @@ import {
 } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
-import { normalizeTitle } from "../util/short-title.js";
 import { truncate } from "../util/truncate.js";
 import {
   buildAccessRequestContractText,
@@ -45,7 +44,7 @@ import {
   type ConversationCandidateSet,
   serializeCandidatesForPrompt,
 } from "./conversation-candidates.js";
-import { composeFallbackCopy, deriveTitle } from "./copy-composer.js";
+import { composeFallbackCopy, resolveTitle } from "./copy-composer.js";
 import { createDecision } from "./decisions-store.js";
 import {
   buildGuardianRequestCodeInstruction,
@@ -416,21 +415,6 @@ function buildFallbackDecision(
 // ── Validation ─────────────────────────────────────────────────────────
 
 const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
-
-/**
- * Clean a title authored elsewhere (the decision model, or a producer payload),
- * falling back to one derived from the body when `normalizeTitle` returns its
- * empty-string rejection signal.
- *
- * The two branches carry different budgets. An accepted authored title is
- * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
- * `deriveTitle`, which never sees the normalizer and applies the composer's own
- * `NOTIFICATION_TITLE_MAX_LENGTH` (60) cap plus a trailing ellipsis, so a
- * derived title can reach 61 characters.
- */
-function resolveTitle(raw: string | undefined, body: string): string {
-  return normalizeTitle(raw ?? "") || deriveTitle(body);
-}
 
 function validateDecisionOutput(
   input: Record<string, unknown>,

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -229,6 +229,26 @@ function buildUserPrompt(signal: NotificationSignal): string {
 
 // ── Tool definition ────────────────────────────────────────────────────
 
+/**
+ * Spec for the per-channel notification title. Mirrors the conversation title
+ * prompt (`persistence/conversation-title-service.ts`), which gets clean
+ * noun-phrase headlines out of this same model profile.
+ */
+const TITLE_FIELD_DESCRIPTION = [
+  "Scannable headline naming the TOPIC of this notification, not a summary of it.",
+  "Rules:",
+  "- 2 to 5 words. Longer titles are unacceptable, ruthlessly compress",
+  "- 40 characters absolute maximum, longer titles get truncated and look broken",
+  "- A noun phrase naming the topic, never a sentence, question, or greeting (e.g. 'Platform Standup', 'Nightly Backup Failure')",
+  "- Do NOT restate, summarize, or echo the body. The title and the body must carry different information",
+  "- No quotes, no markdown, no trailing punctuation",
+  "- Never describe missing or thin context. Titles like 'Notification', 'Update', 'Missing Context' are forbidden. Extract a topic from the words that ARE present",
+  "Examples:",
+  "- Body 'Your 9am standup with the platform team starts in 5 minutes' -> 'Platform Standup', NOT 'Standup Starts In 5 Minutes'",
+  "- Body 'The nightly backup job failed on db-primary at 02:14' -> 'Nightly Backup Failure', NOT 'Nightly Backup Job Failed On db-primary'",
+  "- Body 'Alice replied about the Q3 pricing deck and wants your notes' -> 'Q3 Pricing Deck', NOT 'Alice Replied About The Pricing Deck'",
+].join("\n");
+
 function buildDecisionTool(availableChannels: NotificationChannel[]) {
   return {
     name: "record_notification_decision",
@@ -264,7 +284,7 @@ function buildDecisionTool(availableChannels: NotificationChannel[]) {
                 properties: {
                   title: {
                     type: "string",
-                    description: "Short notification popup title (≤ 8 words)",
+                    description: TITLE_FIELD_DESCRIPTION,
                   },
                   body: {
                     type: "string",

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -422,9 +422,11 @@ const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
  * falling back to one derived from the body when `normalizeTitle` returns its
  * empty-string rejection signal.
  *
- * `normalizeTitle` is the last clamp a title passes through, so its 40-char
- * budget is the effective one. `NOTIFICATION_TITLE_MAX_LENGTH` (60) still bounds
- * `deriveTitle` and the control-character stripping in `notification-utils.ts`.
+ * The two branches carry different budgets. An accepted authored title is
+ * bounded by `normalizeTitle` at 40 characters. A rejected one falls through to
+ * `deriveTitle`, which never sees the normalizer and applies the composer's own
+ * `NOTIFICATION_TITLE_MAX_LENGTH` (60) cap plus a trailing ellipsis, so a
+ * derived title can reach 61 characters.
  */
 function resolveTitle(raw: string | undefined, body: string): string {
   return normalizeTitle(raw ?? "") || deriveTitle(body);

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -26,6 +26,7 @@ import {
 } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { normalizeTitle } from "../util/short-title.js";
 import { truncate } from "../util/truncate.js";
 import {
   buildAccessRequestContractText,
@@ -416,6 +417,19 @@ function buildFallbackDecision(
 
 const VALID_CHANNELS = new Set<string>(getDeliverableChannels());
 
+/**
+ * Clean a title authored elsewhere (the decision model, or a producer payload),
+ * falling back to one derived from the body when `normalizeTitle` returns its
+ * empty-string rejection signal.
+ *
+ * `normalizeTitle` is the last clamp a title passes through, so its 40-char
+ * budget is the effective one. `NOTIFICATION_TITLE_MAX_LENGTH` (60) still bounds
+ * `deriveTitle` and the control-character stripping in `notification-utils.ts`.
+ */
+function resolveTitle(raw: string | undefined, body: string): string {
+  return normalizeTitle(raw ?? "") || deriveTitle(body);
+}
+
 function validateDecisionOutput(
   input: Record<string, unknown>,
   availableChannels: NotificationChannel[],
@@ -465,7 +479,7 @@ function validateDecisionOutput(
             );
           }
           renderedCopy[ch] = {
-            title: c.title,
+            title: resolveTitle(c.title, c.body),
             body: c.body,
             deliveryText:
               typeof c.deliveryText === "string" ? c.deliveryText : undefined,
@@ -894,7 +908,8 @@ function ensureInviteFlowDirectiveInCopy(
 /**
  * Build, guard, and persist a decision whose copy came verbatim from the
  * producer, bypassing the LLM classifier. The title falls back to one derived
- * from the body when the producer supplies none.
+ * from the body when the producer supplies none or supplies one that fails
+ * normalization.
  *
  * `renderedCopy` and `conversationActions` are populated for every available
  * channel, not just `selectedChannels`: downstream guards (routing-intent
@@ -911,9 +926,10 @@ function buildPassThroughDecision(params: {
   reasoningSummary: string;
 }): NotificationDecision {
   const { availableChannels, body, signal } = params;
-  const title =
-    nonEmpty(readPayloadString(signal.contextPayload, "requestedTitle")) ??
-    deriveTitle(body);
+  const title = resolveTitle(
+    readPayloadString(signal.contextPayload, "requestedTitle"),
+    body,
+  );
   const deepLinkTarget = readPayloadObject(
     signal.contextPayload,
     "deepLinkMetadata",

--- a/assistant/src/notifications/edit-notification.ts
+++ b/assistant/src/notifications/edit-notification.ts
@@ -22,6 +22,7 @@ import {
   updateDeliveryRenderedCopy,
 } from "./deliveries-store.js";
 import { getBroadcaster } from "./emit-signal.js";
+import { nonEmpty } from "./notification-utils.js";
 import type { NotificationChannel } from "./types.js";
 
 const log = getLogger("edit-notification");
@@ -88,8 +89,12 @@ export async function editNotification(
 ): Promise<EditNotificationResult | null> {
   const feedItemId = normalizeFeedItemId(params.id);
 
+  // Titles are never cleared, so a blank one is dropped before it can
+  // reach the feed patch or a channel update.
+  const title = nonEmpty(params.title);
+
   const feedItem = await patchFeedItemContent(feedItemId, {
-    title: params.title,
+    title,
     summary: params.body,
     urgency: params.urgency,
     status: params.status,
@@ -102,8 +107,7 @@ export async function editNotification(
   // Only edit channel messages when the user-visible text changed.
   // Urgency/status are feed-only — pushing a channel update for those
   // alone would re-deliver the same body and confuse the recipient.
-  const shouldUpdateChannels =
-    params.title !== undefined || params.body !== undefined;
+  const shouldUpdateChannels = title !== undefined || params.body !== undefined;
   if (!shouldUpdateChannels) {
     return { feedItem, channels: [] };
   }
@@ -120,7 +124,7 @@ export async function editNotification(
 
   const deliveries = findDeliveriesByDecisionId(decision.id);
   const channels = await updateChannelDeliveries(deliveries, {
-    title: params.title,
+    title,
     body: params.body,
   });
 

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -20,7 +20,7 @@ import { appendFeedItem } from "../home/feed-writer.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { getLogger } from "../util/logger.js";
-import { normalizeTitle } from "../util/short-title.js";
+import { normalizeTitle, stripMarkdown } from "../util/short-title.js";
 import { isConversationSeedSane } from "./conversation-seed-composer.js";
 import { deriveTitle } from "./copy-composer.js";
 import { readPayloadString } from "./notification-utils.js";
@@ -89,12 +89,13 @@ export async function writeHomeFeedItemForSignal(
   }
 
   // Title order: payload, then the rendered copy, then a headline derived
-  // from the summary. The derivation always yields something, so every feed
-  // item lands with a title.
+  // from the summary. `normalizeTitle` returns "" for empty, prose-shaped, and
+  // meta-failure candidates; the derivation always yields something, so every
+  // feed item lands with a title.
   const resolvedTitle =
-    acceptTitle(payloadTitle, resolvedSummary) ??
-    acceptTitle(renderedCopy?.title, resolvedSummary) ??
-    deriveTitle(resolvedSummary);
+    normalizeTitle(payloadTitle ?? "") ||
+    normalizeTitle(renderedCopy?.title ?? "") ||
+    deriveFallbackTitle(resolvedSummary);
 
   const urgency = signal.attentionHints.urgency;
   const now = new Date().toISOString();
@@ -156,31 +157,30 @@ export async function writeHomeFeedItemForSignal(
 }
 
 /**
- * Clean an authored title (producer payload or model-rendered copy) and keep
- * it only when it says something the summary does not.
+ * Derive the terminal fallback headline from the summary.
  *
- * `normalizeTitle` returns "" for empty, prose-shaped, and meta-failure
- * titles. On top of that, a title that is a case-insensitive prefix of the
- * summary, or that matches the summary's first sentence, stutters against the
- * row's own body text. Rejection returns undefined so the caller falls
- * through to the next candidate.
+ * The summary is preferentially a conversation seed, which carries structured
+ * markdown and hard line breaks, so flatten it to plain single-line text
+ * before slicing a headline off the front. A non-empty summary always yields a
+ * non-empty title.
  */
-function acceptTitle(
-  raw: string | undefined,
-  summary: string,
-): string | undefined {
-  const candidate = normalizeTitle(raw ?? "");
-  if (!candidate) {
-    return undefined;
-  }
-  const lowered = candidate.toLowerCase();
-  if (summary.toLowerCase().startsWith(lowered)) {
-    return undefined;
-  }
-  if (lowered === deriveTitle(summary).toLowerCase()) {
-    return undefined;
-  }
-  return candidate;
+function deriveFallbackTitle(summary: string): string {
+  // Block markers are line-anchored, so they have to go before the whitespace
+  // collapse, and before `stripMarkdown` (whose inline-code rule would chew a
+  // fence into a stray backtick). Ordered markers matter most: the seed prompt
+  // asks the model for numbered lists, and a leading `1.` also reads as a
+  // sentence terminator, which would truncate the title to the first digit.
+  const deblocked = summary
+    .replace(/^[ \t]*```.*$/gm, "")
+    .replace(/^[ \t]*>[ \t]?/gm, "")
+    .replace(/^[ \t]*(?:[-*+]|\d+[.)])[ \t]+/gm, "");
+  const plain = flattenWhitespace(stripMarkdown(deblocked));
+  return deriveTitle(plain || flattenWhitespace(summary));
+}
+
+/** Collapse whitespace runs, including hard line breaks, into single spaces. */
+function flattenWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
 }
 
 // ── Category & detail-panel derivation ────────────────────────────────

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -170,10 +170,14 @@ function deriveFallbackTitle(summary: string): string {
   // fence into a stray backtick). Ordered markers matter most: the seed prompt
   // asks the model for numbered lists, and a leading `1.` also reads as a
   // sentence terminator, which would truncate the title to the first digit.
+  // The leading-space allowance and rule set mirror `flattenToPlainText` in
+  // workspace migration 138, which must stay self-contained and so cannot share
+  // this code. A backfilled title and a freshly written one have to match.
   const deblocked = summary
-    .replace(/^[ \t]*```.*$/gm, "")
-    .replace(/^[ \t]*>[ \t]?/gm, "")
-    .replace(/^[ \t]*(?:[-*+]|\d+[.)])[ \t]+/gm, "");
+    .replace(/^\s{0,3}(?:```|~~~).*$/gm, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm, "");
   const plain = flattenWhitespace(stripMarkdown(deblocked));
   return deriveTitle(plain || flattenWhitespace(summary));
 }

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -20,7 +20,9 @@ import { appendFeedItem } from "../home/feed-writer.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { getLogger } from "../util/logger.js";
+import { normalizeTitle } from "../util/short-title.js";
 import { isConversationSeedSane } from "./conversation-seed-composer.js";
+import { deriveTitle } from "./copy-composer.js";
 import { readPayloadString } from "./notification-utils.js";
 import type { NotificationSignal } from "./signal.js";
 import type { NotificationDecision, RenderedChannelCopy } from "./types.js";
@@ -66,11 +68,6 @@ export async function writeHomeFeedItemForSignal(
     readPayloadString(signal.contextPayload, "body") ??
     readPayloadString(signal.contextPayload, "requestedMessage");
 
-  // Source the title from the payload only. The LLM's `renderedCopy.title`
-  // often echoes the body when no explicit title was passed, which stutters
-  // against `summary` in the row. Leave undefined when absent; renderers
-  // fall back to `summary`.
-  const resolvedTitle = payloadTitle?.trim() || undefined;
   // Prefer conversationSeedMessage over body for the home feed: the seed
   // message is richer and may contain structured markdown (lists, headers,
   // bold) that the detail panel renders. The popup-oriented `body` is
@@ -90,6 +87,14 @@ export async function writeHomeFeedItemForSignal(
     );
     return null;
   }
+
+  // Title order: payload, then the rendered copy, then a headline derived
+  // from the summary. The derivation always yields something, so every feed
+  // item lands with a title.
+  const resolvedTitle =
+    acceptTitle(payloadTitle, resolvedSummary) ??
+    acceptTitle(renderedCopy?.title, resolvedSummary) ??
+    deriveTitle(resolvedSummary);
 
   const urgency = signal.attentionHints.urgency;
   const now = new Date().toISOString();
@@ -122,7 +127,7 @@ export async function writeHomeFeedItemForSignal(
     id: `notif:${signal.signalId}`,
     type: "notification",
     priority: 50,
-    ...(resolvedTitle ? { title: resolvedTitle } : {}),
+    title: resolvedTitle,
     summary: resolvedSummary,
     timestamp: now,
     createdAt: now,
@@ -148,6 +153,34 @@ export async function writeHomeFeedItemForSignal(
 
   await appendFeedItem(item);
   return item;
+}
+
+/**
+ * Clean an authored title (producer payload or model-rendered copy) and keep
+ * it only when it says something the summary does not.
+ *
+ * `normalizeTitle` returns "" for empty, prose-shaped, and meta-failure
+ * titles. On top of that, a title that is a case-insensitive prefix of the
+ * summary, or that matches the summary's first sentence, stutters against the
+ * row's own body text. Rejection returns undefined so the caller falls
+ * through to the next candidate.
+ */
+function acceptTitle(
+  raw: string | undefined,
+  summary: string,
+): string | undefined {
+  const candidate = normalizeTitle(raw ?? "");
+  if (!candidate) {
+    return undefined;
+  }
+  const lowered = candidate.toLowerCase();
+  if (summary.toLowerCase().startsWith(lowered)) {
+    return undefined;
+  }
+  if (lowered === deriveTitle(summary).toLowerCase()) {
+    return undefined;
+  }
+  return candidate;
 }
 
 // ── Category & detail-panel derivation ────────────────────────────────

--- a/assistant/src/notifications/notification-utils.ts
+++ b/assistant/src/notifications/notification-utils.ts
@@ -91,8 +91,14 @@ export function sanitizeMessagePreview(value: string): string {
 export const NOTIFICATION_TITLE_MAX_LENGTH = 60;
 
 /**
- * Sanitize an untrusted notification title for inclusion in notification copy.
- * Strips control characters and clamps to `NOTIFICATION_TITLE_MAX_LENGTH`.
+ * Flatten an untrusted notification title onto a single line, stripping control
+ * characters and newlines and bounding it at `NOTIFICATION_TITLE_MAX_LENGTH`.
+ *
+ * The newline flattening is the load-bearing part: downstream consumers re-run
+ * the value through `normalizeTitle`, whose prose guard discards any string
+ * containing a newline outright, so a multi-line conversation title would be
+ * thrown away wholesale instead of salvaged. The length bound is a backstop;
+ * `normalizeTitle`'s tighter 40-character budget is what callers observe.
  */
 export function sanitizeNotificationTitle(value: string): string {
   return sanitize(value, NOTIFICATION_TITLE_MAX_LENGTH);

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -19,6 +19,11 @@ import { publishConversationTitleChanged } from "../runtime/sync/resource-sync-e
 import { getLogger } from "../util/logger.js";
 import { Mutex } from "../util/mutex.js";
 import {
+  normalizeTitle,
+  stripThinkingTags,
+  truncateTitle,
+} from "../util/short-title.js";
+import {
   getConversation,
   getMessages,
   type MessageRow,
@@ -575,176 +580,6 @@ function logRetryableFallback(
     retryableFallbackLogFields(params, reason),
     "Conversation title generation used retryable fallback",
   );
-}
-
-const META_FAILURE_TITLES = new Set([
-  "missing context",
-  "no context",
-  "insufficient context",
-  "unclear context",
-  "empty context",
-  "no topic",
-  "unclear topic",
-  "unclear request",
-  "unclear message",
-  "empty conversation",
-  "empty message",
-  "no content",
-]);
-
-const MAX_TITLE_LENGTH = 40;
-const MAX_TITLE_WORDS = 7;
-
-function truncateTitle(title: string): string {
-  if (title.length <= MAX_TITLE_LENGTH) {
-    return title;
-  }
-  const words = title.split(/\s+/);
-  if (words.length <= MAX_TITLE_WORDS) {
-    // Long words but few of them — truncate to char limit at word boundary
-    let result = "";
-    for (const word of words) {
-      const candidate = result ? result + " " + word : word;
-      if (candidate.length > MAX_TITLE_LENGTH) {
-        break;
-      }
-      result = candidate;
-    }
-    return result || title.slice(0, MAX_TITLE_LENGTH);
-  }
-  // Too many words — trim to 5 words
-  return words.slice(0, 5).join(" ");
-}
-
-function normalizeTitle(raw: string): string {
-  let title = raw.trim().replace(/^["']|["']$/g, "");
-  title = stripMarkdown(title);
-  title = stripThinkingTags(title).trim();
-  if (!title) {
-    return "";
-  }
-  // Reject outputs that are the model reasoning aloud or continuing the
-  // conversation instead of naming it (e.g. "I need to generate a…", "I'll
-  // work through these files…"). Callers fall back to a deterministic title.
-  if (looksLikeLeakedProse(title)) {
-    return "";
-  }
-  if (META_FAILURE_TITLES.has(title.toLowerCase())) {
-    return "";
-  }
-  return truncateTitle(title);
-}
-
-/** Reasoning/sentence openers that never start a legitimate topic title. */
-const LEAKED_PROSE_PREFIXES = [
-  "i need to",
-  "i needed to",
-  "i should",
-  "i will",
-  "i'll",
-  "i can ",
-  "i can't",
-  "i cannot",
-  "i'm ",
-  "i am ",
-  "i've ",
-  "i have ",
-  "i'd ",
-  "i would",
-  "let me",
-  "looking at",
-  "based on",
-  "given the",
-  "to generate",
-  "to summarize",
-  "to title",
-  // Subject-led reasoning openers. A bare noun phrase ("The User Interface
-  // Redesign", "The Conversation API") is a valid title, so each subject only
-  // counts as leaked prose when a verb or possessive follows it — marking the
-  // output as a sentence rather than a topic.
-  "the user wants",
-  "the user asked",
-  "the user is",
-  "the user wanted",
-  "the user needs",
-  "the user said",
-  "the user has",
-  "the user would",
-  "the user's request",
-  "the conversation is",
-  "this conversation is",
-  "the conversation appears",
-  "the conversation seems",
-  "the conversation covers",
-  "the conversation discusses",
-  "the assistant should",
-  "the assistant is",
-  "the assistant wants",
-  "the assistant needs",
-  "the title should",
-  "the title is",
-  "the title would",
-  "the title for",
-  "here's ",
-  "here is ",
-  "here are ",
-  "sure,",
-  "okay,",
-  "ok,",
-];
-
-/**
- * Heuristic guard for title outputs that are clearly prose — the model
- * reasoning aloud or replying to the conversation rather than naming it. A real
- * title is a single-line short noun phrase, so we reject multi-line output,
- * embedded transcript markers, leading reasoning openers, and sentence-shaped
- * clauses. Deliberately tight: a false reject only costs a deterministic
- * fallback title, while a false accept persists a broken one.
- */
-function looksLikeLeakedProse(title: string): boolean {
-  if (/\n/.test(title)) {
-    return true;
-  }
-  if (/\b(?:user|assistant)\s*:/i.test(title)) {
-    return true;
-  }
-  const lower = title.toLowerCase();
-  if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
-    return true;
-  }
-  // Sentence-shaped: terminal punctuation on a multi-word clause.
-  if (/[.?!]$/.test(title) && title.split(/\s+/).length > 5) {
-    return true;
-  }
-  return false;
-}
-
-/** Strip thinking tags so they don't bleed into generated titles. */
-function stripThinkingTags(text: string): string {
-  return text
-    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
-    .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
-    .replace(/<think>[\s\S]*?<\/think>/gi, "")
-    .replace(/<thought>/gi, "")
-    .replace(/<\/thought>/gi, "")
-    .replace(/<thinking>/gi, "")
-    .replace(/<\/thinking>/gi, "")
-    .replace(/<think>/gi, "")
-    .replace(/<\/think>/gi, "")
-    .replace(/<:[^>]*>/gi, "");
-}
-
-/** Strip common markdown formatting so titles render as plain text. */
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, "$1") // **bold**
-    .replace(/__(.+?)__/g, "$1") // __bold__
-    .replace(/\*(.+?)\*/g, "$1") // *italic*
-    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1") // _italic_ (word-boundary-aware to preserve snake_case)
-    .replace(/~~(.+?)~~/g, "$1") // ~~strikethrough~~
-    .replace(/`(.+?)`/g, "$1") // `code`
-    .replace(/\[(.+?)\]\(.+?\)/g, "$1") // [link](url)
-    .replace(/^#{1,6}\s+/gm, ""); // # headings
 }
 
 function deriveFallbackTitle(context?: TitleContext): string | null {

--- a/assistant/src/runtime/routes/notification-routes.ts
+++ b/assistant/src/runtime/routes/notification-routes.ts
@@ -116,7 +116,10 @@ async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
 const EditNotificationParams = z
   .object({
     id: z.string().min(1).describe("Feed item id (notif:<uuid>) or bare uuid"),
-    title: z.string().optional(),
+    title: z
+      .string()
+      .optional()
+      .describe("New title. An empty value is ignored, never cleared."),
     body: z.string().optional(),
     urgency: UrgencySchema.optional(),
     status: z.enum(["new", "seen", "acted_on", "dismissed"]).optional(),

--- a/assistant/src/util/__tests__/short-title.test.ts
+++ b/assistant/src/util/__tests__/short-title.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  LEAKED_PROSE_PREFIXES,
-  looksLikeLeakedProse,
-  MAX_TITLE_LENGTH,
-  MAX_TITLE_WORDS,
-  META_FAILURE_TITLES,
   normalizeTitle,
   stripMarkdown,
   stripThinkingTags,
   truncateTitle,
 } from "../short-title.js";
+
+/** The character and word budgets `short-title.ts` documents and enforces. */
+const MAX_TITLE_LENGTH = 40;
+const MAX_TITLE_WORDS = 7;
 
 describe("stripMarkdown", () => {
   test("unwraps bold, italic, strikethrough, and code spans", () => {
@@ -91,74 +90,80 @@ describe("truncateTitle", () => {
     expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
     expect(truncateTitle(title)).toBe("alpha bravo charlie delta echo");
   });
+
+  test("still honors the char limit when the first five words overflow it", () => {
+    const title =
+      "Authentication Infrastructure Modernization Deployment Verification Report Complete Today";
+    expect(title.length).toBeGreaterThan(MAX_TITLE_LENGTH);
+    expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
+    const result = truncateTitle(title);
+    expect(result).toBe("Authentication Infrastructure");
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+  });
 });
 
-describe("looksLikeLeakedProse", () => {
+describe("normalizeTitle prose rejection", () => {
   test("rejects multi-line output", () => {
-    expect(looksLikeLeakedProse("Auth Rewrite\nand more")).toBe(true);
+    expect(normalizeTitle("Auth Rewrite\nand more")).toBe("");
   });
 
   test("rejects embedded transcript markers", () => {
-    expect(looksLikeLeakedProse("User: how do I log in")).toBe(true);
-    expect(looksLikeLeakedProse("Assistant : here you go")).toBe(true);
+    expect(normalizeTitle("User: how do I log in")).toBe("");
+    expect(normalizeTitle("Assistant : here you go")).toBe("");
   });
 
   test("rejects sentence-shaped clauses ending in terminal punctuation", () => {
-    expect(looksLikeLeakedProse("This is a topic about authentication.")).toBe(
-      true,
-    );
-    expect(looksLikeLeakedProse("What did they want to build here?")).toBe(
-      true,
-    );
+    expect(normalizeTitle("This is a topic about authentication.")).toBe("");
+    expect(normalizeTitle("What did they want to build here?")).toBe("");
   });
 
   test("keeps short phrases that end in punctuation", () => {
-    expect(looksLikeLeakedProse("Auth Rewrite?")).toBe(false);
+    expect(normalizeTitle("Auth Rewrite?")).toBe("Auth Rewrite?");
   });
 
   test("rejects first-person reasoning openers", () => {
-    expect(looksLikeLeakedProse("I need to generate a title")).toBe(true);
-    expect(looksLikeLeakedProse("I'll work through these files")).toBe(true);
-    expect(looksLikeLeakedProse("I cannot title this")).toBe(true);
+    expect(normalizeTitle("I need to generate a title")).toBe("");
+    expect(normalizeTitle("I'll work through these files")).toBe("");
+    expect(normalizeTitle("I cannot title this")).toBe("");
   });
 
   test("rejects imperative and deferral openers", () => {
-    expect(looksLikeLeakedProse("Let me summarize the request")).toBe(true);
-    expect(looksLikeLeakedProse("Looking at the conversation")).toBe(true);
-    expect(looksLikeLeakedProse("Based on the messages")).toBe(true);
-    expect(looksLikeLeakedProse("Given the context")).toBe(true);
+    expect(normalizeTitle("Let me summarize the request")).toBe("");
+    expect(normalizeTitle("Looking at the conversation")).toBe("");
+    expect(normalizeTitle("Based on the messages")).toBe("");
+    expect(normalizeTitle("Given the context")).toBe("");
   });
 
   test("rejects infinitive openers", () => {
-    expect(looksLikeLeakedProse("To generate a good title")).toBe(true);
-    expect(looksLikeLeakedProse("To summarize the discussion")).toBe(true);
-    expect(looksLikeLeakedProse("To title this thread")).toBe(true);
+    expect(normalizeTitle("To generate a good title")).toBe("");
+    expect(normalizeTitle("To summarize the discussion")).toBe("");
+    expect(normalizeTitle("To title this thread")).toBe("");
   });
 
   test("rejects subject-led reasoning openers", () => {
-    expect(looksLikeLeakedProse("The user wants a summary")).toBe(true);
-    expect(looksLikeLeakedProse("The conversation is about Docker")).toBe(true);
-    expect(looksLikeLeakedProse("The assistant should reply")).toBe(true);
-    expect(looksLikeLeakedProse("The title should be short")).toBe(true);
+    expect(normalizeTitle("The user wants a summary")).toBe("");
+    expect(normalizeTitle("The conversation is about Docker")).toBe("");
+    expect(normalizeTitle("The assistant should reply")).toBe("");
+    expect(normalizeTitle("The title should be short")).toBe("");
   });
 
   test("rejects preamble openers", () => {
-    expect(looksLikeLeakedProse("Here's a title")).toBe(true);
-    expect(looksLikeLeakedProse("Here is a title")).toBe(true);
-    expect(looksLikeLeakedProse("Sure, Auth Rewrite")).toBe(true);
-    expect(looksLikeLeakedProse("Okay, Auth Rewrite")).toBe(true);
+    expect(normalizeTitle("Here's a title")).toBe("");
+    expect(normalizeTitle("Here is a title")).toBe("");
+    expect(normalizeTitle("Here are the options")).toBe("");
+    expect(normalizeTitle("Sure, Auth Rewrite")).toBe("");
+    expect(normalizeTitle("Okay, Auth Rewrite")).toBe("");
+    expect(normalizeTitle("Ok, Auth Rewrite")).toBe("");
   });
 
   test("accepts bare noun-phrase titles that share a subject word", () => {
-    expect(looksLikeLeakedProse("The Conversation API")).toBe(false);
-    expect(looksLikeLeakedProse("The User Interface Redesign")).toBe(false);
-    expect(looksLikeLeakedProse("Auth Middleware Rewrite")).toBe(false);
-  });
-
-  test("every configured prefix is treated as prose", () => {
-    for (const prefix of LEAKED_PROSE_PREFIXES) {
-      expect(looksLikeLeakedProse(`${prefix} something`)).toBe(true);
-    }
+    expect(normalizeTitle("The Conversation API")).toBe("The Conversation API");
+    expect(normalizeTitle("The User Interface Redesign")).toBe(
+      "The User Interface Redesign",
+    );
+    expect(normalizeTitle("Auth Middleware Rewrite")).toBe(
+      "Auth Middleware Rewrite",
+    );
   });
 });
 
@@ -187,7 +192,21 @@ describe("normalizeTitle", () => {
   });
 
   test("returns empty for meta-failure titles regardless of case", () => {
-    for (const meta of META_FAILURE_TITLES) {
+    const metaFailures = [
+      "missing context",
+      "no context",
+      "insufficient context",
+      "unclear context",
+      "empty context",
+      "no topic",
+      "unclear topic",
+      "unclear request",
+      "unclear message",
+      "empty conversation",
+      "empty message",
+      "no content",
+    ];
+    for (const meta of metaFailures) {
       expect(normalizeTitle(meta)).toBe("");
     }
     expect(normalizeTitle("Missing Context")).toBe("");
@@ -198,5 +217,13 @@ describe("normalizeTitle", () => {
     expect(
       normalizeTitle("alpha bravo charlie delta echo foxtrot golf hotel india"),
     ).toBe("alpha bravo charlie delta echo");
+  });
+
+  test("keeps a wordy title inside the character budget", () => {
+    const result = normalizeTitle(
+      "Authentication Infrastructure Modernization Deployment Verification Report Complete Today",
+    );
+    expect(result).toBe("Authentication Infrastructure");
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
   });
 });

--- a/assistant/src/util/__tests__/short-title.test.ts
+++ b/assistant/src/util/__tests__/short-title.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  LEAKED_PROSE_PREFIXES,
+  looksLikeLeakedProse,
+  MAX_TITLE_LENGTH,
+  MAX_TITLE_WORDS,
+  META_FAILURE_TITLES,
+  normalizeTitle,
+  stripMarkdown,
+  stripThinkingTags,
+  truncateTitle,
+} from "../short-title.js";
+
+describe("stripMarkdown", () => {
+  test("unwraps bold, italic, strikethrough, and code spans", () => {
+    expect(stripMarkdown("**Auth** Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("__Auth__ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("*Auth* Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("_Auth_ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("~~Auth~~ Rewrite")).toBe("Auth Rewrite");
+    expect(stripMarkdown("`Auth` Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("keeps link text and drops the target", () => {
+    expect(stripMarkdown("[Auth Rewrite](https://example.com)")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("removes heading markers", () => {
+    expect(stripMarkdown("## Auth Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("preserves snake_case identifiers", () => {
+    expect(stripMarkdown("record_conversation_title")).toBe(
+      "record_conversation_title",
+    );
+  });
+});
+
+describe("stripThinkingTags", () => {
+  test("removes paired thinking blocks and their contents", () => {
+    expect(stripThinkingTags("<thinking>hmm</thinking>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+    expect(stripThinkingTags("<thought>hmm</thought>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+    expect(stripThinkingTags("<think>hmm</think>Auth Rewrite")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("removes unpaired tags but keeps the surrounding text", () => {
+    expect(stripThinkingTags("<thinking>Auth Rewrite")).toBe("Auth Rewrite");
+    expect(stripThinkingTags("Auth Rewrite</think>")).toBe("Auth Rewrite");
+  });
+
+  test("removes colon-prefixed pseudo tags", () => {
+    expect(stripThinkingTags("<:anything>Auth Rewrite")).toBe("Auth Rewrite");
+  });
+
+  test("leaves plain text untouched", () => {
+    expect(stripThinkingTags("Auth Rewrite")).toBe("Auth Rewrite");
+  });
+});
+
+describe("truncateTitle", () => {
+  test("leaves titles within the character limit untouched", () => {
+    const title = "Auth Middleware Rewrite";
+    expect(title.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(truncateTitle(title)).toBe(title);
+  });
+
+  test("trims at a word boundary when few but long words exceed the char limit", () => {
+    const title = "Supercalifragilistic Authentication Middleware Rewrite";
+    expect(title.split(" ").length).toBeLessThanOrEqual(MAX_TITLE_WORDS);
+    expect(truncateTitle(title)).toBe("Supercalifragilistic Authentication");
+  });
+
+  test("hard-slices a single word longer than the char limit", () => {
+    const title = "a".repeat(MAX_TITLE_LENGTH + 5);
+    expect(truncateTitle(title)).toBe("a".repeat(MAX_TITLE_LENGTH));
+  });
+
+  test("keeps the first five words when the word limit is exceeded", () => {
+    const title =
+      "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+    expect(title.length).toBeGreaterThan(MAX_TITLE_LENGTH);
+    expect(title.split(" ").length).toBeGreaterThan(MAX_TITLE_WORDS);
+    expect(truncateTitle(title)).toBe("alpha bravo charlie delta echo");
+  });
+});
+
+describe("looksLikeLeakedProse", () => {
+  test("rejects multi-line output", () => {
+    expect(looksLikeLeakedProse("Auth Rewrite\nand more")).toBe(true);
+  });
+
+  test("rejects embedded transcript markers", () => {
+    expect(looksLikeLeakedProse("User: how do I log in")).toBe(true);
+    expect(looksLikeLeakedProse("Assistant : here you go")).toBe(true);
+  });
+
+  test("rejects sentence-shaped clauses ending in terminal punctuation", () => {
+    expect(looksLikeLeakedProse("This is a topic about authentication.")).toBe(
+      true,
+    );
+    expect(looksLikeLeakedProse("What did they want to build here?")).toBe(
+      true,
+    );
+  });
+
+  test("keeps short phrases that end in punctuation", () => {
+    expect(looksLikeLeakedProse("Auth Rewrite?")).toBe(false);
+  });
+
+  test("rejects first-person reasoning openers", () => {
+    expect(looksLikeLeakedProse("I need to generate a title")).toBe(true);
+    expect(looksLikeLeakedProse("I'll work through these files")).toBe(true);
+    expect(looksLikeLeakedProse("I cannot title this")).toBe(true);
+  });
+
+  test("rejects imperative and deferral openers", () => {
+    expect(looksLikeLeakedProse("Let me summarize the request")).toBe(true);
+    expect(looksLikeLeakedProse("Looking at the conversation")).toBe(true);
+    expect(looksLikeLeakedProse("Based on the messages")).toBe(true);
+    expect(looksLikeLeakedProse("Given the context")).toBe(true);
+  });
+
+  test("rejects infinitive openers", () => {
+    expect(looksLikeLeakedProse("To generate a good title")).toBe(true);
+    expect(looksLikeLeakedProse("To summarize the discussion")).toBe(true);
+    expect(looksLikeLeakedProse("To title this thread")).toBe(true);
+  });
+
+  test("rejects subject-led reasoning openers", () => {
+    expect(looksLikeLeakedProse("The user wants a summary")).toBe(true);
+    expect(looksLikeLeakedProse("The conversation is about Docker")).toBe(true);
+    expect(looksLikeLeakedProse("The assistant should reply")).toBe(true);
+    expect(looksLikeLeakedProse("The title should be short")).toBe(true);
+  });
+
+  test("rejects preamble openers", () => {
+    expect(looksLikeLeakedProse("Here's a title")).toBe(true);
+    expect(looksLikeLeakedProse("Here is a title")).toBe(true);
+    expect(looksLikeLeakedProse("Sure, Auth Rewrite")).toBe(true);
+    expect(looksLikeLeakedProse("Okay, Auth Rewrite")).toBe(true);
+  });
+
+  test("accepts bare noun-phrase titles that share a subject word", () => {
+    expect(looksLikeLeakedProse("The Conversation API")).toBe(false);
+    expect(looksLikeLeakedProse("The User Interface Redesign")).toBe(false);
+    expect(looksLikeLeakedProse("Auth Middleware Rewrite")).toBe(false);
+  });
+
+  test("every configured prefix is treated as prose", () => {
+    for (const prefix of LEAKED_PROSE_PREFIXES) {
+      expect(looksLikeLeakedProse(`${prefix} something`)).toBe(true);
+    }
+  });
+});
+
+describe("normalizeTitle", () => {
+  test("strips surrounding quotes", () => {
+    expect(normalizeTitle('"Auth Rewrite"')).toBe("Auth Rewrite");
+    expect(normalizeTitle("'Auth Rewrite'")).toBe("Auth Rewrite");
+  });
+
+  test("strips markdown and thinking tags together", () => {
+    expect(normalizeTitle("<thinking>hmm</thinking> **Auth Rewrite**")).toBe(
+      "Auth Rewrite",
+    );
+  });
+
+  test("returns empty for blank input", () => {
+    expect(normalizeTitle("")).toBe("");
+    expect(normalizeTitle("   ")).toBe("");
+    expect(normalizeTitle("<thinking>hmm</thinking>")).toBe("");
+  });
+
+  test("returns empty for leaked prose", () => {
+    expect(normalizeTitle("I need to generate a title for this")).toBe("");
+    expect(normalizeTitle("User: how do I log in")).toBe("");
+    expect(normalizeTitle("Auth Rewrite\nand more")).toBe("");
+  });
+
+  test("returns empty for meta-failure titles regardless of case", () => {
+    for (const meta of META_FAILURE_TITLES) {
+      expect(normalizeTitle(meta)).toBe("");
+    }
+    expect(normalizeTitle("Missing Context")).toBe("");
+    expect(normalizeTitle('"No Topic"')).toBe("");
+  });
+
+  test("truncates an over-long accepted title", () => {
+    expect(
+      normalizeTitle("alpha bravo charlie delta echo foxtrot golf hotel india"),
+    ).toBe("alpha bravo charlie delta echo");
+  });
+});

--- a/assistant/src/util/short-title.ts
+++ b/assistant/src/util/short-title.ts
@@ -4,10 +4,13 @@
  * meta-failure rejection, and length truncation.
  */
 
-export const MAX_TITLE_LENGTH = 40;
-export const MAX_TITLE_WORDS = 7;
+const MAX_TITLE_LENGTH = 40;
+const MAX_TITLE_WORDS = 7;
 
-export const META_FAILURE_TITLES = new Set([
+/** Word count a title exceeding `MAX_TITLE_WORDS` is cut back to. */
+const TRIMMED_TITLE_WORDS = 5;
+
+const META_FAILURE_TITLES = new Set([
   "missing context",
   "no context",
   "insufficient context",
@@ -23,7 +26,7 @@ export const META_FAILURE_TITLES = new Set([
 ]);
 
 /** Reasoning/sentence openers that never start a legitimate topic title. */
-export const LEAKED_PROSE_PREFIXES = [
+const LEAKED_PROSE_PREFIXES = [
   "i need to",
   "i needed to",
   "i should",
@@ -108,25 +111,31 @@ export function stripThinkingTags(text: string): string {
     .replace(/<:[^>]*>/gi, "");
 }
 
+/**
+ * Clamp a title to `MAX_TITLE_LENGTH` characters and `MAX_TITLE_WORDS` words.
+ * Both budgets apply: a wordy title is cut back to `TRIMMED_TITLE_WORDS` words
+ * and the survivors are still trimmed at a word boundary to fit the character
+ * budget, so the returned string is never longer than `MAX_TITLE_LENGTH`.
+ */
 export function truncateTitle(title: string): string {
   if (title.length <= MAX_TITLE_LENGTH) {
     return title;
   }
   const words = title.split(/\s+/);
-  if (words.length <= MAX_TITLE_WORDS) {
-    // Long words but few of them: truncate to char limit at word boundary
-    let result = "";
-    for (const word of words) {
-      const candidate = result ? result + " " + word : word;
-      if (candidate.length > MAX_TITLE_LENGTH) {
-        break;
-      }
-      result = candidate;
+  const kept =
+    words.length > MAX_TITLE_WORDS
+      ? words.slice(0, TRIMMED_TITLE_WORDS)
+      : words;
+  let result = "";
+  for (const word of kept) {
+    const candidate = result ? result + " " + word : word;
+    if (candidate.length > MAX_TITLE_LENGTH) {
+      break;
     }
-    return result || title.slice(0, MAX_TITLE_LENGTH);
+    result = candidate;
   }
-  // Too many words: trim to 5 words
-  return words.slice(0, 5).join(" ");
+  // Empty when even the first word overflows: hard-slice rather than return "".
+  return result || title.slice(0, MAX_TITLE_LENGTH);
 }
 
 /**
@@ -137,7 +146,7 @@ export function truncateTitle(title: string): string {
  * clauses. Deliberately tight: a false reject only costs a deterministic
  * fallback title, while a false accept persists a broken one.
  */
-export function looksLikeLeakedProse(title: string): boolean {
+function looksLikeLeakedProse(title: string): boolean {
   if (/\n/.test(title)) {
     return true;
   }

--- a/assistant/src/util/short-title.ts
+++ b/assistant/src/util/short-title.ts
@@ -1,0 +1,180 @@
+/**
+ * Title hygiene helpers shared by every surface that renders a short,
+ * scannable conversation title: markdown/thinking-tag stripping, prose and
+ * meta-failure rejection, and length truncation.
+ */
+
+export const MAX_TITLE_LENGTH = 40;
+export const MAX_TITLE_WORDS = 7;
+
+export const META_FAILURE_TITLES = new Set([
+  "missing context",
+  "no context",
+  "insufficient context",
+  "unclear context",
+  "empty context",
+  "no topic",
+  "unclear topic",
+  "unclear request",
+  "unclear message",
+  "empty conversation",
+  "empty message",
+  "no content",
+]);
+
+/** Reasoning/sentence openers that never start a legitimate topic title. */
+export const LEAKED_PROSE_PREFIXES = [
+  "i need to",
+  "i needed to",
+  "i should",
+  "i will",
+  "i'll",
+  "i can ",
+  "i can't",
+  "i cannot",
+  "i'm ",
+  "i am ",
+  "i've ",
+  "i have ",
+  "i'd ",
+  "i would",
+  "let me",
+  "looking at",
+  "based on",
+  "given the",
+  "to generate",
+  "to summarize",
+  "to title",
+  // Subject-led reasoning openers. A bare noun phrase ("The User Interface
+  // Redesign", "The Conversation API") is a valid title, so each subject only
+  // counts as leaked prose when a verb or possessive follows it, marking the
+  // output as a sentence rather than a topic.
+  "the user wants",
+  "the user asked",
+  "the user is",
+  "the user wanted",
+  "the user needs",
+  "the user said",
+  "the user has",
+  "the user would",
+  "the user's request",
+  "the conversation is",
+  "this conversation is",
+  "the conversation appears",
+  "the conversation seems",
+  "the conversation covers",
+  "the conversation discusses",
+  "the assistant should",
+  "the assistant is",
+  "the assistant wants",
+  "the assistant needs",
+  "the title should",
+  "the title is",
+  "the title would",
+  "the title for",
+  "here's ",
+  "here is ",
+  "here are ",
+  "sure,",
+  "okay,",
+  "ok,",
+];
+
+/** Strip common markdown formatting so titles render as plain text. */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "$1") // **bold**
+    .replace(/__(.+?)__/g, "$1") // __bold__
+    .replace(/\*(.+?)\*/g, "$1") // *italic*
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1") // _italic_ (word-boundary-aware to preserve snake_case)
+    .replace(/~~(.+?)~~/g, "$1") // ~~strikethrough~~
+    .replace(/`(.+?)`/g, "$1") // `code`
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1") // [link](url)
+    .replace(/^#{1,6}\s+/gm, ""); // # headings
+}
+
+/** Strip thinking tags so they don't bleed into generated titles. */
+export function stripThinkingTags(text: string): string {
+  return text
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
+    .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .replace(/<thought>/gi, "")
+    .replace(/<\/thought>/gi, "")
+    .replace(/<thinking>/gi, "")
+    .replace(/<\/thinking>/gi, "")
+    .replace(/<think>/gi, "")
+    .replace(/<\/think>/gi, "")
+    .replace(/<:[^>]*>/gi, "");
+}
+
+export function truncateTitle(title: string): string {
+  if (title.length <= MAX_TITLE_LENGTH) {
+    return title;
+  }
+  const words = title.split(/\s+/);
+  if (words.length <= MAX_TITLE_WORDS) {
+    // Long words but few of them: truncate to char limit at word boundary
+    let result = "";
+    for (const word of words) {
+      const candidate = result ? result + " " + word : word;
+      if (candidate.length > MAX_TITLE_LENGTH) {
+        break;
+      }
+      result = candidate;
+    }
+    return result || title.slice(0, MAX_TITLE_LENGTH);
+  }
+  // Too many words: trim to 5 words
+  return words.slice(0, 5).join(" ");
+}
+
+/**
+ * Heuristic guard for title outputs that are clearly prose: the model
+ * reasoning aloud or replying to the conversation rather than naming it. A real
+ * title is a single-line short noun phrase, so we reject multi-line output,
+ * embedded transcript markers, leading reasoning openers, and sentence-shaped
+ * clauses. Deliberately tight: a false reject only costs a deterministic
+ * fallback title, while a false accept persists a broken one.
+ */
+export function looksLikeLeakedProse(title: string): boolean {
+  if (/\n/.test(title)) {
+    return true;
+  }
+  if (/\b(?:user|assistant)\s*:/i.test(title)) {
+    return true;
+  }
+  const lower = title.toLowerCase();
+  if (LEAKED_PROSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return true;
+  }
+  // Sentence-shaped: terminal punctuation on a multi-word clause.
+  if (/[.?!]$/.test(title) && title.split(/\s+/).length > 5) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Clean a raw title into a short, scannable label. Returns "" when the input is
+ * empty, reads as leaked prose, or is a meta-failure title, signalling that
+ * callers should fall back to a deterministic title.
+ */
+export function normalizeTitle(raw: string): string {
+  let title = raw.trim().replace(/^["']|["']$/g, "");
+  title = stripMarkdown(title);
+  title = stripThinkingTags(title).trim();
+  if (!title) {
+    return "";
+  }
+  // Reject outputs that are the model reasoning aloud or continuing the
+  // conversation instead of naming it (e.g. "I need to generate a…", "I'll
+  // work through these files…"). Callers fall back to a deterministic title.
+  if (looksLikeLeakedProse(title)) {
+    return "";
+  }
+  if (META_FAILURE_TITLES.has(title.toLowerCase())) {
+    return "";
+  }
+  return truncateTitle(title);
+}

--- a/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
+++ b/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
@@ -2,15 +2,16 @@
  * Workspace migration `138-backfill-home-feed-titles`.
  *
  * Gives every item in `<workspace>/data/home-feed.json` a non-empty
- * `title`. The wire schema requires the field, and an item on disk that
- * lacks it is dropped when the feed is read, so the title is derived
- * from the item's own `summary` instead.
+ * `title`. The feed writer sets one on every item it appends; stored
+ * items that lack the field get a headline derived from their own
+ * `summary`, so the field is uniformly present across the file.
  *
  * Behaviour:
  *   - Missing file, unparseable JSON, or a non-object root: no-op.
  *   - Item that already has a non-empty `title`: untouched.
- *   - Item without one: title derived from `summary` (first sentence,
- *     capped at 40 characters with an ellipsis).
+ *   - Item without one: title derived from `summary` (markdown and
+ *     newlines flattened, first sentence, capped at 60 characters with
+ *     an ellipsis).
  *   - `version`, `updatedAt`, and every other item field are preserved.
  *
  * Idempotent: a second run finds every item titled, so it writes
@@ -27,7 +28,14 @@ import type { WorkspaceMigration } from "./types.js";
 const log = getLogger("workspace-migration-138-backfill-home-feed-titles");
 
 const HOME_FEED_RELATIVE_PATH = join("data", "home-feed.json");
-const MAX_TITLE_LENGTH = 40;
+
+/**
+ * Matches `NOTIFICATION_TITLE_MAX_LENGTH` in
+ * `notifications/notification-utils.ts`, the cap on the headline the feed
+ * writer derives from a summary, so a backfilled item and a freshly
+ * written one with the same summary carry the same title.
+ */
+const MAX_TITLE_LENGTH = 60;
 
 /**
  * The persisted item fields this migration touches. Inlined rather than
@@ -125,18 +133,45 @@ export const backfillHomeFeedTitlesMigration: WorkspaceMigration = {
 // ---------------------------------------------------------------------------
 
 /**
- * Derive a short headline from a summary: the first sentence when the
- * text has a terminator, capped at `MAX_TITLE_LENGTH` characters with an
- * ellipsis. Mirrors the notification copy composer's derivation, inlined
- * rather than imported so the migration stays self-contained.
+ * Derive a short headline from a summary: the markdown is flattened to a
+ * single line of plain text, the first sentence is taken when the text
+ * has a terminator, and the result is capped at `MAX_TITLE_LENGTH`
+ * characters with an ellipsis. Returns "" when nothing usable survives.
+ *
+ * Inlined rather than imported from the notification pipeline so the
+ * migration stays self-contained per the migrations AGENTS.md.
  */
 function deriveTitle(summary: string): string {
-  const firstSentenceEnd = summary.search(/[.!?](\s|$)/);
+  const text = flattenToPlainText(summary);
+  const firstSentenceEnd = text.search(/[.!?](\s|$)/);
   const candidate =
-    firstSentenceEnd > 0 ? summary.slice(0, firstSentenceEnd + 1) : summary;
+    firstSentenceEnd > 0 ? text.slice(0, firstSentenceEnd + 1) : text;
   return candidate.length > MAX_TITLE_LENGTH
     ? candidate.slice(0, MAX_TITLE_LENGTH).trim() + "…"
     : candidate.trim();
+}
+
+/**
+ * Reduce markdown-rich summary text to a single line of plain prose:
+ * block structure (code fences, headings, blockquotes, list markers) is
+ * dropped, inline formatting is unwrapped, and every run of whitespace,
+ * newlines included, collapses to one space.
+ */
+function flattenToPlainText(text: string): string {
+  return text
+    .replace(/^\s{0,3}(?:```|~~~).*$/gm, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, "$1")
+    .replace(/~~(.+?)~~/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\[(.+?)\]\(.*?\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
+++ b/assistant/src/workspace/migrations/138-backfill-home-feed-titles.ts
@@ -1,0 +1,144 @@
+/**
+ * Workspace migration `138-backfill-home-feed-titles`.
+ *
+ * Gives every item in `<workspace>/data/home-feed.json` a non-empty
+ * `title`. The wire schema requires the field, and an item on disk that
+ * lacks it is dropped when the feed is read, so the title is derived
+ * from the item's own `summary` instead.
+ *
+ * Behaviour:
+ *   - Missing file, unparseable JSON, or a non-object root: no-op.
+ *   - Item that already has a non-empty `title`: untouched.
+ *   - Item without one: title derived from `summary` (first sentence,
+ *     capped at 40 characters with an ellipsis).
+ *   - `version`, `updatedAt`, and every other item field are preserved.
+ *
+ * Idempotent: a second run finds every item titled, so it writes
+ * nothing. The runner's checkpoint also skips re-runs, but this in-file
+ * guard keeps the migration safe even if the checkpoint is wiped.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-138-backfill-home-feed-titles");
+
+const HOME_FEED_RELATIVE_PATH = join("data", "home-feed.json");
+const MAX_TITLE_LENGTH = 40;
+
+/**
+ * The persisted item fields this migration touches. Inlined rather than
+ * imported from `home/feed-types.ts` so the migration stays
+ * self-contained per the migrations AGENTS.md.
+ */
+interface PersistedFeedItem {
+  /** Missing, empty, or non-string on the items repaired here. */
+  title?: unknown;
+  /** Source text for the derived title. */
+  summary?: unknown;
+  /** Every other persisted field is carried through untouched. */
+  [key: string]: unknown;
+}
+
+export const backfillHomeFeedTitlesMigration: WorkspaceMigration = {
+  id: "138-backfill-home-feed-titles",
+  description:
+    "Backfill a summary-derived title on home-feed items that lack one",
+
+  run(workspaceDir: string): void {
+    const path = join(workspaceDir, HOME_FEED_RELATIVE_PATH);
+    if (!existsSync(path)) {
+      return;
+    }
+
+    // Read outside the parse catch: a transient filesystem error (EIO,
+    // EACCES) must reach the runner so the migration retries, while
+    // malformed JSON is a permanent state this migration cannot repair.
+    const rawText = readFileSync(path, "utf-8");
+
+    let feed: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawText);
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      feed = parsed;
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to parse home-feed.json; skipping title backfill",
+      );
+      return;
+    }
+
+    const rawItems = Array.isArray(feed.items) ? feed.items : [];
+    let backfilled = 0;
+    for (const entry of rawItems) {
+      if (!isPlainObject(entry)) {
+        continue;
+      }
+      const item: PersistedFeedItem = entry;
+      if (typeof item.title === "string" && item.title.trim().length > 0) {
+        continue;
+      }
+      if (typeof item.summary !== "string") {
+        continue;
+      }
+      const derived = deriveTitle(item.summary);
+      if (derived.length === 0) {
+        continue;
+      }
+      item.title = derived;
+      backfilled++;
+    }
+
+    if (backfilled === 0) {
+      return;
+    }
+
+    // Write-then-rename so an interrupted write cannot leave
+    // home-feed.json truncated: the reader treats an unparseable file as
+    // an empty feed, so a torn in-place write would discard the user's
+    // notification history outright.
+    const tmpPath = `${path}.migration-138.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(feed, null, 2), "utf-8");
+    renameSync(tmpPath, path);
+
+    log.info({ path, backfilled }, "Backfilled titles on home-feed items");
+  },
+
+  // Deriving a title from the summary is idempotent, so a transient
+  // failure (full disk, I/O error) is safe to retry on later startups.
+  retryFailedCheckpoint: true,
+
+  down(_workspaceDir: string): void {
+    // Forward-only: a derived title is indistinguishable from an
+    // authored one, so there is nothing safe to strip back out.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per the workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a short headline from a summary: the first sentence when the
+ * text has a terminator, capped at `MAX_TITLE_LENGTH` characters with an
+ * ellipsis. Mirrors the notification copy composer's derivation, inlined
+ * rather than imported so the migration stays self-contained.
+ */
+function deriveTitle(summary: string): string {
+  const firstSentenceEnd = summary.search(/[.!?](\s|$)/);
+  const candidate =
+    firstSentenceEnd > 0 ? summary.slice(0, firstSentenceEnd + 1) : summary;
+  return candidate.length > MAX_TITLE_LENGTH
+    ? candidate.slice(0, MAX_TITLE_LENGTH).trim() + "…"
+    : candidate.trim();
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -135,6 +135,7 @@ import { imageGenerationModeToProviderMigration } from "./134-image-generation-m
 import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js";
 import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fireworks-kimi-model-id.js";
 import { repairRetiredFireworksMinimaxModelIdMigration } from "./137-repair-retired-fireworks-minimax-model-id.js";
+import { backfillHomeFeedTitlesMigration } from "./138-backfill-home-feed-titles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -285,4 +286,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   copySubstrateTunablesMigration,
   repairStaleFireworksKimiModelIdMigration,
   repairRetiredFireworksMinimaxModelIdMigration,
+  backfillHomeFeedTitlesMigration,
 ];

--- a/clients/web/src/domains/home/detail-panel/home-tool-permission-card.test.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-tool-permission-card.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for `HomeToolPermissionCard`.
+ *
+ * Uses `renderToStaticMarkup` (SSR) like `notifications-bell.test.tsx`. The
+ * card is presentational, so static markup covers it fully.
+ *
+ * The no-provider branch is the one that matters: the panel header above this
+ * card already renders `item.title`, so the card must show the body. Now that
+ * the daemon sets a title on every feed item, echoing the title here would
+ * print the same string twice.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FeedItem } from "@vellumai/assistant-api";
+
+import { HomeToolPermissionCard } from "./home-tool-permission-card";
+
+function feedItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: "notif:1",
+    type: "notification",
+    priority: 50,
+    summary: "Gmail lost access to the mailbox scope.",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    status: "new",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as FeedItem;
+}
+
+function render(item: FeedItem): string {
+  return renderToStaticMarkup(createElement(HomeToolPermissionCard, { item }));
+}
+
+describe("HomeToolPermissionCard without a provider", () => {
+  test("renders the summary, not the title", () => {
+    const html = render(
+      feedItem({
+        title: "Gmail Access Lost",
+        summary: "Gmail lost access to the mailbox scope.",
+      }),
+    );
+
+    expect(html).toContain("Gmail lost access to the mailbox scope.");
+    expect(html).not.toContain("Gmail Access Lost");
+  });
+
+  test("does not repeat a title that matches the summary", () => {
+    // The daemon derives a title from the summary when no authored candidate
+    // survives, so the two can legitimately be identical. The card must still
+    // render the string once.
+    const shared = "Gmail lost access to the mailbox scope.";
+    const html = render(feedItem({ title: shared, summary: shared }));
+
+    expect(html.split(shared).length - 1).toBe(1);
+  });
+
+  test("still renders when the daemon omits a title", () => {
+    // Older daemons omit `title`; web ships always-latest, so this path stays
+    // reachable.
+    const html = render(feedItem({ title: undefined }));
+
+    expect(html).toContain("Gmail lost access to the mailbox scope.");
+  });
+});
+
+describe("HomeToolPermissionCard with a provider", () => {
+  test("renders the provider detail view instead of the summary", () => {
+    const html = render(
+      feedItem({
+        title: "Gmail Access Lost",
+        metadata: {
+          provider: "gmail",
+          status: "unreachable",
+          details: "Token expired.",
+        },
+      }),
+    );
+
+    expect(html).toContain("Token expired.");
+    expect(html).not.toContain("Gmail lost access to the mailbox scope.");
+  });
+});

--- a/clients/web/src/domains/home/detail-panel/home-tool-permission-card.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-tool-permission-card.tsx
@@ -40,12 +40,14 @@ export function HomeToolPermissionCard({ item }: HomeToolPermissionCardProps) {
   const provider = metadata?.provider as string | undefined;
 
   if (!provider) {
+    // The panel header above this card already renders the title, so this
+    // fallback shows the body. Matches HomeGenericDetail.
     return (
       <Typography
         variant="body-medium-default"
         className="text-[var(--content-secondary)]"
       >
-        {item.title ?? item.summary}
+        {item.summary}
       </Typography>
     );
   }


### PR DESCRIPTION
## Summary

Home-feed rows showed a truncated body where a headline belongs, and the detail header fell back to the capitalized category ("System"). The title was already being computed upstream for push and the desktop banner; the feed writer discarded it. This reclaims it, adds the validation layer it never had, and backfills existing items.

No new LLM calls. The notification decision already asks the model for a title on the same `cost-optimized` profile.

## What changed

**Root cause.** The decision tool gave the model a single nine-word field description buried in a large multi-field tool, then assigned the result raw with zero normalization. The conversation sidebar uses the *same* model profile but pairs it with a dedicated prompt and ~200 lines of output hygiene, and produces clean noun-phrase titles. This closes that gap rather than re-litigating model capability.

- **#39845** replaces the title field description with a real spec (2-5 words, 40 chars, noun phrase, explicit no-echo rule, worked examples)
- **#39844** extracts the sidebar's hygiene helpers into `util/short-title.ts` as a pure move; the sidebar's own tests pass unmodified
- **#39848** / **#39860** run every authored title through `normalizeTitle`, on both the classifier and fallback paths, via a single shared `resolveTitle`
- **#39851** / **#39858** make the feed resolve payload title, then rendered title, then a summary derivation, with markdown and newlines stripped from the derived case
- **#39849** / **#39860** add workspace migration 138 to backfill existing items
- **#39843** hardens the feed reader so one malformed row no longer empties the file
- **#39846** stops an empty title edit from clearing the field
- **#39859** fixes a real bug where `truncateTitle` could return 67 characters against a documented 40-char budget

## Reverses a prior decision

**#31063 (`872c611a96`)** stopped using `renderedCopy.title` because it "often echoed the body." That is now safe: the model is properly instructed and the output is validated, where previously it was neither. The two tests that asserted `title === undefined` were inverted rather than deleted so the reversal is visible in review.

## Deliberately not included

`FeedItem.title` is still `z.string().optional()`. Making it required is gated on sampling real `notification_deliveries.rendered_title` values to confirm the prompt fix is sufficient, which could not be done on the machine that produced this branch.

## Known follow-ups

- `home-tool-permission-card.tsx:48` renders `item.title ?? item.summary` inside a panel whose header already printed the title. With a title always present it prints the same string twice.
- When no authored title exists the header shows summary-derived text, which repeats the body's first line in the detail panel. This is an accepted trade-off, decided explicitly.
- #39849's body claims a dropped row "degrades rather than data loss." That is wrong: `runWrite` reads the filtered list and writes it back, erasing dropped rows. Harmless while title stays optional, but it must be resolved before the schema is tightened.

## Testing

371 tests across 14 files, typecheck clean. Includes the sidebar's `conversation-title-service` and `title-generate-hook` suites, confirming the helper extraction did not disturb that flow. The two markdown flatteners (runtime and the self-contained migration copy) were run over a 16-input corpus and produce identical output.

Ten PRs merged into this branch. Four self-review passes ran against the merged result and produced three remediation PRs.