### PR TITLE
feat(web): collapse assistant-message attachments to 5 with a files side panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared `DisplayAttachment` fixtures for the attachment renderers' tests and
+ * stories. Kept free of any test-runner import so `.stories.tsx` files can use
+ * it; the `bun:test` stubs live in `attachment-test-helpers.tsx`.
+ */
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+/**
+ * Tiny generated 96x96 PNGs, one per hue, used wherever a story needs a real
+ * decodable thumbnail rather than an icon fallback.
+ */
+export const SAMPLE_PREVIEWS: string[] = [
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQ2DQBREwdcZJRA6oAW3QO80gDa25JEu3Ogl9zUd5/X6Pt/79f3bPnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnV4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgfx4N4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTzop/cPo8PkO85qWSYAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQ2DQBREwdcZBVCAE3KXQes0gDa25JEu3Ogl9zVd5/H67u/n9f3bPnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnV4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgfx4N4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTzop/cPi1d4O2QKRFUAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwdebiTsIMUsTLt8NWIsjZaSDix65r+n4nK/vur+v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8A3VnELJtLlW4AAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA7klEQVR42u3YsQ3DMBAEwS3OuTpQBW7CnasB4mIBHoDhRZvwMV2f+/i+9+/4/m2fOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOjyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5I/jQTyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5ALgQTyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5ALgQTyIB/EgHvTq/QMeCDpZKCPwnAAAAABJRU5ErkJggg==",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQnDQBREwVeWmhAG1eFE/SdqQGxs8MCFG73kPtP1OV7f/T1f37/tU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU4cH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg/xxPIgH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg1wAPIgH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg1wAPIgH8SAexIN+ev8A6As4HS9kpJoAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA7UlEQVR42u3YsQ3DMBAEwS3MVShTGU5VvRogLjbgARhetAkf0+e6j+/6Psf3b/vU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU4UE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgfxwP4kE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgFwAP4kE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgFwAP4kE8iAfxoJ/ev2/xijtU5xswAAAAAElFTkSuQmCC",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwVeemTsIMU0T7twNWIsjZaSDix65r+lznK/vvr6v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8AkMfcWd+1vLwAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwdeamXGYcSpw/8QNWIsjZaSDix65r+n8HK/ve1+v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8Au7CSHXnIoW4AAAAASUVORK5CYII=",
+];
+
+/**
+ * A display attachment with sensible PNG defaults. Pass `overrides` for the
+ * fields a test actually cares about.
+ */
+export function makeDisplayAttachment(
+  overrides: Partial<DisplayAttachment> = {},
+): DisplayAttachment {
+  const id = overrides.id ?? "att-1";
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+/** `count` distinct image attachments, named `photo-<i>.png`. */
+export function makeImageAttachments(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: `https://example.com/photo-${index}.png`,
+    }),
+  );
+}
+
+/**
+ * `count` image attachments carrying a real decodable preview, so stories
+ * render actual thumbnails instead of the icon fallback.
+ */
+export function makePreviewableImages(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `slide-${String(index + 1).padStart(2, "0")}.png`,
+      sizeBytes: 184_320 + index * 4_096,
+      previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+    }),
+  );
+}
+
+/** A mixed media / non-media set covering each icon fallback kind. */
+export function makeMixedAttachments(): DisplayAttachment[] {
+  return [
+    makeImageAttachments(1)[0]!,
+    makeDisplayAttachment({
+      id: "deck-1",
+      filename: "deck.pptx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      sizeBytes: 4_096,
+    }),
+    makeDisplayAttachment({
+      id: "report-1",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_048,
+    }),
+    makeDisplayAttachment({
+      id: "bundle-1",
+      filename: "bundle.zip",
+      mimeType: "application/zip",
+      sizeBytes: 8_192,
+    }),
+  ];
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -1,32 +1,56 @@
 import { Typography } from "@vellumai/design-library";
 
+import { ATTACHMENT_TILE_BOX_CLASS } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import {
+  sameMessageFilesTarget,
+  useViewerStore,
+  type MessageFilesPayload,
+} from "@/stores/viewer-store";
+
 interface AttachmentOverflowSquareProps {
   /** How many attachments are hidden behind this tile. */
   count: number;
-  onClick: () => void;
-  /** Whether this tile's files panel is currently open. */
-  active?: boolean;
+  /** The files-panel target this tile opens, closes, and reflects. */
+  payload: MessageFilesPayload;
 }
 
 /**
  * Terminal tile of a truncated attachment strip. Stands in for the
- * attachments past the inline limit.
+ * attachments past the inline limit, and toggles the files side panel that
+ * lists all of them.
+ *
+ * The viewer-store reads live here rather than in {@link MessageAttachments}
+ * because this tile mounts only on the minority of strips that actually
+ * overflow. Reading `mainView` one level up would subscribe EVERY assistant
+ * attachment strip in the transcript to a global, reference-equality slice, so
+ * opening any overlay anywhere would re-render all of them.
  */
 export function AttachmentOverflowSquare({
   count,
-  onClick,
-  active = false,
+  payload,
 }: AttachmentOverflowSquareProps) {
+  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
+  const mainView = useViewerStore.use.mainView();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
+
+  // The tile whose files panel is currently open renders with the persistent
+  // active surface, mirroring the activity group header's selected state.
+  const active =
+    mainView === "message-files" &&
+    activeMessageFiles != null &&
+    sameMessageFilesTarget(activeMessageFiles, payload);
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => toggleMessageFiles(payload)}
       aria-label={`Show all files (${count} more)`}
+      aria-expanded={active}
       title={`${count} more`}
-      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
+      className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center border border-dashed transition-colors ${
         active
-          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
-          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
+          ? "border-[var(--border-active)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-element)] hover:bg-[var(--surface-lift)]"
       }`}
     >
       <Typography

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -1,0 +1,33 @@
+import { Typography } from "@vellumai/design-library";
+
+interface AttachmentOverflowSquareProps {
+  /** How many attachments are hidden behind this tile. */
+  count: number;
+  onClick: () => void;
+}
+
+/**
+ * Terminal tile of a truncated attachment strip. Stands in for the
+ * attachments past the inline limit.
+ */
+export function AttachmentOverflowSquare({
+  count,
+  onClick,
+}: AttachmentOverflowSquareProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Show all files (${count} more)`}
+      title={`${count} more`}
+      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--border-base)] transition-colors hover:bg-[var(--surface-lift)]"
+    >
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+      >
+        +{count}
+      </Typography>
+    </button>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-overflow-square.tsx
@@ -4,6 +4,8 @@ interface AttachmentOverflowSquareProps {
   /** How many attachments are hidden behind this tile. */
   count: number;
   onClick: () => void;
+  /** Whether this tile's files panel is currently open. */
+  active?: boolean;
 }
 
 /**
@@ -13,6 +15,7 @@ interface AttachmentOverflowSquareProps {
 export function AttachmentOverflowSquare({
   count,
   onClick,
+  active = false,
 }: AttachmentOverflowSquareProps) {
   return (
     <button
@@ -20,7 +23,11 @@ export function AttachmentOverflowSquare({
       onClick={onClick}
       aria-label={`Show all files (${count} more)`}
       title={`${count} more`}
-      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed border-[var(--border-base)] transition-colors hover:bg-[var(--surface-lift)]"
+      className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-dashed transition-colors ${
+        active
+          ? "border-[var(--border-hover)] bg-[var(--surface-lift)]"
+          : "border-[var(--border-base)] hover:bg-[var(--surface-lift)]"
+      }`}
     >
       <Typography
         variant="body-small-default"

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-strip.stories.tsx
@@ -1,0 +1,236 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import {
+  makeDisplayAttachment,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+
+/**
+ * The assistant-message attachment strip. Past five attachments it collapses
+ * to the first five squares plus a `+N` tile that opens the files panel. The
+ * cap is type blind: images, video, documents and archives all count toward
+ * it.
+ */
+
+const MIXED: DisplayAttachment[] = [
+  makeDisplayAttachment({
+    id: "deck-1",
+    filename: "On_Site_Safety.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_194_304,
+  }),
+  ...makePreviewableImages(2),
+  makeDisplayAttachment({
+    id: "report-1",
+    filename: "annual-report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_097_152,
+  }),
+  makeDisplayAttachment({
+    id: "slide-17",
+    filename: "slide-17.png",
+    sizeBytes: 192_512,
+    previewUrl: SAMPLE_PREVIEWS[3]!,
+  }),
+  makeDisplayAttachment({
+    id: "bundle-1",
+    filename: "source-bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_388_608,
+  }),
+  makeDisplayAttachment({
+    id: "cover-1",
+    filename: "cover.png",
+    sizeBytes: 196_608,
+    previewUrl: SAMPLE_PREVIEWS[4]!,
+  }),
+  makeDisplayAttachment({
+    id: "sheet-1",
+    filename: "forecast.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    sizeBytes: 65_536,
+  }),
+];
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-[var(--border-base)] pb-6">
+      <span className="text-xs uppercase tracking-wide text-[var(--content-tertiary)]">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: "Chat/AttachmentStrip",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+/** Every count at which the strip changes behaviour. */
+export const Counts: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-[var(--surface-base)] p-8">
+      <Row label="3 photos - under the limit, no tile">
+        <MessageAttachments
+          attachments={makePreviewableImages(3)}
+          messageId="m-3"
+        />
+      </Row>
+      <Row label="5 photos - exactly at the limit, still no tile">
+        <MessageAttachments
+          attachments={makePreviewableImages(5)}
+          messageId="m-5"
+        />
+      </Row>
+      <Row label="6 photos - first overflow, +1">
+        <MessageAttachments
+          attachments={makePreviewableImages(6)}
+          messageId="m-6"
+        />
+      </Row>
+      <Row label="8 mixed files - pptx / pdf / zip count toward the cap, +3">
+        <MessageAttachments attachments={MIXED} messageId="m-mixed" />
+      </Row>
+      <Row label="41 photos - +36">
+        <MessageAttachments
+          attachments={makePreviewableImages(41)}
+          messageId="m-41"
+        />
+      </Row>
+    </div>
+  ),
+};
+
+/**
+ * Every state a square can land on. Only the first has a decodable preview;
+ * the rest fall back to the file-kind icon, which is the common case for large
+ * images the daemon does not inline and for attachments rehydrated from a
+ * text summary.
+ */
+export const Fallbacks: StoryObj = {
+  render: () => {
+    const cases: Array<[string, DisplayAttachment]> = [
+      [
+        "image + preview",
+        makeDisplayAttachment({
+          id: "f1",
+          filename: "photo.png",
+          sizeBytes: 184_320,
+          previewUrl: SAMPLE_PREVIEWS[0]!,
+        }),
+      ],
+      [
+        "image, no preview",
+        makeDisplayAttachment({
+          id: "f2",
+          filename: "large-photo.png",
+          sizeBytes: 24_117_248,
+        }),
+      ],
+      [
+        "image, decode fails",
+        makeDisplayAttachment({
+          id: "f3",
+          filename: "shot.heic",
+          mimeType: "image/heic",
+          sizeBytes: 3_145_728,
+          previewUrl: "data:image/heic;base64,AAAAAAAA",
+        }),
+      ],
+      [
+        "video + poster",
+        makeDisplayAttachment({
+          id: "f4",
+          filename: "clip.mp4",
+          mimeType: "video/mp4",
+          sizeBytes: 12_582_912,
+          thumbnailUrl: SAMPLE_PREVIEWS[3]!,
+        }),
+      ],
+      [
+        "video, no poster",
+        makeDisplayAttachment({
+          id: "f5",
+          filename: "raw.mov",
+          mimeType: "video/quicktime",
+          sizeBytes: 8_388_608,
+        }),
+      ],
+      [
+        "pdf",
+        makeDisplayAttachment({
+          id: "f6",
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 2_097_152,
+        }),
+      ],
+      [
+        "zip",
+        makeDisplayAttachment({
+          id: "f7",
+          filename: "bundle.zip",
+          mimeType: "application/zip",
+          sizeBytes: 8_388_608,
+        }),
+      ],
+      [
+        "spreadsheet",
+        makeDisplayAttachment({
+          id: "f8",
+          filename: "data.csv",
+          mimeType: "text/csv",
+          sizeBytes: 65_536,
+        }),
+      ],
+      [
+        "audio",
+        makeDisplayAttachment({
+          id: "f9",
+          filename: "voice.mp3",
+          mimeType: "audio/mpeg",
+          sizeBytes: 1_048_576,
+        }),
+      ],
+      [
+        "code",
+        makeDisplayAttachment({
+          id: "f10",
+          filename: "migrate.ts",
+          mimeType: "text/plain",
+          sizeBytes: 9_216,
+        }),
+      ],
+      [
+        "unknown",
+        makeDisplayAttachment({
+          id: "f11",
+          filename: "firmware.bin",
+          mimeType: "application/octet-stream",
+          sizeBytes: 524_288,
+        }),
+      ],
+    ];
+    return (
+      <div className="flex flex-wrap gap-6 bg-[var(--surface-base)] p-8">
+        {cases.map(([label, att]) => (
+          <div key={att.id} className="flex w-[110px] flex-col gap-2">
+            <MessageAttachments attachments={[att]} messageId={`fb-${att.id}`} />
+            <span className="text-[11px] uppercase tracking-wide text-[var(--content-tertiary)]">
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -1,0 +1,114 @@
+/**
+ * Shared fixtures and stubs for the attachment renderers' tests
+ * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`) and the
+ * viewer store's message-files actions.
+ *
+ * The preview-modal stub is exported as a function rather than run on import,
+ * because `mock.module` must be applied BEFORE the module under test is
+ * imported and a bare side-effecting import gives the test no control over
+ * that ordering.
+ */
+
+import { mock } from "bun:test";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+/**
+ * A display attachment with sensible PNG defaults. Pass `overrides` for the
+ * fields a test actually cares about.
+ */
+export function makeDisplayAttachment(
+  overrides: Partial<DisplayAttachment> = {},
+): DisplayAttachment {
+  const id = overrides.id ?? "att-1";
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+/** `count` distinct image attachments, named `photo-<i>.png`. */
+export function makeImageAttachments(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: `https://example.com/photo-${index}.png`,
+    }),
+  );
+}
+
+/** A mixed media / non-media set covering each icon fallback kind. */
+export function makeMixedAttachments(): DisplayAttachment[] {
+  return [
+    makeImageAttachments(1)[0]!,
+    makeDisplayAttachment({
+      id: "deck-1",
+      filename: "deck.pptx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      sizeBytes: 4_096,
+    }),
+    makeDisplayAttachment({
+      id: "report-1",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_048,
+    }),
+    makeDisplayAttachment({
+      id: "bundle-1",
+      filename: "bundle.zip",
+      mimeType: "application/zip",
+      sizeBytes: 8_192,
+    }),
+  ];
+}
+
+/**
+ * Replace the preview modal with a probe exposing the opened attachment, its
+ * preview URL, and its gallery siblings - enough for both the gallery-size
+ * assertions and the failed-decode assertions. Call this at module scope,
+ * above the import of the component under test.
+ */
+export function mockAttachmentPreviewModal(): void {
+  mock.module(
+    "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+    () => ({
+      AttachmentPreviewModal: ({
+        attachment,
+        siblingAttachments,
+      }: {
+        attachment: { id: string; previewUrl: string | null };
+        siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
+      }) => (
+        <div
+          data-testid="preview-modal"
+          data-attachment-id={attachment.id}
+          data-preview-url={String(attachment.previewUrl)}
+          data-sibling-count={String((siblingAttachments ?? []).length)}
+          data-sibling-preview-urls={JSON.stringify(
+            (siblingAttachments ?? []).map((a) => ({
+              id: a.id,
+              previewUrl: a.previewUrl,
+            })),
+          )}
+        />
+      ),
+    }),
+  );
+}
+
+/**
+ * The `aria-label` of every attachment square in `container`. Squares are divs
+ * with `role="button"`; the download and overflow affordances are real
+ * `<button>` elements, so this counts only squares.
+ */
+export function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -3,6 +3,9 @@
  * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`) and the
  * viewer store's message-files actions.
  *
+ * Fixtures live in `attachment-fixtures.ts`, which imports no test runner so
+ * stories can share them; this module adds the `bun:test` stubs on top.
+ *
  * The preview-modal stub is exported as a function rather than run on import,
  * because `mock.module` must be applied BEFORE the module under test is
  * imported and a bare side-effecting import gives the test no control over
@@ -11,62 +14,15 @@
 
 import { mock } from "bun:test";
 
-import type { DisplayAttachment } from "@/domains/chat/types/types";
-
-/**
- * A display attachment with sensible PNG defaults. Pass `overrides` for the
- * fields a test actually cares about.
- */
-export function makeDisplayAttachment(
-  overrides: Partial<DisplayAttachment> = {},
-): DisplayAttachment {
-  const id = overrides.id ?? "att-1";
-  return {
-    id,
-    filename: `${id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: null,
-    ...overrides,
-  };
-}
-
-/** `count` distinct image attachments, named `photo-<i>.png`. */
-export function makeImageAttachments(count: number): DisplayAttachment[] {
-  return Array.from({ length: count }, (_, index) =>
-    makeDisplayAttachment({
-      id: `img-${index}`,
-      filename: `photo-${index}.png`,
-      previewUrl: `https://example.com/photo-${index}.png`,
-    }),
-  );
-}
-
-/** A mixed media / non-media set covering each icon fallback kind. */
-export function makeMixedAttachments(): DisplayAttachment[] {
-  return [
-    makeImageAttachments(1)[0]!,
-    makeDisplayAttachment({
-      id: "deck-1",
-      filename: "deck.pptx",
-      mimeType:
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      sizeBytes: 4_096,
-    }),
-    makeDisplayAttachment({
-      id: "report-1",
-      filename: "report.pdf",
-      mimeType: "application/pdf",
-      sizeBytes: 2_048,
-    }),
-    makeDisplayAttachment({
-      id: "bundle-1",
-      filename: "bundle.zip",
-      mimeType: "application/zip",
-      sizeBytes: 8_192,
-    }),
-  ];
-}
+// Re-exported so existing test imports keep resolving from one place; the
+// factories themselves live in a test-runner-free module the stories share.
+export {
+  makeDisplayAttachment,
+  makeImageAttachments,
+  makeMixedAttachments,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 
 /**
  * Replace the preview modal with a probe exposing the opened attachment, its

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -1,30 +1,9 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string; previewUrl: string | null };
-      siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-preview-url={String(attachment.previewUrl)}
-        data-sibling-preview-urls={JSON.stringify(
-          (siblingAttachments ?? []).map((a) => ({
-            id: a.id,
-            previewUrl: a.previewUrl,
-          })),
-        )}
-      />
-    ),
-  }),
-);
+import { mockAttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+
+mockAttachmentPreviewModal();
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,11 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
 
 interface BubbleAttachmentsProps {
@@ -22,46 +19,21 @@ interface BubbleAttachmentsProps {
  * compact {@link MessageAttachmentSquare} chip. Both kinds are clickable and
  * open the full-screen {@link AttachmentPreviewModal}.
  *
- * Distinct from {@link MessageAttachments}, the legacy separate-strip renderer
- * still used for assistant messages, which renders every attachment as a chip.
+ * Every attachment renders - this surface is deliberately uncapped, unlike the
+ * assistant strip ({@link MessageAttachments}), which collapses past a limit
+ * behind an overflow tile.
  */
 export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   attachments,
   assistantId,
 }) => {
-  // Ids whose previewUrl the browser failed to decode (e.g. a HEIC blob on a
-  // Chromium renderer). Those fall back to the chip instead of the browser's
-  // broken-image glyph.
-  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(
-    new Set(),
-  );
-  const markImageFailed = useCallback((id: string) => {
-    setFailedImageIds((prev) => new Set(prev).add(id));
-  }, []);
-
-  // A failed inline decode leaves a dead previewUrl (e.g. an undecodable HEIC
-  // blob on Chromium). Nulling it by id across the whole array — which is also
-  // forwarded as the modal's `siblingAttachments` — makes the chip, the modal,
-  // and gallery navigation all refetch stored bytes instead of the broken blob.
-  const previewAttachments = useMemo(
-    () =>
-      attachments.map((att) =>
-        failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
-      ),
-    [attachments, failedImageIds],
-  );
-
-  const { openPreview, previewModal } = useAttachmentPreview(
-    assistantId,
-    previewAttachments,
-  );
-
-  const handleDownload = useCallback(
-    (att: DisplayAttachment) => {
-      void downloadAttachment(att, assistantId);
-    },
-    [assistantId],
-  );
+  const {
+    displayAttachments,
+    renderSquare,
+    openPreview,
+    markImageFailed,
+    previewModal,
+  } = useAttachmentSquares({ attachments, assistantId });
 
   if (attachments.length === 0) {
     return null;
@@ -70,7 +42,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   return (
     <>
       <div className="flex flex-col gap-2">
-        {previewAttachments.map((att, index) => {
+        {displayAttachments.map((att, index) => {
           const isInlineImage =
             classifyAttachment(att.mimeType, att.filename) === "image" &&
             att.previewUrl != null;
@@ -98,21 +70,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
             );
           }
 
-          return (
-            <MessageAttachmentSquare
-              key={att.id}
-              filename={att.filename}
-              mimeType={att.mimeType}
-              sizeBytes={att.sizeBytes}
-              previewUrl={att.previewUrl}
-              thumbnailUrl={att.thumbnailUrl}
-              onPreview={() => openPreview(att)}
-              // Download falls back to previewUrl when the daemon content fetch
-              // is unavailable, so it takes the unsanitized attachment — a blob
-              // that can't be *rendered* is still valid bytes to save.
-              onDownload={() => handleDownload(attachments[index]!)}
-            />
-          );
+          return renderSquare(att, index);
         })}
       </div>
       {previewModal}

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -10,7 +10,7 @@ import {
   FileType2,
   FileVideo,
 } from "lucide-react";
-import type { FC, MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useCallback } from "react";
 
 import { Tooltip, Typography } from "@vellumai/design-library";
@@ -21,21 +21,26 @@ import {
   middleTruncate,
   type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 
+/**
+ * Geometry of the square's inner tile box. Shared with
+ * {@link AttachmentOverflowSquare} so the terminal overflow tile lines up with
+ * the squares it sits beside - the two must stay identical or the strip breaks.
+ */
+export const ATTACHMENT_TILE_BOX_CLASS = "h-16 w-16 shrink-0 rounded-lg";
+
 interface MessageAttachmentSquareProps {
-  filename: string;
-  mimeType: string;
-  sizeBytes: number;
-  previewUrl: string | null;
-  /** JPEG thumbnail URL (from daemon thumbnailData). Used as a background
-   *  image for video attachment chips so they show a poster frame instead of
-   *  a bare icon. Null for non-video or when no thumbnail is available. */
-  thumbnailUrl?: string | null;
+  attachment: DisplayAttachment;
   /** Called when the user clicks the thumbnail to open a full-screen preview. */
   onPreview?: () => void;
   /** Called when the user clicks a download button. */
   onDownload?: () => void;
+  /** Called when the browser fails to decode the image preview (e.g. a HEIC
+   *  blob on a Chromium renderer). Lets the owner null the dead `previewUrl`
+   *  so this square falls back to its file-kind icon. */
+  onPreviewError?: () => void;
 }
 
 const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
@@ -57,23 +62,20 @@ const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
  * with an icon. On hover, a download overlay appears at the bottom-right of
  * the thumbnail.
  */
-export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
-  filename,
-  mimeType,
-  sizeBytes,
-  previewUrl,
-  thumbnailUrl,
+export function MessageAttachmentSquare({
+  attachment,
   onPreview,
   onDownload,
-}) => {
+  onPreviewError,
+}: MessageAttachmentSquareProps) {
+  const { filename, mimeType, sizeBytes, previewUrl, thumbnailUrl } =
+    attachment;
   const kind = classifyAttachment(mimeType, filename);
   const hasImagePreview = kind === "image" && previewUrl !== null;
-  const hasVideoThumbnail = kind === "video" && thumbnailUrl != null;
-  const backgroundImageUrl = hasImagePreview
-    ? previewUrl
-    : hasVideoThumbnail
-      ? thumbnailUrl
-      : null;
+  // Video posters stay a CSS background: there is no fallback to swap to when
+  // a poster fails, so an <img> would surface the browser's broken glyph.
+  const backgroundImageUrl =
+    kind === "video" && thumbnailUrl != null ? thumbnailUrl : null;
   const isClickable = onPreview != null;
   const displayName = middleTruncate(filename, 18);
   const displaySize = formatAttachmentSize(sizeBytes);
@@ -108,7 +110,7 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
     >
       <div className="relative w-fit">
         <div
-          className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]"
+          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]`}
           style={
             backgroundImageUrl
               ? {
@@ -117,7 +119,19 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
               : undefined
           }
         >
-          {backgroundImageUrl ? null : ICON_BY_KIND[kind]}
+          {hasImagePreview ? (
+            // A real <img> rather than a CSS background so an undecodable
+            // preview raises `onError` and the owner can fall back to the icon.
+            <img
+              src={previewUrl}
+              alt=""
+              aria-hidden
+              onError={onPreviewError}
+              className="h-full w-full object-cover"
+            />
+          ) : backgroundImageUrl ? null : (
+            ICON_BY_KIND[kind]
+          )}
         </div>
         {onDownload && (
           <div className="pointer-events-none absolute inset-0 rounded-lg bg-black/50 opacity-0 transition-opacity group-hover/square:pointer-events-auto group-hover/square:opacity-100 group-focus-within/square:pointer-events-auto group-focus-within/square:opacity-100">
@@ -153,4 +167,4 @@ export const MessageAttachmentSquare: FC<MessageAttachmentSquareProps> = ({
       )}
     </div>
   );
-};
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -76,6 +76,11 @@ export function MessageAttachmentSquare({
   // a poster fails, so an <img> would surface the browser's broken glyph.
   const backgroundImageUrl =
     kind === "video" && thumbnailUrl != null ? thumbnailUrl : null;
+  // With nothing filling the tile, its `--surface-lift` fill disappears on a
+  // container painted the same colour (the files panel's `DetailShell` body),
+  // leaving a bare glyph. A `--border-element` hairline is the one outline that
+  // reads against both `--surface-base` and `--surface-lift` in every theme.
+  const showsIcon = !hasImagePreview && backgroundImageUrl === null;
   const isClickable = onPreview != null;
   const displayName = middleTruncate(filename, 18);
   const displaySize = formatAttachmentSize(sizeBytes);
@@ -110,7 +115,7 @@ export function MessageAttachmentSquare({
     >
       <div className="relative w-fit">
         <div
-          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]`}
+          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]${showsIcon ? " border border-[var(--border-element)]" : ""}`}
           style={
             backgroundImageUrl
               ? {

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -23,12 +23,14 @@ mock.module(
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+import { useViewerStore } from "@/stores/viewer-store";
 
 afterAll(() => {
   mock.restore();
 });
 afterEach(() => {
   cleanup();
+  useViewerStore.setState({ mainView: "chat", activeMessageFiles: null });
 });
 
 function image(index: number): DisplayAttachment {
@@ -130,16 +132,33 @@ describe("MessageAttachments", () => {
     expect(getByText("+3")).toBeTruthy();
   });
 
-  test("opens the preview on the first hidden attachment with the full gallery", () => {
-    const { getByRole, getByTestId } = render(
-      <MessageAttachments attachments={images(8)} />,
+  test("the overflow tile opens the files panel with every attachment", () => {
+    const { getByRole, queryByTestId } = render(
+      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
     );
 
     fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
 
-    const modal = getByTestId("preview-modal");
-    expect(modal.getAttribute("data-attachment-id")).toBe("img-5");
-    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("message-files");
+    expect(viewer.activeMessageFiles?.messageId).toBe("msg-1");
+    expect(viewer.activeMessageFiles?.attachments).toHaveLength(8);
+    // The tile targets the panel, so the preview modal stays shut.
+    expect(queryByTestId("preview-modal")).toBeNull();
+  });
+
+  test("clicking the overflow tile again closes the files panel", () => {
+    const { getByRole } = render(
+      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+    );
+
+    const tile = getByRole("button", { name: "Show all files (3 more)" });
+    fireEvent.click(tile);
+    fireEvent.click(tile);
+
+    const viewer = useViewerStore.getState();
+    expect(viewer.mainView).toBe("chat");
+    expect(viewer.activeMessageFiles).toBeNull();
   });
 
   test("returns null for an empty attachments array", () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -1,0 +1,149 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+      siblingAttachments,
+    }: {
+      attachment: { id: string };
+      siblingAttachments?: Array<{ id: string }>;
+    }) => (
+      <div
+        data-testid="preview-modal"
+        data-attachment-id={attachment.id}
+        data-sibling-count={String((siblingAttachments ?? []).length)}
+      />
+    ),
+  }),
+);
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+function image(index: number): DisplayAttachment {
+  return {
+    id: `img-${index}`,
+    filename: `photo-${index}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: `https://example.com/photo-${index}.png`,
+  };
+}
+
+function images(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) => image(index));
+}
+
+/** The squares are divs with `role="button"`; the download and overflow
+ *  affordances are real `<button>` elements, so this selector counts only
+ *  attachment squares. */
+function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}
+
+describe("MessageAttachments", () => {
+  test("renders every square and no overflow tile at the visible limit", () => {
+    const { container, queryByRole } = render(
+      <MessageAttachments attachments={images(5)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(queryByRole("button", { name: /Show all files/ })).toBeNull();
+  });
+
+  test("renders five squares plus a +1 tile for six attachments", () => {
+    const { container, getByText, getByRole } = render(
+      <MessageAttachments attachments={images(6)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(getByText("+1")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Show all files (1 more)" }),
+    ).toBeTruthy();
+  });
+
+  test("renders five squares plus a +36 tile for forty-one attachments", () => {
+    const { container, getByText } = render(
+      <MessageAttachments attachments={images(41)} />,
+    );
+
+    expect(squareLabels(container)).toHaveLength(5);
+    expect(getByText("+36")).toBeTruthy();
+  });
+
+  test("counts non-media attachments toward the limit and keeps source order", () => {
+    const mixed: DisplayAttachment[] = [
+      image(0),
+      {
+        id: "deck-1",
+        filename: "deck.pptx",
+        mimeType:
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        sizeBytes: 4_096,
+        previewUrl: null,
+      },
+      image(1),
+      {
+        id: "report-1",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 2_048,
+        previewUrl: null,
+      },
+      {
+        id: "bundle-1",
+        filename: "bundle.zip",
+        mimeType: "application/zip",
+        sizeBytes: 8_192,
+        previewUrl: null,
+      },
+      image(2),
+      image(3),
+      image(4),
+    ];
+
+    const { container, getByText } = render(
+      <MessageAttachments attachments={mixed} />,
+    );
+
+    expect(squareLabels(container)).toEqual([
+      "photo-0.png",
+      "deck.pptx",
+      "photo-1.png",
+      "report.pdf",
+      "bundle.zip",
+    ]);
+    expect(getByText("+3")).toBeTruthy();
+  });
+
+  test("opens the preview on the first hidden attachment with the full gallery", () => {
+    const { getByRole, getByTestId } = render(
+      <MessageAttachments attachments={images(8)} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("img-5");
+    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+  });
+
+  test("returns null for an empty attachments array", () => {
+    const { container } = render(<MessageAttachments attachments={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.test.tsx
@@ -1,24 +1,14 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string };
-      siblingAttachments?: Array<{ id: string }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-sibling-count={String((siblingAttachments ?? []).length)}
-      />
-    ),
-  }),
-);
+import {
+  makeDisplayAttachment,
+  makeImageAttachments,
+  mockAttachmentPreviewModal,
+  squareLabels,
+} from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+
+mockAttachmentPreviewModal();
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
@@ -33,33 +23,13 @@ afterEach(() => {
   useViewerStore.setState({ mainView: "chat", activeMessageFiles: null });
 });
 
-function image(index: number): DisplayAttachment {
-  return {
-    id: `img-${index}`,
-    filename: `photo-${index}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: `https://example.com/photo-${index}.png`,
-  };
-}
-
-function images(count: number): DisplayAttachment[] {
-  return Array.from({ length: count }, (_, index) => image(index));
-}
-
-/** The squares are divs with `role="button"`; the download and overflow
- *  affordances are real `<button>` elements, so this selector counts only
- *  attachment squares. */
-function squareLabels(container: HTMLElement): Array<string | null> {
-  return Array.from(container.querySelectorAll('div[role="button"]')).map(
-    (el) => el.getAttribute("aria-label"),
-  );
-}
-
 describe("MessageAttachments", () => {
   test("renders every square and no overflow tile at the visible limit", () => {
     const { container, queryByRole } = render(
-      <MessageAttachments attachments={images(5)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(5)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -68,7 +38,10 @@ describe("MessageAttachments", () => {
 
   test("renders five squares plus a +1 tile for six attachments", () => {
     const { container, getByText, getByRole } = render(
-      <MessageAttachments attachments={images(6)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(6)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -80,7 +53,10 @@ describe("MessageAttachments", () => {
 
   test("renders five squares plus a +36 tile for forty-one attachments", () => {
     const { container, getByText } = render(
-      <MessageAttachments attachments={images(41)} />,
+      <MessageAttachments
+        attachments={makeImageAttachments(41)}
+        messageId="msg-1"
+      />,
     );
 
     expect(squareLabels(container)).toHaveLength(5);
@@ -88,38 +64,36 @@ describe("MessageAttachments", () => {
   });
 
   test("counts non-media attachments toward the limit and keeps source order", () => {
+    const images = makeImageAttachments(5);
     const mixed: DisplayAttachment[] = [
-      image(0),
-      {
+      images[0]!,
+      makeDisplayAttachment({
         id: "deck-1",
         filename: "deck.pptx",
         mimeType:
           "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         sizeBytes: 4_096,
-        previewUrl: null,
-      },
-      image(1),
-      {
+      }),
+      images[1]!,
+      makeDisplayAttachment({
         id: "report-1",
         filename: "report.pdf",
         mimeType: "application/pdf",
         sizeBytes: 2_048,
-        previewUrl: null,
-      },
-      {
+      }),
+      makeDisplayAttachment({
         id: "bundle-1",
         filename: "bundle.zip",
         mimeType: "application/zip",
         sizeBytes: 8_192,
-        previewUrl: null,
-      },
-      image(2),
-      image(3),
-      image(4),
+      }),
+      images[2]!,
+      images[3]!,
+      images[4]!,
     ];
 
     const { container, getByText } = render(
-      <MessageAttachments attachments={mixed} />,
+      <MessageAttachments attachments={mixed} messageId="msg-1" />,
     );
 
     expect(squareLabels(container)).toEqual([
@@ -132,9 +106,30 @@ describe("MessageAttachments", () => {
     expect(getByText("+3")).toBeTruthy();
   });
 
+  test("a visible square opens the preview with every attachment as siblings", () => {
+    const { getByLabelText, getByTestId } = render(
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
+    );
+
+    fireEvent.click(getByLabelText("photo-0.png"));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("img-0");
+    // Gallery navigation spans the whole set, not just the visible squares.
+    expect(modal.getAttribute("data-sibling-count")).toBe("8");
+    // Opening a preview must not open the files panel.
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
   test("the overflow tile opens the files panel with every attachment", () => {
     const { getByRole, queryByTestId } = render(
-      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
     );
 
     fireEvent.click(getByRole("button", { name: "Show all files (3 more)" }));
@@ -147,9 +142,26 @@ describe("MessageAttachments", () => {
     expect(queryByTestId("preview-modal")).toBeNull();
   });
 
+  test("the overflow tile reports its expanded state", () => {
+    const { getByRole } = render(
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
+    );
+
+    const tile = getByRole("button", { name: "Show all files (3 more)" });
+    expect(tile.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(tile);
+    expect(tile.getAttribute("aria-expanded")).toBe("true");
+  });
+
   test("clicking the overflow tile again closes the files panel", () => {
     const { getByRole } = render(
-      <MessageAttachments attachments={images(8)} messageId="msg-1" />,
+      <MessageAttachments
+        attachments={makeImageAttachments(8)}
+        messageId="msg-1"
+      />,
     );
 
     const tile = getByRole("button", { name: "Show all files (3 more)" });
@@ -162,7 +174,9 @@ describe("MessageAttachments", () => {
   });
 
   test("returns null for an empty attachments array", () => {
-    const { container } = render(<MessageAttachments attachments={[]} />);
+    const { container } = render(
+      <MessageAttachments attachments={[]} messageId="msg-1" />,
+    );
     expect(container.innerHTML).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
@@ -7,12 +7,19 @@ import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachm
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import {
+  sameMessageFilesTarget,
+  useViewerStore,
+  type MessageFilesPayload,
+} from "@/stores/viewer-store";
 
 interface MessageAttachmentsProps {
   attachments: DisplayAttachment[];
   /** Forwarded to {@link AttachmentPreviewModal} so it can lazily fetch
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
+  /** Transcript message identity, forwarded to the files panel payload. */
+  messageId?: string;
 }
 
 /**
@@ -29,16 +36,21 @@ const VISIBLE_LIMIT = 5;
  * opens a full-screen preview modal — the modal handles type-specific
  * rendering (image/video/fallback) and lazily fetches missing content when
  * needed. A hover overlay on each square provides direct download without
- * opening the preview first.
+ * opening the preview first. Past {@link VISIBLE_LIMIT} the strip collapses
+ * behind an overflow tile that opens the files side panel.
  */
 export const MessageAttachments: FC<MessageAttachmentsProps> = ({
   attachments,
   assistantId,
+  messageId,
 }) => {
   const { openPreview, previewModal } = useAttachmentPreview(
     assistantId,
     attachments,
   );
+  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
+  const mainView = useViewerStore.use.mainView();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
 
   const handleDownload = useCallback(
     (att: DisplayAttachment) => {
@@ -46,6 +58,18 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
     },
     [assistantId],
   );
+
+  const filesPayload: MessageFilesPayload = useMemo(
+    () => ({ messageId, attachments, assistantId }),
+    [messageId, attachments, assistantId],
+  );
+
+  // The tile whose files panel is currently open renders with the persistent
+  // active surface, mirroring the activity group header's selected state.
+  const tileActive =
+    mainView === "message-files" &&
+    activeMessageFiles != null &&
+    sameMessageFilesTarget(activeMessageFiles, filesPayload);
 
   if (attachments.length === 0) {
     return null;
@@ -72,7 +96,8 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
         {overflowCount > 0 && (
           <AttachmentOverflowSquare
             count={overflowCount}
-            onClick={() => openPreview(attachments[VISIBLE_LIMIT]!)}
+            active={tileActive}
+            onClick={() => toggleMessageFiles(filesPayload)}
           />
         )}
       </div>

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
+import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
@@ -13,6 +14,13 @@ interface MessageAttachmentsProps {
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
 }
+
+/**
+ * How many attachment squares render inline before the strip collapses.
+ * A message with more than this many attachments shows the first
+ * VISIBLE_LIMIT squares plus one overflow tile.
+ */
+const VISIBLE_LIMIT = 5;
 
 /**
  * Read-only strip of attachment thumbnails rendered as a separate strip for
@@ -43,10 +51,13 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
     return null;
   }
 
+  const visible = attachments.slice(0, VISIBLE_LIMIT);
+  const overflowCount = attachments.length - visible.length;
+
   return (
     <>
-      <div className="flex flex-wrap gap-2">
-        {attachments.map((att) => (
+      <div className="flex flex-wrap items-start gap-2">
+        {visible.map((att) => (
           <MessageAttachmentSquare
             key={att.id}
             filename={att.filename}
@@ -58,6 +69,12 @@ export const MessageAttachments: FC<MessageAttachmentsProps> = ({
             onDownload={() => handleDownload(att)}
           />
         ))}
+        {overflowCount > 0 && (
+          <AttachmentOverflowSquare
+            count={overflowCount}
+            onClick={() => openPreview(attachments[VISIBLE_LIMIT]!)}
+          />
+        )}
       </div>
       {previewModal}
     </>

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachments.tsx
@@ -1,17 +1,7 @@
-import { useCallback, useMemo } from "react";
-import type { FC } from "react";
-
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
-import {
-  sameMessageFilesTarget,
-  useViewerStore,
-  type MessageFilesPayload,
-} from "@/stores/viewer-store";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 
 interface MessageAttachmentsProps {
   attachments: DisplayAttachment[];
@@ -19,7 +9,7 @@ interface MessageAttachmentsProps {
    *  attachment content when `previewUrl` is missing. */
   assistantId?: string | null;
   /** Transcript message identity, forwarded to the files panel payload. */
-  messageId?: string;
+  messageId: string;
 }
 
 /**
@@ -31,77 +21,41 @@ const VISIBLE_LIMIT = 5;
 
 /**
  * Read-only strip of attachment thumbnails rendered as a separate strip for
- * assistant messages (the user path now renders attachments inside the message
+ * assistant messages (the user path renders attachments inside the message
  * bubble via {@link BubbleAttachments}). Every attachment is clickable and
- * opens a full-screen preview modal — the modal handles type-specific
+ * opens a full-screen preview modal - the modal handles type-specific
  * rendering (image/video/fallback) and lazily fetches missing content when
  * needed. A hover overlay on each square provides direct download without
  * opening the preview first. Past {@link VISIBLE_LIMIT} the strip collapses
  * behind an overflow tile that opens the files side panel.
  */
-export const MessageAttachments: FC<MessageAttachmentsProps> = ({
+export function MessageAttachments({
   attachments,
   assistantId,
   messageId,
-}) => {
-  const { openPreview, previewModal } = useAttachmentPreview(
-    assistantId,
-    attachments,
-  );
-  const toggleMessageFiles = useViewerStore.use.toggleMessageFiles();
-  const mainView = useViewerStore.use.mainView();
-  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
-
-  const handleDownload = useCallback(
-    (att: DisplayAttachment) => {
-      void downloadAttachment(att, assistantId);
-    },
-    [assistantId],
-  );
-
-  const filesPayload: MessageFilesPayload = useMemo(
-    () => ({ messageId, attachments, assistantId }),
-    [messageId, attachments, assistantId],
-  );
-
-  // The tile whose files panel is currently open renders with the persistent
-  // active surface, mirroring the activity group header's selected state.
-  const tileActive =
-    mainView === "message-files" &&
-    activeMessageFiles != null &&
-    sameMessageFilesTarget(activeMessageFiles, filesPayload);
+}: MessageAttachmentsProps) {
+  const { displayAttachments, renderSquare, previewModal } =
+    useAttachmentSquares({ attachments, assistantId });
 
   if (attachments.length === 0) {
     return null;
   }
 
-  const visible = attachments.slice(0, VISIBLE_LIMIT);
-  const overflowCount = attachments.length - visible.length;
+  const visible = displayAttachments.slice(0, VISIBLE_LIMIT);
+  const overflowCount = displayAttachments.length - visible.length;
 
   return (
     <>
       <div className="flex flex-wrap items-start gap-2">
-        {visible.map((att) => (
-          <MessageAttachmentSquare
-            key={att.id}
-            filename={att.filename}
-            mimeType={att.mimeType}
-            sizeBytes={att.sizeBytes}
-            previewUrl={att.previewUrl}
-            thumbnailUrl={att.thumbnailUrl}
-            onPreview={() => openPreview(att)}
-            onDownload={() => handleDownload(att)}
-          />
-        ))}
+        {visible.map((att, index) => renderSquare(att, index))}
         {overflowCount > 0 && (
           <AttachmentOverflowSquare
             count={overflowCount}
-            active={tileActive}
-            onClick={() => toggleMessageFiles(filesPayload)}
+            payload={{ messageId, attachments, assistantId }}
           />
         )}
       </div>
       {previewModal}
     </>
   );
-};
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
@@ -1,0 +1,106 @@
+/**
+ * The shared attachment-square renderer behind every surface that lists a
+ * message's attachments: the assistant strip ({@link MessageAttachments}), the
+ * user bubble ({@link BubbleAttachments}), and the files side panel
+ * ({@link MessageFilesPanel}).
+ *
+ * Owns the three pieces those surfaces must agree on:
+ *
+ *  - the failed-decode fallback - image previews the browser cannot decode
+ *    (e.g. a HEIC blob on a Chromium renderer) get their `previewUrl` nulled
+ *    by id, so the square falls back to its file-kind icon instead of a dead
+ *    image, and the preview modal refetches stored bytes instead of the
+ *    broken blob;
+ *  - the preview modal plus its gallery siblings;
+ *  - the download forwarder.
+ *
+ * Callers own only their own layout: they map over {@link displayAttachments}
+ * and place `renderSquare(att, index)` inside whatever container they need.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+
+interface UseAttachmentSquaresOptions {
+  attachments: DisplayAttachment[];
+  /** Forwarded to the preview modal and the download helper so both can
+   *  lazily fetch attachment content when `previewUrl` is missing. */
+  assistantId?: string | null;
+}
+
+interface UseAttachmentSquaresResult {
+  /** `attachments` with the `previewUrl` of every undecodable image nulled.
+   *  Render from this list rather than the input, so a dead preview cannot
+   *  reach the DOM. */
+  displayAttachments: DisplayAttachment[];
+  /** One attachment square, wired to the preview modal, the downloader, and
+   *  the failed-decode fallback. `index` is the position in
+   *  {@link displayAttachments}. */
+  renderSquare: (attachment: DisplayAttachment, index: number) => ReactNode;
+  /** Opens the preview modal, for call sites that render their own affordance
+   *  alongside the squares (the bubble's large inline images). */
+  openPreview: (attachment: DisplayAttachment) => void;
+  /** Records an attachment id whose preview the browser could not decode. */
+  markImageFailed: (id: string) => void;
+  /** The rendered preview modal, or `null`. Render it somewhere stable. */
+  previewModal: ReactNode;
+}
+
+export function useAttachmentSquares({
+  attachments,
+  assistantId,
+}: UseAttachmentSquaresOptions): UseAttachmentSquaresResult {
+  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const markImageFailed = useCallback((id: string) => {
+    setFailedImageIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  const displayAttachments = useMemo(
+    () =>
+      failedImageIds.size === 0
+        ? attachments
+        : attachments.map((att) =>
+            failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
+          ),
+    [attachments, failedImageIds],
+  );
+
+  const { openPreview, previewModal } = useAttachmentPreview(
+    assistantId,
+    displayAttachments,
+  );
+
+  const renderSquare = useCallback(
+    (attachment: DisplayAttachment, index: number) => (
+      <MessageAttachmentSquare
+        key={attachment.id}
+        attachment={attachment}
+        onPreview={() => openPreview(attachment)}
+        // Download falls back to previewUrl when the daemon content fetch is
+        // unavailable, so it takes the UNSANITIZED attachment - a blob that
+        // can't be rendered is still valid bytes to save.
+        onDownload={() =>
+          void downloadAttachment(attachments[index] ?? attachment, assistantId)
+        }
+        onPreviewError={() => markImageFailed(attachment.id)}
+      />
+    ),
+    [attachments, assistantId, openPreview, markImageFailed],
+  );
+
+  return {
+    displayAttachments,
+    renderSquare,
+    openPreview,
+    markImageFailed,
+    previewModal,
+  };
+}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -46,6 +46,8 @@ const importToolDetailPanel = () =>
   import("@/domains/chat/components/tool-detail-panel");
 const importActivityStepsPanel = () =>
   import("@/domains/chat/components/activity-steps-panel");
+const importMessageFilesPanel = () =>
+  import("@/domains/chat/components/message-files-panel");
 const importAcpRunDetailPanel = () =>
   import("@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel");
 const importWorkflowDetailPanel = () =>
@@ -69,6 +71,9 @@ const ToolDetailPanel = lazy(() =>
 );
 const ActivityStepsPanel = lazy(() =>
   importActivityStepsPanel().then((m) => ({ default: m.ActivityStepsPanel })),
+);
+const MessageFilesPanel = lazy(() =>
+  importMessageFilesPanel().then((m) => ({ default: m.MessageFilesPanel })),
 );
 const BackgroundTaskDetailPanel = lazy(() =>
   importBackgroundTaskDetailPanel().then((m) => ({
@@ -95,6 +100,8 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   const closeToolDetail = useViewerStore.use.closeToolDetail();
   const activeActivitySteps = useViewerStore.use.activeActivitySteps();
   const closeActivitySteps = useViewerStore.use.closeActivitySteps();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
+  const closeMessageFiles = useViewerStore.use.closeMessageFiles();
   // Subscribe to only the active subagent's entry rather than the whole `byId`
   // map, so streaming events from *other* subagents don't re-render the chat
   // layout (and the chat transcript it hosts) on every token.
@@ -313,6 +320,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       importSubagentDetailPanel().catch(() => {});
       importToolDetailPanel().catch(() => {});
       importActivityStepsPanel().catch(() => {});
+      importMessageFilesPanel().catch(() => {});
       importAcpRunDetailPanel().catch(() => {});
       importWorkflowDetailPanel().catch(() => {});
       importBackgroundTaskDetailPanel().catch(() => {});
@@ -461,6 +469,18 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             }`}
             payload={activeActivitySteps}
             onClose={closeActivitySteps}
+          />
+        </LazyBoundary>
+      );
+    } else if (mainView === "message-files" && activeMessageFiles) {
+      rightPanel = (
+        <LazyBoundary>
+          <MessageFilesPanel
+            // Re-key per message so the panel resets when a different
+            // message's tile is clicked while the panel is already open.
+            key={activeMessageFiles.messageId ?? "snapshot"}
+            payload={activeMessageFiles}
+            onClose={closeMessageFiles}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -478,7 +478,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           <MessageFilesPanel
             // Re-key per message so the panel resets when a different
             // message's tile is clicked while the panel is already open.
-            key={activeMessageFiles.messageId ?? "snapshot"}
+            key={activeMessageFiles.messageId}
             payload={activeMessageFiles}
             onClose={closeMessageFiles}
           />

--- a/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
+import { MessageFilesPanel } from "./message-files-panel";
+
+/**
+ * The message-files side panel: every attachment on one transcript message,
+ * each square opening the shared full-screen preview modal with gallery
+ * navigation. Opened by the overflow tile at the end of a truncated assistant
+ * attachment strip.
+ */
+
+function makeAttachment(
+  overrides: Partial<DisplayAttachment> & { id: string },
+): DisplayAttachment {
+  return {
+    filename: `${overrides.id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+const MIXED: DisplayAttachment[] = [
+  makeAttachment({
+    id: "img-0",
+    filename: "quarterly-revenue.png",
+    sizeBytes: 184_320,
+  }),
+  makeAttachment({
+    id: "deck-1",
+    filename: "board-deck.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_194_304,
+  }),
+  makeAttachment({
+    id: "report-1",
+    filename: "annual-report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_097_152,
+  }),
+  makeAttachment({
+    id: "sheet-1",
+    filename: "forecast.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    sizeBytes: 65_536,
+  }),
+  makeAttachment({
+    id: "bundle-1",
+    filename: "source-bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_388_608,
+  }),
+  makeAttachment({
+    id: "clip-1",
+    filename: "walkthrough.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 12_582_912,
+  }),
+  makeAttachment({
+    id: "notes-1",
+    filename: "meeting-notes.md",
+    mimeType: "text/markdown",
+    sizeBytes: 3_072,
+  }),
+  makeAttachment({
+    id: "script-1",
+    filename: "migrate.ts",
+    mimeType: "text/plain",
+    sizeBytes: 9_216,
+  }),
+];
+
+const meta: Meta<typeof MessageFilesPanel> = {
+  title: "Chat/MessageFilesPanel",
+  component: MessageFilesPanel,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageFilesPanel>;
+
+/**
+ * A mixed media / non-media set: an image renders its preview edge to edge,
+ * everything else falls back to its file-kind icon on a neutral tile.
+ */
+export const MixedMedia: Story = {
+  args: {
+    payload: { messageId: "story-msg", attachments: MIXED },
+    onClose: () => {},
+  },
+};
+
+/**
+ * A message whose attachments have all gone away - the panel shows its empty
+ * state rather than a blank grid under a `Files · 0` header.
+ */
+export const Empty: Story = {
+  args: {
+    payload: { messageId: "story-empty", attachments: [] },
+    onClose: () => {},
+  },
+};
+
+/**
+ * The overflow tile itself, in both states. The resting tile must read as a
+ * dashed outline against the chat surface, and the active tile - the one whose
+ * panel is open - must be clearly distinct from a plain hover. Hover the first
+ * tile to compare.
+ */
+export const OverflowTileStates: StoryObj = {
+  render: () => (
+    <div className="flex items-start gap-6 bg-[var(--surface-base)] p-6">
+      <div className="flex flex-col items-center gap-2">
+        <AttachmentOverflowSquare
+          count={3}
+          payload={{ messageId: "story-resting", attachments: MIXED }}
+        />
+        <span className="text-xs text-[var(--content-tertiary)]">
+          resting / hover
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <AttachmentOverflowSquare
+          count={12}
+          payload={{ messageId: "story-active", attachments: MIXED }}
+        />
+        <span className="text-xs text-[var(--content-tertiary)]">
+          click to activate
+        </span>
+      </div>
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
@@ -2,6 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
+import {
+  makeDisplayAttachment,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
 import { MessageFilesPanel } from "./message-files-panel";
 
@@ -12,63 +17,53 @@ import { MessageFilesPanel } from "./message-files-panel";
  * attachment strip.
  */
 
-function makeAttachment(
-  overrides: Partial<DisplayAttachment> & { id: string },
-): DisplayAttachment {
-  return {
-    filename: `${overrides.id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: null,
-    ...overrides,
-  };
-}
-
 const MIXED: DisplayAttachment[] = [
-  makeAttachment({
+  makeDisplayAttachment({
     id: "img-0",
     filename: "quarterly-revenue.png",
     sizeBytes: 184_320,
+    previewUrl: SAMPLE_PREVIEWS[0]!,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "deck-1",
     filename: "board-deck.pptx",
     mimeType:
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     sizeBytes: 4_194_304,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "report-1",
     filename: "annual-report.pdf",
     mimeType: "application/pdf",
     sizeBytes: 2_097_152,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
+    id: "img-1",
+    filename: "hazard-gallery.png",
+    sizeBytes: 188_416,
+    previewUrl: SAMPLE_PREVIEWS[1]!,
+  }),
+  makeDisplayAttachment({
     id: "sheet-1",
     filename: "forecast.xlsx",
     mimeType:
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     sizeBytes: 65_536,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "bundle-1",
     filename: "source-bundle.zip",
     mimeType: "application/zip",
     sizeBytes: 8_388_608,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "clip-1",
     filename: "walkthrough.mp4",
     mimeType: "video/mp4",
     sizeBytes: 12_582_912,
+    thumbnailUrl: SAMPLE_PREVIEWS[2]!,
   }),
-  makeAttachment({
-    id: "notes-1",
-    filename: "meeting-notes.md",
-    mimeType: "text/markdown",
-    sizeBytes: 3_072,
-  }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "script-1",
     filename: "migrate.ts",
     mimeType: "text/plain",
@@ -145,4 +140,19 @@ export const OverflowTileStates: StoryObj = {
       </div>
     </div>
   ),
+};
+
+/**
+ * A photo-heavy message: the grid wraps to the panel's width rather than a
+ * fixed column count, so it fills a widened drawer and the full-width mobile
+ * overlay alike.
+ */
+export const Photos: Story = {
+  args: {
+    payload: {
+      messageId: "story-photos",
+      attachments: makePreviewableImages(12),
+    },
+    onClose: () => {},
+  },
 };

--- a/clients/web/src/domains/chat/components/message-files-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for `MessageFilesPanel` - the side drawer listing every attachment on
+ * one transcript message.
+ *
+ *  - Renders one square per attachment, media and non-media alike, from the
+ *    payload snapshot when no live message resolves.
+ *  - The header count matches the attachment total.
+ *  - The close button fires `onClose`.
+ *  - Clicking a square opens the shared preview modal with the whole set as
+ *    gallery siblings.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
+  () => ({
+    AttachmentPreviewModal: ({
+      attachment,
+      siblingAttachments,
+    }: {
+      attachment: { id: string };
+      siblingAttachments?: Array<{ id: string }>;
+    }) => (
+      <div
+        data-testid="preview-modal"
+        data-attachment-id={attachment.id}
+        data-sibling-count={String((siblingAttachments ?? []).length)}
+      />
+    ),
+  }),
+);
+
+const { MessageFilesPanel } = await import(
+  "@/domains/chat/components/message-files-panel"
+);
+
+afterEach(() => {
+  cleanup();
+});
+
+const ATTACHMENTS: DisplayAttachment[] = [
+  {
+    id: "img-0",
+    filename: "photo-0.png",
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: "https://example.com/photo-0.png",
+  },
+  {
+    id: "deck-1",
+    filename: "deck.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_096,
+    previewUrl: null,
+  },
+  {
+    id: "report-1",
+    filename: "report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_048,
+    previewUrl: null,
+  },
+  {
+    id: "bundle-1",
+    filename: "bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_192,
+    previewUrl: null,
+  },
+];
+
+function renderPanel(onClose: () => void = () => {}) {
+  return render(
+    <MessageFilesPanel
+      payload={{ attachments: ATTACHMENTS }}
+      onClose={onClose}
+    />,
+  );
+}
+
+/** The squares are divs with `role="button"`; the download affordance is a
+ *  real `<button>`, so this selector counts only attachment squares. */
+function squareLabels(container: HTMLElement): Array<string | null> {
+  return Array.from(container.querySelectorAll('div[role="button"]')).map(
+    (el) => el.getAttribute("aria-label"),
+  );
+}
+
+describe("MessageFilesPanel", () => {
+  test("renders one square per attachment, media and non-media alike", () => {
+    const { container } = renderPanel();
+    expect(squareLabels(container)).toEqual([
+      "photo-0.png",
+      "deck.pptx",
+      "report.pdf",
+      "bundle.zip",
+    ]);
+  });
+
+  test("header count matches the attachment total", () => {
+    const { getByText } = renderPanel();
+    expect(getByText("Files · 4")).toBeTruthy();
+  });
+
+  test("close button fires onClose", () => {
+    let closed = false;
+    const { getByLabelText } = renderPanel(() => {
+      closed = true;
+    });
+    fireEvent.click(getByLabelText("Close files"));
+    expect(closed).toBe(true);
+  });
+
+  test("clicking a square opens the preview with the whole set as siblings", () => {
+    const { getByLabelText, getByTestId } = renderPanel();
+    fireEvent.click(getByLabelText("report.pdf"));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("report-1");
+    expect(modal.getAttribute("data-sibling-count")).toBe("4");
+  });
+});

--- a/clients/web/src/domains/chat/components/message-files-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.test.tsx
@@ -2,38 +2,35 @@
  * Tests for `MessageFilesPanel` - the side drawer listing every attachment on
  * one transcript message.
  *
- *  - Renders one square per attachment, media and non-media alike, from the
- *    payload snapshot when no live message resolves.
+ *  - Renders one square per attachment, media and non-media alike.
+ *  - Re-derives from the live transcript when the payload's `messageId`
+ *    resolves, and falls back to the open-time snapshot when it does not.
+ *  - A resolved message with no attachments renders the empty state rather
+ *    than resurrecting the snapshot.
  *  - The header count matches the attachment total.
  *  - The close button fires `onClose`.
  *  - Clicking a square opens the shared preview modal with the whole set as
  *    gallery siblings.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import type { DisplayAttachment } from "@/types/attachment-types";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  makeDisplayAttachment,
+  makeMixedAttachments,
+  mockAttachmentPreviewModal,
+  squareLabels,
+} from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type {
+  DisplayAttachment,
+  DisplayMessage,
+} from "@/domains/chat/types/types";
 
-mock.module(
-  "@/domains/chat/components/chat-attachments/attachment-preview-modal",
-  () => ({
-    AttachmentPreviewModal: ({
-      attachment,
-      siblingAttachments,
-    }: {
-      attachment: { id: string };
-      siblingAttachments?: Array<{ id: string }>;
-    }) => (
-      <div
-        data-testid="preview-modal"
-        data-attachment-id={attachment.id}
-        data-sibling-count={String((siblingAttachments ?? []).length)}
-      />
-    ),
-  }),
-);
+mockAttachmentPreviewModal();
 
 const { MessageFilesPanel } = await import(
   "@/domains/chat/components/message-files-panel"
@@ -41,54 +38,37 @@ const { MessageFilesPanel } = await import(
 
 afterEach(() => {
   cleanup();
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
 });
 
-const ATTACHMENTS: DisplayAttachment[] = [
-  {
-    id: "img-0",
-    filename: "photo-0.png",
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: "https://example.com/photo-0.png",
-  },
-  {
-    id: "deck-1",
-    filename: "deck.pptx",
-    mimeType:
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    sizeBytes: 4_096,
-    previewUrl: null,
-  },
-  {
-    id: "report-1",
-    filename: "report.pdf",
-    mimeType: "application/pdf",
-    sizeBytes: 2_048,
-    previewUrl: null,
-  },
-  {
-    id: "bundle-1",
-    filename: "bundle.zip",
-    mimeType: "application/zip",
-    sizeBytes: 8_192,
-    previewUrl: null,
-  },
-];
+const ATTACHMENTS = makeMixedAttachments();
+
+/** Seed the transcript with one assistant row carrying `attachments`. */
+function seedTranscript(
+  messageId: string,
+  attachments: DisplayAttachment[],
+): void {
+  const message: DisplayMessage = {
+    id: messageId,
+    role: "assistant",
+    attachments,
+  };
+  const snapshot: PaginatedHistoryResult = {
+    messages: [message],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 1,
+  };
+  useChatSessionStore.setState({ snapshot, optimisticSends: [] });
+}
 
 function renderPanel(onClose: () => void = () => {}) {
   return render(
     <MessageFilesPanel
-      payload={{ attachments: ATTACHMENTS }}
+      payload={{ messageId: "msg-1", attachments: ATTACHMENTS }}
       onClose={onClose}
     />,
-  );
-}
-
-/** The squares are divs with `role="button"`; the download affordance is a
- *  real `<button>`, so this selector counts only attachment squares. */
-function squareLabels(container: HTMLElement): Array<string | null> {
-  return Array.from(container.querySelectorAll('div[role="button"]')).map(
-    (el) => el.getAttribute("aria-label"),
   );
 }
 
@@ -105,7 +85,8 @@ describe("MessageFilesPanel", () => {
 
   test("header count matches the attachment total", () => {
     const { getByText } = renderPanel();
-    expect(getByText("Files · 4")).toBeTruthy();
+    expect(getByText("Files")).toBeTruthy();
+    expect(getByText("4")).toBeTruthy();
   });
 
   test("close button fires onClose", () => {
@@ -124,5 +105,42 @@ describe("MessageFilesPanel", () => {
     const modal = getByTestId("preview-modal");
     expect(modal.getAttribute("data-attachment-id")).toBe("report-1");
     expect(modal.getAttribute("data-sibling-count")).toBe("4");
+  });
+
+  test("renders the LIVE attachment list when the message resolves", () => {
+    seedTranscript("msg-1", [
+      ...ATTACHMENTS,
+      makeDisplayAttachment({ id: "late-1", filename: "late.png" }),
+      makeDisplayAttachment({ id: "late-2", filename: "later.png" }),
+    ]);
+
+    const { container, getByText } = renderPanel();
+
+    // Six live attachments beat the four-entry open-time snapshot.
+    expect(squareLabels(container)).toHaveLength(6);
+    expect(getByText("6")).toBeTruthy();
+    expect(squareLabels(container)).toContain("late.png");
+  });
+
+  test("falls back to the snapshot when the message id resolves to nothing", () => {
+    seedTranscript("other-message", [
+      makeDisplayAttachment({ id: "unrelated-1", filename: "unrelated.png" }),
+    ]);
+
+    const { container, getByText } = renderPanel();
+
+    expect(squareLabels(container)).toHaveLength(4);
+    expect(getByText("4")).toBeTruthy();
+    expect(squareLabels(container)).not.toContain("unrelated.png");
+  });
+
+  test("a resolved message with no attachments renders the empty state", () => {
+    seedTranscript("msg-1", []);
+
+    const { container, getByText } = renderPanel();
+
+    expect(squareLabels(container)).toHaveLength(0);
+    expect(getByText("0")).toBeTruthy();
+    expect(getByText("No files on this message")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -1,0 +1,64 @@
+/**
+ * Side-drawer panel listing every attachment on one transcript message.
+ * Opened by the overflow tile on a truncated attachment strip (see
+ * `MessageAttachments`). Each tile opens the shared full-screen preview
+ * modal with gallery navigation across the whole set.
+ *
+ * Streams live: the panel re-derives the message's attachments from the
+ * transcript by `messageId` via `useLiveMessageAttachments`, so files that
+ * land mid-turn appear while the panel is open. The payload's embedded
+ * snapshot is the fallback when the message can't be resolved (paged out, or
+ * identity-less callers like stories).
+ */
+
+import { Paperclip } from "lucide-react";
+
+import { DetailShell } from "@/components/detail-shell";
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
+import type { MessageFilesPayload } from "@/stores/viewer-store";
+
+interface MessageFilesPanelProps {
+  payload: MessageFilesPayload;
+  onClose: () => void;
+}
+
+export function MessageFilesPanel({
+  payload,
+  onClose,
+}: MessageFilesPanelProps) {
+  const live = useLiveMessageAttachments(payload.messageId);
+  const attachments = live ?? payload.attachments;
+  const { openPreview, previewModal } = useAttachmentPreview(
+    payload.assistantId,
+    attachments,
+  );
+
+  return (
+    <DetailShell
+      Glyph={Paperclip}
+      title={`Files · ${attachments.length}`}
+      closeLabel="Close files"
+      onClose={onClose}
+    >
+      {/* Three across fits the drawer's 400px default width. */}
+      <div className="grid grid-cols-3 gap-3">
+        {attachments.map((att) => (
+          <MessageAttachmentSquare
+            key={att.id}
+            filename={att.filename}
+            mimeType={att.mimeType}
+            sizeBytes={att.sizeBytes}
+            previewUrl={att.previewUrl}
+            thumbnailUrl={att.thumbnailUrl}
+            onPreview={() => openPreview(att)}
+            onDownload={() => void downloadAttachment(att, payload.assistantId)}
+          />
+        ))}
+      </div>
+      {previewModal}
+    </DetailShell>
+  );
+}

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -7,16 +7,16 @@
  * Streams live: the panel re-derives the message's attachments from the
  * transcript by `messageId` via `useLiveMessageAttachments`, so files that
  * land mid-turn appear while the panel is open. The payload's embedded
- * snapshot is the fallback when the message can't be resolved (paged out, or
- * identity-less callers like stories).
+ * snapshot is the fallback for the one case the live source cannot answer -
+ * the message having been paged out of the loaded transcript.
  */
 
 import { Paperclip } from "lucide-react";
 
+import { Typography } from "@vellumai/design-library";
+
 import { DetailShell } from "@/components/detail-shell";
-import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
-import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
-import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
 import type { MessageFilesPayload } from "@/stores/viewer-store";
 
@@ -31,33 +31,53 @@ export function MessageFilesPanel({
 }: MessageFilesPanelProps) {
   const live = useLiveMessageAttachments(payload.messageId);
   const attachments = live ?? payload.attachments;
-  const { openPreview, previewModal } = useAttachmentPreview(
-    payload.assistantId,
-    attachments,
-  );
+  const { displayAttachments, renderSquare, previewModal } =
+    useAttachmentSquares({
+      attachments,
+      assistantId: payload.assistantId,
+    });
 
   return (
     <DetailShell
       Glyph={Paperclip}
-      title={`Files · ${attachments.length}`}
+      // Matches the activity-steps panel header: title · N inline at the same
+      // size, separated by a 3px midline dot, count in the secondary tone.
+      titleNode={
+        <span className="flex min-w-0 items-center gap-1.5 py-0.5">
+          <Typography
+            variant="title-medium"
+            className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+          >
+            Files
+          </Typography>
+          <span
+            aria-hidden
+            className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
+          />
+          <Typography
+            variant="title-medium"
+            className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
+          >
+            {displayAttachments.length}
+          </Typography>
+        </span>
+      }
       closeLabel="Close files"
       onClose={onClose}
     >
-      {/* Three across fits the drawer's 400px default width. */}
-      <div className="grid grid-cols-3 gap-3">
-        {attachments.map((att) => (
-          <MessageAttachmentSquare
-            key={att.id}
-            filename={att.filename}
-            mimeType={att.mimeType}
-            sizeBytes={att.sizeBytes}
-            previewUrl={att.previewUrl}
-            thumbnailUrl={att.thumbnailUrl}
-            onPreview={() => openPreview(att)}
-            onDownload={() => void downloadAttachment(att, payload.assistantId)}
-          />
-        ))}
-      </div>
+      {displayAttachments.length === 0 ? (
+        <Typography
+          variant="body-small-default"
+          className="py-4 text-center text-[var(--content-tertiary)]"
+        >
+          No files on this message
+        </Typography>
+      ) : (
+        // Three across fits the drawer's 400px default width.
+        <div className="grid grid-cols-3 gap-3">
+          {displayAttachments.map((att, index) => renderSquare(att, index))}
+        </div>
+      )}
       {previewModal}
     </DetailShell>
   );

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -73,8 +73,11 @@ export function MessageFilesPanel({
           No files on this message
         </Typography>
       ) : (
-        // Three across fits the drawer's 400px default width.
-        <div className="grid grid-cols-3 gap-3">
+        // Wraps rather than sitting on a fixed column count: the drawer is
+        // drag-resizable and the mobile overlay renders this same panel at
+        // full viewport width. `items-start` keeps squares with taller
+        // captions from stretching their neighbours.
+        <div className="flex flex-wrap items-start gap-3">
           {displayAttachments.map((att, index) => renderSquare(att, index))}
         </div>
       )}

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -1,6 +1,7 @@
 /**
- * Portal-based mobile overlay container for app, document, subagent-detail,
- * workflow-detail, acp-run-detail, and tool-detail viewers. Reads from Zustand
+ * Portal-based mobile overlay container for the app, document,
+ * subagent-detail, workflow-detail, acp-run-detail, background-task-detail,
+ * tool-detail, activity-steps, and message-files viewers. Reads from Zustand
  * stores directly so the parent (ActiveChatView) doesn't need to assemble
  * inline handlers.
  *

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -26,6 +26,7 @@ import { MobileActivityStepsOverlay } from "@/domains/chat/components/mobile-act
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileBackgroundTaskDetailOverlay } from "@/domains/chat/components/mobile-background-task-detail-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
+import { MobileMessageFilesOverlay } from "@/domains/chat/components/mobile-message-files-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
 import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
 import { MobileWorkflowDetailOverlay } from "@/domains/chat/components/mobile-workflow-detail-overlay";
@@ -44,6 +45,7 @@ export function MobileChatOverlays() {
   const activeSubagentId = useViewerStore.use.activeSubagentId();
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const activeActivitySteps = useViewerStore.use.activeActivitySteps();
+  const activeMessageFiles = useViewerStore.use.activeMessageFiles();
   const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const activeAcpRunId = useViewerStore.use.activeAcpRunId();
   const activeBackgroundTaskId = useViewerStore.use.activeBackgroundTaskId();
@@ -148,6 +150,10 @@ export function MobileChatOverlays() {
     useViewerStore.getState().closeActivitySteps();
   }, []);
 
+  const handleCloseMessageFiles = useCallback(() => {
+    useViewerStore.getState().closeMessageFiles();
+  }, []);
+
   if (!overlayTarget) {
     return null;
   }
@@ -219,6 +225,10 @@ export function MobileChatOverlays() {
       <MobileActivityStepsOverlay
         payload={mainView === "activity-steps" ? activeActivitySteps : null}
         onClose={handleCloseActivitySteps}
+      />
+      <MobileMessageFilesOverlay
+        payload={mainView === "message-files" ? activeMessageFiles : null}
+        onClose={handleCloseMessageFiles}
       />
     </>,
     overlayTarget,

--- a/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
@@ -38,7 +38,14 @@ export function MobileMessageFilesOverlay({
   return (
     <div className="fixed inset-x-0 z-30" style={shellStyle}>
       <LazyBoundary>
-        <MessageFilesPanel payload={payload} onClose={onClose} />
+        {/* Re-key per message so switching targets remounts the panel rather
+            than reusing one whose internal preview state belongs to the
+            previous message. */}
+        <MessageFilesPanel
+          key={payload.messageId}
+          payload={payload}
+          onClose={onClose}
+        />
       </LazyBoundary>
     </div>
   );

--- a/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-message-files-overlay.tsx
@@ -1,0 +1,45 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
+import type { MessageFilesPayload } from "@/stores/viewer-store";
+
+const MessageFilesPanel = lazy(() =>
+  import("@/domains/chat/components/message-files-panel").then((m) => ({
+    default: m.MessageFilesPanel,
+  })),
+);
+
+interface MobileMessageFilesOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  payload: MessageFilesPayload | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the message-files panel (every
+ * attachment on one transcript message, each opening the shared preview
+ * modal).
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ */
+export function MobileMessageFilesOverlay({
+  payload,
+  onClose,
+}: MobileMessageFilesOverlayProps) {
+  const shellStyle = useMobileOverlayViewportStyle();
+
+  if (!payload) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 z-30" style={shellStyle}>
+      <LazyBoundary>
+        <MessageFilesPanel payload={payload} onClose={onClose} />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -39,8 +39,8 @@ export interface SubagentNotificationLike {
  *
  * Entry lifecycle cleanup is owned elsewhere: cross-conversation clearing by
  * the conversation-change reset (`use-conversation-change-effects`' layout
- * effect and `switchConversation`), staleness by reconcile's generation guard,
- * and stuck-active settling by reconcile's orphan pass.
+ * effect and `navigateToConversation`), staleness by reconcile's generation
+ * guard, and stuck-active settling by reconcile's orphan pass.
  *
  * `parentConversationId` is the conversation being hydrated, it scopes the
  * Active-Subagents overlay. A notification's own `conversationId` is the

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -2,7 +2,7 @@
  * Consolidates side effects that fire when `activeConversationId` changes:
  *
  * - Reset subagent tracking state (needed for URL-navigation paths that
- *   bypass the `switchConversation` / `startNewConversation` wrappers)
+ *   bypass the `navigateToConversation` / `startNewConversation` wrappers)
  * - Auto-fetch detail for the subagents that can't wait for a click: the ones
  *   still running, and the stubs deferring their live events until a backfill
  *   lands
@@ -57,7 +57,7 @@ export function useConversationChangeEffects(
   // child (effects fire children-first), letting a card capture the pre-reset
   // `generation`; the reset would then bump it and the in-flight hydration
   // would discard its own result as stale — leaving the card blank with no
-  // retry. The wrapper-initiated path (`switchConversation` /
+  // retry. The wrapper-initiated path (`navigateToConversation` /
   // `startNewConversation`) also resets eagerly; the double-reset is idempotent.
   // This effect catches the URL-navigation path where wrappers don't run.
   useLayoutEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -430,6 +430,7 @@ export function useConversationLoader({
       }
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
+      useViewerStore.getState().clearTranscriptPanelPayloads();
       void navigate(routes.conversation(key));
     },
     [navigate],
@@ -445,6 +446,7 @@ export function useConversationLoader({
       }
       useSubagentStore.getState().reset();
       useWorkflowStore.getState().reset();
+      useViewerStore.getState().clearTranscriptPanelPayloads();
       useViewerStore.getState().setMainView("chat");
       const draftConversationId = createDraftConversationId();
       useConversationStore

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -81,8 +81,8 @@ interface UseConversationLoaderParams {
  * polling for new messages.
  *
  * Owns the primary data-fetching lifecycle for the chat sidebar and
- * transcript. Returns `switchConversation`, `startNewConversation`,
- * and `refreshConversations` for use by sibling hooks.
+ * transcript. Returns `startNewConversation` and `refreshConversations` for
+ * use by sibling hooks.
  *
  * Delegates to:
  * - `useConversationHistory` -- conversation switch, cache, and history loading
@@ -416,27 +416,6 @@ export function useConversationLoader({
   });
 
   // -------------------------------------------------------------------------
-  // switchConversation
-  // -------------------------------------------------------------------------
-  const switchConversation = useCallback(
-    (key: string) => {
-      useViewerStore.getState().setMainView("chat");
-      // Same-conversation reselect: return to the chat view but keep the
-      // per-conversation process stores — wiping them kills the inline
-      // cards of still-running subagents, which only repopulate from live
-      // SSE events (LUM-2875).
-      if (key === useConversationStore.getState().activeConversationId) {
-        return;
-      }
-      useSubagentStore.getState().reset();
-      useWorkflowStore.getState().reset();
-      useViewerStore.getState().clearTranscriptPanelPayloads();
-      void navigate(routes.conversation(key));
-    },
-    [navigate],
-  );
-
-  // -------------------------------------------------------------------------
   // startNewConversation
   // -------------------------------------------------------------------------
   const startNewConversation = useCallback(
@@ -460,7 +439,6 @@ export function useConversationLoader({
 
   return {
     refreshConversations,
-    switchConversation,
     startNewConversation,
     conversationExistsOnServer,
     historyResult,

--- a/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
@@ -14,8 +14,7 @@ import {
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
 
@@ -91,7 +90,7 @@ export function useLiveActivityGroup(
   messageId: string | undefined,
   groupIndex: number | undefined,
 ): { items: ToolCallCardItem[]; toolCalls: ChatMessageToolCall[] } | null {
-  const messages = useTranscriptMessages();
+  const message = useTranscriptMessageById(messageId);
   // Card-backed process suppression reads the same store slices the
   // transcript subscribes to, so a card's backing flipping (an entry
   // appearing) drops the raw step from an open panel in the same render.
@@ -105,13 +104,7 @@ export function useLiveActivityGroup(
   const backgroundTaskById = useBackgroundTaskStore.use.byId();
 
   return useMemo(() => {
-    if (!messageId || groupIndex == null) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    if (!message) {
+    if (!message || groupIndex == null) {
       return null;
     }
     const groups = groupContentBlocks(message.contentBlocks ?? [], {
@@ -134,8 +127,7 @@ export function useLiveActivityGroup(
       backgroundTaskById,
     });
   }, [
-    messages,
-    messageId,
+    message,
     groupIndex,
     workflowById,
     workflowByToolUseId,

--- a/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
@@ -1,27 +1,27 @@
-import { useMemo } from "react";
-
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 import type { DisplayAttachment } from "@/types/attachment-types";
+
+/** Stable empty result, so a resolved message with no attachments doesn't
+ *  hand callers a fresh array on every render. */
+const NO_ATTACHMENTS: DisplayAttachment[] = [];
 
 /**
  * A message's attachments re-derived from the rendered transcript on every
  * render, so an open files panel picks up attachments that land while a
- * message is still streaming. Returns `null` when the message cannot be
- * found (paged out of the loaded transcript) so callers fall back to the
- * open-time snapshot.
+ * message is still streaming.
+ *
+ * Returns `null` only when the message itself cannot be resolved (paged out
+ * of the loaded transcript), so callers fall back to the open-time snapshot.
+ * A message that resolves with no attachments returns an empty array, not
+ * `null` - it is a live answer, and the panel must show its empty state
+ * rather than resurrect a stale snapshot.
  */
 export function useLiveMessageAttachments(
   messageId: string | undefined,
 ): DisplayAttachment[] | null {
-  const messages = useTranscriptMessages();
-  return useMemo(() => {
-    if (!messageId) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    return message?.attachments ?? null;
-  }, [messages, messageId]);
+  const message = useTranscriptMessageById(messageId);
+  if (!message) {
+    return null;
+  }
+  return message.attachments ?? NO_ATTACHMENTS;
 }

--- a/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-message-attachments.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+/**
+ * A message's attachments re-derived from the rendered transcript on every
+ * render, so an open files panel picks up attachments that land while a
+ * message is still streaming. Returns `null` when the message cannot be
+ * found (paged out of the loaded transcript) so callers fall back to the
+ * open-time snapshot.
+ */
+export function useLiveMessageAttachments(
+  messageId: string | undefined,
+): DisplayAttachment[] | null {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    if (!messageId) {
+      return null;
+    }
+    const message = messages.find((m) =>
+      messageMatchKeys(m).includes(messageId),
+    );
+    return message?.attachments ?? null;
+  }, [messages, messageId]);
+}

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 
 import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
-import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 
 /**
  * Reasoning text for a thinking detail drawer, re-derived from the rendered
@@ -34,15 +33,9 @@ export function useLiveThinkingText(
   groupIndex: number | undefined,
   thinkingItemIndex?: number,
 ): string | null {
-  const messages = useTranscriptMessages();
+  const message = useTranscriptMessageById(messageId);
   return useMemo(() => {
-    if (!messageId || groupIndex == null) {
-      return null;
-    }
-    const message = messages.find((m) =>
-      messageMatchKeys(m).includes(messageId),
-    );
-    if (!message) {
+    if (!message || groupIndex == null) {
       return null;
     }
     const groups = groupContentBlocks(message.contentBlocks ?? [], {
@@ -59,5 +52,5 @@ export function useLiveThinkingText(
       return segments.join("\n");
     }
     return segments[thinkingItemIndex] ?? null;
-  }, [messages, messageId, groupIndex, thinkingItemIndex]);
+  }, [message, groupIndex, thinkingItemIndex]);
 }

--- a/clients/web/src/domains/chat/hooks/use-transcript-message-by-id.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-message-by-id.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * One transcript row resolved from the rendered transcript (server history ⊕
+ * the in-flight turn) on every render, matched on any of its identity keys -
+ * server id, merged ids, or the client nonce - so an optimistic row and its
+ * confirmed echo both resolve.
+ *
+ * The shared lookup behind the live re-derive hooks
+ * ({@link useLiveThinkingText}, {@link useLiveActivityGroup},
+ * {@link useLiveMessageAttachments}), which keep an open detail panel
+ * streaming instead of frozen at its open-time snapshot.
+ *
+ * Returns `undefined` when no `messageId` was supplied or the row is not in
+ * the loaded transcript (paged out). Callers must distinguish that from a
+ * resolved row whose derived content happens to be empty.
+ */
+export function useTranscriptMessageById(
+  messageId: string | undefined,
+): DisplayMessage | undefined {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    if (!messageId) {
+      return undefined;
+    }
+    return messages.find((m) => messageMatchKeys(m).includes(messageId));
+  }, [messages, messageId]);
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1103,6 +1103,7 @@ export function TranscriptMessageBody({
           <MessageAttachments
             attachments={message.attachments ?? []}
             assistantId={assistantId}
+            messageId={message.id}
           />
         )}
         {trailer}

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -4,8 +4,10 @@ import {
   isAppNotFoundError,
   useViewerStore,
   type ActivityStepsPayload,
+  type MessageFilesPayload,
   type ToolDetailPayload,
 } from "@/stores/viewer-store";
+import type { DisplayAttachment } from "@/types/attachment-types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -562,6 +564,14 @@ describe("closeActiveOverlay", () => {
     expect(getState().activeWorkflowRunId).toBeNull();
   });
 
+  it("closes the message-files overlay and restores its prior view", () => {
+    getState().openMessageFiles({ messageId: "m1", attachments: [] });
+
+    expect(getState().closeActiveOverlay()).toBe(true);
+    expect(getState().mainView).toBe("chat");
+    expect(getState().activeMessageFiles).toBeNull();
+  });
+
   it("returns false without changing a non-overlay view", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1" });
 
@@ -758,6 +768,68 @@ describe("openActivitySteps / toggleActivitySteps / closeActivitySteps", () => {
     expect(getState().viewBeforeActivitySteps).toBe("app");
     getState().closeActivitySteps();
     expect(getState().mainView).toBe("app");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message files panel
+// ---------------------------------------------------------------------------
+
+function makeAttachment(id: string): DisplayAttachment {
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1024,
+    previewUrl: null,
+  };
+}
+
+const SAMPLE_FILES: MessageFilesPayload = {
+  messageId: "m1",
+  attachments: [makeAttachment("a1"), makeAttachment("a2")],
+  assistantId: "asst-1",
+};
+
+describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
+  it("opens the panel with the payload and records the prior view", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    const state = getState();
+    expect(state.mainView).toBe("message-files");
+    expect(state.activeMessageFiles).toBe(SAMPLE_FILES);
+    expect(state.viewBeforeMessageFiles).toBe("chat");
+  });
+
+  it("close restores the prior view and clears the payload", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openMessageFiles(SAMPLE_FILES);
+    expect(getState().viewBeforeMessageFiles).toBe("app");
+    getState().closeMessageFiles();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeMessageFiles).toBeNull();
+  });
+
+  it("toggle closes the panel when targeting the SAME message", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().toggleMessageFiles({ ...SAMPLE_FILES });
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeMessageFiles).toBeNull();
+  });
+
+  it("toggle switches to a DIFFERENT message instead of closing", () => {
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().toggleMessageFiles({ ...SAMPLE_FILES, messageId: "m2" });
+    const state = getState();
+    expect(state.mainView).toBe("message-files");
+    expect(state.activeMessageFiles?.messageId).toBe("m2");
+  });
+
+  it("identity-less payloads match on the first attachment id", () => {
+    getState().openMessageFiles({ attachments: [makeAttachment("a1")] });
+    getState().toggleMessageFiles({ attachments: [makeAttachment("a1")] });
+    expect(getState().mainView).toBe("chat");
   });
 });
 

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -7,7 +7,7 @@ import {
   type MessageFilesPayload,
   type ToolDetailPayload,
 } from "@/stores/viewer-store";
-import type { DisplayAttachment } from "@/types/attachment-types";
+import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -775,19 +775,12 @@ describe("openActivitySteps / toggleActivitySteps / closeActivitySteps", () => {
 // Message files panel
 // ---------------------------------------------------------------------------
 
-function makeAttachment(id: string): DisplayAttachment {
-  return {
-    id,
-    filename: `${id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1024,
-    previewUrl: null,
-  };
-}
-
 const SAMPLE_FILES: MessageFilesPayload = {
   messageId: "m1",
-  attachments: [makeAttachment("a1"), makeAttachment("a2")],
+  attachments: [
+    makeDisplayAttachment({ id: "a1" }),
+    makeDisplayAttachment({ id: "a2" }),
+  ],
   assistantId: "asst-1",
 };
 
@@ -826,10 +819,15 @@ describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
     expect(state.activeMessageFiles?.messageId).toBe("m2");
   });
 
-  it("identity-less payloads match on the first attachment id", () => {
-    getState().openMessageFiles({ attachments: [makeAttachment("a1")] });
-    getState().toggleMessageFiles({ attachments: [makeAttachment("a1")] });
-    expect(getState().mainView).toBe("chat");
+  it("clears the transcript panel payloads without touching mainView", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openMessageFiles(SAMPLE_FILES);
+    getState().clearTranscriptPanelPayloads();
+    const state = getState();
+    expect(state.activeMessageFiles).toBeNull();
+    expect(state.activeActivitySteps).toBeNull();
+    expect(state.activeToolDetail).toBeNull();
+    expect(state.mainView).toBe("message-files");
   });
 });
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -285,28 +285,21 @@ export function sameActivityStepsTarget(
  * Payload for the message-files side panel: every attachment on one
  * transcript message. The open panel re-derives live attachments from the
  * transcript by `messageId`; the embedded `attachments` array is the
- * open-time snapshot, used when the message cannot be resolved (paged out,
- * or identity-less callers like stories).
+ * open-time snapshot, used when that message is no longer in the loaded
+ * transcript (paged out by history windowing).
  */
 export interface MessageFilesPayload {
-  messageId?: string;
+  messageId: string;
   attachments: DisplayAttachment[];
   assistantId?: string | null;
 }
 
-/**
- * Whether two message-files payloads address the same transcript message.
- * Keys on `messageId` when present, falling back to the first attachment id
- * for identity-less callers.
- */
+/** Whether two message-files payloads address the same transcript message. */
 export function sameMessageFilesTarget(
   a: MessageFilesPayload,
   b: MessageFilesPayload,
 ): boolean {
-  if (a.messageId != null || b.messageId != null) {
-    return a.messageId === b.messageId;
-  }
-  return a.attachments[0]?.id === b.attachments[0]?.id;
+  return a.messageId === b.messageId;
 }
 
 /** The identity fields a thinking drawer target is matched on. */
@@ -468,6 +461,16 @@ export interface ViewerActions {
    */
   toggleMessageFiles: (payload: MessageFilesPayload) => void;
   closeMessageFiles: () => void;
+
+  /**
+   * Drop the payloads of the panels whose content is scoped to one
+   * conversation's transcript. Called on conversation switch: the panels are
+   * already dismissed by the `setMainView("chat")` that accompanies it, and
+   * holding their payloads keeps the previous conversation's data alive -
+   * `activeMessageFiles` in particular retains decoded attachment blob/data
+   * URLs. Leaves `mainView` alone; this is a memory concern, not navigation.
+   */
+  clearTranscriptPanelPayloads: () => void;
 
   // --- Channel setup ---
   openChannelSetup: (payload: ChannelSetupPayload) => void;
@@ -941,6 +944,14 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeMessageFiles,
       activeMessageFiles: null,
+    });
+  },
+
+  clearTranscriptPanelPayloads: () => {
+    set({
+      activeMessageFiles: null,
+      activeActivitySteps: null,
+      activeToolDetail: null,
     });
   },
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -15,6 +15,7 @@
  * - `activeSubagentId` — subagent detail panel
  * - `activeToolDetail` — tool-call detail drawer payload
  * - `activeActivitySteps` — activity-steps side panel payload (a group's full timeline)
+ * - `activeMessageFiles` - message-files side panel payload (one message's attachments)
  * - `activeWorkflowRunId` — workflow detail panel
  * - `activeAcpRunId` — ACP run detail panel
  * - `activeBackgroundTaskId` — background-task detail panel
@@ -32,6 +33,7 @@ import type { SetupChannelId } from "@/types/channel-types";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
+import type { DisplayAttachment } from "@/types/attachment-types";
 import { appsByIdOpenPost, documentsByIdGet } from "@/generated/daemon/sdk.gen";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
@@ -44,6 +46,7 @@ type OverlayView =
   | "subagent-detail"
   | "tool-detail"
   | "activity-steps"
+  | "message-files"
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
@@ -115,6 +118,7 @@ function resolveViewBefore(
     | "viewBeforeSubagentDetail"
     | "viewBeforeToolDetail"
     | "viewBeforeActivitySteps"
+    | "viewBeforeMessageFiles"
     | "viewBeforeWorkflowDetail"
     | "viewBeforeAcpRunDetail"
     | "viewBeforeBackgroundTaskDetail"
@@ -127,6 +131,7 @@ function resolveViewBefore(
     mv === "subagent-detail" ||
     mv === "tool-detail" ||
     mv === "activity-steps" ||
+    mv === "message-files" ||
     mv === "workflow-detail" ||
     mv === "acp-run-detail" ||
     mv === "background-task-detail" ||
@@ -150,6 +155,7 @@ export type MainView =
   | "subagent-detail"
   | "tool-detail"
   | "activity-steps"
+  | "message-files"
   | "workflow-detail"
   | "acp-run-detail"
   | "background-task-detail"
@@ -275,6 +281,34 @@ export function sameActivityStepsTarget(
   return a.toolCalls[0]?.id === b.toolCalls[0]?.id;
 }
 
+/**
+ * Payload for the message-files side panel: every attachment on one
+ * transcript message. The open panel re-derives live attachments from the
+ * transcript by `messageId`; the embedded `attachments` array is the
+ * open-time snapshot, used when the message cannot be resolved (paged out,
+ * or identity-less callers like stories).
+ */
+export interface MessageFilesPayload {
+  messageId?: string;
+  attachments: DisplayAttachment[];
+  assistantId?: string | null;
+}
+
+/**
+ * Whether two message-files payloads address the same transcript message.
+ * Keys on `messageId` when present, falling back to the first attachment id
+ * for identity-less callers.
+ */
+export function sameMessageFilesTarget(
+  a: MessageFilesPayload,
+  b: MessageFilesPayload,
+): boolean {
+  if (a.messageId != null || b.messageId != null) {
+    return a.messageId === b.messageId;
+  }
+  return a.attachments[0]?.id === b.attachments[0]?.id;
+}
+
 /** The identity fields a thinking drawer target is matched on. */
 type ThinkingTarget = Pick<
   ToolDetailPayload,
@@ -324,6 +358,8 @@ export interface ViewerState {
   viewBeforeToolDetail: Exclude<MainView, OverlayView>;
   activeActivitySteps: ActivityStepsPayload | null;
   viewBeforeActivitySteps: Exclude<MainView, OverlayView>;
+  activeMessageFiles: MessageFilesPayload | null;
+  viewBeforeMessageFiles: Exclude<MainView, OverlayView>;
   activeWorkflowRunId: string | null;
   viewBeforeWorkflowDetail: Exclude<MainView, OverlayView>;
   activeAcpRunId: string | null;
@@ -423,6 +459,16 @@ export interface ViewerActions {
   toggleActivitySteps: (payload: ActivityStepsPayload) => void;
   closeActivitySteps: () => void;
 
+  // --- Message files panel ---
+  openMessageFiles: (payload: MessageFilesPayload) => void;
+  /**
+   * Open the files panel for `payload`, or close it when the panel is already
+   * showing the SAME message. Powers the overflow tile, where clicking the
+   * already-open tile dismisses the panel.
+   */
+  toggleMessageFiles: (payload: MessageFilesPayload) => void;
+  closeMessageFiles: () => void;
+
   // --- Channel setup ---
   openChannelSetup: (payload: ChannelSetupPayload) => void;
   closeChannelSetup: () => void;
@@ -471,6 +517,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeToolDetail: "chat",
   activeActivitySteps: null,
   viewBeforeActivitySteps: "chat",
+  activeMessageFiles: null,
+  viewBeforeMessageFiles: "chat",
   activeWorkflowRunId: null,
   viewBeforeWorkflowDetail: "chat",
   activeAcpRunId: null,
@@ -741,6 +789,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       case "activity-steps":
         get().closeActivitySteps();
         return true;
+      case "message-files":
+        get().closeMessageFiles();
+        return true;
       case "workflow-detail":
         get().closeWorkflowDetail();
         return true;
@@ -856,6 +907,40 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     set({
       mainView: get().viewBeforeActivitySteps,
       activeActivitySteps: null,
+    });
+  },
+
+  // --- Message files panel ---
+
+  openMessageFiles: (payload) => {
+    set({
+      mainView: "message-files",
+      activeMessageFiles: payload,
+      viewBeforeMessageFiles: resolveViewBefore(
+        get(),
+        "viewBeforeMessageFiles",
+      ),
+    });
+  },
+
+  toggleMessageFiles: (payload) => {
+    const state = get();
+    const active = state.activeMessageFiles;
+    const isSameTarget =
+      state.mainView === "message-files" &&
+      active != null &&
+      sameMessageFilesTarget(active, payload);
+    if (isSameTarget) {
+      get().closeMessageFiles();
+    } else {
+      get().openMessageFiles(payload);
+    }
+  },
+
+  closeMessageFiles: () => {
+    set({
+      mainView: get().viewBeforeMessageFiles,
+      activeMessageFiles: null,
     });
   },
 

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for the imperative `navigateToConversation` navigator.
+ * Unit tests for the imperative `navigateToConversation` and
+ * `navigateToNewConversation` navigators.
  *
- * Focus: it resets stale viewer state (main view, subagent / workflow panels),
- * updates the active conversation, and fires exactly one haptic tap — unless
- * the caller opts out via `{ silent: true }`. The fork action taps at action
- * start and routes navigation through this helper, so it relies on `silent`
- * to avoid a double buzz.
+ * Focus: they reset stale viewer state (main view, subagent / workflow panels,
+ * transcript side-panel payloads), update the active conversation, and fire
+ * exactly one haptic tap, unless the caller opts out via `{ silent: true }`.
+ * The fork action taps at action start and routes navigation through this
+ * helper, so it relies on `silent` to avoid a double buzz.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -15,9 +16,12 @@ import { routes } from "@/utils/routes";
 
 const hapticLight = mock(() => {});
 const setMainView = mock((_view: string) => {});
+const clearTranscriptPanelPayloads = mock(() => {});
 const subagentReset = mock(() => {});
 const workflowReset = mock(() => {});
 const setActiveConversationId = mock((_id: string) => {});
+const playSound = mock((_name: string) => Promise.resolve());
+const composerFocus = mock(() => {});
 
 mock.module("@/utils/haptics", () => ({
   haptic: {
@@ -28,7 +32,15 @@ mock.module("@/utils/haptics", () => ({
   },
 }));
 mock.module("@/stores/viewer-store", () => ({
-  useViewerStore: { getState: () => ({ setMainView }) },
+  useViewerStore: {
+    getState: () => ({ setMainView, clearTranscriptPanelPayloads }),
+  },
+}));
+mock.module("@/lib/sounds/sound-manager", () => ({
+  getSoundManager: () => ({ play: playSound }),
+}));
+mock.module("@/domains/chat/composer-focus", () => ({
+  requestComposerFocus: composerFocus,
 }));
 mock.module("@/domains/chat/subagent-store", () => ({
   useSubagentStore: { getState: () => ({ reset: subagentReset }) },
@@ -43,15 +55,19 @@ mock.module("@/stores/conversation-store", () => ({
   },
 }));
 
-const { navigateToConversation } =
-  await import("@/utils/conversation-navigation");
+const { navigateToConversation, navigateToNewConversation } = await import(
+  "@/utils/conversation-navigation"
+);
 
 beforeEach(() => {
   hapticLight.mockClear();
   setMainView.mockClear();
+  clearTranscriptPanelPayloads.mockClear();
   subagentReset.mockClear();
   workflowReset.mockClear();
   setActiveConversationId.mockClear();
+  playSound.mockClear();
+  composerFocus.mockClear();
   activeConversationId = null;
 });
 
@@ -104,15 +120,46 @@ describe("navigateToConversation", () => {
     expect(setMainView).toHaveBeenCalledWith("chat");
     expect(subagentReset).not.toHaveBeenCalled();
     expect(workflowReset).not.toHaveBeenCalled();
+    expect(clearTranscriptPanelPayloads).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-1"));
   });
 
-  test("genuine switch still resets subagent/workflow state", () => {
+  test("genuine switch resets subagent/workflow state and panel payloads", () => {
     activeConversationId = "conv-1";
     const navigate = mock((_to: string) => {});
     navigateToConversation(navigate as unknown as NavigateFunction, "conv-2");
 
     expect(subagentReset).toHaveBeenCalledTimes(1);
     expect(workflowReset).toHaveBeenCalledTimes(1);
+    // A files or activity-steps panel opened from the previous transcript
+    // points at a message this conversation does not contain.
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("navigateToNewConversation", () => {
+  test("resets panel payloads and process stores, taps, focuses the composer", () => {
+    activeConversationId = "conv-1";
+    const navigate = mock((_to: string) => {});
+    navigateToNewConversation(navigate as unknown as NavigateFunction);
+
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(setMainView).toHaveBeenCalledWith("chat");
+    expect(subagentReset).toHaveBeenCalledTimes(1);
+    expect(workflowReset).toHaveBeenCalledTimes(1);
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+    expect(setActiveConversationId).toHaveBeenCalledTimes(1);
+    expect(composerFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test("silent suppresses the haptic and sound but still clears panel payloads", () => {
+    const navigate = mock((_to: string) => {});
+    navigateToNewConversation(navigate as unknown as NavigateFunction, {
+      silent: true,
+    });
+
+    expect(hapticLight).not.toHaveBeenCalled();
+    expect(playSound).not.toHaveBeenCalled();
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -23,8 +23,8 @@ export interface NavigateToConversationOptions {
 
 /**
  * Navigate to an existing conversation, resetting stale viewer state (main
- * view, subagent / workflow panels) and updating the active conversation in
- * the store.
+ * view, subagent / workflow panels, transcript side-panel payloads) and
+ * updating the active conversation in the store.
  *
  * Pure imperative function — reads stores via `.getState()`, no React hooks.
  */
@@ -46,6 +46,7 @@ export function navigateToConversation(
   ) {
     useSubagentStore.getState().reset();
     useWorkflowStore.getState().reset();
+    useViewerStore.getState().clearTranscriptPanelPayloads();
   }
   useConversationStore.getState().setActiveConversationId(conversationId);
   void navigate(
@@ -64,8 +65,9 @@ export interface NavigateToNewConversationOptions {
 /**
  * Create a fresh draft conversation and navigate to it.
  *
- * Always resets subagent state (a subagent detail panel from a prior
- * conversation must not persist into the new draft). When `silent` is true
+ * Always resets subagent state and the transcript side-panel payloads (a
+ * subagent detail or files panel from a prior conversation must not persist
+ * into the new draft). When `silent` is true
  * (e.g. fallback after archiving the active conversation), the haptic tap
  * is suppressed.
  *
@@ -86,6 +88,7 @@ export function navigateToNewConversation(
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();
+  useViewerStore.getState().clearTranscriptPanelPayloads();
   const draftId = createDraftConversationId();
   useConversationStore.getState().setActiveConversationId(draftId);
 


### PR DESCRIPTION
## Summary

An assistant message with more than 5 attachments now renders the first 5 squares plus a `+N` overflow tile. Clicking that tile opens a side panel listing **every** attachment on that message — a right drawer on desktop, a full-screen portal overlay on mobile — mirroring the existing activity-steps panel at every layer (shared `AnimatedRightDrawer`, `DetailShell` chrome, Escape / Android-back close, live re-derive from the transcript).

The cap is **type-blind**: images, videos, PDFs, PowerPoints and zips all count toward the limit and all appear in the panel. Panel tiles reuse the shared preview modal, so gallery prev/next and hover-download work unchanged.

## Scope

Assistant messages only. User-message bubbles (`BubbleAttachments`) and tool-result images are deliberately out of scope and render exactly as before.

## PRs merged into this branch

- #39856 — add the `message-files` overlay view to the viewer store
- #39854 — cap assistant-message attachments at 5 with a `+N` overflow tile
- #39865 — open a files side panel from the attachment overflow tile
- #39881 — address self-review findings (see below)

## Self-review result

Four independent review passes ran against the merged feature. Pass 1 (external feedback) returned PASS; the other three found 19 issues, all addressed in #39881. The three that were real bugs:

- **The `+N` tile was invisible in light mode.** `--border-base` is ~1.02:1 against `--surface-base`, and the active-state `--border-hover` is byte-identical to it, so "panel open" was indistinguishable from "hovering". Now `--border-element` at rest and `--border-active` when open, verified against all three theme blocks.
- **An undecodable image (e.g. HEIC on Chromium) rendered a broken preview in the files panel** while correctly falling back to a chip in a user bubble. Root cause was deeper than a missing guard: the square painted previews as a CSS `background-image`, which has no `onError`, so the fallback could never fire outside the bubble. Image previews now render as an `<img>` with `onError`; video posters stay on CSS background since there is no fallback to swap to.
- **`useLiveMessageAttachments` conflated "message not found" with "message has no attachments"**, so a message whose attachments legitimately disappeared kept rendering the open-time snapshot forever.

Also fixed: every attachment strip subscribed to the global `mainView` and re-rendered whenever any panel anywhere opened or closed; decoded file bytes were retained across conversation switches; and the thrice-duplicated attachment-square rendering block and transcript message lookup were extracted per AGENTS.md's extract-on-second rule.

## Verification

`bunx tsc --noEmit`, `bun run lint`, and `bun run test:ci` (821 passing) are green, and CI passed on every constituent PR.

**Not yet browser-verified.** Every signal here is CI plus unit tests, which is precisely how the light-mode visibility bug survived three PRs and five Codex reviews. Worth a look before merge: a light-mode chat with 6+ attachments, confirming the tile reads as a real affordance and that panel images render (the latter exercises the `background-image` → `<img>` change).

Part of plan: message-attachment-overflow.md