### PR TITLE
fix(web): address self-review findings on the attachment files panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -1,32 +1,56 @@
 import { Typography } from "@vellumai/design-library";
 
+import { ATTACHMENT_TILE_BOX_CLASS } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import {
+  sameMessageFilesTarget,
+  useViewerStore,
+  type MessageFilesPayload,
+} from "@/stores/viewer-store";
+
 interface AttachmentOverflowSquareProps {
   /** How many attachments are hidden behind this tile. */
   count: number;
-  onClick: () => void;
-  /** Whether this tile's files panel is currently open. */
-  active?: boolean;
+  /** The files-panel target this tile opens, closes, and reflects. */
+  payload: MessageFilesPayload;
 }
 
 /**
  * Terminal tile of a truncated attachment strip. Stands in for the
- * attachments past the inline limit.
+ * attachments past the inline limit, and toggles the files side panel that
+ * lists all of them.
+ *
+ * The viewer-store reads live here rather than in {@link MessageAttachments}
+ * because this tile mounts only on the minority of strips that actually
+ * overflow. Reading `mainView` one level up would subscribe EVERY assistant
+ * attachment strip in the transcript to a global, reference-equality slice, so
+ * opening any overlay anywhere would re-render all of them.
  */
 export function AttachmentOverflowSquare({
   count,
-  onClick,
-  active = false,
+  payload,
 }: AttachmentOverflowSquareProps) {
+  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
+  const mainView = useViewerStore.use.mainView();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
+
+  // The tile whose files panel is currently open renders with the persistent
+  // active surface, mirroring the activity group header's selected state.
+  const active =
+    mainView === "message-files" &&
+    activeMessageFiles != null &&
+    sameMessageFilesTarget(activeMessageFiles, payload);
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => toggleMessageFiles(payload)}
       aria-label={`Show all files (${count} more)`}
+      aria-expanded={active}
       title={`${count} more`}
