### PR TITLE
fix(web): stop a superseded SSE stream from killing the live one

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -138,8 +138,9 @@ describe("sseService.attach — connection lifecycle", () => {
     expect(publishSpy).toHaveBeenCalledWith("sse.event", envelope);
   });
 
-  test("publishes sse.opened with cause=fresh on first open", () => {
+  test("publishes sse.opened with cause=fresh once the stream establishes", () => {
     sseService.attach("asst-1");
+    activeOnStreamOpen!();
 
     expect(publishSpy).toHaveBeenCalledWith("sse.opened", {
       assistantId: "asst-1",
@@ -188,6 +189,44 @@ describe("sseService.attach — connection lifecycle", () => {
     });
   });
 
+  test("a superseded stream's late error does not disconnect the live one", async () => {
+    // GIVEN a connection that is bounced, so an older stream handle is still
+    // holding the callbacks it was created with
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    sseService.attach("asst-1");
+    const supersededOnError = activeOnError!;
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    eventBus.publish("app.resume", { signal: "visibility" });
+    activeOnStreamOpen!();
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+    publishSpy.mockClear();
+
+    // WHEN the daemon closes the superseded connection, which arrives as an
+    // error on the OLD stream after its replacement is already live
+    supersededOnError(new Error("stream closed"));
+
+    // THEN the live stream keeps ownership. Acting on the stale signal would
+    // clear it, and the next trigger would open a connection that closes the
+    // live one in turn, which is the self-sustaining reconnect loop.
+    expect(useSSEConnectedStore.getState().isConnected).toBe(true);
+    const closedCalls = publishSpy.mock.calls.filter(
+      ([name]) => name === "sse.closed",
+    );
+    expect(closedCalls).toHaveLength(0);
+  });
+
+  test("does not publish sse.opened for an attempt that never establishes", () => {
+    // A connect that never opens has nothing for consumers to reconcile, and
+    // announcing it fans a refetch across every domain.
+    sseService.attach("asst-1");
+
+    const openedCalls = publishSpy.mock.calls.filter(
+      ([name]) => name === "sse.opened",
+    );
+    expect(openedCalls).toHaveLength(0);
+  });
+
   test("detach cancels the SSE", () => {
     const detach = sseService.attach("asst-1");
     expect(cancelMock).not.toHaveBeenCalled();
@@ -222,6 +261,7 @@ describe("sseService.attach — connection lifecycle", () => {
 
     // WHEN cold-start anchoring requests a re-anchor (cursor now seeded at S)
     eventBus.publish("sse.anchor-requested", {});
+    activeOnStreamOpen!();
 
     // THEN the cursor-less connection is torn down and reopened
     expect(cancelMock).toHaveBeenCalledTimes(1);
@@ -444,6 +484,7 @@ describe("sseService.attach — visibility-driven bounce", () => {
     eventBus.publish("app.hidden", { signal: "visibility" });
     await sleep(TEST_HIDDEN_GRACE_MS + 20);
     eventBus.publish("app.resume", { signal: "visibility" });
+    activeOnStreamOpen!();
 
     expect(publishSpy).toHaveBeenCalledWith("sse.opened", {
       assistantId: "asst-1",
@@ -579,6 +620,7 @@ describe("sseService.attach — reachability bounce", () => {
     publishSpy.mockClear();
 
     eventBus.publish("reachability.retry-requested", {});
+    activeOnStreamOpen!();
 
     expect(publishSpy).toHaveBeenCalledWith("sse.opened", {
       assistantId: "asst-1",
@@ -609,6 +651,7 @@ describe("sseService.attach — debug-driven reconnect", () => {
 
     // WHEN a debug reconnect is requested
     requestSseReconnect(0);
+    activeOnStreamOpen!();
 
     // THEN the reopen is labeled as a debug-triggered reconnect so
     // reconcile consumers (which only skip on "fresh") still fire

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -149,40 +149,65 @@ export const sseService: SseService = {
       // request limiter. Reconciling has nothing to recover when we never went
       // live, so suppress it until the stream proves established.
       let everOpened = false;
+      // The stream these callbacks belong to, so a late signal from one that
+      // has already been replaced cannot act on behalf of the live one. The
+      // daemon closes a superseded connection as soon as its replacement
+      // registers (same clientId), and that close arrives here as an error on
+      // the OLD stream. Clearing `current` on it would blank the pointer to
+      // the healthy new stream, and the next trigger would open another
+      // connection, which closes that one in turn: a reconnect loop that
+      // sustains itself with no network fault at all.
+      let ownStream: EventStream | null = null;
+      const isLiveStream = (): boolean =>
+        ownStream === null || ownStream === current;
       const stream = subscribeEvents(
         assistantId,
         (envelope) => {
           publish("sse.event", envelope);
         },
         (err) => {
-          setCurrent(null);
-          setConnected(false);
-          publish("sse.closed", { reason: err.message });
           Sentry.addBreadcrumb({
             category: "event_bus.sse",
             level: "warning",
             message: err.message,
           });
+          if (!isLiveStream()) {
+            return;
+          }
+          setCurrent(null);
+          setConnected(false);
+          publish("sse.closed", { reason: err.message });
         },
         {
           onReconnect: (cause) => {
-            if (everOpened) {
+            if (everOpened && isLiveStream()) {
               publish("sse.opened", { assistantId, cause });
             }
           },
           onStreamOpen: () => {
+            const firstOpen = !everOpened;
             everOpened = true;
             setConnected(true);
+            // Announce the stream once it genuinely establishes rather than
+            // when its handle is created, so an attempt that never connects
+            // does not fan out a reconcile across every domain.
+            if (firstOpen && isLiveStream()) {
+              publish("sse.opened", { assistantId, cause: causeAtOpen });
+            }
           },
-          onStreamClose: () => setConnected(false),
+          onStreamClose: () => {
+            if (isLiveStream()) {
+              setConnected(false);
+            }
+          },
         },
       );
+      ownStream = stream;
       if (cancelled) {
         stream.cancel();
         return;
       }
       setCurrent(stream);
-      publish("sse.opened", { assistantId, cause: causeAtOpen });
     };
 
     const teardown = () => {


### PR DESCRIPTION
ref ATL-1177

The daemon closes an SSE connection as soon as a replacement with the same `clientId` registers, and that close reaches the client as an error on the *old* stream. Its handler cleared the shared current-stream pointer without checking whether it still owned it, so the pointer to the healthy new stream was blanked. The service then read itself as disconnected and the next trigger opened another connection, which closed the live one in turn.

That loop sustains itself with no network fault. One production instance registered 61 connections in 11 minutes, 58 of which displaced a predecessor, and every reconnect fanned a refetch across conversations, messages, identity, flags and avatar. A customer typing into that app lost a message.

Stream callbacks now act only while their own stream is the current one. `sse.opened` also moves from handle creation to genuine establishment, so a connect that never opens no longer triggers a reconcile with nothing to recover.

Note the second change alters when consumers see `sse.opened`: it now fires on the transport's open signal rather than immediately after `subscribeEvents` returns. Five existing tests asserted the old timing and were updated to fire the open signal first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)