### PR TITLE
fix(assistant): withdraw Telegram approval cards in place on resolution

### DIFF
--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -232,7 +232,7 @@ describe("withdrawGuardianRequestCards", () => {
     });
   });
 
-  test("suppresses the Telegram status reply when the decision originated on Telegram", async () => {
+  test("suppresses the Telegram status reply only when the origin flow replies to the guardian", async () => {
     const req = makeRequest({ sourceChannel: "telegram" });
     bridgeState.seedDelivery({
       requestId: req.id,
@@ -246,9 +246,10 @@ describe("withdrawGuardianRequestCards", () => {
       status: "denied",
       originChannel: "telegram",
       decidedAction: "reject",
+      hasOriginGuardianReply: true,
     });
 
-    // The reply router already delivered its outcome message in that chat;
+    // The resolver's guardian-facing reply is being delivered in that chat;
     // withdrawal only drops the keyboard.
     expect(withdrawTelegramApprovalCard).toHaveBeenCalledWith({
       chatId: "T1",
@@ -256,6 +257,35 @@ describe("withdrawGuardianRequestCards", () => {
       status: "denied",
       decidedAction: "reject",
       postStatusReply: false,
+    });
+  });
+
+  test("posts the Telegram status reply for origin decisions without a guardian-facing resolver reply", async () => {
+    const req = makeRequest({ sourceChannel: "telegram" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "T1",
+      destinationMessageId: "9",
+    });
+
+    // Most resolvers (tool grants, tool approvals, questions) reply to the
+    // requester only, so the quoted status reply is the guardian's only
+    // durable outcome even for a decision made on Telegram itself.
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "approved",
+      originChannel: "telegram",
+      decidedAction: "approve_once",
+      hasOriginGuardianReply: false,
+    });
+
+    expect(withdrawTelegramApprovalCard).toHaveBeenCalledWith({
+      chatId: "T1",
+      messageId: "9",
+      status: "approved",
+      decidedAction: "approve_once",
+      postStatusReply: true,
     });
   });
 

--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -14,6 +14,13 @@ mock.module("../messaging/providers/slack/withdraw.js", () => ({
   withdrawSlackApprovalCard,
 }));
 
+const withdrawTelegramApprovalCard = mock(
+  async (_params: Record<string, unknown>) => {},
+);
+mock.module("../messaging/providers/telegram-bot/withdraw.js", () => ({
+  withdrawTelegramApprovalCard,
+}));
+
 // The recorder writes through the gateway client; serve that surface from
 // the in-memory sim the assertions read.
 import {
@@ -60,6 +67,7 @@ describe("withdrawGuardianRequestCards", () => {
     completeSurfaceAndNotify.mockClear();
     markSurfaceCompleted.mockClear();
     withdrawSlackApprovalCard.mockClear();
+    withdrawTelegramApprovalCard.mockClear();
   });
 
   test("withdraws + broadcasts the in-app card when the decision came from another surface", async () => {
@@ -199,7 +207,7 @@ describe("withdrawGuardianRequestCards", () => {
     expect(withdrawSlackApprovalCard).toHaveBeenCalledTimes(1);
   });
 
-  test("ignores channels without in-place edit support (telegram)", async () => {
+  test("withdraws the Telegram card with a status reply when resolved from another surface", async () => {
     const req = makeRequest({ sourceChannel: "telegram" });
     bridgeState.seedDelivery({
       requestId: req.id,
@@ -208,10 +216,60 @@ describe("withdrawGuardianRequestCards", () => {
       destinationMessageId: "9",
     });
 
-    await withdrawGuardianRequestCards({ request: req, status: "approved" });
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "approved",
+      originChannel: "vellum",
+    });
 
     expect(withdrawSlackApprovalCard).not.toHaveBeenCalled();
-    expect(completeSurfaceAndNotify).not.toHaveBeenCalled();
+    expect(withdrawTelegramApprovalCard).toHaveBeenCalledTimes(1);
+    expect(withdrawTelegramApprovalCard).toHaveBeenCalledWith({
+      chatId: "T1",
+      messageId: "9",
+      status: "approved",
+      postStatusReply: true,
+    });
+  });
+
+  test("suppresses the Telegram status reply when the decision originated on Telegram", async () => {
+    const req = makeRequest({ sourceChannel: "telegram" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "T1",
+      destinationMessageId: "9",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "denied",
+      originChannel: "telegram",
+      decidedAction: "reject",
+    });
+
+    // The reply router already delivered its outcome message in that chat;
+    // withdrawal only drops the keyboard.
+    expect(withdrawTelegramApprovalCard).toHaveBeenCalledWith({
+      chatId: "T1",
+      messageId: "9",
+      status: "denied",
+      decidedAction: "reject",
+      postStatusReply: false,
+    });
+  });
+
+  test("skips the Telegram edit when no channel message id was captured", async () => {
+    const req = makeRequest({ sourceChannel: "telegram" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "telegram",
+      destinationChatId: "T1",
+    });
+
+    await withdrawGuardianRequestCards({ request: req, status: "approved" });
+
+    expect(withdrawTelegramApprovalCard).not.toHaveBeenCalled();
   });
 
   test("is best-effort: a failing surface never blocks the others or throws", async () => {

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -27,6 +27,9 @@ mock.module("../messaging/providers/telegram-bot/send.js", () => ({
       text,
       approval: approval as (typeof sendCalls)[0]["approval"],
     });
+    // Mirror the real send result: the id of the sent message, which the
+    // adapter surfaces so the delivery row can address the card later.
+    return { lastMessageId: String(1000 + sendCalls.length) };
   },
   sendTelegramAttachments: async () => ({
     allFailed: false,
@@ -196,6 +199,9 @@ describe("TelegramAdapter", () => {
     const result = await adapter.send(payload, makeDestination());
 
     expect(result.success).toBe(true);
+    // The sent message's channel-native id is surfaced so the delivery row
+    // can address the card for in-place withdrawal later.
+    expect(result.messageId).toBe("1001");
     expect(sendCalls).toHaveLength(1);
 
     const call = sendCalls[0]!;

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -36,35 +36,11 @@ import { withdrawTelegramApprovalCard } from "../messaging/providers/telegram-bo
 import { approvalCardSurfaceId } from "../notifications/approval-card-data.js";
 import {
   type ApprovalAction,
-  isParkAction,
-  PARK_STATUS_LABEL,
+  resolveDecisionStatusWord,
 } from "../runtime/channel-approval-types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("guardian-card-withdrawal");
-
-/** Completion-summary label shown on an in-app card for a resolved request. */
-const SURFACE_STATUS_LABELS: Partial<Record<GuardianRequestStatus, string>> = {
-  approved: "Approved",
-  denied: "Denied",
-  expired: "Expired",
-  cancelled: "Cancelled",
-};
-
-/**
- * The completion-summary label for a resolved card. A `denied` status reached by
- * a park action reads as the neutral {@link PARK_STATUS_LABEL} rather than
- * "Denied" — a parked contact was neither trusted nor kept out.
- */
-function resolveStatusLabel(
-  status: GuardianRequestStatus,
-  decidedAction: ApprovalAction | undefined,
-): string {
-  if (status === "denied" && isParkAction(decidedAction)) {
-    return PARK_STATUS_LABEL;
-  }
-  return SURFACE_STATUS_LABELS[status] ?? "Resolved";
-}
 
 /** The request fields withdrawal reads — structural subset of the wire row. */
 export interface WithdrawableGuardianRequest {
@@ -93,10 +69,20 @@ export interface WithdrawGuardianCardsParams {
    * The action the guardian took, when the terminal status came from a decision
    * (omitted for the expiry sweep). A `denied` status can mean either a neutral
    * park (`leave_unverified`) or an active rejection (`block`/`reject`); the
-   * action disambiguates them so a park renders neutrally as
-   * {@link PARK_STATUS_LABEL} instead of "Denied".
+   * action disambiguates them so a park renders neutrally as the park label
+   * (see {@link resolveDecisionStatusWord}) instead of "Denied".
    */
   decidedAction?: ApprovalAction;
+  /**
+   * True when the deciding flow delivers the resolver's own guardian-facing
+   * reply on the origin channel (the resolver returned `guardianReplyText`).
+   * Telegram's quoted status reply is suppressed only when the origin chat is
+   * Telegram AND that richer reply is coming; most resolvers (tool grants,
+   * tool approvals, questions) reply to the requester, not the guardian, so
+   * without this flag the withdrawal's status reply is the only durable
+   * outcome the guardian's chat gets.
+   */
+  hasOriginGuardianReply?: boolean;
 }
 
 /**
@@ -106,7 +92,13 @@ export interface WithdrawGuardianCardsParams {
 export async function withdrawGuardianRequestCards(
   params: WithdrawGuardianCardsParams,
 ): Promise<void> {
-  const { request, status, originChannel, decidedAction } = params;
+  const {
+    request,
+    status,
+    originChannel,
+    decidedAction,
+    hasOriginGuardianReply,
+  } = params;
 
   let deliveries: GuardianRequestDeliveryWire[];
   try {
@@ -137,6 +129,7 @@ export async function withdrawGuardianRequestCards(
           status,
           originChannel,
           decidedAction,
+          hasOriginGuardianReply ?? false,
         );
       }
       // WhatsApp direct delivery can't edit a message in place (it would
@@ -183,7 +176,7 @@ function withdrawVellumCard(
   if (!surfaceId) {
     return;
   }
-  const summary = resolveStatusLabel(status, decidedAction);
+  const summary = resolveDecisionStatusWord(status, decidedAction);
   if (originChannel === "vellum") {
     markSurfaceCompleted(
       { conversationId: delivery.destinationConversationId },
@@ -230,16 +223,20 @@ async function withdrawSlackCard(
  * a quoted reply rather than an in-message edit; the card's own text is left
  * untouched for the audit trail.
  *
- * The status reply is origin-sensitive: a decision made on Telegram already
- * gets the reply router's outcome message in the same chat, so only the
- * keyboard removal applies there. No-ops when the channel-native message id
- * was not captured at delivery time.
+ * The status reply is suppressed only when the decision was made on Telegram
+ * AND its flow delivers the resolver's own guardian-facing reply there
+ * (`hasOriginGuardianReply`), where a second notice would read as a
+ * duplicate. Most resolvers reply to the requester, not the guardian, so a
+ * Telegram-origin decision usually still needs this reply as its durable
+ * outcome. No-ops when the channel-native message id was not captured at
+ * delivery time.
  */
 async function withdrawTelegramCard(
   delivery: GuardianRequestDeliveryWire,
   status: GuardianRequestStatus,
   originChannel: string | undefined,
   decidedAction: ApprovalAction | undefined,
+  hasOriginGuardianReply: boolean,
 ): Promise<void> {
   if (!delivery.destinationChatId || !delivery.destinationMessageId) {
     return;
@@ -249,6 +246,6 @@ async function withdrawTelegramCard(
     messageId: delivery.destinationMessageId,
     status,
     ...(decidedAction ? { decidedAction } : {}),
-    postStatusReply: originChannel !== "telegram",
+    postStatusReply: !(originChannel === "telegram" && hasOriginGuardianReply),
   });
 }

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -32,6 +32,7 @@ import {
   markSurfaceCompleted,
 } from "../daemon/conversation-surfaces.js";
 import { withdrawSlackApprovalCard } from "../messaging/providers/slack/withdraw.js";
+import { withdrawTelegramApprovalCard } from "../messaging/providers/telegram-bot/withdraw.js";
 import { approvalCardSurfaceId } from "../notifications/approval-card-data.js";
 import {
   type ApprovalAction,
@@ -130,9 +131,16 @@ export async function withdrawGuardianRequestCards(
         );
       } else if (delivery.destinationChannel === "slack") {
         await withdrawSlackCard(request, delivery, status, decidedAction);
+      } else if (delivery.destinationChannel === "telegram") {
+        await withdrawTelegramCard(
+          delivery,
+          status,
+          originChannel,
+          decidedAction,
+        );
       }
-      // Telegram/WhatsApp direct delivery can't edit a message in place (it
-      // would post a new one), so their stale clicks are left to the existing
+      // WhatsApp direct delivery can't edit a message in place (it would
+      // post a new one), so its stale clicks are left to the existing
       // "already resolved" reply until in-place edit support lands.
     } catch (err) {
       log.warn(
@@ -212,5 +220,35 @@ async function withdrawSlackCard(
     ...(decidedAction ? { decidedAction } : {}),
     decidedByExternalUserId: request.decidedByExternalUserId ?? undefined,
     decidedAtMs: request.updatedAt,
+  });
+}
+
+/**
+ * Withdraw the Telegram approval card: remove its inline keyboard in place
+ * and post a silent reply quoting the card with the terminal outcome.
+ * Telegram bots cannot re-read a message, so unlike Slack the outcome rides
+ * a quoted reply rather than an in-message edit; the card's own text is left
+ * untouched for the audit trail.
+ *
+ * The status reply is origin-sensitive: a decision made on Telegram already
+ * gets the reply router's outcome message in the same chat, so only the
+ * keyboard removal applies there. No-ops when the channel-native message id
+ * was not captured at delivery time.
+ */
+async function withdrawTelegramCard(
+  delivery: GuardianRequestDeliveryWire,
+  status: GuardianRequestStatus,
+  originChannel: string | undefined,
+  decidedAction: ApprovalAction | undefined,
+): Promise<void> {
+  if (!delivery.destinationChatId || !delivery.destinationMessageId) {
+    return;
+  }
+  await withdrawTelegramApprovalCard({
+    chatId: delivery.destinationChatId,
+    messageId: delivery.destinationMessageId,
+    status,
+    ...(decidedAction ? { decidedAction } : {}),
+    postStatusReply: originChannel !== "telegram",
   });
 }

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -532,6 +532,10 @@ export async function applyGuardianDecision(
     status: targetStatus,
     originChannel: actorContext.channel,
     decidedAction: cardAction,
+    // Tells the Telegram projection whether the origin chat is about to get
+    // the resolver's own guardian-facing reply (delivered by our caller), so
+    // it can skip its quoted status reply instead of duplicating it.
+    hasOriginGuardianReply: Boolean(resolverReplyText),
   }).catch((err) => {
     log.warn(
       { err, requestId },

--- a/assistant/src/messaging/providers/slack/withdraw.ts
+++ b/assistant/src/messaging/providers/slack/withdraw.ts
@@ -17,7 +17,7 @@
 
 import {
   isParkAction,
-  PARK_STATUS_LABEL,
+  resolveDecisionStatusWord,
 } from "../../../runtime/channel-approval-types.js";
 import { getLogger } from "../../../util/logger.js";
 import { callSlackApi, getSlackMessageBlocks } from "./api.js";
@@ -46,13 +46,6 @@ const STATUS_GLYPH: Record<string, string> = {
   cancelled: ":no_entry_sign:",
 };
 
-const STATUS_WORD: Record<string, string> = {
-  approved: "Approved",
-  denied: "Denied",
-  expired: "Expired",
-  cancelled: "Cancelled",
-};
-
 /**
  * Glyph for a parked (leave-unverified) decision. A neutral "on hold" mark
  * rather than the `denied` red cross — the sender was neither trusted nor kept
@@ -69,9 +62,10 @@ export interface WithdrawSlackApprovalCardParams {
   status: string;
   /**
    * The action the guardian took, when known. A `denied` status reached by a
-   * park action (`leave_unverified`) reads as the neutral
-   * {@link PARK_STATUS_LABEL} rather than "Denied"; `block`/`reject` stay a
-   * denial. Omitted for status-only transitions (e.g. the expiry sweep).
+   * park action (`leave_unverified`) reads as the neutral park label (see
+   * {@link resolveDecisionStatusWord}) rather than "Denied"; `block`/`reject`
+   * stay a denial. Omitted for status-only transitions (e.g. the expiry
+   * sweep).
    */
   decidedAction?: string;
   /** Slack user id of the decider, when the decision came from Slack. */
@@ -87,9 +81,7 @@ export interface WithdrawSlackApprovalCardParams {
 function buildStatusText(params: WithdrawSlackApprovalCardParams): string {
   const park = params.status === "denied" && isParkAction(params.decidedAction);
   const glyph = park ? PARK_STATUS_GLYPH : (STATUS_GLYPH[params.status] ?? "");
-  const word = park
-    ? PARK_STATUS_LABEL
-    : (STATUS_WORD[params.status] ?? "Resolved");
+  const word = resolveDecisionStatusWord(params.status, params.decidedAction);
   let line = glyph ? `${glyph} *${word}*` : `*${word}*`;
   if (params.decidedByExternalUserId) {
     line += ` by <@${params.decidedByExternalUserId}>`;

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -30,7 +30,7 @@ mock.module("./api.js", () => ({
 }));
 
 const { TelegramNonRetryableError } = await import("./api.js");
-const { sendTelegramRichReply } = await import("./send.js");
+const { sendTelegramReply, sendTelegramRichReply } = await import("./send.js");
 const { telegramTransport } = await import("./transport.js");
 
 const approval: ApprovalUIMetadata = {
@@ -145,6 +145,36 @@ describe("sendTelegramRichReply", () => {
 
     expect(callsTo("sendRichMessage")).toHaveLength(1);
     expect(callsTo("sendMessage")).toHaveLength(0);
+  });
+});
+
+describe("sendTelegramReply message id capture", () => {
+  test("returns the sent message id so approval cards can be addressed later", async () => {
+    callTelegramBotApiMock.mockImplementation(
+      async () => ({ message_id: 42 }) as never,
+    );
+
+    const result = await sendTelegramReply("123", "Please approve", approval);
+
+    expect(result.lastMessageId).toBe("42");
+  });
+
+  test("returns the id of the last chunk for a split message", async () => {
+    let nextId = 1;
+    callTelegramBotApiMock.mockImplementation(
+      async () => ({ message_id: nextId++ }) as never,
+    );
+
+    const result = await sendTelegramReply("123", "x".repeat(4500));
+
+    expect(callsTo("sendMessage")).toHaveLength(2);
+    expect(result.lastMessageId).toBe("2");
+  });
+
+  test("omits the message id when the API response lacks one", async () => {
+    const result = await sendTelegramReply("123", "Hello");
+
+    expect(result.lastMessageId).toBeUndefined();
   });
 });
 

--- a/assistant/src/messaging/providers/telegram-bot/send.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.ts
@@ -13,6 +13,7 @@ import { getLogger } from "../../../util/logger.js";
 import {
   callTelegramBotApi,
   callTelegramBotApiMultipart,
+  type TelegramMessage,
   TelegramNonRetryableError,
 } from "./api.js";
 import { renderTelegramHtml } from "./render.js";
@@ -121,6 +122,17 @@ function buildInlineKeyboard(approval: ApprovalUIMetadata): {
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Outcome of a Telegram reply send. */
+export interface TelegramSendResult {
+  /**
+   * Channel-native id of the last sent chunk (the message carrying the
+   * inline keyboard when an approval was attached). Callers that need to
+   * address the message later (e.g. approval-card withdrawal) persist this.
+   * Undefined when the API response did not carry a message id.
+   */
+  lastMessageId?: string;
+}
+
 /**
  * Send a Telegram text reply, splitting long messages and optionally
  * attaching inline keyboard buttons for approval prompts.
@@ -130,9 +142,10 @@ export async function sendTelegramReply(
   text: string,
   approval?: ApprovalUIMetadata,
   opts?: TelegramSendOptions,
-): Promise<void> {
+): Promise<TelegramSendResult> {
   const chunks = splitText(text, TELEGRAM_MAX_MESSAGE_LEN);
 
+  let lastMessageId: string | undefined;
   for (let i = 0; i < chunks.length; i++) {
     const payload: Record<string, unknown> = {
       chat_id: chatId,
@@ -146,10 +159,18 @@ export async function sendTelegramReply(
       payload.reply_markup = buildInlineKeyboard(approval);
     }
 
-    await callTelegramBotApi("sendMessage", payload);
+    const sent = await callTelegramBotApi<TelegramMessage>(
+      "sendMessage",
+      payload,
+    );
+    lastMessageId =
+      typeof sent?.message_id === "number"
+        ? String(sent.message_id)
+        : undefined;
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
+  return lastMessageId !== undefined ? { lastMessageId } : {};
 }
 
 /**

--- a/assistant/src/messaging/providers/telegram-bot/withdraw.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/withdraw.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Derive the mock signature from the real export so the test cannot drift from
+// the production call signature.
+type CallTelegramBotApi = typeof import("./api.js").callTelegramBotApi;
+
+const callTelegramBotApiMock = mock<CallTelegramBotApi>(
+  async () => ({}) as never,
+);
+
+mock.module("./api.js", () => ({
+  callTelegramBotApi: (method: string, body: Record<string, unknown>) =>
+    callTelegramBotApiMock(method, body),
+}));
+
+const { withdrawTelegramApprovalCard } = await import("./withdraw.js");
+
+const callsTo = (method: string) =>
+  callTelegramBotApiMock.mock.calls.filter((call) => call[0] === method);
+
+beforeEach(() => {
+  callTelegramBotApiMock.mockReset();
+  callTelegramBotApiMock.mockImplementation(async () => ({}) as never);
+});
+
+describe("withdrawTelegramApprovalCard", () => {
+  test("clears the inline keyboard and posts a silent quoted status reply", async () => {
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "42",
+      status: "approved",
+      postStatusReply: true,
+    });
+
+    const edits = callsTo("editMessageReplyMarkup");
+    expect(edits).toHaveLength(1);
+    expect(edits[0]?.[1]).toEqual({
+      chat_id: "chat-1",
+      message_id: 42,
+      reply_markup: null,
+    });
+
+    const sends = callsTo("sendMessage");
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.[1]).toEqual({
+      chat_id: "chat-1",
+      text: "✅ Approved",
+      reply_parameters: { message_id: 42, allow_sending_without_reply: true },
+      disable_notification: true,
+    });
+  });
+
+  test("skips the status reply when the decision originated on Telegram", async () => {
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "42",
+      status: "denied",
+      postStatusReply: false,
+    });
+
+    expect(callsTo("editMessageReplyMarkup")).toHaveLength(1);
+    expect(callsTo("sendMessage")).toHaveLength(0);
+  });
+
+  test("falls back to an empty inline keyboard when the null form is rejected", async () => {
+    callTelegramBotApiMock.mockImplementationOnce(async () => {
+      throw new Error("Bad Request: REPLY_MARKUP_INVALID");
+    });
+
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "7",
+      status: "expired",
+      postStatusReply: true,
+    });
+
+    const edits = callsTo("editMessageReplyMarkup");
+    expect(edits).toHaveLength(2);
+    expect(edits[1]?.[1]).toEqual({
+      chat_id: "chat-1",
+      message_id: 7,
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(callsTo("sendMessage")).toHaveLength(1);
+    expect(callsTo("sendMessage")[0]?.[1]).toMatchObject({
+      text: "⌛ Expired",
+    });
+  });
+
+  test("treats 'message is not modified' as already cleared", async () => {
+    callTelegramBotApiMock.mockImplementationOnce(async () => {
+      throw new Error("Bad Request: message is not modified");
+    });
+
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "7",
+      status: "approved",
+      postStatusReply: true,
+    });
+
+    // No empty-keyboard retry: the keyboard is already gone.
+    expect(callsTo("editMessageReplyMarkup")).toHaveLength(1);
+    expect(callsTo("sendMessage")).toHaveLength(1);
+  });
+
+  test("still posts the status reply when both keyboard edits fail", async () => {
+    callTelegramBotApiMock.mockImplementation(
+      async (method: string): Promise<never> => {
+        if (method === "editMessageReplyMarkup") {
+          throw new Error("Bad Request: message to edit not found");
+        }
+        return {} as never;
+      },
+    );
+
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "7",
+      status: "approved",
+      postStatusReply: true,
+    });
+
+    expect(callsTo("editMessageReplyMarkup")).toHaveLength(2);
+    expect(callsTo("sendMessage")).toHaveLength(1);
+  });
+
+  test("renders a parked denial with the neutral park label", async () => {
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "9",
+      status: "denied",
+      decidedAction: "leave_unverified",
+      postStatusReply: true,
+    });
+
+    expect(callsTo("sendMessage")[0]?.[1]).toMatchObject({
+      text: "⏸️ Left unverified",
+    });
+  });
+
+  test("skips everything on a non-numeric message id", async () => {
+    await withdrawTelegramApprovalCard({
+      chatId: "chat-1",
+      messageId: "not-a-number",
+      status: "approved",
+      postStatusReply: true,
+    });
+
+    expect(callTelegramBotApiMock.mock.calls).toHaveLength(0);
+  });
+});

--- a/assistant/src/messaging/providers/telegram-bot/withdraw.ts
+++ b/assistant/src/messaging/providers/telegram-bot/withdraw.ts
@@ -27,7 +27,7 @@
 
 import {
   isParkAction,
-  PARK_STATUS_LABEL,
+  resolveDecisionStatusWord,
 } from "../../../runtime/channel-approval-types.js";
 import { getLogger } from "../../../util/logger.js";
 import { callTelegramBotApi } from "./api.js";
@@ -39,13 +39,6 @@ const STATUS_GLYPH: Record<string, string> = {
   denied: "❌",
   expired: "⌛",
   cancelled: "\u{1f6ab}",
-};
-
-const STATUS_WORD: Record<string, string> = {
-  approved: "Approved",
-  denied: "Denied",
-  expired: "Expired",
-  cancelled: "Cancelled",
 };
 
 /**
@@ -64,9 +57,10 @@ export interface WithdrawTelegramApprovalCardParams {
   status: string;
   /**
    * The action the guardian took, when known. A `denied` status reached by a
-   * park action (`leave_unverified`) reads as the neutral
-   * {@link PARK_STATUS_LABEL} rather than "Denied"; `block`/`reject` stay a
-   * denial. Omitted for status-only transitions (e.g. the expiry sweep).
+   * park action (`leave_unverified`) reads as the neutral park label (see
+   * {@link resolveDecisionStatusWord}) rather than "Denied"; `block`/`reject`
+   * stay a denial. Omitted for status-only transitions (e.g. the expiry
+   * sweep).
    */
   decidedAction?: string;
   /**
@@ -81,7 +75,7 @@ export interface WithdrawTelegramApprovalCardParams {
 function buildStatusText(status: string, decidedAction?: string): string {
   const park = status === "denied" && isParkAction(decidedAction);
   const glyph = park ? PARK_STATUS_GLYPH : (STATUS_GLYPH[status] ?? "");
-  const word = park ? PARK_STATUS_LABEL : (STATUS_WORD[status] ?? "Resolved");
+  const word = resolveDecisionStatusWord(status, decidedAction);
   return glyph ? `${glyph} ${word}` : word;
 }
 

--- a/assistant/src/messaging/providers/telegram-bot/withdraw.ts
+++ b/assistant/src/messaging/providers/telegram-bot/withdraw.ts
@@ -1,0 +1,172 @@
+/**
+ * Withdraw a Telegram approval card when its underlying guardian request
+ * resolves.
+ *
+ * Telegram bots cannot re-read a delivered message, so the Slack shape
+ * (fetch the original content, strip the buttons, append a status line in
+ * one edit) is not available here. The closest faithful projection is:
+ *
+ *   1. Remove the inline keyboard in place (`editMessageReplyMarkup`), which
+ *      preserves the card's text for the audit trail while dropping every
+ *      live affordance.
+ *   2. Post the terminal outcome as a silent reply quoting the card, so the
+ *      message thread durably shows what was decided. The reply is skipped
+ *      when the decision originated on Telegram: the guardian reply router
+ *      already delivers its own outcome message in that chat, and a second
+ *      notice would read as a duplicate.
+ *
+ * Bot API wrappers differ on the "remove markup" form, so the edit tries the
+ * explicit `null` first and falls back to an empty inline keyboard, mirroring
+ * the gateway's callback-time clearing. "message is not modified" means the
+ * keyboard is already gone (e.g. the gateway cleared it when the deciding tap
+ * arrived) and is treated as success. Unlike the gateway's tap path, a failed
+ * edit never deletes the message: withdrawal must preserve the audit trail,
+ * and a tap on a leftover button already gets the stale "already resolved"
+ * handling.
+ */
+
+import {
+  isParkAction,
+  PARK_STATUS_LABEL,
+} from "../../../runtime/channel-approval-types.js";
+import { getLogger } from "../../../util/logger.js";
+import { callTelegramBotApi } from "./api.js";
+
+const log = getLogger("telegram-withdraw");
+
+const STATUS_GLYPH: Record<string, string> = {
+  approved: "✅",
+  denied: "❌",
+  expired: "⌛",
+  cancelled: "\u{1f6ab}",
+};
+
+const STATUS_WORD: Record<string, string> = {
+  approved: "Approved",
+  denied: "Denied",
+  expired: "Expired",
+  cancelled: "Cancelled",
+};
+
+/**
+ * Glyph for a parked (leave-unverified) decision: a neutral "on hold" mark
+ * rather than the `denied` cross, since the sender was neither trusted nor
+ * kept out.
+ */
+const PARK_STATUS_GLYPH = "⏸️";
+
+export interface WithdrawTelegramApprovalCardParams {
+  /** Telegram chat the approval message lives in. */
+  chatId: string;
+  /** Channel-native id of the approval message to withdraw. */
+  messageId: string;
+  /** Terminal status of the request (e.g. "approved", "denied", "expired"). */
+  status: string;
+  /**
+   * The action the guardian took, when known. A `denied` status reached by a
+   * park action (`leave_unverified`) reads as the neutral
+   * {@link PARK_STATUS_LABEL} rather than "Denied"; `block`/`reject` stay a
+   * denial. Omitted for status-only transitions (e.g. the expiry sweep).
+   */
+  decidedAction?: string;
+  /**
+   * Whether to post the quoted status reply. False when the decision
+   * originated on Telegram, where the guardian reply router already delivers
+   * the outcome message in the same chat.
+   */
+  postStatusReply: boolean;
+}
+
+/** Build the plain-text outcome line for the quoted status reply. */
+function buildStatusText(status: string, decidedAction?: string): string {
+  const park = status === "denied" && isParkAction(decidedAction);
+  const glyph = park ? PARK_STATUS_GLYPH : (STATUS_GLYPH[status] ?? "");
+  const word = park ? PARK_STATUS_LABEL : (STATUS_WORD[status] ?? "Resolved");
+  return glyph ? `${glyph} ${word}` : word;
+}
+
+/** True for the Bot API's "message is not modified" no-op edit rejection. */
+function isNoOpMarkupError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("message is not modified");
+}
+
+/**
+ * Remove the card's inline keyboard in place, keeping its text. Tries the
+ * explicit `reply_markup: null` form first, then an empty inline keyboard.
+ * Returns true when the keyboard is gone (including the already-cleared
+ * no-op case); false when both edit forms failed.
+ */
+async function clearInlineKeyboard(
+  chatId: string,
+  messageId: number,
+): Promise<boolean> {
+  const basePayload = { chat_id: chatId, message_id: messageId };
+  try {
+    await callTelegramBotApi("editMessageReplyMarkup", {
+      ...basePayload,
+      reply_markup: null,
+    });
+    return true;
+  } catch (primaryErr) {
+    if (isNoOpMarkupError(primaryErr)) {
+      return true;
+    }
+    try {
+      await callTelegramBotApi("editMessageReplyMarkup", {
+        ...basePayload,
+        reply_markup: { inline_keyboard: [] },
+      });
+      return true;
+    } catch (fallbackErr) {
+      if (isNoOpMarkupError(fallbackErr)) {
+        return true;
+      }
+      log.warn(
+        { primaryErr, fallbackErr, chatId, messageId },
+        "Failed to clear inline keyboard on resolved Telegram approval card",
+      );
+      return false;
+    }
+  }
+}
+
+/**
+ * Project a resolved guardian request onto its Telegram approval card:
+ * drop the inline keyboard in place and (unless suppressed) post a silent
+ * reply quoting the card with the terminal outcome.
+ *
+ * Both steps are attempted independently, so a failed keyboard edit does not
+ * lose the durable outcome notice. Throws only if the status reply send
+ * fails, which the caller treats as non-fatal.
+ */
+export async function withdrawTelegramApprovalCard(
+  params: WithdrawTelegramApprovalCardParams,
+): Promise<void> {
+  const parsedMessageId = Number(params.messageId);
+  if (!Number.isFinite(parsedMessageId)) {
+    log.warn(
+      { chatId: params.chatId, messageId: params.messageId },
+      "Skipping Telegram card withdrawal due to invalid message id",
+    );
+    return;
+  }
+
+  await clearInlineKeyboard(params.chatId, parsedMessageId);
+
+  if (!params.postStatusReply) {
+    return;
+  }
+
+  // Silent (no push) reply quoting the card. `allow_sending_without_reply`
+  // keeps the outcome notice deliverable even if the card was deleted.
+  await callTelegramBotApi("sendMessage", {
+    chat_id: params.chatId,
+    text: buildStatusText(params.status, params.decidedAction),
+    reply_parameters: {
+      message_id: parsedMessageId,
+      allow_sending_without_reply: true,
+    },
+    disable_notification: true,
+  });
+}

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -49,14 +49,16 @@ export class TelegramAdapter implements ChannelAdapter {
         // Attempt rich delivery with inline keyboard buttons.
         // On failure, fall back to plain text below.
         try {
-          await sendTelegramReply(chatId, messageText, approval);
+          const sent = await sendTelegramReply(chatId, messageText, approval);
 
           log.info(
             { sourceEventName: payload.sourceEventName, chatId },
             "Telegram approval notification delivered with inline buttons",
           );
 
-          return { success: true };
+          // The message id lets the delivery row address the card later
+          // (in-place withdrawal when the request resolves elsewhere).
+          return { success: true, messageId: sent.lastMessageId };
         } catch (richErr) {
           log.warn(
             { err: richErr, sourceEventName: payload.sourceEventName, chatId },
@@ -73,14 +75,14 @@ export class TelegramAdapter implements ChannelAdapter {
           ? `${messageText}\n\n${approval.plainTextFallback}`
           : messageText;
 
-      await sendTelegramReply(chatId, fallbackText);
+      const sent = await sendTelegramReply(chatId, fallbackText);
 
       log.info(
         { sourceEventName: payload.sourceEventName, chatId },
         "Telegram notification delivered",
       );
 
-      return { success: true };
+      return { success: true, messageId: sent.lastMessageId };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       // A missing bot token means the operator simply hasn't configured

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -102,6 +102,31 @@ export function isParkAction(action: string | undefined): boolean {
   return action !== undefined && PARK_ACTION_SET.has(action);
 }
 
+/** Outcome word per terminal guardian-request status on a resolved card. */
+const DECISION_STATUS_WORDS: Record<string, string> = {
+  approved: "Approved",
+  denied: "Denied",
+  expired: "Expired",
+  cancelled: "Cancelled",
+};
+
+/**
+ * The outcome word shown on a resolved guardian-request card, shared by every
+ * surface (in-app, Slack, Telegram); surfaces add only their own glyph
+ * vocabulary around it. A `denied` status reached by a park action reads as
+ * the neutral {@link PARK_STATUS_LABEL} rather than "Denied": a parked
+ * contact was neither trusted nor kept out.
+ */
+export function resolveDecisionStatusWord(
+  status: string,
+  decidedAction?: string,
+): string {
+  if (status === "denied" && isParkAction(decidedAction)) {
+    return PARK_STATUS_LABEL;
+  }
+  return DECISION_STATUS_WORDS[status] ?? "Resolved";
+}
+
 /**
  * Map `GuardianDecisionAction[]` to `ApprovalActionOption[]` so channel
  * prompt payloads can be derived from the unified decision action set.


### PR DESCRIPTION
## TL;DR

Telegram guardian approval cards (tool-grant escalations and every other guardian-request kind delivered to Telegram) kept their live **Approve / Deny** inline buttons forever when the request was resolved on another surface (in-app, Slack) or expired via the sweep, and the card never showed a durable outcome. This PR captures the Telegram message id at delivery and adds Telegram to the cross-surface card-withdrawal projector.

Related to LUM-3010

## What was actually broken (verified against the code)

The ticket says the tapped card "stays undecided". Tracing the live-tap path shows the gateway *does* ack the callback and clear the tapped message's keyboard (`clearInlineApprovalButtons` in `gateway/src/http/routes/telegram-webhook.ts`), and the reply router posts an outcome message. The real gaps were:

- **Cross-surface decisions and expiry**: `withdrawGuardianRequestCards` explicitly skipped Telegram, so a decision made in-app/Slack (or the expiry sweep, whose contract says "the withdrawn card already reflects expiry") left the Telegram card's buttons live indefinitely.
- **No addressing**: the Telegram notification adapter never returned the sent `message_id`, so `guardian_request_deliveries.destination_message_id` was always null for Telegram and no withdrawal path could target the card.
- **Text-based decisions on Telegram** ("CODE approve"): no callback ever fires, so even the gateway's tap-time clearing didn't apply; the card kept live buttons.

## The change

| Piece | Before | After |
| --- | --- | --- |
| `telegram-bot/send.ts` | `sendTelegramReply` discarded the Bot API response | Returns the sent message id (last chunk, the one carrying the keyboard) |
| `notifications/adapters/telegram.ts` | `{ success: true }` | `{ success: true, messageId }`; the existing broadcaster/recorder plumbing persists it onto the delivery row |
| `telegram-bot/withdraw.ts` (new) | n/a | Removes the inline keyboard in place (`editMessageReplyMarkup` null form, empty-keyboard fallback, "message is not modified" treated as already-cleared) and posts a **silent reply quoting the card** with the outcome (✅ Approved / ❌ Denied / ⌛ Expired / ⏸️ Left unverified for parks) |
| `approvals/guardian-card-withdrawal.ts` | Telegram branch absent | Telegram branch mirroring Slack; status reply suppressed when the decision originated on Telegram (the reply router already posts its outcome message there) |

## What changes for the guardian

| Scenario | Before | After |
| --- | --- | --- |
| Approve on web/Slack, card also on Telegram | Telegram card keeps live Approve/Deny buttons forever | Buttons removed; silent quoted reply "✅ Approved" |
| Request expires | Buttons stay live forever | Buttons removed; silent quoted reply "⌛ Expired" |
| Tap Approve on Telegram | Buttons cleared by gateway + outcome message (unchanged) | Same, plus withdrawal idempotently clears any other Telegram delivery of the card |
| Typed "CODE approve" on Telegram | Card keeps live buttons | Buttons removed (router's outcome reply unchanged, no duplicate notice) |

## Why it's safe

- Withdrawal is already fire-and-forget and per-surface try/caught; a Telegram API failure can't affect the committed decision (CAS happens first) or other surfaces.
- The keyboard edit tolerates "message is not modified", so it composes with the gateway's tap-time clearing with no race (both only remove markup; neither deletes the message, unlike the gateway's last-resort delete which is untouched and still tap-path-only).
- Delivery rows without a captured message id (all pre-existing rows) are skipped exactly like the Slack branch, so rollout is forward-only with no migration.
- The status reply uses `disable_notification` (no push; the expiry sweep's "guardian stays passive" contract holds) and `allow_sending_without_reply` (still lands if the card was deleted).

## Design constraint worth knowing

Telegram bots cannot fetch a message they sent, and the card copy can be LLM-composed, so Slack's withdrawal shape (fetch blocks → strip actions → append status line in one edit) is impossible. Replacing the text wholesale would destroy the audit content the withdrawal contract requires preserving. The chosen projection (in-place keyboard removal + quoted silent status reply) is the closest Telegram-native equivalent. Storing the sent text on the delivery row for a true in-place rewrite was considered and rejected as schema/PII weight for cosmetic parity.

## Out of scope / deferred

- WhatsApp still has no in-place withdrawal (the pre-existing comment now names only WhatsApp). Same shape as this PR if wanted later; left out to keep this reviewable.
- `sendTelegramRichReply` does not propagate message ids; approval cards go through the plain send path, so nothing consumes it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->