### PR TITLE
feat(ios): richer live-voice island state and a session timer

### DIFF
--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -104,6 +104,27 @@ struct VoiceSessionAttributes: ActivityAttributes {
 
     var assistantName: String
 
+    /// When the session's activity was requested, so the presentations can run
+    /// a live elapsed timer.
+    ///
+    /// **Stamped natively, at `request`, on purpose.** SwiftUI's
+    /// `Text(timerInterval:)` is driven by the system, so a timer costs zero
+    /// ActivityKit updates: it is the one thing on the island that keeps
+    /// moving while a suspended web layer pushes nothing, which is exactly when
+    /// the user is looking at it. Reading the clock here rather than accepting
+    /// a timestamp from the web side (or from a server push, which composes
+    /// content state on a different machine) also means the value is on the
+    /// same clock as the device rendering it, so there is no skew to show.
+    ///
+    /// An attribute, not `ContentState`: it is fixed for the activity's
+    /// lifetime. Being an attribute is also what makes it survive the push
+    /// path, since a server-driven update replaces the content state wholesale
+    /// and cannot touch it.
+    ///
+    /// Optional on the wire (see the decoder below) even though it is always
+    /// set for an activity this build requests.
+    var startedAt: Date
+
     /// The assistant's avatar as encoded image data (PNG, or JPEG for
     /// photographic uploads), or `nil` when there is none to show.
     ///
@@ -126,4 +147,37 @@ struct VoiceSessionAttributes: ActivityAttributes {
     /// Oversize does not degrade the avatar, it kills the whole activity, so
     /// the web side sends nothing rather than sending too much.
     var avatarImageData: Data?
+}
+
+extension VoiceSessionAttributes {
+    /// Decodes attributes archived by *any* build that has run on this device.
+    ///
+    /// An activity outlives the app update that replaces the code rendering
+    /// it: a session started before the update is still on screen after it,
+    /// and its attributes were archived without whatever fields the new build
+    /// added. Synthesized decoding treats a missing field as a failure, and a
+    /// `VoiceSessionAttributes` that cannot decode is one ActivityKit cannot
+    /// hand back at all, so the activity becomes unrenderable *and* invisible
+    /// to `endActivitiesStrandedByAPreviousLaunch()`. The user is left with an
+    /// island nothing can reach or dismiss.
+    ///
+    /// Every field added from here on therefore decodes with a fallback.
+    /// `startedAt` falling back to now restarts the elapsed count for such an
+    /// activity, which is the right trade: a stale count on an activity that
+    /// is about to be swept, instead of an island that cannot be swept.
+    ///
+    /// Written in an extension so the memberwise initializer the plugin calls
+    /// survives.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            assistantName: try container.decode(String.self, forKey: .assistantName),
+            startedAt: try container.decodeIfPresent(Date.self, forKey: .startedAt)
+                ?? Date(),
+            avatarImageData: try container.decodeIfPresent(
+                Data.self,
+                forKey: .avatarImageData
+            )
+        )
+    }
 }

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -169,6 +169,13 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 let requested = try Activity.request(
                     attributes: VoiceSessionAttributes(
                         assistantName: assistantName,
+                        // Stamped here, at the one moment an activity begins.
+                        // A `start` that lands on a running activity takes the
+                        // branch above and only updates its content, so the
+                        // timer keeps counting the session rather than
+                        // restarting on a redundant start (the controller
+                        // remounting across a route change issues exactly one).
+                        startedAt: Date(),
                         avatarImageData: Self.avatarImageData(from: call)
                     ),
                     content: Self.content(state),

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -4,9 +4,16 @@ import UIKit
 // Shared building blocks for the live-voice Live Activity.
 //
 // The Lock Screen, expanded, compact and minimal presentations are four
-// separately-sized renderings of the *same* three facts — accent, phase
-// label, assistant name — so they compose from these primitives rather than
-// each growing its own copy that drifts.
+// separately-sized renderings of the *same* facts: identity (the avatar and
+// the assistant's name), the current phase (as a glyph and as passed-through
+// wording), how long the call has been running, and whether the mic is muted.
+// They compose from these primitives rather than each growing its own copy
+// that drifts.
+//
+// Which of those a slot can show is a function of its size, and the order they
+// drop in is by how much they tell the user: the compact and minimal
+// presentations keep identity and the phase glyph, because a glyph survives
+// being 20 points wide and a sentence does not.
 //
 // Two rules run through all of them:
 //
@@ -50,6 +57,90 @@ extension VoiceSessionAttributes.ContentState {
     /// assistant does exist, and tapping through still returns to it.
     func displayLabel(isStale: Bool) -> String {
         isStale ? "" : label
+    }
+
+    /// The SF Symbol standing for this phase.
+    ///
+    /// **A glyph is not copy, which is why this may switch on `phase` when
+    /// nothing else here may.** The rule the rest of this file follows exists
+    /// because wording deploys continuously while this shell ships on App Store
+    /// review; a symbol has no such second source to drift from. The phase
+    /// vocabulary itself is the contract, and it already cannot change without
+    /// changing ``Phase``, where a new case makes this switch a compile error.
+    ///
+    /// It earns its place by being the one part of the island that is legible
+    /// at every size. Before this, all six phases rendered the same waveform
+    /// and the compact trailing slot's job was done by a caption truncated to
+    /// two or three characters, so in the presentation the user actually sees
+    /// most of the time, "Listening…" and "Thinking…" were indistinguishable.
+    var phaseSymbol: String {
+        switch phase {
+        case .connecting: return "antenna.radiowaves.left.and.right"
+        case .listening: return "waveform"
+        case .transcribing: return "text.bubble"
+        case .thinking: return "ellipsis"
+        case .speaking: return "speaker.wave.2.fill"
+        case .ending: return "phone.down.fill"
+        }
+    }
+}
+
+/// The phase glyph: an accent-tinted symbol standing for the current phase.
+///
+/// Drops to nothing once ActivityKit marks the content stale, for the same
+/// reason the label does: it is a claim about a session nothing has confirmed
+/// is still running. See ``VoiceSessionAttributes/ContentState/displayLabel``.
+struct VoicePhaseGlyph: View {
+    let state: VoiceSessionAttributes.ContentState
+    let isStale: Bool
+    var scale: Image.Scale = .medium
+
+    var body: some View {
+        if !isStale {
+            Image(systemName: state.phaseSymbol)
+                .imageScale(scale)
+                .foregroundStyle(state.accentColor)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+/// Elapsed call time.
+///
+/// **The only moving part on the island that costs no update.**
+/// `Text(timerInterval:)` is driven by the system from a start date carried in
+/// the attributes, so it keeps counting through a suspended web layer, through
+/// a missed push, and through the ActivityKit rate limit that makes every
+/// content update expensive. That makes it the honest answer to "is this thing
+/// still going". For a session whose phase can sit unchanged for minutes,
+/// it is the difference between an island that looks frozen and one that
+/// visibly is not.
+///
+/// Hidden once the content is stale: at that point how long the *activity* has
+/// been up is no longer evidence of how long a session has, and the whole point
+/// of staleness is to stop the island making claims it cannot support.
+struct VoiceSessionTimer: View {
+    let startedAt: Date
+    let isStale: Bool
+    var font: Font = .caption
+
+    var body: some View {
+        if !isStale {
+            Text(
+                timerInterval: startedAt...Date.distantFuture,
+                countsDown: false,
+                showsHours: false
+            )
+            .font(font)
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            // Fixed so a digit rolling over cannot shove the layout around;
+            // the timer sits next to truncating text in every slot it appears
+            // in, and that text would reflow on every tick.
+            .frame(minWidth: 40, alignment: .trailing)
+            .accessibilityLabel("Call duration")
+        }
     }
 }
 
@@ -186,8 +277,12 @@ struct VoiceSessionText: View {
     }
 }
 
-/// Lock Screen and notification-banner presentation: badge, assistant name,
-/// phase label, and a mute glyph while muted.
+/// Lock Screen and notification-banner presentation: the avatar, the assistant
+/// name, the phase (glyph and label), elapsed call time, and a mute glyph while
+/// muted.
+///
+/// The roomiest of the four presentations, so it is the one that shows
+/// everything; the island slots below are this, minus whatever does not fit.
 ///
 /// No `activityBackgroundTint` — the system background already adapts to the
 /// Lock Screen's appearance, and tinting it with an arbitrary avatar color is
@@ -195,8 +290,13 @@ struct VoiceSessionText: View {
 struct VoiceSessionLockScreenView: View {
     let assistantName: String
     let state: VoiceSessionAttributes.ContentState
-    /// Whether ActivityKit considers this content out of date; drops the phase
-    /// label. See `ContentState.displayLabel(isStale:)`.
+    /// When the activity started, for the elapsed timer. See
+    /// ``VoiceSessionAttributes/startedAt``.
+    let startedAt: Date
+    /// Whether ActivityKit considers this content out of date; drops
+    /// everything that asserts something about a live session (the phase
+    /// label, the phase glyph, and the timer). See
+    /// `ContentState.displayLabel(isStale:)`.
     let isStale: Bool
     var avatarImageData: Data?
 
@@ -205,11 +305,23 @@ struct VoiceSessionLockScreenView: View {
             VoiceAccentBadge(accent: state.accentColor, avatarImageData: avatarImageData)
             VStack(alignment: .leading, spacing: 2) {
                 VoiceSessionText(text: assistantName, font: .headline)
-                VoiceSessionText(text: state.displayLabel(isStale: isStale), color: .secondary)
+                HStack(spacing: 5) {
+                    VoicePhaseGlyph(state: state, isStale: isStale, scale: .small)
+                    VoiceSessionText(
+                        text: state.displayLabel(isStale: isStale),
+                        color: .secondary
+                    )
+                }
             }
             Spacer(minLength: 0)
-            if state.muted {
-                VoiceMuteGlyph()
+            // Trailing column, top-aligned with the name: the two status facts
+            // that are not the phase. Stacked rather than inline so the mute
+            // glyph keeps its place when the timer's width changes.
+            VStack(alignment: .trailing, spacing: 4) {
+                VoiceSessionTimer(startedAt: startedAt, isStale: isStale)
+                if state.muted {
+                    VoiceMuteGlyph()
+                }
             }
         }
         .padding(.horizontal, 16)

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -5,9 +5,10 @@ import WidgetKit
 /// The live-voice session, rendered on the Lock Screen and in the Dynamic
 /// Island.
 ///
-/// All four presentations are the same three facts at four sizes, composed
+/// All four presentations are the same handful of facts at four sizes, composed
 /// from the primitives in `VoiceSessionIslandViews.swift`; see that file for
-/// the two rules they share (no native phase copy, accent as decoration only).
+/// the two rules they share (no native phase copy, accent as decoration only)
+/// and for which facts survive into the tightest slots.
 ///
 /// **There are no interactive controls, by design.** An in-island end button
 /// would need a `LiveActivityIntent` plus a signalling path into the running
@@ -30,27 +31,37 @@ struct VoiceSessionLiveActivity: Widget {
             VoiceSessionLockScreenView(
                 assistantName: context.attributes.assistantName,
                 state: context.state,
+                startedAt: context.attributes.startedAt,
                 isStale: context.isStale,
                 avatarImageData: context.attributes.avatarImageData
             )
             .widgetURL(VoiceModeDeepLink.resume.url())
         } dynamicIsland: { context in
             let state = context.state
-            let label = state.displayLabel(isStale: context.isStale)
+            let isStale = context.isStale
+            let label = state.displayLabel(isStale: isStale)
             let avatar = context.attributes.avatarImageData
+            let startedAt = context.attributes.startedAt
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     VoiceAccentBadge(accent: state.accentColor, avatarImageData: avatar)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    // Nothing to say when unmuted: an always-present mic glyph
-                    // would read as a control, and there are none here.
-                    if state.muted {
-                        VoiceMuteGlyph()
+                    // Elapsed time, plus the mute glyph while muted. There is
+                    // still no always-present mic glyph, which would read as a
+                    // control, and there are none here.
+                    HStack(spacing: 6) {
+                        VoiceSessionTimer(startedAt: startedAt, isStale: isStale)
+                        if state.muted {
+                            VoiceMuteGlyph()
+                        }
                     }
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    VoiceSessionText(text: label, font: .headline)
+                    HStack(spacing: 6) {
+                        VoicePhaseGlyph(state: state, isStale: isStale)
+                        VoiceSessionText(text: label, font: .headline)
+                    }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     VoiceSessionText(
@@ -61,10 +72,14 @@ struct VoiceSessionLiveActivity: Widget {
             } compactLeading: {
                 VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
             } compactTrailing: {
-                // The tightest slot there is. It still shows the passed label,
-                // truncated — substituting a shorter native string here is
-                // precisely the fossilization this design avoids.
-                VoiceSessionText(text: label, font: .caption2, color: .secondary)
+                // The tightest slot there is, and the presentation the user
+                // spends the most time looking at. It used to show the passed
+                // label truncated, which at this width is two or three
+                // characters, identical for "Listening…" and "Thinking…". The
+                // glyph says the same thing legibly, and says it without
+                // substituting a native *string*, which is the fossilization
+                // this design actually guards against.
+                VoicePhaseGlyph(state: state, isStale: isStale, scale: .small)
             } minimal: {
                 VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
             }

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -122,11 +122,44 @@ of importance:
    natively means shipping more state across the bridge and duplicating the rule.
 3. **Localization.** The web layer already owns user-facing copy.
 
-The compact trailing slot is very tight. It *truncates* the passed label
-(`.lineLimit(1)` + `.truncationMode(.tail)` in `VoiceSessionText`); it does not
-substitute a shorter native string. Every phase that reaches an activity has a
-non-empty label, so there is no empty-string case for `VoiceSessionText` to
-handle.
+Wherever the label *is* rendered it is only ever truncated (`.lineLimit(1)` +
+`.truncationMode(.tail)` in `VoiceSessionText`), never swapped for a shorter
+native string. Every phase that reaches an activity has a non-empty label, so
+there is no empty-string case for `VoiceSessionText` to handle.
+
+### What the native side may derive: the phase glyph
+
+The rule above is about *wording*, and `ContentState.phaseSymbol` is the one
+place that switches on `phase` without breaking it. An SF Symbol has no
+second source deploying on a different cadence to drift from, and the phase
+vocabulary it switches over is already a contract both sides must change
+together, so a new case is a Swift compile error rather than silent drift.
+
+It exists because the compact trailing slot is roughly three characters wide.
+Truncated to that, "Listening…" and "Thinking…" are the same string, which made
+the presentation the user sees most of the time say nothing at all. That slot
+now renders the glyph, and the roomier presentations render glyph *and* label.
+
+### What moves without an update: the elapsed timer
+
+`VoiceSessionAttributes.startedAt` is stamped natively at `Activity.request`,
+and `VoiceSessionTimer` renders it with `Text(timerInterval:)`, a
+system-driven timer. It therefore keeps counting with no `ContentState` update
+at all: through a suspended web layer, through a dropped push, and through
+ActivityKit's update rate limit. For a session whose phase can legitimately sit
+unchanged for minutes, it is what distinguishes an island that looks frozen
+from one that visibly is not.
+
+It is an attribute rather than content for two reasons: it is fixed for the
+activity's lifetime, and being an attribute is what keeps a server-driven push
+(which replaces the content state wholesale) from touching it. Stamping it
+natively also puts it on the same clock as the device rendering it, which a
+timestamp composed on the platform would not be.
+
+Everything phase-derived (label, glyph, and the timer) drops when
+`context.isStale` goes true. Identity (avatar, name, accent) stays: that a
+session with this assistant exists is still true, and tapping through still
+reaches it.
 
 ## The deep-link contract
 
@@ -422,6 +455,16 @@ Three rules fall out of this:
   continuously — applies to the platform too, one layer further out. The client
   registers a phase→label map and dispatch only ever looks a phase up in it,
   skipping a phase it has no label for.
+- **Nor does it invent the rest of the content state.** A push replaces
+  `ContentState` wholesale, and two of its fields (`accentHex` and `muted`)
+  are things only the client can see: the accent is the avatar color this web
+  layer renders, and mute is a local control the daemon's session never hears
+  about. They are therefore stored on the token row at registration and
+  composed from there, and the client re-registers whenever either moves. When
+  the dispatch payload carried them instead, the daemon (which has neither) sent
+  nothing and every field defaulted, so the first server-driven update grayed
+  the island's accent out and dropped its mute glyph, which is to say it did so
+  the moment the app was backgrounded.
 - **`aps.timestamp` is a counter, not wall time.** iOS discards a push whose
   timestamp is not newer than the state it holds, and `transcribing` →
   `thinking` is routinely sub-second.
@@ -432,27 +475,38 @@ Three rules fall out of this:
 
 Even with both drivers, a push can be missed — so every update still carries a
 `staleDate` (`VoiceLiveActivityPlugin.contentStaleAfter`), and the views drop
-the phase label once `context.isStale` goes true. An island frozen on
+everything phase-derived once `context.isStale` goes true. An island frozen on
 "Listening…" is a claim about a live socket and a live mic that nothing is
 checking; the horizon does not make it correct, only honest about not knowing.
 
+**Both drivers must use the same horizon**, since either can deliver the state
+whose staleness is being judged. They are two constants in two repos
+(`VoiceLiveActivityPlugin.contentStaleAfter` and the platform's
+`STALE_AFTER_SECONDS`), and they had already drifted (120 against 45) once.
+The client's 120 is the correct one: a quiet call emits no frames, so nothing
+dispatches, and a 45-second horizon would strip the phase off a perfectly
+healthy session that nobody happens to be talking to.
+
 ### 2. No App Group
 
-`ContentState` carries only primitives: `phase`, `label`, `accentHex`, `muted`,
-plus `assistantName` on the attributes. The extension ships **no entitlements
-file at all**.
+`ContentState` carries only primitives (`phase`, `label`, `accentHex`,
+`muted`), and the attributes carry `assistantName`, `startedAt`, and the
+avatar as `Data`. The extension ships **no entitlements file at all**.
 
-*Why:* an App Group is only needed to share *files* — the obvious candidate being
-a user's custom avatar image in the island. A hex accent gets most of the visual
-identity for none of the plumbing, and no entitlement means one less Apple
-Developer portal capability to keep in sync (an entitlement enabled in the portal
-but not satisfiable by the build is a provisioning failure waiting to happen).
+*Why:* an App Group is only needed to share *files*, and nothing here needs
+one. The obvious candidate was the avatar, but `ActivityAttributes` is
+`Codable`, so the bytes travel in the attributes and render via
+`Image(uiImage:)`: no entitlement, and one less Apple Developer portal
+capability to keep in sync across six App IDs (an entitlement enabled in the
+portal but not satisfiable by the build is a provisioning failure waiting to
+happen).
 
-*To revisit:* enable an App Group capability on all six App IDs (three apps,
-three extensions), add entitlements files, regenerate all six profiles, write the
-avatar into the shared container on the app side, and read it in
-`VoiceSessionIslandViews`. Note that the container write has to happen before the
-activity starts, so it also needs an avatar-caching path.
+What is genuinely impossible is fetching anything at render time: a Live
+Activity draws from a snapshot, so a URL would only ever render `AsyncImage`'s
+placeholder. That is also why the avatar is sized to a measured byte ceiling
+before it is sent. See `ISLAND_AVATAR_MAX_BYTES` in
+`clients/web/src/utils/avatar-island-encode.ts`, where oversize kills the whole
+activity rather than degrading the image.
 
 ### 3. The island is tap-to-return only — no interactive End button
 

--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -7529,6 +7529,11 @@ components:
         deliberately not allowed to invent wording of its own (see the model).
         Validating it here makes that a 400 at registration rather than a silently
         dropped push mid-session.
+
+        ``accent_hex`` and ``muted`` ride along for a related reason: they are
+        ``ContentState`` fields only the client can observe, and every push replaces
+        that state wholesale. The client re-registers when either changes, so the
+        newest registration is always what a dispatch composes from.
       properties:
         token:
           type: string
@@ -7542,6 +7547,11 @@ components:
           type: string
           maxLength: 64
         labels: {}
+        accent_hex:
+          type: string
+          maxLength: 9
+        muted:
+          type: boolean
       required:
       - apns_environment
       - bundle_id
@@ -7557,6 +7567,11 @@ components:
         deliberately not allowed to invent wording of its own (see the model).
         Validating it here makes that a 400 at registration rather than a silently
         dropped push mid-session.
+
+        ``accent_hex`` and ``muted`` ride along for a related reason: they are
+        ``ContentState`` fields only the client can observe, and every push replaces
+        that state wholesale. The client re-registers when either changes, so the
+        newest registration is always what a dispatch composes from.
       properties:
         token:
           type: string
@@ -7573,6 +7588,11 @@ components:
           minLength: 1
           maxLength: 64
         labels: {}
+        accent_hex:
+          type: string
+          maxLength: 9
+        muted:
+          type: boolean
       required:
       - apns_environment
       - bundle_id

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -36,6 +36,8 @@ interface UpsertArg {
     apns_environment: string;
     conversation_id: string;
     labels: Record<string, string>;
+    accent_hex: string;
+    muted: boolean;
   };
   throwOnError: boolean;
 }
@@ -71,13 +73,17 @@ beforeEach(() => {
   localStorage.removeItem("vellum:live_activity_registration");
 });
 
+const REGISTRATION = {
+  token: "activity-token",
+  assistantId: "assistant-1",
+  conversationId: "conv-1",
+  accentHex: "#FF8800",
+  muted: false,
+};
+
 describe("registerLiveActivityPushToken APNs environment", () => {
   test("tags the upsert with the shared resolver's environment", async () => {
-    await registerLiveActivityPushToken(
-      "activity-token",
-      "assistant-1",
-      "conv-1",
-    );
+    await registerLiveActivityPushToken(REGISTRATION);
 
     expect(resolveSignedApnsEnvironmentMock).toHaveBeenCalledWith(bundleId);
     expect(upsertMock).toHaveBeenCalledTimes(1);
@@ -86,5 +92,58 @@ describe("registerLiveActivityPushToken APNs environment", () => {
     expect(lastUpsertArg?.body.bundle_id).toBe(bundleId);
     expect(lastUpsertArg?.body.conversation_id).toBe("conv-1");
     expect(lastUpsertArg?.body.apns_environment).toBe("production");
+  });
+});
+
+describe("registerLiveActivityPushToken content state", () => {
+  // The daemon that drives the server-side pushes observes neither, so the
+  // registration is the only path either has into a pushed content state.
+  test("carries the accent and mute state the daemon cannot see", async () => {
+    await registerLiveActivityPushToken({
+      ...REGISTRATION,
+      accentHex: "#22CC99",
+      muted: true,
+    });
+
+    expect(lastUpsertArg?.body.accent_hex).toBe("#22CC99");
+    expect(lastUpsertArg?.body.muted).toBe(true);
+  });
+
+  // The stored row is what every background push composes from, so a slow
+  // first request landing after a fast second one would leave the island
+  // rendering the state the user moved away from.
+  test("registrations reach the platform in call order", async () => {
+    const arrived: boolean[] = [];
+    let releaseFirst!: () => void;
+    const firstInFlight = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let calls = 0;
+    upsertMock.mockImplementation(async (arg: UpsertArg) => {
+      lastUpsertArg = arg;
+      calls += 1;
+      // Hold the first request open past the point the second is issued, so
+      // an unserialized implementation would let the second overtake it.
+      if (calls === 1) {
+        await firstInFlight;
+      }
+      arrived.push(arg.body.muted);
+      return { data: {}, error: undefined };
+    });
+
+    const first = registerLiveActivityPushToken({
+      ...REGISTRATION,
+      muted: true,
+    });
+    const second = registerLiveActivityPushToken({
+      ...REGISTRATION,
+      muted: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(arrived).toEqual([true, false]);
+    expect(lastUpsertArg?.body.muted).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -23,7 +23,8 @@
  * Store cadence while this bundle deploys continuously. A server composing its
  * own strings would reintroduce exactly that drift one layer further out, so
  * registration hands over a phase→label map and the platform only ever looks a
- * phase up in it.
+ * phase up in it. The accent and mute state travel the same way and for the
+ * same underlying reason. See {@link LiveActivityRegistration}.
  *
  * Best-effort throughout, like everything else that touches the island: a
  * failure here costs a background update, never a voice session.
@@ -128,6 +129,42 @@ function trackUpsert(upsert: Promise<void>): void {
 }
 
 /**
+ * Tail of the upsert chain, so registrations reach the platform in the order
+ * they were made.
+ *
+ * The row is now content the platform composes its pushes from, which makes
+ * ordering load-bearing: two registrations in flight at once (a mute toggled
+ * twice, or a mute landing while an avatar that loaded late re-registers the
+ * accent) can arrive in either order, and the loser is what every subsequent
+ * background push renders. Serializing costs nothing here, because a
+ * registration is never on a latency path, and it makes "last call wins" true.
+ */
+let upsertChain: Promise<void> = Promise.resolve();
+
+/** Everything the platform needs to push at one running activity. */
+export interface LiveActivityRegistration {
+  token: string;
+  assistantId: string;
+  conversationId: string;
+  /**
+   * The island's accent and mute state, as {@link VoiceLiveActivityContent}
+   * carries them.
+   *
+   * **They register rather than dispatch because the daemon cannot see
+   * them.** The accent is the avatar color this layer renders and mute is a
+   * local control the session never hears about, yet both are `ContentState`
+   * fields, and a server push replaces that state wholesale, so a dispatch
+   * composed without them would gray out the island and drop its mute glyph on
+   * the first phase change after the app is backgrounded, which is the only
+   * state the island is ever seen in. The platform stores them on the token row
+   * and composes every push from there; the caller re-registers when either
+   * moves.
+   */
+  accentHex: string;
+  muted: boolean;
+}
+
+/**
  * Register (or re-register) the activity's push token for a conversation.
  *
  * Safe to call repeatedly: iOS rotates tokens mid-activity and each value
@@ -135,20 +172,24 @@ function trackUpsert(upsert: Promise<void>): void {
  * `(user, token)`, so a rotation replaces the row rather than accumulating one.
  */
 export async function registerLiveActivityPushToken(
-  token: string,
-  assistantId: string,
-  conversationId: string,
+  registration: LiveActivityRegistration,
 ): Promise<void> {
-  const upsert = upsertToken(token, assistantId, conversationId);
+  const upsert = upsertChain.then(() => upsertToken(registration));
+  // The chain must not inherit a rejection, or one failed upsert would poison
+  // every later registration for the session. `upsertToken` already swallows
+  // its own failures; this covers the boundary.
+  upsertChain = upsert.catch(() => undefined);
   trackUpsert(upsert);
   await upsert;
 }
 
-async function upsertToken(
-  token: string,
-  assistantId: string,
-  conversationId: string,
-): Promise<void> {
+async function upsertToken({
+  token,
+  assistantId,
+  conversationId,
+  accentHex,
+  muted,
+}: LiveActivityRegistration): Promise<void> {
   try {
     // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
     const { App } = await import("@capacitor/app");
@@ -164,6 +205,8 @@ async function upsertToken(
         apns_environment: apnsEnvironment,
         conversation_id: conversationId,
         labels: phaseLabels(),
+        accent_hex: accentHex,
+        muted,
       },
       throwOnError: false,
     });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -56,11 +56,13 @@ const subscribeVoiceLiveActivityPushToken = mock(
   },
 );
 const registerLiveActivityPushToken = mock(
-  async (
-    _token: string,
-    _assistantId: string,
-    _conversationId: string,
-  ): Promise<void> => undefined,
+  async (_registration: {
+    token: string;
+    assistantId: string;
+    conversationId: string;
+    accentHex: string;
+    muted: boolean;
+  }): Promise<void> => undefined,
 );
 const unregisterLiveActivityPushToken = mock(
   async (): Promise<void> => undefined,
@@ -638,9 +640,13 @@ describe("registering the activity for server-driven updates", () => {
 
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
     expect(registerLiveActivityPushToken.mock.calls.at(-1)).toEqual([
-      "token-abc",
-      "assistant-1",
-      "conv-1",
+      {
+        token: "token-abc",
+        assistantId: "assistant-1",
+        conversationId: "conv-1",
+        accentHex: ORANGE,
+        muted: false,
+      },
     ]);
   });
 
@@ -659,7 +665,9 @@ describe("registering the activity for server-driven updates", () => {
     });
 
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
-    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[2]).toBe("conv-9");
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject(
+      { conversationId: "conv-9" },
+    );
   });
 
   // iOS reissues tokens mid-activity and each value invalidates the last, so a
@@ -676,9 +684,31 @@ describe("registering the activity for server-driven updates", () => {
     await emitToken("token-def");
 
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(2);
-    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toBe(
-      "token-def",
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject(
+      { token: "token-def" },
     );
+  });
+
+  // The platform composes every push from the registration, so a mute the
+  // registration never heard about is a mute the island loses the moment a
+  // server-driven update lands, which is to say the moment it matters.
+  test("re-registers when the mute state changes", async () => {
+    renderMirror();
+    await settled(() => {
+      useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+      useLiveVoiceStore.getState().setState("listening");
+    });
+    await emitToken("token-abc");
+    registerLiveActivityPushToken.mockClear();
+
+    await settled(() => {
+      useLiveVoiceStore.getState().setMuted(true);
+    });
+
+    expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject({
+      muted: true,
+    });
   });
 
   test("a phase change alone does not re-register", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -189,13 +189,16 @@ export function useLiveActivityMirror(): void {
     let pushToken: string | null = null;
     /**
      * What was last registered with the platform, as `token:assistant:
-     * conversation`.
+     * conversation:accent:muted`.
      *
-     * All three matter and none of them is stable: the token rotates, and a
-     * session started from a draft has no conversation id until the server's
-     * `ready` assigns one — registering against `null` and never revisiting it
-     * would leave the activity addressable by nothing. Comparing the triple
-     * re-registers when any part moves and stays quiet when none does.
+     * Every part matters and none is stable: the token rotates; a session
+     * started from a draft has no conversation id until the server's `ready`
+     * assigns one; registering against `null` and never revisiting it would
+     * leave the activity addressable by nothing; and the accent and mute state
+     * are content the platform composes its pushes from, so a stale
+     * registration would push the island back to whatever they were at start.
+     * Comparing the whole tuple re-registers when any part moves and stays
+     * quiet when none does.
      */
     let registeredKey: string | null = null;
 
@@ -206,7 +209,10 @@ export function useLiveActivityMirror(): void {
      * This is what lets the island keep updating after iOS suspends this web
      * view — see `live-activity-push-registration.ts`.
      */
-    const syncPushRegistration = (session: LiveVoiceState): void => {
+    const syncPushRegistration = (
+      session: LiveVoiceState,
+      content: VoiceLiveActivityContent,
+    ): void => {
       const { assistantId, conversationId } = session;
       if (
         pushToken === null ||
@@ -215,16 +221,19 @@ export function useLiveActivityMirror(): void {
       ) {
         return;
       }
-      const key = `${pushToken}:${assistantId}:${conversationId}`;
+      const { accentHex, muted } = content;
+      const key = `${pushToken}:${assistantId}:${conversationId}:${accentHex}:${String(muted)}`;
       if (key === registeredKey) {
         return;
       }
       registeredKey = key;
-      void registerLiveActivityPushToken(
-        pushToken,
+      void registerLiveActivityPushToken({
+        token: pushToken,
         assistantId,
         conversationId,
-      );
+        accentHex,
+        muted,
+      });
     };
 
     const sync = (session: LiveVoiceState): void => {
@@ -246,7 +255,7 @@ export function useLiveActivityMirror(): void {
         return;
       }
 
-      syncPushRegistration(session);
+      syncPushRegistration(session, content);
 
       if (pushed === null) {
         pushed = content;
@@ -292,7 +301,14 @@ export function useLiveActivityMirror(): void {
     const unsubscribeToken = subscribeVoiceLiveActivityPushToken(
       ({ token }) => {
         pushToken = token;
-        syncPushRegistration(useLiveVoiceStore.getState());
+        const session = useLiveVoiceStore.getState();
+        const content = toActivityContent(session);
+        // A token for a session that has already ended registers nothing: the
+        // activity it addresses is on its way out, and the `end` path has
+        // already dropped the registration.
+        if (content !== null) {
+          syncPushRegistration(session, content);
+        }
       },
     );
 


### PR DESCRIPTION
The Dynamic Island and Lock Screen showed the same waveform glyph for all six phases, so the compact trailing slot — the presentation the user actually sees most of the time — was a caption truncated to two or three characters, identical for "Listening…" and "Thinking…".

| | before | after |
|---|---|---|
| compact trailing | `"List…"` | phase glyph |
| expanded / Lock Screen | label only | glyph + label, elapsed timer |
| muted | mute glyph | unchanged |

## What's here

**Per-phase SF Symbol.** `ContentState.phaseSymbol` is the one place allowed to switch on `phase` where wording is not: a glyph has no continuously-deploying second source to drift from, and a new phase is a Swift compile error rather than silent staleness. The tight slots render it in place of the truncated caption; the roomy ones render it alongside the label.

**A session timer that costs no updates.** `VoiceSessionAttributes.startedAt` is stamped natively at `Activity.request`, and `Text(timerInterval:)` is driven by the system — so it keeps counting through a suspended web layer, a dropped push, and ActivityKit's update rate limit. For a phase that can legitimately sit still for minutes, that is the difference between an island that looks frozen and one that visibly is not. It is an attribute rather than content, so a server push (which replaces content state wholesale) cannot touch it, and stamping it natively keeps it on the same clock as the device rendering it.

Everything phase-derived — label, glyph, timer — still drops on `isStale`. Identity (avatar, name, accent) stays.

**Push-path state loss.** `accentHex` and `muted` now register with the token instead of riding the dispatch payload, and the mirror re-registers when either moves. See the platform PR for why the old shape silently grayed the island out.

## Testing

- iOS build (app + widget extension) green; `bun run typecheck`, `bun run lint`, and both Live Activity test files green (31 + 2 tests, incl. new coverage for re-registering on a mute change and for the registered accent/mute).
- Lock Screen presentation rendered on an iPhone 17 Pro simulator at all six phases plus muted and stale, in both appearances. The timer advanced between the two captures with no content update in flight, which is the property it exists for.
- **Not verifiable here:** the Dynamic Island's compact/expanded/minimal slots (no island hardware in the simulator) and the push path end to end. Both are TestFlight checks.

## Dependency

Needs vellum-ai/vellum-assistant-platform#9729 first — this carries the regenerated `platform.yaml`.

Part of JARVIS-1404 (1 of 4); does not close it. Still to come: a progress/detail line in `ContentState`, `ui_show` surfaces during a call, and interactive approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)