### PR TITLE
feat(web): add an opt-in debug flag that unsandboxes app iframes

### DIFF
--- a/clients/web/src/components/app-viewer-container.test.tsx
+++ b/clients/web/src/components/app-viewer-container.test.tsx
@@ -13,7 +13,7 @@
  * while open.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
@@ -36,8 +36,33 @@ mock.module("@/utils/sandbox-bridge", () => ({
 }));
 
 import { AppViewerContainer } from "@/components/app-viewer-container";
+import { installAppSandboxDebugFlag } from "@/lib/app-sandbox-debug-flag";
+
+type DebugWindow = Omit<Window, "_vellumDebug"> & {
+  _vellumDebug?: { apps?: { disableIframeSandbox?: unknown } };
+};
+
+// The flag namespace is installed at boot in the real app; `main.tsx`
+// never runs under the test harness.
+installAppSandboxDebugFlag();
+spyOn(console, "warn").mockImplementation(() => {});
+spyOn(console, "info").mockImplementation(() => {});
+
+function setSandboxFlag(value: unknown): void {
+  const apps = (window as DebugWindow)._vellumDebug?.apps;
+  act(() => {
+    if (apps) {
+      apps.disableIframeSandbox = value;
+    }
+  });
+}
+
+function getIframe(): HTMLIFrameElement {
+  return document.querySelector("iframe") as HTMLIFrameElement;
+}
 
 afterEach(() => {
+  setSandboxFlag(false);
   cleanup();
   capturedOptions = undefined;
 });
@@ -152,5 +177,47 @@ describe("AppViewerContainer app actions", () => {
     renderViewer();
 
     expect(capturedOptions?.onAction).toBeUndefined();
+  });
+});
+
+describe("AppViewerContainer sandbox debug flag", () => {
+  test("sandboxes the app frame by default", () => {
+    renderViewer();
+
+    expect(getIframe().getAttribute("sandbox")).toBe(
+      "allow-scripts allow-popups allow-popups-to-escape-sandbox",
+    );
+  });
+
+  test("drops the sandbox and reloads the frame once the flag is set", () => {
+    renderViewer();
+    const sandboxed = getIframe();
+
+    setSandboxFlag(true);
+
+    const unsandboxed = getIframe();
+    expect(unsandboxed.hasAttribute("sandbox")).toBe(false);
+    // A new element, so the document reloads into the real origin instead
+    // of keeping the opaque one it was created with.
+    expect(unsandboxed).not.toBe(sandboxed);
+  });
+
+  test("restores the sandbox when the flag goes back to false", () => {
+    renderViewer();
+
+    setSandboxFlag(true);
+    setSandboxFlag(false);
+
+    expect(getIframe().getAttribute("sandbox")).toBe(
+      "allow-scripts allow-popups allow-popups-to-escape-sandbox",
+    );
+  });
+
+  test("ignores truthy values that are not the literal true", () => {
+    renderViewer();
+
+    setSandboxFlag("true");
+
+    expect(getIframe().hasAttribute("sandbox")).toBe(true);
   });
 });

--- a/clients/web/src/components/app-viewer-container.tsx
+++ b/clients/web/src/components/app-viewer-container.tsx
@@ -4,9 +4,18 @@ import { Minimize2 } from "lucide-react";
 
 import { AppNavBar } from "@/components/app-nav-bar";
 import { useSandboxFetchProxy } from "@/hooks/use-sandbox-fetch-proxy";
+import { useAppIframeSandboxDisabled } from "@/lib/app-sandbox-debug-flag";
 import { cn } from "@/utils/misc";
 import { injectBridge } from "@/utils/sandbox-bridge";
 import { Button } from "@vellumai/design-library";
