### PR TITLE
feat(web): open a files side panel from the attachment overflow tile

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -4,6 +4,8 @@ interface AttachmentOverflowSquareProps {
   /** How many attachments are hidden behind this tile. */
   count: number;
   onClick: () => void;
+  /** Whether this tile's files panel is currently open. */
+  active?: boolean;
 }
 
 /**
@@ -13,6 +15,7 @@ interface AttachmentOverflowSquareProps {
 export function AttachmentOverflowSquare({
   count,
   onClick,
+  active = false,
 }: AttachmentOverflowSquareProps) {
   return (
     <button
@@ -20,7 +23,11 @@ export function AttachmentOverflowSquare({
       onClick={onClick}
       aria-label={`Show all files (${count} more)`}
       title={`${count} more`}
-      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--border-base)] transition-colors hover:bg-[var(--surface-lift)]"
+      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
+        active
+          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
+      }`}
     >
       <Typography
         variant="body-small-default"

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -23,12 +23,14 @@ mock.module(
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+import { useViewerStore } from "@/stores/viewer-store";
 
 afterAll(() => {
   mock.restore();
 });
 afterEach(() => {
   cleanup();
+  useViewerStore.setState({ mainView: "chat", activeMessageFiles: null });
 });
 
 function image(index: number): DisplayAttachment {
@@ -130,16 +132,33 @@ describe("MessageAttachments", () => {
     expect(getByText("+3")).toBeTruthy();
   });
 
-  test("opens the preview on the first hidden attachment with the full gallery", () => {
-    const { getByRole, getByTestId } = render(
-      <MessageAttachments attachments={images(8)} />,
+  test("the overflow tile opens the files panel with every attachment", () => {
+    const { getByRole, queryByTestId } = render(
+      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
     );
 
     fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
 
-    const modal = getByTestId("preview-modal");
-    expect(modal.getAttribute("data-attachment-id")).toBe("img-5");
-    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("message-files");
+    expect(viewer.activeMessageFiles?.messageId).toBe("msg-1");
+    expect(viewer.activeMessageFiles?.attachments).toHaveLength(8);
+    // The tile targets the panel, so the preview modal stays shut.
+    expect(queryByTestId("preview-modal")).toBeNull();
+  });
+
+  test("clicking the overflow tile again closes the files panel", () => {
+    const { getByRole } = render(
+      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+    );
+
+    const tile = getByRole("button", { name: "Show all files (3 more)" });
+    fireEvent.click(tile);
+    fireEvent.click(tile);
+
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("chat");
+    expect(viewer.activeMessageFiles).toBeNull();
   });
 
   test("returns null for an empty attachments array", () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
@@ -7,12 +7,19 @@ import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachm
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import {
+  sameMessageFilesTarget,
+  useViewerStore,
+  type MessageFilesPayload,
+} from "@/stores/viewer-store";
 
 interface MessageAttachmentsProps {
   attachments: DisplayAttachment[];
   /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
+  /** Transcript message identity, forwarded to the files panel payload. */
+  messageId?: string;
 }
 
 /**
@@ -29,16 +36,21 @@ const VISIBLE_LIMIT = 5;
  * opens a full-screen preview modal — the modal handles type-specific
  * rendering (image/video/fallback) and lazily fetches missing content when
  * needed. A hover overlay on each square provides direct download without
- * opening the preview first.
+ * opening the preview first. Past {@link VISIBLE_LIMIT} the strip collapses
+ * behind an overflow tile that opens the files side panel.
  */
 export const MessageAttachments: FC<MessageAttachmentsProps> = ({
   attachments,
   assistantId,
+  messageId,
 }) => {
   const { openPreview, previewModal } = useAttachmentPreview(
     assistantId,
     attachments,
   );
+  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
+  const mainView = useViewerStore.use.mainView();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
 
   const handleDownload = useCallback(
     (att: DisplayAttachment) => {
@@ -46,6 +58,18 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
     },
     [assistantId],
   );
+
+  const filesPayload: MessageFilesPayload = useMemo(
+    () => ({ messageId, attachments, assistantId }),
+    [messageId, attachments, assistantId],
+  );
+
+  // The tile whose files panel is currently open renders with the persistent
+  // active surface, mirroring the activity group header's selected state.
+  const tileActive =
+    mainView === "message-files" &&
+    activeMessageFiles != null &&
+    sameMessageFilesTarget(activeMessageFiles, filesPayload);
 
   if (attachments.length === 0) {
     return null;
@@ -72,7 +96,8 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
         {overflowCount > 0 && (
           <AttachmentOverflowSquare
             count={overflowCount}
-            onClick={() => openPreview(attachments[VISIBLE_LIMIT]!)}
+            active={tileActive}
+            onClick={() => toggleMessageFiles(filesPayload)}
           />
         )}
       </div>

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -46,6 +46,8 @@ const importToolDetailPanel = () =>
   import("@/domains/chat/components/tool-detail-panel");
 const importActivityStepsPanel = () =>
   import("@/domains/chat/components/activity-steps-panel");
+const importMessageFilesPanel = () =>
+  import("@/domains/chat/components/message-files-panel");
 const importAcpRunDetailPanel = () =>
   import("@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel");
 const importWorkflowDetailPanel = () =>
@@ -69,6 +71,9 @@ const ToolDetailPanel = lazy(() =>
 );
 const ActivityStepsPanel = lazy(() =>
   importActivityStepsPanel().then((m) => ({ default: m.ActivityStepsPanel })),
+);
+const MessageFilesPanel = lazy(() =>
+  importMessageFilesPanel().then((m) => ({ default: m.MessageFilesPanel })),
 );
 const BackgroundTaskDetailPanel = lazy(() =>
   importBackgroundTaskDetailPanel().then((m) => ({
@@ -95,6 +100,8 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   const closeToolDetail = useViewerStore.use.closeToolDetail();
   const activeActivitySteps = useViewerStore.use.activeActivitySteps();
   const closeActivitySteps = useViewerStore.use.closeActivitySteps();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
+  const closeMessageFiles = useViewerStore.use.closeMessageFiles();
   // Subscribe to only the active subagent's entry rather than the whole `byId`
   // map, so streaming events from *other* subagents don't re-render the chat
   // layout (and the chat transcript it hosts) on every token.
@@ -313,6 +320,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       importSubagentDetailPanel().catch(() => {});
       importToolDetailPanel().catch(() => {});
       importActivityStepsPanel().catch(() => {});
+      importMessageFilesPanel().catch(() => {});
       importAcpRunDetailPanel().catch(() => {});
       importWorkflowDetailPanel().catch(() => {});
       importBackgroundTaskDetailPanel().catch(() => {});
@@ -461,6 +469,18 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             }`}
             payload={activeActivitySteps}
             onClose={closeActivitySteps}
+          />
+        </LazyBoundary>
+      );
+    } else if (mainView === "message-files" && activeMessageFiles) {
+      rightPanel = (
+        <LazyBoundary>
+          <MessageFilesPanel
+            // Re-key per message so the panel resets when a different
+            // message's tile is clicked while the panel is already open.
+            key={activeMessageFiles.messageId ?? "snapshot"}
+            payload={activeMessageFiles}
+            onClose={closeMessageFiles}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/message-files-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for `MessageFilesPanel` - the side drawer listing every attachment on
+ * one transcript message.
+ *
+ *  - Renders one square per attachment, media and non-media alike, from the
+ *    payload snapshot when no live message resolves.
+ *  - The header count matches the attachment total.
+ *  - The close button fires `onClose`.
+ *  - Clicking a square opens the shared preview modal with the whole set as
+ *    gallery siblings.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+      siblingAttachments,
+    }: {
+      attachment: { id: string };
+      siblingAttachments?: Array<{ id: string }>;
+    }) => (
+      <div
+        data-testid="preview-modal"
+        data-attachment-id={attachment.id}
+        data-sibling-count={String((siblingAttachments ?? []).length)}
+      />
+    ),
+  }),
+);
+
+const { MessageFilesPanel } = await import(
+  "@/domains/chat/components/message-files-panel"
+);
+
+afterEach(() => {
+  cleanup();
+});
+
+const ATTACHMENTS: DisplayAttachment[] = [
+  {
+    id: "img-0",
+    filename: "photo-0.png",
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: "https://example.com/photo-0.png",
+  },
+  {
+    id: "deck-1",
+    filename: "deck.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_096,
+    previewUrl: null,
+  },
+  {
+    id: "report-1",
+    filename: "report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_048,
+    previewUrl: null,
+  },
+  {
+    id: "bundle-1",
+    filename: "bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_192,
+    previewUrl: null,
+  },
+];
+
+function renderPanel(onClose: () => void = () => {}) {
+  return render(
+    <MessageFilesPanel
+      payload={{ attachments: ATTACHMENTS }}
+      onClose={onClose}
+    />,
+  );
+}
+
+/** The squares are divs with `role="button"`; the download affordance is a
+ *  real `<button>`, so this selector counts only attachment squares. */
+function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}
+
+describe("MessageFilesPanel", () => {
+  test("renders one square per attachment, media and non-media alike", () => {
+    const { container } = renderPanel();
+    expect(squareLabels(container)).toEqual([
+      "photo-0.png",
+      "deck.pptx",
+      "report.pdf",
+      "bundle.zip",
+    ]);
+  });
+
+  test("header count matches the attachment total", () => {
+    const { getByText } = renderPanel();
+    expect(getByText("Files · 4")).toBeTruthy();
+  });
+
+  test("close button fires onClose", () => {
+    let closed = false;
+    const { getByLabelText } = renderPanel(() => {
+      closed = true;
+    });
+    fireEvent.click(getByLabelText("Close files"));
+    expect(closed).toBe(true);
+  });
+
+  test("clicking a square opens the preview with the whole set as siblings", () => {
+    const { getByLabelText, getByTestId } = renderPanel();
+    fireEvent.click(getByLabelText("report.pdf"));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("report-1");
+    expect(modal.getAttribute("data-sibling-count")).toBe("4");
+  });
+});

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -1,0 +1,64 @@
+/**
+ * Side-drawer panel listing every attachment on one transcript message.
+ * Opened by the overflow tile on a truncated attachment strip (see
+ * `MessageAttachments`). Each tile opens the shared full-screen preview
+ * modal with gallery navigation across the whole set.
+ *
+ * Streams live: the panel re-derives the message's attachments from the
+ * transcript by `messageId` via `useLiveMessageAttachments`, so files that
+ * land mid-turn appear while the panel is open. The payload's embedded
+ * snapshot is the fallback when the message can't be resolved (paged out, or
+ * identity-less callers like stories).
+ */
+
+import { Paperclip } from "lucide-react";
+
+import { DetailShell } from "@/components/detail-shell";
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
+import type { MessageFilesPayload } from "@/stores/viewer-store";
+
+interface MessageFilesPanelProps {
+  payload: MessageFilesPayload;
+  onClose: () => void;
+}
+
+export function MessageFilesPanel({
+  payload,
+  onClose,
+}: MessageFilesPanelProps) {
+  const live = useLiveMessageAttachments(payload.messageId);
+  const attachments = live ?? payload.attachments;
+  const { openPreview, previewModal } = useAttachmentPreview(
+    payload.assistantId,
+    attachments,
+  );
+
+  return (
+    <DetailShell
+      Glyph={Paperclip}
+      title={`Files · ${attachments.length}`}
+      closeLabel="Close files"
+      onClose={onClose}
+    >
+      {/* Three across fits the drawer's 400px default width. */}
+      <div className="grid grid-cols-3 gap-3">
+        {attachments.map((att) => (
+          <MessageAttachmentSquare
+            key={att.id}
+            filename={att.filename}
+            mimeType={att.mimeType}
+            sizeBytes={att.sizeBytes}
+            previewUrl={att.previewUrl}
+            thumbnailUrl={att.thumbnailUrl}
+            onPreview={() => openPreview(att)}
+            onDownload={() => void downloadAttachment(att, payload.assistantId)}
+          />
+        ))}
+      </div>
+      {previewModal}
+    </DetailShell>
+  );
+}

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -26,6 +26,7 @@ import { MobileActivityStepsOverlay } from "@/domains/chat/components/mobile-act
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileBackgroundTaskDetailOverlay } from "@/domains/chat/components/mobile-background-task-detail-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
+import { MobileMessageFilesOverlay } from "@/domains/chat/components/mobile-message-files-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
 import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
 import { MobileWorkflowDetailOverlay } from "@/domains/chat/components/mobile-workflow-detail-overlay";
@@ -44,6 +45,7 @@ export function MobileChatOverlays() {
   const activeSubagentId = useViewerStore.use.activeSubagentId();
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const activeActivitySteps = useViewerStore.use.activeActivitySteps();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
   const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const activeAcpRunId = useViewerStore.use.activeAcpRunId();
   const activeBackgroundTaskId = useViewerStore.use.activeBackgroundTaskId();
@@ -148,6 +150,10 @@ export function MobileChatOverlays() {
     useViewerStore.getState().closeActivitySteps();
   }, []);
 
+  const handleCloseMessageFiles = useCallback(() => {
+    useViewerStore.getState().closeMessageFiles();
+  }, []);
+
   if (!overlayTarget) {
     return null;
   }
@@ -219,6 +225,10 @@ export function MobileChatOverlays() {
       <MobileActivityStepsOverlay
         payload={mainView === "activity-steps" ? activeActivitySteps : null}
         onClose={handleCloseActivitySteps}
+      />
+      <MobileMessageFilesOverlay
+        payload={mainView === "message-files" ? activeMessageFiles : null}
+        onClose={handleCloseMessageFiles}
       />
     </>,
     overlayTarget,

--- a/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
@@ -1,0 +1,60 @@
+import { lazy, type MouseEvent } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { MessageFilesPayload } from "@/stores/viewer-store";
+
+const MessageFilesPanel = lazy(() =>
+  import("@/domains/chat/components/message-files-panel").then((m) => ({
+    default: m.MessageFilesPanel,
+  })),
+);
+
+interface MobileMessageFilesOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  payload: MessageFilesPayload | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the message-files panel (every
+ * attachment on one transcript message, each opening the shared preview
+ * modal).
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ */
+export function MobileMessageFilesOverlay({
+  payload,
+  onClose,
+}: MobileMessageFilesOverlayProps) {
+  if (!payload) {
+    return null;
+  }
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh] bg-black/40"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom:
+          "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft:
+          "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight:
+          "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+      onClick={handleBackdropClick}
+    >
+      <LazyBoundary>
+        <MessageFilesPanel payload={payload} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
@@ -1,6 +1,7 @@
-import { lazy, type MouseEvent } from "react";
+import { lazy } from "react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
+import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
 import type { MessageFilesPayload } from "@/stores/viewer-store";
 
 const MessageFilesPanel = lazy(() =>
@@ -28,30 +29,14 @@ export function MobileMessageFilesOverlay({
   payload,
   onClose,
 }: MobileMessageFilesOverlayProps) {
+  const shellStyle = useMobileOverlayViewportStyle();
+
   if (!payload) {
     return null;
   }
 
-  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh] bg-black/40"
-      style={{
-        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
-        paddingBottom:
-          "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
-        paddingLeft:
-          "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
-        paddingRight:
-          "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
-      }}
-      onClick={handleBackdropClick}
-    >
+    <div className="fixed inset-x-0 z-30" style={shellStyle}>
       <LazyBoundary>
         <MessageFilesPanel payload={payload} onClose={onClose} />
       </LazyBoundary>

--- a/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+/**
+ * A message's attachments re-derived from the rendered transcript on every
+ * render, so an open files panel picks up attachments that land while a
+ * message is still streaming. Returns `null` when the message cannot be
+ * found (paged out of the loaded transcript) so callers fall back to the
+ * open-time snapshot.
+ */
+export function useLiveMessageAttachments(
+  messageId: string | undefined,
+): DisplayAttachment[] | null {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    if (!messageId) {
+      return null;
+    }
+    const message = messages.find((m) =>
+      messageMatchKeys(m).includes(messageId),
+    );
+    return message?.attachments ?? null;
+  }, [messages, messageId]);
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1103,6 +1103,7 @@ export function TranscriptMessageBody({
           <MessageAttachments
             attachments={message.attachments ?? []}
             assistantId={assistantId}
+            messageId={message.id}
           />
         )}
         {trailer}


### PR DESCRIPTION
## Summary
- Clicking the `+N` overflow tile opens a side panel listing every attachment on that message, mirroring the activity-steps panel at every layer (desktop drawer, mobile portal overlay, Escape-to-close).
- Adds `MessageFilesPanel`, `useLiveMessageAttachments`, and `MobileMessageFilesOverlay`, and wires the `message-files` overlay view landed in #39856.
- Panel tiles reuse `MessageAttachmentSquare` and the shared preview modal, so gallery navigation and hover-download work unchanged.

Part of plan: message-attachment-overflow.md (PR 3 of 3)