### PR TITLE
fix(voice): require sustained speech for barge-in

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -1,0 +1,483 @@
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "LiveVoiceChannelManager")
+
+protocol LiveVoiceAudioCapturing: AnyObject {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool
+    func stop()
+    func shutdown()
+}
+
+extension LiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        await start(onChunk: onChunk, onAmplitude: nil)
+    }
+}
+
+@MainActor
+protocol LiveVoiceAudioPlaying: AnyObject {
+    var isPlaying: Bool { get }
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int
+    )
+    func handleInterrupt()
+    func handleEnd()
+    func handleSessionError()
+    func resetForNextResponse()
+    func waitUntilPlaybackFinishes() async
+}
+
+extension LiveVoiceAudioPlayer: LiveVoiceAudioPlaying {}
+
+@MainActor
+@Observable
+final class LiveVoiceChannelManager {
+    enum State: Equatable {
+        case idle
+        case connecting
+        case listening
+        case transcribing
+        case thinking
+        case speaking
+        case ending
+        case failed
+    }
+
+    private(set) var state: State = .idle
+    private(set) var activeConversationId: String?
+    private(set) var sessionId: String?
+    private(set) var partialTranscript: String = ""
+    private(set) var finalTranscript: String = ""
+    private(set) var assistantTranscript: String = ""
+    private(set) var inputAmplitude: Float = 0
+    private(set) var errorMessage: String = ""
+
+    var isActive: Bool {
+        switch state {
+        case .idle, .failed:
+            return false
+        case .connecting, .listening, .transcribing, .thinking, .speaking, .ending:
+            return true
+        }
+    }
+
+    @ObservationIgnored private let clientFactory: @MainActor () -> any LiveVoiceChannelClientProtocol
+    @ObservationIgnored private let capture: any LiveVoiceAudioCapturing
+    @ObservationIgnored private let playback: any LiveVoiceAudioPlaying
+    @ObservationIgnored private let bargeInAmplitudeThreshold: Float
+    @ObservationIgnored private let speechAmplitudeThreshold: Float
+    @ObservationIgnored private let silenceDurationBeforeRelease: TimeInterval
+    @ObservationIgnored private let minimumSpeechDurationBeforeRelease: TimeInterval
+    @ObservationIgnored private let minimumBargeInSpeechDuration: TimeInterval
+
+    @ObservationIgnored private var client: (any LiveVoiceChannelClientProtocol)?
+    @ObservationIgnored private var captureStartTask: Task<Void, Never>?
+    @ObservationIgnored private var sessionGeneration: UInt64 = 0
+    @ObservationIgnored private var captureRunning = false
+    @ObservationIgnored private var captureStartInFlight = false
+    @ObservationIgnored private var responseAudioStarted = false
+    @ObservationIgnored private var interruptSentForCurrentResponse = false
+    @ObservationIgnored private var speechDurationInCurrentUtterance: TimeInterval = 0
+    @ObservationIgnored private var silenceDurationAfterSpeech: TimeInterval = 0
+    @ObservationIgnored private var automaticReleaseInFlight = false
+    @ObservationIgnored private var loudDurationForPendingBargeIn: TimeInterval = 0
+
+    init(
+        clientFactory: @escaping @MainActor () -> any LiveVoiceChannelClientProtocol = { LiveVoiceChannelClient() },
+        capture: any LiveVoiceAudioCapturing = LiveVoiceAudioCapture(),
+        playback: (any LiveVoiceAudioPlaying)? = nil,
+        bargeInAmplitudeThreshold: Float = 0.05,
+        speechAmplitudeThreshold: Float = 0.03,
+        silenceDurationBeforeRelease: TimeInterval = 1.0,
+        minimumSpeechDurationBeforeRelease: TimeInterval = 0.12,
+        minimumBargeInSpeechDuration: TimeInterval = 0.15
+    ) {
+        self.clientFactory = clientFactory
+        self.capture = capture
+        self.playback = playback ?? LiveVoiceAudioPlayer()
+        self.bargeInAmplitudeThreshold = bargeInAmplitudeThreshold
+        self.speechAmplitudeThreshold = speechAmplitudeThreshold
+        self.silenceDurationBeforeRelease = silenceDurationBeforeRelease
+        self.minimumSpeechDurationBeforeRelease = minimumSpeechDurationBeforeRelease
+        self.minimumBargeInSpeechDuration = minimumBargeInSpeechDuration
+    }
+
+    func start(conversationId: String) async {
+        let trimmedConversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedConversationId.isEmpty else {
+            failWithoutActiveClient(message: "A conversation is required to start live voice.")
+            return
+        }
+        guard state == .idle || state == .failed else { return }
+
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        let newClient = clientFactory()
+
+        resetObservedSessionState(conversationId: trimmedConversationId)
+        client = newClient
+        state = .connecting
+
+        await newClient.start(
+            conversationId: trimmedConversationId,
+            audioFormat: .pcm16kMono,
+            onEvent: { [weak self] event in
+                self?.handle(event, generation: generation)
+            },
+            onFailure: { [weak self] failure in
+                self?.handle(failure, generation: generation)
+            }
+        )
+    }
+
+    func interruptSpeakingAndStartListening(conversationId: String) async {
+        let trimmedConversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedConversationId.isEmpty else {
+            failWithoutActiveClient(message: "A conversation is required to start live voice.")
+            return
+        }
+        guard client != nil, state != .idle, state != .failed else {
+            await start(conversationId: trimmedConversationId)
+            return
+        }
+
+        sessionGeneration &+= 1
+        let interruptedClient = client
+
+        stopCapture()
+        playback.handleInterrupt()
+        resetIgnoredSessionState()
+        resetObservedSessionState(conversationId: nil)
+        state = .idle
+
+        await interruptedClient?.interrupt()
+        await interruptedClient?.close()
+        await start(conversationId: trimmedConversationId)
+    }
+
+    func stopListening() async {
+        guard state != .idle, state != .failed, state != .ending else { return }
+        guard captureRunning || captureStartInFlight else { return }
+
+        stopCapture()
+        await client?.releasePushToTalk()
+
+        if state == .listening {
+            state = .transcribing
+        }
+    }
+
+    func end() async {
+        guard state != .failed, state != .ending else { return }
+        guard state != .idle || client != nil || captureRunning || captureStartInFlight else { return }
+
+        state = .ending
+        sessionGeneration &+= 1
+        let clientToEnd = client
+
+        stopCapture()
+        playback.handleEnd()
+        resetIgnoredSessionState()
+
+        await clientToEnd?.end()
+
+        resetObservedSessionState(conversationId: nil)
+        state = .idle
+    }
+
+    private func resetObservedSessionState(conversationId: String?) {
+        activeConversationId = conversationId
+        sessionId = nil
+        partialTranscript = ""
+        finalTranscript = ""
+        assistantTranscript = ""
+        inputAmplitude = 0
+        errorMessage = ""
+        resetVoiceActivityTracking()
+    }
+
+    private func resetIgnoredSessionState() {
+        client = nil
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+        automaticReleaseInFlight = false
+    }
+
+    private func resetVoiceActivityTracking() {
+        speechDurationInCurrentUtterance = 0
+        silenceDurationAfterSpeech = 0
+        automaticReleaseInFlight = false
+        loudDurationForPendingBargeIn = 0
+    }
+
+    private func handle(_ event: LiveVoiceChannelEvent, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        switch event {
+        case .ready(let sessionId, let conversationId):
+            guard state == .connecting else { return }
+            self.sessionId = sessionId
+            activeConversationId = conversationId
+            startCapture(generation: generation)
+
+        case .sttPartial(let text, _):
+            update(&partialTranscript, to: text)
+            if captureRunning {
+                state = .listening
+            } else if state == .listening || state == .transcribing {
+                state = .transcribing
+            }
+
+        case .sttFinal(let text, _):
+            update(&finalTranscript, to: text)
+            update(&partialTranscript, to: "")
+            if state != .ending {
+                state = captureRunning ? .listening : .thinking
+            }
+
+        case .thinking:
+            prepareForAssistantResponse()
+            if state != .ending {
+                state = .thinking
+            }
+
+        case .assistantTextDelta(let text, _):
+            guard !text.isEmpty else { return }
+            assistantTranscript += text
+            if state == .listening || state == .transcribing {
+                state = .thinking
+            }
+
+        case .ttsAudio(let data, let mimeType, let sampleRate, _):
+            beginAssistantAudioIfNeeded()
+            playback.enqueueTTSAudio(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: 1
+            )
+            state = .speaking
+
+        case .ttsDone:
+            closeCompletedUtteranceSessionAfterPlayback(generation: generation)
+
+        case .metrics, .archived:
+            break
+        }
+    }
+
+    private func handle(_ failure: LiveVoiceChannelFailure, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        log.warning("Live voice session failed: \(failure.localizedDescription, privacy: .public)")
+        sessionGeneration &+= 1
+        stopCapture()
+        playback.handleSessionError()
+
+        let failedClient = client
+        resetIgnoredSessionState()
+
+        errorMessage = failure.errorDescription ?? failure.localizedDescription
+        state = .failed
+
+        Task {
+            await failedClient?.close()
+        }
+    }
+
+    private func failWithoutActiveClient(message: String) {
+        resetObservedSessionState(conversationId: nil)
+        stopCapture()
+        playback.handleSessionError()
+        resetIgnoredSessionState()
+        errorMessage = message
+        state = .failed
+    }
+
+    private func startCapture(generation: UInt64) {
+        captureStartTask?.cancel()
+        captureStartTask = Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+
+            self.captureStartInFlight = true
+            let started = await self.capture.start { [weak self] chunk in
+                Task { @MainActor [weak self] in
+                    self?.handleCapturedAudioChunk(chunk, generation: generation)
+                }
+            }
+            self.captureStartInFlight = false
+            self.captureStartTask = nil
+
+            guard generation == self.sessionGeneration, !Task.isCancelled else {
+                if started {
+                    self.capture.stop()
+                }
+                return
+            }
+
+            guard started else {
+                self.handle(
+                    .protocolError(code: "capture_failed", message: "Microphone capture could not start."),
+                    generation: generation
+                )
+                return
+            }
+
+            self.captureRunning = true
+            if self.state == .connecting || self.state == .idle {
+                self.state = .listening
+            }
+        }
+    }
+
+    private func handleCapturedAudioChunk(_ chunk: LiveVoiceAudioCaptureChunk, generation: UInt64) {
+        guard generation == sessionGeneration, captureRunning else { return }
+
+        update(&inputAmplitude, to: chunk.amplitude)
+
+        let audioData = chunk.pcm16LittleEndian
+        if !audioData.isEmpty, let client {
+            Task {
+                await client.sendAudio(audioData)
+            }
+        }
+
+        updateAutomaticPushToTalkRelease(with: chunk, generation: generation)
+        updateBargeInTracking(with: chunk, generation: generation)
+    }
+
+    private func chunkDuration(_ chunk: LiveVoiceAudioCaptureChunk) -> TimeInterval {
+        guard chunk.sampleRate > 0, chunk.frameCount > 0 else { return 0 }
+        return TimeInterval(chunk.frameCount) / TimeInterval(chunk.sampleRate)
+    }
+
+    private func updateAutomaticPushToTalkRelease(
+        with chunk: LiveVoiceAudioCaptureChunk,
+        generation: UInt64
+    ) {
+        guard state == .listening, captureRunning, client != nil else { return }
+
+        let duration = chunkDuration(chunk)
+        guard duration > 0 else { return }
+
+        if chunk.amplitude >= speechAmplitudeThreshold {
+            speechDurationInCurrentUtterance += duration
+            silenceDurationAfterSpeech = 0
+            return
+        }
+
+        guard speechDurationInCurrentUtterance >= minimumSpeechDurationBeforeRelease else { return }
+        silenceDurationAfterSpeech += duration
+
+        guard silenceDurationAfterSpeech >= silenceDurationBeforeRelease else { return }
+        automaticallyReleasePushToTalk(generation: generation)
+    }
+
+    /// Requires a short run of consecutive over-threshold chunks before
+    /// treating captured audio as an intentional barge-in. A single loud
+    /// chunk is often a cough, click, or other transient noise; genuine
+    /// speech sustains above the threshold for multiple consecutive chunks.
+    /// Any chunk that dips back below the threshold resets the accumulator,
+    /// so transient noise never accumulates toward the gate.
+    private func updateBargeInTracking(with chunk: LiveVoiceAudioCaptureChunk, generation: UInt64) {
+        guard chunk.amplitude >= bargeInAmplitudeThreshold else {
+            loudDurationForPendingBargeIn = 0
+            return
+        }
+
+        loudDurationForPendingBargeIn += chunkDuration(chunk)
+        guard loudDurationForPendingBargeIn >= minimumBargeInSpeechDuration else { return }
+
+        loudDurationForPendingBargeIn = 0
+        interruptIfAssistantAudioIsPlaying(generation: generation)
+    }
+
+    private func automaticallyReleasePushToTalk(generation: UInt64) {
+        guard !automaticReleaseInFlight else { return }
+        automaticReleaseInFlight = true
+
+        Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+            await self.stopListening()
+        }
+    }
+
+    private func interruptIfAssistantAudioIsPlaying(generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+        guard playback.isPlaying, !interruptSentForCurrentResponse else { return }
+
+        interruptSentForCurrentResponse = true
+        playback.handleInterrupt()
+        if state == .speaking {
+            state = captureRunning ? .listening : .idle
+        }
+
+        let interruptedClient = client
+        Task {
+            await interruptedClient?.interrupt()
+        }
+    }
+
+    private func prepareForAssistantResponse() {
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+        loudDurationForPendingBargeIn = 0
+        update(&assistantTranscript, to: "")
+    }
+
+    private func beginAssistantAudioIfNeeded() {
+        guard !responseAudioStarted else { return }
+
+        responseAudioStarted = true
+        interruptSentForCurrentResponse = false
+        playback.resetForNextResponse()
+    }
+
+    private func closeCompletedUtteranceSessionAfterPlayback(generation: UInt64) {
+        responseAudioStarted = false
+        let completedClient = client
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.playback.waitUntilPlaybackFinishes()
+            guard generation == self.sessionGeneration else { return }
+
+            self.sessionGeneration &+= 1
+            self.stopCapture()
+            self.resetIgnoredSessionState()
+            self.sessionId = nil
+            self.state = .idle
+            await completedClient?.close()
+        }
+    }
+
+    private func stopCapture() {
+        captureStartTask?.cancel()
+        captureStartTask = nil
+
+        if captureRunning || captureStartInFlight {
+            capture.stop()
+        }
+        captureRunning = false
+        captureStartInFlight = false
+        inputAmplitude = 0
+        resetVoiceActivityTracking()
+    }
+
+    private func update<T: Equatable>(_ value: inout T, to newValue: T) {
+        guard value != newValue else { return }
+        value = newValue
+    }
+
+    deinit {
+        captureStartTask?.cancel()
+        capture.shutdown()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -1,0 +1,665 @@
+import Foundation
+import AVFoundation
+import Speech
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "OpenAIVoiceService")
+
+enum VoiceServiceError: Error, LocalizedError {
+    case speechRecognitionUnavailable
+    case notAuthorized
+    case invalidResponse
+    case noAudioData
+    case noTranscription
+
+    var errorDescription: String? {
+        switch self {
+        case .speechRecognitionUnavailable: return "Speech recognition unavailable"
+        case .notAuthorized: return "Speech recognition not authorized"
+        case .invalidResponse: return "Invalid API response"
+        case .noAudioData: return "No audio data recorded"
+        case .noTranscription: return "No transcription result"
+        }
+    }
+}
+
+/// Tracks consecutive over-threshold audio buffers so a single short
+/// transient (a cough, a click, a door closing) can't fire a barge-in on its
+/// own — only sustained loud audio across multiple consecutive buffers
+/// counts as intentional speech. Any buffer at or below the threshold resets
+/// the run, so transient noise never accumulates toward the gate.
+struct BargeInActivityGate {
+    let rmsThreshold: Float
+    let consecutiveBuffersRequired: Int
+
+    private var consecutiveLoudBuffers = 0
+
+    init(rmsThreshold: Float = 0.05, consecutiveBuffersRequired: Int = 2) {
+        self.rmsThreshold = rmsThreshold
+        self.consecutiveBuffersRequired = consecutiveBuffersRequired
+    }
+
+    /// Feed one buffer's RMS value. Returns `true` once loud audio has been
+    /// observed for `consecutiveBuffersRequired` buffers in a row.
+    mutating func observe(rms: Float) -> Bool {
+        guard rms > rmsThreshold else {
+            consecutiveLoudBuffers = 0
+            return false
+        }
+        consecutiveLoudBuffers += 1
+        return consecutiveLoudBuffers >= consecutiveBuffersRequired
+    }
+}
+
+/// Voice service: service-first STT + Apple fallback + gateway TTS.
+/// Records audio, detects silence, captures per-turn PCM for service STT,
+/// runs live SFSpeechRecognizer for partial text and fallback transcription,
+/// speaks via the assistant's `/v1/tts/synthesize` endpoint.
+@MainActor
+@Observable
+final class OpenAIVoiceService: VoiceServiceProtocol {
+    var amplitude: Float = 0
+    var speakingAmplitude: Float = 0
+    var livePartialText: String = ""
+
+    // MARK: - Speech Recognizer Adapter
+
+    /// Injected adapter wrapping SFSpeechRecognizer static APIs and instance creation.
+    @ObservationIgnored let speechRecognizerAdapter: any SpeechRecognizerAdapter
+
+    // MARK: - Recording State
+
+    @ObservationIgnored private let engineController = AudioEngineController(label: "com.vellum.audioEngine.voiceService")
+    @ObservationIgnored private var isRecording = false
+
+    /// Fires once when silence is detected after speech.
+    @ObservationIgnored var onSilenceDetected: (() -> Void)?
+    /// Callback fired when mic permission is granted after being requested.
+    @ObservationIgnored var onMicrophoneAuthorized: (() -> Void)?
+    /// Fires when speech is detected during TTS playback (barge-in).
+    @ObservationIgnored var onBargeInDetected: (() -> Void)?
+
+    @ObservationIgnored private var lastSpeechTime = Date()
+    @ObservationIgnored private var recordingStartTime: Date?
+    @ObservationIgnored private var silenceHandled = false
+    @ObservationIgnored private var hasSpeechOccurred = false
+    @ObservationIgnored private var enginePrewarmed = false
+    @ObservationIgnored private var rmsLogCounter = 0
+
+    private static let silenceThreshold: Float = 0.003
+    private static let speechThreshold: Float = 0.003
+    private static let silenceTimeout: TimeInterval = 1.0
+    private static let minRecordingDuration: TimeInterval = 0.5
+
+    // MARK: - SFSpeechRecognizer STT State
+
+    @ObservationIgnored private var speechRecognizer: SFSpeechRecognizer?
+    @ObservationIgnored private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    @ObservationIgnored private var recognitionTask: SFSpeechRecognitionTask?
+    /// The latest transcription text from the ongoing recognition task.
+    @ObservationIgnored private var latestTranscription: String = ""
+    /// Continuation to deliver the final transcription when recording stops.
+    @ObservationIgnored private var transcriptionContinuation: CheckedContinuation<String?, Never>?
+
+    // MARK: - Per-Turn Audio Capture (for service STT)
+
+    /// Raw 16-bit PCM samples accumulated during the current recording turn.
+    /// Converted from the tap's float32 buffers on the fly, then WAV-encoded
+    /// and sent to the STT service at turn end.
+    @ObservationIgnored private var capturedPCMData = Data()
+    /// Sample rate of the captured audio, recorded from the tap's buffer format.
+    @ObservationIgnored private var capturedSampleRate: Int = 16000
+
+    /// Gateway STT client — routes through the assistant's configured STT service.
+    @ObservationIgnored private let sttClient: any STTClientProtocol
+
+    // MARK: - TTS State
+
+    /// Accumulated text from streaming deltas — sent to the gateway when response completes.
+    @ObservationIgnored private var ttsTextBuffer = ""
+    @ObservationIgnored private var ttsOnComplete: (() -> Void)?
+    @ObservationIgnored private var audioPlayer: AVAudioPlayer?
+    @ObservationIgnored private var speakingTimer: Timer?
+    @ObservationIgnored private var ttsTask: Task<Void, Never>?
+
+    /// Gateway TTS client — routes through the provider selected by `services.tts.provider`.
+    @ObservationIgnored private let ttsClient: any TTSClientProtocol
+
+    /// Current conversation ID, set by VoiceModeManager on activation.
+    /// Passed to TTSClient for provider context.
+    @ObservationIgnored var conversationId: String?
+
+    nonisolated init(
+        ttsClient: any TTSClientProtocol = TTSClient(),
+        sttClient: any STTClientProtocol = STTClient(),
+        speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
+    ) {
+        self.ttsClient = ttsClient
+        self.sttClient = sttClient
+        self.speechRecognizerAdapter = speechRecognizerAdapter
+    }
+
+    // MARK: - Speech Recognition Authorization
+
+    /// Check if speech recognition is authorized. Returns true if authorized.
+    nonisolated func isSpeechRecognitionAuthorized() -> Bool {
+        speechRecognizerAdapter.authorizationStatus() == .authorized
+    }
+
+    /// Request speech recognition authorization if not yet determined.
+    nonisolated func requestSpeechRecognitionAuthorization(completion: @escaping (Bool) -> Void) {
+        let status = speechRecognizerAdapter.authorizationStatus()
+        switch status {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            speechRecognizerAdapter.requestAuthorization { newStatus in
+                completion(newStatus == .authorized)
+            }
+        default:
+            completion(false)
+        }
+    }
+
+    // MARK: - Recording
+
+    /// Pre-initialize the audio engine so the first recording starts instantly.
+    /// Skips pre-warming when microphone permission hasn't been granted yet —
+    /// accessing the input node triggers the system permission dialog, which we want to
+    /// avoid on dev rebuilds (where TCC resets to `.notDetermined` after re-signing).
+    func prewarmEngine() {
+        guard !enginePrewarmed else { return }
+        guard AVCaptureDevice.authorizationStatus(for: .audio) == .authorized else {
+            log.info("Skipping audio engine pre-warm — microphone not yet authorized")
+            return
+        }
+        engineController.prewarm()
+        enginePrewarmed = true
+        log.info("Audio engine pre-warmed")
+    }
+
+    @discardableResult
+    func startRecording() -> Bool {
+        guard !isRecording else { return false }
+
+        silenceHandled = false
+        hasSpeechOccurred = false
+        rmsLogCounter = 0
+        latestTranscription = ""
+        livePartialText = ""
+        capturedPCMData = Data()
+
+        let sttConfigured = STTProviderRegistry.isServiceConfigured
+
+        // Reuse existing SFSpeechRecognizer across turns to avoid OS resource
+        // release delays that make isAvailable return false on the second turn.
+        // Recreate if transiently unavailable (e.g. after sleep/wake or heavy use).
+        if speechRecognizer == nil || speechRecognizer?.isAvailable != true {
+            speechRecognizer = speechRecognizerAdapter.makeRecognizer(locale: Locale(identifier: "en-US"))
+        }
+
+        // When STT is configured, the native recognizer is optional — we can
+        // record audio and rely entirely on the STT service for transcription.
+        // When STT is NOT configured, the recognizer is required.
+        let recognizerAvailable = speechRecognizer != nil && speechRecognizer!.isAvailable
+        guard sttConfigured || recognizerAvailable else {
+            log.error("SFSpeechRecognizer not available")
+            return false
+        }
+
+        // Set up native recognition request and task only when the recognizer
+        // is available. In STT-only mode (recognizer unavailable), the audio
+        // tap still runs, PCM accumulates, and silence detection works — but
+        // livePartialText remains empty and resolveLocalTranscription returns nil.
+        if let recognizer = speechRecognizer, recognizer.isAvailable {
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.shouldReportPartialResults = true
+            if recognizer.supportsOnDeviceRecognition {
+                request.requiresOnDeviceRecognition = true
+            }
+            request.addsPunctuation = false
+            recognitionRequest = request
+
+            // Start recognition task
+            recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                guard let self else { return }
+
+                if let result {
+                    let text = result.bestTranscription.formattedString
+                    log.debug("Partial transcription: \(text, privacy: .public)")
+                    Task { @MainActor [weak self] in
+                        self?.latestTranscription = text
+                        self?.livePartialText = text
+                    }
+
+                    if result.isFinal {
+                        let finalText = text
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            log.info("Final transcription: \(finalText, privacy: .public)")
+                            self.transcriptionContinuation?.resume(returning: finalText.isEmpty ? nil : finalText)
+                            self.transcriptionContinuation = nil
+                        }
+                    }
+                }
+
+                if let error {
+                    let nsError = error as NSError
+                    // Ignore cancellation errors (code 216) — expected when we call endAudio()
+                    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
+                        return
+                    }
+                    // Code 1110 = "no speech detected" — not a real error, just empty input
+                    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1110 {
+                        log.info("No speech detected in audio")
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            self.transcriptionContinuation?.resume(returning: nil)
+                            self.transcriptionContinuation = nil
+                        }
+                        return
+                    }
+                    log.error("Recognition error: \(nsError.domain, privacy: .public)/\(nsError.code, privacy: .public) \(error.localizedDescription, privacy: .public)")
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        // If we have partial transcription, use it despite the error
+                        let text = self.latestTranscription
+                        self.transcriptionContinuation?.resume(returning: text.isEmpty ? nil : text)
+                        self.transcriptionContinuation = nil
+                    }
+                }
+            }
+        } else {
+            log.info("Recording without native recognizer — STT service will handle transcription")
+        }
+
+        // Capture a local reference to the recognition request (may be nil in
+        // STT-only mode) so the audio tap closure doesn't need to capture self
+        // to read the property.
+        let activeRequest = recognitionRequest
+
+        // Atomically validate format, install tap, and start engine.
+        // Passes nil for format so AVAudioEngine uses its internal hardware
+        // format, preventing sampleRate mismatch crashes.
+        guard engineController.installTapAndStart(bufferSize: 4096, block: { [weak self] buffer, _ in
+            guard let floatData = buffer.floatChannelData else { return }
+            let frameCount = Int(buffer.frameLength)
+            guard frameCount > 0 else { return }
+
+            // Feed buffer to speech recognizer (when available)
+            activeRequest?.append(buffer)
+
+            // Capture raw PCM for service STT: convert float32 to 16-bit PCM
+            // and accumulate alongside the live recognizer path.
+            let sampleRate = Int(buffer.format.sampleRate)
+            var pcmChunk = Data(capacity: frameCount * MemoryLayout<Int16>.size)
+            for i in 0..<frameCount {
+                let clamped = max(-1.0, min(1.0, floatData[0][i]))
+                let sample = Int16(clamped * Float(Int16.max))
+                withUnsafeBytes(of: sample.littleEndian) { pcmChunk.append(contentsOf: $0) }
+            }
+
+            // Compute RMS for amplitude display and silence detection
+            var sum: Float = 0
+            for i in 0..<frameCount {
+                let sample = floatData[0][i]
+                sum += sample * sample
+            }
+            let rms = sqrt(sum / Float(frameCount))
+
+            Task { @MainActor [weak self] in
+                guard let self, self.isRecording else { return }
+
+                // Accumulate PCM data for service STT
+                self.capturedPCMData.append(pcmChunk)
+                self.capturedSampleRate = sampleRate
+
+                self.amplitude = min(rms * 5, 1.0)
+
+                // Log RMS every ~50 buffers (~1s) for diagnostics
+                self.rmsLogCounter += 1
+                if self.rmsLogCounter % 50 == 0 {
+                    log.info("Voice RMS: \(rms, privacy: .public) (speech threshold: \(Self.speechThreshold, privacy: .public), hasSpeech: \(self.hasSpeechOccurred, privacy: .public))")
+                }
+
+                if rms > Self.speechThreshold {
+                    self.hasSpeechOccurred = true
+                }
+                if rms > Self.silenceThreshold {
+                    self.lastSpeechTime = Date()
+                }
+                let silenceDuration = Date().timeIntervalSince(self.lastSpeechTime)
+                let recordingDuration = self.recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
+                if !self.silenceHandled,
+                   self.hasSpeechOccurred,
+                   recordingDuration > Self.minRecordingDuration,
+                   silenceDuration > Self.silenceTimeout {
+                    log.info("Silence detected: rms=\(rms, privacy: .public) silenceDuration=\(silenceDuration, privacy: .public)")
+                    self.silenceHandled = true
+                    self.onSilenceDetected?()
+                }
+            }
+        }) else {
+            log.error("Failed to start audio engine for recording")
+            tearDownRecognition()
+            return false
+        }
+
+        isRecording = true
+        lastSpeechTime = Date()
+        recordingStartTime = Date()
+        log.info("Recording started (recognizer: \(recognizerAvailable ? "active" : "none (STT-only)"), sttConfigured: \(sttConfigured, privacy: .public))")
+        return true
+    }
+
+    /// Stop recording and return the final transcription.
+    ///
+    /// Uses a service-first strategy: attempts STT via the gateway service with
+    /// the captured WAV audio, falling back to the local SFSpeechRecognizer
+    /// transcription when the service is unavailable or unconfigured.
+    func stopRecordingAndGetTranscription() async -> String? {
+        guard isRecording else { return nil }
+
+        isRecording = false
+        amplitude = 0
+
+        engineController.stopAndRemoveTap()
+
+        // Signal end of audio to the recognizer
+        recognitionRequest?.endAudio()
+
+        // Snapshot captured PCM and local recognizer text before async work
+        let pcmData = capturedPCMData
+        let sampleRate = capturedSampleRate
+        capturedPCMData = Data()
+
+        // Run local and service transcriptions concurrently so the total wait
+        // time is max(local, service) instead of local + service. Under
+        // degraded conditions this avoids blocking in .processing for up to
+        // 17 s (2 s local + 15 s service) — instead the ceiling is ~15 s.
+        async let localTextTask = resolveLocalTranscription()
+        async let serviceTextTask = resolveServiceTranscription(pcmData: pcmData, sampleRate: sampleRate)
+
+        let localText = await localTextTask
+        let serviceText = await serviceTextTask
+
+        tearDownRecognition()
+        recordingStartTime = nil
+
+        // Prefer service result, fall back to local recognizer
+        let finalText = serviceText ?? localText
+        log.info("Recording stopped, transcription: \(finalText ?? "<none>", privacy: .public) (source: \(serviceText != nil ? "service" : "local", privacy: .public))")
+        return finalText
+    }
+
+    /// Resolve the local SFSpeechRecognizer transcription. Returns the current
+    /// partial text immediately if available, otherwise waits briefly for the
+    /// final recognition callback.
+    ///
+    /// When no recognition task exists (STT-only mode — native recognizer was
+    /// unavailable), returns nil immediately rather than waiting for a result
+    /// that will never arrive.
+    private func resolveLocalTranscription() async -> String? {
+        // In STT-only mode there is no recognition task — return nil
+        // immediately so we don't block waiting for a callback that won't come.
+        guard recognitionTask != nil else {
+            log.info("No native recognition task — skipping local transcription")
+            return nil
+        }
+
+        let currentText = latestTranscription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !currentText.isEmpty {
+            return currentText
+        }
+
+        // Wait briefly for the final result from the recognition task
+        let result: String? = await withCheckedContinuation { continuation in
+            self.transcriptionContinuation = continuation
+
+            // Timeout: don't wait forever if recognizer doesn't respond
+            Task {
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s timeout
+                if let cont = self.transcriptionContinuation {
+                    self.transcriptionContinuation = nil
+                    let text = self.latestTranscription.trimmingCharacters(in: .whitespacesAndNewlines)
+                    cont.resume(returning: text.isEmpty ? nil : text)
+                }
+            }
+        }
+        return result
+    }
+
+    /// Attempt STT transcription via the gateway service. Returns nil if the
+    /// service is unconfigured, unavailable, or if no audio was captured.
+    private func resolveServiceTranscription(pcmData: Data, sampleRate: Int) async -> String? {
+        guard !pcmData.isEmpty else {
+            log.info("STT service: no captured audio, skipping")
+            return nil
+        }
+
+        let wavFormat = AudioWavEncoder.Format(sampleRate: sampleRate, channels: 1, bitsPerSample: 16)
+        let wavData = await Task.detached(priority: .userInitiated) {
+            AudioWavEncoder.encode(pcmData: pcmData, format: wavFormat)
+        }.value
+
+        let result = await sttClient.transcribe(audioData: wavData)
+        switch result {
+        case .success(let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                log.info("STT service: empty transcription, falling back to local")
+                return nil
+            }
+            log.info("STT service: transcription succeeded (\(trimmed.count) chars)")
+            return text
+        case .notConfigured:
+            log.info("STT service: not configured, falling back to local recognizer")
+            return nil
+        case .serviceUnavailable:
+            log.warning("STT service: unavailable, falling back to local recognizer")
+            return nil
+        case .error(let statusCode, let message):
+            log.warning("STT service: error (HTTP \(statusCode ?? 0)): \(message), falling back to local recognizer")
+            return nil
+        }
+    }
+
+    /// Force stop recording without returning transcription.
+    func cancelRecording() {
+        guard isRecording else { return }
+        isRecording = false
+        amplitude = 0
+        capturedPCMData = Data()
+        engineController.stopAndRemoveTap()
+        // Resume any waiting continuation with nil
+        transcriptionContinuation?.resume(returning: nil)
+        transcriptionContinuation = nil
+        tearDownRecognition()
+        recordingStartTime = nil
+    }
+
+    /// Fully shut down the audio engine and release the microphone.
+    func shutdown() {
+        cancelRecording()
+        stopBargeInMonitor()
+        stopSpeaking()
+        engineController.stop()
+        speechRecognizer = nil
+        enginePrewarmed = false
+        log.info("Audio engine shut down")
+    }
+
+    private func tearDownRecognition() {
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        // Keep speechRecognizer alive — reused across turns.
+        // Only destroy it on full shutdown().
+        latestTranscription = ""
+        livePartialText = ""
+    }
+
+    // MARK: - Gateway TTS
+
+    /// Called with each text delta — just accumulates text.
+    func feedTextDelta(_ delta: String) {
+        ttsTextBuffer += delta
+    }
+
+    /// Called when the full response is complete — sends accumulated text to the gateway TTS endpoint.
+    func finishTextStream(onComplete: @escaping () -> Void) {
+        let raw = ttsTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = TTSRedactor.redact(raw)
+        ttsTextBuffer = ""
+
+        guard !text.isEmpty else {
+            log.info("TTS: no text, completing immediately")
+            onComplete()
+            return
+        }
+
+        ttsOnComplete = onComplete
+        startSpeakingAmplitudePolling()
+
+        ttsTask = Task {
+            guard !Task.isCancelled else { return }
+            do {
+                let result = await ttsClient.synthesizeText(text, context: "voice-mode", conversationId: conversationId)
+                guard !Task.isCancelled else { return }
+
+                switch result {
+                case .success(let audioData):
+                    let player = try AVAudioPlayer(data: audioData)
+                    self.audioPlayer = player
+                    player.delegate = nil // We poll for completion below
+                    player.play()
+                    log.info("TTS: playing \(audioData.count) bytes of audio")
+
+                    // Poll until playback finishes
+                    while player.isPlaying && !Task.isCancelled {
+                        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+                    }
+
+                    guard !Task.isCancelled else { return }
+                    log.info("TTS: playback complete")
+
+                case .notConfigured:
+                    log.info("TTS: provider not configured, completing immediately")
+
+                case .featureDisabled:
+                    log.info("TTS: feature disabled, completing immediately")
+
+                case .notFound:
+                    log.warning("TTS: endpoint returned not found")
+
+                case .error(let statusCode, let message):
+                    log.error("TTS endpoint error (HTTP \(statusCode ?? 0)): \(message)")
+                }
+            } catch {
+                if !Task.isCancelled {
+                    log.error("TTS error: \(error.localizedDescription)")
+                }
+            }
+
+            self.audioPlayer = nil
+            self.finishSpeaking()
+            self.ttsOnComplete?()
+            self.ttsOnComplete = nil
+        }
+    }
+
+    /// Reset TTS state for a new conversation turn.
+    func resetStreamingTTS() {
+        ttsTextBuffer = ""
+        ttsOnComplete = nil
+    }
+
+    func stopSpeaking() {
+        ttsTask?.cancel()
+        ttsTask = nil
+        audioPlayer?.stop()
+        audioPlayer = nil
+        stopBargeInMonitor()
+        finishSpeaking()
+        ttsOnComplete?()
+        ttsOnComplete = nil
+    }
+
+    private func finishSpeaking() {
+        stopSpeakingAmplitudePolling()
+        stopBargeInMonitor()
+        speakingAmplitude = 0
+    }
+
+    // MARK: - Barge-in (interrupt TTS by speaking)
+
+    @ObservationIgnored private var bargeInMonitorActive = false
+
+    /// Start monitoring the mic for speech during TTS playback.
+    /// Uses a higher threshold than normal to avoid picking up speaker output.
+    func startBargeInMonitor() {
+        guard !bargeInMonitorActive else { return }
+        bargeInMonitorActive = true
+
+        var bargeInGate = BargeInActivityGate()
+
+        // Atomically validate format, install tap, and start engine.
+        // Passes nil for format so AVAudioEngine uses its internal hardware
+        // format, preventing sampleRate mismatch crashes.
+        if engineController.installTapAndStart(bufferSize: 4096, block: { [weak self] buffer, _ in
+            guard let floatData = buffer.floatChannelData else { return }
+            let frameCount = Int(buffer.frameLength)
+            guard frameCount > 0 else { return }
+
+            var sum: Float = 0
+            for i in 0..<frameCount {
+                let s = floatData[0][i]
+                sum += s * s
+            }
+            let rms = sqrt(sum / Float(frameCount))
+
+            // Require sustained loud audio across multiple consecutive
+            // buffers before treating this as intentional speech, so a
+            // single short transient (a cough, a click, a door closing)
+            // can't fire a barge-in on its own.
+            guard bargeInGate.observe(rms: rms) else { return }
+
+            Task { @MainActor [weak self] in
+                guard let self, self.bargeInMonitorActive else { return }
+                log.info("Barge-in detected: rms=\(rms, privacy: .public)")
+                self.stopBargeInMonitor()
+                self.onBargeInDetected?()
+            }
+        }) {
+            log.info("Barge-in monitor started")
+        } else {
+            log.error("Failed to start barge-in monitor")
+            bargeInMonitorActive = false
+        }
+    }
+
+    func stopBargeInMonitor() {
+        guard bargeInMonitorActive else { return }
+        bargeInMonitorActive = false
+        engineController.stopAndRemoveTap()
+    }
+
+    // MARK: - Speaking Amplitude
+
+    private func startSpeakingAmplitudePolling() {
+        speakingTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.audioPlayer?.isPlaying == true else { return }
+                let target = Float.random(in: 0.3...0.8)
+                // Smooth toward target to avoid jerky jumps
+                self.speakingAmplitude = self.speakingAmplitude * 0.7 + target * 0.3
+            }
+        }
+    }
+
+    private func stopSpeakingAmplitudePolling() {
+        speakingTimer?.invalidate()
+        speakingTimer = nil
+    }
+}

