### PR TITLE
fix(web): bound the local-gateway 401 reload recovery

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1020,6 +1020,8 @@ function clearGatewayTokenStorage(): void {
 describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
   const GATEWAY_URL = "http://localhost:9090";
   const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
+  const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
+  const GW_401_MAX_RELOADS = 3;
 
   function makeResponse(status: number, url: string): Response {
     const response = new Response(null, { status });
@@ -1049,6 +1051,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
     isLocalClientMock.mockImplementation(() => true);
     setSelfHostedConnection({ url: GATEWAY_URL, token: "tok" });
     sessionStorage.removeItem(GW_401_RELOAD_KEY);
+    sessionStorage.removeItem(GW_401_ATTEMPTS_KEY);
     clearGatewayTokenStorage();
     resetGw401RecoveryFlag();
   });
@@ -1061,6 +1064,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
     isLocalClientMock.mockImplementation(() => !process.env.VITE_PLATFORM_MODE);
     setSelfHostedConnection(null);
     sessionStorage.removeItem(GW_401_RELOAD_KEY);
+    sessionStorage.removeItem(GW_401_ATTEMPTS_KEY);
     clearGatewayTokenStorage();
     resetGw401RecoveryFlag();
   });
@@ -1238,6 +1242,47 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
 
     // THEN only one reload fires
+    expect(reloadCalls).toBe(1);
+  });
+
+  test("stops reloading once the attempt budget is spent", () => {
+    // Each round models a fresh page lifecycle: the in-memory latch resets
+    // on reload and the cooldown has elapsed, so only the budget can stop it.
+    for (let i = 0; i < GW_401_MAX_RELOADS; i++) {
+      resetGw401RecoveryFlag();
+      sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
+      localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+    }
+    expect(reloadCalls).toBe(GW_401_MAX_RELOADS);
+
+    resetGw401RecoveryFlag();
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+
+    expect(reloadCalls).toBe(GW_401_MAX_RELOADS);
+  });
+
+  test("hands the 401 back unchanged once the budget is spent", () => {
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+    const response = gatewayResponse(401);
+
+    expect(localGatewayAuthRecoveryInterceptor(response)).toBe(response);
+    expect(reloadCalls).toBe(0);
+  });
+
+  test("a fresh renderer session grants a new budget", () => {
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+    expect(reloadCalls).toBe(0);
+
+    // Quitting and reopening the app ends the renderer session, which is
+    // what clearing sessionStorage models here.
+    sessionStorage.removeItem(GW_401_ATTEMPTS_KEY);
+    sessionStorage.removeItem(GW_401_RELOAD_KEY);
+    sessionStorage.removeItem(GW_401_ATTEMPTS_KEY);
+    resetGw401RecoveryFlag();
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+
     expect(reloadCalls).toBe(1);
   });
 });

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1022,6 +1022,7 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
   const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
   const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
   const GW_401_MAX_RELOADS = 3;
