### PR TITLE
ci(docs): dispatch docs-cd instead of the full platform Helm deploy

### DIFF
--- a/.github/workflows/publish-docs-image.yaml
+++ b/.github/workflows/publish-docs-image.yaml
@@ -1,8 +1,8 @@
 name: Publish Docs Image
 
 # Builds and publishes the docs-site image to each environment's Artifact
-# Registry, then dispatches the platform repo's Helm deploy so the docs
-# backend rolls to the freshly published SHA. Pushes to main publish to dev,
+# Registry, then dispatches the platform repo's docs-cd workflow so the docs
+# Deployment (and nothing else) rolls to the freshly published SHA. Pushes to main publish to dev,
 # staging, and production so every environment's registry always has the
 # latest main build; `workflow_dispatch` republishes (and redeploys) a single
 # chosen environment. The image lives under the existing `sandbox-images` AR
@@ -94,8 +94,8 @@ jobs:
 
       # The dispatch lives inside the matrix leg so each environment deploys
       # only after its own publish succeeded, and a cancelled (superseded)
-      # publish never triggers a deploy. helm-cd pins the docs Deployment to
-      # this SHA and preserves every other image tag from the live release.
+      # publish never triggers a deploy. docs-cd rolls only the docs
+      # Deployment to this SHA — it does not run a full platform Helm deploy.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
@@ -109,7 +109,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run helm-cd.yaml \
+          gh workflow run docs-cd.yaml \
             --repo vellum-ai/vellum-assistant-platform \
             --field environment="${{ matrix.environment }}" \
             --field docs_image_tag="${{ github.sha }}"


### PR DESCRIPTION
## Why

The dispatch added in #39841 targets `helm-cd.yaml`, which runs a **full platform chart upgrade** (migration hooks, every backend, 15-minute `--wait`) for every docs image publish. Docs publishes should roll only the docs site.

## What

Retargets the per-leg dispatch to the platform repo's new `docs-cd.yaml` (vellum-ai/vellum-assistant-platform#9734), which takes the same `environment` + `docs_image_tag` inputs but only sets the docs Deployment's image and waits for its rollout. Everything else about the trigger (per-leg gating, path filter, app-token pattern) is unchanged.

## Merge order

Merge **vellum-ai/vellum-assistant-platform#9734 first** — it adds the `docs-cd.yaml` this dispatch targets (plus the helm-cd tag-preserve fix that makes out-of-Helm docs rolls safe). Then merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)