### PR TITLE
polish: sidebar section header, Threads rename, pinned apps

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.test.tsx
+++ b/clients/web/src/components/collapsible-nav-section.test.tsx
@@ -101,10 +101,61 @@ describe("CollapsibleNavSection", () => {
     expect(html).toContain("text-body-medium-lighter");
   });
 
-  test("emits both leading glyphs (category icon + chevron-right) layered", () => {
+  // No leading icon: the header's only glyph is the trailing disclosure
+  // chevron, whatever `icon` the caller passes.
+  test("renders no leading icon, just the trailing chevron", () => {
     const html = renderSingleSection({ value: "recents", label: "Recents" });
     const svgCount = (html.match(/<\/svg>/g) ?? []).length;
-    expect(svgCount).toBeGreaterThanOrEqual(2);
+    expect(svgCount).toBe(1);
+    expect(html).toContain("lucide-chevron-down");
+    expect(html).not.toContain("lucide-clock");
+  });
+
+  // Regression: the title used to be the whole clickable trigger. Now only
+  // the chevron toggles, so the title can be press-and-held to drag the
+  // section without also expanding or collapsing it.
+  test("only the chevron toggles; the title is a plain, non-button label", () => {
+    const html = renderSingleSection({ value: "recents", label: "Recents" });
+    const container = document.createElement("div");
+    container.innerHTML = html;
+
+    const title = container.querySelector(
+      '[data-slot="collapsible-nav-section-title"]',
+    );
+    expect(title).not.toBeNull();
+    expect(title?.closest("button")).toBeNull();
+    expect(title?.querySelector("button")).toBeNull();
+
+    const chevronButton = Array.from(
+      container.querySelectorAll("button"),
+    ).find((button) => button.querySelector(".lucide-chevron-down"));
+    expect(chevronButton).toBeDefined();
+    expect(chevronButton?.getAttribute("aria-label")).toBe("Recents");
+    // Icon-only: the label text isn't duplicated inside the toggle button.
+    expect(chevronButton?.textContent?.trim()).toBe("");
+  });
+
+  // The chevron stays hidden at rest so a resting row stays quiet, but
+  // reveals on hover, or whenever the section is open: an expanded section
+  // always keeps a visible way to collapse itself again.
+  test("the chevron stays visible while the section is expanded", () => {
+    const html = renderSingleSection({
+      value: "recents",
+      label: "Recents",
+      defaultValue: ["recents"],
+    });
+    const container = document.createElement("div");
+    container.innerHTML = html;
+
+    const item = container.querySelector(
+      '[data-slot="collapsible-nav-section-section"]',
+    );
+    expect(item?.getAttribute("data-state")).toBe("open");
+
+    const chevron = container.querySelector(".lucide-chevron-down");
+    expect(chevron?.getAttribute("class")).toContain(
+      "group-data-[state=open]/section:opacity-100",
+    );
   });
 
   test("composes on top of design library Collapsible", () => {

--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, type LucideIcon } from "lucide-react";
+import { ChevronDown, type LucideIcon } from "lucide-react";
 import { type DragEvent, type ReactNode, type Ref } from "react";
 
 import { BottomSheet, ContextMenu } from "@vellumai/design-library";
@@ -22,9 +22,14 @@ import { isPointerCoarse } from "@/utils/pointer";
  * Navigation-specific collapsible section — composes the design library
  * `Collapsible` primitive with sidebar-tuned trigger styling:
  *
- *   - Leading icon that swaps to a disclosure chevron on hover
- *     (matching macOS SidebarSectionHeader). The original icon is
- *     always visible when not hovered, regardless of expanded state.
+ *   - No leading icon. The title itself isn't the toggle: it's a plain
+ *     label that just sits inside the draggable header, so clicking and
+ *     holding it drags the section (see `drag`) without also expanding
+ *     or collapsing it. The one toggle target is a small chevron button
+ *     on the trailing edge, left of the "…", revealed only on hover or
+ *     while the section is open (so an expanded section keeps its own
+ *     visible way to collapse again), not on click-then-release focus,
+ *     which would otherwise linger after the click that opened/closed it.
  *   - Optional `trailing` slot for an ellipsis menu or other per-row
  *     affordance. Pointer events are isolated so clicking trailing
  *     content doesn't toggle the section.
@@ -34,7 +39,8 @@ import { isPointerCoarse } from "@/utils/pointer";
  *     pointer type — Radix `ContextMenu` alone renders a pointer-positioned
  *     popover on touch, which is the wrong surface on mobile. Mirrors the
  *     conversation-row long-press pattern.
- *   - No hover background — the chevron swap is the affordance.
+ *   - No hover background on the title; the chevron button's own hover
+ *     state is the affordance.
  *
  * Usage:
  *
@@ -216,9 +222,13 @@ function CollapsibleNavSectionSection({
           the New Chat plus and the assistant eyes. Only the vertical
           metrics grow on mobile. */}
       {collapsible ? (
-        <Collapsible.Trigger
+        // Not the toggle target: clicking/holding the title drags the
+        // section (native HTML5 drag on the header div, see `drag` below).
+        // Only the chevron toggles, in the trailing cluster.
+        <div
+          data-slot="collapsible-nav-section-title"
           className={cn(
-            "group h-[30px] max-md:h-auto",
+            "flex h-[30px] min-w-0 flex-1 items-center max-md:h-auto",
             "rounded-[6px] py-[6px] max-md:py-3",
             "text-left text-body-medium-lighter max-md:text-body-large-lighter",
             "text-[var(--content-tertiary)]",
@@ -229,41 +239,13 @@ function CollapsibleNavSectionSection({
             gap: SIDEBAR_CHIP_GAP,
           }}
         >
-          <span
-            className="relative inline-flex h-[14px] shrink-0 items-center justify-center"
-            style={{ width: SIDEBAR_CHIP_SIZE }}
-          >
-            {Icon ? (
-              <Icon
-                size={12}
-                aria-hidden
-                className={cn(
-                  "absolute inset-0 m-auto transition-opacity",
-                  "text-[var(--content-tertiary)]",
-                  "group-hover:opacity-0 group-focus-visible:opacity-0",
-                )}
-              />
-            ) : null}
-            <ChevronRight
-              size={12}
-              aria-hidden
-              className={cn(
-                "absolute inset-0 m-auto transition-[opacity,transform]",
-                "text-[var(--content-tertiary)]",
-                Icon
-                  ? "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
-                  : "opacity-100",
-                "group-data-[state=open]:rotate-90",
-              )}
-            />
-          </span>
           <span className="min-w-0 flex-1 truncate">{label}</span>
           {collapsedIndicator ? (
-            <span className="ml-1 flex shrink-0 items-center group-data-[state=open]:hidden">
+            <span className="ml-1 flex shrink-0 items-center group-data-[state=open]/section:hidden">
               {collapsedIndicator}
             </span>
           ) : null}
-        </Collapsible.Trigger>
+        </div>
       ) : (
         // Non-collapsible: no chevron, no toggle affordance, just the icon
         // slot (if given) and the label, always at rest.
@@ -291,28 +273,57 @@ function CollapsibleNavSectionSection({
           <span className="min-w-0 flex-1 truncate">{label}</span>
         </div>
       )}
-      {trailing ? (
-        <span
-          data-slot="collapsible-nav-section-trailing"
-          /* `empty:hidden` so a trailing component that renders nothing (a
-             menu with no wired actions) doesn't leave a padded box behind.
+      {collapsible || trailing ? (
+        <span className="flex shrink-0 items-center gap-1 pr-[6px] max-md:pr-2">
+          {collapsible ? (
+            // The toggle target, moved off the title (which now only
+            // drags) and off the leading icon slot (there is no icon
+            // anymore) onto its own small trailing button, left of the
+            // "…". Icon-only, so it needs its own accessible name.
+            <Collapsible.Trigger
+              aria-label={label}
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] hover:bg-[var(--surface-hover)]"
+            >
+              <ChevronDown
+                size={12}
+                aria-hidden
+                className={cn(
+                  "shrink-0 transition-[opacity,transform]",
+                  "text-[var(--content-tertiary)]",
+                  "opacity-0 group-hover/header:opacity-100",
+                  "group-data-[state=open]/section:opacity-100",
+                  "max-md:opacity-100",
+                  "group-data-[state=open]/section:rotate-180",
+                )}
+              />
+            </Collapsible.Trigger>
+          ) : null}
+          {trailing ? (
+            <span
+              data-slot="collapsible-nav-section-trailing"
+              /* `empty:hidden` so a trailing component that renders nothing
+                 (a menu with no wired actions) doesn't leave a padded box
+                 behind.
 
-             Revealed on hover so a row of resting section headers stays quiet.
-             It also stays up while its own menu is open (`aria-expanded`),
-             or the control would vanish the moment it was clicked, and while
-             anything inside holds focus, so it is reachable by keyboard. Touch
-             has no hover, and the header's long-press sheet is the equivalent
-             affordance there, so below `md` it simply stays visible. */
-          className={cn(
-            "flex items-center shrink-0 pr-[6px] max-md:pr-2 empty:hidden",
-            "opacity-0 transition-opacity",
-            "group-hover/header:opacity-100 focus-within:opacity-100",
-            "has-[[aria-expanded=true]]:opacity-100",
-            "max-md:opacity-100",
-          )}
-          onClick={(event) => event.stopPropagation()}
-        >
-          {trailing}
+                 Revealed on hover so a row of resting section headers stays
+                 quiet. It also stays up while its own menu is open
+                 (`aria-expanded`), or the control would vanish the moment it
+                 was clicked, and while anything inside holds focus, so it is
+                 reachable by keyboard. Touch has no hover, and the header's
+                 long-press sheet is the equivalent affordance there, so
+                 below `md` it simply stays visible. */
+              className={cn(
+                "flex items-center shrink-0 empty:hidden",
+                "opacity-0 transition-opacity",
+                "group-hover/header:opacity-100 focus-within:opacity-100",
+                "has-[[aria-expanded=true]]:opacity-100",
+                "max-md:opacity-100",
+              )}
+              onClick={(event) => event.stopPropagation()}
+            >
+              {trailing}
+            </span>
+          ) : null}
         </span>
       ) : null}
     </div>
@@ -348,6 +359,10 @@ function CollapsibleNavSectionSection({
          this section" from reading as "lands inside it" when the section is
          expanded. */
       className={cn(
+        // Named so the trailing chevron (a header-level sibling of the
+        // Trigger, not a descendant) can read this item's own open/closed
+        // `data-state` for its rotation.
+        "group/section",
         drag?.dragging && "opacity-50",
         // Insertion line, matching the conversation-row drop indicator.
         drag?.dropEdge === "before" &&

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -295,10 +295,10 @@ describe("AssistantSideMenu · All view", () => {
     expect(indexOfText("Alpha")).toBeLessThan(indexOfText("Chats"));
   });
 
-  test("offers the view switch behind the Conversations actions menu", async () => {
-    // This describe block runs in List view (see its own `beforeEach`), so
-    // "Conversations" is what carries the toggle here; Grouped view's
-    // "Chats actions" menu covers the other side of the same control.
+  test("offers the view switch behind the Threads actions menu", async () => {
+    // "Threads" is the persistent header carrying the toggle, in every
+    // view mode, including this describe block's List view (see its own
+    // `beforeEach`).
     const { container } = render(
       createElement(AssistantSideMenu, {
         assistantId: "asst-1",
@@ -310,7 +310,7 @@ describe("AssistantSideMenu · All view", () => {
     );
     try {
       const trigger = container.querySelector<HTMLElement>(
-        '[aria-label="Conversations actions"]',
+        '[aria-label="Threads actions"]',
       );
       expect(trigger).not.toBeNull();
       act(() => {
@@ -956,13 +956,13 @@ describe("AssistantSideMenu · section spacing", () => {
       }),
     );
 
-    // "Conversations" is the persistent header for everything that isn't
+    // "Threads" is the persistent header for everything that isn't
     // Pinned or a custom group; Chats and each channel section nest inside
     // it in Grouped view rather than sitting as its top-level siblings.
     expect(sectionLabels(container)).toEqual([
       "Pinned",
       "Alpha",
-      "Conversations",
+      "Threads",
       "Chats",
       "Slack",
     ]);
@@ -1045,20 +1045,26 @@ describe("AssistantSideMenu · equal section treatment", () => {
     const children = Array.from(root.children);
     const indexOfText = (text: string) =>
       children.findIndex((el) => (el.textContent ?? "").includes(text));
+    // The rule sits inside a wrapper div (pulls it 4px closer to the
+    // curated block above), so it's a grandchild of root, not a direct
+    // child.
+    const ruleSelector = '[data-slot="sidebar-section-resize-handle"]';
     const ruleIndex = children.findIndex((el) =>
-      el.matches('[data-slot="sidebar-section-resize-handle"]'),
+      el.matches(ruleSelector) ? true : el.querySelector(ruleSelector) != null,
     );
 
-    expect(
-      root.querySelectorAll('[data-slot="sidebar-section-resize-handle"]'),
-    ).toHaveLength(1);
+    expect(root.querySelectorAll(ruleSelector)).toHaveLength(1);
     // Pinned and Alpha above it, Chats and Slack below.
     expect(indexOfText("Pinned")).toBeLessThan(ruleIndex);
     expect(indexOfText("Alpha")).toBeLessThan(ruleIndex);
     expect(indexOfText("Chats")).toBeGreaterThan(ruleIndex);
     expect(indexOfText("Slack")).toBeGreaterThan(ruleIndex);
     // Pinned is present and open by default, so the rule drags.
-    expect(children[ruleIndex]?.hasAttribute("data-resizable")).toBe(true);
+    expect(
+      children[ruleIndex]
+        ?.querySelector(ruleSelector)
+        ?.hasAttribute("data-resizable"),
+    ).toBe(true);
   });
 
   test("the rule is absent until something is curated", () => {
@@ -1145,10 +1151,10 @@ describe("AssistantSideMenu · equal section treatment", () => {
   });
 
   // The switch isn't statically rendered at all: it lives behind the
-  // persistent "Conversations" header's "…" button, reachable rather than
-  // always on screen (Chats itself, nested inside Conversations in Grouped
+  // persistent "Threads" header's "…" button, reachable rather than
+  // always on screen (Chats itself, nested inside Threads in Grouped
   // view, carries no button of its own, see `sidebar-section-item.tsx`).
-  test("the view switch is behind the Conversations actions menu, not statically rendered", async () => {
+  test("the view switch is behind the Threads actions menu, not statically rendered", async () => {
     const html = renderMenu({
       conversations: LAYOUT_CONVERSATIONS,
       conversationGroups: LAYOUT_GROUPS,
@@ -1167,7 +1173,7 @@ describe("AssistantSideMenu · equal section treatment", () => {
     );
     try {
       const trigger = container.querySelector<HTMLElement>(
-        '[aria-label="Conversations actions"]',
+        '[aria-label="Threads actions"]',
       );
       expect(trigger).not.toBeNull();
       act(() => {
@@ -1192,13 +1198,13 @@ describe("AssistantSideMenu · equal section treatment", () => {
     const sections = sectionElements(container);
     expect(sections).toHaveLength(5);
 
-    // "Conversations" is the persistent wrapper, not itself a member of
+    // "Threads" is the persistent wrapper, not itself a member of
     // `sidebar.sections`: it doesn't drag and carries no icon (matching
     // Pinned's icon-less header). Everything else still shares the same
     // affordances.
     const labels = sectionLabels(container);
     const reorderable = sections.filter(
-      (_, index) => labels[index] !== "Conversations",
+      (_, index) => labels[index] !== "Threads",
     );
     expect(reorderable).toHaveLength(4);
 
@@ -1206,7 +1212,8 @@ describe("AssistantSideMenu · equal section treatment", () => {
       const header = section.querySelector<HTMLElement>(
         '[data-slot="collapsible-nav-section-header"]',
       );
-      // Draggable header (the reorder handle) and a leading icon, on all four.
+      // Draggable header (the reorder handle) and a disclosure chevron, on
+      // all four.
       expect(header?.getAttribute("draggable")).toBe("true");
       expect(header?.querySelector("svg")).not.toBeNull();
     }
@@ -1222,7 +1229,7 @@ describe("AssistantSideMenu · section reordering", () => {
       }),
     );
 
-    // "Conversations" is the persistent wrapper (not a member of
+    // "Threads" is the persistent wrapper (not a member of
     // `sidebar.sections`), so it never drags; everything else does.
     const labels = sectionLabels(container);
     const headers = Array.from(
@@ -1232,7 +1239,7 @@ describe("AssistantSideMenu · section reordering", () => {
     );
     expect(headers).toHaveLength(5);
     const draggable = headers.filter(
-      (_, index) => labels[index] !== "Conversations",
+      (_, index) => labels[index] !== "Threads",
     );
     expect(draggable).toHaveLength(4);
     expect(
@@ -1247,8 +1254,8 @@ describe("AssistantSideMenu · section reordering", () => {
       }),
     );
 
-    // "Conversations" (always present) plus the lone nested "Chats" section:
-    // neither drags. Conversations isn't a member of `sidebar.sections` to
+    // "Threads" (always present) plus the lone nested "Chats" section:
+    // neither drags. Threads isn't a member of `sidebar.sections` to
     // begin with, and Chats has nothing to reorder against.
     const headers = Array.from(
       container.querySelectorAll<HTMLElement>(

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,5 +1,6 @@
 import { Search, SquarePen, X } from "lucide-react";
 import {
+  Fragment,
   useCallback,
   useLayoutEffect,
   useRef,
@@ -11,6 +12,10 @@ import {
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import {
+  SIDEBAR_CHIP_GAP,
+  SIDEBAR_ROW_PADDING_X,
+} from "@/components/sidebar-nav-geometry";
 import {
   CollapsedGroupIcon,
   getGroupIndicatorState,
@@ -423,7 +428,7 @@ export function AssistantSideMenu({
     });
   };
 
-  // List/Groups switch, in the persistent "Conversations" header's menu.
+  // List/Groups switch, in the persistent "Threads" header's menu.
   const viewAsFooter = (
     <div className="mt-2 px-2 pb-1">
       <div
@@ -453,45 +458,22 @@ export function AssistantSideMenu({
     />
   );
 
-  // The persistent "Conversations" header: same bulk-action menu shape as a
+  // The persistent "Threads" header: same bulk-action menu shape as a
   // section's, minus move-up/down since it isn't a member of
   // `sidebar.sections`. Scoped to `flatList` regardless of view mode:
   // that's every conversation neither pinned nor in a custom group, the same
   // set whether it's currently rendered as one list (List view) or split
   // into Chats + channel sub-sections (Grouped view).
-  const conversationsMenu = buildGroupMenu("Conversations", sidebar.flatList);
+  const conversationsMenu = buildGroupMenu("Threads", sidebar.flatList);
 
   // --- Built-in navigation ---
-  // Pinned apps above the built-in nav, separated by a divider. On the rail
-  // this block lives in the non-scrolling header; on the overlay it renders
-  // at the top of the body so the whole menu scrolls as one surface (Figma
-  // 6764:6745).
+  // Assistant cluster leads, pinned apps follow beneath New Chat, separated
+  // by a divider. On the rail this block lives in the non-scrolling header;
+  // on the overlay it renders at the top of the body so the whole menu
+  // scrolls as one surface (Figma 6764:6745).
 
   const builtInNav = (
     <>
-      {pinnedApps.length > 0 ? (
-        <>
-          <div className="flex flex-col gap-[4px]">
-            {pinnedApps.map((app) => (
-              <PinnedAppNavItem
-                key={app.appId}
-                app={app}
-                collapsed={collapsed}
-                active={activeAppId === app.appId}
-                onOpen={
-                  onOpenApp
-                    ? (appId) => {
-                        onOpenApp(appId);
-                        onClose?.();
-                      }
-                    : undefined
-                }
-              />
-            ))}
-          </div>
-          <SideMenu.Separator />
-        </>
-      ) : null}
       {/* The assistant cluster: the avatar-colored assistant row with the
           New Chat row (avatar-tinted, plus + label; icon-only tile on the
           collapsed rail) beneath it, so the identity leads and the action
@@ -526,8 +508,52 @@ export function AssistantSideMenu({
           }
         />
       </div>
-      {/* The collapsed rail separates the cluster from the group icons
-          below it (Figma 7257:135826). */}
+      {pinnedApps.length > 0 ? (
+        <>
+          {/* Not the accordion's "Threads"/"Pinned" title component: this
+              block lives outside `CollapsibleNavSection.Root` entirely (in
+              the non-scrolling rail header, or the overlay's top-of-body),
+              so it's just the same label styling, non-interactive. */}
+          {!isCollapsedRail ? (
+            <div
+              className="flex h-[30px] items-center rounded-[6px] py-[6px] text-left text-body-medium-lighter text-[var(--content-tertiary)]"
+              style={{
+                paddingLeft: SIDEBAR_ROW_PADDING_X,
+                paddingRight: SIDEBAR_ROW_PADDING_X,
+                gap: SIDEBAR_CHIP_GAP,
+                // Shaves 4px off the parent's own gap (8px on the rail,
+                // 16px on the overlay): additive since flex `gap` doesn't
+                // collapse with margins, so this works in both contexts.
+                marginBottom: -4,
+              }}
+            >
+              Pinned Apps
+            </div>
+          ) : null}
+          <div className="flex flex-col gap-[4px]">
+            {pinnedApps.map((app) => (
+              <PinnedAppNavItem
+                key={app.appId}
+                app={app}
+                collapsed={collapsed}
+                active={activeAppId === app.appId}
+                onOpen={
+                  onOpenApp
+                    ? (appId) => {
+                        onOpenApp(appId);
+                        onClose?.();
+                      }
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+          <SideMenu.Separator />
+        </>
+      ) : null}
+      {/* The collapsed rail separates the cluster (or, when pinned apps
+          exist, the pinned-apps block above) from the group icons below it
+          (Figma 7257:135826). */}
       {isCollapsedRail ? <SideMenu.Separator /> : null}
     </>
   );
@@ -689,28 +715,39 @@ export function AssistantSideMenu({
                 onValueChange={sidebar.onOpenSectionsChange}
               >
                 {/* Pinned and the custom groups: the user's own curation,
-                    identical in both views. No dividers *between* them, since
-                    a custom group is a peer of Pinned rather than a different
-                    class of thing. */}
+                    identical in both views. A divider between each pair, so
+                    Pinned's own boundary reads the same as the curated
+                    block's outer one below. */}
                 {sidebar.sections
                   .slice(0, sidebar.curatedSectionCount)
-                  .map(renderSection)}
+                  .map((section, index) => (
+                    <Fragment key={section.key}>
+                      {index > 0 ? (
+                        // 2px closer to the section below than the
+                        // separator's own default my-1 (4px) gives.
+                        <SideMenu.Separator style={{ marginBottom: 2 }} />
+                      ) : null}
+                      {renderSection(section)}
+                    </Fragment>
+                  ))}
                 {/* The list's one rule, marking where curation ends and the
                     conversations begin. Absent when nothing is curated yet, so
-                    a fresh sidebar never opens on a stray line. It carries no
-                    margin, sitting on the root's own gap, and doubles as the
-                    Pinned section's resize handle while Pinned is expanded. */}
+                    a fresh sidebar never opens on a stray line. Sits on the
+                    root's own gap, pulled up 2px so the curated block's last
+                    row sits closer to it than the root's default gap-3. */}
                 {sidebar.curatedSectionCount > 0 ? (
-                  <SidebarSectionResizeHandle
-                    targetRef={pinnedListRef}
-                    resizable={pinnedResizable}
-                    onCommit={(height) =>
-                      savePinnedSectionHeight(assistantId, height)
-                    }
-                    onReset={() => resetPinnedSectionHeight(assistantId)}
-                  />
+                  <div style={{ marginTop: -2 }}>
+                    <SidebarSectionResizeHandle
+                      targetRef={pinnedListRef}
+                      resizable={pinnedResizable}
+                      onCommit={(height) =>
+                        savePinnedSectionHeight(assistantId, height)
+                      }
+                      onReset={() => resetPinnedSectionHeight(assistantId)}
+                    />
+                  </div>
                 ) : null}
-                {/* "Conversations" is the persistent header for everything
+                {/* "Threads" is the persistent header for everything
                     that isn't Pinned or a custom group: it never swaps out
                     for "Chats". In List view its content is the flat list;
                     in Grouped view, Chats and each channel section nest
@@ -721,11 +758,11 @@ export function AssistantSideMenu({
                     `sidebar.sections`. */}
                 <ConversationNavSection
                   value="conversations"
-                  label="Conversations"
+                  label="Threads"
                   collapsible={false}
                   trailing={
                     <GroupActionsMenu
-                      label="Conversations"
+                      label="Threads"
                       footer={viewAsFooter}
                       {...conversationsMenu}
                     />

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.test.tsx
@@ -112,12 +112,23 @@ describe("PinnedAppNavItem", () => {
     expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(false);
   });
 
+  test("expanded: the hover-revealed unpin button also clears the pin", () => {
+    seedPin(APP);
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(true);
+
+    render(<PinnedAppNavItem app={APP} active={false} collapsed={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "Unpin My App" }));
+
+    expect(usePinnedAppsStore.getState().isPinned("app-1")).toBe(false);
+  });
+
   test("collapsed rail: renders the row without the context-menu wrapper", () => {
     render(<PinnedAppNavItem app={APP} active={false} collapsed />);
 
     expect(screen.getByTestId("app-row").textContent).toBe("My App");
     expect(screen.queryByTestId("ctx-root")).toBeNull();
     expect(screen.queryByRole("button", { name: "Unpin" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Unpin My App" })).toBeNull();
   });
 
   test("marks the row active when active is true", () => {

--- a/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/pinned-app-nav-item.tsx
@@ -27,6 +27,13 @@ export interface PinnedAppNavItemProps {
  * complementing the long-press context menu. In the collapsed rail the
  * swipe is omitted (the tooltip provider would interfere, same as the
  * context menu).
+ *
+ * On desktop, a third path: a hover-revealed unpin button on the row's
+ * trailing edge. `SideMenu.Item` has no `trailingAction` slot (unlike
+ * `PanelItem`), and it renders as a real `<button>` when `onSelect` is
+ * given, so the unpin button can't nest inside it: it's a sibling,
+ * absolutely positioned over the row's right edge by their shared
+ * `relative` wrapper.
  */
 export function PinnedAppNavItem({
   app,
@@ -36,7 +43,7 @@ export function PinnedAppNavItem({
 }: PinnedAppNavItemProps) {
   const unpin = usePinnedAppsStore.use.unpin();
 
-  const item = (
+  const sideMenuItem = (
     <SideMenu.Item
       // Apps source their icon as an emoji string on the manifest
       // (`app.icon`). Fall back to the Rocket lucide glyph so unmojified
@@ -46,12 +53,36 @@ export function PinnedAppNavItem({
       showCollapsedTooltip
       active={active}
       onSelect={onOpen ? () => onOpen(app.appId) : undefined}
+      className="text-[color:var(--content-default)]"
     />
   );
 
   if (collapsed) {
-    return item;
+    return sideMenuItem;
   }
+
+  const item = (
+    <div className="group/pinned-app relative">
+      <SideMenu.Item
+        icon={app.icon ?? Rocket}
+        label={app.name}
+        active={active}
+        onSelect={onOpen ? () => onOpen(app.appId) : undefined}
+        className="pr-8 text-[color:var(--content-default)]"
+      />
+      <button
+        type="button"
+        aria-label={`Unpin ${app.name}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          unpin(app.appId);
+        }}
+        className="absolute top-1/2 right-[6px] flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-[4px] text-[var(--content-tertiary)] opacity-0 transition-opacity hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] group-hover/pinned-app:opacity-100 focus-visible:opacity-100"
+      >
+        <PinOff size={12} aria-hidden />
+      </button>
+    </div>
+  );
 
   const trailingActions: SwipeAction[] = isPointerCoarse()
     ? [


### PR DESCRIPTION
Collapsible section headers (Chats, channel sections, custom groups): the title is no longer the toggle target, it's a plain drag handle now; a dedicated icon-only chevron button on the trailing edge (pointing down at rest, up when open) is the only click target, visible on hover or while expanded, not on lingering post-click focus.

Renamed the persistent "Conversations" header to "Threads".

Pinned apps: moved below New Chat with a "Pinned Apps" title matching the section-header treatment, a divider between each curated section, a hover-revealed unpin button alongside the existing context-menu/swipe paths, and several spacing tweaks. App row text now matches conversation row text color.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