+  const GW_401_ATTEMPT_WINDOW_MS = 1_800_000;
 
   function makeResponse(status: number, url: string): Response {
     const response = new Response(null, { status });
@@ -1264,14 +1265,43 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
 
   test("hands the 401 back unchanged once the budget is spent", () => {
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+    // Inside the ageing window, so the spent budget still binds.
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
     const response = gatewayResponse(401);
 
     expect(localGatewayAuthRecoveryInterceptor(response)).toBe(response);
     expect(reloadCalls).toBe(0);
   });
 
+  test("attempts age out, so successful recoveries do not spend the budget", () => {
+    // Three recoveries that each worked, spread out over a long-lived
+    // session. The budget must not be consumed by them.
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+    sessionStorage.setItem(
+      GW_401_RELOAD_KEY,
+      String(Date.now() - GW_401_ATTEMPT_WINDOW_MS - 1),
+    );
+
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+
+    expect(reloadCalls).toBe(1);
+    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBe("1");
+  });
+
+  test("attempts inside the window still accumulate", () => {
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, "2");
+    // Past the cooldown but well inside the ageing window.
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
+
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+
+    expect(reloadCalls).toBe(1);
+    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBe("3");
+  });
+
   test("a fresh renderer session grants a new budget", () => {
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
     expect(reloadCalls).toBe(0);
 

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -79,6 +79,8 @@ mock.module("@/lib/auth/hard-navigate", () => ({
   hardNavigate: hardNavigateMock,
 }));
 
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { client as gatewayClient } from "@/generated/gateway/client.gen";
 import {
   authorizeRemoteGatewayRequest,
   daemonErrorInterceptor,
@@ -1017,12 +1019,39 @@ function clearGatewayTokenStorage(): void {
   }
 }
 
+describe("api-interceptors / recovery interceptor registration", () => {
+  // Direct calls to the interceptor prove what it does, not where it runs.
+  // These pin which generated clients actually carry it, so adding or
+  // dropping a registration has to be deliberate.
+  function responseFns(c: {
+    interceptors: { response: unknown };
+  }): readonly unknown[] {
+    const chain = c.interceptors.response as unknown as { fns?: unknown[] };
+    return chain.fns ?? [];
+  }
+
+  test("daemonClient carries the local-gateway 401 recovery", () => {
+    expect(responseFns(daemonClient)).toContain(
+      localGatewayAuthRecoveryInterceptor,
+    );
+  });
+
+  test("gatewayClient deliberately does not carry it", () => {
+    // A 401 raised through the generated gateway SDK surfaces to the caller
+    // rather than reloading the app. Widening the set of responses that can
+    // restart the app is the opposite of what the budget is for, so this
+    // exclusion is intentional and tracked separately.
+    expect(responseFns(gatewayClient)).not.toContain(
+      localGatewayAuthRecoveryInterceptor,
+    );
+  });
+});
+
 describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
   const GATEWAY_URL = "http://localhost:9090";
   const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
   const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
   const GW_401_MAX_RELOADS = 3;
-  const GW_401_ATTEMPT_WINDOW_MS = 1_800_000;
 
   function makeResponse(status: number, url: string): Response {
     const response = new Response(null, { status });
@@ -1265,43 +1294,69 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
 
   test("hands the 401 back unchanged once the budget is spent", () => {
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
-    // Inside the ageing window, so the spent budget still binds.
-    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
     const response = gatewayResponse(401);
 
     expect(localGatewayAuthRecoveryInterceptor(response)).toBe(response);
     expect(reloadCalls).toBe(0);
   });
 
-  test("attempts age out, so successful recoveries do not spend the budget", () => {
-    // Three recoveries that each worked, spread out over a long-lived
-    // session. The budget must not be consumed by them.
+  test("a quiet gap alone does not restore the budget", () => {
+    // A gateway that is still rejecting every token must not earn a fresh
+    // budget out of a lull in traffic, or it reloads forever in bursts.
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
-    sessionStorage.setItem(
-      GW_401_RELOAD_KEY,
-      String(Date.now() - GW_401_ATTEMPT_WINDOW_MS - 1),
-    );
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 86_400_000));
 
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
 
-    expect(reloadCalls).toBe(1);
-    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBe("1");
+    expect(reloadCalls).toBe(0);
   });
 
-  test("attempts inside the window still accumulate", () => {
-    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, "2");
-    // Past the cooldown but well inside the ageing window.
+  test("a successful gateway response restores the budget", () => {
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
     sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
 
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(200));
+
+    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBeNull();
+    expect(sessionStorage.getItem(GW_401_RELOAD_KEY)).toBeNull();
+  });
+
+  test("recovery, then a later failure episode, gets a full budget", () => {
+    // Episode one exhausts the budget.
+    for (let i = 0; i < GW_401_MAX_RELOADS; i++) {
+      resetGw401RecoveryFlag();
+      sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
+      localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+    }
+    resetGw401RecoveryFlag();
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
+    expect(reloadCalls).toBe(GW_401_MAX_RELOADS);
+
+    // The gateway starts working again.
+    localGatewayAuthRecoveryInterceptor(gatewayResponse(200));
+
+    // A genuinely new episode later gets its own budget.
+    resetGw401RecoveryFlag();
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
 
-    expect(reloadCalls).toBe(1);
-    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBe("3");
+    expect(reloadCalls).toBe(GW_401_MAX_RELOADS + 1);
+  });
+
+  test("a non-gateway 2xx does not restore the budget", () => {
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
+
+    localGatewayAuthRecoveryInterceptor(
+      makeResponse(200, "https://api.vellum.ai/v1/whatever"),
+    );
+
+    expect(sessionStorage.getItem(GW_401_ATTEMPTS_KEY)).toBe(
+      String(GW_401_MAX_RELOADS),
+    );
   });
 
   test("a fresh renderer session grants a new budget", () => {
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(GW_401_MAX_RELOADS));
-    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now() - 700_000));
     localGatewayAuthRecoveryInterceptor(gatewayResponse(401));
     expect(reloadCalls).toBe(0);
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -406,11 +406,22 @@ export function daemonUnreachableInterceptor(response: Response): Response {
  * token), clears the cached gateway tokens from localStorage and
  * reloads the page so the app acquires a fresh token on startup.
  *
- * A sessionStorage cooldown prevents infinite reload loops when the
- * gateway consistently rejects tokens (e.g. after a misconfiguration).
+ * A sessionStorage cooldown spaces the attempts, and a sessionStorage
+ * attempt budget stops them. The cooldown alone only paces a gateway that
+ * rejects every token (a mismatched signing key, say): the page reloads
+ * once per cooldown for as long as the app stays open, which reaches the
+ * user as an app that restarts itself every ten minutes and never settles.
+ * Past the budget the 401 is handed back untouched, so the normal error
+ * path surfaces it and the tray's re-pair action stays available.
+ *
+ * Both keys live in sessionStorage, so quitting and reopening the app
+ * grants a fresh budget: a genuinely transient rejection still recovers on
+ * the next launch.
  */
 const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
+const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
 const GW_401_COOLDOWN_MS = 600_000;
+const GW_401_MAX_RELOADS = 3;
 
 // In-memory latch: once recovery fires, all subsequent 401s in the same
 // page lifecycle are no-ops. Resets naturally on reload.
@@ -446,14 +457,26 @@ export function localGatewayAuthRecoveryInterceptor(
   }
 
   try {
+    const attempts = Number(
+      sessionStorage.getItem(GW_401_ATTEMPTS_KEY) ?? "0",
+    );
+    // A budget that has already been spent means reloading has not fixed
+    // this gateway and will not; let the 401 through to the error path.
+    if (Number.isFinite(attempts) && attempts >= GW_401_MAX_RELOADS) {
+      return response;
+    }
     const lastReload = sessionStorage.getItem(GW_401_RELOAD_KEY);
     if (lastReload && Date.now() - Number(lastReload) < GW_401_COOLDOWN_MS) {
       return response;
     }
     sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now()));
+    sessionStorage.setItem(
+      GW_401_ATTEMPTS_KEY,
+      String((Number.isFinite(attempts) ? attempts : 0) + 1),
+    );
   } catch {
-    // sessionStorage unavailable — cannot enforce cooldown, skip reload
-    // to avoid infinite reload loops.
+    // sessionStorage unavailable — cannot enforce cooldown or budget, skip
+    // reload to avoid infinite reload loops.
     return response;
   }
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -422,6 +422,10 @@ const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
 const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
 const GW_401_COOLDOWN_MS = 600_000;
 const GW_401_MAX_RELOADS = 3;
