### PR TITLE
feat(design-library): render ChatGPT-style LaTeX delimiters

### DIFF
--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -129,6 +129,28 @@ export const Math: Story = {
   },
 };
 
+/**
+ * ChatGPT-style math delimiters: `\(…\)` inline and `\[…\]` display, including
+ * a display span typed mid-sentence and one inside a list item. Both render
+ * identically to the `$`-delimited equivalents in the Math story.
+ */
+export const ChatGptMathDelimiters: Story = {
+  args: {
+    content: [
+      "Mass and energy relate by \\(E = mc^2\\), so the total is:",
+      "",
+      "\\[",
+      "E_{\\text{total}} = \\sum_{i=1}^{n} m_i c^2",
+      "\\]",
+      "",
+      "Substituting \\[\\int_0^1 x^2 \\, dx = \\frac{1}{3}\\] mid-sentence still typesets in display mode.",
+      "",
+      "1. Compute \\[a^2 + b^2 = c^2\\]",
+      "2. Then take the square root",
+    ].join("\n"),
+  },
+};
+
 /** Currency and real equations coexisting in a single response. */
 export const CurrencyAndMath: Story = {
   args: {

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -440,6 +440,142 @@ describe("MarkdownMessage", () => {
     expect(html).not.toContain("\\$");
   });
 
+  test("ChatGPT-style inline delimiters render as inline math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "The identity \\(E = mc^2\\) still holds.",
+      }),
+    );
+
+    expect(html).toContain("katex");
+    // Inline math stays inline: no display-mode wrapper, no leaked delimiters.
+    expect(html).not.toContain("katex-display");
+    expect(html).not.toContain("\\(");
+    expect(html).not.toContain("(E = mc^2)");
+  });
+
+  test("ChatGPT-style display delimiters render as display math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "The area is:\n\n\\[\nA = \\pi r^2\n\\]\n\nas expected.",
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("\\[");
+  });
+
+  test("display delimiters mid-sentence still typeset in display mode", () => {
+    // remark-math only treats `$$` as a block when the fence opens a line, so a
+    // `\[…\]` span inside a sentence has to be lifted out of its paragraph.
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Given \\[\\sum_{i=1}^n i\\] we are done.",
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    expect(html).toContain("Given");
+    expect(html).toContain("we are done.");
+  });
+
+  test("display math inside a list item stays inside the list", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "1. First compute \\[x = a + b\\]\n2. Then stop",
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    // The math is lifted to a block *within* the list item, not after the list.
+    expect(html).toMatch(/<li[^>]*>[\s\S]*katex-display[\s\S]*<\/li>/);
+    expect(html).toContain("Then stop");
+  });
+
+  test("both delimiter styles coexist in one message", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "With \\(a\\) and \\(b\\):\n\n\\[\nc = a + b\n\\]",
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    expect(html.match(/katex/g)?.length).toBeGreaterThan(2);
+    expect(html).not.toContain("\\(");
+    expect(html).not.toContain("\\[");
+  });
+
+  test("escaped delimiters inside code stay verbatim", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Write `\\(x\\)` for inline math.\n\n```tex\n\\[x\\]\n```",
+      }),
+    );
+
+    // Code is a verbatim region: no math runs and the source survives exactly.
+    expect(html).not.toContain("katex");
+    expect(html).toContain("\\(x\\)");
+    expect(html).toContain("\\[x\\]");
+  });
+
+  test("an unpaired delimiter is left as literal text", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "An open \\[ bracket and a stray $ sign.",
+      }),
+    );
+
+    // Converting the lone opener would let it pair with the unrelated `$`.
+    expect(html).not.toContain("katex");
+    expect(html).toContain("[ bracket");
+  });
+
+  test("delimiters separated by a blank line are not paired into math", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Arrays use \\[ here.\n\nAnd close \\] over there.",
+      }),
+    );
+
+    expect(html).not.toContain("katex");
+  });
+
+  test("a delimiter pair straddling inline code is left alone", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Use \\( the `code()` call \\) carefully.",
+      }),
+    );
+
+    // Math tokenization would swallow the code span, so the pair is skipped.
+    expect(html).not.toContain("katex");
+    expect(html).toContain("<code");
+  });
+
+  test("display delimiters survive hard line breaks", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Result:\n\\[\nE = mc^2\n\\]",
+        hardLineBreaks: true,
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("\\[");
+  });
+
+  test("currency is not mangled by delimiter conversion", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "It costs $5, and \\(x = 5\\) is the count.",
+      }),
+    );
+
+    expect(html).toContain("$5");
+    expect(html).toContain("katex");
+    expect(html).not.toContain("\\$");
+  });
+
   test("custom linkComponent replaces the default link renderer", () => {
     function CustomLink({
       href,

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -530,6 +530,34 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("[ bracket");
   });
 
+  test("a stray opener does not consume the equation that follows it", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Prefix \\( literal; then \\(x = 1\\) here.",
+      }),
+    );
+
+    // Pairing the stray opener with the real equation's closer would hand
+    // KaTeX `\( literal; then \(x = 1` and lose the equation entirely.
+    expect(html).toContain("katex");
+    expect(html).not.toContain("katex-error");
+    expect(html).toContain("Prefix ( literal; then ");
+    expect(html).toContain("here.");
+  });
+
+  test("a stray display opener does not consume the equation that follows", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "Arrays \\[ literal; the identity \\[E = mc^2\\] holds.",
+      }),
+    );
+
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("katex-error");
+    expect(html).toContain("Arrays [ literal; the identity");
+    expect(html).toContain("holds.");
+  });
+
   test("delimiters separated by a blank line are not paired into math", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -484,22 +484,31 @@ const CURRENCY_AMOUNT =
  */
 const structureParser = unified().use(remarkParse).use(remarkGfm);
 
+/** Prose: the only node type a source rewrite may touch. */
+const TEXT_NODES: ReadonlySet<string> = new Set(["text"]);
+
+/** Regions a source rewrite must leave byte-for-byte intact. */
+const VERBATIM_NODES: ReadonlySet<string> = new Set([
+  "inlineCode",
+  "code",
+  "html",
+]);
+
 /**
- * Source offset ranges of every `text` node in `content`, in document order.
- * Verbatim regions — inline code, fenced code, link/image destinations,
- * autolinks — are non-`text` nodes, so they are excluded: a rewrite scoped to
- * these ranges leaves them byte-for-byte intact. Shared by currency escaping
- * and soft-break conversion so both stay confined to prose.
+ * Source offset ranges of every node in `tree` whose type is in `types`, in
+ * document order. Matched nodes are not descended into.
  */
-function collectTextRanges(content: string): Array<[number, number]> {
-  const tree = structureParser.parse(content);
+function collectRanges(
+  tree: unknown,
+  types: ReadonlySet<string>,
+): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   const collect = (node: {
     type: string;
     position?: { start: { offset?: number }; end: { offset?: number } };
     children?: unknown[];
   }) => {
-    if (node.type === "text") {
+    if (types.has(node.type)) {
       const start = node.position?.start.offset;
       const end = node.position?.end.offset;
       if (typeof start === "number" && typeof end === "number") {
@@ -515,6 +524,18 @@ function collectTextRanges(content: string): Array<[number, number]> {
   };
   collect(tree as Parameters<typeof collect>[0]);
   return ranges;
+}
+
+/**
+ * Source offset ranges of every `text` node in `content`, in document order.
+ * Verbatim regions (inline code, fenced code, link/image destinations,
+ * autolinks) are non-`text` nodes, so they are excluded: a rewrite scoped to
+ * these ranges leaves them byte-for-byte intact. Shared by currency escaping,
+ * soft-break conversion, and math-delimiter conversion so all three stay
+ * confined to prose.
+ */
+function collectTextRanges(content: string): Array<[number, number]> {
+  return collectRanges(structureParser.parse(content), TEXT_NODES);
 }
 
 /**
@@ -574,6 +595,228 @@ function hardBreakNewlines(content: string): string {
   return rewriteTextSlices(content, ranges, (slice) =>
     slice.replace(/\n/g, "  \n"),
   );
+}
+
+/**
+ * Math delimiter pairs in the ChatGPT house style (`\(…\)` inline, `\[…\]`
+ * display), mapped to the `$`-delimited form remark-math understands.
+ */
+const LATEX_MATH_DELIMITERS = [
+  { open: "\\[", close: "\\]", dollars: "$$" },
+  { open: "\\(", close: "\\)", dollars: "$" },
+] as const;
+
+/**
+ * Offset of the next `close` delimiter at or after `from` that sits in prose,
+ * or -1. Every other backslash consumes the character it escapes, so a `\\]`
+ * (an escaped backslash followed by a bracket) never reads as a closer.
+ */
+function findClosingDelimiter(
+  content: string,
+  from: number,
+  close: string,
+  inProse: (offset: number) => boolean,
+): number {
+  for (let i = from; i < content.length; i += 1) {
+    if (content[i] !== "\\") {
+      continue;
+    }
+    if (content.startsWith(close, i) && inProse(i)) {
+      return i;
+    }
+    i += 1;
+  }
+  return -1;
+}
+
+/**
+ * Rewrite ChatGPT-style math delimiters to the `$` form remark-math parses:
+ * `\(x\)` becomes `$x$` and `\[x\]` becomes `$$x$$`. Models trained on that
+ * house style emit it regardless of which renderer is downstream, and CommonMark
+ * reads `\(` as a plain escaped paren, so without this the equation renders as
+ * literal text with the backslashes stripped.
+ *
+ * Only paired delimiters are converted, and only where both halves sit in
+ * prose: a lone `\[` left as `$$` would pair with the next unrelated `$$` and
+ * swallow the text between them. For the same reason a pair whose contents span
+ * a blank line (which ends the enclosing block) or a verbatim region (inline or
+ * fenced code) is left alone: neither is a real equation.
+ */
+function convertLatexDelimiters(content: string): string {
+  // Fast path: neither opener present means no work to do.
+  if (!content.includes("\\[") && !content.includes("\\(")) {
+    return content;
+  }
+  const tree = structureParser.parse(content);
+  const prose = collectRanges(tree, TEXT_NODES);
+  if (prose.length === 0) {
+    return content;
+  }
+  const verbatim = collectRanges(tree, VERBATIM_NODES);
+  const inProse = (offset: number) =>
+    prose.some(([start, end]) => offset >= start && offset + 2 <= end);
+
+  let result = "";
+  let cursor = 0;
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] !== "\\") {
+      i += 1;
+      continue;
+    }
+    const delimiter = LATEX_MATH_DELIMITERS.find((candidate) =>
+      content.startsWith(candidate.open, i),
+    );
+    if (!delimiter || !inProse(i)) {
+      i += 2; // skip the escaped character
+      continue;
+    }
+    const close = findClosingDelimiter(
+      content,
+      i + delimiter.open.length,
+      delimiter.close,
+      inProse,
+    );
+    const inner =
+      close === -1 ? "" : content.slice(i + delimiter.open.length, close);
+    if (!inner.trim() || /\n[ \t]*\n/.test(inner)) {
+      i += 2;
+      continue;
+    }
+    if (verbatim.some(([start, end]) => start < close && end > i)) {
+      i += 2;
+      continue;
+    }
+    result += content.slice(cursor, i);
+    result += `${delimiter.dollars}${inner}${delimiter.dollars}`;
+    cursor = close + delimiter.close.length;
+    i = cursor;
+  }
+  return result + content.slice(cursor);
+}
+
+/**
+ * The block-level `math` node remark-math emits for a `$$` fence that opens a
+ * line, built by hand for a `$$…$$` span found mid-paragraph. The `data` hints
+ * are what mdast→hast turns into the `math-display` element rehype-katex
+ * typesets in display mode.
+ */
+function displayMathNode(value: string) {
+  return {
+    type: "math",
+    value,
+    data: {
+      hName: "pre",
+      hChildren: [
+        {
+          type: "element",
+          tagName: "code",
+          properties: { className: ["language-math", "math-display"] },
+          children: [{ type: "text", value }],
+        },
+      ],
+    },
+  };
+}
+
+interface PhrasingNode {
+  type: string;
+  value?: string;
+  position?: { start: { offset?: number } };
+}
+
+/** A node that contributes nothing visible once its paragraph is split. */
+function isBlankPhrasing(node: PhrasingNode): boolean {
+  if (node.type === "break") {
+    return true;
+  }
+  return node.type === "text" && (node.value ?? "").trim() === "";
+}
+
+/**
+ * remark plugin: lift `$$…$$` math out of the paragraph it was typed in so
+ * KaTeX typesets it in display mode.
+ *
+ * remark-math only produces a block `math` node when the `$$` fence opens a
+ * line; the same span mid-sentence becomes an inline `inlineMath` node, which
+ * KaTeX renders in text mode (cramped sum/integral limits, inline fractions).
+ * Display delimiters mean display math wherever they appear (`\[x\]` arrives
+ * here as `$$x$$` after delimiter conversion), so each double-dollar span
+ * becomes its own block and the surrounding prose splits around it. Single-`$`
+ * math is untouched, and math inside a heading or table cell stays inline
+ * because neither can host a block child.
+ */
+function remarkDisplayMathBlocks() {
+  return (tree: unknown, file: { toString(): string }) => {
+    const source = String(file);
+    const isDisplay = (node: PhrasingNode) => {
+      const offset = node.position?.start.offset;
+      return (
+        node.type === "inlineMath" &&
+        typeof offset === "number" &&
+        source.startsWith("$$", offset)
+      );
+    };
+    const split = (paragraph: { children: PhrasingNode[] }) => {
+      const blocks: unknown[] = [];
+      let buffer: PhrasingNode[] = [];
+      const flush = () => {
+        while (buffer.length > 0 && isBlankPhrasing(buffer[0]!)) {
+          buffer.shift();
+        }
+        while (
+          buffer.length > 0 &&
+          isBlankPhrasing(buffer[buffer.length - 1]!)
+        ) {
+          buffer.pop();
+        }
+        if (buffer.length > 0) {
+          blocks.push({ type: "paragraph", children: buffer });
+        }
+        buffer = [];
+      };
+      for (const child of paragraph.children) {
+        if (isDisplay(child)) {
+          flush();
+          blocks.push(displayMathNode(child.value ?? ""));
+        } else {
+          buffer.push(child);
+        }
+      }
+      flush();
+      return blocks;
+    };
+    const visit = (node: { type: string; children?: unknown[] }) => {
+      if (!Array.isArray(node.children)) {
+        return;
+      }
+      const rebuilt: unknown[] = [];
+      let changed = false;
+      for (const child of node.children) {
+        const candidate = child as {
+          type: string;
+          children?: PhrasingNode[];
+        };
+        if (
+          candidate.type === "paragraph" &&
+          Array.isArray(candidate.children) &&
+          candidate.children.some(isDisplay)
+        ) {
+          rebuilt.push(...split(candidate as { children: PhrasingNode[] }));
+          changed = true;
+        } else {
+          rebuilt.push(child);
+        }
+      }
+      if (changed) {
+        node.children = rebuilt;
+      }
+      for (const child of node.children) {
+        visit(child as Parameters<typeof visit>[0]);
+      }
+    };
+    visit(tree as Parameters<typeof visit>[0]);
+  };
 }
 
 /** Leading marker of an ordered-list item: up to 3 spaces, digits, then `.`/`)`. */
@@ -703,7 +946,10 @@ export function MarkdownMessage({
 }: MarkdownMessageProps) {
   const processed = useMemo(() => {
     const escaped = escapeCurrencyDollars(content);
-    return hardLineBreaks ? hardBreakNewlines(escaped) : escaped;
+    const broken = hardLineBreaks ? hardBreakNewlines(escaped) : escaped;
+    // Last: currency escaping would otherwise read a converted `\(5\)` as an
+    // amount and escape the `$` it just introduced.
+    return convertLatexDelimiters(broken);
   }, [content, hardLineBreaks]);
   const Link = linkComponent ?? DefaultLink;
   const components = useMemo(
@@ -730,6 +976,7 @@ export function MarkdownMessage({
           remarkGfm,
           remarkMath,
           remarkPreserveOrderedListNumbers,
+          remarkDisplayMathBlocks,
         ]}
         rehypePlugins={rehypePlugins}
         components={components}

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -607,9 +607,46 @@ const LATEX_MATH_DELIMITERS = [
 ] as const;
 
 /**
- * Offset of the next `close` delimiter at or after `from` that sits in prose,
- * or -1. Every other backslash consumes the character it escapes, so a `\\]`
- * (an escaped backslash followed by a bracket) never reads as a closer.
+ * Whether a single range in `ranges` holds both characters of the delimiter at
+ * `offset`. Binary search, not a linear probe: this runs at every delimiter in
+ * the message, and a long message has many of both.
+ *
+ * `ranges` must be sorted and non-overlapping, which document-order collection
+ * guarantees.
+ */
+function containsDelimiter(
+  ranges: Array<[number, number]>,
+  offset: number,
+): boolean {
+  let low = 0;
+  let high = ranges.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const [start, end] = ranges[mid]!;
+    if (offset < start) {
+      high = mid - 1;
+    } else if (offset >= end) {
+      low = mid + 1;
+    } else {
+      return offset + 2 <= end;
+    }
+  }
+  return false;
+}
+
+/**
+ * Offset of the `close` delimiter pairing with the opener that ends at `from`,
+ * or -1 when there is none.
+ *
+ * The search stops at the next opener of either style: no equation contains
+ * one, so a closer reached past it belongs to that opener rather than this one.
+ * Without the stop, a stray `\(` earlier in the prose would pair with the
+ * closer of the next real equation and swallow it. Stopping also bounds the
+ * scan by the distance to the next opener, which keeps a message full of
+ * unmatched openers linear rather than quadratic.
+ *
+ * Every other backslash consumes the character it escapes, so a `\\]` (an
+ * escaped backslash followed by a bracket) never reads as a closer.
  */
 function findClosingDelimiter(
   content: string,
@@ -623,6 +660,12 @@ function findClosingDelimiter(
     }
     if (content.startsWith(close, i) && inProse(i)) {
       return i;
+    }
+    const opensAgain = LATEX_MATH_DELIMITERS.some((candidate) =>
+      content.startsWith(candidate.open, i),
+    );
+    if (opensAgain && inProse(i)) {
+      return -1;
     }
     i += 1;
   }
@@ -639,8 +682,10 @@ function findClosingDelimiter(
  * Only paired delimiters are converted, and only where both halves sit in
  * prose: a lone `\[` left as `$$` would pair with the next unrelated `$$` and
  * swallow the text between them. For the same reason a pair whose contents span
- * a blank line (which ends the enclosing block) or a verbatim region (inline or
- * fenced code) is left alone: neither is a real equation.
+ * a blank line (which ends the enclosing block), a verbatim region (inline or
+ * fenced code), or another opener is left alone: none of those is an equation.
+ * A rejected opener is skipped rather than abandoning the rest of the message,
+ * so a stray delimiter never costs a real equation that follows it.
  */
 function convertLatexDelimiters(content: string): string {
   // Fast path: neither opener present means no work to do.
@@ -653,8 +698,7 @@ function convertLatexDelimiters(content: string): string {
     return content;
   }
   const verbatim = collectRanges(tree, VERBATIM_NODES);
-  const inProse = (offset: number) =>
-    prose.some(([start, end]) => offset >= start && offset + 2 <= end);
+  const inProse = (offset: number) => containsDelimiter(prose, offset);
 
   let result = "";
   let cursor = 0;


### PR DESCRIPTION
## Prompt / plan

> Add LATEX rendering if the assistant uses [ or ( for display and inline, chatgpt is used to it

`MarkdownMessage` already runs remark-math + KaTeX, but only for the `$`-delimited forms. Models trained on the ChatGPT house style emit `\(x\)` for inline math and `\[x\]` for display math, and CommonMark reads those as plain escaped parens and brackets, so the equation reached the reader as literal text with the backslashes stripped (`\(E = mc^2\)` rendered as `(E = mc^2)`).

Approach, following the existing currency-escaping precedent in the same file:

1. **`convertLatexDelimiters`** rewrites paired delimiters to the `$` form remark-math parses (`\(x\)` to `$x$`, `\[x\]` to `$$x$$`) before the real parse, so the math body is never markdown-parsed. The rewrite is scoped to prose `text` nodes via the existing `structureParser`, so inline code, fenced code, and link destinations stay byte-exact.

   Only *paired* delimiters convert. A lone `\[` turned into `$$` would pair with the next unrelated `$$` and swallow everything between them, so these are all left as literal text: unpaired openers, pairs whose contents span a blank line (which ends the enclosing block), and pairs straddling a code span (math tokenization would eat the code).

   It runs last in the preprocessing chain: currency escaping would otherwise read a converted `\(5\)` as a dollar amount and escape the `$` it just introduced.

2. **`remarkDisplayMathBlocks`** lifts mid-paragraph `$$...$$` spans out to their own block. remark-math only emits a block `math` node when the `$$` fence opens a line; the same span inside a sentence becomes an inline node that KaTeX renders in text mode (cramped sum/integral limits, inline fractions). Splitting the paragraph in mdast rather than injecting newlines into the source means display math stays correctly nested inside list items and blockquotes.

Both fixes land in `packages/design-library`, which is the single markdown renderer behind web, macOS, Windows, and the Capacitor mobile shells.

Trade-off worth flagging: a paired `\[...\]` is treated as math unconditionally, matching the ChatGPT contract. Prose that escapes brackets for literal display (`\[INFO\]`) will now typeset as math. This seemed like the right call given the delimiters are unambiguous in assistant output, but it is the one behavior change for text that previously rendered as literal brackets.

No release-note migration: `AGENTS.md` freezes the historical `0XX-release-notes-*` set and forbids new ones.

## Test plan

- 11 new cases in `markdown-message.test.tsx` (47 pass total, no regressions): inline delimiters, display delimiters as a block, display delimiters mid-sentence, display math inside a list item, both styles in one message, delimiters inside inline and fenced code staying verbatim, unpaired opener, delimiters separated by a blank line, a pair straddling inline code, display delimiters with `hardLineBreaks`, and currency coexisting with converted math.
- Rendered HTML inspected directly for each case to confirm `katex-display` is emitted, the math lands *inside* the `<li>` / `<blockquote>` rather than after it, and no delimiters leak.
- `bun run typecheck` clean; existing web-client markdown tests (`chat-markdown-message`, `transcript-message-body`, `workspace-path-link`) pass, 80 tests.
- New `ChatGptMathDelimiters` story added and `bun run build-storybook` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNs9nNYpS5jyjSZtg3MuiE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNs9nNYpS5jyjSZtg3MuiE)_