### PR TITLE
feat(subagent): output_contract param with evidence-backed verdict preset

### DIFF
--- a/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
+++ b/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
@@ -231,4 +231,29 @@ describe("SubagentManager fork — prompt source and role decoupling", () => {
     expect(first).toContain("FORK TASK");
     expect(first).not.toContain("Act as");
   });
+
+  test("a fork's output contract reaches the child in its first message", async () => {
+    const created = await spawnFork({
+      role: "researcher",
+      outputContract: "verdict",
+    });
+    const first = await firstUserMessage(created);
+
+    // Same carrier as the persona, and for the same reason: the system prompt
+    // is the parent's, so nothing the contract says can land there.
+    expect(created.systemPrompt).toBe(PARENT_PROMPT);
+    expect(created.systemPrompt).not.toContain("PASS or FAIL");
+    expect(first).toContain(
+      "Output contract: For each criterion in the objective return PASS or FAIL",
+    );
+    expect(first).toContain("do something");
+  });
+
+  test("a fork under the default report contract gets no contract line", async () => {
+    const created = await spawnFork({ outputContract: "report" });
+    const first = await firstUserMessage(created);
+
+    expect(first).toContain("FORK TASK");
+    expect(first).not.toContain("Output contract:");
+  });
 });

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -2582,6 +2582,241 @@ describe("Subagent role-based spawn", () => {
   });
 });
 
