### PR TITLE
feat(voice): show what a turn is doing on the island

### DIFF
--- a/assistant/src/live-voice/__tests__/activity-label.test.ts
+++ b/assistant/src/live-voice/__tests__/activity-label.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the voice activity line.
+ *
+ * The invariant worth guarding is totality: the tool vocabulary is open
+ * (plugins, MCP servers, and skills all contribute names this module has never
+ * seen), and the surface this feeds is a Lock Screen the user cannot correct.
+ * A label that came back empty would blank the island exactly when the
+ * assistant is busiest.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  activityLabelForTool,
+  GENERIC_ACTIVITY_LABEL,
+} from "../activity-label.js";
+
+describe("activityLabelForTool", () => {
+  test("names what the user would say is happening, not the tool", () => {
+    expect(activityLabelForTool("bash")).toBe("Running a command");
+    expect(activityLabelForTool("web_search")).toBe("Searching the web");
+    expect(activityLabelForTool("file_read")).toBe("Reading a file");
+  });
+
+  // Where a tool runs is not a distinction anyone glancing at a Lock Screen is
+  // making.
+  test("host and sandbox variants read the same", () => {
+    expect(activityLabelForTool("host_bash")).toBe(
+      activityLabelForTool("bash"),
+    );
+    expect(activityLabelForTool("host_file_read")).toBe(
+      activityLabelForTool("file_read"),
+    );
+  });
+
+  test("falls back by prefix for structured tool families", () => {
+    expect(activityLabelForTool("browser_click")).toBe("Using the browser");
+    expect(activityLabelForTool("mcp_notion_search")).toBe(
+      "Using a connected app",
+    );
+  });
+
+  test("every tool gets a label, including ones this module has never seen", () => {
+    for (const name of [
+      "slack_conversations_history",
+      "",
+      "a",
+      "some_vendor::weird.tool/name",
+    ]) {
+      expect(activityLabelForTool(name)).toBe(GENERIC_ACTIVITY_LABEL);
+    }
+  });
+
+  test("labels stay short enough for the slot they land in", () => {
+    for (const name of [
+      "bash",
+      "web_search",
+      "host_file_transfer",
+      "computer_use",
+      "ui_show",
+      "unknown_tool",
+    ]) {
+      const label = activityLabelForTool(name);
+      expect(label.length).toBeLessThanOrEqual(32);
+      expect(label).not.toMatch(/[.!?]$/);
+    }
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-activity-reporter.test.ts
+++ b/assistant/src/live-voice/__tests__/live-activity-reporter.test.ts
@@ -34,14 +34,24 @@ function sttFinal(text: string): LiveVoiceServerFramePayload {
 
 /** A reporter whose dispatches are captured instead of sent. */
 class RecordingReporter extends LiveActivityReporter {
-  readonly dispatched: Array<{ phase: string; event: string }> = [];
+  readonly dispatched: Array<{ phase: string; event: string; detail: string }> =
+    [];
 
   protected override async dispatch(
     phase: string,
     event: "update" | "end",
+    detail: string,
   ): Promise<void> {
-    this.dispatched.push({ phase, event });
+    this.dispatched.push({ phase, event, detail });
   }
+}
+
+function activity(label: string): LiveVoiceServerFramePayload {
+  return {
+    type: "activity",
+    turnId: "t1",
+    label,
+  } as LiveVoiceServerFramePayload;
 }
 
 describe("phaseForFrame", () => {
@@ -92,7 +102,7 @@ describe("LiveActivityReporter", () => {
     reporter.report(frame("thinking"));
 
     expect(reporter.dispatched).toEqual([
-      { phase: "thinking", event: "update" },
+      { phase: "thinking", event: "update", detail: "" },
     ]);
   });
 
@@ -105,7 +115,7 @@ describe("LiveActivityReporter", () => {
     reporter.report(frame("tts_audio"));
 
     expect(reporter.dispatched).toEqual([
-      { phase: "speaking", event: "update" },
+      { phase: "speaking", event: "update", detail: "" },
     ]);
   });
 
@@ -144,6 +154,7 @@ describe("LiveActivityReporter", () => {
     expect(reporter.dispatched.at(-1)).toEqual({
       phase: "ending",
       event: "end",
+      detail: "",
     });
   });
 
@@ -165,7 +176,77 @@ describe("LiveActivityReporter", () => {
     reporter.end();
     reporter.report(frame("tts_audio"));
 
-    expect(reporter.dispatched).toEqual([{ phase: "ending", event: "end" }]);
+    expect(reporter.dispatched).toEqual([
+      { phase: "ending", event: "end", detail: "" },
+    ]);
+  });
+});
+
+describe("LiveActivityReporter activity line", () => {
+  test("carries the activity label alongside the phase it holds", () => {
+    const reporter = new RecordingReporter("conv-1");
+
+    reporter.report(frame("utterance_end"));
+    reporter.report(frame("thinking"));
+    reporter.report(activity("Running a command"));
+
+    expect(reporter.dispatched.at(-1)).toEqual({
+      phase: "thinking",
+      event: "update",
+      detail: "Running a command",
+    });
+  });
+
+  // A push replaces the whole content state, so the label has to ride along on
+  // phase changes too, or the next phase would blank it.
+  test("keeps the label through a later phase change", () => {
+    const reporter = new RecordingReporter("conv-1");
+
+    reporter.report(frame("thinking"));
+    reporter.report(activity("Reading a file"));
+    reporter.report(frame("tts_audio"));
+
+    expect(reporter.dispatched.at(-1)).toEqual({
+      phase: "speaking",
+      event: "update",
+      detail: "Reading a file",
+    });
+  });
+
+  test("an empty label clears the line", () => {
+    const reporter = new RecordingReporter("conv-1");
+
+    reporter.report(frame("thinking"));
+    reporter.report(activity("Reading a file"));
+    reporter.report(activity(""));
+
+    expect(reporter.dispatched.at(-1)?.detail).toBe("");
+  });
+
+  test("does not dispatch a label it already sent", () => {
+    const reporter = new RecordingReporter("conv-1");
+
+    reporter.report(frame("thinking"));
+    reporter.report(activity("Reading a file"));
+    const before = reporter.dispatched.length;
+    reporter.report(activity("Reading a file"));
+
+    expect(reporter.dispatched.length).toBe(before);
+  });
+
+  // A tool can start before any phase-bearing frame lands. There is no content
+  // state to attach a label to yet, and the phase that follows carries it.
+  test("holds a label that arrives before any phase", () => {
+    const reporter = new RecordingReporter("conv-1");
+
+    reporter.report(activity("Searching the web"));
+    expect(reporter.dispatched).toEqual([]);
+
+    reporter.report(frame("thinking"));
+
+    expect(reporter.dispatched).toEqual([
+      { phase: "thinking", event: "update", detail: "Searching the web" },
+    ]);
   });
 });
 

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -442,7 +442,7 @@ describe("LiveVoiceSession assistant turn", () => {
     });
   });
 
-  test("records tool_use_start on the active turn without emitting frames", async () => {
+  test("records tool_use_start on the active turn and publishes what it is doing", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       callbacks = options.callbacks;
@@ -459,9 +459,8 @@ describe("LiveVoiceSession assistant turn", () => {
       "thinking",
     ]);
 
-    const frameCountBefore = frames.length;
     callbacks?.tool_use_start?.("some_tool");
-    await flushAsyncCallbacks();
+    await waitForFrameCount(frames, 4);
 
     const activeTurn = (
       session as unknown as {
@@ -469,20 +468,30 @@ describe("LiveVoiceSession assistant turn", () => {
       }
     ).activeAssistantTurn;
     expect(activeTurn?.toolUseStarted).toBe(true);
-    expect(frames).toHaveLength(frameCountBefore);
+    // One activity frame, so a silent stretch of tool work is visible on the
+    // surfaces that show the session. An unrecognized tool still gets a line.
+    expect(frames.at(-1)).toMatchObject({
+      type: "activity",
+      label: "Working on it",
+    });
 
     callbacks?.message_complete?.({
       type: "message_complete",
       conversationId: "conversation-123",
       messageId: "assistant-message-123",
     });
-    await waitForFrameCount(frames, 4);
+    await waitForFrameCount(frames, 6);
     expect(frames.map((frame) => frame.type)).toEqual([
       "ready",
       "stt_final",
       "thinking",
+      "activity",
       "tts_done",
+      // The turn is over, so the line clears: no surface should keep showing
+      // the last tool it touched through the silence that follows.
+      "activity",
     ]);
+    expect(frames.at(-1)).toMatchObject({ type: "activity", label: "" });
   });
 
   test("interrupt aborts the in-flight turn and ignores late bridge events", async () => {

--- a/assistant/src/live-voice/activity-label.ts
+++ b/assistant/src/live-voice/activity-label.ts
@@ -1,0 +1,106 @@
+/**
+ * Turns a tool call into one short user-facing line for the surfaces that show
+ * a running voice session.
+ *
+ * ## Why the copy lives here
+ *
+ * The iOS Live Activity has two drivers that must carry identical content: the
+ * live-voice socket, and an APNs push the daemon dispatches when the app is
+ * backgrounded and the web layer is suspended. Only one of them runs web code,
+ * so a label composed client-side could not be reproduced by the other. Both
+ * are therefore handed the same string, and this is where it is made.
+ *
+ * That does not contradict the rule that phase wording belongs to the web
+ * layer. The reason phase copy lives there is cadence: the iOS shell ships on
+ * App Store review while the web bundle deploys continuously, so a native
+ * `switch` would fossilize. This module deploys with the daemon, i.e.
+ * continuously, and it is the only layer that knows a tool ran at all.
+ *
+ * ## What makes a good label
+ *
+ * It is read on a Lock Screen, in a glance, by someone who is mid-conversation
+ * and not looking for detail. So: a present-participle phrase, no tool names,
+ * no arguments, no punctuation, and short enough to survive one line. Arguments
+ * are deliberately absent even though {@link summarizeToolInput} could supply
+ * them: a path or a URL on a Lock Screen is unreadable at a glance and can
+ * carry content the user would not choose to show a passer-by.
+ */
+
+/**
+ * Present-participle phrases for the built-in tools, by exact name.
+ *
+ * Grouped by what the user would say is happening, not by how the tool is
+ * implemented: `bash` and `host_bash` differ in where they run, which is not a
+ * distinction anyone glancing at a Lock Screen is making.
+ */
+const TOOL_ACTIVITY_LABELS: Readonly<Record<string, string>> = {
+  bash: "Running a command",
+  terminal: "Running a command",
+  host_bash: "Running a command",
+  file_read: "Reading a file",
+  host_file_read: "Reading a file",
+  file_write: "Writing a file",
+  host_file_write: "Writing a file",
+  file_edit: "Editing a file",
+  host_file_edit: "Editing a file",
+  host_file_transfer: "Moving a file",
+  file_search: "Searching files",
+  web_search: "Searching the web",
+  web_fetch: "Reading a page",
+  network_request: "Making a request",
+  browser: "Using the browser",
+  computer_use: "Using the computer",
+  memory: "Checking memory",
+  schedule: "Checking the schedule",
+  ui_show: "Putting something on screen",
+  ui_update: "Putting something on screen",
+};
+
+/**
+ * Prefix-matched fallbacks, tried in order when a tool has no exact entry.
+ *
+ * The tool vocabulary is open: plugins, MCP servers, and skills all contribute
+ * names this module has never seen, and a new built-in should not have to be
+ * registered here to avoid a blank island. Prefixes cover the families whose
+ * names are structured; {@link GENERIC_ACTIVITY_LABEL} covers the rest.
+ */
+const TOOL_ACTIVITY_LABEL_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  ["browser_", "Using the browser"],
+  ["computer_", "Using the computer"],
+  ["file_", "Working with files"],
+  ["host_file_", "Working with files"],
+  ["web_", "Looking something up"],
+  ["mcp_", "Using a connected app"],
+  ["skill_", "Running a skill"],
+  ["subagent", "Working on it"],
+];
+
+/**
+ * What an unrecognized tool reads as.
+ *
+ * Deliberately vague rather than derived from the tool's name. A humanized
+ * `slack_conversations_history` is worse than "Working on it": it is longer
+ * than the slot, it leaks an internal vocabulary, and it reads like an error
+ * message. The label's job is to show the turn is alive and doing something,
+ * and this does that job for every tool that will ever exist.
+ */
+export const GENERIC_ACTIVITY_LABEL = "Working on it";
+
+/**
+ * The line to show while `toolName` runs.
+ *
+ * Total, by construction: every tool gets a label, because the alternative is
+ * a surface that goes blank precisely when the assistant is busiest.
+ */
+export function activityLabelForTool(toolName: string): string {
+  const exact = TOOL_ACTIVITY_LABELS[toolName];
+  if (exact !== undefined) {
+    return exact;
+  }
+  for (const [prefix, label] of TOOL_ACTIVITY_LABEL_PREFIXES) {
+    if (toolName.startsWith(prefix)) {
+      return label;
+    }
+  }
+  return GENERIC_ACTIVITY_LABEL;
+}

--- a/assistant/src/live-voice/live-activity-reporter.ts
+++ b/assistant/src/live-voice/live-activity-reporter.ts
@@ -109,21 +109,45 @@ export function phaseForFrame(
  */
 export class LiveActivityReporter {
   private lastPhase: LiveActivityPhase | null = null;
+  private lastDetail = "";
   private ended = false;
 
   constructor(private readonly conversationId: string) {}
 
   /**
-   * Report the phase a frame implies, if it changed. Fire-and-forget: callers
-   * are on the session's send path and must not await this.
+   * Report what a frame implies about the phase or the activity line, if
+   * either changed. Fire-and-forget: callers are on the session's send path
+   * and must not await this.
+   *
+   * Both travel in one dispatch because they are two fields of one content
+   * state: ActivityKit replaces the whole thing per push, so a dispatch that
+   * carried only the field that moved would blank the other.
    */
   report(frame: LiveVoiceServerFramePayload): void {
-    const phase = phaseForFrame(frame, this.lastPhase);
-    if (phase === null || phase === this.lastPhase || this.ended) {
+    if (this.ended) {
       return;
     }
-    this.lastPhase = phase;
-    void this.dispatch(phase, "update");
+    const phase = phaseForFrame(frame, this.lastPhase);
+    // The session sends this frame only on a change it wants surfaced, and
+    // sends an empty label when the turn stops working, so it is taken
+    // verbatim rather than derived.
+    const detail = frame.type === "activity" ? frame.label : this.lastDetail;
+    const phaseMoved = phase !== null && phase !== this.lastPhase;
+    if (!phaseMoved && detail === this.lastDetail) {
+      return;
+    }
+    if (phase !== null) {
+      this.lastPhase = phase;
+    }
+    this.lastDetail = detail;
+    // An activity line can arrive before any phase has been established (a
+    // turn whose first tool starts before the phase-bearing frame lands).
+    // There is no content state to attach it to yet, and the phase the next
+    // frame sets will carry it.
+    if (this.lastPhase === null) {
+      return;
+    }
+    void this.dispatch(this.lastPhase, "update", this.lastDetail);
   }
 
   /**
@@ -139,13 +163,17 @@ export class LiveActivityReporter {
       return;
     }
     this.ended = true;
-    void this.dispatch("ending", "end");
+    // No detail on the way out: whatever the turn was doing, it is not doing
+    // it any more, and this state is the one that lingers on the Lock Screen
+    // through the dismissal window.
+    void this.dispatch("ending", "end", "");
   }
 
   /** `protected` so a test can observe what would be sent without sending it. */
   protected async dispatch(
     phase: LiveActivityPhase,
     event: "update" | "end",
+    detail: string,
   ): Promise<void> {
     try {
       const client = await VellumPlatformClient.create();
@@ -162,6 +190,7 @@ export class LiveActivityReporter {
           conversation_id: this.conversationId,
           phase,
           event,
+          detail,
         }),
       });
       if (!response.ok) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -59,6 +59,7 @@ import { getToolOwner } from "../tools/registry.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
+import { activityLabelForTool } from "./activity-label.js";
 import {
   createVoiceFrontDecider,
   type VoiceFrontDecider,
@@ -481,6 +482,10 @@ interface ActiveAssistantTurn {
   // Latched when the leg's stream contains MINIMIZE_ROOM_MARKER; consumed
   // once at TTS drain, where the minimize_room frame goes out after tts_done.
   minimizeRequested: boolean;
+  // The activity label the client was last told about, so a run of tools that
+  // map to the same line sends one frame rather than one per call. Empty means
+  // the client believes nothing is running, which is also where a turn ends.
+  activityLabel: string;
   // A tts_audio frame actually went out to the client — latches on the first
   // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
@@ -1920,6 +1925,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         "barge_in",
         turn.turnId,
       );
+      // A cancelled turn's tools are abandoned, not finished, so nothing will
+      // arrive to clear the line it left behind.
+      this.publishActivity(turn, "");
       await this.sendFrame({ type: "turn_cancelled", turnId: turn.turnId });
       await this.cancelAssistantTurn("barge_in");
       // Keep the interrupted turn's work alive on a background subagent; the
@@ -2315,6 +2323,47 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       this.scheduleContinuationAnnouncement(true, drainRearms);
     }, drainMs + this.continuationAnnounceSilenceMs);
+  }
+
+  /**
+   * The line describing what this turn is doing right now: the newest tool
+   * still running, or nothing when none is.
+   *
+   * Newest-first because parallel ops are the interesting case. A turn that
+   * starts a search and a file read, then finishes the search, is still
+   * reading a file, and a surface that went blank there would claim the turn
+   * had gone idle while it plainly has not.
+   */
+  private currentActivityLabel(turn: ActiveAssistantTurn): string {
+    for (let i = turn.progress.ops.length - 1; i >= 0; i -= 1) {
+      const op = turn.progress.ops[i];
+      if (op !== undefined && op.completedAtMs === undefined) {
+        return activityLabelForTool(op.toolName);
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Tell the client what the turn is doing, if it changed.
+   *
+   * De-duplicated for the same reason the Live Activity reporter de-duplicates
+   * phases: this frame reaches ActivityKit, whose update budget is finite and
+   * whose overflow is dropped silently, and a turn that runs four file reads in
+   * a row would otherwise spend that budget restating one line.
+   *
+   * Fire-and-forget. An activity label is a flourish, and nothing about the
+   * conversation may wait on one.
+   */
+  private publishActivity(turn: ActiveAssistantTurn, label: string): void {
+    if (turn.activityLabel === label) {
+      return;
+    }
+    turn.activityLabel = label;
+    void this.sendFrame(
+      { type: "activity", turnId: turn.turnId, label },
+      () => !this.isClosed,
+    );
   }
 
   private clearActiveAssistantTurn(token: symbol): void {
@@ -3409,6 +3458,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       assistantCompleted: false,
       ttsDone: false,
       minimizeRequested: false,
+      activityLabel: "",
       ttsAudioStarted: false,
       finalized: false,
       speculativePending: opts?.speculative === true,
@@ -3835,6 +3885,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             });
             current.progress.opsSinceNarration += 1;
             current.progress.stateEpoch += 1;
+            this.publishActivity(current, this.currentActivityLabel(current));
             log.debug({ turnId, toolName }, "Live voice turn started tool use");
             // Definitive tool use means the turn is guaranteed slow: speak
             // the floor-holding ack now instead of waiting out the
@@ -3888,6 +3939,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               }
             }
             current.progress.stateEpoch += 1;
+            this.publishActivity(current, this.currentActivityLabel(current));
             this.maybeNarrateProgress(current, trigger);
           },
         },
@@ -4568,6 +4620,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             currentTurn.finalized &&
             !this.isClosed,
         );
+
+        // The turn is over, so nothing is running. Ordinarily the line is
+        // already clear (the last tool_result cleared it); this is the net
+        // for a turn that ends with an op still open, which would otherwise
+        // leave the last tool it touched on screen through the next silence.
+        this.publishActivity(currentTurn, "");
 
         // Drain-scoped minimize: the latched marker is consumed here, after
         // the turn's speech has fully drained — never mid-speech, never for

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -18,6 +18,7 @@ const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "stt_partial",
   "stt_final",
   "thinking",
+  "activity",
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
@@ -217,6 +218,26 @@ export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
   readonly turnId: string;
 }
 
+/**
+ * What the assistant is doing inside a turn, as one short user-facing line.
+ *
+ * Exists because a live-voice turn can go silent for a long time while it
+ * works, and the surfaces that show the session (the iOS Live Activity, and
+ * the room) can otherwise only say "Thinking...". The label is composed here
+ * rather than by each surface for the same reason phase wording is composed
+ * once: the Live Activity has two independent drivers (this socket and an APNs
+ * push the daemon dispatches), they must carry identical content, and the only
+ * way to guarantee that is for both to be handed the same string.
+ *
+ * An empty `label` means "no current activity", which is what a turn's end
+ * sends. Emitted only on change, never per tool result.
+ */
+export interface LiveVoiceActivityServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "activity";
+  readonly turnId: string;
+  readonly label: string;
+}
+
 export interface LiveVoiceAssistantTextDeltaServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "assistant_text_delta";
   readonly text: string;
@@ -321,6 +342,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame
+  | LiveVoiceActivityServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
@@ -341,6 +363,7 @@ export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceSttPartialServerFrame>
   | WithoutSeq<LiveVoiceSttFinalServerFrame>
   | WithoutSeq<LiveVoiceThinkingServerFrame>
+  | WithoutSeq<LiveVoiceActivityServerFrame>
   | WithoutSeq<LiveVoiceAssistantTextDeltaServerFrame>
   | WithoutSeq<LiveVoiceTtsAudioServerFrame>
   | WithoutSeq<LiveVoiceTtsDoneServerFrame>

--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -61,11 +61,29 @@ struct VoiceSessionAttributes: ActivityAttributes {
 
         var muted: Bool
 
-        init(phase: Phase, label: String, accentHex: String, muted: Bool) {
+        /// One short line describing what the current turn is doing ("Reading
+        /// a file"), or `""` when it is doing nothing nameable.
+        ///
+        /// Like ``label``, wording that is passed through rather than derived,
+        /// but composed a layer further back: the *daemon* words it, because
+        /// it is the only layer that knows a tool ran, and because the island
+        /// has two drivers (this app, and an APNs push sent while this app is
+        /// suspended) that must render identical content. Composing it in the
+        /// web layer would leave the push path with nothing to send.
+        var detail: String
+
+        init(
+            phase: Phase,
+            label: String,
+            accentHex: String,
+            muted: Bool,
+            detail: String
+        ) {
             self.phase = phase
             self.label = label
             self.accentHex = Self.canonicalAccentHex(accentHex)
             self.muted = muted
+            self.detail = detail
         }
 
         /// Decoding funnels through the validating initializer so the
@@ -77,7 +95,14 @@ struct VoiceSessionAttributes: ActivityAttributes {
                 phase: try container.decode(Phase.self, forKey: .phase),
                 label: try container.decode(String.self, forKey: .label),
                 accentHex: try container.decode(String.self, forKey: .accentHex),
-                muted: try container.decode(Bool.self, forKey: .muted)
+                muted: try container.decode(Bool.self, forKey: .muted),
+                // Absent from a state pushed by a platform that predates it,
+                // and from one archived by an earlier build of this app. Both
+                // read as "no activity line", which is what those versions
+                // meant. See the attributes decoder for why a missing field
+                // must never fail here.
+                detail: try container.decodeIfPresent(String.self, forKey: .detail)
+                    ?? ""
             )
         }
 

--- a/clients/ios/App/App/VoiceLiveActivityPlugin.swift
+++ b/clients/ios/App/App/VoiceLiveActivityPlugin.swift
@@ -353,7 +353,10 @@ public class VoiceLiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             label: call.getString("label") ?? "",
             accentHex: call.getString("accentHex")
                 ?? VoiceSessionAttributes.ContentState.neutralAccentHex,
-            muted: call.getBool("muted") ?? false
+            muted: call.getBool("muted") ?? false,
+            // Absent from a web bundle older than this field, which simply has
+            // no activity line to show.
+            detail: call.getString("detail") ?? ""
         )
     }
 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -59,6 +59,17 @@ extension VoiceSessionAttributes.ContentState {
         isStale ? "" : label
     }
 
+    /// The activity line to render, or nothing when there is none and once the
+    /// content has gone stale.
+    ///
+    /// Stale drops it for the same reason it drops the phase label, only more
+    /// so: "Reading a file" is a claim about work happening *right now*, which
+    /// makes it the sentence on the island most likely to be a lie once
+    /// nothing is driving updates any more.
+    func displayDetail(isStale: Bool) -> String {
+        isStale ? "" : detail
+    }
+
     /// The SF Symbol standing for this phase.
     ///
     /// **A glyph is not copy, which is why this may switch on `phase` when
@@ -301,7 +312,8 @@ struct VoiceSessionLockScreenView: View {
     var avatarImageData: Data?
 
     var body: some View {
-        HStack(spacing: 12) {
+        let detail = state.displayDetail(isStale: isStale)
+        return HStack(spacing: 12) {
             VoiceAccentBadge(accent: state.accentColor, avatarImageData: avatarImageData)
             VStack(alignment: .leading, spacing: 2) {
                 VoiceSessionText(text: assistantName, font: .headline)
@@ -310,6 +322,20 @@ struct VoiceSessionLockScreenView: View {
                     VoiceSessionText(
                         text: state.displayLabel(isStale: isStale),
                         color: .secondary
+                    )
+                }
+                // The activity line, when there is one. Below the phase rather
+                // than replacing it: the two answer different questions ("is
+                // it my turn to talk" and "what is it doing"), and a turn that
+                // is thinking *and* reading a file is both.
+                //
+                // Absent rather than blank when empty, so an idle session's
+                // card is two lines tall instead of two lines and a gap.
+                if !detail.isEmpty {
+                    VoiceSessionText(
+                        text: detail,
+                        font: .caption,
+                        color: .tertiary
                     )
                 }
             }

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -233,12 +233,11 @@ struct VoiceAccentBadge: View {
     }
 }
 
-/// The identity mark for the two tightest slots, the compact leading and the
-/// minimal presentation: the avatar if there is one, the accent waveform if
-/// not.
+/// The identity mark for the compact leading slot: the avatar if there is one,
+/// the accent waveform if not.
 ///
-/// Sized rather than left to the slot because these are the only presentations
-/// iOS renders inline with the status bar, where an unconstrained image would
+/// Sized rather than left to the slot because the inline presentations are the
+/// ones iOS renders against the status bar, where an unconstrained image would
 /// be laid out against the whole island rather than its own corner.
 struct VoiceCompactIdentity: View {
     let accent: Color
@@ -249,6 +248,33 @@ struct VoiceCompactIdentity: View {
             VoiceAvatarImage(image: image, diameter: 20)
         } else {
             VoiceAccentGlyph(accent: accent, scale: .small)
+        }
+    }
+}
+
+/// The minimal presentation: the phase glyph, falling back to the identity
+/// mark once the content is stale.
+///
+/// The fallback is what keeps this slot from rendering nothing at all.
+/// ``VoicePhaseGlyph`` draws no view when stale, which is correct wherever
+/// something else remains on screen, and wrong here: this circle *is* the whole
+/// island in the shared presentation, so an empty one reads as a broken app
+/// rather than as an activity with nothing to claim. Identity is the right
+/// thing to fall back to, for the same reason the Lock Screen keeps the avatar
+/// and drops the phase: the session's existence is not the part in doubt.
+struct VoiceMinimalPresentation: View {
+    let state: VoiceSessionAttributes.ContentState
+    let isStale: Bool
+    var avatarImageData: Data?
+
+    var body: some View {
+        if isStale {
+            VoiceCompactIdentity(
+                accent: state.accentColor,
+                avatarImageData: avatarImageData
+            )
+        } else {
+            VoicePhaseGlyph(state: state, isStale: false, scale: .small)
         }
     }
 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -40,6 +40,7 @@ struct VoiceSessionLiveActivity: Widget {
             let state = context.state
             let isStale = context.isStale
             let label = state.displayLabel(isStale: isStale)
+            let detail = state.displayDetail(isStale: isStale)
             let avatar = context.attributes.avatarImageData
             let startedAt = context.attributes.startedAt
             return DynamicIsland {
@@ -64,8 +65,14 @@ struct VoiceSessionLiveActivity: Widget {
                     }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
+                    // The activity line takes this row while there is one, and
+                    // the assistant's name takes it otherwise. Not both: the
+                    // expanded island is one line tall here, and of the two,
+                    // what the assistant is *doing* is the one that changes and
+                    // the one the user opened the island to find out. Identity
+                    // is already carried by the avatar in the leading region.
                     VoiceSessionText(
-                        text: context.attributes.assistantName,
+                        text: detail.isEmpty ? context.attributes.assistantName : detail,
                         color: .secondary
                     )
                 }

--- a/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionLiveActivity.swift
@@ -59,36 +59,61 @@ struct VoiceSessionLiveActivity: Widget {
                     }
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    HStack(spacing: 6) {
-                        VoicePhaseGlyph(state: state, isStale: isStale)
-                        VoiceSessionText(text: label, font: .headline)
-                    }
+                    VoiceSessionText(
+                        text: context.attributes.assistantName,
+                        font: .headline
+                    )
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    // The activity line takes this row while there is one, and
-                    // the assistant's name takes it otherwise. Not both: the
-                    // expanded island is one line tall here, and of the two,
-                    // what the assistant is *doing* is the one that changes and
-                    // the one the user opened the island to find out. Identity
-                    // is already carried by the avatar in the leading region.
-                    VoiceSessionText(
-                        text: detail.isEmpty ? context.attributes.assistantName : detail,
-                        color: .secondary
-                    )
+                    // Everything the activity knows, because reaching this
+                    // presentation is deliberate: it takes a touch and hold,
+                    // and someone who did that is asking for the detail the
+                    // inline slots had to drop. So the phase and the activity
+                    // line both render here rather than competing for one row.
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            VoicePhaseGlyph(state: state, isStale: isStale)
+                            VoiceSessionText(text: label, color: .secondary)
+                        }
+                        if !detail.isEmpty {
+                            VoiceSessionText(
+                                text: detail,
+                                font: .caption,
+                                color: .tertiary
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             } compactLeading: {
                 VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
             } compactTrailing: {
-                // The tightest slot there is, and the presentation the user
-                // spends the most time looking at. It used to show the passed
-                // label truncated, which at this width is two or three
-                // characters, identical for "Listening…" and "Thinking…". The
-                // glyph says the same thing legibly, and says it without
-                // substituting a native *string*, which is the fossilization
-                // this design actually guards against.
+                // A few characters wide. The passed label truncates to a
+                // fragment here, and the fragments for "Listening…" and
+                // "Thinking…" are not worth telling apart, so the phase shows
+                // as a glyph instead. A glyph is not a native *string*, which
+                // is what the copy rule actually guards against; shortening
+                // the wording, if it is ever wanted here, belongs to the web
+                // layer that owns the wording.
                 VoicePhaseGlyph(state: state, isStale: isStale, scale: .small)
             } minimal: {
-                VoiceCompactIdentity(accent: state.accentColor, avatarImageData: avatar)
+                // **The presentation a voice session most likely gets.** iOS
+                // shows the minimal slot when the island is shared, and a live
+                // session always shares it: the system's microphone privacy
+                // indicator is on for the whole call, including while muted,
+                // because muting streams silence rather than stopping capture.
+                //
+                // So this one circle is the entire island for most of a call,
+                // and it carries the phase rather than the avatar. Identity is
+                // the fact that does not change and that the user already
+                // knows; whether it is still listening is the one they cannot
+                // get from a locked phone. The accent tint keeps identity
+                // present, weakly, in the glyph's color.
+                VoiceMinimalPresentation(
+                    state: state,
+                    isStale: isStale,
+                    avatarImageData: avatar
+                )
             }
             .widgetURL(VoiceModeDeepLink.resume.url())
             .keylineTint(state.accentColor)

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -140,6 +140,35 @@ Truncated to that, "Listening…" and "Thinking…" are the same string, which m
 the presentation the user sees most of the time say nothing at all. That slot
 now renders the glyph, and the roomier presentations render glyph *and* label.
 
+### The activity line: wording from a third layer
+
+`ContentState.detail` is one short line saying what the turn is doing right now
+("Reading a file"), or `""` when nothing nameable is. The phase says whether it
+is your turn to talk; this says what it is busy with, and a turn can be
+thinking *and* reading a file.
+
+Its wording comes from neither this shell nor the web layer but from the
+**daemon** (`assistant/src/live-voice/activity-label.ts`). Two reasons, and the
+first is the binding one:
+
+1. The island has two drivers carrying identical content state, and only one of
+   them runs web code. A label composed in the web layer could not be
+   reproduced by the APNs push that takes over once that layer is suspended, so
+   both are handed the same string: the daemon sends an `activity` frame down
+   the socket *and* the same text in its dispatch.
+2. The daemon is the only layer that knows a tool ran at all.
+
+This does not reopen the cadence question the phase-label rule answers. That
+rule exists because *this shell* ships on App Store review; the daemon deploys
+continuously, like the web bundle.
+
+The label names what the user would say is happening, never the tool and never
+its arguments: a path or a URL is unreadable at a glance and may be something
+the user would not choose to show whoever else can see the Lock Screen. Every
+tool gets a line, including ones the map has never seen, because the vocabulary
+is open (plugins, MCP, skills) and a blank line at the busiest moment is the
+worst of the options.
+
 ### What moves without an update: the elapsed timer
 
 `VoiceSessionAttributes.startedAt` is stamped natively at `Activity.request`,
@@ -156,8 +185,8 @@ activity's lifetime, and being an attribute is what keeps a server-driven push
 natively also puts it on the same clock as the device rendering it, which a
 timestamp composed on the platform would not be.
 
-Everything phase-derived (label, glyph, and the timer) drops when
-`context.isStale` goes true. Identity (avatar, name, accent) stays: that a
+Everything phase-derived (label, glyph, the activity line, and the timer)
+drops when `context.isStale` goes true. Identity (avatar, name, accent) stays: that a
 session with this assistant exists is still true, and tapping through still
 reaches it.
 
@@ -489,8 +518,8 @@ healthy session that nobody happens to be talking to.
 
 ### 2. No App Group
 
-`ContentState` carries only primitives (`phase`, `label`, `accentHex`,
-`muted`), and the attributes carry `assistantName`, `startedAt`, and the
+`ContentState` carries only primitives (`phase`, `label`, `detail`,
+`accentHex`, `muted`), and the attributes carry `assistantName`, `startedAt`, and the
 avatar as `Data`. The extension ships **no entitlements file at all**.
 
 *Why:* an App Group is only needed to share *files*, and nothing here needs

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -135,10 +135,47 @@ second source deploying on a different cadence to drift from, and the phase
 vocabulary it switches over is already a contract both sides must change
 together, so a new case is a Swift compile error rather than silent drift.
 
-It exists because the compact trailing slot is roughly three characters wide.
-Truncated to that, "Listening…" and "Thinking…" are the same string, which made
-the presentation the user sees most of the time say nothing at all. That slot
-now renders the glyph, and the roomier presentations render glyph *and* label.
+It exists because the inline slots are a few characters wide. The passed label
+truncates to a fragment there, and the fragments of "Listening…" and
+"Thinking…" are not worth telling apart. Those slots render the glyph; the
+roomier presentations render glyph *and* label. If short *wording* is ever
+wanted inline, it belongs to the web layer that owns the wording, as a second
+short label, not to a native `switch`.
+
+### Which presentation a voice session actually gets
+
+Probably the minimal one, which is why the phase glyph is what it renders.
+
+iOS falls back to the minimal presentation when the Dynamic Island is shared,
+and a live-voice session always shares it: the system's microphone privacy
+indicator is on for the entire call. It stays on while muted, too, because
+muting streams silence rather than stopping capture. That indicator cannot be
+suppressed and should not be.
+
+Two consequences worth keeping in mind when changing these views:
+
+- **The minimal slot is the island, for most of a call.** It carries the phase
+  rather than the avatar: identity is the fact that does not change and that
+  the user already knows, and the accent tint keeps it weakly present anyway.
+  It falls back to the identity mark when the content is stale, because a
+  presentation that renders nothing reads as a broken app.
+- **The expanded presentation is reached deliberately**, by touch and hold
+  (a tap opens the app through `widgetURL`; the gesture mapping is the
+  system's). Someone who held is asking for what the inline slots dropped, so
+  it shows everything the activity knows: avatar, name, elapsed time, mute,
+  phase glyph, phase label, and the activity line.
+
+None of this is verifiable in the simulator, which has no island and no real
+microphone. It is a device check.
+
+### Alerting updates are reserved
+
+`AlertConfiguration` forces a brief expanded presentation plus a haptic, a
+sound, a Lock Screen banner, and an Apple Watch forward. No phase change ever
+uses it: at the rate a conversation changes phase it would be intolerable, and
+the phase is not something the user must be interrupted for. It is reserved for
+a state change that genuinely requires attention, the first of which is an
+approval request the turn is blocked on.
 
 ### The activity line: wording from a third layer
 
@@ -537,10 +574,12 @@ before it is sent. See `ISLAND_AVATAR_MAX_BYTES` in
 `clients/web/src/utils/avatar-island-encode.ts`, where oversize kills the whole
 activity rather than degrading the image.
 
-### 3. The island is tap-to-return only — no interactive End button
+### 3. The island is tap-to-return only, with no interactive End button
 
 `VoiceSessionLiveActivity` has no buttons. The only affordance is
-`.widgetURL(VoiceModeDeepLink.resume.url())`.
+`.widgetURL(VoiceModeDeepLink.resume.url())`, which a tap follows; a touch and
+hold expands the presentation instead, and that is the system's gesture
+mapping, not a choice made here.
 
 *Why:* two reasons. Mechanically, an in-island control needs a
 `LiveActivityIntent` plus a signalling path into the running app (the appex

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -33,6 +33,7 @@ import {
   type LiveVoiceSpeechStartedServerFrame,
   type LiveVoiceSttFinalServerFrame,
   type LiveVoiceSttPartialServerFrame,
+  type LiveVoiceActivityServerFrame,
   type LiveVoiceThinkingServerFrame,
   type LiveVoiceTtsAudioServerFrame,
   type LiveVoiceTtsDoneServerFrame,
@@ -108,6 +109,8 @@ export interface LiveVoiceClientEventMap {
   sttPartial: LiveVoiceSttPartialServerFrame;
   sttFinal: LiveVoiceSttFinalServerFrame;
   thinking: LiveVoiceThinkingServerFrame;
+  /** What the turn is doing right now, or `""` when nothing nameable is. */
+  activity: LiveVoiceActivityServerFrame;
   assistantTextDelta: LiveVoiceAssistantTextDeltaServerFrame;
   ttsAudio: LiveVoiceTtsAudioServerFrame;
   ttsDone: LiveVoiceTtsDoneServerFrame;
@@ -193,6 +196,7 @@ export class LiveVoiceChannelClient {
     sttPartial: new Set(),
     sttFinal: new Set(),
     thinking: new Set(),
+    activity: new Set(),
     assistantTextDelta: new Set(),
     ttsAudio: new Set(),
     ttsDone: new Set(),
@@ -431,6 +435,9 @@ export class LiveVoiceChannelClient {
         return;
       case "thinking":
         this.emit("thinking", frame);
+        return;
+      case "activity":
+        this.emit("activity", frame);
         return;
       case "assistant_text_delta":
         this.emit("assistantTextDelta", frame);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -253,6 +253,20 @@ export interface LiveVoiceState {
    * registered.
    */
   starter: LiveVoiceSessionStarter | null;
+  /**
+   * One short line describing what the current turn is doing ("Reading a
+   * file"), or `""` when it is doing nothing nameable.
+   *
+   * **The wording is the daemon's**, delivered by the `activity` frame, not
+   * composed here. The iOS Live Activity is driven both by that socket and by
+   * an APNs push the daemon dispatches when this web layer is suspended; the
+   * two must carry identical content state, and only one of them can run web
+   * code. See `assistant/src/live-voice/activity-label.ts`.
+   *
+   * Turn-scoped: the daemon sends `""` when a turn stops working, and
+   * `reset()` clears it with everything else.
+   */
+  activityLabel: string;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -337,6 +351,8 @@ export interface LiveVoiceActions {
   setState: (state: LiveVoiceSessionState) => void;
   /** Record whether assistant TTS audio is currently queued/playing. */
   setAssistantAudioActive: (active: boolean) => void;
+  /** Record what the current turn is doing, as the daemon worded it. */
+  setActivityLabel: (activityLabel: string) => void;
   /** Set whether the controller is retrying a dropped connection. */
   setReconnecting: (reconnecting: boolean) => void;
   /**
@@ -492,6 +508,7 @@ export function isLiveVoiceSessionOwnedBy(
 const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   state: "idle",
   assistantAudioActive: false,
+  activityLabel: "",
   reconnecting: false,
   assistantId: null,
   conversationId: null,
@@ -519,6 +536,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setState: (state) => set({ state }),
   setAssistantAudioActive: (assistantAudioActive) =>
     set({ assistantAudioActive }),
+  setActivityLabel: (activityLabel) => set({ activityLabel }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
     // A fresh session always opens with the mic live, even if the controller

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -113,6 +113,7 @@ const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "stt_partial",
   "stt_final",
   "thinking",
+  "activity",
   "assistant_text_delta",
   "tts_audio",
   "tts_done",
@@ -187,6 +188,22 @@ export interface LiveVoiceSttFinalServerFrame extends LiveVoiceServerFrameBase {
 export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "thinking";
   readonly turnId: string;
+}
+
+/**
+ * What the assistant is doing inside a turn, as one short user-facing line
+ * ("Reading a file"), or `""` when it is doing nothing nameable.
+ *
+ * The wording is the daemon's, not this layer's, and that is deliberate: the
+ * iOS Live Activity is driven both by this socket and by an APNs push the
+ * daemon dispatches when this web layer is suspended, the two must carry
+ * identical content state, and handing both the same string is the only way to
+ * guarantee it. See `assistant/src/live-voice/activity-label.ts`.
+ */
+export interface LiveVoiceActivityServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "activity";
+  readonly turnId: string;
+  readonly label: string;
 }
 
 export interface LiveVoiceAssistantTextDeltaServerFrame extends LiveVoiceServerFrameBase {
@@ -300,6 +317,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceSttPartialServerFrame
   | LiveVoiceSttFinalServerFrame
   | LiveVoiceThinkingServerFrame
+  | LiveVoiceActivityServerFrame
   | LiveVoiceAssistantTextDeltaServerFrame
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -223,6 +223,7 @@ describe("starting the activity", () => {
       label: "Connecting…",
       accentHex: ORANGE,
       muted: false,
+      detail: "",
       assistantName: "Ada",
     });
     expect(updateVoiceLiveActivity).not.toHaveBeenCalled();
@@ -334,6 +335,33 @@ describe("starting the activity", () => {
 // ---------------------------------------------------------------------------
 
 describe("updating the activity", () => {
+  test("pushes the activity line the daemon worded", async () => {
+    renderMirror();
+    await setPhase("thinking");
+    updateVoiceLiveActivity.mockClear();
+
+    await settled(() => {
+      useLiveVoiceStore.getState().setActivityLabel("Reading a file");
+    });
+
+    expect(lastUpdatePayload()?.detail).toBe("Reading a file");
+  });
+
+  test("clears the line when the turn stops working", async () => {
+    renderMirror();
+    await setPhase("thinking");
+    await settled(() => {
+      useLiveVoiceStore.getState().setActivityLabel("Reading a file");
+    });
+    updateVoiceLiveActivity.mockClear();
+
+    await settled(() => {
+      useLiveVoiceStore.getState().setActivityLabel("");
+    });
+
+    expect(lastUpdatePayload()?.detail).toBe("");
+  });
+
   test("pushes one update per phase change and none for a repeated phase", async () => {
     renderMirror();
     await setPhase("connecting");
@@ -349,6 +377,7 @@ describe("updating the activity", () => {
       label: "Listening…",
       accentHex: ORANGE,
       muted: false,
+      detail: "",
     });
 
     // Re-publishing the same phase changes no `ContentState` field.
@@ -491,6 +520,7 @@ describe("a hands-free reconnect", () => {
       label: "Reconnecting…",
       accentHex: ORANGE,
       muted: true,
+      detail: "",
     });
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -28,7 +28,8 @@
  * reconnecting, `assistantAudioActive` for the label remap, muted, accent) and
  * compares each candidate against the last payload it pushed. `inputAmplitude`
  * is never read: it changes per animation frame and would exhaust the budget
- * within a second.
+ * within a second. `activityLabel` is read and is safe to: the daemon emits it
+ * only on a change it wants surfaced, a few times per turn at most.
  */
 
 import { useEffect } from "react";
@@ -92,6 +93,11 @@ function toActivityContent(
     // not an attribute, so it is not frozen at `start`.
     accentHex: getRenderedAvatarAccentHex() ?? "",
     muted: session.muted,
+    // The daemon's wording, verbatim, for the same reason the phase label is
+    // the room's wording verbatim: the island has a second driver (the APNs
+    // push the daemon dispatches while this layer is suspended) and the two
+    // must render the same thing.
+    detail: session.activityLabel,
   };
 }
 
@@ -161,7 +167,8 @@ function sameContent(
     a.phase === b.phase &&
     a.label === b.label &&
     a.accentHex === b.accentHex &&
-    a.muted === b.muted
+    a.muted === b.muted &&
+    a.detail === b.detail
   );
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -906,6 +906,15 @@ export function useLiveVoice(
           s.clearAssistantTranscript();
           s.setState("thinking");
         }),
+        client.on("activity", (frame) => {
+          if (!live()) {
+            return;
+          }
+          // Stored verbatim. The daemon composes this wording precisely so
+          // that this driver and the APNs push carry the same string, and
+          // rewording it here would break the equality it exists to provide.
+          useLiveVoiceStore.getState().setActivityLabel(frame.label);
+        }),
         client.on("assistantTextDelta", (frame) => {
           if (!live() || frame.text.length === 0) {
             return;

--- a/clients/web/src/runtime/native-live-activity.test.ts
+++ b/clients/web/src/runtime/native-live-activity.test.ts
@@ -47,6 +47,7 @@ const content: VoiceLiveActivityContent = {
   label: "Listening…",
   accentHex: "#7C3AED",
   muted: false,
+  detail: "",
 };
 const startOptions: VoiceLiveActivityStart = {
   ...content,

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -60,6 +60,13 @@ export interface VoiceLiveActivityContent {
   /** Avatar accent as `#RRGGBB`. Unparseable values fall back to a neutral gray natively. */
   accentHex: string;
   muted: boolean;
+  /**
+   * One short line describing what the current turn is doing ("Reading a
+   * file"), or `""` for none. Pass the live-voice store's `activityLabel`
+   * verbatim: the daemon words it so that this local push and the APNs push it
+   * dispatches carry identical content.
+   */
+  detail: string;
 }
 
 /** {@link VoiceLiveActivityContent} plus the fields fixed for the activity's lifetime. */


### PR DESCRIPTION
Stacked on #39868.

A live-voice turn can go silent for a long time while it works, and the island could only ever say "Thinking…". It now carries a line naming the activity, under the phase on the Lock Screen and in the expanded island's bottom row.

```
(avatar)  Ada                    2:36
          ⋯ Thinking…
          Running a command
```

## Where the wording comes from, and why that is a third layer

The daemon composes it (`assistant/src/live-voice/activity-label.ts`), not the shell and not the web bundle. One binding reason: the island has **two drivers** carrying identical content state, and only one of them runs web code. A label composed in the web layer could not be reproduced by the APNs push that takes over once that layer is suspended, so both are handed the same string, via a new `activity` server frame and the dispatch payload. The daemon is also the only layer that knows a tool ran at all.

This does not reopen the cadence question that keeps phase wording out of the shell: that rule exists because the shell ships on App Store review, and the daemon deploys continuously.

## Choices worth reviewing

- **Names the activity, never the tool or its arguments.** `summarizeToolInput` could supply a path or a URL, but neither is readable at a glance, and both can be content the user would not choose to show whoever else can see the Lock Screen.
- **Every tool resolves to a label**, including ones the map has never seen — the vocabulary is open (plugins, MCP, skills), and a blank line at the busiest moment is the worst option. Unknown tools read "Working on it" rather than a humanized tool name, which would leak an internal vocabulary and overflow the slot.
- **Cleared when the work stops**: on the last tool result (falling back to another op still running), on barge-in, and at the turn's end. Dropped entirely, like everything phase-derived, once the content goes stale — "Reading a file" is the claim on the island most likely to be a lie when nothing is driving updates.
- **De-duplicated at both ends**, because ActivityKit's update budget is finite and its overflow is dropped silently.

## Testing

- 385 daemon live-voice tests, the web live-voice/mirror suites, `bun run typecheck`, `bun run lint`, and an iOS build (app + widget extension) all green. New coverage: the label map's totality and length bounds, the reporter carrying the line through a later phase change, and the mirror pushing/clearing it.
- Lock Screen rendered on an iPhone 17 Pro simulator across phase-with-detail, long detail, muted-with-detail, and stale-with-detail, in both appearances.
- The `tool_use_start` test that asserted "without emitting frames" now asserts the frame it emits; that invariant is what this PR changes.

## Dependency

Needs vellum-ai/vellum-assistant-platform#9737, and #39868 below it.

Part of JARVIS-1404 (2 of 4); does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)