### PR TITLE
feat(voice): add shared session control semantics

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -1,0 +1,760 @@
+# Clients Architecture
+
+This document owns macOS/iOS client architecture details. The repo-level architecture index lives in [`/ARCHITECTURE.md`](../ARCHITECTURE.md).
+
+## macOS App — Service and State Ownership
+
+The macOS app uses a centralized service container (`AppServices`) created once in `AppDelegate` and passed down via dependency injection rather than singletons or ambient state.
+
+### AppServices Container
+
+`AppServices` is the single owner of all long-lived services. `AppDelegate` creates it on launch and passes individual services to windows, views, and managers.
+
+| Service | Type | Purpose |
+|---------|------|---------|
+| `connectionManager` | `GatewayConnectionManager` | Gateway connection lifecycle, health checks, event stream |
+| `surfaceManager` | `SurfaceManager` | Routes `ui_surface_show` messages |
+| `toolConfirmationManager` | `ToolConfirmationManager` | Handles tool permission prompts |
+| `secretPromptManager` | `SecretPromptManager` | Handles secret input prompts |
+| `zoomManager` | `ZoomManager` | Window zoom level (`@Observable`) |
+| `settingsStore` | `SettingsStore` | Shared settings state for both SettingsView and SettingsPanel |
+
+### Main Window State
+
+The main window has three dedicated state objects:
+
+| Object | Pattern | Scope |
+|--------|---------|-------|
+| `MainWindowState` | `ObservableObject` | Cross-view UI state: active panel, dynamic workspace, API key status |
+| `ConversationManager` | `ObservableObject` | Conversation CRUD, tab management, conforms to `ConversationRestorerDelegate` |
+| `ConversationRestorer` | Plain class with delegate | Daemon conversation restoration (conversation list responses, history hydration) |
+
+`ConversationManager` owns conversation lifecycle. `ConversationRestorer` handles the async daemon communication for restoring conversations on reconnect, delegating state mutations back through the `ConversationRestorerDelegate` protocol for testability.
+
+### Observation Framework Migration
+
+Low-risk types use Swift's `@Observable` macro (Observation framework) instead of `ObservableObject`/`@Published`:
+
+| Type | Consumer pattern |
+|------|-----------------|
+| `ZoomManager` | Plain `var` (read-only in views) |
+| `ConversationInputState` | `@Bindable` (bindings needed for text input) |
+| `BundleConfirmationViewModel` | Plain `var` (read-only in view) |
+
+Types that use Combine `$`-prefixed publishers (e.g., `VoiceTranscriptionViewModel`) remain as `ObservableObject`.
+
+### macOS Voice Mode Live Channel
+
+Voice mode can use a local live channel when the current conversation has an ID, the gateway connection is healthy, and no tool permission prompt is pending. `MainWindow` creates one `LiveVoiceChannelManager` and injects it into `VoiceModeManager` with `liveVoiceAvailability: { connectionManager.isConnected }`. `VoiceModeManager.startListening()` then selects the live channel path before the standard turn-based voice path.
+
+```mermaid
+sequenceDiagram
+    participant VM as VoiceModeManager
+    participant LVM as LiveVoiceChannelManager
+    participant LVC as LiveVoiceChannelClient
+    participant CAP as LiveVoiceAudioCapture
+    participant PLAY as LiveVoiceAudioPlayer
+    participant GW as Gateway /v1/live-voice
+    participant AS as Assistant runtime
+
+    VM->>LVM: start(conversationId)
+    LVM->>LVC: start(conversationId, audioFormat: pcm16kMono)
+    LVC->>GW: WebSocket live-voice + token query param
+    GW->>AS: upstream WebSocket with gateway service token
+    AS-->>LVC: ready(sessionId, conversationId)
+    LVM->>CAP: start mic capture
+    CAP-->>LVC: binary PCM chunks
+    VM->>LVM: stopListening()
+    LVM->>LVC: ptt_release
+    AS-->>LVC: stt_partial / stt_final / thinking / assistant_text_delta
+    AS-->>LVC: tts_audio chunks / tts_done / metrics / archived
+    LVC-->>LVM: LiveVoiceChannelEvent
+    LVM->>PLAY: enqueueTTSAudio(...)
+    LVM-->>VM: state + transcript updates
+```
+
+**Transport:** `clients/shared/Network/LiveVoiceChannelClient.swift` is the shared WebSocket client. It builds the authenticated request with `GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: nil)`, sends the conversation ID in the initial `start` JSON frame, sends mic audio as binary WebSocket frames, sends `ptt_release`, `interrupt`, and `end` control frames, and decodes `ready`, `busy`, `stt_*`, `assistant_text_delta`, `tts_*`, `metrics`, `archived`, and `error` server frames.
+
+**macOS session state:** `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift` owns the live session state machine (`idle`, `connecting`, `listening`, `transcribing`, `thinking`, `speaking`, `ending`, `failed`). It wires `LiveVoiceAudioCapture` for push-to-talk PCM capture and `LiveVoiceAudioPlayer` for streamed assistant audio. `VoiceModeManager` observes the manager with `withObservationTracking()` and maps live-channel states onto the existing voice-mode UI states (`listening`, `processing`, `speaking`, `idle`).
+
+**Fallback behavior:** When live voice is unavailable at listen start, `VoiceModeManager` uses the standard turn-based voice path. If a live session fails after selection, `VoiceModeManager` attempts one fallback to turn-based voice for that session and then relies on the existing STT/service and Apple Speech permission checks. Pending tool permissions also move voice mode back to the turn-based path so the existing approval prompt behavior stays unchanged.
+
+**Provider requirements:** The assistant side requires a configured streaming STT provider for live partial/final transcripts and a streaming-capable TTS provider for `tts_audio` frames. Missing or non-streaming providers surface as live-channel failures; the macOS fallback path can still use standard voice mode if its own STT or speech-recognition requirements are satisfied.
+
+**V1 scope:** The live channel is local/gateway-scoped. Managed/cloud WebSocket proxy support and latency guarantees are not part of this version. `metrics` events expose timing data for measurement, but the client must not assume a hard p50/p95 latency SLO.
+
+**Voice session controls (mic mute, assistant-output mute, end):** `clients/shared/Network/VoiceSessionControlling.swift` defines a small, platform-agnostic protocol (`isMicrophoneMuted`, `isAssistantOutputMuted`, `setMicrophoneMuted(_:)`, `setAssistantOutputMuted(_:)`, `end()`) so any control surface can drive these three controls without depending on `LiveVoiceChannelManager` directly. `LiveVoiceChannelManager` conforms to it: muting the microphone keeps capture running (input amplitude and barge-in detection stay live for the UI) but stops sending audio upstream and suppresses auto-release/barge-in while muted; muting assistant output keeps the session state machine and transcript updating normally but drops TTS audio before it reaches `LiveVoiceAudioPlayer`. `LiveVoiceChannelManaging` (used by `VoiceModeManager`) refines `VoiceSessionControlling`, and `VoiceModeManager.setMicrophoneMuted(_:)` / `setAssistantOutputMuted(_:)` forward to the active live channel session (no-op outside the live-channel voice path). Mute state resets to unmuted when a session fully ends (`LiveVoiceChannelManager.end()`) or voice mode deactivates.
+
+Known gaps, not implemented because no existing seam supports them yet:
+- **No iOS voice session exists.** `clients/ios` has no mic capture, playback, or manager equivalent to the macOS `LiveVoiceChannelManager` — only `clients/shared/Network/LiveVoiceChannelClient.swift` (the WebSocket client) is cross-platform today. `VoiceSessionControlling` is ready for an iOS manager to conform to, but that manager does not exist yet.
+- **No Live Activity / Dynamic Island infrastructure exists in this repo.** There is no widget extension target in `clients/ios/project.yml`, no `NSSupportsLiveActivities` entitlement, no App Group for cross-process state sharing, and no `ActivityKit`/App Intents code anywhere in the codebase. Wiring the controls above to a real Live Activity requires adding an Xcode widget extension target (via XcodeGen), an App Group, and `LiveActivityIntent`-based App Intents to relay button taps back to the host app process — a scoped follow-up, not something to fabricate without Xcode to build and verify it.
+- **No spoken-command dispatcher exists.** The only precedent is `VoiceModeManager.classifyPermissionResponse(_:)`, a narrow yes/no classifier used solely for tool-permission prompts. There is no general seam that intercepts a live-voice transcript to recognize commands like "mute yourself" before treating it as a chat message; adding one is a separate design decision (grammar, false-positive risk during normal conversation) and is out of scope here.
+
+---
+
+## Data Persistence — Where Everything Lives
+
+```mermaid
+graph LR
+    subgraph "Credential Store"
+        K1["API Key<br/>service: vellum-assistant<br/>account: anthropic<br/>stored via secure-keys.ts"]
+        K2["Credential Secrets<br/>key: credential/{service}/{field}<br/>stored via secure-keys.ts"]
+    end
+
+    subgraph "UserDefaults (plist)"
+        UD1["hasCompletedOnboarding"]
+        UD2["assistantName"]
+        UD3["activationKey (fn/ctrl)"]
+        UD4["ambientAgentEnabled"]
+        UD5["ambientCaptureInterval"]
+        UD6["maxStepsPerSession"]
+    end
+
+    subgraph "~/Library/Application Support/vellum-assistant/"
+        direction TB
+        SL["logs/session-*.json<br/>───────────────<br/>Per-session JSON log<br/>task, start/end times, result<br/>Per-turn: AX tree, screenshot,<br/>action, token usage"]
+    end
+
+    subgraph "~/.vellum/workspace/data/db/assistant.db (SQLite + WAL)"
+        direction TB
+        CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>conversation_type: 'standard' | 'background' | 'scheduled'<br/>memory_scope_id: 'default' | '_pkb_workspace' | 'subagent:&lt;id&gt;'"]
+        MSG["messages<br/>───────────────<br/>id, conversation_id (FK)<br/>role: user | assistant<br/>content: JSON array<br/>created_at"]
+        TOOL["tool_invocations<br/>───────────────<br/>tool_name, input, result<br/>decision, risk_level<br/>duration_ms"]
+        SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
+        ITEMS["memory_items<br/>───────────────<br/>Extracted facts/entities<br/>kind, subject, statement<br/>confidence, fingerprint (dedup)<br/>verification_state, scope_id<br/>first/last seen timestamps"]
+        SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
+        EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
+        JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill, cleanup<br/>Status: pending → running →<br/>completed | failed"]
+        ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
+        REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled"]
+        SCHED_JOBS["cron_jobs (recurrence schedules)<br/>───────────────<br/>Recurring schedule definitions<br/>cron_expression: cron or RRULE string<br/>schedule_syntax: 'cron' | 'rrule'<br/>timezone, message, next_run_at<br/>enabled, retry_count<br/>Legacy alias: scheduleJobs"]
+        SCHED_RUNS["cron_runs (schedule runs)<br/>───────────────<br/>Execution history per schedule<br/>job_id (FK → cron_jobs)<br/>status: ok | error<br/>duration_ms, output, error<br/>Legacy alias: scheduleRuns"]
+        TASKS["tasks<br/>───────────────<br/>Reusable prompt templates<br/>title, Handlebars template<br/>inputSchema, contextFlags<br/>requiredTools, status"]
+        TASK_RUNS["task_runs<br/>───────────────<br/>Execution history per task<br/>taskId (FK → tasks)<br/>conversationId, status<br/>startedAt, finishedAt, error"]
+        WORK_ITEMS["work_items<br/>───────────────<br/>Task Queue entries<br/>taskId (FK → tasks)<br/>title, notes, status<br/>priority_tier (0-3), sort_index<br/>last_run_id, last_run_status<br/>source_type, source_id"]
+    end
+
+    subgraph "~/.vellum/ (Root Files)"
+        TRUST["protected/trust.json<br/>Tool permission rules"]
+    end
+
+    subgraph "~/.vellum/workspace/ (Workspace Files)"
+        CONFIG["config files<br/>Hot-reloaded by daemon"]
+        ONBOARD_PLAYBOOKS["onboarding/playbooks/<br/>[channel]_onboarding.md<br/>assistant-updatable checklists"]
+        ONBOARD_REGISTRY["onboarding/playbooks/registry.json<br/>channel-start index for fast-path + reconciliation"]
+        APPS_STORE["data/apps/<br/><app-id>.json + pages/*.html<br/>User-created apps stored here"]
+        SKILLS_DIR["skills/<br/>managed skill directories<br/>SKILL.md + TOOLS.json + tools/"]
+    end
+
+    subgraph "PostgreSQL (Web Server Only)"
+        PG["assistants, users,<br/>channel_accounts,<br/>channel_contacts,<br/>api_tokens, api_keys<br/>───────────────<br/>Multi-tenant management<br/>Billing & provisioning"]
+    end
+```
+
+---
+
+## Computer Use Session — Detailed Data Flow
+
+Computer use runs through the daemon's main session loop. The daemon decides when to
+invoke CU tools, sends `host_cu_request` messages to the client, which executes them
+locally via `HostCuExecutor` and posts `host_cu_result` back.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Chat as ChatView
+    participant AD as AppDelegate
+    participant HCE as HostCuExecutor
+    participant AX as AccessibilityTree
+    participant SC as ScreenCapture
+    participant GW as GatewayHTTPClient
+    participant ES as EventStreamClient
+    participant Daemon as Daemon (Bun)
+    participant Claude as Claude API
+    participant AV as ActionVerifier
+    participant AE as ActionExecutor
+    participant macOS as macOS (CGEvents)
+
+    User->>Chat: Type task / Voice / Paste
+    Chat->>GW: POST /v1/messages
+    GW->>Daemon: HTTP POST
+    Note over Daemon: Creates conversation in SQLite<br/>Starts agent loop
+
+    Daemon->>Claude: API call with user message
+    Claude-->>Daemon: tool_use (computer use tool)
+    Note over Daemon: Model decides CU is needed
+
+    loop host_cu_request / host_cu_result
+        Daemon-->>ES: host_cu_request (SSE)
+        Note over ES: Contains: tool name, parameters,<br/>step number, reasoning
+
+        ES-->>AD: getOrCreateHostCuOverlay()
+        Note over AD: Creates HostCuSessionProxy<br/>Shows SessionOverlayWindow<br/>Pauses ambient agent
+
+        AD->>HCE: execute(request)
+
+        HCE->>AV: verify(action, history)
+        Note over AV: Step limit (max 50)<br/>Loop detection (3x same)<br/>Sensitive data check<br/>Destructive key check<br/>System menu bar block<br/>AppleScript sandboxing
+
+        alt allowed
+            AV-->>HCE: .allowed
+        else needsConfirmation
+            AV-->>HCE: .needsConfirmation(reason)
+            HCE->>User: confirmation dialog
+            User-->>HCE: approve/block
+        else blocked
+            AV-->>HCE: .blocked(reason)
+        end
+
+        HCE->>AE: execute(action)
+        Note over AE: click: CGEvent mouse down/up<br/>type: clipboard paste + Cmd+V<br/>key: CGEvent key events<br/>scroll: scroll wheel events<br/>openApp: NSWorkspace launch<br/>appleScript: osascript subprocess
+
+        AE->>macOS: CGEvent injection
+        macOS-->>AE: result
+
+        par Parallel Capture
+            HCE->>AX: enumerate()
+            Note over AX: AXUIElement tree walk<br/>Sets AXEnhancedUserInterface<br/>Filters to interactive elements<br/>Format: [ID] role "title" at (x,y)
+            AX-->>HCE: axTree + axDiff
+        and
+            HCE->>SC: capture()
+            Note over SC: ScreenCaptureKit<br/>Exclude own windows<br/>Downscale to 1280x720<br/>JPEG @ 0.6 quality
+            SC-->>HCE: base64 screenshot
+        end
+
+        HCE->>GW: POST host_cu_result
+        Note over GW: Contains: axTree, axDiff,<br/>screenshot, secondaryWindows,<br/>executionResult/error
+
+        GW->>Daemon: HTTP POST
+        Daemon->>Claude: API call with observation
+        Note over Daemon: Appends tool result<br/>Stores in messages table
+        Claude-->>Daemon: next tool_use or end_turn
+    end
+
+    Note over Daemon: Agent loop ends (end_turn)
+    Daemon-->>ES: message_complete (SSE)
+    ES-->>AD: dismissHostCuOverlay()
+end
+```
+
+---
+
+## Standalone Screen Recording
+
+Standalone screen recording allows users to record their screen without starting a full computer-use session. The daemon manages the recording lifecycle and attaches the resulting video file to the conversation as a file-backed attachment.
+
+### Lifecycle
+
+```
+idle → starting → recording → stopping → idle
+                                      └→ failed → idle
+```
+
+A recording is initiated via dedicated HTTP endpoints (`/v1/recordings/*`). The daemon generates a unique `recordingId`, stores bidirectional mappings (`recordingId ↔ conversationId`), and sends a `recording_start` SSE event to the macOS client. The client manages the actual screen capture via `RecordingManager.swift` and reports status transitions back to the daemon via HTTP.
+
+### Key Files
+
+| File | Role |
+|---|---|
+| `assistant/src/daemon/handlers/recording.ts` | Daemon handler for start, stop, and status lifecycle events (dedicated HTTP endpoints) |
+| `clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift` | macOS-side screen capture using ScreenCaptureKit |
+
+### Messages
+
+| Message | Direction | Transport | Purpose |
+|---|---|---|---|
+| `recording_start` | Server → Client | SSE | Instructs the client to begin recording with a `recordingId` and optional `RecordingOptions` |
+| `recording_stop` | Server → Client | SSE | Instructs the client to stop the active recording |
+| `recording_status` | Client → Server | HTTP POST | Reports lifecycle transitions: `started`, `stopped` (with `filePath`), or `failed` (with `error`) |
+
+### Intent Routing
+
+Recording is managed through dedicated HTTP endpoints (`/v1/recordings/*`) rather than intent detection in user messages. Clients call these endpoints directly to start, stop, and query recording status.
+
+### File-Backed Attachments
+
+When a recording stops with a valid `filePath`, the handler:
+1. Validates the file exists and reads its size via `statSync`.
+2. Creates a file-backed attachment via `uploadFileBackedAttachment()` (avoids reading large video files into memory).
+3. Links the attachment to the last assistant message in the conversation (or creates a new one).
+4. Sends `assistant_text_delta` + `message_complete` with attachment metadata to the client.
+
+### Recording Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as macOS Client
+    participant Daemon as Daemon (Bun)
+    participant RM as RecordingManager
+
+    Client->>Daemon: POST /v1/recordings/start
+    Daemon->>Client: recording_start { recordingId, options }
+    Client->>RM: startRecording(recordingId)
+    RM-->>Client: capture started
+    Client->>Daemon: recording_status { status: 'started' }
+
+    Note over RM: Screen capture in progress...
+
+    Client->>Daemon: POST /v1/recordings/stop
+    Daemon->>Client: recording_stop { recordingId }
+    Client->>RM: stopRecording()
+    RM-->>Client: file saved at filePath
+    Client->>Daemon: recording_status { status: 'stopped', filePath, durationMs }
+
+    Note over Daemon: uploadFileBackedAttachment<br/>linkAttachmentToMessage
+    Daemon->>Client: assistant_text_delta + message_complete { attachments }
+```
+
+---
+
+## Dynamic Workspace — Surface Routing and Layout
+
+The workspace is a full-window mode that replaces the chat UI with an interactive dynamic page (WKWebView) and a pinned composer for follow-up messages. It activates when the daemon sends a `ui_surface_show` message with `display != "inline"`.
+
+### Routing Flow (Chat → Workspace)
+
+```mermaid
+sequenceDiagram
+    participant Daemon as Daemon (HTTP)
+    participant ES as EventStreamClient
+    participant SM as SurfaceManager
+    participant AD as AppDelegate
+    participant MW as MainWindowView
+
+    Daemon->>ES: ui_surface_show (display != "inline")
+    ES->>SM: onSurfaceShow callback
+    SM->>SM: Check display field
+    alt display == "inline"
+        SM->>SM: Show floating NSPanel
+    else display != "inline" (workspace route)
+        SM->>SM: Add to workspaceRoutedSurfaces set
+        SM->>AD: onDynamicPageShow callback
+        AD->>AD: Post .openDynamicWorkspace notification
+        AD->>MW: Notification with UiSurfaceShowMessage
+        MW->>MW: Parse Surface from message
+        MW->>MW: Set activeDynamicSurface,<br/>activeDynamicParsedSurface,<br/>isDynamicExpanded = true
+        MW->>MW: Render dynamicWorkspaceView()<br/>instead of normal chat
+    end
+
+    Note over SM,MW: Updates and dismissals follow<br/>the same notification pattern:<br/>.updateDynamicWorkspace<br/>.dismissDynamicWorkspace
+```
+
+**Key types:** `SurfaceManager` routes surfaces by `display` field. `MainWindowView` listens for three notifications (`.openDynamicWorkspace`, `.updateDynamicWorkspace`, `.dismissDynamicWorkspace`) and manages `@State` properties to toggle between chat and workspace views.
+
+### Full-Window Workspace Layout
+
+```
+┌────────────────────────────────────────────────┐
+│  ← Back    App Title                     ✕     │  ← Toolbar (HStack)
+├────────────────────────────────────────────────┤
+│                                                │
+│                                                │
+│           DynamicPageSurfaceView               │  ← WKWebView (fills space)
+│              (interactive HTML)                 │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│  ComposerView (pinned at bottom)               │  ← Follow-up input
+└────────────────────────────────────────────────┘
+```
+
+The workspace is a `VStack(spacing: 0)` with `VColor.backgroundSubtle` background. The toolbar has back (returns to gallery) and close (exits workspace + panel) buttons. `DynamicPageSurfaceView` grows to fill remaining vertical space. `ComposerView` is pinned at the bottom, bound to the active `ChatViewModel` so users can send follow-up messages while the page is open.
+
+### Widget Injection Pipeline (CSS + JS into WKWebView)
+
+`DynamicPageSurfaceView` is an `NSViewRepresentable` that wraps a `WKWebView`. On creation, three `WKUserScript`s are injected at document start:
+
+```mermaid
+graph LR
+    subgraph "Injection (at document start)"
+        BRIDGE["1. Bridge Script<br/>───────────────<br/>window.vellum.sendAction()<br/>window.vellum.confirm()<br/>window.vellum.data.* (if appId)<br/>console forwarding"]
+        CSS["2. Design System CSS<br/>───────────────<br/>vellum-design-system.css<br/>Semantic tokens (--v-*)<br/>Element defaults<br/>Dark/light mode"]
+        WIDGETS["3. Widget Utilities JS<br/>───────────────<br/>vellum-widgets.js<br/>sparkline(), barChart()<br/>lineChart(), gauge()<br/>format() helpers"]
+    end
+
+    subgraph "Message Passing"
+        JS_CALL["JS: window.webkit.messageHandlers<br/>.vellumBridge.postMessage()"]
+        COORD["Coordinator<br/>(WKScriptMessageHandler)"]
+        DAEMON["AppDelegate → Daemon"]
+    end
+
+    BRIDGE --> JS_CALL
+    JS_CALL --> COORD
+    COORD --> DAEMON
+```
+
+**Per-app isolation:** Each app gets its own origin (`https://{appId}.vellum.local/`). The `VellumAppSchemeHandler` handles `vellumapp://` URLs for serving bundled app files from the sandbox directory. Sandbox mode blocks external network requests.
+
+**Data RPC flow:** App JS calls `window.vellum.data.query()` → Coordinator → AppDelegate → Daemon `app_data_request`. Daemon responds with `app_data_response` → `SurfaceManager.resolveDataResponse()` → Coordinator evaluates `window.vellum.data._resolve()` in the WebView.
+
+---
+
+
+---
+
+## Inline Media Embeds — URL Detection and Rendering Pipeline
+
+Chat messages containing image or video URLs are rendered inline with a click-to-play card (videos) or lazy-loaded preview (images). The pipeline runs entirely on the macOS client with no daemon involvement; settings are persisted to the workspace config file via `WorkspaceConfigIO`.
+
+### Resolution Flow
+
+```mermaid
+graph TD
+    MSG["ChatMessage.text"] --> EXTRACT["MessageURLExtractor<br/>NSDataDetector + markdown regex<br/>strips code blocks first"]
+    EXTRACT --> URLS["Deduplicated URL list"]
+
+    URLS --> VP{"Video parsers<br/>(tried in order)"}
+    VP -->|match| ALLOWLIST["DomainAllowlistMatcher<br/>exact + subdomain matching"]
+    VP -->|no match| IMG_CLASS["ImageURLClassifier<br/>extension-based (.png, .jpg, ...)"]
+
+    ALLOWLIST -->|allowed| VIDEO_INTENT["MediaEmbedIntent.video<br/>(provider, videoID, embedURL)"]
+    ALLOWLIST -->|blocked| SKIP["Skip URL"]
+
+    IMG_CLASS -->|.image| IMAGE_INTENT["MediaEmbedIntent.image(url)"]
+    IMG_CLASS -->|.unknown| MIME_PROBE["ImageMIMEProbe<br/>async HTTP HEAD<br/>NSCache-backed"]
+    IMG_CLASS -->|.notImage| SKIP
+
+    MIME_PROBE -->|image/*| IMAGE_INTENT
+    MIME_PROBE -->|other| SKIP
+
+    subgraph "Video Parsers"
+        YT["YouTubeParser<br/>watch, shorts, embed, youtu.be"]
+        VIMEO["VimeoParser<br/>standard, player, channels, groups"]
+        LOOM["LoomParser<br/>share, embed"]
+    end
+
+    VP --> YT
+    VP --> VIMEO
+    VP --> LOOM
+```
+
+`MediaEmbedResolver` is the single entry point. It checks whether the feature is enabled, filters out messages that predate the `enabledSince` timestamp, calls `MessageURLExtractor.extractAllURLs`, and runs each URL through the video parsers and image classifier. The result is an array of `MediaEmbedIntent` values consumed by the chat view.
+
+### Rendering Components
+
+| Component | Purpose |
+|---|---|
+| `InlineImageEmbedView` | `AsyncImage` wrapper; defers loading until `onAppear` to avoid eager fetches in long histories. Tapping opens the URL in the default browser. Silent `EmptyView` on failure. |
+| `InlineVideoEmbedCard` | Click-to-play card with state machine (`placeholder` -> `initializing` -> `playing` / `failed`). Tears down webview on `onDisappear` to prevent background audio and memory leaks. |
+| `InlineVideoWebView` | `NSViewRepresentable` wrapping `WKWebView`. Uses `VideoEmbedURLBuilder` to add provider-specific autoplay parameters. |
+| `InlineVideoEmbedStateManager` | `@MainActor @Observable` class driving the card's lifecycle states. |
+
+### Security Policies
+
+The video webview applies three hardening layers:
+
+1. **Ephemeral storage** -- `WKWebViewConfiguration.websiteDataStore = .nonPersistent()` so no cookies, local storage, or cache survive the session.
+2. **Navigation policy** -- The first programmatic load (the embed URL we control) is always allowed. Subsequent `navigationType == .other` loads are checked against a per-provider host allowlist (e.g. `*.googlevideo.com`, `*.ytimg.com` for YouTube; `*.vimeocdn.com` for Vimeo; `*.loomcdn.com` for Loom). Unrecognised hosts and all user-initiated navigations (link clicks, form submissions) are cancelled and opened in the system browser via `NSWorkspace`.
+3. **Popup blocking** -- `createWebViewWith` returns `nil`, preventing embedded players from opening new windows.
+
+### Settings Persistence
+
+Appearance-related preferences that must be shared with the daemon live in the workspace config file (`~/.vellum/workspace/config.json`) under `ui`:
+
+```json
+{
+  "ui": {
+    "userTimezone": "America/New_York",
+    "mediaEmbeds": {
+      "enabled": true,
+      "enabledSince": "2026-02-15T12:00:00Z",
+      "videoAllowlistDomains": ["youtube.com", "youtu.be", "vimeo.com", "loom.com"]
+    }
+  }
+}
+```
+
+`SettingsStore` loads these values on init via `WorkspaceConfigIO.read` and writes them back via `WorkspaceConfigIO.merge`. `ui.userTimezone` provides an explicit user-local timezone hint for daemon-side temporal grounding when profile memory is unavailable. The `enabledSince` timestamp ensures only messages created after the user enabled embeds are eligible, so toggling the feature on doesn't retroactively embed every historical link.
+
+### Key Source Files
+
+| File | Role |
+|---|---|
+| `clients/macos/.../MediaEmbeds/MessageURLExtractor.swift` | URL extraction (plain text + markdown links, code-block exclusion) |
+| `clients/macos/.../MediaEmbeds/ImageURLClassifier.swift` | Extension-based image classification |
+| `clients/macos/.../MediaEmbeds/ImageMIMEProbe.swift` | Async HTTP HEAD probe for extensionless URLs |
+| `clients/macos/.../MediaEmbeds/DomainAllowlistMatcher.swift` | HTTPS-only domain allowlist with subdomain support |
+| `clients/macos/.../MediaEmbeds/MediaEmbedResolver.swift` | Pipeline orchestrator: settings gate, extraction, classification, dedup |
+| `clients/macos/.../MediaEmbeds/VideoProviders/YouTubeParser.swift` | YouTube URL parsing (watch, shorts, embed, youtu.be) |
+| `clients/macos/.../MediaEmbeds/VideoProviders/VimeoParser.swift` | Vimeo URL parsing (standard, player, channels, groups) |
+| `clients/macos/.../MediaEmbeds/VideoProviders/LoomParser.swift` | Loom URL parsing (share, embed) |
+| `clients/macos/.../MediaEmbeds/VideoEmbedURLBuilder.swift` | Provider-specific embed URL construction with autoplay params |
+| `clients/macos/.../MediaEmbeds/InlineImageEmbedView.swift` | Lazy-loaded inline image rendering |
+| `clients/macos/.../MediaEmbeds/InlineVideoEmbedCard.swift` | Click-to-play video card with state machine |
+| `clients/macos/.../MediaEmbeds/InlineVideoWebView.swift` | Privacy-hardened WKWebView wrapper |
+| `clients/macos/.../MediaEmbeds/InlineVideoEmbedState.swift` | Video embed lifecycle state + manager |
+| `clients/macos/.../Features/Settings/MediaEmbedSettings.swift` | Centralized defaults and domain normalization |
+| `clients/macos/.../Features/Settings/SettingsStore.swift` | Settings persistence (reads/writes `ui.userTimezone` and `ui.mediaEmbeds` in workspace config) |
+
+---
+
+
+---
+
+## Avatar System
+
+The avatar uses a simple image-based approach: a custom user-uploaded profile picture, or a colored-circle initial-letter fallback.
+
+**Components:**
+- `AvatarAppearanceManager` — Observable singleton that provides `chatAvatarImage` (custom PNG or initial-letter fallback). Watches the custom avatar file for live updates.
+- `AvatarCustomizationPanel` — User surface for uploading/clearing a custom profile picture
+
+**Custom avatar storage:** User-uploaded profile pictures are stored at `~/.vellum/workspace/data/avatar/avatar-image.png`. On first launch after upgrade, any legacy avatar from `~/Library/Application Support/vellum-assistant/` is automatically migrated (copied, not moved). The avatar customization panel is accessible from the Identity panel via a "Customize Avatar" CTA button.
+
+**Fallback:** When no custom avatar exists, `buildInitialLetterAvatar(name:)` renders a Forest._600 circle with the assistant's first initial in white.
+
+## Managed Sign-In (macOS)
+
+Managed sign-in allows macOS users to connect to a platform-hosted assistant during first-run onboarding instead of running a local daemon. When a user clicks "Sign in" on the onboarding screen, the app authenticates via WorkOS through the platform, ensures a managed assistant exists (via the idempotent hatch endpoint), and connects to it through platform proxy endpoints.
+
+### Sign-In Flow
+
+```
+User clicks "Sign in"
+  --> WorkOS authentication (via AuthManager)
+  --> ManagedAssistantBootstrapService.ensureManagedAssistant()
+      --> If activeAssistant in lockfile: GET /v1/assistants/{id}/  (retrieve by ID)
+      --> Otherwise: POST /v1/assistants/hatch/  (idempotent — returns existing or creates new)
+  --> Upsert lockfile entry (cloud: "vellum")
+  --> Set activeAssistant in lockfile
+  --> Configure managed HTTP transport
+  --> Proceed to app
+```
+
+If managed bootstrap fails, the user stays on the onboarding screen with an error message and a retry option. The app does not proceed until bootstrap succeeds or the user chooses a different path.
+
+### Transport Modes
+
+`GatewayHTTPClient` supports two route modes, selected based on the lockfile entry's `cloud` field:
+
+| Mode | Route Pattern | Auth Header | When Used |
+|------|--------------|-------------|-----------|
+| `runtimeFlat` | `/health`, `/v1/messages`, `/v1/events` | `Authorization: Bearer {token}` | Local daemon, gateway-proxied remote |
+| `platformAssistantProxy` | `/v1/assistants/{id}/health/`, `/v1/assistants/{id}/messages/` | `X-Session-Token: {token}` | Platform-managed assistants (`cloud == "vellum"`) |
+
+The route mode is determined by `GatewayHTTPClient.resolveConnection()` based on the lockfile entry. `AppDelegate` configures the connection via `GatewayConnectionManager`.
+
+### Startup Guardrails
+
+When the current assistant is managed (`isCurrentAssistantManaged == true`), the app skips:
+- **Local daemon hatching** -- the platform hosts the daemon, so `vellumCli.hatch()` is not called.
+- **Actor credential bootstrap** -- identity is derived from the platform session token, not local actor tokens. The `ensureActorCredentials()` flow is skipped entirely.
+- **Server-unavailable re-hatch** -- the reconnection loop does not attempt local re-hatch when the daemon HTTP server is unreachable.
+
+### Credential and State Storage
+
+| Data | Storage | Location |
+|------|---------|----------|
+| Session token | Credential Store | provider: `session-token` (via `SessionTokenManager`) |
+| Platform token file | Filesystem | `~/.vellum/platform-token` (0600 permissions, daemon-readable) |
+| Managed lockfile entry | Filesystem | `~/.vellum.lock.json` (entry with `cloud: "vellum"`) |
+| Connected assistant ID | Lockfile | `activeAssistant` field in `~/.vellum.lock.json` |
+
+### 401 Handling in Managed Mode
+
+When a managed-mode HTTP request receives a 401, `GatewayHTTPClient` does not attempt the bearer token refresh flow (which is designed for local actor tokens). Instead, it emits a `conversation_error` event so the app can prompt re-authentication through the platform.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `clients/shared/App/Auth/ManagedAssistantBootstrapService.swift` | Discover-or-create orchestrator for managed assistants |
+| `clients/shared/App/Auth/AuthService.swift` | Platform API methods (`getAssistant`, `hatchAssistant`) |
+| `clients/shared/App/Auth/SessionTokenManager.swift` | Session token storage (Credential Store + `~/.vellum/platform-token` file bridge) |
+| `clients/shared/Network/GatewayHTTPClient.swift` | Authenticated HTTP client for gateway and platform proxy requests |
+| `clients/macos/vellum-assistant/App/AppDelegate.swift` | Transport selection (`configureDaemonTransport`) and startup guardrails |
+| `clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift` | Onboarding sign-in UI and managed bootstrap invocation |
+| `clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift` | `LockfileAssistant.isManaged` computed property and managed entry upsert |
+
+---
+
+## GatewayHTTPClient
+
+All HTTP API calls go through `GatewayHTTPClient` — a stateless enum with static async methods that handles gateway and platform proxy requests.
+
+### Pattern
+
+Each API surface gets a focused protocol + struct, instantiated inline on the consuming type:
+
+1. **Define a protocol** describing the operations (e.g. `ConversationClientProtocol`).
+2. **Implement a struct** that calls `GatewayHTTPClient.get/post/delete(path:timeout:)`.
+3. **Instantiate the struct** inline as a private property on the consuming type (e.g. `private let client: any SurfaceClientProtocol = SurfaceClient()`).
+4. Stateless network client structs and protocols (enums with static methods, request builders) are naturally `nonisolated`. Stateful managers that own mutable state should be `@MainActor`. See `clients/AGENTS.md` § "@MainActor Isolation Boundaries".
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `clients/shared/Network/GatewayHTTPClient.swift` | Authenticated HTTP client for gateway and platform proxy requests |
+
+---
+
+## iOS Connection Architecture
+
+The iOS app connects to the macOS assistant exclusively via HTTPS through the gateway.
+
+### Connection Flow
+
+```
+iOS App  --HTTPS-->  Ingress (tunnel/public URL)  -->  Gateway  -->  Runtime
+         <--SSE---                                 <--          <--
+```
+
+1. **Pairing** provides the iOS app with an ingress URL and bearer token via QR code scan with Mac-side approval.
+2. **HTTP+SSE transport**: The iOS client sends commands via HTTP POST to the gateway (through `GatewayHTTPClient`) and receives events via Server-Sent Events (SSE). All communication is authenticated with the bearer token.
+3. **Gateway proxy**: The gateway's runtime proxy forwards `/v1/*` requests to the local runtime, validating the bearer token on each request.
+
+### Pairing Flow (v4)
+
+iOS pairing uses a v4 QR code protocol with Mac-side approval. There is no manual entry option.
+
+**QR payload (v4):**
+```json
+{
+  "type": "vellum-daemon", "v": 4,
+  "id": "<mac-hash>",
+  "g": "<resolved-gateway-url>",
+  "pairingRequestId": "<uuid>",
+  "pairingSecret": "<Random Hex Value>",
+  "localLanUrl": "http://<lan-ip>:7830"  // only present when VELLUM_ENABLE_INSECURE_LAN_PAIRING=1
+}
+```
+
+**Flow:**
+1. macOS generates a v4 QR code (no bearer token in QR) and pre-registers the pairing request with the daemon via `POST /v1/pairing/register`.
+2. iOS scans the QR code, extracts the `pairingRequestId` and `pairingSecret`, and sends a pairing request to the gateway (`POST /pairing/request`). If `localLanUrl` is present (requires `VELLUM_ENABLE_INSECURE_LAN_PAIRING=1`), tries it first (3s timeout), then falls back to cloud gateway URL (`g`).
+3. The daemon validates the secret and either auto-approves (if the device is in the allowlist) or sends an SSE event to macOS to show an approval prompt.
+4. macOS shows a floating approval window with three options: Deny, Approve Once, Always Allow.
+5. iOS polls `GET /pairing/status?id=<id>&secret=<secret>` every 2.5s until approved, denied, or expired (5-min TTL).
+6. On approval, the response includes the bearer token and gateway URL. iOS saves these and connects.
+
+**Daemon endpoints:**
+- `POST /v1/pairing/register` -- macOS pre-registers a pairing request (bearer-authenticated).
+- `POST /v1/pairing/request` -- iOS initiates pairing (unauthenticated, secret-gated).
+- `GET /v1/pairing/status` -- iOS polls for approval status (unauthenticated, secret-gated).
+
+**Gateway proxy endpoints** (unauthenticated, proxied to daemon):
+- `POST /pairing/request` -> daemon `/v1/pairing/request`
+- `GET /pairing/status` -> daemon `/v1/pairing/status`
+
+**Approved devices:** Devices paired with "Always Allow" are persisted to `~/.vellum/protected/approved-devices.json` (keyed by hashed deviceId). Future pairings from allowlisted devices auto-approve without a prompt. The macOS Connect tab shows an Approved Devices list with remove/clear actions.
+
+### JWT Credential Refresh (Shared: macOS + iOS)
+
+Both macOS and iOS clients use a single JWT access token for all HTTP authentication, sent as `Authorization: Bearer <jwt>`. The JWT serves as both authentication and identity — there is no separate `X-Actor-Token` header. A shared credential refresh mechanism maintains valid tokens without re-bootstrapping or re-pairing. Bootstrap (macOS) and pairing (iOS) are only used for initial credential issuance.
+
+**Credential storage:** The client stores the following in the Credential Store:
+
+| Data | Storage | Purpose |
+|------|---------|---------|
+| Access token (JWT) | Credential Store | `Authorization: Bearer <jwt>` header for authenticated requests |
+| Refresh token | Credential Store | Presented to the refresh endpoint to rotate credentials |
+| Access token expiry | Credential Store | Absolute expiry timestamp of the current access token |
+| Refresh token expiry | Credential Store | Absolute expiry timestamp of the current refresh token |
+| `refreshAfter` | Credential Store | Timestamp at which the client should proactively refresh (80% of access token TTL) |
+
+**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/guardian/refresh` (through the gateway) with the current refresh token and `Authorization: Bearer <jwt>`. On success, the response provides a new `accessToken`, `refreshToken`, `accessTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
+
+**401 recovery:** When an HTTP request receives a 401 response with `{ "code": "refresh_required" }`, `GatewayHTTPClient` attempts a single refresh before surfacing a "Session expired" error. If the refresh succeeds, the original request is retried with the new JWT. If the 401 contains a different code or the refresh fails (e.g., refresh token expired or revoked), the client surfaces the session-expired error and the user must re-pair (iOS) or re-bootstrap (macOS).
+
+**Shared utility:** `ActorCredentialRefresher` is a shared utility used by both platforms. It encapsulates the refresh HTTP call, credential update, and error handling. `ActorTokenManager` on each platform delegates to this refresher for both proactive and reactive (401-recovery) refresh flows.
+
+**No legacy bootstrap-as-renewal:** macOS no longer re-bootstraps on every launch. Bootstrap runs only when no access token exists at all (first launch or after credential wipe). All subsequent renewal is handled by the refresh flow.
+
+### Prerequisites
+
+- A gateway URL must be configured (cloud tunnel or LAN). LAN pairing requires setting `VELLUM_ENABLE_INSECURE_LAN_PAIRING=1`; when enabled, `localLanUrl` is included in the QR payload.
+- A conversation key is auto-generated on first connect and stored in UserDefaults.
+- iOS maintains a stable `deviceId` (UUID) in the Credential Store across reinstalls.
+
+### Configuration Storage (iOS)
+
+| Data | Storage | Key |
+|------|---------|-----|
+| Gateway URL | UserDefaults | `gateway_base_url` |
+| Bearer token | Credential Store | provider: `runtime-bearer-token` |
+| Actor token | Credential Store | provider: `actor-token` |
+| Refresh token | Credential Store | provider: `actor-refresh-token` |
+| Conversation key | UserDefaults | `conversation_key` |
+| Host ID | UserDefaults | `gateway_host_id` |
+| Device ID | Credential Store | provider: `pairing-device-id` |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift` | macOS v4 QR generation, pre-registration with daemon |
+| `clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift` | Floating approval prompt window |
+| `assistant/src/daemon/pairing-store.ts` | In-memory pairing request store with TTL |
+| `assistant/src/daemon/approved-devices-store.ts` | Persistent approved devices allowlist |
+| `assistant/src/daemon/handlers/pairing.ts` | Pairing approval handlers |
+| `gateway/src/http/routes/pairing-proxy.ts` | Gateway proxy for pairing endpoints |
+
+### Offline Message Queue (iOS)
+
+When the daemon is unreachable, outgoing user messages are buffered in `OfflineMessageQueue` (a persistent FIFO stored in UserDefaults) instead of surfacing an error. The message bubble shows a "Pending" indicator (`ChatMessageStatus.pendingOffline`) while offline. On reconnect (`daemonDidReconnect`), `ChatViewModel.flushOfflineQueue()` drains the queue and sends messages in order, clearing the pending indicator.
+
+| Component | Role |
+|-----------|------|
+| `clients/ios/App/OfflineMessageQueue.swift` | Persistent FIFO queue; serialized to `offline_message_queue_v1` in UserDefaults |
+| `ChatMessageStatus.pendingOffline` | Message status for locally buffered, unsent messages |
+| `ChatViewModel.flushOfflineQueue()` | Drains the queue on reconnect, sending messages in FIFO order |
+| `MessageBubbleView` | Renders a clock icon + "Pending" label for `.pendingOffline` messages |
+
+Storage key: `offline_message_queue_v1` (UserDefaults).
+
+### Guardian Approval Card UI (macOS/iOS)
+
+Guardian approval prompts are rendered as structured card UIs in the chat timeline using a "buttons first, text fallback" model. The daemon delivers `GuardianDecisionPrompt` objects via HTTP+SSE, and the client renders them as kind-aware cards with tappable action buttons.
+
+**Kind-aware rendering:** `GuardianDecisionBubble` renders distinct card headers for each canonical request kind:
+
+| Kind | Header | Icon | Accent |
+|------|--------|------|--------|
+| `tool_approval` | "Tool Approval Required" | `shield.lefthalf.filled` | Warning |
+| `pending_question` | "Question Pending" | `questionmark.circle.fill` | Accent |
+| `access_request` | "Access Request" | `person.badge.key.fill` | Warning |
+
+**Interaction model:** Each card displays the `questionText` (which includes text fallback directives for `access_request`), action buttons (Approve once / Reject), and secondary metadata (tool name, request code). Buttons submit decisions via `POST /v1/guardian-actions/decision` with the `requestId` and chosen action. The `requestCode` is always visible as a "Ref:" label so guardians can use text-based fallback (`<code> approve` / `<code> reject`) if buttons are not available or not used.
+
+**Shared primitives:** Action buttons use `VButton` (from the design system), and the button row is rendered by `GuardianApprovalActionRow`. Resolved prompts collapse to `ApprovalStatusRow` showing the outcome.
+
+| File | Purpose |
+|------|---------|
+| `clients/shared/Features/Chat/GuardianDecisionBubble.swift` | Kind-aware guardian approval card with action buttons |
+| `clients/shared/Features/Chat/ApprovalActionRow.swift` | `GuardianApprovalActionRow` — renders action buttons using `VButton` |
+| `clients/shared/Features/Chat/ApprovalStatusRow.swift` | Collapsed resolved-state display |
+| `clients/shared/Features/Chat/ToolConfirmationBubble.swift` | Tool confirmation card with approve/deny actions |
+
+---
+
+## Shared Feature Stores
+
+Cross-platform `ObservableObject` stores in `clients/shared/Features/` encapsulate daemon communication and state management. Platform views delegate data operations to these stores while owning their own UI presentation state.
+
+| Store | Location | Purpose |
+|-------|----------|---------|
+| `SkillsStore` | `shared/Features/Skills/SkillsStore.swift` | Skills CRUD: list, search, inspect, install, uninstall, enable/disable, configure, draft, and create. Caches inspect results and uses generation counters to handle stale responses. |
+| `ContactsStore` | `shared/Features/Contacts/ContactsStore.swift` | Contacts CRUD: list, get, update channel policy, delete. Auto-refreshes on `contactsChanged` daemon broadcasts with 500ms debounce. |
+| `DirectoryStore` | `shared/Features/Directory/DirectoryStore.swift` | Directory data: local apps, shared apps, documents. Supports open, delete, share-to-cloud, fork, and bundle operations. Auto-refreshes on `appFilesChanged` broadcasts. |
+| `ChannelTrustStore` | `shared/Features/ChannelTrust/ChannelTrustStore.swift` | Guardian state and channel trust management. Composes `ContactsStore` for guardian contact data, manages pending guardian action prompts via daemon HTTP API. |
+
+### Store Patterns
+
+All shared stores follow the same async pattern for daemon communication:
+
+1. Subscribe to the event stream via `EventStreamClient`
+2. Send a request message via `GatewayHTTPClient`
+3. Iterate the stream with `for await`, matching on the expected response case
+4. Update `@Published` state on the main actor
+5. Cancel subscription tasks in `deinit` to prevent leaks
+
+Stores use `[weak self]` in all `Task` closures and background subscriptions. Platform views own stores via `@ObservedObject` or `@StateObject` and pass them down to child views.
+
+---
+
+## macOS Deep-Link Send (M11)
+
+The macOS app registers a `vellum://send?message=...` URL scheme handler. When invoked, it creates or reuses a conversation and sends the message through the daemon. This enables external tools, scripts, and iOS Shortcuts to trigger assistant actions on the Mac.
+
+---

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -1,0 +1,494 @@
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "LiveVoiceChannelManager")
+
+protocol LiveVoiceAudioCapturing: AnyObject {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool
+    func stop()
+    func shutdown()
+}
+
+extension LiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        await start(onChunk: onChunk, onAmplitude: nil)
+    }
+}
+
+@MainActor
+protocol LiveVoiceAudioPlaying: AnyObject {
+    var isPlaying: Bool { get }
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int
+    )
+    func handleInterrupt()
+    func handleEnd()
+    func handleSessionError()
+    func resetForNextResponse()
+    func waitUntilPlaybackFinishes() async
+}
+
+extension LiveVoiceAudioPlayer: LiveVoiceAudioPlaying {}
+
+@MainActor
+@Observable
+final class LiveVoiceChannelManager {
+    enum State: Equatable {
+        case idle
+        case connecting
+        case listening
+        case transcribing
+        case thinking
+        case speaking
+        case ending
+        case failed
+    }
+
+    private(set) var state: State = .idle
+    private(set) var activeConversationId: String?
+    private(set) var sessionId: String?
+    private(set) var partialTranscript: String = ""
+    private(set) var finalTranscript: String = ""
+    private(set) var assistantTranscript: String = ""
+    private(set) var inputAmplitude: Float = 0
+    private(set) var errorMessage: String = ""
+    private(set) var isMicrophoneMuted: Bool = false
+    private(set) var isAssistantOutputMuted: Bool = false
+
+    var isActive: Bool {
+        switch state {
+        case .idle, .failed:
+            return false
+        case .connecting, .listening, .transcribing, .thinking, .speaking, .ending:
+            return true
+        }
+    }
+
+    @ObservationIgnored private let clientFactory: @MainActor () -> any LiveVoiceChannelClientProtocol
+    @ObservationIgnored private let capture: any LiveVoiceAudioCapturing
+    @ObservationIgnored private let playback: any LiveVoiceAudioPlaying
+    @ObservationIgnored private let bargeInAmplitudeThreshold: Float
+    @ObservationIgnored private let speechAmplitudeThreshold: Float
+    @ObservationIgnored private let silenceDurationBeforeRelease: TimeInterval
+    @ObservationIgnored private let minimumSpeechDurationBeforeRelease: TimeInterval
+
+    @ObservationIgnored private var client: (any LiveVoiceChannelClientProtocol)?
+    @ObservationIgnored private var captureStartTask: Task<Void, Never>?
+    @ObservationIgnored private var sessionGeneration: UInt64 = 0
+    @ObservationIgnored private var captureRunning = false
+    @ObservationIgnored private var captureStartInFlight = false
+    @ObservationIgnored private var responseAudioStarted = false
+    @ObservationIgnored private var interruptSentForCurrentResponse = false
+    @ObservationIgnored private var speechDurationInCurrentUtterance: TimeInterval = 0
+    @ObservationIgnored private var silenceDurationAfterSpeech: TimeInterval = 0
+    @ObservationIgnored private var automaticReleaseInFlight = false
+
+    init(
+        clientFactory: @escaping @MainActor () -> any LiveVoiceChannelClientProtocol = { LiveVoiceChannelClient() },
+        capture: any LiveVoiceAudioCapturing = LiveVoiceAudioCapture(),
+        playback: (any LiveVoiceAudioPlaying)? = nil,
+        bargeInAmplitudeThreshold: Float = 0.05,
+        speechAmplitudeThreshold: Float = 0.03,
+        silenceDurationBeforeRelease: TimeInterval = 1.0,
+        minimumSpeechDurationBeforeRelease: TimeInterval = 0.12
+    ) {
+        self.clientFactory = clientFactory
+        self.capture = capture
+        self.playback = playback ?? LiveVoiceAudioPlayer()
+        self.bargeInAmplitudeThreshold = bargeInAmplitudeThreshold
+        self.speechAmplitudeThreshold = speechAmplitudeThreshold
+        self.silenceDurationBeforeRelease = silenceDurationBeforeRelease
+        self.minimumSpeechDurationBeforeRelease = minimumSpeechDurationBeforeRelease
+    }
+
+    func start(conversationId: String) async {
+        let trimmedConversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedConversationId.isEmpty else {
+            failWithoutActiveClient(message: "A conversation is required to start live voice.")
+            return
+        }
+        guard state == .idle || state == .failed else { return }
+
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        let newClient = clientFactory()
+
+        resetObservedSessionState(conversationId: trimmedConversationId)
+        client = newClient
+        state = .connecting
+
+        await newClient.start(
+            conversationId: trimmedConversationId,
+            audioFormat: .pcm16kMono,
+            onEvent: { [weak self] event in
+                self?.handle(event, generation: generation)
+            },
+            onFailure: { [weak self] failure in
+                self?.handle(failure, generation: generation)
+            }
+        )
+    }
+
+    func interruptSpeakingAndStartListening(conversationId: String) async {
+        let trimmedConversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedConversationId.isEmpty else {
+            failWithoutActiveClient(message: "A conversation is required to start live voice.")
+            return
+        }
+        guard client != nil, state != .idle, state != .failed else {
+            await start(conversationId: trimmedConversationId)
+            return
+        }
+
+        sessionGeneration &+= 1
+        let interruptedClient = client
+
+        stopCapture()
+        playback.handleInterrupt()
+        resetIgnoredSessionState()
+        resetObservedSessionState(conversationId: nil)
+        state = .idle
+
+        await interruptedClient?.interrupt()
+        await interruptedClient?.close()
+        await start(conversationId: trimmedConversationId)
+    }
+
+    func stopListening() async {
+        guard state != .idle, state != .failed, state != .ending else { return }
+        guard captureRunning || captureStartInFlight else { return }
+
+        stopCapture()
+        await client?.releasePushToTalk()
+
+        if state == .listening {
+            state = .transcribing
+        }
+    }
+
+    func end() async {
+        guard state != .failed, state != .ending else { return }
+        guard state != .idle || client != nil || captureRunning || captureStartInFlight else { return }
+
+        state = .ending
+        sessionGeneration &+= 1
+        let clientToEnd = client
+
+        stopCapture()
+        playback.handleEnd()
+        resetIgnoredSessionState()
+
+        await clientToEnd?.end()
+
+        resetObservedSessionState(conversationId: nil)
+        // Mute preferences do not carry across a fully ended session — the
+        // next session starts unmuted, matching most call-style UIs.
+        isMicrophoneMuted = false
+        isAssistantOutputMuted = false
+        state = .idle
+    }
+
+    /// Mute or unmute the local microphone without ending the session.
+    /// Capture keeps running (so input amplitude and barge-in stay
+    /// observable to the UI), but no audio is sent upstream while muted.
+    func setMicrophoneMuted(_ muted: Bool) {
+        guard isMicrophoneMuted != muted else { return }
+        isMicrophoneMuted = muted
+        if muted {
+            inputAmplitude = 0
+        }
+    }
+
+    /// Mute or unmute assistant speech playback without ending the session.
+    /// The assistant may still be producing a response while muted; TTS
+    /// audio frames are simply dropped instead of being enqueued for playback.
+    func setAssistantOutputMuted(_ muted: Bool) {
+        update(&isAssistantOutputMuted, to: muted)
+    }
+
+    private func resetObservedSessionState(conversationId: String?) {
+        activeConversationId = conversationId
+        sessionId = nil
+        partialTranscript = ""
+        finalTranscript = ""
+        assistantTranscript = ""
+        inputAmplitude = 0
+        errorMessage = ""
+        resetVoiceActivityTracking()
+    }
+
+    private func resetIgnoredSessionState() {
+        client = nil
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+        automaticReleaseInFlight = false
+    }
+
+    private func resetVoiceActivityTracking() {
+        speechDurationInCurrentUtterance = 0
+        silenceDurationAfterSpeech = 0
+        automaticReleaseInFlight = false
+    }
+
+    private func handle(_ event: LiveVoiceChannelEvent, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        switch event {
+        case .ready(let sessionId, let conversationId):
+            guard state == .connecting else { return }
+            self.sessionId = sessionId
+            activeConversationId = conversationId
+            startCapture(generation: generation)
+
+        case .sttPartial(let text, _):
+            update(&partialTranscript, to: text)
+            if captureRunning {
+                state = .listening
+            } else if state == .listening || state == .transcribing {
+                state = .transcribing
+            }
+
+        case .sttFinal(let text, _):
+            update(&finalTranscript, to: text)
+            update(&partialTranscript, to: "")
+            if state != .ending {
+                state = captureRunning ? .listening : .thinking
+            }
+
+        case .thinking:
+            prepareForAssistantResponse()
+            if state != .ending {
+                state = .thinking
+            }
+
+        case .assistantTextDelta(let text, _):
+            guard !text.isEmpty else { return }
+            assistantTranscript += text
+            if state == .listening || state == .transcribing {
+                state = .thinking
+            }
+
+        case .ttsAudio(let data, let mimeType, let sampleRate, _):
+            beginAssistantAudioIfNeeded()
+            if !isAssistantOutputMuted {
+                playback.enqueueTTSAudio(
+                    data: data,
+                    mimeType: mimeType,
+                    sampleRate: sampleRate,
+                    channels: 1
+                )
+            }
+            state = .speaking
+
+        case .ttsDone:
+            closeCompletedUtteranceSessionAfterPlayback(generation: generation)
+
+        case .metrics, .archived:
+            break
+        }
+    }
+
+    private func handle(_ failure: LiveVoiceChannelFailure, generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+
+        log.warning("Live voice session failed: \(failure.localizedDescription, privacy: .public)")
+        sessionGeneration &+= 1
+        stopCapture()
+        playback.handleSessionError()
+
+        let failedClient = client
+        resetIgnoredSessionState()
+
+        errorMessage = failure.errorDescription ?? failure.localizedDescription
+        state = .failed
+
+        Task {
+            await failedClient?.close()
+        }
+    }
+
+    private func failWithoutActiveClient(message: String) {
+        resetObservedSessionState(conversationId: nil)
+        stopCapture()
+        playback.handleSessionError()
+        resetIgnoredSessionState()
+        errorMessage = message
+        state = .failed
+    }
+
+    private func startCapture(generation: UInt64) {
+        captureStartTask?.cancel()
+        captureStartTask = Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+
+            self.captureStartInFlight = true
+            let started = await self.capture.start { [weak self] chunk in
+                Task { @MainActor [weak self] in
+                    self?.handleCapturedAudioChunk(chunk, generation: generation)
+                }
+            }
+            self.captureStartInFlight = false
+            self.captureStartTask = nil
+
+            guard generation == self.sessionGeneration, !Task.isCancelled else {
+                if started {
+                    self.capture.stop()
+                }
+                return
+            }
+
+            guard started else {
+                self.handle(
+                    .protocolError(code: "capture_failed", message: "Microphone capture could not start."),
+                    generation: generation
+                )
+                return
+            }
+
+            self.captureRunning = true
+            if self.state == .connecting || self.state == .idle {
+                self.state = .listening
+            }
+        }
+    }
+
+    private func handleCapturedAudioChunk(_ chunk: LiveVoiceAudioCaptureChunk, generation: UInt64) {
+        guard generation == sessionGeneration, captureRunning else { return }
+
+        guard !isMicrophoneMuted else {
+            update(&inputAmplitude, to: 0)
+            return
+        }
+
+        update(&inputAmplitude, to: chunk.amplitude)
+
+        let audioData = chunk.pcm16LittleEndian
+        if !audioData.isEmpty, let client {
+            Task {
+                await client.sendAudio(audioData)
+            }
+        }
+
+        updateAutomaticPushToTalkRelease(with: chunk, generation: generation)
+
+        guard chunk.amplitude >= bargeInAmplitudeThreshold else { return }
+        interruptIfAssistantAudioIsPlaying(generation: generation)
+    }
+
+    private func updateAutomaticPushToTalkRelease(
+        with chunk: LiveVoiceAudioCaptureChunk,
+        generation: UInt64
+    ) {
+        guard state == .listening, captureRunning, client != nil else { return }
+
+        let chunkDuration: TimeInterval
+        if chunk.sampleRate > 0, chunk.frameCount > 0 {
+            chunkDuration = TimeInterval(chunk.frameCount) / TimeInterval(chunk.sampleRate)
+        } else {
+            chunkDuration = 0
+        }
+
+        guard chunkDuration > 0 else { return }
+
+        if chunk.amplitude >= speechAmplitudeThreshold {
+            speechDurationInCurrentUtterance += chunkDuration
+            silenceDurationAfterSpeech = 0
+            return
+        }
+
+        guard speechDurationInCurrentUtterance >= minimumSpeechDurationBeforeRelease else { return }
+        silenceDurationAfterSpeech += chunkDuration
+
+        guard silenceDurationAfterSpeech >= silenceDurationBeforeRelease else { return }
+        automaticallyReleasePushToTalk(generation: generation)
+    }
+
+    private func automaticallyReleasePushToTalk(generation: UInt64) {
+        guard !automaticReleaseInFlight else { return }
+        automaticReleaseInFlight = true
+
+        Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+            await self.stopListening()
+        }
+    }
+
+    private func interruptIfAssistantAudioIsPlaying(generation: UInt64) {
+        guard generation == sessionGeneration else { return }
+        guard playback.isPlaying, !interruptSentForCurrentResponse else { return }
+
+        interruptSentForCurrentResponse = true
+        playback.handleInterrupt()
+        if state == .speaking {
+            state = captureRunning ? .listening : .idle
+        }
+
+        let interruptedClient = client
+        Task {
+            await interruptedClient?.interrupt()
+        }
+    }
+
+    private func prepareForAssistantResponse() {
+        responseAudioStarted = false
+        interruptSentForCurrentResponse = false
+        update(&assistantTranscript, to: "")
+    }
+
+    private func beginAssistantAudioIfNeeded() {
+        guard !responseAudioStarted else { return }
+
+        responseAudioStarted = true
+        interruptSentForCurrentResponse = false
+        playback.resetForNextResponse()
+    }
+
+    private func closeCompletedUtteranceSessionAfterPlayback(generation: UInt64) {
+        responseAudioStarted = false
+        let completedClient = client
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.playback.waitUntilPlaybackFinishes()
+            guard generation == self.sessionGeneration else { return }
+
+            self.sessionGeneration &+= 1
+            self.stopCapture()
+            self.resetIgnoredSessionState()
+            self.sessionId = nil
+            self.state = .idle
+            await completedClient?.close()
+        }
+    }
+
+    private func stopCapture() {
+        captureStartTask?.cancel()
+        captureStartTask = nil
+
+        if captureRunning || captureStartInFlight {
+            capture.stop()
+        }
+        captureRunning = false
+        captureStartInFlight = false
+        inputAmplitude = 0
+        resetVoiceActivityTracking()
+    }
+
+    private func update<T: Equatable>(_ value: inout T, to newValue: T) {
+        guard value != newValue else { return }
+        value = newValue
+    }
+
+    deinit {
+        captureStartTask?.cancel()
+        capture.shutdown()
+    }
+}
+
+extension LiveVoiceChannelManager: VoiceSessionControlling {}

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -1,0 +1,1129 @@
+import Foundation
+import Observation
+import Speech
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "VoiceModeManager")
+
+@MainActor
+protocol LiveVoiceChannelManaging: VoiceSessionControlling {
+    var state: LiveVoiceChannelManager.State { get }
+    var inputAmplitude: Float { get }
+    var partialTranscript: String { get }
+    var finalTranscript: String { get }
+    var errorMessage: String { get }
+
+    func start(conversationId: String) async
+    func interruptSpeakingAndStartListening(conversationId: String) async
+    func stopListening() async
+}
+
+extension LiveVoiceChannelManager: LiveVoiceChannelManaging {}
+
+/// Voice-mode state model.
+///
+/// Marked `@Observable` so views reading only `state` are not invalidated by
+/// high-frequency writes to `partialTranscription` / `liveTranscription`, and
+/// synchronous property mutations inside `handleStateTransition` do not fan
+/// out to unrelated observers.
+@MainActor
+@Observable
+final class VoiceModeManager {
+    /// Override set via `client_settings_update` from the daemon.
+    /// When non-nil, used instead of the default 30-second conversation timeout.
+    static var conversationTimeoutOverride: Int?
+
+    enum State: Equatable {
+        case off, idle, listening, processing, speaking
+    }
+
+    private enum VoicePath {
+        case turnBased
+        case liveChannel
+    }
+
+    var state: State = .off {
+        didSet { handleStateTransition(from: oldValue, to: state) }
+    }
+    var partialTranscription: String = ""
+    var liveTranscription: String = ""
+    var inputAmplitude: Float = 0
+    var errorMessage: String = ""
+    /// Mirrors the active live voice session's microphone mute state. Always
+    /// false when no live voice session is active (e.g. turn-based voice).
+    var isMicrophoneMuted: Bool = false
+    /// Mirrors the active live voice session's assistant-output mute state.
+    /// Always false when no live voice session is active.
+    var isAssistantOutputMuted: Bool = false
+    /// Set to true when deactivation was triggered by the conversation timeout
+    /// (as opposed to manual deactivation).
+    var wasAutoDeactivated: Bool = false
+
+    /// How long to wait in `.idle` before auto-deactivating voice mode.
+    @ObservationIgnored var conversationTimeoutInterval: TimeInterval = 30
+
+    @ObservationIgnored let voiceService: any VoiceServiceProtocol
+
+    /// Adapter for speech recognition authorization checks.
+    /// Injected separately from `voiceService` so VoiceModeManager does not
+    /// need to know about `OpenAIVoiceService` or any concrete voice service type.
+    @ObservationIgnored private let speechRecognizerAdapter: any SpeechRecognizerAdapter
+    @ObservationIgnored private let liveVoiceChannelManager: (any LiveVoiceChannelManaging)?
+    @ObservationIgnored private let liveVoiceAvailability: @MainActor () -> Bool
+
+    /// Typed accessor for UI views that need observed amplitude properties.
+    var openAIVoiceService: OpenAIVoiceService? {
+        voiceService as? OpenAIVoiceService
+    }
+
+    @ObservationIgnored weak var chatViewModel: ChatViewModel?
+    @ObservationIgnored private weak var settingsStore: SettingsStore?
+    @ObservationIgnored private var previousOnVoiceResponseComplete: ((String) -> Void)?
+    @ObservationIgnored private var previousOnVoiceTextDelta: ((String) -> Void)?
+    /// Guards against async auth callback activating after the panel is closed.
+    @ObservationIgnored private var awaitingAuthorization = false
+    /// Safety timeout to recover from stuck TTS.
+    @ObservationIgnored private var ttsTimeoutTask: Task<Void, Never>?
+    /// Timer that fires when the conversation has been idle too long.
+    @ObservationIgnored private var conversationTimeoutTask: Task<Void, Never>?
+    /// When true, `handleStateTransition` will not re-arm the conversation
+    /// timeout on transitions to `.idle`. Used during CU escalation so that
+    /// `speakTransient`'s completion (which sets state to `.idle`) does not
+    /// prematurely restart the 30s timer while the CU session is still running.
+    @ObservationIgnored private var conversationTimeoutPaused = false
+    /// Permission request IDs currently being handled via voice.
+    @ObservationIgnored var pendingPermissionIds: [String] = []
+    /// Generation counter controlling the lifetime of the voice-service observation loop.
+    @ObservationIgnored private var voiceObservationGeneration: Int = 0
+    /// Last observed value from the isThinking observation loop, used to
+    /// deduplicate redundant same-value writes and only act on actual transitions.
+    @ObservationIgnored private var lastObservedIsThinking: Bool = false
+    @ObservationIgnored private var activeVoicePath: VoicePath = .turnBased
+    @ObservationIgnored private var liveVoiceObservationGeneration: Int = 0
+    @ObservationIgnored private var liveVoiceStartTask: Task<Void, Never>?
+    @ObservationIgnored private var liveFallbackAttemptedForSession = false
+    @ObservationIgnored private var liveVoicePausedForPermission = false
+
+    init(
+        voiceService: any VoiceServiceProtocol = OpenAIVoiceService(),
+        liveVoiceChannelManager: (any LiveVoiceChannelManaging)? = nil,
+        liveVoiceAvailability: @escaping @MainActor () -> Bool = { false },
+        speechRecognizerAdapter: any SpeechRecognizerAdapter = AppleSpeechRecognizerAdapter()
+    ) {
+        self.voiceService = voiceService
+        self.liveVoiceChannelManager = liveVoiceChannelManager
+        self.liveVoiceAvailability = liveVoiceAvailability
+        self.speechRecognizerAdapter = speechRecognizerAdapter
+    }
+
+    var stateLabel: String {
+        if !pendingPermissionIds.isEmpty {
+            switch state {
+            case .speaking: return "Asking permission..."
+            case .listening: return "Say yes, no, 10 minutes, or always..."
+            case .processing: return "Processing approval..."
+            default: break
+            }
+        }
+        switch state {
+        case .off: return ""
+        case .idle: return "Ready"
+        case .listening: return "Listening..."
+        case .processing: return "Thinking..."
+        case .speaking: return "Speaking..."
+        }
+    }
+
+    var canToggleListening: Bool {
+        switch state {
+        case .idle, .listening, .speaking:
+            return true
+        case .processing:
+            return activeVoicePath == .liveChannel
+        case .off:
+            return false
+        }
+    }
+
+    func activate(chatViewModel: ChatViewModel, settingsStore: SettingsStore? = nil) {
+        guard state == .off else { return }
+        wasAutoDeactivated = false
+
+        // When an LLM-based STT provider is configured (e.g. Deepgram, OpenAI
+        // Whisper), native speech recognition permission is not required — the
+        // service handles transcription. Skip the speech auth guard entirely.
+        let sttConfigured = STTProviderRegistry.isServiceConfigured
+        let liveVoiceEligible = canStartLiveVoiceSession(for: chatViewModel)
+
+        guard liveVoiceEligible || sttConfigured || speechRecognizerAdapter.authorizationStatus() == .authorized else {
+            log.error("Voice mode: speech recognition not authorized")
+            awaitingAuthorization = true
+            let status = speechRecognizerAdapter.authorizationStatus()
+            if status == .notDetermined {
+                speechRecognizerAdapter.requestAuthorization { [weak self] newStatus in
+                    Task { @MainActor in
+                        guard let self, self.awaitingAuthorization else { return }
+                        self.awaitingAuthorization = false
+                        if newStatus == .authorized {
+                            log.info("Speech recognition authorized — retrying activation")
+                            self.activate(chatViewModel: chatViewModel, settingsStore: settingsStore)
+                            self.startListening()
+                        } else {
+                            log.warning("Speech recognition authorization denied")
+                        }
+                    }
+                }
+            } else {
+                // Already determined but not authorized (denied/restricted) — nothing to request.
+                awaitingAuthorization = false
+                log.warning("Speech recognition authorization denied (status: \(status.rawValue))")
+            }
+            return
+        }
+
+        awaitingAuthorization = false
+        self.chatViewModel = chatViewModel
+        self.settingsStore = settingsStore
+        activeVoicePath = .turnBased
+        liveFallbackAttemptedForSession = false
+        liveVoicePausedForPermission = false
+
+        // Provide the conversation ID to the voice service so the gateway TTS
+        // endpoint can resolve the correct provider context.
+        if let service = voiceService as? OpenAIVoiceService {
+            service.conversationId = chatViewModel.conversationId
+        }
+
+        // Keep the user's current model — don't downgrade for voice mode.
+        // Capable models (Opus) are much better at tool use (osascript, etc.).
+
+        // Save existing callbacks to restore on deactivation
+        previousOnVoiceResponseComplete = chatViewModel.onVoiceResponseComplete
+        previousOnVoiceTextDelta = chatViewModel.onVoiceTextDelta
+
+        // Stream text deltas to TTS as they arrive
+        chatViewModel.onVoiceTextDelta = { [weak self] delta in
+            guard let self, self.activeVoicePath == .turnBased else { return }
+            self.handleTextDelta(delta)
+        }
+
+        // When the full response is complete, flush remaining text to TTS
+        chatViewModel.onVoiceResponseComplete = { [weak self] _ in
+            guard let self, self.activeVoicePath == .turnBased else { return }
+            self.handleResponseComplete()
+        }
+        chatViewModel.isVoiceModeActive = true
+
+        // Start observation loops for messages, isThinking, and voice partial text.
+        // All loops share voiceObservationGeneration and are invalidated on deactivate.
+        startVoiceServiceObservation()
+        observeMessages(generation: voiceObservationGeneration, messageManager: chatViewModel.messageManager)
+        observeIsThinking(generation: voiceObservationGeneration, messageManager: chatViewModel.messageManager)
+
+        // Pre-warm audio engine so first recording starts instantly
+        voiceService.prewarmEngine()
+
+        // Set up silence detection callback
+        voiceService.onSilenceDetected = { [weak self] in
+            self?.handleSilenceDetected()
+        }
+
+        // If mic permission is requested and granted, auto-start listening
+        voiceService.onMicrophoneAuthorized = { [weak self] in
+            guard let self, self.state == .idle else { return }
+            self.startListening()
+        }
+
+        // Barge-in: user speaks while assistant is talking → interrupt and listen
+        voiceService.onBargeInDetected = { [weak self] in
+            self?.handleBargeIn()
+        }
+
+        state = .idle
+        log.info("Voice mode activated (daemon + gateway TTS)")
+    }
+
+    func deactivate() {
+        awaitingAuthorization = false
+        guard state != .off else { return }
+
+        // Cancel conversation timeout before setting state to .off
+        // (didSet would cancel it too, but be explicit for clarity).
+        conversationTimeoutPaused = false
+        cancelConversationTimeout()
+
+        // Set state to .off BEFORE shutdown so that any synchronous
+        // ttsOnComplete callbacks (from stopSpeaking) won't re-enter
+        // startListening() during teardown.
+        state = .off
+
+        stopLiveVoiceObservation()
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = nil
+        if let liveVoiceChannelManager {
+            Task { @MainActor in
+                await liveVoiceChannelManager.end()
+            }
+        }
+        activeVoicePath = .turnBased
+        liveFallbackAttemptedForSession = false
+        liveVoicePausedForPermission = false
+
+        // Fully shut down audio engine to release the microphone
+        voiceService.shutdown()
+
+        voiceService.onSilenceDetected = nil
+        voiceService.onMicrophoneAuthorized = nil
+        voiceService.onBargeInDetected = nil
+
+        if let chatViewModel {
+            chatViewModel.onVoiceResponseComplete = previousOnVoiceResponseComplete
+            chatViewModel.onVoiceTextDelta = previousOnVoiceTextDelta
+            chatViewModel.isVoiceModeActive = false
+        }
+        previousOnVoiceResponseComplete = nil
+        previousOnVoiceTextDelta = nil
+        stopVoiceServiceObservation()
+        pendingPermissionIds = []
+
+        // Clear the conversation ID from the voice service.
+        if let service = voiceService as? OpenAIVoiceService {
+            service.conversationId = nil
+        }
+
+        chatViewModel = nil
+        settingsStore = nil
+        state = .off
+        partialTranscription = ""
+        liveTranscription = ""
+        inputAmplitude = 0
+        isMicrophoneMuted = false
+        isAssistantOutputMuted = false
+        log.info("Voice mode deactivated")
+    }
+
+    func toggleListening() {
+        switch state {
+        case .idle:
+            startListening()
+        case .listening:
+            stopListening()
+        case .speaking:
+            if activeVoicePath == .liveChannel {
+                interruptLiveVoiceAndStartListening()
+            } else {
+                handleBargeIn()
+            }
+        case .processing:
+            if activeVoicePath == .liveChannel {
+                interruptLiveVoiceAndStartListening()
+            }
+        default:
+            break
+        }
+    }
+
+    func startListening() {
+        guard state == .idle else { return }
+        if canStartLiveVoiceSession(for: chatViewModel),
+           let conversationId = liveVoiceConversationId(for: chatViewModel) {
+            startLiveVoiceListening(conversationId: conversationId)
+            return
+        }
+
+        startTurnBasedListeningWithAuthorization()
+    }
+
+    private func startTurnBasedListeningWithAuthorization() {
+        guard STTProviderRegistry.isServiceConfigured || speechRecognizerAdapter.authorizationStatus() == .authorized else {
+            requestTurnBasedSpeechAuthorizationThenStart()
+            return
+        }
+
+        startTurnBasedListening()
+    }
+
+    private func startTurnBasedListening() {
+        guard state == .idle else { return }
+        activeVoicePath = .turnBased
+        partialTranscription = ""
+        liveTranscription = ""
+        errorMessage = ""
+        state = .listening
+        guard voiceService.startRecording() else {
+            log.error("Voice mode: startRecording() failed — mic may not be available yet")
+            errorMessage = "Microphone not ready. Try again."
+            state = .idle
+            return
+        }
+        log.info("Voice mode: started listening")
+    }
+
+    private func stopListening() {
+        guard state == .listening else { return }
+
+        if activeVoicePath == .liveChannel {
+            let liveVoiceChannelManager = liveVoiceChannelManager
+            Task { @MainActor in
+                guard let liveVoiceChannelManager else { return }
+                await liveVoiceChannelManager.stopListening()
+                self.syncLiveVoiceState(from: liveVoiceChannelManager)
+            }
+            log.info("Voice mode: released live voice push-to-talk")
+            return
+        }
+
+        voiceService.cancelRecording()
+        state = .idle
+        log.info("Voice mode: stopped listening")
+    }
+
+    // MARK: - Voice Session Controls (mic mute, output mute)
+    //
+    // Shared entry points for any control surface — the in-app composer
+    // today, and platform surfaces such as an iOS Live Activity/Dynamic
+    // Island control or a spoken-command dispatcher in the future — so a
+    // control surface only needs to call through `VoiceModeManager` without
+    // knowing whether live voice is active or which manager backs it.
+
+    /// Mute or unmute the microphone for the active live voice session.
+    /// No-op when live voice is unavailable or not the active voice path.
+    func setMicrophoneMuted(_ muted: Bool) {
+        guard activeVoicePath == .liveChannel, let liveVoiceChannelManager else { return }
+        liveVoiceChannelManager.setMicrophoneMuted(muted)
+        isMicrophoneMuted = liveVoiceChannelManager.isMicrophoneMuted
+    }
+
+    /// Mute or unmute assistant speech playback for the active live voice
+    /// session. No-op when live voice is unavailable or not the active
+    /// voice path.
+    func setAssistantOutputMuted(_ muted: Bool) {
+        guard activeVoicePath == .liveChannel, let liveVoiceChannelManager else { return }
+        liveVoiceChannelManager.setAssistantOutputMuted(muted)
+        isAssistantOutputMuted = liveVoiceChannelManager.isAssistantOutputMuted
+    }
+
+    private func requestTurnBasedSpeechAuthorizationThenStart() {
+        let status = speechRecognizerAdapter.authorizationStatus()
+        guard status == .notDetermined else {
+            errorMessage = "Speech recognition permission is required for standard voice mode."
+            state = .idle
+            log.warning("Voice mode: standard voice fallback unavailable (speech status: \(status.rawValue))")
+            return
+        }
+
+        awaitingAuthorization = true
+        speechRecognizerAdapter.requestAuthorization { [weak self] newStatus in
+            Task { @MainActor in
+                guard let self, self.awaitingAuthorization, self.state == .idle else { return }
+                self.awaitingAuthorization = false
+                guard newStatus == .authorized else {
+                    self.errorMessage = "Speech recognition permission is required for standard voice mode."
+                    log.warning("Voice mode: speech recognition authorization denied during fallback")
+                    return
+                }
+                self.startTurnBasedListening()
+            }
+        }
+    }
+
+    private func liveVoiceConversationId(for chatViewModel: ChatViewModel?) -> String? {
+        guard let conversationId = chatViewModel?.conversationId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !conversationId.isEmpty else {
+            return nil
+        }
+        return conversationId
+    }
+
+    private func canStartLiveVoiceSession(for chatViewModel: ChatViewModel?) -> Bool {
+        liveVoiceChannelManager != nil
+            && liveVoiceAvailability()
+            && pendingPermissionIds.isEmpty
+            && liveVoiceConversationId(for: chatViewModel) != nil
+    }
+
+    private func startLiveVoiceListening(conversationId: String) {
+        guard let liveVoiceChannelManager else { return }
+
+        activeVoicePath = .liveChannel
+        liveFallbackAttemptedForSession = false
+        liveVoicePausedForPermission = false
+        partialTranscription = ""
+        liveTranscription = ""
+        inputAmplitude = 0
+        errorMessage = ""
+        state = .listening
+        startLiveVoiceObservation()
+
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = Task { @MainActor [weak self, weak liveVoiceChannelManager] in
+            guard let self, let liveVoiceChannelManager else { return }
+            await liveVoiceChannelManager.start(conversationId: conversationId)
+            guard !Task.isCancelled, self.activeVoicePath == .liveChannel else { return }
+            self.syncLiveVoiceState(from: liveVoiceChannelManager)
+        }
+        log.info("Voice mode: starting live voice channel")
+    }
+
+    private func startLiveVoiceObservation() {
+        liveVoiceObservationGeneration += 1
+        observeLiveVoiceLoop(generation: liveVoiceObservationGeneration)
+    }
+
+    private func stopLiveVoiceObservation() {
+        liveVoiceObservationGeneration += 1
+    }
+
+    private func observeLiveVoiceLoop(generation: Int) {
+        guard generation == liveVoiceObservationGeneration,
+              activeVoicePath == .liveChannel,
+              let liveVoiceChannelManager else { return }
+
+        withObservationTracking {
+            _ = liveVoiceChannelManager.state
+            _ = liveVoiceChannelManager.inputAmplitude
+            _ = liveVoiceChannelManager.partialTranscript
+            _ = liveVoiceChannelManager.finalTranscript
+            _ = liveVoiceChannelManager.errorMessage
+            _ = liveVoiceChannelManager.isMicrophoneMuted
+            _ = liveVoiceChannelManager.isAssistantOutputMuted
+        } onChange: { [weak self, weak liveVoiceChannelManager] in
+            Task { @MainActor [weak self, weak liveVoiceChannelManager] in
+                guard let self,
+                      let liveVoiceChannelManager,
+                      generation == self.liveVoiceObservationGeneration else { return }
+                self.syncLiveVoiceState(from: liveVoiceChannelManager)
+                self.observeLiveVoiceLoop(generation: generation)
+            }
+        }
+    }
+
+    private func syncLiveVoiceState(from liveVoiceChannelManager: any LiveVoiceChannelManaging) {
+        guard activeVoicePath == .liveChannel, state != .off else { return }
+
+        let visibleTranscript = liveVoiceChannelManager.partialTranscript.isEmpty
+            ? liveVoiceChannelManager.finalTranscript
+            : liveVoiceChannelManager.partialTranscript
+        if liveTranscription != visibleTranscript {
+            liveTranscription = visibleTranscript
+        }
+        if partialTranscription != liveVoiceChannelManager.finalTranscript {
+            partialTranscription = liveVoiceChannelManager.finalTranscript
+        }
+        if inputAmplitude != liveVoiceChannelManager.inputAmplitude {
+            inputAmplitude = liveVoiceChannelManager.inputAmplitude
+        }
+        if isMicrophoneMuted != liveVoiceChannelManager.isMicrophoneMuted {
+            isMicrophoneMuted = liveVoiceChannelManager.isMicrophoneMuted
+        }
+        if isAssistantOutputMuted != liveVoiceChannelManager.isAssistantOutputMuted {
+            isAssistantOutputMuted = liveVoiceChannelManager.isAssistantOutputMuted
+        }
+
+        switch liveVoiceChannelManager.state {
+        case .idle:
+            let wasListening = state == .listening
+            state = .idle
+            if !wasListening,
+               canStartLiveVoiceSession(for: chatViewModel),
+               let conversationId = liveVoiceConversationId(for: chatViewModel) {
+                startLiveVoiceListening(conversationId: conversationId)
+            }
+        case .connecting, .listening:
+            state = .listening
+        case .transcribing, .thinking, .ending:
+            state = .processing
+        case .speaking:
+            state = .speaking
+        case .failed:
+            handleLiveVoiceFailure(message: liveVoiceChannelManager.errorMessage)
+        }
+    }
+
+    private func handleLiveVoiceFailure(message: String) {
+        guard activeVoicePath == .liveChannel else { return }
+        stopLiveVoiceObservation()
+        liveVoicePausedForPermission = false
+
+        let fallbackMessage = message.isEmpty ? "Live voice is unavailable." : message
+        guard !liveFallbackAttemptedForSession else {
+            errorMessage = fallbackMessage
+            state = .idle
+            return
+        }
+
+        liveFallbackAttemptedForSession = true
+        activeVoicePath = .turnBased
+        errorMessage = "Live voice is unavailable. Using standard voice mode."
+        state = .idle
+        log.warning("Voice mode: live channel failed, falling back to standard voice mode — \(fallbackMessage, privacy: .public)")
+        startTurnBasedListeningWithAuthorization()
+    }
+
+    private func pauseLiveVoiceForTurnBasedPermission() {
+        guard activeVoicePath == .liveChannel else { return }
+
+        stopLiveVoiceObservation()
+        liveVoiceStartTask?.cancel()
+        liveVoiceStartTask = nil
+        activeVoicePath = .turnBased
+        liveVoicePausedForPermission = true
+    }
+
+    private func resumeLiveVoiceAfterPermissionIfNeeded() {
+        guard liveVoicePausedForPermission else { return }
+        liveVoicePausedForPermission = false
+        guard let liveVoiceChannelManager else { return }
+
+        activeVoicePath = .liveChannel
+        startLiveVoiceObservation()
+        syncLiveVoiceState(from: liveVoiceChannelManager)
+    }
+
+    // MARK: - Silence Detection → Transcription
+
+    private func handleSilenceDetected() {
+        guard state == .listening else { return }
+
+        state = .processing
+        log.info("Voice mode: silence detected, getting transcription")
+
+        // Reset streaming TTS state for the new turn
+        voiceService.resetStreamingTTS()
+
+        Task {
+            let text = await voiceService.stopRecordingAndGetTranscription()
+            let trimmed = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !trimmed.isEmpty, let chatViewModel else {
+                state = .idle
+                return
+            }
+
+            // If we're awaiting a permission response, handle it separately
+            if !self.pendingPermissionIds.isEmpty {
+                self.partialTranscription = trimmed
+                self.handlePermissionResponse(trimmed)
+                return
+            }
+
+            partialTranscription = trimmed
+
+            chatViewModel.pendingVoiceMessage = true
+            chatViewModel.inputText = trimmed
+            chatViewModel.sendMessage()
+            log.info("Voice mode: sent transcription to chat via daemon")
+        }
+    }
+
+    // MARK: - Streaming TTS from daemon response
+
+    private func handleTextDelta(_ delta: String) {
+        guard state == .processing || state == .speaking else { return }
+        guard pendingPermissionIds.isEmpty else { return }
+
+        // Transition to speaking on first delta
+        if state == .processing {
+            state = .speaking
+            log.info("Voice mode: first text delta, starting streaming TTS")
+        }
+
+        voiceService.feedTextDelta(delta)
+    }
+
+    private func handleResponseComplete() {
+        log.info("Voice mode: response complete, flushing remaining TTS")
+
+        // If we never got any text deltas (empty response), go back to idle
+        if state == .processing {
+            state = .idle
+            partialTranscription = ""
+            startListening()
+            return
+        }
+
+        guard state == .speaking else { return }
+
+        // Safety timeout: if TTS completion doesn't fire within 15s, recover
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard let self, !Task.isCancelled, self.state == .speaking else { return }
+            log.warning("Voice mode: TTS timeout, recovering to idle")
+            self.voiceService.stopSpeaking()
+            self.state = .idle
+            self.partialTranscription = ""
+            self.startListening()
+        }
+
+        // Start monitoring mic for barge-in BEFORE finishTextStream,
+        // because finishTextStream may complete synchronously (e.g. TTS not configured)
+        // and its completion calls startListening() which installs a recording tap.
+        // Starting barge-in after that would install a conflicting second tap.
+        voiceService.startBargeInMonitor()
+
+        voiceService.finishTextStream { [weak self] in
+            guard let self, self.state == .speaking else { return }
+            self.ttsTimeoutTask?.cancel()
+            self.ttsTimeoutTask = nil
+            self.voiceService.stopBargeInMonitor()
+            self.state = .idle
+            self.partialTranscription = ""
+            // Auto-start listening for the next turn
+            self.startListening()
+        }
+    }
+
+    // MARK: - Voice-Driven Permission Handling
+
+    private func checkForConfirmations(in messages: [ChatMessage]) {
+        guard pendingPermissionIds.isEmpty else { return }
+        guard state == .processing || state == .speaking || state == .idle || state == .listening else { return }
+
+        let pending = messages
+            .compactMap { $0.confirmation }
+            .filter { $0.state == .pending }
+
+        guard !pending.isEmpty else { return }
+
+        pendingPermissionIds = pending.map { $0.requestId }
+
+        let wasUsingLiveVoice = activeVoicePath == .liveChannel
+        if wasUsingLiveVoice {
+            pauseLiveVoiceForTurnBasedPermission()
+        }
+
+        // Stop any current activity before speaking the permission prompt
+        switch state {
+        case .speaking:
+            // Set state to .processing first so ttsOnComplete callback (from stopSpeaking)
+            // won't auto-transition to idle/listening
+            ttsTimeoutTask?.cancel()
+            ttsTimeoutTask = nil
+            state = .processing
+            if !wasUsingLiveVoice {
+                voiceService.stopSpeaking()
+            }
+        case .listening:
+            if wasUsingLiveVoice {
+                state = .processing
+            } else {
+                voiceService.cancelRecording()
+            }
+        default:
+            break
+        }
+
+        speakPermissionSummary(pending)
+    }
+
+    private func speakPermissionSummary(_ confirmations: [ToolConfirmationData]) {
+        let summary = generatePermissionSummary(confirmations)
+        log.info("Voice mode: asking permission via voice — \(summary, privacy: .public)")
+
+        state = .speaking
+        voiceService.resetStreamingTTS()
+        voiceService.feedTextDelta(summary)
+
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard let self, !Task.isCancelled, self.state == .speaking else { return }
+            log.warning("Voice mode: permission TTS timeout, recovering")
+            self.voiceService.stopSpeaking()
+            self.state = .idle
+            self.startListening()
+        }
+
+        voiceService.finishTextStream { [weak self] in
+            guard let self, self.state == .speaking else { return }
+            self.ttsTimeoutTask?.cancel()
+            self.ttsTimeoutTask = nil
+            self.voiceService.stopBargeInMonitor()
+            self.state = .idle
+            self.startListening()
+        }
+    }
+
+    private static let permissionPhrases: [(String) -> String] = [
+        { "Sure thing! To do that, I'll need to \($0). Can I go ahead?" },
+        { "Yeah let me try! I just need access to \($0). Is that okay?" },
+        { "On it! To do what you're asking I need to \($0). Want me to?" },
+    ]
+    private var lastPhraseIndex = -1
+
+    func generatePermissionSummary(_ confirmations: [ToolConfirmationData]) -> String {
+        let descriptions = confirmations.map { describeAction($0) }
+        let unique = Array(Set(descriptions))
+
+        let actions: String
+        if unique.count == 1 {
+            actions = unique[0]
+        } else if unique.count == 2 {
+            actions = "\(unique[0]), and then \(unique[1])"
+        } else {
+            actions = unique.dropLast().joined(separator: ", ") + ", and \(unique.last!)"
+        }
+
+        // Rotate through phrases so it doesn't sound repetitive
+        var idx = Int.random(in: 0..<Self.permissionPhrases.count)
+        if idx == lastPhraseIndex { idx = (idx + 1) % Self.permissionPhrases.count }
+        lastPhraseIndex = idx
+        return Self.permissionPhrases[idx](actions)
+    }
+
+    /// Produce a short, non-technical voice description for a single tool action.
+    func describeAction(_ confirmation: ToolConfirmationData) -> String {
+        let reason = (confirmation.input["reason"]?.value as? String) ?? ""
+
+        // If the model provided a reason, use it directly — it's already high-level.
+        if !reason.isEmpty {
+            return reason.prefix(1).lowercased() + reason.dropFirst()
+        }
+
+        // Fall back to tool-specific descriptions
+        switch confirmation.toolName {
+        case "bash", "host_bash":
+            let cmd = (confirmation.input["command"]?.value as? String) ?? ""
+            if cmd.hasPrefix("open ") { return "open an app for you" }
+            if cmd.contains("osascript") { return "run a quick script on your Mac" }
+            return "run something on your Mac"
+        case "file_write", "host_file_write":
+            let path = (confirmation.input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "create a file for you" }
+            return "create a file called \(URL(fileURLWithPath: path).lastPathComponent)"
+        case "file_edit", "host_file_edit":
+            let path = (confirmation.input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "make some changes to a file" }
+            return "make some changes to \(URL(fileURLWithPath: path).lastPathComponent)"
+        case "file_read", "host_file_read":
+            let path = (confirmation.input["path"]?.value as? String) ?? ""
+            if path.isEmpty { return "take a look at a file" }
+            return "take a look at \(URL(fileURLWithPath: path).lastPathComponent)"
+        case "web_fetch":
+            let url = (confirmation.input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host { return "grab some info from \(host)" }
+            return "look something up online"
+        case "browser_navigate":
+            let url = (confirmation.input["url"]?.value as? String) ?? ""
+            if let host = URL(string: url)?.host { return "open up \(host)" }
+            return "open up a webpage"
+        default:
+            return confirmation.toolCategory.lowercased()
+        }
+    }
+
+    /// Classify a voice response into a specific permission decision.
+    enum PermissionDecision {
+        case allow
+        case denied
+        case ambiguous
+
+        /// The decision string sent to the daemon via HTTP.
+        var decisionString: String {
+            switch self {
+            case .allow: return "allow"
+            case .denied: return "deny"
+            case .ambiguous: return "deny"
+            }
+        }
+    }
+
+    static func classifyPermissionResponse(_ text: String) -> PermissionDecision {
+        let lower = text.lowercased()
+
+        let negative = ["no", "nope", "don't", "deny", "stop", "cancel", "reject"]
+        let hasNegative = negative.contains(where: { lower.contains($0) })
+
+        // Generic approval
+        let affirmative = ["yes", "yeah", "yep", "go ahead", "allow", "approve",
+                           "sure", "okay", "ok", "do it", "proceed"]
+        let hasAffirmative = affirmative.contains(where: { lower.contains($0) })
+
+        // If both affirmative and negative substrings match (e.g. "no, don't do it"
+        // contains "do it" + "no"/"don't"), treat as denial for safety.
+        if hasAffirmative && !hasNegative { return .allow }
+        if hasNegative { return .denied }
+        return .ambiguous
+    }
+
+    private func handlePermissionResponse(_ text: String) {
+        let decision = Self.classifyPermissionResponse(text)
+
+        guard let chatViewModel else {
+            pendingPermissionIds = []
+            state = .idle
+            return
+        }
+
+        switch decision {
+        case .allow:
+            log.info("Voice mode: permissions \(decision.decisionString, privacy: .public) via voice")
+            for requestId in pendingPermissionIds {
+                chatViewModel.respondToConfirmation(requestId: requestId, decision: decision.decisionString)
+            }
+            pendingPermissionIds = []
+            partialTranscription = ""
+            resumeLiveVoiceAfterPermissionIfNeeded()
+            state = .processing
+        case .denied:
+            log.info("Voice mode: permissions denied via voice")
+            for requestId in pendingPermissionIds {
+                chatViewModel.respondToConfirmation(requestId: requestId, decision: "deny")
+            }
+            pendingPermissionIds = []
+            partialTranscription = ""
+            resumeLiveVoiceAfterPermissionIfNeeded()
+            state = .processing
+        case .ambiguous:
+            log.info("Voice mode: unclear permission response — \(text, privacy: .public)")
+            state = .speaking
+            voiceService.resetStreamingTTS()
+            voiceService.feedTextDelta("Sorry, I didn't quite catch that. You can say yes to allow or no to deny.")
+            voiceService.finishTextStream { [weak self] in
+                guard let self else { return }
+                self.voiceService.stopBargeInMonitor()
+                self.state = .idle
+                self.startListening()
+            }
+        }
+    }
+
+    // MARK: - Voice Service Observation
+
+    /// Start observing the voice service's livePartialText. Called during activation.
+    private func startVoiceServiceObservation() {
+        voiceObservationGeneration += 1
+        observeVoiceServiceLoop(generation: voiceObservationGeneration)
+    }
+
+    /// Stop observing. Called from deactivate().
+    private func stopVoiceServiceObservation() {
+        voiceObservationGeneration += 1  // invalidates any in-flight re-arm
+    }
+
+    private func observeVoiceServiceLoop(generation: Int) {
+        guard generation == voiceObservationGeneration,
+              let service = openAIVoiceService else { return }
+        withObservationTracking {
+            _ = service.livePartialText
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      generation == self.voiceObservationGeneration else { return }
+                // Only update liveTranscription while actively listening.
+                // Always re-arm so the loop survives state transitions
+                // (e.g., .processing clears partial text but we need to
+                // keep observing for the next .listening turn).
+                if self.state == .listening,
+                   let service = self.openAIVoiceService {
+                    self.liveTranscription = service.livePartialText
+                }
+                self.observeVoiceServiceLoop(generation: generation) // re-arm
+            }
+        }
+    }
+
+    // MARK: - Message & Thinking Observation
+
+    private func observeMessages(generation: Int, messageManager: ChatMessageManager) {
+        guard generation == voiceObservationGeneration else { return }
+        // Check current state immediately so confirmations already pending
+        // before voice activation are spoken without waiting for the next
+        // messages mutation.
+        checkForConfirmations(in: messageManager.messages)
+        withObservationTracking {
+            _ = messageManager.messages
+        } onChange: { [weak self, weak messageManager] in
+            Task { @MainActor [weak self, weak messageManager] in
+                guard let self, let messageManager,
+                      generation == self.voiceObservationGeneration else { return }
+                self.checkForConfirmations(in: messageManager.messages)
+                self.observeMessages(generation: generation, messageManager: messageManager)
+            }
+        }
+    }
+
+    private func observeIsThinking(generation: Int, messageManager: ChatMessageManager) {
+        guard generation == voiceObservationGeneration else { return }
+        // Seed deduplication state so we only act on actual transitions.
+        lastObservedIsThinking = messageManager.isThinking
+        withObservationTracking {
+            _ = messageManager.isThinking
+        } onChange: { [weak self, weak messageManager] in
+            Task { @MainActor [weak self, weak messageManager] in
+                guard let self, let messageManager,
+                      generation == self.voiceObservationGeneration else { return }
+                let thinking = messageManager.isThinking
+                // Deduplicate redundant same-value writes (equivalent to
+                // the removed Combine .removeDuplicates()).
+                guard thinking != self.lastObservedIsThinking else {
+                    self.observeIsThinking(generation: generation, messageManager: messageManager)
+                    return
+                }
+                self.lastObservedIsThinking = thinking
+                guard self.state == .idle else {
+                    self.observeIsThinking(generation: generation, messageManager: messageManager)
+                    return
+                }
+                if thinking {
+                    self.cancelConversationTimeout()
+                } else if !self.conversationTimeoutPaused {
+                    self.startConversationTimeout()
+                }
+                self.observeIsThinking(generation: generation, messageManager: messageManager)
+            }
+        }
+    }
+
+    // MARK: - Conversation Timeout
+
+    private func handleStateTransition(from oldState: State, to newState: State) {
+        guard oldState != newState else { return }
+
+        if newState == .idle {
+            // Don't start the timeout if the agent is currently executing tools —
+            // the isThinking observer will restart it when thinking completes.
+            // Also skip if the timeout is paused (e.g., during CU escalation).
+            if !conversationTimeoutPaused && chatViewModel?.isThinking != true {
+                startConversationTimeout()
+            }
+        } else {
+            cancelConversationTimeout()
+        }
+    }
+
+    private func startConversationTimeout() {
+        cancelConversationTimeout()
+        // Read the override each time so daemon broadcasts take effect immediately.
+        // Fall back to UserDefaults so the user's last-configured value survives
+        // app restarts (before the daemon sends a client_settings_update).
+        let interval: TimeInterval
+        if let override = Self.conversationTimeoutOverride, override > 0 {
+            interval = TimeInterval(override)
+        } else if let stored = UserDefaults.standard.object(forKey: "voiceConversationTimeoutSeconds") as? Int, stored > 0 {
+            interval = TimeInterval(stored)
+        } else {
+            interval = conversationTimeoutInterval
+        }
+        let clampedInterval = max(1.0, interval.isFinite ? interval : 30.0)
+        conversationTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(clampedInterval * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            // Only auto-deactivate if we're still in an active session
+            guard self.state == .idle, self.chatViewModel != nil else { return }
+            log.info("Voice mode: conversation timeout — auto-deactivating")
+            self.wasAutoDeactivated = true
+            self.deactivate()
+        }
+    }
+
+    private func cancelConversationTimeout() {
+        conversationTimeoutTask?.cancel()
+        conversationTimeoutTask = nil
+    }
+
+    // MARK: - Transient Speech & Timeout Control
+
+    /// Speak a one-off message using the TTS system without affecting the voice
+    /// mode state machine. The message is spoken and then the state returns to
+    /// whatever it was before. Callers can use this to provide audible feedback
+    /// (e.g., announcing a computer use escalation) without disrupting the
+    /// conversation flow.
+    func speakTransient(_ message: String) {
+        guard state != .off else { return }
+        log.info("Voice mode: transient speech — \(message, privacy: .public)")
+
+        // Stop any in-progress recording so the TTS output isn't picked up
+        // by the microphone as input.
+        if state == .listening {
+            voiceService.cancelRecording()
+        }
+
+        let previousState = state
+        state = .speaking
+        voiceService.resetStreamingTTS()
+        voiceService.feedTextDelta(message)
+
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard let self, !Task.isCancelled, self.state == .speaking else { return }
+            log.warning("Voice mode: transient speech timeout, recovering")
+            self.voiceService.stopSpeaking()
+            self.state = previousState == .listening ? .idle : previousState
+        }
+
+        voiceService.finishTextStream { [weak self] in
+            guard let self, self.state == .speaking else { return }
+            self.ttsTimeoutTask?.cancel()
+            self.ttsTimeoutTask = nil
+            self.voiceService.stopBargeInMonitor()
+            // Return to idle rather than the previous state so the conversation
+            // timeout logic is properly re-engaged via handleStateTransition.
+            self.state = .idle
+        }
+    }
+
+    /// Pause the conversation timeout timer. Use this when the assistant is
+    /// performing a long-running operation (e.g., computer use) and the
+    /// conversation should not auto-deactivate.
+    func pauseConversationTimeout() {
+        log.info("Voice mode: conversation timeout paused")
+        conversationTimeoutPaused = true
+        cancelConversationTimeout()
+    }
+
+    /// Resume the conversation timeout timer. Call this after a long-running
+    /// operation completes so idle auto-deactivation can kick in again.
+    func resumeConversationTimeout() {
+        log.info("Voice mode: conversation timeout resumed")
+        // Clear the paused flag BEFORE the state guard so that when
+        // speakTransient finishes and transitions to .idle,
+        // handleStateTransition will properly restart the timeout.
+        conversationTimeoutPaused = false
+        guard state == .idle else { return }
+        startConversationTimeout()
+    }
+
+    // MARK: - Barge-in (interrupt TTS)
+
+    private func interruptLiveVoiceAndStartListening() {
+        guard activeVoicePath == .liveChannel,
+              let liveVoiceChannelManager,
+              let conversationId = liveVoiceConversationId(for: chatViewModel) else { return }
+
+        log.info("Voice mode: live voice resume — interrupting current turn")
+
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = nil
+        liveVoiceStartTask?.cancel()
+        partialTranscription = ""
+        liveTranscription = ""
+        errorMessage = ""
+        activeVoicePath = .liveChannel
+        state = .listening
+        startLiveVoiceObservation()
+
+        liveVoiceStartTask = Task { @MainActor [weak self, weak liveVoiceChannelManager] in
+            guard let self, let liveVoiceChannelManager else { return }
+            await liveVoiceChannelManager.interruptSpeakingAndStartListening(conversationId: conversationId)
+            guard !Task.isCancelled, self.activeVoicePath == .liveChannel else { return }
+            self.syncLiveVoiceState(from: liveVoiceChannelManager)
+        }
+    }
+
+    private func handleBargeIn() {
+        guard state == .speaking else { return }
+        log.info("Voice mode: barge-in — interrupting TTS")
+
+        ttsTimeoutTask?.cancel()
+        ttsTimeoutTask = nil
+        voiceService.stopSpeaking()
+        state = .idle
+        partialTranscription = ""
+        // Immediately start listening so the user's speech is captured
+        startListening()
+    }
+}

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -1,0 +1,723 @@
+import Foundation
+import Observation
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+private final class FakeLiveVoiceChannelClient: LiveVoiceChannelClientProtocol, @unchecked Sendable {
+    private(set) var startCalls: [(conversationId: String?, audioFormat: LiveVoiceChannelAudioFormat)] = []
+    private(set) var audioFrames: [Data] = []
+    private(set) var releasePushToTalkCallCount = 0
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var closeCallCount = 0
+
+    private var onEvent: (@MainActor (LiveVoiceChannelEvent) -> Void)?
+    private var onFailure: (@MainActor (LiveVoiceChannelFailure) -> Void)?
+
+    func start(
+        conversationId: String?,
+        audioFormat: LiveVoiceChannelAudioFormat,
+        onEvent: @escaping @MainActor (LiveVoiceChannelEvent) -> Void,
+        onFailure: @escaping @MainActor (LiveVoiceChannelFailure) -> Void
+    ) async {
+        startCalls.append((conversationId, audioFormat))
+        self.onEvent = onEvent
+        self.onFailure = onFailure
+    }
+
+    func sendAudio(_ data: Data) async {
+        audioFrames.append(data)
+    }
+
+    func releasePushToTalk() async {
+        releasePushToTalkCallCount += 1
+    }
+
+    func interrupt() async {
+        interruptCallCount += 1
+    }
+
+    func end() async {
+        endCallCount += 1
+    }
+
+    func close() async {
+        closeCallCount += 1
+    }
+
+    func emit(_ event: LiveVoiceChannelEvent) {
+        onEvent?(event)
+    }
+
+    func fail(_ failure: LiveVoiceChannelFailure) {
+        onFailure?(failure)
+    }
+}
+
+private final class FakeLiveVoiceAudioCapture: LiveVoiceAudioCapturing {
+    var startResult = true
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var shutdownCallCount = 0
+
+    private var onChunk: ((LiveVoiceAudioCaptureChunk) -> Void)?
+
+    func start(onChunk: @escaping (LiveVoiceAudioCaptureChunk) -> Void) async -> Bool {
+        startCallCount += 1
+        self.onChunk = onChunk
+        return startResult
+    }
+
+    func stop() {
+        stopCallCount += 1
+        onChunk = nil
+    }
+
+    func shutdown() {
+        shutdownCallCount += 1
+        onChunk = nil
+    }
+
+    func emitChunk(
+        data: Data = Data([1, 2, 3, 4]),
+        sampleRate: Int = 16_000,
+        channelCount: Int = 1,
+        frameCount: Int = 2,
+        amplitude: Float = 0.01
+    ) {
+        onChunk?(
+            LiveVoiceAudioCaptureChunk(
+                pcm16LittleEndian: data,
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                amplitude: amplitude
+            )
+        )
+    }
+}
+
+@MainActor
+private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
+    private(set) var enqueuedChunks: [LiveVoiceAudioChunk] = []
+    private(set) var interruptCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var sessionErrorCallCount = 0
+    private(set) var resetCallCount = 0
+
+    var isPlaying = false
+    private var playbackWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func enqueueTTSAudio(
+        data: Data,
+        mimeType: String,
+        sampleRate: Int,
+        channels: Int
+    ) {
+        enqueuedChunks.append(
+            LiveVoiceAudioChunk(
+                data: data,
+                mimeType: mimeType,
+                sampleRate: sampleRate,
+                channels: channels
+            )
+        )
+        isPlaying = true
+    }
+
+    func handleInterrupt() {
+        interruptCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func handleEnd() {
+        endCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func handleSessionError() {
+        sessionErrorCallCount += 1
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func resetForNextResponse() {
+        resetCallCount += 1
+        enqueuedChunks.removeAll()
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func waitUntilPlaybackFinishes() async {
+        guard isPlaying else { return }
+
+        await withCheckedContinuation { continuation in
+            playbackWaiters.append(continuation)
+        }
+    }
+
+    func finishPlayback() {
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    private func notifyPlaybackWaiters() {
+        guard !isPlaying else { return }
+
+        let waiters = playbackWaiters
+        playbackWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}
+
+@MainActor
+final class LiveVoiceChannelManagerTests: XCTestCase {
+    private var client: FakeLiveVoiceChannelClient!
+    private var capture: FakeLiveVoiceAudioCapture!
+    private var playback: FakeLiveVoiceAudioPlayback!
+    private var manager: LiveVoiceChannelManager!
+
+    override func setUp() {
+        super.setUp()
+        client = FakeLiveVoiceChannelClient()
+        capture = FakeLiveVoiceAudioCapture()
+        playback = FakeLiveVoiceAudioPlayback()
+        manager = LiveVoiceChannelManager(
+            clientFactory: { [client] in client! },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+    }
+
+    override func tearDown() {
+        manager = nil
+        playback = nil
+        capture = nil
+        client = nil
+        super.tearDown()
+    }
+
+    func testStartOpensClientAndStartsCaptureAfterReady() async {
+        await manager.start(conversationId: " conv-123 ")
+
+        XCTAssertEqual(manager.state, .connecting)
+        XCTAssertEqual(manager.activeConversationId, "conv-123")
+        XCTAssertEqual(client.startCalls.count, 1)
+        XCTAssertEqual(client.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(client.startCalls[0].audioFormat, .pcm16kMono)
+        XCTAssertEqual(capture.startCallCount, 0)
+
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.sessionId, "session-123")
+        XCTAssertEqual(capture.startCallCount, 1)
+    }
+
+    func testAudioChunksStreamWithoutMutatingObservedState() async {
+        await startReadySession()
+
+        let observedInvalidations = ObservationCounter()
+        withObservationTracking {
+            _ = manager.state
+            _ = manager.partialTranscript
+            _ = manager.finalTranscript
+            _ = manager.assistantTranscript
+        } onChange: {
+            Task { @MainActor in observedInvalidations.increment() }
+        }
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.01)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.01)
+        capture.emitChunk(data: Data([5, 6]), amplitude: 0.01)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4]), Data([5, 6])])
+        XCTAssertEqual(observedInvalidations.value, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testInputAmplitudeTracksCaptureAndResetsWhenStopped() async {
+        await startReadySession()
+
+        capture.emitChunk(data: Data([1, 2]), frameCount: 1_600, amplitude: 0.4)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.inputAmplitude, 0.4)
+
+        await manager.stopListening()
+
+        XCTAssertEqual(manager.inputAmplitude, 0)
+    }
+
+    func testInitialSilenceDoesNotAutomaticallyReleasePushToTalk() async {
+        await startReadySession()
+
+        for _ in 0..<20 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 0)
+        XCTAssertEqual(capture.stopCallCount, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testSpeechThenSilenceAutomaticallyReleasesPushToTalk() async {
+        await startReadySession()
+
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        for _ in 0..<11 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
+    func testStopListeningSendsPushToTalkRelease() async {
+        await startReadySession()
+
+        await manager.stopListening()
+
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
+    func testSttEventsKeepListeningWhileCaptureRuns() async {
+        await startReadySession()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testSttEventsUpdateProcessingStateAfterPushToTalkRelease() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .transcribing)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .thinking)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testAssistantSpeechStreamsToPlaybackAndClosesSessionAfterTtsDone() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.assistantTextDelta(text: "Hi", seq: 3))
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.assistantTranscript, "Hi")
+        XCTAssertEqual(playback.resetCallCount, 1)
+        XCTAssertEqual(playback.enqueuedChunks.count, 1)
+        XCTAssertEqual(playback.enqueuedChunks[0].data, Data([9, 8]))
+        XCTAssertEqual(playback.enqueuedChunks[0].mimeType, "audio/pcm")
+        XCTAssertEqual(playback.enqueuedChunks[0].sampleRate, 16_000)
+
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertNotNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 0)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testTtsDoneWithoutQueuedPlaybackClosesSessionImmediately() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testManualBargeInBeforePlaybackFinishesInterruptsInsteadOfAutoClosing() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        firstClient.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(firstClient.closeCallCount, 0)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+    }
+
+    func testSpeakingOverAssistantAudioSendsInterruptOnce() async {
+        await startReadySession()
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertTrue(playback.isPlaying)
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.5)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.7)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(client.interruptCallCount, 1)
+        XCTAssertEqual(client.audioFrames, [Data([1, 2]), Data([3, 4])])
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testManualBargeInInterruptsAndStartsFreshSession() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(manager.state, .connecting)
+
+        secondClient.emit(.ready(sessionId: "session-2", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(capture.startCallCount, 2)
+    }
+
+    func testManualResumeWhileThinkingInterruptsAndStartsFreshSession() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.thinking(turnId: "turn-1"))
+
+        XCTAssertEqual(manager.state, .thinking)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(manager.state, .connecting)
+
+        secondClient.emit(.ready(sessionId: "session-2", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(capture.startCallCount, 2)
+    }
+
+    func testEndCleansUpResourcesAndReturnsToIdle() async {
+        await startReadySession()
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        await manager.end()
+
+        XCTAssertEqual(client.endCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.endCallCount, 1)
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.activeConversationId)
+        XCTAssertNil(manager.sessionId)
+    }
+
+    func testNextStartCreatesFreshClientAfterTtsDone() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsDone(turnId: "turn-1"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+
+        await manager.start(conversationId: "conv-123")
+
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(firstClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+    }
+
+    func testFailureCleansUpResourcesAndStoresError() async {
+        await startReadySession()
+
+        client.fail(.connectionFailed(message: "connection dropped"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "connection dropped")
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testCaptureStartFailureFailsSession() async {
+        capture.startResult = false
+
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .failed)
+        XCTAssertEqual(manager.errorMessage, "Microphone capture could not start.")
+        XCTAssertEqual(playback.sessionErrorCallCount, 1)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    // MARK: - Voice Session Controls (mic mute, assistant-output mute)
+
+    func testMicrophoneMuteSuppressesOutgoingAudioWhileKeepingCaptureRunning() async {
+        await startReadySession()
+
+        manager.setMicrophoneMuted(true)
+        XCTAssertTrue(manager.isMicrophoneMuted)
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.4)
+        await flushAsyncTasks()
+
+        XCTAssertTrue(client.audioFrames.isEmpty)
+        XCTAssertEqual(manager.inputAmplitude, 0)
+        XCTAssertEqual(capture.stopCallCount, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testMicrophoneMuteSuppressesAutomaticPushToTalkReleaseAndBargeIn() async {
+        await startReadySession()
+        manager.setMicrophoneMuted(true)
+
+        // Speech-then-silence pattern that would normally auto-release push-to-talk.
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        for _ in 0..<11 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 0)
+        XCTAssertEqual(manager.state, .listening)
+
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        XCTAssertEqual(manager.state, .speaking)
+
+        // A loud chunk would normally trigger barge-in over assistant audio.
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.9)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(playback.interruptCallCount, 0)
+        XCTAssertEqual(client.interruptCallCount, 0)
+        XCTAssertEqual(manager.state, .speaking)
+    }
+
+    func testUnmutingMicrophoneResumesSendingAudio() async {
+        await startReadySession()
+        manager.setMicrophoneMuted(true)
+
+        capture.emitChunk(data: Data([1, 2]), amplitude: 0.4)
+        await flushAsyncTasks()
+        XCTAssertTrue(client.audioFrames.isEmpty)
+
+        manager.setMicrophoneMuted(false)
+        capture.emitChunk(data: Data([3, 4]), amplitude: 0.4)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.audioFrames, [Data([3, 4])])
+        XCTAssertEqual(manager.inputAmplitude, 0.4)
+    }
+
+    func testAssistantOutputMuteSuppressesPlaybackButKeepsSessionStateAndTranscript() async {
+        await startReadySession()
+        await manager.stopListening()
+        manager.setAssistantOutputMuted(true)
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.assistantTextDelta(text: "Hi", seq: 3))
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.assistantTranscript, "Hi")
+        XCTAssertTrue(playback.enqueuedChunks.isEmpty)
+        XCTAssertEqual(playback.resetCallCount, 1)
+
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testUnmutingAssistantOutputResumesPlaybackForSubsequentChunks() async {
+        await startReadySession()
+        await manager.stopListening()
+        manager.setAssistantOutputMuted(true)
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.ttsAudio(data: Data([1]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 1))
+        XCTAssertTrue(playback.enqueuedChunks.isEmpty)
+
+        manager.setAssistantOutputMuted(false)
+        client.emit(.ttsAudio(data: Data([2]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 2))
+
+        XCTAssertEqual(playback.enqueuedChunks.count, 1)
+        XCTAssertEqual(playback.enqueuedChunks[0].data, Data([2]))
+    }
+
+    func testEndResetsMuteState() async {
+        await startReadySession()
+        manager.setMicrophoneMuted(true)
+        manager.setAssistantOutputMuted(true)
+
+        await manager.end()
+
+        XCTAssertFalse(manager.isMicrophoneMuted)
+        XCTAssertFalse(manager.isAssistantOutputMuted)
+    }
+
+    /// Proves the mute/end controls form a shared foundation: a control
+    /// surface (composer UI, a future Live Activity intent handler, a
+    /// future spoken-command dispatcher) can drive them through
+    /// `VoiceSessionControlling` alone, without depending on
+    /// `LiveVoiceChannelManager` directly.
+    func testMuteControlsAreUsableThroughVoiceSessionControllingProtocol() async {
+        await startReadySession()
+
+        let controls: any VoiceSessionControlling = manager
+        controls.setMicrophoneMuted(true)
+        controls.setAssistantOutputMuted(true)
+
+        XCTAssertTrue(controls.isMicrophoneMuted)
+        XCTAssertTrue(controls.isAssistantOutputMuted)
+        XCTAssertTrue(manager.isMicrophoneMuted)
+        XCTAssertTrue(manager.isAssistantOutputMuted)
+
+        await controls.end()
+        XCTAssertEqual(client.endCallCount, 1)
+    }
+
+    private func startReadySession() async {
+        await manager.start(conversationId: "conv-123")
+        client.emit(.ready(sessionId: "session-123", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    private func flushAsyncTasks() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
+@MainActor
+private final class ObservationCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -1,0 +1,1154 @@
+import XCTest
+import Observation
+import Speech
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Controllable mock of `SpeechRecognizerAdapter` for testing
+/// VoiceModeManager's activation guard with and without speech auth.
+private final class MockSpeechRecognizerAdapter: SpeechRecognizerAdapter {
+    var stubbedAuthorizationStatus: SFSpeechRecognizerAuthorizationStatus = .authorized
+    var stubbedRecognizer: SFSpeechRecognizer? = nil
+    var stubbedIsRecognizerAvailable: Bool = true
+    var requestAuthorizationResult: SFSpeechRecognizerAuthorizationStatus = .authorized
+    var requestAuthorizationCallCount = 0
+
+    func authorizationStatus() -> SFSpeechRecognizerAuthorizationStatus {
+        stubbedAuthorizationStatus
+    }
+
+    func requestAuthorization(completion: @escaping @Sendable (SFSpeechRecognizerAuthorizationStatus) -> Void) {
+        requestAuthorizationCallCount += 1
+        completion(requestAuthorizationResult)
+    }
+
+    func makeRecognizer(locale: Locale) -> SFSpeechRecognizer? {
+        stubbedRecognizer
+    }
+
+    var isRecognizerAvailable: Bool {
+        stubbedIsRecognizerAvailable
+    }
+}
+
+@MainActor
+@Observable
+private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
+    var state: LiveVoiceChannelManager.State = .idle
+    var inputAmplitude: Float = 0
+    var partialTranscript: String = ""
+    var finalTranscript: String = ""
+    var errorMessage: String = ""
+    var isMicrophoneMuted: Bool = false
+    var isAssistantOutputMuted: Bool = false
+
+    private(set) var startCalls: [String] = []
+    private(set) var interruptSpeakingAndStartListeningCalls: [String] = []
+    private(set) var stopListeningCallCount = 0
+    private(set) var endCallCount = 0
+    private(set) var setMicrophoneMutedCalls: [Bool] = []
+    private(set) var setAssistantOutputMutedCalls: [Bool] = []
+    var stopListeningUpdatesState = true
+
+    func start(conversationId: String) async {
+        startCalls.append(conversationId)
+        state = .connecting
+    }
+
+    func interruptSpeakingAndStartListening(conversationId: String) async {
+        interruptSpeakingAndStartListeningCalls.append(conversationId)
+        state = .listening
+    }
+
+    func stopListening() async {
+        stopListeningCallCount += 1
+        if stopListeningUpdatesState {
+            state = .transcribing
+        }
+    }
+
+    func end() async {
+        endCallCount += 1
+        state = .idle
+    }
+
+    func setMicrophoneMuted(_ muted: Bool) {
+        setMicrophoneMutedCalls.append(muted)
+        isMicrophoneMuted = muted
+    }
+
+    func setAssistantOutputMuted(_ muted: Bool) {
+        setAssistantOutputMutedCalls.append(muted)
+        isAssistantOutputMuted = muted
+    }
+
+    func becomeReady() {
+        state = .listening
+    }
+
+    func fail(message: String) {
+        errorMessage = message
+        state = .failed
+    }
+}
+
+@MainActor
+final class VoiceModeManagerTests: XCTestCase {
+
+    private var mockVoiceService: MockVoiceService!
+    private var manager: VoiceModeManager!
+    private var chatViewModel: ChatViewModel!
+    private var connectionManager: GatewayConnectionManager!
+
+    override func setUp() {
+        super.setUp()
+        mockVoiceService = MockVoiceService()
+        manager = VoiceModeManager(voiceService: mockVoiceService)
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        chatViewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: connectionManager.eventStreamClient)
+    }
+
+    override func tearDown() {
+        manager.deactivate()
+        manager = nil
+        mockVoiceService = nil
+        chatViewModel = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Activate voice mode, bypassing the speech recognition auth check.
+    /// Tests use MockVoiceService so we call activate then manually set state.
+    private func activateManager() {
+        // Directly set state to idle since we bypass auth checks
+        // by not calling activate() which checks SFSpeechRecognizer.
+        manager.activate(chatViewModel: chatViewModel)
+        // If activation didn't go through (no speech auth in test env),
+        // force the state for testing.
+        if manager.state == .off {
+            // We need to simulate activation manually
+            forceActivate()
+        }
+    }
+
+    /// Force the manager into an activated state for testing.
+    /// Sets chatViewModel and wires up voice service callbacks like `activate()` would.
+    private func forceActivate() {
+        manager.chatViewModel = chatViewModel
+        manager.state = .idle
+
+        // Wire up callbacks that activate() would set
+        mockVoiceService.onSilenceDetected = { [weak self] in
+            // Mirror activate()'s handleSilenceDetected
+            _ = self
+        }
+        mockVoiceService.onBargeInDetected = { [weak self] in
+            guard let self, self.manager.state == .speaking else { return }
+            self.manager.toggleListening()
+        }
+    }
+
+    // MARK: - State Transitions
+
+    func testInitialStateIsOff() {
+        XCTAssertEqual(manager.state, .off)
+    }
+
+    func testStartListeningFromIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.state, .idle)
+
+        manager.startListening()
+
+        if mockVoiceService.startRecordingResult {
+            XCTAssertEqual(manager.state, .listening)
+            XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        }
+    }
+
+    func testStartListeningWhenNotIdle() {
+        forceActivate()
+        manager.state = .processing
+
+        manager.startListening()
+        // Should be a no-op — state shouldn't change
+        XCTAssertEqual(manager.state, .processing)
+    }
+
+    func testStartRecordingFailure() {
+        forceActivate()
+        mockVoiceService.startRecordingResult = false
+
+        manager.startListening()
+
+        XCTAssertEqual(manager.state, .idle, "Should return to idle on recording failure")
+        XCTAssertEqual(manager.errorMessage, "Microphone not ready. Try again.")
+    }
+
+    func testDeactivateFromIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.state, .idle)
+
+        manager.deactivate()
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertTrue(mockVoiceService.shutdownCalled)
+    }
+
+    func testDeactivateWhenAlreadyOff() {
+        manager.deactivate()
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertFalse(mockVoiceService.shutdownCalled, "Should not call shutdown when already off")
+    }
+
+    func testToggleListeningFromIdle() {
+        forceActivate()
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testToggleListeningFromListening() {
+        forceActivate()
+        manager.state = .listening
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertTrue(mockVoiceService.cancelRecordingCalled)
+    }
+
+    // MARK: - Barge-in
+
+    func testBargeInFromSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+
+        // toggleListening from .speaking triggers handleBargeIn
+        manager.toggleListening()
+
+        // After barge-in: stops speaking, goes idle, then starts listening
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+        // State should transition to listening (idle → startListening)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testToggleListeningFromSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+
+        manager.toggleListening()
+
+        // Should trigger barge-in behavior
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+    }
+
+    // MARK: - State Labels
+
+    func testStateLabelOff() {
+        XCTAssertEqual(manager.stateLabel, "")
+    }
+
+    func testStateLabelIdle() {
+        forceActivate()
+        XCTAssertEqual(manager.stateLabel, "Ready")
+    }
+
+    func testStateLabelListening() {
+        forceActivate()
+        manager.state = .listening
+        XCTAssertEqual(manager.stateLabel, "Listening...")
+    }
+
+    func testStateLabelProcessing() {
+        forceActivate()
+        manager.state = .processing
+        XCTAssertEqual(manager.stateLabel, "Thinking...")
+    }
+
+    func testStateLabelSpeaking() {
+        forceActivate()
+        manager.state = .speaking
+        XCTAssertEqual(manager.stateLabel, "Speaking...")
+    }
+
+    // MARK: - Conversation Timeout
+
+    func testConversationTimeoutAutoDeactivates() async {
+        forceActivate()
+        // Note: startConversationTimeout clamps to min 1.0s
+        manager.conversationTimeoutInterval = 1.0
+        // Trigger the timeout by transitioning to idle
+        manager.state = .processing
+        manager.state = .idle
+
+        // Wait for timeout to fire (1s timeout + margin)
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .off, "Should auto-deactivate after timeout")
+        XCTAssertTrue(manager.wasAutoDeactivated)
+    }
+
+    func testPauseConversationTimeoutPreventsDeactivation() async {
+        forceActivate()
+        manager.conversationTimeoutInterval = 1.0
+        manager.state = .processing
+        manager.state = .idle
+        manager.pauseConversationTimeout()
+
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .idle, "Should NOT auto-deactivate when timeout is paused")
+        XCTAssertFalse(manager.wasAutoDeactivated)
+    }
+
+    func testResumeConversationTimeoutRestartsTimer() async {
+        forceActivate()
+        manager.conversationTimeoutInterval = 1.0
+        manager.pauseConversationTimeout()
+
+        // Move to idle with timeout paused
+        manager.state = .processing
+        manager.state = .idle
+
+        // Resume — should start the timer
+        manager.resumeConversationTimeout()
+
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        XCTAssertEqual(manager.state, .off, "Should auto-deactivate after resumed timeout")
+        XCTAssertTrue(manager.wasAutoDeactivated)
+    }
+
+    // MARK: - Permission Keyword Classification
+
+    func testClassifyYes() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yes"), .allow)
+    }
+
+    func testClassifyNo() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("no"), .denied)
+    }
+
+    func testClassifyYeahSure() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yeah sure"), .allow)
+    }
+
+    func testClassifyGoAhead() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("go ahead"), .allow)
+    }
+
+    func testClassifyNoDontDoIt() {
+        // Contains both "do it" (affirmative) and "no"/"don't" (negative) → deny wins
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("no don't do it"), .denied)
+    }
+
+    func testClassifyMaybe() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("maybe"), .ambiguous)
+    }
+
+    func testClassifyReject() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("reject that"), .denied)
+    }
+
+    func testClassifyProceed() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("please proceed"), .allow)
+    }
+
+    func testClassifyStopCancel() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("stop cancel"), .denied)
+    }
+
+    func testClassifyRandomText() {
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("I think the weather is nice"), .ambiguous)
+    }
+
+    // MARK: - describeAction
+
+    func testDescribeActionBashOpen() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("open -a Safari")])
+        XCTAssertEqual(manager.describeAction(confirmation), "open an app for you")
+    }
+
+    func testDescribeActionBashOsascript() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("osascript -e 'tell app \"Finder\" to open'")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run a quick script on your Mac")
+    }
+
+    func testDescribeActionBashGeneric() {
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("ls -la")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run something on your Mac")
+    }
+
+    func testDescribeActionHostBash() {
+        let confirmation = makeConfirmation(toolName: "host_bash", input: ["command": AnyCodable("echo hello")])
+        XCTAssertEqual(manager.describeAction(confirmation), "run something on your Mac")
+    }
+
+    func testDescribeActionFileWriteWithPath() {
+        let confirmation = makeConfirmation(toolName: "file_write", input: ["path": AnyCodable("/tmp/test.txt")])
+        XCTAssertEqual(manager.describeAction(confirmation), "create a file called test.txt")
+    }
+
+    func testDescribeActionFileWriteNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_write", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "create a file for you")
+    }
+
+    func testDescribeActionFileEdit() {
+        let confirmation = makeConfirmation(toolName: "file_edit", input: ["path": AnyCodable("/Users/test/doc.md")])
+        XCTAssertEqual(manager.describeAction(confirmation), "make some changes to doc.md")
+    }
+
+    func testDescribeActionFileEditNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_edit", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "make some changes to a file")
+    }
+
+    func testDescribeActionFileRead() {
+        let confirmation = makeConfirmation(toolName: "file_read", input: ["path": AnyCodable("/etc/hosts")])
+        XCTAssertEqual(manager.describeAction(confirmation), "take a look at hosts")
+    }
+
+    func testDescribeActionFileReadNoPath() {
+        let confirmation = makeConfirmation(toolName: "file_read", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "take a look at a file")
+    }
+
+    func testDescribeActionWebFetch() {
+        let confirmation = makeConfirmation(toolName: "web_fetch", input: ["url": AnyCodable("https://example.com/api")])
+        XCTAssertEqual(manager.describeAction(confirmation), "grab some info from example.com")
+    }
+
+    func testDescribeActionWebFetchNoURL() {
+        let confirmation = makeConfirmation(toolName: "web_fetch", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "look something up online")
+    }
+
+    func testDescribeActionBrowserNavigate() {
+        let confirmation = makeConfirmation(toolName: "browser_navigate", input: ["url": AnyCodable("https://github.com/page")])
+        XCTAssertEqual(manager.describeAction(confirmation), "open up github.com")
+    }
+
+    func testDescribeActionBrowserNavigateNoURL() {
+        let confirmation = makeConfirmation(toolName: "browser_navigate", input: [:])
+        XCTAssertEqual(manager.describeAction(confirmation), "open up a webpage")
+    }
+
+    func testDescribeActionWithReason() {
+        let confirmation = makeConfirmation(toolName: "bash", input: [
+            "command": AnyCodable("some-cmd"),
+            "reason": AnyCodable("Install the package")
+        ])
+        XCTAssertEqual(manager.describeAction(confirmation), "install the package")
+    }
+
+    func testDescribeActionUnknownTool() {
+        let confirmation = makeConfirmation(toolName: "custom_tool", input: [:])
+        // Falls back to toolCategory which returns a category label based on toolName
+        let result = manager.describeAction(confirmation)
+        XCTAssertFalse(result.isEmpty, "Should return a non-empty string for unknown tools")
+    }
+
+    // MARK: - Voice-Mode Completion Path
+
+    func testCompletionPath_processingToSpeakingToIdleToListening() {
+        forceActivate()
+        manager.state = .processing
+
+        // Simulate first text delta arriving — should transition to speaking
+        chatViewModel.onVoiceTextDelta?("Hello")
+        // The manager's handleTextDelta feeds the voice service and transitions state
+        // Since we bypass activate(), wire up callbacks manually:
+        manager.state = .processing
+        mockVoiceService.feedTextDelta("Hello")
+
+        // Simulate the manager receiving a text delta
+        // (manually drive since we can't invoke private handleTextDelta directly)
+        manager.state = .speaking
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        // Simulate TTS completion by calling the stored finishTextStream completion
+        mockVoiceService.finishTextStreamCompletion?()
+
+        // After TTS completes, the manager should return to idle
+        // (finishTextStream completion sets state = .idle then calls startListening)
+        // But since we're calling the mock's completion directly,
+        // we verify the mock received the right calls.
+        XCTAssertTrue(mockVoiceService.feedTextDeltaCalled, "Should have fed text to voice service")
+    }
+
+    func testCompletionPath_emptyResponseGoesBackToIdle() {
+        forceActivate()
+        manager.state = .processing
+
+        // Simulate handleResponseComplete when no text deltas were received
+        // (state is still .processing — empty response)
+        // The manager checks state == .processing and goes back to idle.
+        // We can't call handleResponseComplete directly, but we can verify
+        // the expected behavior through state transitions.
+        XCTAssertEqual(manager.state, .processing)
+    }
+
+    func testCompletionPath_finishTextStreamCalledOnResponseComplete() {
+        forceActivate()
+        manager.state = .speaking
+
+        // Wire up the voice response complete callback
+        var responseCompleteCalled = false
+        chatViewModel.onVoiceResponseComplete = { _ in
+            responseCompleteCalled = true
+        }
+
+        // Simulate the TTS flow: feed text then complete
+        mockVoiceService.feedTextDelta("Test response text")
+
+        // When in .speaking state, finishTextStream should be callable
+        mockVoiceService.finishTextStream { }
+
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled, "Should call finishTextStream on voice service")
+    }
+
+    // MARK: - Error Fallback Path
+
+    func testErrorFallback_ttsCompletionCalledOnError() {
+        forceActivate()
+        manager.state = .speaking
+
+        // Simulate TTS flow: start speaking, then TTS completes with error
+        // (the mock's finishTextStream stores the completion)
+        mockVoiceService.finishTextStream { }
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled)
+
+        // Invoke the completion to simulate TTS finishing (either success or error)
+        // The manager should transition back to idle
+        mockVoiceService.finishTextStreamCompletion?()
+
+        // Manager should not be stuck in .speaking
+        // (the completion handler in VoiceModeManager checks state == .speaking
+        // before transitioning, and since we called it, it should proceed)
+    }
+
+    func testErrorFallback_stopSpeakingCleansUpState() {
+        forceActivate()
+        manager.state = .speaking
+
+        // Stop speaking (simulates error recovery or manual interruption)
+        mockVoiceService.stopSpeaking()
+
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+    }
+
+    // MARK: - Barge-in Transition Regression
+
+    func testBargeIn_stopsCurrentTTSAndTransitionsToListening() {
+        forceActivate()
+        manager.state = .speaking
+
+        // Simulate barge-in via toggleListening
+        manager.toggleListening()
+
+        // Verify TTS was stopped
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled, "Barge-in should stop TTS playback")
+
+        // State should go from speaking -> idle -> listening
+        XCTAssertEqual(manager.state, .listening, "Barge-in should start listening immediately")
+        XCTAssertTrue(mockVoiceService.startRecordingCalled, "Barge-in should start recording")
+    }
+
+    func testBargeIn_clearsPartialTranscription() {
+        forceActivate()
+        manager.state = .speaking
+        manager.partialTranscription = "previous response text"
+
+        manager.toggleListening()
+
+        XCTAssertEqual(manager.partialTranscription, "", "Barge-in should clear partial transcription")
+    }
+
+    func testBargeIn_noEffectWhenNotSpeaking() {
+        forceActivate()
+        manager.state = .idle
+
+        // toggleListening from idle should start listening, not trigger barge-in
+        manager.toggleListening()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.stopSpeakingCalled, "Should not stop speaking when not in speaking state")
+    }
+
+    func testBargeIn_fromProcessingIsNoOp() {
+        forceActivate()
+        manager.state = .processing
+
+        // toggleListening from processing should be a no-op
+        manager.toggleListening()
+
+        XCTAssertEqual(manager.state, .processing, "Should not change state from processing")
+        XCTAssertFalse(mockVoiceService.stopSpeakingCalled)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
+    func testCanToggleListeningAllowsLiveChannelProcessingOnly() {
+        forceActivate()
+        manager.state = .idle
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .listening
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .speaking
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .processing
+        XCTAssertFalse(manager.canToggleListening)
+    }
+
+    // MARK: - Service-First STT: State Transitions
+
+    /// Verify voice mode cycles through listening -> processing -> speaking -> idle -> listening
+    /// when transcription succeeds (regardless of whether service or local STT provided the text).
+    func testFullCycle_listeningToProcessingToSpeakingToListening() {
+        forceActivate()
+
+        // 1. Start listening
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+
+        // 2. Simulate silence detection -> processing
+        manager.state = .processing
+        XCTAssertEqual(manager.state, .processing)
+
+        // 3. Simulate text delta arriving -> speaking
+        manager.state = .speaking
+        mockVoiceService.feedTextDelta("Hello from assistant")
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertTrue(mockVoiceService.feedTextDeltaCalled)
+
+        // 4. Simulate TTS completion -> idle -> listening
+        // Wire up finishTextStream to verify it gets called
+        mockVoiceService.finishTextStream { }
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled)
+
+        // Simulate the completion callback firing
+        mockVoiceService.finishTextStreamCompletion?()
+    }
+
+    /// Verify voice mode falls back gracefully when transcription returns nil
+    /// (simulates service unavailable + local recognizer failure).
+    func testFallback_nilTranscriptionReturnsToIdle() {
+        forceActivate()
+        mockVoiceService.transcriptionToReturn = nil
+
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // When stopRecordingAndGetTranscription returns nil, the silence handler
+        // should transition back to idle (no text to send).
+        // Verify the mock is configured to return nil.
+        XCTAssertNil(mockVoiceService.transcriptionToReturn)
+    }
+
+    /// Verify voice mode works correctly when service STT succeeds (transcription
+    /// is non-nil). The mock returns configurable text regardless of source.
+    func testServiceSuccess_transcriptionSentToChat() {
+        forceActivate()
+        mockVoiceService.transcriptionToReturn = "service transcription result"
+
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // The transcription text is configured
+        XCTAssertEqual(mockVoiceService.transcriptionToReturn, "service transcription result")
+    }
+
+    /// Verify the full state cycle: listening -> processing -> speaking -> idle
+    /// including barge-in recovery and restart.
+    func testFullCycle_withBargeInRecovery() {
+        forceActivate()
+
+        // Start listening
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // Move to processing (silence detected)
+        manager.state = .processing
+        XCTAssertEqual(manager.state, .processing)
+
+        // Move to speaking (text delta arrived)
+        manager.state = .speaking
+        XCTAssertEqual(manager.state, .speaking)
+
+        // Barge-in interrupts TTS
+        manager.toggleListening()
+        XCTAssertTrue(mockVoiceService.stopSpeakingCalled)
+        XCTAssertEqual(manager.state, .listening, "After barge-in, should be listening again")
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+    }
+
+    /// Verify that cancelRecording from listening returns to idle cleanly.
+    func testCancelRecording_returnsToIdle() {
+        forceActivate()
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        manager.toggleListening()
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertTrue(mockVoiceService.cancelRecordingCalled)
+    }
+
+    // MARK: - STT-Only Mode (speech recognition not required)
+
+    /// When STT is configured and speech recognition is denied, voice mode
+    /// should still activate successfully.
+    func testActivation_sttConfigured_speechDenied_activates() {
+        // Simulate STT configured via UserDefaults
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
+
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .denied
+
+        let sttManager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        sttManager.activate(chatViewModel: chatViewModel)
+
+        XCTAssertEqual(sttManager.state, .idle,
+                       "Voice mode should activate when STT is configured, even if speech recognition is denied")
+        XCTAssertTrue(mockVoiceService.prewarmEngineCalled,
+                      "Should pre-warm audio engine during activation")
+
+        sttManager.deactivate()
+    }
+
+    /// When STT is configured, startRecording should work even without a
+    /// native speech recognizer — the audio tap runs, silence detection works,
+    /// and PCM data accumulates for the STT service.
+    func testStartRecording_sttConfigured_noRecognizer_succeeds() {
+        UserDefaults.standard.set("openai-whisper", forKey: "sttProvider")
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
+
+        forceActivate()
+        manager.startListening()
+
+        // MockVoiceService.startRecording always returns true by default,
+        // simulating successful recording without native recognizer.
+        XCTAssertEqual(manager.state, .listening,
+                       "Should transition to listening when STT is configured")
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+    }
+
+    /// When STT is configured and native recognizer is unavailable, the voice
+    /// mode transcription path should rely on the STT service. The mock voice
+    /// service returns a configurable transcription result.
+    func testTranscription_sttOnly_usesServiceSTT() {
+        UserDefaults.standard.set("deepgram", forKey: "sttProvider")
+        defer { UserDefaults.standard.removeObject(forKey: "sttProvider") }
+
+        forceActivate()
+        mockVoiceService.transcriptionToReturn = "service transcription result"
+
+        manager.startListening()
+        XCTAssertEqual(manager.state, .listening)
+
+        // The transcription is available from the STT service
+        XCTAssertEqual(mockVoiceService.transcriptionToReturn, "service transcription result")
+    }
+
+    /// When STT is NOT configured and speech recognition is denied, voice mode
+    /// should NOT activate — preserving existing behavior.
+    func testActivation_noSTT_speechDenied_doesNotActivate() {
+        // Ensure no STT provider is configured
+        UserDefaults.standard.removeObject(forKey: "sttProvider")
+
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .denied
+
+        let sttManager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        sttManager.activate(chatViewModel: chatViewModel)
+
+        XCTAssertEqual(sttManager.state, .off,
+                       "Voice mode should NOT activate when STT is not configured and speech recognition is denied")
+
+        sttManager.deactivate()
+    }
+
+    // MARK: - Live Voice Channel Wiring
+
+    func testStartListeningUsesLiveChannelWhenAvailable() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .denied
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true },
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        manager.activate(chatViewModel: chatViewModel)
+        manager.startListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(liveManager.startCalls, ["conv-123"])
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+        XCTAssertTrue(chatViewModel.isVoiceModeActive)
+    }
+
+    func testStartListeningFallsBackWhenLiveChannelUnavailable() {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { false }
+        )
+        forceActivate()
+
+        manager.startListening()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        XCTAssertTrue(liveManager.startCalls.isEmpty)
+    }
+
+    func testLiveChannelFailureFallsBackToTurnBasedVoice() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.fail(message: "Live voice connection rejected")
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(mockVoiceService.startRecordingCalled)
+        XCTAssertEqual(liveManager.startCalls, ["conv-123"])
+    }
+
+    func testLiveChannelStopListeningReleasesPushToTalk() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.stopListeningCallCount, 1)
+        XCTAssertEqual(manager.state, .processing)
+        XCTAssertFalse(mockVoiceService.cancelRecordingCalled)
+    }
+
+    func testLiveChannelStopListeningDoesNotTrapProcessingWhenReleaseIsNoOp() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        liveManager.stopListeningUpdatesState = false
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.stopListeningCallCount, 1)
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(manager.canToggleListening)
+    }
+
+    func testLiveChannelProcessingToggleInterruptsAndRestartsListening() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.state = .thinking
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .processing)
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.interruptSpeakingAndStartListeningCalls, ["conv-123"])
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.stopSpeakingCalled)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
+    func testLiveChannelAmplitudeIsExposedForComposerWaveform() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        liveManager.inputAmplitude = 0.42
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.inputAmplitude, 0.42)
+    }
+
+    func testLiveChannelBargeInInterruptsAndRestartsLiveListening() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+        liveManager.state = .speaking
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.interruptSpeakingAndStartListeningCalls, ["conv-123"])
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.stopSpeakingCalled)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
+    func testLiveChannelCompletionRestartsListening() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+        liveManager.state = .speaking
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        liveManager.state = .idle
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.startCalls, ["conv-123", "conv-123"])
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
+    func testDeactivateEndsLiveChannelAndClearsVoiceMode() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+        chatViewModel.isVoiceModeActive = true
+
+        manager.startListening()
+        await flushAsyncTasks()
+        manager.deactivate()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .off)
+        XCTAssertEqual(liveManager.endCallCount, 1)
+        XCTAssertFalse(chatViewModel.isVoiceModeActive)
+        XCTAssertTrue(mockVoiceService.shutdownCalled)
+    }
+
+    func testPendingPermissionPreservesLiveChannelAndUsesExistingPrompt() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        let speechAdapter = MockSpeechRecognizerAdapter()
+        speechAdapter.stubbedAuthorizationStatus = .authorized
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true },
+            speechRecognizerAdapter: speechAdapter
+        )
+
+        manager.activate(chatViewModel: chatViewModel)
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        let confirmation = makeConfirmation(toolName: "bash", input: ["command": AnyCodable("echo hello")])
+        chatViewModel.messages = [
+            ChatMessage(
+                role: .assistant,
+                text: "",
+                confirmation: confirmation
+            )
+        ]
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.endCallCount, 0)
+        XCTAssertEqual(liveManager.state, .listening)
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(manager.pendingPermissionIds, [confirmation.requestId])
+        XCTAssertTrue(mockVoiceService.feedTextDeltaCalled)
+        XCTAssertTrue(mockVoiceService.finishTextStreamCalled)
+    }
+
+    // MARK: - Voice Session Controls (mic mute, assistant-output mute)
+
+    func testSetMicrophoneMutedForwardsToActiveLiveChannelSession() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+        manager.startListening()
+        await flushAsyncTasks()
+
+        manager.setMicrophoneMuted(true)
+
+        XCTAssertEqual(liveManager.setMicrophoneMutedCalls, [true])
+        XCTAssertTrue(manager.isMicrophoneMuted)
+    }
+
+    func testSetAssistantOutputMutedForwardsToActiveLiveChannelSession() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+        manager.startListening()
+        await flushAsyncTasks()
+
+        manager.setAssistantOutputMuted(true)
+
+        XCTAssertEqual(liveManager.setAssistantOutputMutedCalls, [true])
+        XCTAssertTrue(manager.isAssistantOutputMuted)
+    }
+
+    func testMuteControlsAreNoOpsWhenLiveVoiceIsNotTheActivePath() {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { false }
+        )
+        forceActivate()
+
+        manager.startListening()
+        manager.setMicrophoneMuted(true)
+        manager.setAssistantOutputMuted(true)
+
+        XCTAssertTrue(liveManager.setMicrophoneMutedCalls.isEmpty)
+        XCTAssertTrue(liveManager.setAssistantOutputMutedCalls.isEmpty)
+        XCTAssertFalse(manager.isMicrophoneMuted)
+        XCTAssertFalse(manager.isAssistantOutputMuted)
+    }
+
+    func testDeactivateResetsMuteStateOnVoiceModeManager() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+        manager.startListening()
+        await flushAsyncTasks()
+        manager.setMicrophoneMuted(true)
+        manager.setAssistantOutputMuted(true)
+
+        manager.deactivate()
+
+        XCTAssertFalse(manager.isMicrophoneMuted)
+        XCTAssertFalse(manager.isAssistantOutputMuted)
+    }
+
+    // MARK: - Helpers
+
+    private func makeConfirmation(
+        toolName: String,
+        input: [String: AnyCodable]
+    ) -> ToolConfirmationData {
+        ToolConfirmationData(
+            requestId: "test-\(UUID().uuidString)",
+            toolName: toolName,
+            input: input,
+            riskLevel: "low",
+            diff: nil,
+            allowlistOptions: [],
+            scopeOptions: [],
+            executionTarget: nil,
+            state: .pending
+        )
+    }
+
+    private func flushAsyncTasks() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+}

--- a/clients/shared/Network/VoiceSessionControlling.swift
+++ b/clients/shared/Network/VoiceSessionControlling.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Session-level controls shared across every live voice control surface —
+/// in-app UI, a platform control surface such as an iOS Live Activity or
+/// Dynamic Island, or a future spoken-command dispatcher.
+///
+/// This is intentionally decoupled from any concrete session's state machine
+/// (e.g. `LiveVoiceChannelManager.State` on macOS) so a control surface can
+/// mute the microphone, mute assistant speech, or end the session without
+/// depending on a platform-specific manager type. Any live voice session
+/// manager, on any platform, should conform to this protocol so new control
+/// surfaces can be written once against `VoiceSessionControlling` instead of
+/// against each platform's concrete manager.
+@MainActor
+public protocol VoiceSessionControlling: AnyObject {
+    /// True when the local microphone is muted. The session may still be
+    /// connected and capturing input amplitude for UI, but no audio is sent
+    /// upstream while muted.
+    var isMicrophoneMuted: Bool { get }
+
+    /// True when assistant speech playback is muted locally. The assistant
+    /// may still be producing a response while muted; audio simply is not
+    /// played back to the user.
+    var isAssistantOutputMuted: Bool { get }
+
+    /// Mute or unmute the local microphone without ending the session.
+    func setMicrophoneMuted(_ muted: Bool)
+
+    /// Mute or unmute assistant speech playback without ending the session.
+    func setAssistantOutputMuted(_ muted: Bool)
+
+    /// End the voice session gracefully.
+    func end() async
+}

--- a/clients/shared/Tests/VoiceSessionControllingTests.swift
+++ b/clients/shared/Tests/VoiceSessionControllingTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+/// A minimal fake conforming only to `VoiceSessionControlling`, with no
+/// dependency on any platform-specific session manager. Standing in for a
+/// future control surface (e.g. an iOS Live Activity/Dynamic Island control,
+/// or a spoken-command dispatcher) that should be writable against this
+/// protocol alone.
+@MainActor
+private final class FakeVoiceSessionControls: VoiceSessionControlling {
+    private(set) var isMicrophoneMuted = false
+    private(set) var isAssistantOutputMuted = false
+    private(set) var endCallCount = 0
+
+    func setMicrophoneMuted(_ muted: Bool) {
+        isMicrophoneMuted = muted
+    }
+
+    func setAssistantOutputMuted(_ muted: Bool) {
+        isAssistantOutputMuted = muted
+    }
+
+    func end() async {
+        endCallCount += 1
+    }
+}
+
+/// Simulates a control surface written once against `VoiceSessionControlling`
+/// and reusable across any conforming session manager, on any platform.
+@MainActor
+private func muteEverythingThenEndSession(_ controls: any VoiceSessionControlling) async {
+    controls.setMicrophoneMuted(true)
+    controls.setAssistantOutputMuted(true)
+    await controls.end()
+}
+
+@MainActor
+final class VoiceSessionControllingTests: XCTestCase {
+    func testControlSurfaceCanDriveMuteAndEndThroughTheProtocolAlone() async {
+        let controls = FakeVoiceSessionControls()
+
+        await muteEverythingThenEndSession(controls)
+
+        XCTAssertTrue(controls.isMicrophoneMuted)
+        XCTAssertTrue(controls.isAssistantOutputMuted)
+        XCTAssertEqual(controls.endCallCount, 1)
+    }
+
+    func testMicrophoneAndAssistantOutputMuteAreIndependentToggles() {
+        let controls = FakeVoiceSessionControls()
+
+        controls.setMicrophoneMuted(true)
+
+        XCTAssertTrue(controls.isMicrophoneMuted)
+        XCTAssertFalse(controls.isAssistantOutputMuted)
+
+        controls.setAssistantOutputMuted(true)
+        controls.setMicrophoneMuted(false)
+
+        XCTAssertFalse(controls.isMicrophoneMuted)
+        XCTAssertTrue(controls.isAssistantOutputMuted)
+    }
+}


### PR DESCRIPTION
## Summary

- Add shared voice-session control semantics for microphone mute, assistant-output mute, and ending a session.
- Wire the existing macOS live voice manager and mode manager to the shared contract.
- Document the current iOS Live Activity and spoken-command seams without fabricating unsupported infrastructure.

Linear: JARVIS-1402, JARVIS-1405

## Validation

- Focused tests are written but require macOS/Xcode and were not runnable in this Linux sandbox.
- iOS ActivityKit/Dynamic Island wiring remains a follow-up because no such target exists in the current repository.