+// ── Output contract ─────────────────────────────────────────────────
+
+describe("Subagent output contract", () => {
+  /**
+   * Run a spawn with the manager stubbed, reporting both the config it was
+   * handed and whether it was called at all (a rejected contract must not
+   * spawn).
+   */
+  async function spawnCapturing(
+    input: Record<string, unknown>,
+    contextExtras: Record<string, unknown> = {},
+  ): Promise<{
+    result: { content: string; isError: boolean };
+    config: Record<string, unknown> | undefined;
+  }> {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "contract-subagent-id";
+    };
+    try {
+      const result = await executeSubagentSpawn(
+        input,
+        makeContext("sess-contract", {
+          sendToClient: () => {},
+          ...contextExtras,
+        }),
+      );
+      return { result, config: capturedConfig };
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  }
+
+  test.each([
+    ["report", "builder"],
+    ["verdict", "researcher"],
+    ["artifact", "builder"],
+  ])("output_contract %s is accepted for a %s", async (contract, role) => {
+    const { result, config } = await spawnCapturing({
+      label: "Contract task",
+      objective: "Do it",
+      role,
+      output_contract: contract,
+    });
+    expect(result.isError).toBe(false);
+    expect(config!.outputContract).toBe(contract);
+  });
+
+  test("an unknown output_contract fails validation without spawning", async () => {
+    const { result, config } = await spawnCapturing({
+      label: "Bad contract",
+      objective: "Do it",
+      role: "researcher",
+      output_contract: "checklist",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Invalid input for tool "subagent_spawn"');
+    expect(result.content).toContain("output_contract");
+    expect(config).toBeUndefined();
+  });
+
+  test("verdict on a builder returns a mismatch error instead of spawning", async () => {
+    const { result, config } = await spawnCapturing({
+      label: "Check it",
+      objective: "Verify the migration ran",
+      role: "builder",
+      output_contract: "verdict",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("only available to researcher-typed");
+    expect(result.content).toContain('resolved to "builder"');
+    expect(config).toBeUndefined();
+  });
+
+  test("verdict on a spawn that names no role is a mismatch (the default is builder)", async () => {
+    const { result, config } = await spawnCapturing({
+      label: "Check it",
+      objective: "Verify the migration ran",
+      output_contract: "verdict",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('role "researcher"');
+    expect(config).toBeUndefined();
+  });
+
+  test("verdict rides the researcher fallback an unknown role resolves to", async () => {
+    const { result, config } = await spawnCapturing({
+      label: "Check it",
+      objective: "Verify the migration ran",
+      role: "release auditor",
+      output_contract: "verdict",
+    });
+    expect(result.isError).toBe(false);
+    expect(config!.role).toBe("researcher");
+    expect(config!.outputContract).toBe("verdict");
+  });
+
+  test("artifact on a researcher returns a mismatch error instead of spawning", async () => {
+    const { result, config } = await spawnCapturing({
+      label: "Write it",
+      objective: "Produce the migration file",
+      role: "researcher",
+      output_contract: "artifact",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("only available to builder-typed");
+    expect(config).toBeUndefined();
+  });
+
+  test("the advisor takes no output contract and never consults", async () => {
+    const manager = getSubagentManager();
+    const originalAwait = manager.spawnAndAwait.bind(manager);
+    let consulted = false;
+    manager.spawnAndAwait = async () => {
+      consulted = true;
+      return "advice";
+    };
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Consult",
+          objective: "Check the plan",
+          role: "advisor",
+          output_contract: "verdict",
+        },
+        makeContext("sess-contract-advisor", { sendToClient: () => {} }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not apply to the advisor");
+      expect(consulted).toBe(false);
+    } finally {
+      manager.spawnAndAwait = originalAwait;
+    }
+  });
+
+  test("verdict defaults the child to the cost-optimized tier", async () => {
+    const { result, config } = await spawnCapturing(
+      {
+        label: "Check it",
+        objective: "Verify each acceptance criterion",
+        role: "researcher",
+        output_contract: "verdict",
+      },
+      { invokingCallSite: "mainAgent" },
+    );
+    expect(result.isError).toBe(false);
+    // Ahead of the mainAgent default (balanced) this spawn would otherwise
+    // inherit, and unforced like every other inheritance rung.
+    expect(config!.overrideProfile).toBe("cost-optimized");
+    expect(config!.forceOverrideProfile).toBeUndefined();
+  });
+
+  test("an explicit inference_profile beats the verdict default", async () => {
+    const { config } = await spawnCapturing({
+      label: "Check it",
+      objective: "Verify each acceptance criterion",
+      role: "researcher",
+      output_contract: "verdict",
+      inference_profile: "quality-optimized",
+    });
+    expect(config!.overrideProfile).toBe("quality-optimized");
+    expect(config!.forceOverrideProfile).toBe(true);
+  });
+
+  test("a report contract changes neither the profile nor the framing", async () => {
+    const { config } = await spawnCapturing(
+      {
+        label: "Research it",
+        objective: "Find the pricing data",
+        role: "researcher",
+        output_contract: "report",
+      },
+      { invokingCallSite: "mainAgent" },
+    );
+    expect(config!.overrideProfile).toBe("balanced");
+    expect(
+      buildSubagentSystemPrompt(
+        {
+          id: "sub-report",
+          parentConversationId: "conv-1",
+          label: "Research it",
+          objective: "Find the pricing data",
+          outputContract: "report",
+        },
+        "researcher",
+      ),
+    ).not.toContain("Output contract");
+  });
+
+  test("the verdict contract reaches the child's system prompt", () => {
+    const prompt = buildSubagentSystemPrompt(
+      {
+        id: "sub-verdict",
+        parentConversationId: "conv-1",
+        label: "Check it",
+        objective: "Verify each acceptance criterion",
+        outputContract: "verdict",
+      },
+      "researcher",
+    );
+    expect(prompt).toContain("- Output contract: ");
+    expect(prompt).toContain("return PASS or FAIL plus the exact evidence");
+    expect(prompt).toContain("CANNOT VERIFY");
+  });
+
+  test("the artifact contract reaches the child's system prompt", () => {
+    const prompt = buildSubagentSystemPrompt(
+      {
+        id: "sub-artifact",
+        parentConversationId: "conv-1",
+        label: "Write it",
+        objective: "Produce the migration file",
+        outputContract: "artifact",
+      },
+      "builder",
+    );
+    expect(prompt).toContain("Your deliverable is the artifact itself.");
+  });
+
+  test("spawn tool definition declares output_contract", () => {
+    const def = findTool("subagent_spawn");
+    expect(def.input_schema.properties.output_contract).toBeDefined();
+    expect(def.input_schema.properties.output_contract.type).toBe("string");
+    expect(def.input_schema.properties.output_contract.enum).toEqual([
+      "report",
+      "verdict",
+      "artifact",
+    ]);
+    expect(def.input_schema.required).not.toContain("output_contract");
+  });
+});
+
 // ── Advisor-role consult ────────────────────────────────────────────
 
 describe("Subagent advisor-role consult", () => {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -2720,6 +2720,51 @@ describe("Subagent output contract", () => {
     }
   });
 
+  test("an explicit report is rejected for the advisor too", async () => {
+    const manager = getSubagentManager();
+    const originalAwait = manager.spawnAndAwait.bind(manager);
+    let consulted = false;
+    manager.spawnAndAwait = async () => {
+      consulted = true;
+      return "advice";
+    };
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Consult",
+          objective: "Check the plan",
+          role: "advisor",
+          output_contract: "report",
+        },
+        makeContext("sess-contract-advisor-report", {
+          sendToClient: () => {},
+        }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not apply to the advisor");
+      expect(result.content).toContain('"report"');
+      expect(consulted).toBe(false);
+    } finally {
+      manager.spawnAndAwait = originalAwait;
+    }
+  });
+
+  test("a null contract reads as omitted and reaches the advisor branch", async () => {
+    const result = await executeSubagentSpawn(
+      {
+        label: "Consult",
+        objective: "Check the plan",
+        role: "advisor",
+        output_contract: null,
+      },
+      makeContext("sess-contract-advisor-none", { sendToClient: () => {} }),
+    );
+    // The advisor branch runs and reports its own missing-parent notice, so
+    // the contract check waved this spawn through.
+    expect(result.content).toContain("advisor unavailable");
+    expect(result.content).not.toContain("does not apply to the advisor");
+  });
+
   test("verdict defaults the child to the cost-optimized tier", async () => {
     const { result, config } = await spawnCapturing(
       {

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -53,6 +53,16 @@ Any other `role` text is treated as a persona, not a type. The subagent runs as 
 
 Omitting `role` entirely runs a `builder`, so a spawn that names no type keeps your full tool surface.
 
+### Verification
+
+Checking that something is actually done is not a fourth type. It is a `researcher` with `output_contract: "verdict"`.
+
+A verdict subagent returns, for each criterion in the objective, `PASS` or `FAIL` plus the exact evidence (file path, line, value, or quote), `CANNOT VERIFY` where the evidence is missing, and nothing else. Give it the criteria explicitly in the objective; a vague "check the work" gets you a vague list.
+
+It runs on a cheaper model by default, because checking a claim against evidence that already exists is mechanical work, not investigation. An explicit `inference_profile` still wins if a check genuinely needs a stronger model.
+
+The other contracts: `output_contract: "artifact"` tells a `builder` that the deliverable is the thing produced and to end by listing the exact files it created or modified. `"report"` is the default and asks for nothing extra. A contract that does not match the type is rejected rather than quietly changed, and the `advisor` takes no contract (it has its own framing).
+
 ## Consulting the Advisor
 
 The `advisor` is the one type you spawn on your own judgment, unprompted: you do NOT wait for the user to ask for a subagent. The background types (`researcher`, `builder`) stay delegation-driven: reach for them to offload work, typically when the user's request calls for it. The advisor is different: proactively consult it whenever the conditions below are met.

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -41,6 +41,11 @@
           "confirm_repeat": {
             "type": "boolean",
             "description": "Set true to spawn anyway when the repeat-spawn guard reports that this objective already completed several times in the last day."
+          },
+          "output_contract": {
+            "type": "string",
+            "enum": ["report", "verdict", "artifact"],
+            "description": "What the subagent owes back. 'report' (default): prose answering the objective. 'verdict': per-criterion PASS or FAIL with the exact evidence (file path, line, value, or quote), CANNOT VERIFY where evidence is missing, and no prose beyond that list; researcher-only, and it defaults to a cheaper model because checking is mechanical. Use it for completion checks and audits instead of spawning a premium investigator. 'artifact': the deliverable is the thing produced, ending with the exact files created or modified; builder-only. A contract that does not match the role is rejected rather than coerced, and the advisor takes no contract at all."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -48,6 +48,7 @@ import {
   SUBAGENT_LIMITS,
   SUBAGENT_ROLE_REGISTRY,
   type SubagentConfig,
+  subagentOutputContractText,
   type SubagentRole,
   type SubagentSpawnMode,
   type SubagentState,
@@ -231,6 +232,10 @@ export function buildSubagentSystemPrompt(
   const sections: string[] = [roleConfig.systemPromptPreamble];
   if (config.persona) {
     sections.push(`- Persona: act as ${config.persona} for this task.`);
+  }
+  const contractText = subagentOutputContractText(config.outputContract);
+  if (contractText) {
+    sections.push(`- Output contract: ${contractText}`);
   }
   sections.push("", "## Your Task", config.objective);
   if (config.context) {
@@ -916,19 +921,23 @@ export class SubagentManager {
       // fight that framing. The advisor's objective is already the bare advice
       // request (`advisorRequestText()`), so it is sent uncontested.
       //
-      // A fork's persona rides in this framing rather than the system prompt:
-      // the prompt is the parent's, inherited verbatim to keep the KV cache
-      // aligned, so the task message is the only place a fork-specific
-      // instruction can land.
+      // A fork's persona and output contract ride in this framing rather than
+      // the system prompt: the prompt is the parent's, inherited verbatim to
+      // keep the KV cache aligned, so the task message is the only place a
+      // fork-specific instruction can land.
       const useForkFraming =
         managed.state.isFork && managed.state.config.role !== "advisor";
       const forkPersona = managed.state.config.persona;
+      const forkContract = subagentOutputContractText(
+        managed.state.config.outputContract,
+      );
       const message = useForkFraming
         ? [
             "⎯⎯⎯ FORK TASK ⎯⎯⎯",
             "You have been forked from the parent conversation to execute a specific task.",
             "The conversation above is context — do NOT continue it. Do NOT spawn sub-agents.",
             ...(forkPersona ? [`Act as ${forkPersona} for this task.`] : []),
+            ...(forkContract ? [`Output contract: ${forkContract}`] : []),
             "Complete this task directly and return only your findings:",
             "",
             objective,

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -102,6 +102,12 @@ export interface SubagentConfig {
    */
   persona?: string;
   /**
+   * The shape the child's final message has to take. Omitted spawns run as
+   * `report`, which asks for nothing beyond the role preamble's own reporting
+   * guidance.
+   */
+  outputContract?: SubagentOutputContract;
+  /**
    * How this subagent was spawned: the call site and its context/lifecycle
    * shape. Stamped onto the child conversation row and emitted as
    * `subagent_spawn_mode` on `llm_usage` telemetry so delegated spend is
@@ -306,6 +312,63 @@ export const SUBAGENT_LIMITS = {
  * accepted at the tool boundary as aliases; see ./role-resolution.ts.
  */
 export type SubagentRole = "researcher" | "builder" | "advisor";
+
+// ── Output contracts ─────────────────────────────────────────────────────
+
+/**
+ * Every contract the tool boundary accepts, in advertised order. `report` is
+ * first because it is what a spawn that names none runs under.
+ */
+export const SUBAGENT_OUTPUT_CONTRACTS = [
+  "report",
+  "verdict",
+  "artifact",
+] as const;
+
+/**
+ * The shape a subagent's final message has to take. Orthogonal to
+ * {@link SubagentRole}, which decides what the child may do: the contract
+ * decides what it owes back, so the same read-only researcher can return an
+ * investigation report or an evidence-backed pass/fail list.
+ *
+ * - `report`: prose answering the objective, which is what every role preamble
+ *   already asks for.
+ * - `verdict`: per-criterion PASS/FAIL with the evidence behind each call.
+ *   Researcher-only, since a verdict is a claim about what is already there.
+ *   Checking work this way is mechanical rather than exploratory, so the spawn
+ *   also defaults to the cheap model tier.
+ * - `artifact`: the deliverable is the thing produced, not the write-up.
+ *   Builder-only, since nothing else can produce one.
+ *
+ * "Verifier" is deliberately not a fourth role: verification is a researcher
+ * under the `verdict` contract, and a role would have implied a separate tool
+ * envelope it does not need.
+ */
+export type SubagentOutputContract = (typeof SUBAGENT_OUTPUT_CONTRACTS)[number];
+
+/**
+ * The instruction a contract adds to the child's framing, or `undefined` for
+ * `report`, whose expectations the role preamble already states.
+ *
+ * Rendered into the built system prompt for a regular spawn and into the fork
+ * task framing for a fork, which inherits the parent's prompt verbatim and so
+ * never sees a built one.
+ */
+export function subagentOutputContractText(
+  contract: SubagentOutputContract | undefined,
+): string | undefined {
+  switch (contract) {
+    case "verdict":
+      return (
+        "For each criterion in the objective return PASS or FAIL plus the exact evidence (file path, line, value, or quote). " +
+        "If evidence is unavailable say CANNOT VERIFY and state what is missing. No prose beyond the verdict list."
+      );
+    case "artifact":
+      return "Your deliverable is the artifact itself. End by listing the exact files you created or modified.";
+    default:
+      return undefined;
+  }
+}
 
 // ── Spawn modes ──────────────────────────────────────────────────────────
 

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -387,7 +387,10 @@ export async function executeSubagentSpawn(
  * researcher's job, and an artifact has to be written, which only a builder
  * can do. The advisor takes no contract at all: it is a blocking consult that
  * returns guidance in its own framing, and its child never sees a built system
- * prompt or fork framing to render one into.
+ * prompt or fork framing to render one into. That includes an explicit
+ * `report`, which is checked against the advisor before it is waved through as
+ * the default everywhere else: the caller asked for a shape the consult cannot
+ * produce, and only an omitted contract means it never asked.
  *
  * Mismatches are rejected rather than coerced. Silently promoting a verdict
  * spawn to a builder would hand out write access the caller never asked for,
@@ -399,7 +402,7 @@ function outputContractError(
   contract: SubagentOutputContract | undefined,
   role: SubagentRole,
 ): string | undefined {
-  if (contract === undefined || contract === "report") {
+  if (contract === undefined) {
     return undefined;
   }
   if (role === "advisor") {
@@ -407,6 +410,9 @@ function outputContractError(
       `output_contract "${contract}" does not apply to the advisor: it is a blocking consult that returns guidance in its own shape. ` +
       'Drop output_contract, or spawn role "researcher" with output_contract "verdict" to have work checked.'
     );
+  }
+  if (contract === "report") {
+    return undefined;
   }
   if (contract === "verdict" && role !== "researcher") {
     return (

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -32,6 +32,11 @@ import {
   type ResolvedSubagentRole,
   resolveSubagentRole,
 } from "../../subagent/role-resolution.js";
+import {
+  SUBAGENT_OUTPUT_CONTRACTS,
+  type SubagentOutputContract,
+  type SubagentRole,
+} from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
 import {
   invalidToolInputResult,
@@ -81,6 +86,17 @@ const LOOP_GUARD_CONVERSATION_LIMIT = 3;
 const LOOP_GUARD_ASSISTANT_LIMIT = 10;
 
 /**
+ * The tier a `verdict` spawn runs on when it names no `inference_profile`.
+ *
+ * Checking a criterion against evidence that already exists is mechanical:
+ * find the file, read the value, say PASS or FAIL. A premium model buys
+ * nothing there, and completion checks are frequent enough that paying
+ * investigation rates for them dominates delegated spend, so the contract that
+ * makes a spawn a check also picks the tier the check is worth.
+ */
+const VERDICT_PROFILE_KEY = "cost-optimized";
+
+/**
  * Model-input schema, `safeParse`d at the top of {@link executeSubagentSpawn}.
  * Same in-tool pattern and TOOLS.json drift guard as the other bundled-skill
  * tools — see the schema block in `tools/document/document-tool.ts` for the
@@ -96,6 +112,7 @@ export const subagentSpawnInputSchema = z.looseObject({
   context: nullAsOmitted(z.string()),
   inference_profile: z.string().optional(),
   confirm_repeat: nullAsOmitted(z.boolean()),
+  output_contract: nullAsOmitted(z.enum(SUBAGENT_OUTPUT_CONTRACTS)),
 });
 
 export async function executeSubagentSpawn(
@@ -118,6 +135,7 @@ export async function executeSubagentSpawn(
       : undefined;
   const resolvedRole = resolveSubagentRole(requestedRole);
   const inferenceProfile = parsed.inference_profile;
+  const outputContract = parsed.output_contract;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -130,6 +148,11 @@ export async function executeSubagentSpawn(
       content: 'Both "label" and "objective" are required.',
       isError: true,
     };
+  }
+
+  const contractError = outputContractError(outputContract, resolvedRole.role);
+  if (contractError) {
+    return { content: contractError, isError: true };
   }
 
   let requestedOverrideProfile: string | undefined;
@@ -267,16 +290,27 @@ export async function executeSubagentSpawn(
   let profileNote: string | undefined;
   let inheritedOverrideProfile = requestedOverrideProfile;
   if (inheritedOverrideProfile === undefined) {
-    inheritedOverrideProfile = isolateProfile
-      ? subagentCallSiteProfile()
-      : (context.overrideProfile ??
+    if (outputContract === "verdict") {
+      // A verdict is a check rather than an investigation, so it takes the
+      // cheap tier ahead of every inheritance rung below. It stays unforced
+      // like those rungs: the tier is this tool's preset, not a caller's
+      // choice, so an explicit `llm.callSites.subagentSpawn` pin still
+      // outranks it. Only an `inference_profile` argument beats it, and that
+      // one never enters this branch at all.
+      inheritedOverrideProfile = VERDICT_PROFILE_KEY;
+    } else if (isolateProfile) {
+      inheritedOverrideProfile = subagentCallSiteProfile();
+    } else {
+      inheritedOverrideProfile =
+        context.overrideProfile ??
         getConversationOverrideProfile(context.conversationId) ??
         (llm.callSites?.subagentSpawn?.profile == null
           ? resolveDefaultProfileKey(
               context.invokingCallSite ?? "mainAgent",
               llm,
             )
-          : undefined));
+          : undefined);
+    }
   } else if (
     isolateProfile &&
     profileSupportsTools(inheritedOverrideProfile, config) === false
@@ -305,6 +339,7 @@ export async function executeSubagentSpawn(
         ...(resolvedRole.personaText
           ? { persona: resolvedRole.personaText }
           : {}),
+        ...(outputContract ? { outputContract } : {}),
         // Declare the spawn mode so delegated LLM spend is separable in
         // telemetry: every variety shares `llm_call_site = "subagentSpawn"`,
         // and a fork's inherited transcript costs very differently from a
@@ -339,6 +374,53 @@ export async function executeSubagentSpawn(
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Failed to spawn subagent: ${msg}`, isError: true };
   }
+}
+
+// ── Output contract ──────────────────────────────────────────────────
+
+/**
+ * Why the requested `output_contract` cannot run under the type this spawn
+ * resolved to, or `undefined` when the pairing is fine.
+ *
+ * The two non-default contracts each need a capability only one type has: a
+ * verdict is a claim about what already exists, which is the read-only
+ * researcher's job, and an artifact has to be written, which only a builder
+ * can do. The advisor takes no contract at all: it is a blocking consult that
+ * returns guidance in its own framing, and its child never sees a built system
+ * prompt or fork framing to render one into.
+ *
+ * Mismatches are rejected rather than coerced. Silently promoting a verdict
+ * spawn to a builder would hand out write access the caller never asked for,
+ * and silently demoting one to a report would return prose where the caller
+ * expected pass/fail. Either way the caller is the only one who can say which
+ * half of its request was the mistake.
+ */
+function outputContractError(
+  contract: SubagentOutputContract | undefined,
+  role: SubagentRole,
+): string | undefined {
+  if (contract === undefined || contract === "report") {
+    return undefined;
+  }
+  if (role === "advisor") {
+    return (
+      `output_contract "${contract}" does not apply to the advisor: it is a blocking consult that returns guidance in its own shape. ` +
+      'Drop output_contract, or spawn role "researcher" with output_contract "verdict" to have work checked.'
+    );
+  }
+  if (contract === "verdict" && role !== "researcher") {
+    return (
+      `output_contract "verdict" is only available to researcher-typed subagents, and this spawn resolved to "${role}". ` +
+      'Spawn it with role "researcher" to get an evidence-backed PASS/FAIL check, or drop output_contract to get a report.'
+    );
+  }
+  if (contract === "artifact" && role !== "builder") {
+    return (
+      `output_contract "artifact" is only available to builder-typed subagents, and this spawn resolved to "${role}". ` +
+      'Spawn it with role "builder" so it can actually produce the artifact, or drop output_contract to get a report.'
+    );
+  }
+  return undefined;
 }
 
 // ── Role resolution ──────────────────────────────────────────────────

--- a/clients/docs/AGENTS.md
+++ b/clients/docs/AGENTS.md
@@ -28,9 +28,9 @@ The markdown mirror route lives at `src/app/docs/%5Fmd/[[...slug]]/route.ts` and
 
 ## Generated artifacts
 
-| Command | Output |
-| --- | --- |
-| `bun run docs:search:index` | `public/docs/search-index.json` |
+| Command                           | Output                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------- |
+| `bun run docs:search:index`       | `public/docs/search-index.json`                                           |
 | `bun run generate:agent-markdown` | `generated/md/**`, `generated/md/docs-index.json`, `public/docs/llms.txt` |
 
 Both run automatically via `predev`/`prebuild`. All outputs are gitignored. Next standalone output omits `public/` and `generated/`, so the Dockerfile copies both into the runtime image explicitly.
@@ -48,24 +48,23 @@ Both run automatically via `predev`/`prebuild`. All outputs are gitignored. Next
 - Prefetch suppression (`Next-Router-Prefetch`, `Next-Router-Segment-Prefetch`, `Purpose`/`Sec-Purpose`) is load-bearing: dbt carries a scrubber for a historical phantom-prefetch bug. `skipMiddlewareUrlNormalize: true` in `next.config.ts` keeps those headers visible to the proxy; do not remove it.
 - This app's Kubernetes container name is `docs`. Page_view lines only reach BigQuery after the Phase 2 platform Terraform change extends the pageview sink filter (currently `container_name="nextjs"`) to container `docs`.
 
-## Content sync contract
+## Content ownership: this tree is canonical
 
-Docs content is synced **verbatim** from the platform repo's docs tree (`vellum-assistant-platform/web/src/app/(marketing)/docs`) — the platform source is canonical. Do not editorialize, re-style, or paraphrase during a sync; copy edits (terminology, style, factual corrections) must land in the platform source first and flow down through a sync. The only permitted deltas from the platform source are:
+`src/app/docs/` is the only source of the public docs. The platform repo's docs tree (`vellum-assistant-platform/web/src/app/(marketing)/docs`) was deleted by "Docs migration Phase 4" (platform #9705), so there is no upstream to sync from and no follow-up copy to keep in step. Copy edits, new pages, and factual corrections land here directly.
 
-- Mechanical transforms: `@/app/(marketing)/docs/` → `@/app/docs/` imports, `/docs`-prefixed WebP asset paths, cross-app links absolutized to `https://www.vellum.ai/...`, and `eslint --fix` output for this package's lint rules.
-- Placeholder-persona substitution required by the root `AGENTS.md` "Generic Examples" rule (this repo is public): real names in platform copy are replaced deterministically (`Marina` → `Alice`, `Sarah` → `Alice`, `Becky` → `Bob`). Extend the substitution map if new real names appear upstream.
-- The structural severances and shared-shell components listed under "Deviations from the platform source" below.
+The rules that governed the migration still constrain the content itself:
 
-Verify every sync with a fidelity audit: each file must be byte-identical to its platform source after the transforms above, and every exception must be individually explainable.
+- The root `AGENTS.md` "Generic Examples" rule applies (this repo is public): no real names in docs copy. The migration substituted them deterministically (`Marina` → `Alice`, `Sarah` → `Alice`, `Becky` → `Bob`); keep new copy on placeholder personas.
+- Pages are authored against this app's import paths (`@/app/docs/`), `/docs`-prefixed WebP asset paths, and cross-app links absolutized to `https://www.vellum.ai/...`.
 
-## Deviations from the platform source
+## Behavior ported from the platform app
 
 Behavior ported from the platform app that intentionally differs:
 
 - Attribution referrer/click-id classification is stricter than the platform emitter: empty click-id params (e.g. a bare `?gclid=`) emit no paid attribution, referrer domains match at hostname boundaries (exact host or dot-suffix, never substring), and `copilot.bing.com` classifies as GEO. The emitted JSON key set is unchanged.
 - Search extraction/ranking adds element-boundary spacing during text extraction, indexes standalone headings unconditionally as their own chunks with level-aware scoping, and returns matched-term snippets.
 - Tailwind has no class-keyed dark variant. The pre-hydration bootstrap stamps both `.dark` and `data-theme="dark"` on `<html>`; `dark:` utilities key off `data-theme` (the design-library `tokens.css` custom variant) while `docs-theme.css` selectors key off `.dark`.
-- The mobile nav drawer is refactored around a shared `NavPanelShell` (`_components/nav-panel-shell.tsx`) with a ref-counted body-scroll lock (`_components/body-scroll-lock.ts`) and single-owner Cmd/Ctrl+K registration (`DocsSearch registerShortcut`). `docs-nav.tsx`, `releases-nav.tsx`, and `docs-nav-context.tsx` are therefore **hand-merged** during syncs: keep this app's shell structure and mirror only the platform's nav item data.
+- The mobile nav drawer is refactored around a shared `NavPanelShell` (`_components/nav-panel-shell.tsx`) with a ref-counted body-scroll lock (`_components/body-scroll-lock.ts`) and single-owner Cmd/Ctrl+K registration (`DocsSearch registerShortcut`). `docs-nav.tsx`, `releases-nav.tsx`, and `docs-nav-context.tsx` therefore keep this app's shell structure; edit nav item data inside it rather than restoring the per-drawer copies the port replaced.
 - Release anchor/month formatting is centralized in `src/lib/releases-server.ts` (`releaseAnchor`, `monthLabel`) and shared by `releases-content.tsx` and `releases-nav.tsx` so sidebar links always match article IDs; the platform version keeps local copies of these helpers. `releases-content.tsx` is hand-merged during syncs.
 
 ## Deferred items and known divergences from the platform app

--- a/clients/docs/src/app/docs/_components/skills-reference-subagent-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-subagent-content.tsx
@@ -307,6 +307,15 @@ export function SkillsReferenceSubagentContent() {
               <strong>No role named.</strong> A subagent spawned without a role
               runs as a builder, with the same tools your assistant has.
             </li>
+            <li>
+              <strong>Checking work is a researcher job.</strong> Ask whether
+              something is really done (&ldquo;verify every item on that
+              list&rdquo;) and your assistant sends a read-only researcher that
+              answers pass or fail per item with the evidence behind each call,
+              and says so plainly when the evidence isn&apos;t there. Checking
+              is mechanical, so it runs on a cheaper model than an open-ended
+              investigation would.
+            </li>
           </ul>
         </section>
 

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -55,7 +55,7 @@
     },
     "subagent": {
       "docsSlug": "subagent",
-      "sha256": "8861e43ed8ff791c6d571c2d464829ceea9ffd7eea7daf6fb21dede348de41e4"
+      "sha256": "f3df82733254b42e0e2fdba9cb8a3342ad0afd37764023ac732ed3c600d7feb3"
     },
     "transcribe": {
       "docsSlug": "transcribe",


### PR DESCRIPTION
## Summary

- Adds `output_contract` (`report` | `verdict` | `artifact`) to `subagent_spawn`, declared in both the zod schema and TOOLS.json. `verdict` asks the child for per-criterion PASS/FAIL with exact evidence (or CANNOT VERIFY) and nothing else; `artifact` tells a builder the deliverable is the thing produced.
- `verdict` is researcher-only and defaults the child to the `cost-optimized` profile, since checking evidence that already exists is mechanical. Precedence is explicit `inference_profile` > verdict default > the existing PR 3 resolution. `artifact` is builder-only, the advisor takes no contract, and a mismatch returns an actionable error instead of silently coercing the role or the shape.
- The contract reaches a regular spawn through `buildSubagentSystemPrompt` and a fork through the FORK TASK framing (a fork inherits the parent prompt verbatim, so the task message is the only carrier), following the persona precedent from PR 7. SKILL.md gains a Verification subsection, the docs fingerprint is re-recorded, and the public docs mirror in `clients/docs` is updated; the canonical platform docs page needs the same follow-up edit.

Part of plan: subagent-type-consolidation.md (PR 8 of 9)