### PR TITLE
fix(runtime): fail agent wakes whose loop swallowed a terminal error into a no-output stop

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -422,6 +422,55 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(stateRetried?.lastProcessedMessageId).toBe(fixture.newMessageId);
   });
 
+  test("clean empty reply (HTTP-200, content: []): fails closed, state preserved, window retryable", async () => {
+    const fixture = await stageChainFixture();
+
+    // A well-formed provider success whose finalized output is unusable:
+    // empty content array, clean end_turn. The real loop exits
+    // no_tool_calls; the retrospective's requireUsableOutput turns that
+    // into a failed, retryable pass instead of consuming the window.
+    providerScript = [
+      {
+        response: {
+          content: [],
+          model: "mock-model",
+          usage: { inputTokens: 10, outputTokens: 0 },
+          stopReason: "end_turn",
+        },
+      },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+
+    expect(outcome.kind).toBe("wake_failed");
+    if (outcome.kind === "wake_failed") {
+      expect(outcome.reason).toBe("no_output");
+    }
+
+    // No finalization: cursor, log, and the prior retrospective untouched;
+    // the orphan fork is cleaned up.
+    const state = getRetrospectiveState(fixture.sourceId);
+    expect(state?.lastProcessedMessageId).toBe(fixture.seededCursorId);
+    expect(state?.rememberedLog).toEqual([PRIOR_FACT]);
+    expect(getConversation(fixture.priorRetroId)).not.toBeNull();
+    expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
+
+    // The window stays retryable and a usable reply consumes it.
+    providerScript = [{ response: textResponse("Reviewed; nothing new.") }];
+    providerCallCount = 0;
+    const retry = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+    expect(retry.kind).toBe("invoked");
+    expect(
+      getRetrospectiveState(fixture.sourceId)?.lastProcessedMessageId,
+    ).toBe(fixture.newMessageId);
+  });
+
   test("usable-output control: cursor advances, remembered log grows, prior retrospective is GC'd", async () => {
     const fixture = await stageChainFixture();
 

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Producer-to-finalizer state-chain coverage for the memory retrospective
+ * (LUM-3013).
+ *
+ * These tests run the REAL chain: `runForkBasedRetrospective` (real fork +
+ * real `memory_retrospective_state` rows in the test DB) invokes the REAL
+ * `wakeAgentForOpportunity`, which runs a REAL `AgentLoop` whose provider is
+ * scripted per test. Provider rejections therefore exercise the loop's actual
+ * catch/`stopTurn` path (no manually emitted events), and finalization reads
+ * and writes the actual persisted rows.
+ *
+ * What is stubbed, and why it is outside the contract under proof:
+ * - The wake's conversation resolution: the module mock below re-exports the
+ *   real `wakeAgentForOpportunity` with an injected `resolveTarget` that
+ *   yields a structural conversation double wrapping the real `AgentLoop`
+ *   (the default resolver is daemon-hydration machinery, not state logic).
+ * - `recordUsage` (cost ledger) and `resolveEffectiveContextWindow` /
+ *   disk-pressure status (config lookups): observability and gating leaves.
+ *
+ * The LUM-3013 data-integrity contract proven here:
+ * 1. A provider rejection reaches `invoked: false` BEFORE any state
+ *    mutation: no cursor advance, no remembered-log change, no
+ *    prior-retrospective deletion; the orphan fork is cleaned up.
+ * 2. The failed window stays retryable: a later run over the same window
+ *    succeeds and advances state.
+ * 3. A usable-output control advances state (cursor, remembered log) and
+ *    GCs the superseded prior retrospective.
+ * 4. A run whose checkpoint went live before a later rejection stays
+ *    `invoked: true` (its side effects landed and are honored).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { AgentLoop } from "../../../../agent/loop.js";
+import type { Conversation } from "../../../../daemon/conversation.js";
+import {
+  addMessage,
+  createConversation,
+  forkConversationForRetrospective,
+  getConversation,
+  getMessages,
+} from "../../../../persistence/conversation-crud.js";
+import { getDb, getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import {
+  conversations,
+  memoryJobs,
+  memoryRetrospectiveState,
+  messages as messagesTable,
+} from "../../../../persistence/schema/index.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../../../../providers/types.js";
+// Capture the real wake before the module mock below re-links the module
+// for every importer (including memory-retrospective-job).
+import { wakeAgentForOpportunity as importedWake } from "../../../../runtime/agent-wake.js";
+import * as realAgentWakeModule from "../../../../runtime/agent-wake.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_GROUP_ID,
+} from "../memory-retrospective-constants.js";
+import { runForkBasedRetrospective } from "../memory-retrospective-job.js";
+import {
+  getRetrospectiveState,
+  upsertRetrospectiveState,
+} from "../memory-retrospective-state.js";
+
+const realWake = importedWake;
+
+// ── Scripted provider ────────────────────────────────────────────────
+//
+// Each entry is either a canned response or a thrown rejection, consumed in
+// order; the last entry repeats. Reassigned per test.
+type ProviderStep = { response: ProviderResponse } | { reject: Error };
+let providerScript: ProviderStep[] = [];
+let providerCallCount = 0;
+
+const scriptedProvider: Provider = {
+  name: "mock-provider",
+  async sendMessage(
+    _messages: Message[],
+    _options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const step =
+      providerScript[providerCallCount] ??
+      providerScript[providerScript.length - 1];
+    providerCallCount++;
+    if (!step) {
+      throw new Error("provider script exhausted");
+    }
+    if ("reject" in step) {
+      throw step.reject;
+    }
+    return step.response;
+  },
+};
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+}
+
+function rememberToolUseResponse(fact: string): ProviderResponse {
+  return {
+    content: [
+      {
+        type: "tool_use",
+        id: "tu-1",
+        name: "remember",
+        input: { content: fact },
+      },
+    ],
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "tool_use",
+  };
+}
+
+const rememberToolDef: ToolDefinition[] = [
+  {
+    name: "remember",
+    description: "Save a fact to memory",
+    input_schema: {
+      type: "object",
+      properties: { content: { type: "string" } },
+    },
+  },
+];
+
+// ── Conversation double wrapping a REAL AgentLoop ────────────────────
+//
+// Structural double for the fork conversation the wake resolves: only the
+// members the wake touches, with `agentLoop` a real `AgentLoop` over the
+// scripted provider so provider failures exercise the loop's genuine
+// catch/stopTurn path. Tail persistence, state reads/writes, and fork
+// cleanup all run against the real test DB.
+function makeForkConversationDouble(forkId: string): Conversation {
+  const rows = getMessages(forkId);
+  const messages: Message[] = rows.map((row) => {
+    let content: unknown = row.content;
+    if (typeof content === "string") {
+      try {
+        content = JSON.parse(content);
+      } catch {
+        // Keep the raw string when not JSON.
+      }
+    }
+    return { role: row.role, content } as Message;
+  });
+
+  const agentLoop = new AgentLoop({
+    provider: scriptedProvider,
+    systemPrompt: "chain-test system prompt",
+    conversationId: forkId,
+    tools: rememberToolDef,
+    toolExecutor: async () => ({ content: "Saved.", isError: false }),
+  });
+
+  let processing = false;
+  let activeAllowedTools: Set<string> | undefined;
+  let persistentTrust: unknown;
+  let turnTrust: unknown;
+
+  const conversation = {
+    conversationId: forkId,
+    agentLoop,
+    provider: scriptedProvider,
+    usageStats: {},
+    messages,
+    getMessages: () => messages,
+    isProcessing: () => processing,
+    setProcessing: (on: boolean) => {
+      processing = on;
+    },
+    waitForIdle: async () => true,
+    get subagentAllowedTools() {
+      return activeAllowedTools;
+    },
+    setSubagentAllowedTools: (tools: Set<string> | undefined) => {
+      activeAllowedTools = tools;
+    },
+    preactivatedSkillIds: undefined,
+    setPreactivatedSkillIds: () => {},
+    subagentToolGateMode: undefined,
+    toolContextPin: undefined,
+    currentTurnRequestOrigin: undefined,
+    wakePersonaOverride: undefined,
+    currentCallSite: undefined,
+    currentTurnOverrideProfile: undefined,
+    hasNoClient: false,
+    get currentTurnTrustContext() {
+      return turnTrust;
+    },
+    set currentTurnTrustContext(value: unknown) {
+      turnTrust = value;
+    },
+    get trustContext() {
+      return persistentTrust;
+    },
+    setTrustContext: (ctx: unknown) => {
+      persistentTrust = ctx ?? undefined;
+    },
+    maybeCompact: async () => null,
+    contextWindowManager: {
+      estimateInputTokens: () => 1_000,
+    },
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+    buildCurrentSystemPrompt: () => "chain-test system prompt",
+    modelOverride: undefined,
+    drainQueue: async () => {},
+  };
+  return conversation as unknown as Conversation;
+}
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+// Re-export the REAL wake with the conversation resolver injected, so the
+// retrospective job's unmodified `wakeAgentForOpportunity(...)` call runs the
+// complete production wake logic against the real-AgentLoop double above.
+mock.module("../../../../runtime/agent-wake.js", () => ({
+  ...realAgentWakeModule,
+  wakeAgentForOpportunity: (
+    opts: Parameters<typeof realWake>[0],
+  ): ReturnType<typeof realWake> =>
+    realWake(opts, {
+      resolveTarget: async (wakeOpts) =>
+        makeForkConversationDouble(wakeOpts.conversationId),
+    }),
+}));
+
+// Config-lookup leaves outside the state contract under proof.
+mock.module("../../../../config/llm-context-resolution.js", () => ({
+  resolveEffectiveContextWindow: () => ({ maxInputTokens: 200_000 }),
+}));
+mock.module("../../../../daemon/conversation-usage.js", () => ({
+  recordUsage: () => {},
+}));
+mock.module("../../../../daemon/disk-pressure-guard.js", () => ({
+  getDiskPressureStatus: () => ({
+    enabled: false,
+    state: "disabled",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: null,
+    thresholdPercent: 95,
+    path: null,
+    lastCheckedAt: null,
+    blockedCapabilities: [],
+    error: null,
+  }),
+}));
+
+await initializeDb();
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const chainConfig = {
+  memory: {
+    v2: { enabled: true },
+    retrospective: {
+      keepSupersededRuns: false,
+      matchConversationProfile: false,
+      promptPath: null,
+      requireUserActivity: false,
+      sweepIntervalMs: 8 * 60 * 60 * 1000,
+      sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
+    },
+  },
+  ui: {},
+} as unknown as Parameters<typeof runForkBasedRetrospective>[1];
+
+const PRIOR_FACT = "User's cat is named Mochi";
+
+interface ChainFixture {
+  sourceId: string;
+  priorRetroId: string;
+  seededCursorId: string;
+  newMessageId: string;
+}
+
+/**
+ * Stage the full pre-run world in the real DB: a source conversation with
+ * processed history, a genuine prior retrospective fork, a seeded state row
+ * (cursor + remembered log), and one new unprocessed user message.
+ */
+async function stageChainFixture(): Promise<ChainFixture> {
+  const source = await createConversation("Chain source");
+  const first = await addMessage(
+    source.id,
+    "user",
+    JSON.stringify([{ type: "text", text: "Hi, my cat is named Mochi." }]),
+  );
+  await addMessage(
+    source.id,
+    "assistant",
+    JSON.stringify([{ type: "text", text: "Noted!" }]),
+  );
+
+  const prior = await forkConversationForRetrospective({
+    conversationId: source.id,
+    throughMessageId: first.id,
+    source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    title: "Chain source (Retrospective)",
+    conversationType: "background",
+    groupId: MEMORY_RETROSPECTIVE_GROUP_ID,
+  });
+
+  const processedThrough = await addMessage(
+    source.id,
+    "assistant",
+    JSON.stringify([{ type: "text", text: "Anything else?" }]),
+  );
+  await upsertRetrospectiveState({
+    conversationId: source.id,
+    lastProcessedMessageId: processedThrough.id,
+    lastRunAt: Date.now() - 60 * 60 * 1000,
+    rememberedLog: [PRIOR_FACT],
+  });
+
+  const fresh = await addMessage(
+    source.id,
+    "user",
+    JSON.stringify([{ type: "text", text: "I just moved to Lisbon." }]),
+  );
+
+  return {
+    sourceId: source.id,
+    priorRetroId: prior.id,
+    seededCursorId: processedThrough.id,
+    newMessageId: fresh.id,
+  };
+}
+
+/** Fork conversations currently rooted at the given source. */
+function listRetroForksOf(sourceId: string): string[] {
+  const db = getDb();
+  return db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .all()
+    .map((row) => row.id)
+    .filter((id) => {
+      const conv = getConversation(id);
+      return (
+        conv?.source === MEMORY_RETROSPECTIVE_FORK_SOURCE &&
+        conv.forkParentConversationId === sourceId
+      );
+    });
+}
+
+function resetTables(): void {
+  const db = getDb();
+  getMemoryDb()!.delete(memoryRetrospectiveState).run();
+  getMemoryDb()!.delete(memoryJobs).run();
+  db.delete(messagesTable).run();
+  db.delete(conversations).run();
+}
+
+beforeEach(() => {
+  resetTables();
+  providerScript = [];
+  providerCallCount = 0;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("memory retrospective wake state chain (real AgentLoop)", () => {
+  test("provider rejection: no cursor advance, no log mutation, prior kept, fork cleaned up, window retryable", async () => {
+    const fixture = await stageChainFixture();
+    const stateBefore = getRetrospectiveState(fixture.sourceId);
+
+    // The real loop swallows this into agent_loop_exit("error"); nothing is
+    // scripted at the event level.
+    providerScript = [
+      { reject: new Error("400 this model does not support image input") },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+
+    expect(outcome.kind).toBe("wake_failed");
+    if (outcome.kind === "wake_failed") {
+      expect(outcome.reason).toBe("run_error");
+    }
+
+    // (1) No successful finalization: cursor and remembered log unchanged.
+    const stateAfter = getRetrospectiveState(fixture.sourceId);
+    expect(stateAfter?.lastProcessedMessageId).toBe(fixture.seededCursorId);
+    expect(stateAfter?.rememberedLog).toEqual([PRIOR_FACT]);
+    // Cooldown applies to the failed attempt.
+    expect(stateAfter!.lastRunAt).toBeGreaterThan(stateBefore!.lastRunAt!);
+
+    // Prior retrospective (the dedup-baseline fallback) survives.
+    expect(getConversation(fixture.priorRetroId)).not.toBeNull();
+    // This run's own orphan fork is deleted; the prior is the only fork left.
+    expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
+
+    // (2) The window stays retryable: the same slice succeeds on retry.
+    providerScript = [
+      { response: textResponse("Reviewed. Nothing new worth saving.") },
+    ];
+    providerCallCount = 0;
+    const retry = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+    expect(retry.kind).toBe("invoked");
+    const stateRetried = getRetrospectiveState(fixture.sourceId);
+    expect(stateRetried?.lastProcessedMessageId).toBe(fixture.newMessageId);
+  });
+
+  test("usable-output control: cursor advances, remembered log grows, prior retrospective is GC'd", async () => {
+    const fixture = await stageChainFixture();
+
+    providerScript = [
+      { response: rememberToolUseResponse("User moved to Lisbon") },
+      { response: textResponse("Saved the move to memory.") },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind === "invoked") {
+      expect(outcome.cutoffMessageId).toBe(fixture.newMessageId);
+    }
+
+    // (3) Real finalization against real rows: cursor advanced, this run's
+    // remember (extracted from the fork's persisted tail) appended to the
+    // cumulative log, superseded prior GC'd.
+    const state = getRetrospectiveState(fixture.sourceId);
+    expect(state?.lastProcessedMessageId).toBe(fixture.newMessageId);
+    expect(state?.rememberedLog).toEqual([PRIOR_FACT, "User moved to Lisbon"]);
+    expect(getConversation(fixture.priorRetroId)).toBeNull();
+  });
+
+  test("rejection after a live checkpoint stays invoked: landed side effects are honored", async () => {
+    const fixture = await stageChainFixture();
+
+    // First call: a full remember tool round (checkpoint goes live and the
+    // tail is persisted). Second call: provider rejection, swallowed by the
+    // real loop into a no-output stop.
+    providerScript = [
+      { response: rememberToolUseResponse("User moved to Lisbon") },
+      { reject: new Error("500 provider died mid-run") },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+
+    // (4) The run's `remember` executed, so it must not read as skipped:
+    // the wake reports invoked and finalization honors the landed work.
+    expect(outcome.kind).toBe("invoked");
+    const state = getRetrospectiveState(fixture.sourceId);
+    expect(state?.lastProcessedMessageId).toBe(fixture.newMessageId);
+    expect(state?.rememberedLog).toEqual([PRIOR_FACT, "User moved to Lisbon"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -527,6 +527,11 @@ export async function runForkBasedRetrospective(
       hintRole: "user",
       skipHintInjection: true,
       suppressAutoCompaction: true,
+      // Finalization consumes the window (cursor advance + prior-retro GC)
+      // on `invoked: true`, so an empty reply with no usable output must
+      // fail the wake and leave the window retryable instead of reading as
+      // a successful pass (LUM-3013).
+      requireUsableOutput: true,
       // The fork's title already reads "(Retrospective)", so an empty-body
       // "Conversation Woke" surface card on top of it would be noise. Suppress
       // it — clients should display the fork as a normal background conv.

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1624,6 +1624,81 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.persistedTailCalls.length).toBeGreaterThan(0);
   });
 
+  test("reports run_error when the loop swallows a provider rejection into a no-output stop", async () => {
+    // The loop's catch does not rethrow provider rejections: it emits
+    // `error` + `agent_loop_exit(reason: "error")` and returns the history
+    // unchanged. Without the exit-reason gate this read as a successful
+    // silent no-op, so state-advancing callers (the memory retrospective
+    // watermark) permanently consumed their trigger on a pass that never
+    // ran.
+    const conversation = makeWakeConversation({
+      conversationId: "conv-swallowed-rejection",
+      runImpl: async (input, onEvent) => {
+        await onEvent({
+          type: "error",
+          error: new Error("provider 400: image input not supported"),
+        });
+        await onEvent({ type: "agent_loop_exit", reason: "error" });
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-swallowed-rejection", hint: "boom", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
+    // Nothing pushed, persisted, or emitted: the failed run left no trace.
+    expect(conversation.pushedMessages).toEqual([]);
+    expect(conversation.persistedTailCalls).toEqual([]);
+    expect(conversation.emittedEvents).toHaveLength(0);
+  });
+
+  test("reports run_error when a no-output run was aborted", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "conv-aborted-no-output",
+      runImpl: async (input, onEvent) => {
+        await onEvent({ type: "agent_loop_exit", reason: "aborted_pre_call" });
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-aborted-no-output", hint: "boom", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
+  });
+
+  test("keeps the silent no-op on a clean no_tool_calls exit with no output", async () => {
+    // A clean model-driven stop that produced nothing stays `invoked: true`:
+    // the pass really ran, the model just had nothing to say.
+    const conversation = makeWakeConversation({
+      conversationId: "conv-clean-empty",
+      runImpl: async (input, onEvent) => {
+        await onEvent({ type: "agent_loop_exit", reason: "no_tool_calls" });
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-clean-empty", hint: "hi", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+  });
+
   test("elevates the turn's trust context before the agent loop runs", async () => {
     // Background system jobs (e.g. memory consolidation) need guardian trust to
     // clear the side-effect approval gate. The wake must set

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1680,6 +1680,80 @@ describe("wakeAgentForOpportunity", () => {
     });
   });
 
+  test("reports run_error when a no-output run exhausted its output budget (max_tokens_reached)", async () => {
+    // Hidden thinking can consume the whole output budget before any
+    // visible text or executable tool call lands. That is "no usable
+    // output", not a clean silent no-op: state-advancing callers must see
+    // a retryable failure. A truncated response that produced SOME output
+    // takes the normal produced-output path and never reaches this check.
+    const conversation = makeWakeConversation({
+      conversationId: "conv-max-tokens-no-output",
+      runImpl: async (input, onEvent) => {
+        await onEvent({
+          type: "agent_loop_exit",
+          reason: "max_tokens_reached",
+        });
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-max-tokens-no-output",
+        hint: "boom",
+        source: "t",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
+  });
+
+  test("keeps invoked true on a non-clean exit when a checkpoint already went live", async () => {
+    // Mirror of the throw path's went-live guard: once a checkpoint fired,
+    // side effects (e.g. `remember` calls) have already landed, so even a
+    // rebased history whose tail slice reads empty must not report the run
+    // as skipped: callers would re-run a pass whose side effects fired.
+    const assistantToolMsg: Message = {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "tu-1", name: "remember", input: {} }],
+    };
+    const toolResultMsg: Message = {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tu-1", content: "saved" }],
+    };
+    const conversation = makeWakeConversation({
+      conversationId: "conv-live-then-error",
+      runImpl: async (input, onEvent, runOptions) => {
+        const history = [...input, assistantToolMsg, toolResultMsg];
+        await runOptions?.onCheckpoint?.({
+          turnIndex: 0,
+          toolCount: 1,
+          hasToolUse: true,
+          history,
+        });
+        await onEvent({ type: "agent_loop_exit", reason: "error" });
+        // Return a history rebased below the wake's tail boundary, as the
+        // loop's deep-repair / recovery-hook paths can produce.
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-live-then-error", hint: "boom", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // The checkpoint's flush pushed + persisted the partial tail.
+    expect(conversation.pushedMessages.length).toBeGreaterThan(0);
+    expect(conversation.persistedTailCalls.length).toBeGreaterThan(0);
+  });
+
   test("keeps the silent no-op on a clean no_tool_calls exit with no output", async () => {
     // A clean model-driven stop that produced nothing stays `invoked: true`:
     // the pass really ran, the model just had nothing to say.

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1773,6 +1773,38 @@ describe("wakeAgentForOpportunity", () => {
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
   });
 
+  test("reports no_output on a clean empty reply when the caller requires usable output", async () => {
+    // Same clean no_tool_calls empty run as above, but the caller consumes
+    // its trigger on success (memory retrospective): the empty reply must
+    // read as a retryable failure, not a silent success.
+    const conversation = makeWakeConversation({
+      conversationId: "conv-clean-empty-required",
+      runImpl: async (input, onEvent) => {
+        await onEvent({ type: "agent_loop_exit", reason: "no_tool_calls" });
+        return runResult([...input]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-clean-empty-required",
+        hint: "hi",
+        source: "t",
+        requireUsableOutput: true,
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "no_output",
+    });
+    // Nothing persisted or emitted by the failed pass.
+    expect(conversation.persistedTailCalls).toEqual([]);
+    expect(conversation.emittedEvents).toHaveLength(0);
+  });
+
   test("elevates the turn's trust context before the agent loop runs", async () => {
     // Background system jobs (e.g. memory consolidation) need guardian trust to
     // clear the side-effect approval gate. The wake must set

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -185,20 +185,22 @@ const OVER_WINDOW_REJECTION_LOG_MESSAGE =
  * Terminal `agent_loop_exit` reasons under which a no-output run is a
  * legitimate silent no-op: the loop reached a real model reply (or a
  * model-driven stop) and the model simply produced nothing worth emitting.
- * Every other reason on a no-output run (`error`, where the loop's catch
- * swallowed a provider rejection or an unhandled throw into a graceful
- * no-output stop; the `aborted_*` family, cancellation before any output;
- * and the overflow terminals) means the pass never actually ran, so the wake
- * must report `invoked: false` instead of a phantom success. Membership is
- * an allowlist deliberately: a future exit reason defaults to the failure
- * side, which state-advancing callers recover from by retrying, rather than
- * the data-loss side.
+ * Every other reason on a no-output run means the pass never committed
+ * usable output, so the wake must report `invoked: false` instead of a
+ * phantom success: `error` (the loop's catch swallowed a provider rejection
+ * or an unhandled throw into a graceful no-output stop), the `aborted_*`
+ * family (cancellation before any output), the overflow terminals, and
+ * `max_tokens_reached` (the output budget was exhausted, e.g. by hidden
+ * thinking, before any visible text or executable tool call landed; a
+ * truncated response that DID produce output takes the normal path and
+ * never reaches this check). Membership is an allowlist deliberately: a
+ * future exit reason defaults to the failure side, which state-advancing
+ * callers recover from by retrying, rather than the data-loss side.
  */
 const CLEAN_NO_OUTPUT_EXIT_REASONS: ReadonlySet<AgentLoopExitReason> = new Set([
   "no_tool_calls",
   "yield_to_user",
   "checkpoint_handoff",
-  "max_tokens_reached",
 ]);
 
 export interface WakeOptions {
@@ -1517,7 +1519,15 @@ export async function wakeAgentForOpportunity(
         // pass that never ran. Gate on the terminal exit reason: a clean
         // model-driven stop is a real silent no-op; anything else fails the
         // wake so the caller retries.
+        // The went-live guard mirrors the throw path above: once a
+        // checkpoint fired or a tail message was persisted, side effects
+        // have already landed and the run must keep `invoked: true` even if
+        // the returned history's tail slice reads empty (the loop's
+        // deep-repair and recovery-hook paths rebase `history`, which can
+        // misalign the wake's external tail indexes).
         if (
+          mode === "buffering" &&
+          persistedTailIndex === 0 &&
           terminalExitReason !== null &&
           !CLEAN_NO_OUTPUT_EXIT_REASONS.has(terminalExitReason)
         ) {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -32,8 +32,13 @@
  *       text stay on the ephemeral trio above.
  *   - Invokes the agent loop with all conversation tools available unless
  *     the caller provides an explicit `allowedTools` scope.
- *   - No tool calls AND no assistant text → silent no-op (nothing persisted,
- *     nothing emitted). Returns `{ invoked: true, producedToolCalls: false }`.
+ *   - No tool calls AND no assistant text on a clean model-driven stop →
+ *     silent no-op (nothing persisted, nothing emitted). Returns
+ *     `{ invoked: true, producedToolCalls: false }`. When the no-output run
+ *     instead ended on a non-clean terminal exit (the loop swallowed a
+ *     provider rejection, unhandled throw, or cancellation into a graceful
+ *     no-output stop), returns `{ invoked: false, reason: "run_error" }` so
+ *     state-advancing callers retry instead of recording a phantom pass.
  *   - Tool calls produced → normal tool execution runs (the conversation's
  *     `AgentLoop` has its tool executor already wired). Returns
  *     `{ invoked: true, producedToolCalls: true }`.
@@ -64,6 +69,7 @@
 
 import type {
   AgentEvent,
+  AgentLoopExitReason,
   CheckpointDecision,
   CheckpointInfo,
 } from "../agent/loop.js";
@@ -174,6 +180,26 @@ function buildBackgroundEventText(
  */
 const OVER_WINDOW_REJECTION_LOG_MESSAGE =
   "agent-wake: provider rejected the input as over-window with auto-compaction suppressed; failing the wake";
+
+/**
+ * Terminal `agent_loop_exit` reasons under which a no-output run is a
+ * legitimate silent no-op: the loop reached a real model reply (or a
+ * model-driven stop) and the model simply produced nothing worth emitting.
+ * Every other reason on a no-output run (`error`, where the loop's catch
+ * swallowed a provider rejection or an unhandled throw into a graceful
+ * no-output stop; the `aborted_*` family, cancellation before any output;
+ * and the overflow terminals) means the pass never actually ran, so the wake
+ * must report `invoked: false` instead of a phantom success. Membership is
+ * an allowlist deliberately: a future exit reason defaults to the failure
+ * side, which state-advancing callers recover from by retrying, rather than
+ * the data-loss side.
+ */
+const CLEAN_NO_OUTPUT_EXIT_REASONS: ReadonlySet<AgentLoopExitReason> = new Set([
+  "no_tool_calls",
+  "yield_to_user",
+  "checkpoint_handoff",
+  "max_tokens_reached",
+]);
 
 export interface WakeOptions {
   conversationId: string;
@@ -383,13 +409,16 @@ export type WakeSkipReason =
    */
   | "context_overflow"
   /**
-   * The agent loop threw before producing ANY output — no checkpoint fired
-   * and no tail message was emitted or persisted (typically a provider
-   * failure on the run's first LLM call). The wake did no work, so callers
-   * that treat `invoked: true` as "the pass ran" (e.g. the memory
+   * The agent loop terminated abnormally before producing ANY output: either
+   * it threw before a checkpoint fired or a tail message was persisted, or it
+   * swallowed a terminal failure (provider rejection, unhandled throw,
+   * cancellation) into a graceful no-output stop whose `agent_loop_exit`
+   * reason is not a clean model-driven one (typically a provider failure on
+   * the run's first LLM call, e.g. rejected input). The wake did no work, so
+   * callers that treat `invoked: true` as "the pass ran" (e.g. the memory
    * retrospective, which advances its processed-message watermark and
    * finalizes on success) must see a retryable failure rather than a
-   * silent no-op. A throw AFTER output went live keeps `invoked: true` —
+   * silent no-op. A throw AFTER output went live keeps `invoked: true`:
    * side effects have already landed and the run must not read as skipped.
    */
   | "run_error";
@@ -942,6 +971,14 @@ export async function wakeAgentForOpportunity(
     // job. Capture the signal here so the wake can fail deterministically
     // instead (`reason: "context_overflow"`).
     let suppressedContextOverflow = false;
+    // Terminal exit reason captured from the loop's `agent_loop_exit` event.
+    // `agentLoop.run()`'s returned `exitReason` only distinguishes checkpoint
+    // handoffs, so this event is the wake's only view of HOW the loop ended.
+    // Read by the no-output branch below to tell a genuine silent no-op
+    // (model produced nothing) from a swallowed terminal failure (the loop's
+    // catch turns provider rejections and unhandled throws into a graceful
+    // no-output stop instead of rethrowing).
+    let terminalExitReason: AgentLoopExitReason | null = null;
     const persistLog = (record: PendingLog): void => {
       try {
         recordRequestLog(
@@ -1072,6 +1109,7 @@ export async function wakeAgentForOpportunity(
       // reason is stashed and applied in `goLive` after pendingLogs are
       // persisted, preserving the same ordering guarantee.
       if (event.type === "agent_loop_exit") {
+        terminalExitReason = event.reason;
         if (mode === "buffering") {
           pendingExitReason = event.reason;
         } else {
@@ -1264,6 +1302,12 @@ export async function wakeAgentForOpportunity(
     // finally's error log names the reported outcome so the line matches
     // what the caller actually saw.
     let reportedRunErrorAsFailure = false;
+    // Set when a no-output run ended on a non-clean terminal exit reason and
+    // was reported as `invoked: false` (reason "run_error"). The failure site
+    // logs its own dedicated warn line; the finally skips its generic
+    // "silent no-op" line for this path so a failed wake never reads as a
+    // successful empty one.
+    let reportedSwallowedStopAsFailure = false;
     // Shared failure path for an over-window condition on a
     // compaction-suppressed wake (reached from the pre-flight estimate, from
     // the run's catch when the rejection escaped as a throw, or post-run when
@@ -1464,6 +1508,30 @@ export async function wakeAgentForOpportunity(
       const producedOutput = producedToolCalls || hasVisibleText;
 
       if (!producedOutput || tailMessages.length === 0) {
+        // No output. Whether that reads as success depends on WHY the loop
+        // stopped: the loop's catch swallows provider rejections, unhandled
+        // throws, and cancellation into a graceful no-output stop instead of
+        // rethrowing, and reporting that as a successful silent no-op lets
+        // state-advancing callers (the memory retrospective watermark, the
+        // scheduler's success feed) permanently consume their trigger on a
+        // pass that never ran. Gate on the terminal exit reason: a clean
+        // model-driven stop is a real silent no-op; anything else fails the
+        // wake so the caller retries.
+        if (
+          terminalExitReason !== null &&
+          !CLEAN_NO_OUTPUT_EXIT_REASONS.has(terminalExitReason)
+        ) {
+          reportedSwallowedStopAsFailure = true;
+          log.warn(
+            { conversationId, source, exitReason: terminalExitReason },
+            "agent-wake: agent loop ended with no output on a non-clean exit; reported as run_error",
+          );
+          return {
+            invoked: false,
+            producedToolCalls: false,
+            reason: "run_error" as const,
+          };
+        }
         // Silent no-op: drop buffered events, push nothing, persist
         // nothing, emit nothing. (No checkpoint fired during the run
         // since checkpoints only fire after tool turns and there were
@@ -1540,7 +1608,7 @@ export async function wakeAgentForOpportunity(
 
       const durationMs = nowFn() - startedAt;
       const suppressWakeSurface = opts.suppressWakeSurface === true;
-      if (failedContextOverflow) {
+      if (failedContextOverflow || reportedSwallowedStopAsFailure) {
         // Already logged its own dedicated warn line at the failure site;
         // a generic "silent no-op" line here would misclassify a failed
         // wake as a successful empty one.

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -39,6 +39,9 @@
  *     provider rejection, unhandled throw, or cancellation into a graceful
  *     no-output stop), returns `{ invoked: false, reason: "run_error" }` so
  *     state-advancing callers retry instead of recording a phantom pass.
+ *     Callers that pass `requireUsableOutput: true` additionally get
+ *     `{ invoked: false, reason: "no_output" }` for the clean-stop empty
+ *     reply instead of the silent no-op.
  *   - Tool calls produced → normal tool execution runs (the conversation's
  *     `AgentLoop` has its tool executor already wired). Returns
  *     `{ invoked: true, producedToolCalls: true }`.
@@ -292,6 +295,23 @@ export interface WakeOptions {
    */
   suppressWakeSurface?: boolean;
   /**
+   * Treat a run that commits NO usable output (no executable tool call, no
+   * visible assistant text) as a failure even when the loop's terminal exit
+   * was a clean model-driven stop, e.g. an HTTP-200 reply with an empty
+   * content array or thinking-only output. Default false: generic
+   * opportunity wakes (meet chat, scheduled nudges) legitimately let the
+   * model decide to stay silent, and their silent no-op stays
+   * `invoked: true`.
+   *
+   * Set by state-advancing callers whose trigger is consumed on success and
+   * whose contract requires committed output: the fork-based memory
+   * retrospective advances its processed-message watermark and GCs the
+   * prior retrospective on `invoked: true`, so for it an empty reply is a
+   * failed pass to retry, never a success (LUM-3013). Runs whose output
+   * already went live (checkpoint fired / tail persisted) are unaffected.
+   */
+  requireUsableOutput?: boolean;
+  /**
    * Optional exact tool allowlist for this wake. Used by internal maintenance
    * jobs that need the assistant's judgment but must not execute arbitrary
    * side-effect tools. Enforcement depends on `toolGateMode`: in `"wire"`
@@ -423,7 +443,15 @@ export type WakeSkipReason =
    * silent no-op. A throw AFTER output went live keeps `invoked: true`:
    * side effects have already landed and the run must not read as skipped.
    */
-  | "run_error";
+  | "run_error"
+  /**
+   * The run ended cleanly but committed no usable output (no executable tool
+   * call, no visible assistant text: e.g. an HTTP-200 reply with an empty
+   * content array, or thinking-only output) and the caller passed
+   * `requireUsableOutput: true`. Only possible on such wakes; without the
+   * flag the same run is a silent no-op with `invoked: true`.
+   */
+  | "no_output";
 
 export interface WakeResult {
   invoked: boolean;
@@ -1304,10 +1332,11 @@ export async function wakeAgentForOpportunity(
     // finally's error log names the reported outcome so the line matches
     // what the caller actually saw.
     let reportedRunErrorAsFailure = false;
-    // Set when a no-output run ended on a non-clean terminal exit reason and
-    // was reported as `invoked: false` (reason "run_error"). The failure site
-    // logs its own dedicated warn line; the finally skips its generic
-    // "silent no-op" line for this path so a failed wake never reads as a
+    // Set when a no-output run was reported as `invoked: false`, either
+    // because it ended on a non-clean terminal exit reason ("run_error") or
+    // because the caller requires usable output ("no_output"). The failure
+    // site logs its own dedicated warn line; the finally skips its generic
+    // "silent no-op" line for these paths so a failed wake never reads as a
     // successful empty one.
     let reportedSwallowedStopAsFailure = false;
     // Shared failure path for an over-window condition on a
@@ -1525,9 +1554,10 @@ export async function wakeAgentForOpportunity(
         // the returned history's tail slice reads empty (the loop's
         // deep-repair and recovery-hook paths rebase `history`, which can
         // misalign the wake's external tail indexes).
+        const nothingWentLive =
+          mode === "buffering" && persistedTailIndex === 0;
         if (
-          mode === "buffering" &&
-          persistedTailIndex === 0 &&
+          nothingWentLive &&
           terminalExitReason !== null &&
           !CLEAN_NO_OUTPUT_EXIT_REASONS.has(terminalExitReason)
         ) {
@@ -1540,6 +1570,21 @@ export async function wakeAgentForOpportunity(
             invoked: false,
             producedToolCalls: false,
             reason: "run_error" as const,
+          };
+        }
+        // Clean stop with no usable output. For callers that consume a
+        // trigger on success (requireUsableOutput), an empty reply is a
+        // failed pass to retry, not a success to record.
+        if (nothingWentLive && opts.requireUsableOutput === true) {
+          reportedSwallowedStopAsFailure = true;
+          log.warn(
+            { conversationId, source, exitReason: terminalExitReason },
+            "agent-wake: agent loop committed no usable output and the caller requires it; reported as no_output",
+          );
+          return {
+            invoked: false,
+            producedToolCalls: false,
+            reason: "no_output" as const,
           };
         }
         // Silent no-op: drop buffered events, push nothing, persist


### PR DESCRIPTION
## TL;DR

Fixes [LUM-3013](https://linear.app/vellum/issue/LUM-3013/memory-retrospectives-skip-failed-windows-after-provider-no-op): memory retrospective windows silently advanced past provider rejections (and other unusable outcomes), permanently dropping derived memory for those windows. The agent-wake layer now reports a no-output run as a retryable failure when the loop ended abnormally, and — for callers that require committed output, like the retrospective — when a clean run committed nothing usable.

## The bug

`AgentLoop.run()` never rethrows a provider rejection: its catch emits `error` + `agent_loop_exit(reason: "error")` events, stops the turn, and returns the history unchanged. `wakeAgentForOpportunity` only treated a *throw* as failure, so a swallowed rejection with no output landed in the silent no-op branch and returned `invoked: true`. A clean HTTP-200 reply with an empty content array (or thinking-only output) read the same way.

The memory retrospective gates its entire finalization on `invoked`: it advanced `lastProcessedMessageId` past the window, appended nothing to the remembered log, and GC'd the prior retrospective conversation. With the shipped `memoryRetrospective` default resolving to a model that rejects image-bearing input, every image-bearing window completed as a phantom pass with no `last_error` on the job row. Only the context-overflow subclass of this failure was previously detected.

## The fix

Two layers in the wake, both guarded by the throw path's "nothing went live" check (`mode === "buffering" && persistedTailIndex === 0`) so runs whose side effects landed always keep `invoked: true`:

1. **Abnormal terminal exits fail for every caller.** The wake latches the loop's terminal `agent_loop_exit` reason; on a no-output run, an exit outside a clean-stop allowlist (`no_tool_calls`, `yield_to_user`, `checkpoint_handoff`) returns `{ invoked: false, reason: "run_error" }`. A zero-output `max_tokens_reached` stop is a failure, not a clean stop. The allowlist direction is deliberate: an unrecognized future exit reason fails toward retry, not data loss.
2. **Clean-but-empty output fails for callers that require usable output.** A new `requireUsableOutput` wake option makes a clean-stop run with no committed output (empty content array, thinking-only) return `{ invoked: false, reason: "no_output" }`. The retrospective opts in; generic opportunity wakes (meet chat, scheduled nudges) keep their designed silent no-op semantics.

No retrospective-side state change is needed. `invoked: false` flows into the existing `wake_failed` path, which already does exactly what LUM-3013 asks for: cursor and prior retrospective preserved, this run's orphan fork deleted, `lastRunAt` bumped so the cooldown gates retries, `memory_retrospective_run` watchdog outcome recorded with the reason.

## Why this is safe

- Runs that produce any output are untouched, and the went-live guard preserves the documented "output that already landed keeps `invoked: true`" invariant even when the loop's deep-repair/recovery paths rebase the returned history below the wake's tail boundary.
- Fail-closed behavior for clean empty replies is strictly opt-in (`requireUsableOutput`), so no other wake caller changes behavior on that path.
- All other production callers already branch on `invoked` defensively: the scheduler skips its success feed event, the interrupted-turn reconciler logs, shell notification wakes are fire-and-forget.
- **Producer-to-finalizer integration coverage** (`memory-retrospective-wake-chain.test.ts`) runs the real chain — real fork + real `memory_retrospective_state` rows, the real `wakeAgentForOpportunity`, a real `AgentLoop` over a scripted provider — and proves: provider rejection and clean-empty output preserve cursor/log/prior and stay retryable; a usable-output control advances state and GCs the prior; a rejection after a live checkpoint stays `invoked` with its landed `remember` honored. Plus 6 wake unit tests; all suites green per-file.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Retrospective window whose provider call is rejected (e.g. image input on a non-image model) | Window marked processed, prior retrospective deleted, facts permanently missing from derived memory | Window stays unprocessed and is retried after the cooldown; prior retrospective and dedup baseline preserved |
| Retrospective window whose run returned an empty reply or exhausted its output budget with zero output | Same silent loss as above | Same retryable failure as above (`no_output` / `run_error`) |
| Queue/telemetry visibility of such failures | Job `completed`, watchdog outcome `invoked` — queue looks healthy | Watchdog outcome `wake_failed` with the failure reason; dedicated warn log line |
| Scheduled wake whose only LLM call is rejected | Success feed event emitted for a run that never happened | No phantom success event; a one-shot completes without firing (the scheduler's retry path is timeout-only today, see Deferred) |
| Meet/scheduled wake where the model legitimately stays silent | Silent no-op, `invoked: true` | Unchanged (fail-closed is opt-in) |

## Deferred

- The retrospective job row still completes (outcome `wake_failed`) rather than failing the row into the jobs-worker retry machinery. That is the designed retry path (cooldown + event-driven re-enqueue); double-driving it through job-row backoff would conflict. The ticket's "no `last_error`" observation is addressed by the honest `wake_failed` watchdog outcome instead.
- The scheduler's one-shot retry path only handles `reason === "timeout"`; a one-shot whose wake fails with `run_error` now completes without firing (and without the phantom success event it used to emit). Extending one-shot retries to `run_error` is a scheduler policy decision, deferred per review guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)