-      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
+      className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center border border-dashed transition-colors ${
         active
-          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
-          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
+          ? "border-[var(--border-active)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-element)] hover:bg-[var(--surface-lift)]"
       }`}
     >
       <Typography

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -1,0 +1,114 @@
+/**
+ * Shared fixtures and stubs for the attachment renderers' tests
+ * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`) and the
+ * viewer store's message-files actions.
+ *
+ * The preview-modal stub is exported as a function rather than run on import,
+ * because `mock.module` must be applied BEFORE the module under test is
+ * imported and a bare side-effecting import gives the test no control over
+ * that ordering.
+ */
+
+import { mock } from "bun:test";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+/**
+ * A display attachment with sensible PNG defaults. Pass `overrides` for the
+ * fields a test actually cares about.
+ */
+export function makeDisplayAttachment(
+  overrides: Partial<DisplayAttachment> = {},
+): DisplayAttachment {
+  const id = overrides.id ?? "att-1";
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+/** `count` distinct image attachments, named `photo-<i>.png`. */
+export function makeImageAttachments(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: `https://example.com/photo-${index}.png`,
+    }),
+  );
+}
+
+/** A mixed media / non-media set covering each icon fallback kind. */
+export function makeMixedAttachments(): DisplayAttachment[] {
+  return [
+    makeImageAttachments(1)[0]!,
+    makeDisplayAttachment({
+      id: "deck-1",
+      filename: "deck.pptx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      sizeBytes: 4_096,
+    }),
+    makeDisplayAttachment({
+      id: "report-1",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_048,
+    }),
+    makeDisplayAttachment({
+      id: "bundle-1",
+      filename: "bundle.zip",
+      mimeType: "application/zip",
+      sizeBytes: 8_192,
+    }),
+  ];
+}
+
+/**
+ * Replace the preview modal with a probe exposing the opened attachment, its
+ * preview URL, and its gallery siblings - enough for both the gallery-size
+ * assertions and the failed-decode assertions. Call this at module scope,
+ * above the import of the component under test.
+ */
+export function mockAttachmentPreviewModal(): void {
+  mock.module(
+    "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+    () => ({
+      AttachmentPreviewModal: ({
+        attachment,
+        siblingAttachments,
+      }: {
+        attachment: { id: string; previewUrl: string | null };
+        siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
+      }) => (
+        <div
+          data-testid="preview-modal"
+          data-attachment-id={attachment.id}
+          data-preview-url={String(attachment.previewUrl)}
+          data-sibling-count={String((siblingAttachments ?? []).length)}
+          data-sibling-preview-urls={JSON.stringify(
+            (siblingAttachments ?? []).map((a) => ({
+              id: a.id,
+              previewUrl: a.previewUrl,
+            })),
+          )}
+        />
+      ),
+    }),
+  );
+}
+
+/**
+ * The `aria-label` of every attachment square in `container`. Squares are divs
+ * with `role="button"`; the download and overflow affordances are real
+ * `<button>` elements, so this counts only squares.
+ */
+export function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -1,30 +1,9 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string; previewUrl: string | null };
-      siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-preview-url={String(attachment.previewUrl)}
-        data-sibling-preview-urls={JSON.stringify(
-          (siblingAttachments ?? []).map((a) => ({
-            id: a.id,
-            previewUrl: a.previewUrl,
-          })),
-        )}
-      />
-    ),
-  }),
-);
+import { mockAttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+
+mockAttachmentPreviewModal();
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,11 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
 
 interface BubbleAttachmentsProps {
@@ -22,46 +19,21 @@ interface BubbleAttachmentsProps {
  * compact {@link MessageAttachmentSquare} chip. Both kinds are clickable and
  * open the full-screen {@link AttachmentPreviewModal}.
  *
- * Distinct from {@link MessageAttachments}, the legacy separate-strip renderer
- * still used for assistant messages, which renders every attachment as a chip.
+ * Every attachment renders - this surface is deliberately uncapped, unlike the
+ * assistant strip ({@link MessageAttachments}), which collapses past a limit
+ * behind an overflow tile.
  */
 export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   attachments,
   assistantId,
 }) => {
-  // Ids whose previewUrl the browser failed to decode (e.g. a HEIC blob on a
-  // Chromium renderer). Those fall back to the chip instead of the browser's
-  // broken-image glyph.
-  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(
-    new Set(),
-  );
-  const markImageFailed = useCallback((id: string) => {
-    setFailedImageIds((prev) => new Set(prev).add(id));
-  }, []);
-
-  // A failed inline decode leaves a dead previewUrl (e.g. an undecodable HEIC
-  // blob on Chromium). Nulling it by id across the whole array — which is also
-  // forwarded as the modal's `siblingAttachments` — makes the chip, the modal,
-  // and gallery navigation all refetch stored bytes instead of the broken blob.
-  const previewAttachments = useMemo(
-    () =>
-      attachments.map((att) =>
-        failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
-      ),
-    [attachments, failedImageIds],
-  );
-
-  const { openPreview, previewModal } = useAttachmentPreview(
-    assistantId,
-    previewAttachments,
-  );
-
-  const handleDownload = useCallback(
-    (att: DisplayAttachment) => {
-      void downloadAttachment(att, assistantId);
-    },
-    [assistantId],
-  );
+  const {
+    displayAttachments,
+    renderSquare,
+    openPreview,
+    markImageFailed,
+    previewModal,
+  } = useAttachmentSquares({ attachments, assistantId });
 
   if (attachments.length === 0) {
     return null;
@@ -70,7 +42,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   return (
     <>
       <div className="flex flex-col gap-2">
-        {previewAttachments.map((att, index) => {
+        {displayAttachments.map((att, index) => {
           const isInlineImage =
             classifyAttachment(att.mimeType, att.filename) === "image" &&
             att.previewUrl != null;
@@ -98,21 +70,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
             );
           }
 
-          return (
-            <MessageAttachmentSquare
-              key={att.id}
-              filename={att.filename}
-              mimeType={att.mimeType}
-              sizeBytes={att.sizeBytes}
-              previewUrl={att.previewUrl}
-              thumbnailUrl={att.thumbnailUrl}
-              onPreview={() => openPreview(att)}
-              // Download falls back to previewUrl when the daemon content fetch
-              // is unavailable, so it takes the unsanitized attachment — a blob
-              // that can't be *rendered* is still valid bytes to save.
-              onDownload={() => handleDownload(attachments[index]!)}
-            />
-          );
+          return renderSquare(att, index);
         })}
       </div>
       {previewModal}

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -10,7 +10,7 @@ import {
   FileType2,
   FileVideo,
 } from "lucide-react";
-import type { FC, MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useCallback } from "react";
 
 import { Tooltip, Typography } from "@vellumai/design-library";
@@ -21,21 +21,26 @@ import {
   middleTruncate,
   type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 
+/**
+ * Geometry of the square's inner tile box. Shared with
+ * {@link AttachmentOverflowSquare} so the terminal overflow tile lines up with
+ * the squares it sits beside - the two must stay identical or the strip breaks.
+ */
+export const ATTACHMENT_TILE_BOX_CLASS = "h-16 w-16 shrink-0 rounded-lg";
+
 interface MessageAttachmentSquareProps {
-  filename: string;
-  mimeType: string;
-  sizeBytes: number;
-  previewUrl: string | null;
-  /** JPEG thumbnail URL (from daemon thumbnailData). Used as a background
-   *  image for video attachment chips so they show a poster frame instead of
-   *  a bare icon. Null for non-video or when no thumbnail is available. */
-  thumbnailUrl?: string | null;
+  attachment: DisplayAttachment;
   /** Called when the user clicks the thumbnail to open a full-screen preview. */
   onPreview?: () => void;
   /** Called when the user clicks a download button. */
   onDownload?: () => void;
+  /** Called when the browser fails to decode the image preview (e.g. a HEIC
+   *  blob on a Chromium renderer). Lets the owner null the dead `previewUrl`
+   *  so this square falls back to its file-kind icon. */
+  onPreviewError?: () => void;
 }
 
 const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
@@ -57,23 +62,20 @@ const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
  * with an icon. On hover, a download overlay appears at the bottom-right of
  * the thumbnail.
  */
-export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
-  filename,
-  mimeType,
-  sizeBytes,
-  previewUrl,
-  thumbnailUrl,
+export function MessageAttachmentSquare({
+  attachment,
   onPreview,
   onDownload,
-}) => {
+  onPreviewError,
+}: MessageAttachmentSquareProps) {
+  const { filename, mimeType, sizeBytes, previewUrl, thumbnailUrl } =
+    attachment;
   const kind = classifyAttachment(mimeType, filename);
   const hasImagePreview = kind === "image" && previewUrl !== null;
-  const hasVideoThumbnail = kind === "video" && thumbnailUrl != null;
-  const backgroundImageUrl = hasImagePreview
-    ? previewUrl
-    : hasVideoThumbnail
-      ? thumbnailUrl
-      : null;
+  // Video posters stay a CSS background: there is no fallback to swap to when
+  // a poster fails, so an <img> would surface the browser's broken glyph.
+  const backgroundImageUrl =
+    kind === "video" && thumbnailUrl != null ? thumbnailUrl : null;
   const isClickable = onPreview != null;
   const displayName = middleTruncate(filename, 18);
   const displaySize = formatAttachmentSize(sizeBytes);
@@ -108,7 +110,7 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
     >
       <div className="relative w-fit">
         <div
-          className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]"
+          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]`}
           style={
             backgroundImageUrl
               ? {
@@ -117,7 +119,19 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
               : undefined
           }
         >
-          {backgroundImageUrl ? null : ICON_BY_KIND[kind]}
+          {hasImagePreview ? (
+            // A real <img> rather than a CSS background so an undecodable
+            // preview raises `onError` and the owner can fall back to the icon.
+            <img
+              src={previewUrl}
+              alt=""
+              aria-hidden
+              onError={onPreviewError}
+              className="h-full w-full object-cover"
+            />
+          ) : backgroundImageUrl ? null : (
+            ICON_BY_KIND[kind]
+          )}
         </div>
         {onDownload && (
           <div className="pointer-events-none absolute inset-0 rounded-lg bg-black/50 opacity-0 transition-opacity group-hover/square:pointer-events-auto group-hover/square:opacity-100 group-focus-within/square:pointer-events-auto group-focus-within/square:opacity-100">
@@ -153,4 +167,4 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
       )}
     </div>
   );
-};
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -1,24 +1,14 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string };
-      siblingAttachments?: Array<{ id: string }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-sibling-count={String((siblingAttachments ?? []).length)}
-      />
-    ),
-  }),
-);
+import {
+  makeDisplayAttachment,
+  makeImageAttachments,
+  mockAttachmentPreviewModal,
+  squareLabels,
+} from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+
+mockAttachmentPreviewModal();
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
@@ -33,33 +23,13 @@ afterEach(() => {
   useViewerStore.setState({ mainView: "chat", activeMessageFiles: null });
 });
 
-function image(index: number): DisplayAttachment {
-  return {
-    id: `img-${index}`,
-    filename: `photo-${index}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: `https://example.com/photo-${index}.png`,
-  };
-}
-
-function images(count: number): DisplayAttachment[] {
-  return Array.from({ length: count }, (_, index) => image(index));
-}
-
-/** The squares are divs with `role="button"`; the download and overflow
- *  affordances are real `<button>` elements, so this selector counts only
- *  attachment squares. */
-function squareLabels(container: HTMLElement): Array<string | null> {
-  return Array.from(container.querySelectorAll('div[role="button"]')).map(
-    (el) => el.getAttribute("aria-label"),
-  );
-}
-
 describe("MessageAttachments", () => {
   test("renders every square and no overflow tile at the visible limit", () => {
     const { container, queryByRole } = render(
-      <MessageAttachments attachments={images(5)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(5)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -68,7 +38,10 @@ describe("MessageAttachments", () => {
 
   test("renders five squares plus a +1 tile for six attachments", () => {
     const { container, getByText, getByRole } = render(
-      <MessageAttachments attachments={images(6)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(6)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -80,7 +53,10 @@ describe("MessageAttachments", () => {
 
   test("renders five squares plus a +36 tile for forty-one attachments", () => {
     const { container, getByText } = render(
-      <MessageAttachments attachments={images(41)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(41)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -88,38 +64,36 @@ describe("MessageAttachments", () => {
   });
 
   test("counts non-media attachments toward the limit and keeps source order", () => {
+    const images = makeImageAttachments(5);
     const mixed: DisplayAttachment[] = [
-      image(0),
-      {
+      images[0]!,
+      makeDisplayAttachment({
         id: "deck-1",
         filename: "deck.pptx",
         mimeType:
           "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         sizeBytes: 4_096,
-        previewUrl: null,
-      },
-      image(1),
-      {
+      }),
+      images[1]!,
+      makeDisplayAttachment({
         id: "report-1",
         filename: "report.pdf",
         mimeType: "application/pdf",
         sizeBytes: 2_048,
-        previewUrl: null,
-      },
-      {
+      }),
+      makeDisplayAttachment({
         id: "bundle-1",
         filename: "bundle.zip",
         mimeType: "application/zip",
         sizeBytes: 8_192,
-        previewUrl: null,
-      },
-      image(2),
-      image(3),
-      image(4),
+      }),
+      images[2]!,
+      images[3]!,
+      images[4]!,
     ];
 
     const { container, getByText } = render(
-      <MessageAttachments attachments={mixed} />,
+      <MessageAttachments attachments={mixed} messageId="msg-1" />,
     );
 
     expect(squareLabels(container)).toEqual([
@@ -132,9 +106,30 @@ describe("MessageAttachments", () => {
     expect(getByText("+3")).toBeTruthy();
   });
 
+  test("a visible square opens the preview with every attachment as siblings", () => {
+    const { getByLabelText, getByTestId } = render(
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
+    );
+
+    fireEvent.click(getByLabelText("photo-0.png"));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("img-0");
+    // Gallery navigation spans the whole set, not just the visible squares.
+    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+    // Opening a preview must not open the files panel.
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
   test("the overflow tile opens the files panel with every attachment", () => {
     const { getByRole, queryByTestId } = render(
-      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
     );
 
     fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
@@ -147,9 +142,26 @@ describe("MessageAttachments", () => {
     expect(queryByTestId("preview-modal")).toBeNull();
   });
 
+  test("the overflow tile reports its expanded state", () => {
+    const { getByRole } = render(
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
+    );
+
+    const tile = getByRole("button", { name: "Show all files (3 more)" });
+    expect(tile.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(tile);
+    expect(tile.getAttribute("aria-expanded")).toBe("true");
+  });
+
   test("clicking the overflow tile again closes the files panel", () => {
     const { getByRole } = render(
-      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
     );
 
     const tile = getByRole("button", { name: "Show all files (3 more)" });
@@ -162,7 +174,9 @@ describe("MessageAttachments", () => {
   });
 
   test("returns null for an empty attachments array", () => {
-    const { container } = render(<MessageAttachments attachments={[]} />);
+    const { container } = render(
+      <MessageAttachments attachments={[]} messageId="msg-1" />,
+    );
     expect(container.innerHTML).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -1,17 +1,7 @@
-import { useCallback, useMemo } from "react";
-import type { FC } from "react";
-
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
-import {
-  sameMessageFilesTarget,
-  useViewerStore,
-  type MessageFilesPayload,
-} from "@/stores/viewer-store";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 
 interface MessageAttachmentsProps {
   attachments: DisplayAttachment[];
@@ -19,7 +9,7 @@ interface MessageAttachmentsProps {
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
   /** Transcript message identity, forwarded to the files panel payload. */
-  messageId?: string;
+  messageId: string;
 }
 
 /**
@@ -31,77 +21,41 @@ const VISIBLE_LIMIT = 5;
 
 /**
  * Read-only strip of attachment thumbnails rendered as a separate strip for
- * assistant messages (the user path now renders attachments inside the message
+ * assistant messages (the user path renders attachments inside the message
  * bubble via {@link BubbleAttachments}). Every attachment is clickable and
- * opens a full-screen preview modal — the modal handles type-specific
+ * opens a full-screen preview modal - the modal handles type-specific
  * rendering (image/video/fallback) and lazily fetches missing content when
  * needed. A hover overlay on each square provides direct download without
  * opening the preview first. Past {@link VISIBLE_LIMIT} the strip collapses
  * behind an overflow tile that opens the files side panel.
  */
-export const MessageAttachments: FC<MessageAttachmentsProps> = ({
+export function MessageAttachments({
   attachments,
   assistantId,
   messageId,
-}) => {
-  const { openPreview, previewModal } = useAttachmentPreview(
-    assistantId,
-    attachments,
-  );
-  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
-  const mainView = useViewerStore.use.mainView();
-  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
-
-  const handleDownload = useCallback(
-    (att: DisplayAttachment) => {
-      void downloadAttachment(att, assistantId);
-    },
-    [assistantId],
-  );
-
-  const filesPayload: MessageFilesPayload = useMemo(
-    () => ({ messageId, attachments, assistantId }),
-    [messageId, attachments, assistantId],
-  );
-
-  // The tile whose files panel is currently open renders with the persistent
-  // active surface, mirroring the activity group header's selected state.
-  const tileActive =
-    mainView === "message-files" &&
-    activeMessageFiles != null &&
-    sameMessageFilesTarget(activeMessageFiles, filesPayload);
+}: MessageAttachmentsProps) {
+  const { displayAttachments, renderSquare, previewModal } =
+    useAttachmentSquares({ attachments, assistantId });
 
   if (attachments.length === 0) {
     return null;
   }
 
-  const visible = attachments.slice(0, VISIBLE_LIMIT);
-  const overflowCount = attachments.length - visible.length;
+  const visible = displayAttachments.slice(0, VISIBLE_LIMIT);
+  const overflowCount = displayAttachments.length - visible.length;
 
   return (
     <>
       <div className="flex flex-wrap items-start gap-2">
-        {visible.map((att) => (
-          <MessageAttachmentSquare
-            key={att.id}
-            filename={att.filename}
-            mimeType={att.mimeType}
-            sizeBytes={att.sizeBytes}
-            previewUrl={att.previewUrl}
-            thumbnailUrl={att.thumbnailUrl}
-            onPreview={() => openPreview(att)}
-            onDownload={() => handleDownload(att)}
-          />
-        ))}
+        {visible.map((att, index) => renderSquare(att, index))}
         {overflowCount > 0 && (
           <AttachmentOverflowSquare
             count={overflowCount}
-            active={tileActive}
-            onClick={() => toggleMessageFiles(filesPayload)}
+            payload={{ messageId, attachments, assistantId }}
           />
         )}
       </div>
       {previewModal}
     </>
   );
-};
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
@@ -1,0 +1,106 @@
+/**
+ * The shared attachment-square renderer behind every surface that lists a
+ * message's attachments: the assistant strip ({@link MessageAttachments}), the
+ * user bubble ({@link BubbleAttachments}), and the files side panel
+ * ({@link MessageFilesPanel}).
+ *
+ * Owns the three pieces those surfaces must agree on:
+ *
+ *  - the failed-decode fallback - image previews the browser cannot decode
+ *    (e.g. a HEIC blob on a Chromium renderer) get their `previewUrl` nulled
+ *    by id, so the square falls back to its file-kind icon instead of a dead
+ *    image, and the preview modal refetches stored bytes instead of the
+ *    broken blob;
+ *  - the preview modal plus its gallery siblings;
+ *  - the download forwarder.
+ *
+ * Callers own only their own layout: they map over {@link displayAttachments}
+ * and place `renderSquare(att, index)` inside whatever container they need.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+
+interface UseAttachmentSquaresOptions {
+  attachments: DisplayAttachment[];
+  /** Forwarded to the preview modal and the download helper so both can
+   *  lazily fetch attachment content when `previewUrl` is missing. */
+  assistantId?: string | null;
+}
+
+interface UseAttachmentSquaresResult {
+  /** `attachments` with the `previewUrl` of every undecodable image nulled.
+   *  Render from this list rather than the input, so a dead preview cannot
+   *  reach the DOM. */
+  displayAttachments: DisplayAttachment[];
+  /** One attachment square, wired to the preview modal, the downloader, and
+   *  the failed-decode fallback. `index` is the position in
+   *  {@link displayAttachments}. */
+  renderSquare: (attachment: DisplayAttachment, index: number) => ReactNode;
+  /** Opens the preview modal, for call sites that render their own affordance
+   *  alongside the squares (the bubble's large inline images). */
+  openPreview: (attachment: DisplayAttachment) => void;
+  /** Records an attachment id whose preview the browser could not decode. */
+  markImageFailed: (id: string) => void;
+  /** The rendered preview modal, or `null`. Render it somewhere stable. */
+  previewModal: ReactNode;
+}
+
+export function useAttachmentSquares({
+  attachments,
+  assistantId,
+}: UseAttachmentSquaresOptions): UseAttachmentSquaresResult {
+  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const markImageFailed = useCallback((id: string) => {
+    setFailedImageIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  const displayAttachments = useMemo(
+    () =>
+      failedImageIds.size === 0
+        ? attachments
+        : attachments.map((att) =>
+            failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
+          ),
+    [attachments, failedImageIds],
+  );
+
+  const { openPreview, previewModal } = useAttachmentPreview(
+    assistantId,
+    displayAttachments,
+  );
+
+  const renderSquare = useCallback(
+    (attachment: DisplayAttachment, index: number) => (
+      <MessageAttachmentSquare
+        key={attachment.id}
+        attachment={attachment}
+        onPreview={() => openPreview(attachment)}
+        // Download falls back to previewUrl when the daemon content fetch is
+        // unavailable, so it takes the UNSANITIZED attachment - a blob that
+        // can't be rendered is still valid bytes to save.
+        onDownload={() =>
+          void downloadAttachment(attachments[index] ?? attachment, assistantId)
+        }
+        onPreviewError={() => markImageFailed(attachment.id)}
+      />
+    ),
+    [attachments, assistantId, openPreview, markImageFailed],
+  );
+
+  return {
+    displayAttachments,
+    renderSquare,
+    openPreview,
+    markImageFailed,
+    previewModal,
+  };
+}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -478,7 +478,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           <MessageFilesPanel
             // Re-key per message so the panel resets when a different
             // message's tile is clicked while the panel is already open.
-            key={activeMessageFiles.messageId ?? "snapshot"}
+            key={activeMessageFiles.messageId}
             payload={activeMessageFiles}
             onClose={closeMessageFiles}
           />

--- a/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
+import { MessageFilesPanel } from "./message-files-panel";
+
+/**
+ * The message-files side panel: every attachment on one transcript message,
+ * each square opening the shared full-screen preview modal with gallery
+ * navigation. Opened by the overflow tile at the end of a truncated assistant
+ * attachment strip.
+ */
+
+function makeAttachment(
+  overrides: Partial<DisplayAttachment> & { id: string },
+): DisplayAttachment {
+  return {
+    filename: `${overrides.id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+const MIXED: DisplayAttachment[] = [
+  makeAttachment({
+    id: "img-0",
+    filename: "quarterly-revenue.png",
+    sizeBytes: 184_320,
+  }),
+  makeAttachment({
+    id: "deck-1",
+    filename: "board-deck.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_194_304,
+  }),
+  makeAttachment({
+    id: "report-1",
+    filename: "annual-report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_097_152,
+  }),
+  makeAttachment({
+    id: "sheet-1",
+    filename: "forecast.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    sizeBytes: 65_536,
+  }),
+  makeAttachment({
+    id: "bundle-1",
+    filename: "source-bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_388_608,
+  }),
+  makeAttachment({
+    id: "clip-1",
+    filename: "walkthrough.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 12_582_912,
+  }),
+  makeAttachment({
+    id: "notes-1",
+    filename: "meeting-notes.md",
+    mimeType: "text/markdown",
+    sizeBytes: 3_072,
+  }),
+  makeAttachment({
+    id: "script-1",
+    filename: "migrate.ts",
+    mimeType: "text/plain",
+    sizeBytes: 9_216,
+  }),
+];
+
+const meta: Meta<typeof MessageFilesPanel> = {
+  title: "Chat/MessageFilesPanel",
+  component: MessageFilesPanel,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageFilesPanel>;
+
+/**
+ * A mixed media / non-media set: an image renders its preview edge to edge,
+ * everything else falls back to its file-kind icon on a neutral tile.
+ */
+export const MixedMedia: Story = {
+  args: {
+    payload: { messageId: "story-msg", attachments: MIXED },
+    onClose: () => {},
+  },
+};
+
+/**
+ * A message whose attachments have all gone away - the panel shows its empty
+ * state rather than a blank grid under a `Files · 0` header.
+ */
+export const Empty: Story = {
+  args: {
+    payload: { messageId: "story-empty", attachments: [] },
+    onClose: () => {},
+  },
+};
+
+/**
+ * The overflow tile itself, in both states. The resting tile must read as a
+ * dashed outline against the chat surface, and the active tile - the one whose
+ * panel is open - must be clearly distinct from a plain hover. Hover the first
+ * tile to compare.
+ */
+export const OverflowTileStates: StoryObj = {
+  render: () => (
+    <div className="flex items-start gap-6 bg-[var(--surface-base)] p-6">
+      <div className="flex flex-col items-center gap-2">
+        <AttachmentOverflowSquare
+          count={3}
+          payload={{ messageId: "story-resting", attachments: MIXED }}
+        />
+        <span className="text-xs text-[var(--content-tertiary)]">
+          resting / hover
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <AttachmentOverflowSquare
+          count={12}
+          payload={{ messageId: "story-active", attachments: MIXED }}
+        />
+        <span className="text-xs text-[var(--content-tertiary)]">
+          click to activate
+        </span>
+      </div>
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/components/message-files-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.test.tsx
@@ -2,38 +2,35 @@
  * Tests for `MessageFilesPanel` - the side drawer listing every attachment on
  * one transcript message.
  *
- *  - Renders one square per attachment, media and non-media alike, from the
- *    payload snapshot when no live message resolves.
+ *  - Renders one square per attachment, media and non-media alike.
+ *  - Re-derives from the live transcript when the payload's `messageId`
+ *    resolves, and falls back to the open-time snapshot when it does not.
+ *  - A resolved message with no attachments renders the empty state rather
+ *    than resurrecting the snapshot.
  *  - The header count matches the attachment total.
  *  - The close button fires `onClose`.
  *  - Clicking a square opens the shared preview modal with the whole set as
  *    gallery siblings.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { DisplayAttachment } from "@/types/attachment-types";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  makeDisplayAttachment,
+  makeMixedAttachments,
+  mockAttachmentPreviewModal,
+  squareLabels,
+} from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type {
+  DisplayAttachment,
+  DisplayMessage,
+} from "@/domains/chat/types/types";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string };
-      siblingAttachments?: Array<{ id: string }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-sibling-count={String((siblingAttachments ?? []).length)}
-      />
-    ),
-  }),
-);
+mockAttachmentPreviewModal();
 
 const { MessageFilesPanel } = await import(
   "@/domains/chat/components/message-files-panel"
@@ -41,54 +38,37 @@ const { MessageFilesPanel } = await import(
 
 afterEach(() => {
   cleanup();
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
 });
 
-const ATTACHMENTS: DisplayAttachment[] = [
-  {
-    id: "img-0",
-    filename: "photo-0.png",
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: "https://example.com/photo-0.png",
-  },
-  {
-    id: "deck-1",
-    filename: "deck.pptx",
-    mimeType:
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    sizeBytes: 4_096,
-    previewUrl: null,
-  },
-  {
-    id: "report-1",
-    filename: "report.pdf",
-    mimeType: "application/pdf",
-    sizeBytes: 2_048,
-    previewUrl: null,
-  },
-  {
-    id: "bundle-1",
-    filename: "bundle.zip",
-    mimeType: "application/zip",
-    sizeBytes: 8_192,
-    previewUrl: null,
-  },
-];
+const ATTACHMENTS = makeMixedAttachments();
+
+/** Seed the transcript with one assistant row carrying `attachments`. */
+function seedTranscript(
+  messageId: string,
+  attachments: DisplayAttachment[],
+): void {
+  const message: DisplayMessage = {
+    id: messageId,
+    role: "assistant",
+    attachments,
+  };
+  const snapshot: PaginatedHistoryResult = {
+    messages: [message],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 1,
+  };
+  useChatSessionStore.setState({ snapshot, optimisticSends: [] });
+}
 
 function renderPanel(onClose: () => void = () => {}) {
   return render(
     <MessageFilesPanel
-      payload={{ attachments: ATTACHMENTS }}
+      payload={{ messageId: "msg-1", attachments: ATTACHMENTS }}
       onClose={onClose}
     />,
-  );
-}
-
-/** The squares are divs with `role="button"`; the download affordance is a
- *  real `<button>`, so this selector counts only attachment squares. */
-function squareLabels(container: HTMLElement): Array<string | null> {
-  return Array.from(container.querySelectorAll('div[role="button"]')).map(
-    (el) => el.getAttribute("aria-label"),
   );
 }
 
@@ -105,7 +85,8 @@ describe("MessageFilesPanel", () => {
 
   test("header count matches the attachment total", () => {
     const { getByText } = renderPanel();
-    expect(getByText("Files · 4")).toBeTruthy();
+    expect(getByText("Files")).toBeTruthy();
+    expect(getByText("4")).toBeTruthy();
   });
 
   test("close button fires onClose", () => {
@@ -124,5 +105,42 @@ describe("MessageFilesPanel", () => {
     const modal = getByTestId("preview-modal");
     expect(modal.getAttribute("data-attachment-id")).toBe("report-1");
     expect(modal.getAttribute("data-sibling-count")).toBe("4");
+  });
+
+  test("renders the LIVE attachment list when the message resolves", () => {
+    seedTranscript("msg-1", [
+      ...ATTACHMENTS,
+      makeDisplayAttachment({ id: "late-1", filename: "late.png" }),
+      makeDisplayAttachment({ id: "late-2", filename: "later.png" }),
+    ]);
+
+    const { container, getByText } = renderPanel();
+
+    // Six live attachments beat the four-entry open-time snapshot.
+    expect(squareLabels(container)).toHaveLength(6);
+    expect(getByText("6")).toBeTruthy();
+    expect(squareLabels(container)).toContain("late.png");
+  });
+
+  test("falls back to the snapshot when the message id resolves to nothing", () => {
+    seedTranscript("other-message", [
+      makeDisplayAttachment({ id: "unrelated-1", filename: "unrelated.png" }),
+    ]);
+
+    const { container, getByText } = renderPanel();
+
+    expect(squareLabels(container)).toHaveLength(4);
+    expect(getByText("4")).toBeTruthy();
+    expect(squareLabels(container)).not.toContain("unrelated.png");
+  });
+
+  test("a resolved message with no attachments renders the empty state", () => {
+    seedTranscript("msg-1", []);
+
+    const { container, getByText } = renderPanel();
+
+    expect(squareLabels(container)).toHaveLength(0);
+    expect(getByText("0")).toBeTruthy();
+    expect(getByText("No files on this message")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -7,16 +7,16 @@
  * Streams live: the panel re-derives the message's attachments from the
  * transcript by `messageId` via `useLiveMessageAttachments`, so files that
  * land mid-turn appear while the panel is open. The payload's embedded
- * snapshot is the fallback when the message can't be resolved (paged out, or
- * identity-less callers like stories).
+ * snapshot is the fallback for the one case the live source cannot answer -
+ * the message having been paged out of the loaded transcript.
  */
 
 import { Paperclip } from "lucide-react";
 
+import { Typography } from "@vellumai/design-library";
+
 import { DetailShell } from "@/components/detail-shell";
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
 import type { MessageFilesPayload } from "@/stores/viewer-store";
 
@@ -31,33 +31,53 @@ export function MessageFilesPanel({
 }: MessageFilesPanelProps) {
   const live = useLiveMessageAttachments(payload.messageId);
   const attachments = live ?? payload.attachments;
-  const { openPreview, previewModal } = useAttachmentPreview(
-    payload.assistantId,
-    attachments,
-  );
+  const { displayAttachments, renderSquare, previewModal } =
+    useAttachmentSquares({
+      attachments,
+      assistantId: payload.assistantId,
+    });
 
   return (
     <DetailShell
       Glyph={Paperclip}
-      title={`Files · ${attachments.length}`}
+      // Matches the activity-steps panel header: title · N inline at the same
+      // size, separated by a 3px midline dot, count in the secondary tone.
+      titleNode={
+        <span className="flex min-w-0 items-center gap-1.5 py-0.5">
+          <Typography
+            variant="title-medium"
+            className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+          >
+            Files
+          </Typography>
+          <span
+            aria-hidden
+            className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
+          />
+          <Typography
+            variant="title-medium"
+            className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
+          >
+            {displayAttachments.length}
+          </Typography>
+        </span>
+      }
       closeLabel="Close files"
       onClose={onClose}
     >
-      {/* Three across fits the drawer's 400px default width. */}
-      <div className="grid grid-cols-3 gap-3">
-        {attachments.map((att) => (
-          <MessageAttachmentSquare
-            key={att.id}
-            filename={att.filename}
-            mimeType={att.mimeType}
-            sizeBytes={att.sizeBytes}
-            previewUrl={att.previewUrl}
-            thumbnailUrl={att.thumbnailUrl}
-            onPreview={() => openPreview(att)}
-            onDownload={() => void downloadAttachment(att, payload.assistantId)}
-          />
-        ))}
-      </div>
+      {displayAttachments.length === 0 ? (
+        <Typography
+          variant="body-small-default"
+          className="py-4 text-center text-[var(--content-tertiary)]"
+        >
+          No files on this message
+        </Typography>
+      ) : (
+        // Three across fits the drawer's 400px default width.
+        <div className="grid grid-cols-3 gap-3">
+          {displayAttachments.map((att, index) => renderSquare(att, index))}
+        </div>
+      )}
       {previewModal}
     </DetailShell>
   );

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -1,6 +1,7 @@
 /**
- * Portal-based mobile overlay container for app, document, subagent-detail,
- * workflow-detail, acp-run-detail, and tool-detail viewers. Reads from Zustand
+ * Portal-based mobile overlay container for the app, document,
+ * subagent-detail, workflow-detail, acp-run-detail, background-task-detail,
+ * tool-detail, activity-steps, and message-files viewers. Reads from Zustand
  * stores directly so the parent (ActiveChatView) doesn't need to assemble
  * inline handlers.
  *

--- a/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
@@ -38,7 +38,14 @@ export function MobileMessageFilesOverlay({
   return (
     <div className="fixed inset-x-0 z-30" style={shellStyle}>
       <LazyBoundary>
-        <MessageFilesPanel payload={payload} onClose={onClose} />
+        {/* Re-key per message so switching targets remounts the panel rather
+            than reusing one whose internal preview state belongs to the
+            previous message. */}
+        <MessageFilesPanel
+          key={payload.messageId}
+          payload={payload}
+          onClose={onClose}
+        />
       </LazyBoundary>
     </div>
   );

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -430,6 +430,7 @@ export function useConversationLoader({
       }
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
+      useViewerStore.getState().clearTranscriptPanelPayloads();
       void navigate(routes.conversation(key));
     },
     [navigate],
@@ -445,6 +446,7 @@ export function useConversationLoader({
       }
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
+      useViewerStore.getState().clearTranscriptPanelPayloads();
       useViewerStore.getState().setMainView("chat");
       const draftConversationId = createDraftConversationId();
       useConversationStore

--- a/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
@@ -14,8 +14,7 @@ import {
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
 
@@ -91,7 +90,7 @@ export function useLiveActivityGroup(
   messageId: string | undefined,
   groupIndex: number | undefined,
 ): { items: ToolCallCardItem[]; toolCalls: ChatMessageToolCall[] } | null {
-  const messages = useTranscriptMessages();
+  const message = useTranscriptMessageById(messageId);
   // Card-backed process suppression reads the same store slices the
   // transcript subscribes to, so a card's backing flipping (an entry
   // appearing) drops the raw step from an open panel in the same render.
@@ -105,13 +104,7 @@ export function useLiveActivityGroup(
   const backgroundTaskById = useBackgroundTaskStore.use.byId();
 
   return useMemo(() => {
-    if (!messageId || groupIndex == null) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    if (!message) {
+    if (!message || groupIndex == null) {
       return null;
     }
     const groups = groupContentBlocks(message.contentBlocks ?? [], {
@@ -134,8 +127,7 @@ export function useLiveActivityGroup(
       backgroundTaskById,
     });
   }, [
-    messages,
-    messageId,
+    message,
     groupIndex,
     workflowById,
     workflowByToolUseId,

--- a/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
@@ -1,27 +1,27 @@
-import { useMemo } from "react";
-
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 import type { DisplayAttachment } from "@/types/attachment-types";
+
+/** Stable empty result, so a resolved message with no attachments doesn't
+ *  hand callers a fresh array on every render. */
+const NO_ATTACHMENTS: DisplayAttachment[] = [];
 
 /**
  * A message's attachments re-derived from the rendered transcript on every
  * render, so an open files panel picks up attachments that land while a
- * message is still streaming. Returns `null` when the message cannot be
- * found (paged out of the loaded transcript) so callers fall back to the
- * open-time snapshot.
+ * message is still streaming.
+ *
+ * Returns `null` only when the message itself cannot be resolved (paged out
+ * of the loaded transcript), so callers fall back to the open-time snapshot.
+ * A message that resolves with no attachments returns an empty array, not
+ * `null` - it is a live answer, and the panel must show its empty state
+ * rather than resurrect a stale snapshot.
  */
 export function useLiveMessageAttachments(
   messageId: string | undefined,
 ): DisplayAttachment[] | null {
-  const messages = useTranscriptMessages();
-  return useMemo(() => {
-    if (!messageId) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    return message?.attachments ?? null;
-  }, [messages, messageId]);
+  const message = useTranscriptMessageById(messageId);
+  if (!message) {
+    return null;
+  }
+  return message.attachments ?? NO_ATTACHMENTS;
 }

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 
 import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 
 /**
  * Reasoning text for a thinking detail drawer, re-derived from the rendered
@@ -34,15 +33,9 @@ export function useLiveThinkingText(
   groupIndex: number | undefined,
   thinkingItemIndex?: number,
 ): string | null {
-  const messages = useTranscriptMessages();
+  const message = useTranscriptMessageById(messageId);
   return useMemo(() => {
-    if (!messageId || groupIndex == null) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    if (!message) {
+    if (!message || groupIndex == null) {
       return null;
     }
     const groups = groupContentBlocks(message.contentBlocks ?? [], {
@@ -59,5 +52,5 @@ export function useLiveThinkingText(
       return segments.join("\n");
     }
     return segments[thinkingItemIndex] ?? null;
-  }, [messages, messageId, groupIndex, thinkingItemIndex]);
+  }, [message, groupIndex, thinkingItemIndex]);
 }

--- a/clients/web/src/domains/chat/hooks/use-transcript-message-by-id.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-message-by-id.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * One transcript row resolved from the rendered transcript (server history ⊕
+ * the in-flight turn) on every render, matched on any of its identity keys -
+ * server id, merged ids, or the client nonce - so an optimistic row and its
+ * confirmed echo both resolve.
+ *
+ * The shared lookup behind the live re-derive hooks
+ * ({@link useLiveThinkingText}, {@link useLiveActivityGroup},
+ * {@link useLiveMessageAttachments}), which keep an open detail panel
+ * streaming instead of frozen at its open-time snapshot.
+ *
+ * Returns `undefined` when no `messageId` was supplied or the row is not in
+ * the loaded transcript (paged out). Callers must distinguish that from a
+ * resolved row whose derived content happens to be empty.
+ */
+export function useTranscriptMessageById(
+  messageId: string | undefined,
+): DisplayMessage | undefined {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    if (!messageId) {
+      return undefined;
+    }
+    return messages.find((m) => messageMatchKeys(m).includes(messageId));
+  }, [messages, messageId]);
+}

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -7,7 +7,7 @@ import {
   type MessageFilesPayload,
   type ToolDetailPayload,
 } from "@/stores/viewer-store";
-import type { DisplayAttachment } from "@/types/attachment-types";
+import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -775,19 +775,12 @@ describe("openActivitySteps / toggleActivitySteps / closeActivitySteps", () => {
 // Message files panel
 // ---------------------------------------------------------------------------
 
-function makeAttachment(id: string): DisplayAttachment {
-  return {
-    id,
-    filename: `${id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1024,
-    previewUrl: null,
-  };
-}
-
 const SAMPLE_FILES: MessageFilesPayload = {
   messageId: "m1",
-  attachments: [makeAttachment("a1"), makeAttachment("a2")],
+  attachments: [
+    makeDisplayAttachment({ id: "a1" }),
+    makeDisplayAttachment({ id: "a2" }),
+  ],
   assistantId: "asst-1",
 };
 
@@ -826,10 +819,15 @@ describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
     expect(state.activeMessageFiles?.messageId).toBe("m2");
   });
 
-  it("identity-less payloads match on the first attachment id", () => {
-    getState().openMessageFiles({ attachments: [makeAttachment("a1")] });
-    getState().toggleMessageFiles({ attachments: [makeAttachment("a1")] });
-    expect(getState().mainView).toBe("chat");
+  it("clears the transcript panel payloads without touching mainView", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().clearTranscriptPanelPayloads();
+    const state = getState();
+    expect(state.activeMessageFiles).toBeNull();
+    expect(state.activeActivitySteps).toBeNull();
+    expect(state.activeToolDetail).toBeNull();
+    expect(state.mainView).toBe("message-files");
   });
 });
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -285,28 +285,21 @@ export function sameActivityStepsTarget(
  * Payload for the message-files side panel: every attachment on one
  * transcript message. The open panel re-derives live attachments from the
  * transcript by `messageId`; the embedded `attachments` array is the
- * open-time snapshot, used when the message cannot be resolved (paged out,
- * or identity-less callers like stories).
+ * open-time snapshot, used when that message is no longer in the loaded
+ * transcript (paged out by history windowing).
  */
 export interface MessageFilesPayload {
-  messageId?: string;
+  messageId: string;
   attachments: DisplayAttachment[];
   assistantId?: string | null;
 }
 
-/**
- * Whether two message-files payloads address the same transcript message.
- * Keys on `messageId` when present, falling back to the first attachment id
- * for identity-less callers.
- */
+/** Whether two message-files payloads address the same transcript message. */
 export function sameMessageFilesTarget(
   a: MessageFilesPayload,
   b: MessageFilesPayload,
 ): boolean {
-  if (a.messageId != null || b.messageId != null) {
-    return a.messageId === b.messageId;
-  }
-  return a.attachments[0]?.id === b.attachments[0]?.id;
+  return a.messageId === b.messageId;
 }
 
 /** The identity fields a thinking drawer target is matched on. */
@@ -468,6 +461,16 @@ export interface ViewerActions {
    */
   toggleMessageFiles: (payload: MessageFilesPayload) => void;
   closeMessageFiles: () => void;
+
+  /**
+   * Drop the payloads of the panels whose content is scoped to one
+   * conversation's transcript. Called on conversation switch: the panels are
+   * already dismissed by the `setMainView("chat")` that accompanies it, and
+   * holding their payloads keeps the previous conversation's data alive -
+   * `activeMessageFiles` in particular retains decoded attachment blob/data
+   * URLs. Leaves `mainView` alone; this is a memory concern, not navigation.
+   */
+  clearTranscriptPanelPayloads: () => void;
 
   // --- Channel setup ---
   openChannelSetup: (payload: ChannelSetupPayload) => void;
@@ -941,6 +944,14 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeMessageFiles,
       activeMessageFiles: null,
+    });
+  },
+
+  clearTranscriptPanelPayloads: () => {
+    set({
+      activeMessageFiles: null,
+      activeActivitySteps: null,
+      activeToolDetail: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Fix the overflow tile rendering invisibly in light mode: `--border-base` is ~1.02:1 against `--surface-base`, and the active `--border-hover` is byte-identical to it, so active was indistinguishable from hover.
- Extract the shared attachment-square renderer across the three call sites that had drifted; the files panel was missing the failed-decode fallback, so an undecodable HEIC rendered a broken image there while correctly showing a chip in a user bubble.
- Correct `useLiveMessageAttachments` null semantics so a resolved message with no attachments is no longer treated as unresolved, and give the panel an empty state.
- Stop every attachment strip subscribing to the global `mainView`; only strips that actually overflow now read the store.
- Clear the retained files payload on conversation switch, extract the thrice-duplicated transcript message lookup, and add live-re-derive plus visible-square preview test coverage.

Addresses findings from the four-pass self-review of plan message-attachment-overflow.md.