### PR TITLE
fix(macos): stop the test suite writing to real log directories

### DIFF
--- a/clients/macos/test-setup.ts
+++ b/clients/macos/test-setup.ts
@@ -125,3 +125,28 @@ mock.module("electron", () => ({
     writeText: () => undefined,
   },
 }));
+
+/**
+ * Mock surface for `electron-log/main`. `src/main/logger.ts` calls
+ * `log.initialize()` and configures a file transport at import time, and
+ * electron-log resolves that transport to a real path under
+ * `~/Library/Logs/<app name>/` on macOS. Any test that reaches `./logger`
+ * (directly, or through a module that imports it) therefore appends to a
+ * developer's actual log directory, and a mock supplying `app.getName()`
+ * resolves it to the shipping app's own log file.
+ *
+ * Individual tests can still re-mock `./logger` to assert on log calls; this
+ * only guarantees that a test which forgets to cannot write to disk.
+ */
+mock.module("electron-log/main", () => ({
+  default: {
+    initialize: () => undefined,
+    transports: { file: { getFile: () => ({ path: "/dev/null" }) } },
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    verbose: () => undefined,
+    silly: () => undefined,
+  },
+}));


### PR DESCRIPTION
## TL;DR

Running the macOS test suite appends unit-test stack traces to **`~/Library/Logs/Vellum/vellum.log`** — the shipping app's own log file, and the exact file a support request would ask a user to send. One mock in the shared test preload fixes the whole class.

## What happens

`src/main/logger.ts` calls `log.initialize()` and configures a file transport at import time:

```ts
import log from "electron-log/main";
log.initialize({ preload: true });
log.transports.file.fileName = "vellum.log";
```

electron-log resolves that transport to a real path under `~/Library/Logs/<app name>/` on macOS. Any test that reaches `./logger` — directly, or through any module that imports it — writes there for real.

Two tests do: `move-to-applications.test.ts` and `auto-update.test.ts`. The former's electron mock supplies `getName: () => "Vellum"`, which resolves the transport to the **production** app's log path rather than the dev one.

Measured on my machine, before this change:

```
before  19432 bytes
bun test src/main/move-to-applications.test.ts
after   21646 bytes
```

## Why the shared preload rather than another per-file mock

Six test files already guard this with `mock.module("./logger", ...)`. That convention works but is opt-in, and silently fails open — I missed it in both files I added in #39839, and nothing caught it.

`logger.ts` imports `electron-log/main`, a package specifier, so it can be mocked once in `test-setup.ts` (already preloaded via `bunfig.toml`) and no test can write to disk regardless of what its own electron mock claims `app.getName()` is. The existing per-file mocks keep working for tests that want to assert on log calls.

## Why it is safe

Test-only. No `src/` change. The mock supplies the surface `logger.ts` touches at import (`initialize`, `transports.file`, and the level methods) plus `getFile()` for `getLogFilePaths()`. No test asserts on real log output today; all six that mock `./logger` stub it to no-ops.

## Verification

```
bun run test:ci    # 66/66 test files pass
bunx tsc --noEmit  # clean
```

Log sizes unchanged across a full suite run, both paths:

| | Before suite | After suite |
|---|---|---|
| `~/Library/Logs/Vellum/vellum.log` | 21646 | 21646 |
| `~/Library/Logs/@vellumai/macos/vellum.log` | 4550319 | 4550319 |

## Context

Found while investigating LUM-2960, where I read a local `vellum.log` for forensic evidence and found it contaminated with my own test output from earlier the same day. The bug shipped in #39839; this is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->