--- a/clients/macos/vellum-assistantTests/BargeInActivityGateTests.swift
+++ b/clients/macos/vellum-assistantTests/BargeInActivityGateTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class BargeInActivityGateTests: XCTestCase {
+    func testSingleLoudBufferDoesNotFire() {
+        var gate = BargeInActivityGate(rmsThreshold: 0.05, consecutiveBuffersRequired: 2)
+
+        XCTAssertFalse(gate.observe(rms: 0.5))
+    }
+
+    func testConsecutiveLoudBuffersFireOnceThresholdReached() {
+        var gate = BargeInActivityGate(rmsThreshold: 0.05, consecutiveBuffersRequired: 2)
+
+        XCTAssertFalse(gate.observe(rms: 0.5))
+        XCTAssertTrue(gate.observe(rms: 0.5))
+    }
+
+    func testQuietBufferBetweenLoudBuffersResetsTheRun() {
+        // Simulates a short cough: one loud buffer, then quiet, then loud
+        // again — should never accumulate to the consecutive requirement.
+        var gate = BargeInActivityGate(rmsThreshold: 0.05, consecutiveBuffersRequired: 2)
+
+        XCTAssertFalse(gate.observe(rms: 0.5))
+        XCTAssertFalse(gate.observe(rms: 0.01))
+        XCTAssertFalse(gate.observe(rms: 0.5))
+    }
+
+    func testBufferAtExactThresholdDoesNotCount() {
+        var gate = BargeInActivityGate(rmsThreshold: 0.05, consecutiveBuffersRequired: 2)
+
+        XCTAssertFalse(gate.observe(rms: 0.05))
+        XCTAssertFalse(gate.observe(rms: 0.05))
+    }
+
+    func testFiresOnEveryBufferOnceRunIsSustained() {
+        var gate = BargeInActivityGate(rmsThreshold: 0.05, consecutiveBuffersRequired: 2)
+
+        XCTAssertFalse(gate.observe(rms: 0.5))
+        XCTAssertTrue(gate.observe(rms: 0.5))
+        XCTAssertTrue(gate.observe(rms: 0.5))
+    }
+}

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -1,0 +1,640 @@
+import Foundation
+import Observation
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+private final class FakeLiveVoiceChannelClient: LiveVoiceChannelClientProtocol, @unchecked Sendable {
+    private(set) var startCalls: [(conversationId: String?, audioFormat: LiveVoiceChannelAudioFormat)] = []
+    private(set) var audioFrames: [Data] = []
+    private(set) var releasePushToTalkCallCount = 0
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var closeCallCount = 0
+
+    private var onEvent: (@MainActor (LiveVoiceChannelEvent) -> Void)?
+    private var onFailure: (@MainActor (LiveVoiceChannelFailure) -> Void)?
+
+    func start(
+        conversationId: String?,
+        audioFormat: LiveVoiceChannelAudioFormat,
+        onEvent: @escaping @MainActor (LiveVoiceChannelEvent) -> Void,
+        onFailure: @escaping @MainActor (LiveVoiceChannelFailure) -> Void
+    ) async {
+        startCalls.append((conversationId, audioFormat))
+        self.onEvent = onEvent
+        self.onFailure = onFailure
+    }
+
+    func sendAudio(_ data: Data) async {
+        audioFrames.append(data)
+    }
+
+    func releasePushToTalk() async {
+        releasePushToTalkCallCount += 1
+    }
+
+    func interrupt() async {
+        interruptCallCount += 1
+    }
+
+    func end() async {
+        endCallCount += 1
+    }
+
+    func close() async {
+        closeCallCount += 1
+    }
+
+    func emit(_ event: LiveVoiceChannelEvent) {
+        onEvent?(event)
+    }
+
+    func fail(_ failure: LiveVoiceChannelFailure) {
+        onFailure?(failure)
+    }
+}
+
+private final class FakeLiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    var startResult = true
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var shutdownCallCount = 0
+
+    private var onChunk: ((LiveVoiceAudioCaptureChunk) -> Void)?
+
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        startCallCount += 1
+        self.onChunk = onChunk
+        return startResult
+    }
+
+    func stop() {
+        stopCallCount += 1
+        onChunk = nil
+    }
+
+    func shutdown() {
+        shutdownCallCount += 1
+        onChunk = nil
+    }
+
+    func emitChunk(
+        data: Data = Data([1, 2, 3, 4]),
+        sampleRate: Int = 16_000,
+        channelCount: Int = 1,
+        frameCount: Int = 2,
+        amplitude: Float = 0.01
+    ) {
+        onChunk?(
+            LiveVoiceAudioCaptureChunk(
+                pcm16LittleEndian: data,
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                amplitude: amplitude
+            )
+        )
+    }
+}
+
+@MainActor
+private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
+    private(set) var enqueuedChunks: [LiveVoiceAudioChunk] = []
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var sessionErrorCallCount = 0
+    private(set) var resetCallCount = 0
+
+    var isPlaying = false
+    private var playbackWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int
+    ) {
+        enqueuedChunks.append(
+            LiveVoiceAudioChunk(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: channels
+            )
+        )
+        isPlaying = true
+    }
+
+    func handleInterrupt() {
+        interruptCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func handleEnd() {
+        endCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func handleSessionError() {
+        sessionErrorCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func resetForNextResponse() {
+        resetCallCount += 1
+        enqueuedChunks.removeAll()
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func waitUntilPlaybackFinishes() async {
+        guard isPlaying else { return }
+
+        await withCheckedContinuation { continuation in
+            playbackWaiters.append(continuation)
+        }
+    }
+
+    func finishPlayback() {
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    private func notifyPlaybackWaiters() {
+        guard !isPlaying else { return }
+
+        let waiters = playbackWaiters
+        playbackWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}
+
+@MainActor
+final class LiveVoiceChannelManagerTests: XCTestCase {
+    private var client: FakeLiveVoiceChannelClient!
+    private var capture: FakeLiveVoiceAudioCapture!
+    private var playback: FakeLiveVoiceAudioPlayback!
+    private var manager: LiveVoiceChannelManager!
+
+    override func setUp() {
+        super.setUp()
+        client = FakeLiveVoiceChannelClient()
+        capture = FakeLiveVoiceAudioCapture()
+        playback = FakeLiveVoiceAudioPlayback()
+        manager = LiveVoiceChannelManager(
+            clientFactory: { [client] in client! },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+    }
+
+    override func tearDown() {
+        manager = nil
+        playback = nil
+        capture = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testStartOpensClientAndStartsCaptureAfterReady() async {
+        await manager.start(conversationId: " conv-123 ")
+
+        XCTAssertEqual(manager.state, .connecting)
+        XCTAssertEqual(manager.activeConversationId, "conv-123")
+        XCTAssertEqual(client.startCalls.count, 1)
+        XCTAssertEqual(client.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(client.startCalls[0].audioFormat, .pcm16kMono)
+        XCTAssertEqual(capture.startCallCount, 0)
+
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.sessionId, "session-123")
+        XCTAssertEqual(capture.startCallCount, 1)
+    }
+
+    func testAudioChunksStreamWithoutMutatingObservedState() async {
+        await startReadySession()
+
+        let observedInvalidations = ObservationCounter()
+        withObservationTracking {
+            _ = manager.state
+            _ = manager.partialTranscript
+            _ = manager.finalTranscript
+            _ = manager.assistantTranscript
+        } onChange: {
+            Task { @MainActor in observedInvalidations.increment() }
+        }
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.01)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.01)
+        capture.emitChunk(data: Data([5, 6]), amplitude: 0.01)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4]), Data([5, 6])])
+        XCTAssertEqual(observedInvalidations.value, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testInputAmplitudeTracksCaptureAndResetsWhenStopped() async {
+        await startReadySession()
+
+        capture.emitChunk(data: Data([1, 2]), frameCount: 1_600, amplitude: 0.4)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.inputAmplitude, 0.4)
+
+        await manager.stopListening()
+
+        XCTAssertEqual(manager.inputAmplitude, 0)
+    }
+
+    func testInitialSilenceDoesNotAutomaticallyReleasePushToTalk() async {
+        await startReadySession()
+
+        for _ in 0..<20 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 0)
+        XCTAssertEqual(capture.stopCallCount, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testSpeechThenSilenceAutomaticallyReleasesPushToTalk() async {
+        await startReadySession()
+
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        for _ in 0..<11 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
+    func testStopListeningSendsPushToTalkRelease() async {
+        await startReadySession()
+
+        await manager.stopListening()
+
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
+    func testSttEventsKeepListeningWhileCaptureRuns() async {
+        await startReadySession()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testSttEventsUpdateProcessingStateAfterPushToTalkRelease() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .transcribing)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .thinking)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testAssistantSpeechStreamsToPlaybackAndClosesSessionAfterTtsDone() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.assistantTextDelta(text: "Hi", seq: 3))
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.assistantTranscript, "Hi")
+        XCTAssertEqual(playback.resetCallCount, 1)
+        XCTAssertEqual(playback.enqueuedChunks.count, 1)
+        XCTAssertEqual(playback.enqueuedChunks[0].data, Data([9, 8]))
+        XCTAssertEqual(playback.enqueuedChunks[0].mimeType, "audio/pcm")
+        XCTAssertEqual(playback.enqueuedChunks[0].sampleRate, 16_000)
+
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertNotNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 0)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testTtsDoneWithoutQueuedPlaybackClosesSessionImmediately() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testManualBargeInBeforePlaybackFinishesInterruptsInsteadOfAutoClosing() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        firstClient.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(firstClient.closeCallCount, 0)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+    }
+
+    func testSpeakingOverAssistantAudioSendsInterruptOnce() async {
+        await startReadySession()
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertTrue(playback.isPlaying)
+
+        // Sustained loud audio across multiple chunks (100ms each) crosses
+        // the barge-in duration gate (default 150ms) and interrupts exactly
+        // once, even though both chunks individually exceed the amplitude
+        // threshold.
+        capture.emitChunk(data: Data([1, 2]), frameCount: 1_600, amplitude: 0.5)
+        capture.emitChunk(data: Data([3, 4]), frameCount: 1_600, amplitude: 0.7)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(client.interruptCallCount, 1)
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4])])
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testBriefLoudChunkDuringPlaybackDoesNotTriggerBargeIn() async {
+        await startReadySession()
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+
+        // A single short burst of loud audio -- like a cough -- falls well
+        // short of the sustained-duration gate (50ms vs. the 150ms default)
+        // and must not interrupt playback.
+        capture.emitChunk(frameCount: 800, amplitude: 0.9)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 0)
+        XCTAssertEqual(client.interruptCallCount, 0)
+        XCTAssertEqual(manager.state, .speaking)
+    }
+
+    func testLoudBurstFollowedBySilenceResetsBargeInAccumulation() async {
+        await startReadySession()
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+
+        // Two loud bursts (75ms each) separated by a quiet chunk must not
+        // add up across the gap -- each burst alone is short of the 150ms
+        // gate, and the quiet chunk in between resets the accumulator.
+        capture.emitChunk(frameCount: 1_200, amplitude: 0.9)
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        capture.emitChunk(frameCount: 1_200, amplitude: 0.9)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 0)
+        XCTAssertEqual(manager.state, .speaking)
+
+        // Sustained loud audio from here on still triggers a real barge-in.
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.9)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testManualBargeInInterruptsAndStartsFreshSession() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(manager.state, .connecting)
+
+        secondClient.emit(.ready(sessionId: "session-2", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(capture.startCallCount, 2)
+    }
+
+    func testManualResumeWhileThinkingInterruptsAndStartsFreshSession() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.thinking(turnId: "turn-1"))
+
+        XCTAssertEqual(manager.state, .thinking)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(manager.state, .connecting)
+
+        secondClient.emit(.ready(sessionId: "session-2", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(capture.startCallCount, 2)
+    }
+
+    func testEndCleansUpResourcesAndReturnsToIdle() async {
+        await startReadySession()
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        await manager.end()
+
+        XCTAssertEqual(client.endCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.endCallCount, 1)
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.activeConversationId)
+        XCTAssertNil(manager.sessionId)
+    }
+
+    func testNextStartCreatesFreshClientAfterTtsDone() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsDone(turnId: "turn-1"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+
+        await manager.start(conversationId: "conv-123")
+
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(firstClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+    }
+
+    func testFailureCleansUpResourcesAndStoresError() async {
+        await startReadySession()
+
+        client.fail(.connectionFailed(message: "connection dropped"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "connection dropped")
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testCaptureStartFailureFailsSession() async {
+        capture.startResult = false
+
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "Microphone capture could not start.")
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    private func startReadySession() async {
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    private func flushAsyncTasks() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
+@MainActor
+private final class ObservationCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}


### PR DESCRIPTION
## Summary

- Require sustained loud audio before triggering barge-in in both macOS voice paths.
- Reset the gate on quiet input and when a new assistant response begins.
- Add focused tests for transient noise and sustained speech.

Linear: JARVIS-1406

## Validation

- Tests are written but require macOS/Xcode and were not runnable in this Linux sandbox.