### PR TITLE
fix(live-voice): make the VAD continuation-drop test deterministic

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -103,9 +103,13 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   readonly received: Buffer[] = [];
   stopped = false;
   private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+  private flushed = false;
+  // Claimed on the first audio chunk, so the scripted transcript is spent in
+  // the order cycles hear speech (see takeScriptedFinal).
+  private scriptedFinal: string | null = null;
 
   constructor(
-    private readonly stopEvents: SttStreamServerEvent[],
+    private readonly takeScriptedFinal: () => string,
     private readonly holdStopEvents = false,
   ) {}
 
@@ -114,6 +118,7 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 
   sendAudio(chunk: Buffer): void {
+    this.scriptedFinal ??= this.takeScriptedFinal();
     this.received.push(Buffer.from(chunk));
   }
 
@@ -128,19 +133,20 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 
   flushStopEvents(): void {
-    // A stream that was never sent audio has nothing to transcribe, so a real
-    // provider closes without a final. Scripting one anyway let a cycle that
-    // armed and tore down in the same breath — a client interrupt racing the
-    // post-cancel re-arm — hand the session a transcript it never heard, which
-    // launched a turn nothing would ever finalize and wedged the
-    // one-turn-at-a-time gate for every later utterance.
-    const events =
-      this.received.length > 0
-        ? this.stopEvents
-        : this.stopEvents.filter((event) => event.type !== "final");
-    for (const event of events) {
-      this.onEvent?.(event);
+    if (this.flushed) {
+      return;
     }
+    this.flushed = true;
+    // A stream that was never sent audio has nothing to transcribe, so a real
+    // provider closes without a final. Scripting one anyway lets a cycle that
+    // arms and tears down in the same breath (a client interrupt racing the
+    // post-cancel re-arm) hand the session a transcript it never heard, which
+    // launches a turn nothing will ever finalize and wedges the
+    // one-turn-at-a-time gate for every later utterance.
+    if (this.scriptedFinal !== null) {
+      this.onEvent?.({ type: "final", text: this.scriptedFinal });
+    }
+    this.onEvent?.({ type: "closed" });
   }
 
   // Provider-initiated event (e.g. an idle-timeout close), no stop() needed.
@@ -192,12 +198,23 @@ function createHarness(options: {
   };
 
   const finals = options.finals ?? ["hello world"];
+  // Scripted finals are handed out in the order cycles first receive audio,
+  // not in the order they arm. Server VAD arms and discards audio-free cycles
+  // on wall-clock timers (the trailing-silence timer, the post-cancel re-arm),
+  // so how many cycles have armed by a given point depends on how fast the
+  // event loop is, while the order the test feeds audio in does not. Keying
+  // off audio keeps `finals` reading as "what the user says, in order".
+  let scriptedFinalIndex = 0;
+  const takeScriptedFinal = (): string => {
+    const text =
+      finals[scriptedFinalIndex] ?? `utterance ${scriptedFinalIndex + 1}`;
+    scriptedFinalIndex += 1;
+    return text;
+  };
   const transcribers: MockStreamingTranscriber[] = [];
   const resolveTranscriber = mock(async () => {
-    const text =
-      finals[transcribers.length] ?? `utterance ${transcribers.length + 1}`;
     const transcriber = new MockStreamingTranscriber(
-      [{ type: "final", text }, { type: "closed" }],
+      takeScriptedFinal,
       options.holdStopEventsFor?.includes(transcribers.length) ?? false,
     );
     transcribers.push(transcriber);
@@ -2921,8 +2938,11 @@ describe("LiveVoiceSession server VAD", () => {
 
   test("an idle transcriber close before speech re-arms capture for the next utterance", async () => {
     const { startVoiceTurn, calls } = makeAutoCompletingTurnStarter(["Hi."]);
+    // The first transcriber closes before it is sent any audio, so it never
+    // claims a scripted final: the one entry belongs to the cycle that speech
+    // actually reaches.
     const { frames, session, transcribers } = createHarness({
-      finals: ["never spoken", "hello after close"],
+      finals: ["hello after close"],
       startVoiceTurn,
     });
 


### PR DESCRIPTION
## Summary
The VAD test harness assigned each scripted STT final to a transcriber when the cycle armed, keying the transcript on arm order. Server VAD arms and discards audio-free cycles on wall-clock timers (the 40ms trailing-silence timer, the post-cancel re-arm), so the number of cycles that exist at any point in a test depends on how fast the event loop is. On a loaded runner an extra cycle slips in between the barge-in chunk and the interrupt, that cycle silently claims the next scripted final, and the audio the test sends afterwards transcribes as `utterance 4` instead of `third question`. The final `waitFor` then burns its whole 4s budget, which is the ~4100ms signature.

Finals are now claimed on a cycle's first audio chunk instead. A cycle that hears nothing leaves the script untouched, so `finals` is the sequence of things the test actually speaks and arm churn between chunks cannot shift it. `flushStopEvents` is also made idempotent so a held flush plus a later stop cannot emit two finals.

No production code changed, and no production bug was found: the arm/discard churn is correct server-VAD behavior.

### Verification
- Reproduced deterministically by injecting a 100ms delay before the interrupt: same error, same ~4.1s duration. Fixed version passes with injected delays of 50/100/300/800/1400ms.
- Under 48 busy loops on 16 cores: pre-fix failed 4 of 6 runs, post-fix passed 12 of 12.
- 25 consecutive single-test runs green, 8 consecutive whole-file runs green (86 pass / 0 fail), plus 4 whole-file runs under load.

This test fails intermittently on main and blocks unrelated PRs. Not part of the subagent plan's scope; included on this branch to unblock it.