+// Attempts age out after a quiet spell, so the budget bounds a burst rather
+// than the renderer's whole lifetime. Must exceed the cooldown, or every
+// attempt would age out before the next one and the budget would never bind.
+const GW_401_ATTEMPT_WINDOW_MS = 1_800_000;
 
 // In-memory latch: once recovery fires, all subsequent 401s in the same
 // page lifecycle are no-ops. Resets naturally on reload.
@@ -457,25 +461,37 @@ export function localGatewayAuthRecoveryInterceptor(
   }
 
   try {
-    const attempts = Number(
-      sessionStorage.getItem(GW_401_ATTEMPTS_KEY) ?? "0",
-    );
-    // A budget that has already been spent means reloading has not fixed
-    // this gateway and will not; let the 401 through to the error path.
-    if (Number.isFinite(attempts) && attempts >= GW_401_MAX_RELOADS) {
+    const now = Date.now();
+    const rawLast = sessionStorage.getItem(GW_401_RELOAD_KEY);
+    const lastReload = rawLast === null ? null : Number(rawLast);
+    const sinceLast =
+      lastReload !== null && Number.isFinite(lastReload)
+        ? now - lastReload
+        : Infinity;
+
+    // A gap longer than the window means whatever was rejecting tokens has
+    // stopped, so the next failure starts from a full budget. Reading the
+    // counter unconditionally would make it monotonic for the life of the
+    // renderer, and a session left open for days would spend its budget on
+    // recoveries that each succeeded.
+    const stored =
+      sinceLast >= GW_401_ATTEMPT_WINDOW_MS
+        ? 0
+        : Number(sessionStorage.getItem(GW_401_ATTEMPTS_KEY) ?? "0");
+    const attempts = Number.isFinite(stored) ? stored : 0;
+
+    // A budget spent inside the window means reloading is not fixing this
+    // gateway; let the 401 through to the error path.
+    if (attempts >= GW_401_MAX_RELOADS) {
       return response;
     }
-    const lastReload = sessionStorage.getItem(GW_401_RELOAD_KEY);
-    if (lastReload && Date.now() - Number(lastReload) < GW_401_COOLDOWN_MS) {
+    if (sinceLast < GW_401_COOLDOWN_MS) {
       return response;
     }
-    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now()));
-    sessionStorage.setItem(
-      GW_401_ATTEMPTS_KEY,
-      String((Number.isFinite(attempts) ? attempts : 0) + 1),
-    );
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(now));
+    sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(attempts + 1));
   } catch {
-    // sessionStorage unavailable — cannot enforce cooldown or budget, skip
+    // sessionStorage unavailable: cannot enforce cooldown or budget, skip
     // reload to avoid infinite reload loops.
     return response;
   }

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -414,18 +414,24 @@ export function daemonUnreachableInterceptor(response: Response): Response {
  * Past the budget the 401 is handed back untouched, so the normal error
  * path surfaces it and the tray's re-pair action stays available.
  *
- * Both keys live in sessionStorage, so quitting and reopening the app
- * grants a fresh budget: a genuinely transient rejection still recovers on
- * the next launch.
+ * The budget is spent permanently until the gateway demonstrates that it
+ * works: a 2xx from the ingress origin clears it. Elapsed time deliberately
+ * does not, because a gateway that is still rejecting every token would
+ * otherwise earn a fresh budget out of every quiet spell and reload forever
+ * in bursts. A reload that genuinely fixed the session produces that 2xx on
+ * its next request, so a transient rejection is not charged for recovering.
+ *
+ * Both keys live in sessionStorage, so quitting and reopening the app also
+ * grants a fresh budget.
+ *
+ * Installed on `daemonClient` only. `gatewayClient` does not carry this
+ * interceptor, so 401s raised through the generated gateway SDK are not
+ * recovered here; see the registrations at the bottom of this file.
  */
 const GW_401_RELOAD_KEY = "vellum:gw:401-reload-at";
 const GW_401_ATTEMPTS_KEY = "vellum:gw:401-reload-attempts";
 const GW_401_COOLDOWN_MS = 600_000;
 const GW_401_MAX_RELOADS = 3;
-// Attempts age out after a quiet spell, so the budget bounds a burst rather
-// than the renderer's whole lifetime. Must exceed the cooldown, or every
-// attempt would age out before the next one and the budget would never bind.
-const GW_401_ATTEMPT_WINDOW_MS = 1_800_000;
 
 // In-memory latch: once recovery fires, all subsequent 401s in the same
 // page lifecycle are no-ops. Resets naturally on reload.
@@ -439,12 +445,6 @@ export function resetGw401RecoveryFlag(): void {
 export function localGatewayAuthRecoveryInterceptor(
   response: Response,
 ): Response {
-  if (response.status !== 401) {
-    return response;
-  }
-  if (gw401RecoveryFired) {
-    return response;
-  }
   if (!isLocalClient()) {
     return response;
   }
@@ -453,42 +453,50 @@ export function localGatewayAuthRecoveryInterceptor(
     return response;
   }
 
-  // Only recover from 401s that originated from the local gateway.
-  // Daemon requests that don't match ASSISTANT_PATH_RE are not rewritten
-  // and hit the platform instead — their 401s are handled elsewhere.
+  // Only act on responses that originated from the local gateway. Daemon
+  // requests that don't match ASSISTANT_PATH_RE are not rewritten and hit
+  // the platform instead; their 401s are handled elsewhere.
   if (!response.url.startsWith(ingressUrl)) {
     return response;
   }
 
-  try {
-    const now = Date.now();
-    const rawLast = sessionStorage.getItem(GW_401_RELOAD_KEY);
-    const lastReload = rawLast === null ? null : Number(rawLast);
-    const sinceLast =
-      lastReload !== null && Number.isFinite(lastReload)
-        ? now - lastReload
-        : Infinity;
+  // The gateway answering a request is the only evidence that the token it
+  // was rejecting has been replaced by a working one, so it is the only
+  // thing that restores the budget. `/readyz` probes use a bare `fetch`
+  // rather than this client, so an unauthenticated liveness check cannot
+  // stand in for a real one.
+  if (response.ok) {
+    try {
+      sessionStorage.removeItem(GW_401_ATTEMPTS_KEY);
+      sessionStorage.removeItem(GW_401_RELOAD_KEY);
+    } catch {
+      // sessionStorage unavailable; the budget check below fails closed.
+    }
+    return response;
+  }
 
-    // A gap longer than the window means whatever was rejecting tokens has
-    // stopped, so the next failure starts from a full budget. Reading the
-    // counter unconditionally would make it monotonic for the life of the
-    // renderer, and a session left open for days would spend its budget on
-    // recoveries that each succeeded.
-    const stored =
-      sinceLast >= GW_401_ATTEMPT_WINDOW_MS
-        ? 0
-        : Number(sessionStorage.getItem(GW_401_ATTEMPTS_KEY) ?? "0");
+  if (response.status !== 401) {
+    return response;
+  }
+  if (gw401RecoveryFired) {
+    return response;
+  }
+
+  try {
+    const stored = Number(sessionStorage.getItem(GW_401_ATTEMPTS_KEY) ?? "0");
     const attempts = Number.isFinite(stored) ? stored : 0;
 
-    // A budget spent inside the window means reloading is not fixing this
-    // gateway; let the 401 through to the error path.
+    // A spent budget means reloading has not made this gateway work, and
+    // nothing since has shown that it does; let the 401 through to the
+    // error path.
     if (attempts >= GW_401_MAX_RELOADS) {
       return response;
     }
-    if (sinceLast < GW_401_COOLDOWN_MS) {
+    const lastReload = sessionStorage.getItem(GW_401_RELOAD_KEY);
+    if (lastReload && Date.now() - Number(lastReload) < GW_401_COOLDOWN_MS) {
       return response;
     }
-    sessionStorage.setItem(GW_401_RELOAD_KEY, String(now));
+    sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now()));
     sessionStorage.setItem(GW_401_ATTEMPTS_KEY, String(attempts + 1));
   } catch {
     // sessionStorage unavailable: cannot enforce cooldown or budget, skip
@@ -617,6 +625,12 @@ daemonClient.interceptors.error.use(daemonErrorInterceptor);
 
 // Gateway client uses the same routing as daemon — all gateway endpoints
 // are proxied through the same self-hosted ingress / platform gateway path.
+//
+// It deliberately does NOT carry `localGatewayAuthRecoveryInterceptor`: a
+// 401 raised through the generated gateway SDK is surfaced to the caller
+// rather than triggering a reload. Adding it here would widen the set of
+// responses that can restart the app, which is the opposite of what the
+// recovery budget is for, so it is tracked separately.
 gatewayClient.interceptors.request.use(daemonRequestInterceptor);
 gatewayClient.interceptors.response.use(daemonUnreachableInterceptor);
 gatewayClient.interceptors.response.use(platformAuthRecoveryInterceptor);


### PR DESCRIPTION
## TL;DR

A gateway that rejects every token makes the app **reload itself every ten minutes, forever**. At least one production installation has been doing this for days. The recovery has a cooldown that spaces the attempts but nothing that stops them; this adds an attempt budget.

## The evidence

[Sentry VELLUM-ASSISTANT-MACOS-1RX](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-MACOS-1RX) — `ApiError: Invalid token: invalid_signature`, **1664 events**, the largest issue in the macOS project. Sampled on 2026-07-30, release `0.10.12`:

```
19:30:00  19:40:03  19:50:05  20:00:07  20:10:10  20:20:12  20:30:15
20:40:17  20:50:19  21:00:22  21:10:24  21:20:27  21:30:29  21:40:32
```

Two things identify this as the recovery loop rather than a poll:

1. **`GW_401_COOLDOWN_MS = 600_000` is the only ten-minute constant in the web client.** (The one other is a react-query `staleTime` for the Slack roster, which cannot produce a chat-history error.)
2. **Every delta is 10m02–03s, never 10m00s.** A `setInterval` poll lands on 10:00. A reload cycle adds boot cost each round — those ~2.5s are the app restarting.

The same cadence appears on 07-29, 07-30 and 08-03, so this is one installation that has been reloading itself roughly every ten minutes for at least five days.

## What was wrong

```ts
const lastReload = sessionStorage.getItem(GW_401_RELOAD_KEY);
if (lastReload && Date.now() - Number(lastReload) < GW_401_COOLDOWN_MS) {
  return response;
}
sessionStorage.setItem(GW_401_RELOAD_KEY, String(Date.now()));
```

The cooldown paces attempts; the in-memory latch is reset by the very reload it guards ("Resets naturally on reload"). So for a persistently-rejecting gateway there is no terminating condition. Reloading cannot fix a mismatched signing key, but it retries anyway, indefinitely.

## The change

An attempt budget in sessionStorage alongside the cooldown. Past `GW_401_MAX_RELOADS` (3) the 401 is handed back untouched, so the normal error path surfaces it and the tray's re-pair action stays available.

The budget is restored **only by evidence that the gateway works**: a 2xx from the ingress origin clears it. Elapsed time deliberately does not. A gateway that never works never produces that response, so the bound is terminal for the renderer session; a reload that genuinely fixed the session produces it on the very next request, so a transient rejection is not charged for recovering.

`/readyz` probes use a bare `fetch` rather than this client, so an unauthenticated liveness check cannot stand in for a real one.

Both keys live in sessionStorage, so quitting and reopening also grants a fresh budget.

### Scope: `daemonClient` only

`localGatewayAuthRecoveryInterceptor` is registered on `daemonClient` and **not** on `gatewayClient`. A 401 raised through the generated gateway SDK surfaces to the caller rather than restarting the app. That exclusion is deliberate here: widening the set of responses that can trigger a reload is the opposite of what this change is for. Two registration tests pin both sides, because calling the interceptor directly proves what it does but not where it runs. Extending recovery to `gatewayClient` is a separate behavioural change and is not claimed by this PR.

### Review history

Two earlier revisions were wrong in opposite directions, and both reviews were right:

- A **monotonic** counter meant successful recoveries consumed budget, so three successes in a long-lived session disabled the fourth (Devin).
- **Time-based ageing** fixed that but made the bound non-terminal: a still-broken gateway earned a fresh budget out of every quiet gap and would reload in bursts forever (Vex).

Only a success-gated reset satisfies both. That is what `472b0be40b` implements.

## Why it is safe

Strictly reduces reloads; it can never cause one that didn't already happen. The cooldown, the origin check, the latch, and the sessionStorage-unavailable bail-out are all untouched. The counter is parsed defensively (`Number.isFinite`), so a corrupted value falls back to 0 rather than disabling recovery.

The one behavioural trade: a user whose gateway would have healed on reload #4 no longer auto-recovers. They get the error UI and the re-pair path instead of a silent restart, which is the better failure — and three attempts spanning 20+ minutes is a generous window for a transient fault.

## Before / after

| | Before | After |
|---|---|---|
| Transient 401 | Reloads, recovers | Unchanged |
| Persistently rejecting gateway | Reloads every 10 min forever | 3 reloads, then the error surfaces |
| Three recoveries that each succeeded | Recovers each time | Unchanged: each success clears the budget |
| Broken gateway, sparse traffic with long gaps | Reloads forever | 3 reloads total, then terminal |
| App quit and reopened | Loop resumes | Fresh budget, recovery available again |
| Non-gateway / non-401 responses | Unchanged | Unchanged |

## Testing

Coverage now includes a quiet gap not restoring the budget, a successful gateway response restoring it, a recovery followed by a later failure episode getting a full budget, a non-gateway 2xx not restoring it, budget exhaustion, the exhausted path returning the response untouched, a fresh renderer session, and both registration assertions. The registration test was verified to fail when the interceptor is removed.

```
bun test src/lib/api-interceptors.test.ts   # 84 pass
bunx eslint src/lib/api-interceptors*.ts    # clean
bunx tsc --noEmit                           # clean
```

## Scope

**This bounds the symptom, not its cause.** A gateway that rejects every token is its own defect — ATL-979 ("Auto-update leaves gateway and daemon with mismatched `ACTOR_TOKEN_SIGNING_KEY` — `invalid_signature` 401", currently Stale) describes one mechanism that would produce exactly this error string. That remains open and is the higher-value fix.

Found while investigating LUM-2960, which is closed as Can't Reproduce; this is not a fix for that report and is not claimed as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