+
+/**
+ * Sandbox tokens the app frame runs under. No `allow-same-origin`, so the
+ * app document is opaque-origin and reaches the host only through the
+ * bridge in `@/utils/sandbox-bridge`.
+ */
+const APP_IFRAME_SANDBOX =
+  "allow-scripts allow-popups allow-popups-to-escape-sandbox";
 
 export interface AppViewerContainerProps {
   appId: string;
@@ -80,13 +89,19 @@ export function AppViewerContainer({
     [html, appId, route],
   );
 
+  const sandboxDisabled = useAppIframeSandboxDisabled();
+
+  // The sandbox flag is part of the key: a frame keeps the security
+  // context it was created with, so flipping the attribute on a live
+  // iframe changes nothing. Re-keying remounts it, which reloads the
+  // document under the attribute in effect.
   const iframeKey = useMemo(() => {
     let hash = 0;
     for (let i = 0; i < html.length; i++) {
       hash = ((hash << 5) - hash + html.charCodeAt(i)) | 0;
     }
-    return `app-${appId}-${hash}`;
-  }, [html, appId]);
+    return `app-${appId}-${hash}${sandboxDisabled ? "-nosandbox" : ""}`;
+  }, [html, appId, sandboxDisabled]);
 
   useSandboxFetchProxy(iframeRef, {
     frameId: appId,
@@ -139,7 +154,7 @@ export function AppViewerContainer({
           ref={iframeRef}
           key={iframeKey}
           srcDoc={srcdoc}
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+          sandbox={sandboxDisabled ? undefined : APP_IFRAME_SANDBOX}
           referrerPolicy="no-referrer"
           title={appName}
           className="h-full w-full border-none"

--- a/clients/web/src/lib/app-sandbox-debug-flag.test.ts
+++ b/clients/web/src/lib/app-sandbox-debug-flag.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the `window._vellumDebug.apps.disableIframeSandbox` flag: the
+ * default-off contract, the literal-`true` requirement, the warning the
+ * setter logs, and the subscriber notification the app viewer re-keys on.
+ *
+ * The flag is module state, so every test resets it through the public
+ * setter (the window accessor) in `afterEach`.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import {
+  installAppSandboxDebugFlag,
+  isAppIframeSandboxDisabled,
+} from "@/lib/app-sandbox-debug-flag";
+
+type DebugWindow = Omit<Window, "_vellumDebug"> & {
+  _vellumDebug?: Record<string, unknown>;
+};
+
+function apps(): Record<string, unknown> {
+  const root = (window as DebugWindow)._vellumDebug;
+  return root?.apps as Record<string, unknown>;
+}
+
+const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+const infoSpy = spyOn(console, "info").mockImplementation(() => {});
+
+beforeEach(() => {
+  delete (window as DebugWindow)._vellumDebug;
+  installAppSandboxDebugFlag();
+  warnSpy.mockClear();
+  infoSpy.mockClear();
+});
+
+afterEach(() => {
+  apps().disableIframeSandbox = false;
+  delete (window as DebugWindow)._vellumDebug;
+});
+
+describe("app sandbox debug flag", () => {
+  test("installs an `apps` namespace and defaults to off", () => {
+    expect(apps()).toBeDefined();
+    expect(apps().disableIframeSandbox).toBe(false);
+    expect(isAppIframeSandboxDisabled()).toBe(false);
+  });
+
+  test("keeps namespaces other debug domains already attached", () => {
+    (window as DebugWindow)._vellumDebug = { chat: "existing-chat-api" };
+
+    installAppSandboxDebugFlag();
+
+    expect((window as DebugWindow)._vellumDebug?.chat).toBe(
+      "existing-chat-api",
+    );
+    expect(apps().disableIframeSandbox).toBe(false);
+  });
+
+  test("a literal true turns the flag on and warns", () => {
+    apps().disableIframeSandbox = true;
+
+    expect(isAppIframeSandboxDisabled()).toBe(true);
+    expect(apps().disableIframeSandbox).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("disableIframeSandbox = true");
+  });
+
+  test("truthy values that are not the literal true leave it off", () => {
+    for (const value of ["true", 1, {}, [], "yes"]) {
+      apps().disableIframeSandbox = value;
+
+      expect(isAppIframeSandboxDisabled()).toBe(false);
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("setting it back to false restores the sandbox", () => {
+    apps().disableIframeSandbox = true;
+    apps().disableIframeSandbox = false;
+
+    expect(isAppIframeSandboxDisabled()).toBe(false);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-setting the current value neither warns nor re-notifies", () => {
+    apps().disableIframeSandbox = true;
+    apps().disableIframeSandbox = true;
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a fresh install does not reset a flag already set", () => {
+    apps().disableIframeSandbox = true;
+
+    installAppSandboxDebugFlag();
+
+    expect(apps().disableIframeSandbox).toBe(true);
+  });
+});

--- a/clients/web/src/lib/app-sandbox-debug-flag.ts
+++ b/clients/web/src/lib/app-sandbox-debug-flag.ts
@@ -1,0 +1,115 @@
+/**
+ * Opt-in debug flag that drops the `sandbox` attribute from app iframes.
+ *
+ * Apps render as `srcdoc` inside `sandbox="allow-scripts"` (no
+ * `allow-same-origin`), so the app document gets an opaque origin. Every
+ * API gated on a real security origin fails there: `getDisplayMedia()`
+ * rejects with `SecurityError: Invalid security origin`. Dropping
+ * `sandbox` gives the frame the host's origin, which is what those APIs
+ * need, at the cost of the isolation the sandbox buys: the app document
+ * runs same-origin with the host and can reach its DOM, storage, and
+ * cookies.
+ *
+ * That trade is why the flag is off unless a developer types it, in
+ * DevTools, on the session they want it:
+ *
+ *   window._vellumDebug.apps.disableIframeSandbox = true
+ *
+ * Only the literal `true` enables it. The value lives in memory (a page
+ * reload restores the sandbox) and flipping it logs a console warning
+ * that stays in the transcript for the rest of the session.
+ *
+ * The flag ships in production builds. It exists to demo screen-capture
+ * apps against platform-hosted assistants, which run production
+ * bundles, so it must not be compiled out.
+ *
+ * @see {@link @/components/app-viewer-container} for the consumer, which
+ *   re-keys the iframe on every change so the frame reloads under the
+ *   attribute in effect.
+ */
+
+import { useSyncExternalStore } from "react";
+
+const ROOT_NS = "_vellumDebug";
+const APPS_NS = "apps";
+const FLAG_KEY = "disableIframeSandbox";
+
+let sandboxDisabled = false;
+const listeners = new Set<() => void>();
+
+/** Whether app iframes currently render without a `sandbox` attribute. */
+export function isAppIframeSandboxDisabled(): boolean {
+  return sandboxDisabled;
+}
+
+function setAppIframeSandboxDisabled(value: unknown): void {
+  const next = value === true;
+  if (next === sandboxDisabled) {
+    return;
+  }
+  sandboxDisabled = next;
+  if (next) {
+    console.warn(
+      `[vellumDebug] ${APPS_NS}.${FLAG_KEY} = true: app iframes render without ` +
+        "the sandbox attribute. App HTML runs same-origin with the host and can " +
+        "reach its DOM, storage, and cookies. Open apps reload to pick this up. " +
+        "Set it back to false, or reload the page, to restore the sandbox.",
+    );
+  } else {
+    console.info(
+      `[vellumDebug] ${APPS_NS}.${FLAG_KEY} = false: app iframes are sandboxed again.`,
+    );
+  }
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+/**
+ * Subscribe a component to the flag. Returns `false` until someone sets
+ * `window._vellumDebug.apps.disableIframeSandbox = true`, and re-renders
+ * the caller on every change.
+ */
+export function useAppIframeSandboxDisabled(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    isAppIframeSandboxDisabled,
+    () => false,
+  );
+}
+
+/**
+ * Attach the `apps` namespace to `window._vellumDebug`, siblings of the
+ * `chat` and `events` namespaces installed from the chat page.
+ *
+ * The flag is an accessor rather than a plain property so a console
+ * assignment is observable: the setter is what warns and notifies
+ * mounted viewers. Called once at boot so the namespace is there before
+ * an app is open, and safe to call again (the property is
+ * `configurable`). No-op on the server.
+ */
+export function installAppSandboxDebugFlag(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const win = window as Omit<Window, typeof ROOT_NS> & {
+    [ROOT_NS]?: Record<string, unknown>;
+  };
+  const root = win[ROOT_NS] ?? {};
+  const apps = (root[APPS_NS] as Record<string, unknown> | undefined) ?? {};
+  Object.defineProperty(apps, FLAG_KEY, {
+    configurable: true,
+    enumerable: true,
+    get: isAppIframeSandboxDisabled,
+    set: setAppIframeSandboxDisabled,
+  });
+  root[APPS_NS] = apps;
+  win[ROOT_NS] = root;
+}

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -10,6 +10,7 @@ import { RouterProvider } from "react-router";
 
 import { AppProviders } from "@/components/providers";
 import { WindowDragRegion } from "@/components/window-drag-region";
+import { installAppSandboxDebugFlag } from "@/lib/app-sandbox-debug-flag";
 import { isChunkLoadError } from "@/lib/chunk-errors";
 import { setupClientFlagScopeSync } from "@/lib/feature-flags/client-flag-scope";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
@@ -50,6 +51,9 @@ async function boot() {
   }
   initSessionReplay();
   installConsentRefreshListeners();
+  // Namespace only. The flag it exposes stays off until a developer sets
+  // it from the console.
+  installAppSandboxDebugFlag();
 
   setupOrganizationStore();
   // Register before initSession so no identity transition is missed: client


### PR DESCRIPTION
## Prompt / plan

Apps render as `srcdoc` inside `sandbox="allow-scripts"` with no `allow-same-origin`, so the app document has an opaque origin. Anything gated on a real security origin fails there: `getDisplayMedia()` rejects with `SecurityError: Invalid security origin`, which blocks demoing screen-capture apps. Verified in Chromium that dropping the `sandbox` attribute, with a forced frame reload so the new attribute takes effect, is what fixes it.

The ask was a debug flag for that, matching the existing `_vellumDebug.chat` / `_vellumDebug.events` namespacing.

What landed:

- `clients/web/src/lib/app-sandbox-debug-flag.ts` installs `window._vellumDebug.apps.disableIframeSandbox` as an accessor property, so a console assignment is observable. The setter warns, and notifies subscribers.
- `AppViewerContainer` reads the flag through `useSyncExternalStore` and folds it into the iframe `key`. A frame keeps the security context it was created with, so re-keying is what makes the document reload into the host origin instead of the opaque one. The sandbox tokens move to an `APP_IFRAME_SANDBOX` constant.
- Installed once at boot in `main.tsx`, so the namespace exists before an app is open.

Guardrails, since this trades away the iframe's isolation (app HTML then runs same-origin with the host and can reach its DOM, storage, and cookies):

- Default off. Only the literal `true` flips it: `"true"`, `1`, and other truthy values are ignored.
- In-memory only, so a page reload restores the sandbox.
- Enabling logs a `console.warn` naming exactly what the app document can now reach.
- Not build-gated. The point is demoing against platform-hosted assistants, which serve production bundles, so compiling it out would defeat it.

Usage:

```js
window._vellumDebug.apps.disableIframeSandbox = true;
```

## Test plan

- New `src/lib/app-sandbox-debug-flag.test.ts`: install coexists with namespaces other debug domains attached, default off, literal-`true`-only, warning on enable, no re-notify on a no-op set, re-install does not clobber a set flag.
- New cases in `src/components/app-viewer-container.test.tsx`: sandboxed by default, flag drops the attribute and swaps the iframe element (the forced reload), setting it back restores the sandbox, non-literal `true` is ignored.
- `bun test` on the two files above plus `mobile-app-overlay` and `debug-api` (17 and 57 passing), `bunx tsc --noEmit`, `eslint`, and `prettier --check` all clean.
- The Chromium `getDisplayMedia()` behavior itself was verified by hand before this PR, not in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdv8GVMHqp5gYzfhNBmmrU)_