### PR TITLE
feat(chat): keep answered ask_question prompts in the transcript

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18976,6 +18976,76 @@ paths:
                                   - requestId
                                   - entries
                                 additionalProperties: false
+                              answeredQuestion:
+                                type: object
+                                properties:
+                                  requestId:
+                                    type: string
+                                  questions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        id:
+                                          type: string
+                                        question:
+                                          type: string
+                                        description:
+                                          type: string
+                                        options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                                              label:
+                                                type: string
+                                              description:
+                                                type: string
+                                            required:
+                                              - id
+                                              - label
+                                            additionalProperties: false
+                                        freeTextPlaceholder:
+                                          type: string
+                                      required:
+                                        - id
+                                        - question
+                                        - options
+                                      additionalProperties: false
+                                  responses:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        questionId:
+                                          type: string
+                                        decision:
+                                          type: string
+                                          enum:
+                                            - option
+                                            - free_text
+                                            - skipped
+                                        optionId:
+                                          type: string
+                                        text:
+                                          type: string
+                                      required:
+                                        - questionId
+                                        - decision
+                                      additionalProperties: false
+                                  overall:
+                                    type: string
+                                    enum:
+                                      - completed
+                                      - closed
+                                required:
+                                  - requestId
+                                  - questions
+                                  - responses
+                                  - overall
+                                additionalProperties: false
                             required:
                               - name
                               - input
@@ -19414,6 +19484,76 @@ paths:
                                         required:
                                           - requestId
                                           - entries
+                                        additionalProperties: false
+                                      answeredQuestion:
+                                        type: object
+                                        properties:
+                                          requestId:
+                                            type: string
+                                          questions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                id:
+                                                  type: string
+                                                question:
+                                                  type: string
+                                                description:
+                                                  type: string
+                                                options:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      id:
+                                                        type: string
+                                                      label:
+                                                        type: string
+                                                      description:
+                                                        type: string
+                                                    required:
+                                                      - id
+                                                      - label
+                                                    additionalProperties: false
+                                                freeTextPlaceholder:
+                                                  type: string
+                                              required:
+                                                - id
+                                                - question
+                                                - options
+                                              additionalProperties: false
+                                          responses:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                questionId:
+                                                  type: string
+                                                decision:
+                                                  type: string
+                                                  enum:
+                                                    - option
+                                                    - free_text
+                                                    - skipped
+                                                optionId:
+                                                  type: string
+                                                text:
+                                                  type: string
+                                              required:
+                                                - questionId
+                                                - decision
+                                              additionalProperties: false
+                                          overall:
+                                            type: string
+                                            enum:
+                                              - completed
+                                              - closed
+                                        required:
+                                          - requestId
+                                          - questions
+                                          - responses
+                                          - overall
                                         additionalProperties: false
                                     required:
                                       - name

--- a/assistant/src/__tests__/answered-question-persistence.test.ts
+++ b/assistant/src/__tests__/answered-question-persistence.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for persisting an answered `ask_question` prompt onto its tool_use
+ * block, so the question and the user's answer stay in the transcript instead
+ * of disappearing with the interactive card.
+ *
+ * Covers the write half of the round-trip:
+ *   handleToolResult(event carrying answeredQuestion)
+ *     → immediate `_answeredQuestion` stamp on the persisted row
+ *     → state.toolAnsweredQuestions captures it
+ *     → annotatePersistedAssistantMessage re-stamps at end of turn
+ *
+ * The read half (renderHistoryContent in handlers/shared.ts) lives in
+ * server-history-render.test.ts.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockedRowContent = "";
+const updates: Array<{ id: string; content: string }> = [];
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: (id: string) =>
+    mockedRowContent ? { id, content: JSON.parse(mockedRowContent) } : null,
+  updateMessageContent: (id: string, content: string) => {
+    updates.push({ id, content });
+    mockedRowContent = content;
+  },
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type { AnsweredQuestion } from "../api/events/question-answered.js";
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  handleToolResult,
+} from "../daemon/conversation-agent-loop-handlers.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const emitted: Array<Record<string, unknown>> = [];
+
+function makeDeps(): EventHandlerDeps {
+  return {
+    ctx: {
+      conversationId: "test-conv",
+      provider: { name: "anthropic" },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (event: unknown) => {
+      emitted.push(event as Record<string, unknown>);
+    },
+    reqId: "test-req",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as unknown as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "web",
+      assistantMessageInterface: "web",
+    } as unknown as EventHandlerDeps["turnInterfaceContext"],
+    applyCompaction: async () => {},
+  };
+}
+
+/**
+ * Seed a turn whose assistant row holds `toolUseIds` tool_use blocks, all of
+ * them `ask_question` unless stated otherwise. Every id is registered as
+ * in-flight, so end-of-turn annotation only runs once each has a result.
+ */
+function setupState(toolUseIds: string[]): EventHandlerState {
+  const state = createEventHandlerState();
+  state.lastAssistantMessageId = "msg-1";
+  for (const id of toolUseIds) {
+    state.toolUseIdToName.set(id, "ask_question");
+    state.toolCallTimestamps.set(id, { startedAt: Date.now() });
+    state.currentTurnToolUseIds.push(id);
+  }
+  mockedRowContent = JSON.stringify(
+    toolUseIds.map((id) => ({
+      type: "tool_use",
+      id,
+      name: "ask_question",
+      input: { questions: [{ question: "Which Alice?", options: [] }] },
+    })),
+  );
+  return state;
+}
+
+function persistedToolUse(toolUseId: string): Record<string, unknown> {
+  const parsed = JSON.parse(mockedRowContent) as Array<Record<string, unknown>>;
+  const block = parsed.find((b) => b.type === "tool_use" && b.id === toolUseId);
+  if (!block) {
+    throw new Error(`tool_use block ${toolUseId} not found`);
+  }
+  return block;
+}
+
+const ANSWERED: AnsweredQuestion = {
+  requestId: "req-1",
+  questions: [
+    {
+      id: "q1",
+      question: "Which Alice?",
+      options: [
+        { id: "alice_work", label: "Alice (work)" },
+        { id: "alice_personal", label: "Alice (personal)" },
+      ],
+    },
+  ],
+  responses: [{ questionId: "q1", decision: "option", optionId: "alice_work" }],
+  overall: "completed",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("answered ask_question persistence", () => {
+  beforeEach(() => {
+    updates.length = 0;
+    emitted.length = 0;
+    mockedRowContent = "";
+  });
+
+  test("stamps the answered record on the tool_use block and forwards it to clients", () => {
+    const state = setupState(["tu_q"]);
+
+    handleToolResult(state, makeDeps(), {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: 'Question "Which Alice?" → Option: alice_work (Alice (work))',
+      isError: false,
+      answeredQuestion: ANSWERED,
+    });
+
+    expect(persistedToolUse("tu_q")._answeredQuestion).toEqual(ANSWERED);
+    const toolResult = emitted.find((e) => e.type === "tool_result");
+    expect(toolResult?.answeredQuestion).toEqual(ANSWERED);
+  });
+
+  test("stamps immediately, before the turn's other tools have finished", () => {
+    // A batch where `ask_question` settles first: the user can switch away
+    // (forcing a history refetch) while the sibling tool still runs, so the
+    // answer must already be durable rather than waiting for end-of-turn
+    // annotation.
+    const state = setupState(["tu_q", "tu_slow"]);
+
+    handleToolResult(state, makeDeps(), {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: "answered",
+      isError: false,
+      answeredQuestion: ANSWERED,
+    });
+
+    expect(
+      state.toolCallTimestamps.get("tu_slow")?.completedAt,
+    ).toBeUndefined();
+    expect(persistedToolUse("tu_q")._answeredQuestion).toEqual(ANSWERED);
+  });
+
+  test("survives the end-of-turn annotation that re-stamps the row", () => {
+    const state = setupState(["tu_q"]);
+    const deps = makeDeps();
+
+    handleToolResult(state, deps, {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: "answered",
+      isError: false,
+      answeredQuestion: ANSWERED,
+    });
+
+    // The result above completes the turn's only tool, so annotation has
+    // already run. It writes timing metadata alongside, and must not drop the
+    // answered record it did not author.
+    const block = persistedToolUse("tu_q");
+    expect(block._answeredQuestion).toEqual(ANSWERED);
+    expect(block._startedAt).toBeNumber();
+  });
+
+  test("re-stamping the same record does not rewrite the row", () => {
+    const state = setupState(["tu_q"]);
+    const deps = makeDeps();
+
+    handleToolResult(state, deps, {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: "answered",
+      isError: false,
+      answeredQuestion: ANSWERED,
+    });
+    // Early stamp + end-of-turn annotation.
+    expect(updates).toHaveLength(2);
+
+    handleToolResult(state, deps, {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: "answered",
+      isError: false,
+      answeredQuestion: ANSWERED,
+    });
+
+    // The second result re-runs the early stamp; the identical requestId makes
+    // it a no-op, so the row is not rewritten.
+    expect(updates).toHaveLength(2);
+    expect(persistedToolUse("tu_q")._answeredQuestion).toEqual(ANSWERED);
+  });
+
+  test("leaves the block unstamped when the result carries no answered record", () => {
+    const state = setupState(["tu_q"]);
+
+    handleToolResult(state, makeDeps(), {
+      type: "tool_result",
+      toolUseId: "tu_q",
+      content: "User did not respond within timeout",
+      isError: true,
+    });
+
+    expect(persistedToolUse("tu_q")._answeredQuestion).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import type { AnsweredQuestion } from "../api/events/question-answered.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import {
@@ -547,6 +548,95 @@ describe("renderHistoryContent", () => {
     ]);
 
     expect(output.toolCalls[0].activityMetadata).toEqual(activityMetadata);
+  });
+
+  // ── Persisted answered ask_question ────────────────────────────────────────
+
+  test("hydrates a persisted _answeredQuestion onto its tool_use block", () => {
+    // Mirrors what the daemon stamps when an `ask_question` prompt settles, so
+    // the answered card rehydrates on a reopened conversation instead of the
+    // user's decision disappearing with the interactive prompt.
+    const answeredQuestion: AnsweredQuestion = {
+      requestId: "req-1",
+      questions: [
+        {
+          id: "q1",
+          question: "Which Alice?",
+          options: [
+            { id: "alice_work", label: "Alice (work)" },
+            { id: "alice_personal", label: "Alice (personal)" },
+          ],
+        },
+      ],
+      responses: [
+        { questionId: "q1", decision: "option", optionId: "alice_work" },
+      ],
+      overall: "completed",
+    };
+
+    const output = renderHistoryContent([
+      {
+        type: "tool_use",
+        id: "tu_q",
+        name: "ask_question",
+        input: { questions: [{ question: "Which Alice?" }] },
+        _answeredQuestion: answeredQuestion,
+      },
+    ]);
+
+    expect(output.toolCalls[0].answeredQuestion).toEqual(answeredQuestion);
+  });
+
+  test("hydrates a free-text answer verbatim", () => {
+    const output = renderHistoryContent([
+      {
+        type: "tool_use",
+        id: "tu_q",
+        name: "ask_question",
+        input: {},
+        _answeredQuestion: {
+          requestId: "req-2",
+          questions: [{ id: "q1", question: "Which fruit?", options: [] }],
+          responses: [
+            { questionId: "q1", decision: "free_text", text: "Cherry" },
+          ],
+          overall: "completed",
+        },
+      },
+    ]);
+
+    expect(output.toolCalls[0].answeredQuestion?.responses).toEqual([
+      { questionId: "q1", decision: "free_text", text: "Cherry" },
+    ]);
+  });
+
+  test("leaves answeredQuestion absent on rows that predate the annotation", () => {
+    const output = renderHistoryContent([
+      {
+        type: "tool_use",
+        id: "tu_q",
+        name: "ask_question",
+        input: { questions: [{ question: "Which Alice?" }] },
+      },
+    ]);
+
+    expect(output.toolCalls[0].answeredQuestion).toBeUndefined();
+  });
+
+  test("ignores a malformed _answeredQuestion annotation", () => {
+    // The card renders these contents directly, so a rider that does not match
+    // the schema must degrade to no card rather than a crashing render.
+    const output = renderHistoryContent([
+      {
+        type: "tool_use",
+        id: "tu_q",
+        name: "ask_question",
+        input: {},
+        _answeredQuestion: { requestId: "req-3", overall: "sideways" },
+      },
+    ]);
+
+    expect(output.toolCalls[0].answeredQuestion).toBeUndefined();
   });
 
   test("ignores non-object _activityMetadata annotations", () => {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,3 +1,4 @@
+import type { AnsweredQuestion } from "../api/events/question-answered.js";
 import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -289,6 +290,8 @@ export type AgentEvent =
       approvalReason?: string;
       riskThreshold?: string;
       activityMetadata?: ToolActivityMetadata;
+      /** Answered `ask_question` record (see `ToolExecutionResult.answeredQuestion`). */
+      answeredQuestion?: AnsweredQuestion;
       /** Stable machine-readable error classification (see `ToolExecutionResult.errorCode`). */
       errorCode?: string;
       /**
@@ -698,6 +701,7 @@ export type LoopToolExecutor = (
   approvalReason?: string;
   riskThreshold?: string;
   activityMetadata?: ToolActivityMetadata;
+  answeredQuestion?: AnsweredQuestion;
   errorCode?: string;
 }>;
 
@@ -2286,6 +2290,7 @@ export class AgentLoop {
             approvalReason: result.approvalReason,
             riskThreshold: result.riskThreshold,
             activityMetadata: result.activityMetadata,
+            answeredQuestion: result.answeredQuestion,
             errorCode: result.errorCode,
           });
         }

--- a/assistant/src/api/events/question-answered.ts
+++ b/assistant/src/api/events/question-answered.ts
@@ -1,0 +1,53 @@
+/**
+ * Durable record of an `ask_question` prompt the user has answered.
+ *
+ * The pending counterpart (`question_request` / `PendingToolQuestion`) is live
+ * registry state: it exists only while the prompt is outstanding and vanishes
+ * the moment the interaction resolves. This record is the opposite. It is
+ * produced by the `ask_question` executor once the prompt settles, rides the
+ * `tool_result` event, and is persisted on the tool_use block, so the answered
+ * question and the user's choice stay readable in the transcript across
+ * conversation switches, reloads, and history reopens.
+ *
+ * `questions` mirrors the `question_request` event's `questions[]` (same
+ * daemon-assigned `q1`, `q2`, ... ids) so the answered card renders from the
+ * same shape the interactive card did. `responses` is ordered to match, one
+ * entry per question.
+ *
+ * Only user-driven outcomes are recorded: a completed batch, or a card the
+ * user closed without answering (every question `skipped`). A prompt that
+ * timed out or was aborted produced no user decision, so it carries no record
+ * and the tool's own error result stands on its own.
+ *
+ * Canonical wire-contract source. Daemon code imports the type directly from
+ * this file; external consumers import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+import { QuestionEntrySchema } from "./question-request.js";
+
+export const AnsweredQuestionResponseSchema = z.object({
+  /** Daemon-assigned question id (`q1`, `q2`, ...) this answer belongs to. */
+  questionId: z.string(),
+  decision: z.enum(["option", "free_text", "skipped"]),
+  /** Chosen option id. Present only when `decision` is `"option"`. */
+  optionId: z.string().optional(),
+  /** The user's typed answer. Present only when `decision` is `"free_text"`. */
+  text: z.string().optional(),
+});
+
+export type AnsweredQuestionResponse = z.infer<
+  typeof AnsweredQuestionResponseSchema
+>;
+
+export const AnsweredQuestionSchema = z.object({
+  /** The resolved interaction's request id, matching the `question_request` that raised it. */
+  requestId: z.string(),
+  questions: z.array(QuestionEntrySchema),
+  responses: z.array(AnsweredQuestionResponseSchema),
+  /** `"completed"` when the user submitted a batch, `"closed"` when they dismissed the card. */
+  overall: z.enum(["completed", "closed"]),
+});
+
+export type AnsweredQuestion = z.infer<typeof AnsweredQuestionSchema>;

--- a/assistant/src/api/events/tool-result.ts
+++ b/assistant/src/api/events/tool-result.ts
@@ -34,6 +34,7 @@ import {
   ConfirmationDiffSchema,
   DirectoryScopeOptionSchema,
 } from "./confirmation-request.js";
+import { AnsweredQuestionSchema } from "./question-answered.js";
 
 export const RiskScopeOptionSchema = z.object({
   pattern: z.string(),
@@ -131,6 +132,12 @@ export const ToolResultEventSchema = z.object({
   approvalReason: z.string().optional(),
   riskThreshold: z.string().optional(),
   activityMetadata: ToolActivityMetadataSchema.optional(),
+  /**
+   * Set only by `ask_question`: the questions asked and the answers the user
+   * gave. Carried here so the answered card renders the instant the prompt
+   * resolves, from the same record the daemon persists on the tool_use block.
+   */
+  answeredQuestion: AnsweredQuestionSchema.optional(),
   /**
    * Stable, machine-readable classification for an error result (only set when
    * `isError`). Lets a client branch on a known failure — e.g.

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -489,6 +489,12 @@ export {
   PlatformDisconnectedEventSchema,
 } from "./events/platform-disconnected.js";
 export {
+  type AnsweredQuestion,
+  type AnsweredQuestionResponse,
+  AnsweredQuestionResponseSchema,
+  AnsweredQuestionSchema,
+} from "./events/question-answered.js";
+export {
   type QuestionEntry,
   QuestionEntrySchema,
   type QuestionOption,

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -29,6 +29,7 @@ import {
   DirectoryScopeOptionSchema,
   ScopeOptionSchema,
 } from "../events/confirmation-request.js";
+import { AnsweredQuestionSchema } from "../events/question-answered.js";
 import { QuestionEntrySchema } from "../events/question-request.js";
 import { ToolActivityMetadataSchema } from "../events/tool-result.js";
 
@@ -242,6 +243,16 @@ export const ConversationMessageToolCallSchema = z.object({
    * render time). Lets a cold reconnect restore the inline question card.
    */
   pendingQuestion: PendingToolQuestionSchema.optional(),
+  /**
+   * The answered counterpart to `pendingQuestion`: the questions an
+   * `ask_question` call asked and the answers the user gave. Persisted on the
+   * tool_use block rather than stamped from the live registry, so it survives a
+   * conversation switch, a reload, and a history reopen. A tool call carries at
+   * most one of the two: the pending prompt while it is outstanding, the
+   * answered record once it settles. Absent on history rows written before the
+   * daemon recorded it.
+   */
+  answeredQuestion: AnsweredQuestionSchema.optional(),
 });
 export type ConversationMessageToolCall = z.infer<
   typeof ConversationMessageToolCallSchema

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -11,6 +11,7 @@ import type pino from "pino";
 import { v4 as uuid } from "uuid";
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AnsweredQuestion } from "../api/events/question-answered.js";
 import type { AssistantEvent } from "../api/index.js";
 import type {
   TurnChannelContext,
@@ -333,6 +334,12 @@ export interface EventHandlerState {
    * tools (in handleToolResult) and native server tools (server_tool_complete).
    */
   readonly toolActivityMetadata: Map<string, ToolActivityMetadata>;
+  /**
+   * Answered `ask_question` records keyed by tool_use_id, captured when the
+   * result lands so the questions and the user's answers are persisted on the
+   * tool's content block and the answered card survives a history reopen.
+   */
+  readonly toolAnsweredQuestions: Map<string, AnsweredQuestion>;
   /** tool_use_ids emitted in the current turn (populated in handleToolUse, cleared after annotation). */
   currentTurnToolUseIds: string[];
   /** Wall-clock time (ms since epoch) when the agent loop turn started, used as the display timestamp for assistant messages. */
@@ -599,6 +606,7 @@ export function createEventHandlerState(): EventHandlerState {
     toolConfirmationOutcomes: new Map(),
     toolRiskOutcomes: new Map(),
     toolActivityMetadata: new Map(),
+    toolAnsweredQuestions: new Map(),
     currentTurnToolUseIds: [],
     turnStartedAt: Date.now(),
     serverToolStartedAt: new Map(),
@@ -2274,6 +2282,20 @@ export async function handleToolResult(
     state.toolActivityMetadata.set(event.toolUseId, event.activityMetadata);
   }
 
+  // Capture the answered `ask_question` record and stamp it on the durable
+  // tool_use block right away. The end-of-turn annotation re-stamps it, but
+  // that only runs once every tool in the turn has finished: a user who
+  // switches conversations while a sibling tool is still running would
+  // otherwise reload into history that has lost their answer.
+  if (event.answeredQuestion) {
+    state.toolAnsweredQuestions.set(event.toolUseId, event.answeredQuestion);
+    recordAnsweredQuestionOnPersistedMessage(
+      state,
+      event.toolUseId,
+      event.answeredQuestion,
+    );
+  }
+
   const toolName = state.toolUseIdToName.get(event.toolUseId);
   if (toolName === "file_write" || toolName === "bash") {
     deps.ctx.markWorkspaceTopLevelDirty();
@@ -2357,6 +2379,7 @@ export async function handleToolResult(
     approvalReason: event.approvalReason,
     riskThreshold: event.riskThreshold,
     activityMetadata: event.activityMetadata,
+    answeredQuestion: event.answeredQuestion,
     errorCode: event.errorCode,
     completedAt,
   });
@@ -2377,18 +2400,23 @@ export async function handleToolResult(
 }
 
 /**
- * Stamp `_startedAt` onto the in-flight tool_use block in the persisted
- * assistant message the moment the tool begins. The block is already durable
- * (message_complete precedes tool events), so without this a `/messages`
- * snapshot fetched mid-tool would carry no start time and clients could not
- * render a running elapsed-time counter until the whole turn finished. The
- * full timing + risk annotation still happens in
- * `annotatePersistedAssistantMessage` once every tool in the turn completes.
+ * Stamp vellum-internal metadata onto an in-flight tool_use block in the
+ * persisted assistant message, ahead of the turn's end-of-turn annotation. The
+ * block is already durable (message_complete precedes tool events), so without
+ * an early stamp a `/messages` snapshot fetched mid-turn carries none of it and
+ * clients render a degraded row until every tool in the turn has finished.
+ *
+ * `apply` mutates the block record and returns false when the value is already
+ * stamped, which skips the write. The write itself is best-effort:
+ * `annotatePersistedAssistantMessage` re-stamps from the same state maps once
+ * the turn's tools complete, so a transient `SQLITE_BUSY` here must not abort
+ * the turn. `what` names the field for the failure log.
  */
-function recordToolStartOnPersistedMessage(
+function stampToolUseBlockEarly(
   state: EventHandlerState,
   toolUseId: string,
-  startedAt: number,
+  what: string,
+  apply: (block: Record<string, unknown>) => boolean,
 ): void {
   const messageId = state.lastAssistantMessageId;
   if (!messageId) {
@@ -2410,19 +2438,15 @@ function recordToolStartOnPersistedMessage(
     if (rec.id !== toolUseId) {
       continue;
     }
-    if (rec._startedAt === startedAt) {
+    if (!apply(rec)) {
       return;
     }
-    rec._startedAt = startedAt;
-    // Best-effort early stamp: `annotatePersistedAssistantMessage` re-stamps
-    // once every tool in the turn completes, so a transient `SQLITE_BUSY` here
-    // must not abort the turn — the end-of-turn write recovers it.
     try {
       updateMessageContent(messageId, JSON.stringify(content));
     } catch (err) {
       log.error(
         { err, messageId },
-        "stamping tool start time failed; end-of-turn annotation will recover",
+        `stamping ${what} failed; end-of-turn annotation will recover`,
       );
     }
     return;
@@ -2430,57 +2454,63 @@ function recordToolStartOnPersistedMessage(
 }
 
 /**
- * Stamp `_previewStartedAt` (the first-byte timestamp) onto the durable
- * tool_use block, mirroring `recordToolStartOnPersistedMessage`. Called from
- * `handleToolUse` rather than `handleToolUsePreviewStart`: the block only exists
- * once message_complete has written it, which happens after the preview event
- * but before the tool event. Without this a `/messages` snapshot fetched
- * mid-tool would lose the perceived-start anchor and clients would fall back to
- * execution start — hiding the input-streaming gap the user actually waited
- * through.
+ * Stamp `_startedAt` the moment the tool begins, so a mid-tool `/messages`
+ * snapshot can render a running elapsed-time counter.
+ */
+function recordToolStartOnPersistedMessage(
+  state: EventHandlerState,
+  toolUseId: string,
+  startedAt: number,
+): void {
+  stampToolUseBlockEarly(state, toolUseId, "tool start time", (rec) => {
+    if (rec._startedAt === startedAt) {
+      return false;
+    }
+    rec._startedAt = startedAt;
+    return true;
+  });
+}
+
+/**
+ * Stamp `_previewStartedAt` (the first-byte timestamp). Called from
+ * `handleToolUse` rather than `handleToolUsePreviewStart`: the block only
+ * exists once message_complete has written it, which happens after the preview
+ * event but before the tool event. Without it a mid-tool `/messages` snapshot
+ * loses the perceived-start anchor and clients fall back to execution start,
+ * hiding the input-streaming gap the user actually waited through.
  */
 function recordToolPreviewStartOnPersistedMessage(
   state: EventHandlerState,
   toolUseId: string,
   previewStartedAt: number,
 ): void {
-  const messageId = state.lastAssistantMessageId;
-  if (!messageId) {
-    return;
-  }
-
-  const row = getMessageById(messageId);
-  if (!row) {
-    return;
-  }
-
-  const content: ContentBlock[] = row.content;
-
-  for (const block of content) {
-    if (block.type !== "tool_use") {
-      continue;
-    }
-    const rec = block as unknown as Record<string, unknown>;
-    if (rec.id !== toolUseId) {
-      continue;
-    }
+  stampToolUseBlockEarly(state, toolUseId, "tool preview-start time", (rec) => {
     if (rec._previewStartedAt === previewStartedAt) {
-      return;
+      return false;
     }
     rec._previewStartedAt = previewStartedAt;
-    // Best-effort early stamp, mirroring `recordToolStartOnPersistedMessage`:
-    // `annotatePersistedAssistantMessage` re-stamps at end of turn, so a
-    // transient `SQLITE_BUSY` here must not abort the turn.
-    try {
-      updateMessageContent(messageId, JSON.stringify(content));
-    } catch (err) {
-      log.error(
-        { err, messageId },
-        "stamping tool preview-start time failed; end-of-turn annotation will recover",
-      );
+    return true;
+  });
+}
+
+/**
+ * Stamp `_answeredQuestion` the moment an `ask_question` prompt settles, so a
+ * user who leaves the conversation while a sibling tool is still running comes
+ * back to their answer rather than to a question that lost its response.
+ */
+function recordAnsweredQuestionOnPersistedMessage(
+  state: EventHandlerState,
+  toolUseId: string,
+  answeredQuestion: AnsweredQuestion,
+): void {
+  stampToolUseBlockEarly(state, toolUseId, "answered question", (rec) => {
+    const existing = rec._answeredQuestion as AnsweredQuestion | undefined;
+    if (existing?.requestId === answeredQuestion.requestId) {
+      return false;
     }
-    return;
-  }
+    rec._answeredQuestion = answeredQuestion;
+    return true;
+  });
 }
 
 /**
@@ -2578,6 +2608,11 @@ function annotatePersistedAssistantMessage(
       const activity = state.toolActivityMetadata.get(id);
       if (activity) {
         rec._activityMetadata = activity;
+        modified = true;
+      }
+      const answeredQuestion = state.toolAnsweredQuestions.get(id);
+      if (answeredQuestion) {
+        rec._answeredQuestion = answeredQuestion;
         modified = true;
       }
     }

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -2504,8 +2504,18 @@ function recordAnsweredQuestionOnPersistedMessage(
   answeredQuestion: AnsweredQuestion,
 ): void {
   stampToolUseBlockEarly(state, toolUseId, "answered question", (rec) => {
-    const existing = rec._answeredQuestion as AnsweredQuestion | undefined;
-    if (existing?.requestId === answeredQuestion.requestId) {
+    // Narrow the persisted marker rather than casting it: the row is data read
+    // back from the database, so its shape is an assumption until checked. Any
+    // value that is not a record with a string `requestId` is treated as absent
+    // and overwritten, which is the safe direction for a dedup check.
+    const existing: unknown = rec._answeredQuestion;
+    const existingRequestId =
+      typeof existing === "object" &&
+      existing !== null &&
+      typeof (existing as { requestId?: unknown }).requestId === "string"
+        ? (existing as { requestId: string }).requestId
+        : undefined;
+    if (existingRequestId === answeredQuestion.requestId) {
       return false;
     }
     rec._answeredQuestion = answeredQuestion;

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -4,6 +4,7 @@ import {
 } from "@vellumai/service-contracts/redacted-credential";
 import { v4 as uuid } from "uuid";
 
+import { AnsweredQuestionSchema } from "../../api/events/question-answered.js";
 import type {
   ConversationContentBlock,
   ConversationMessageAttachment,
@@ -635,6 +636,17 @@ export function renderHistoryContent(
       if (isRecord(block._activityMetadata)) {
         entry.activityMetadata =
           block._activityMetadata as HistoryToolCall["activityMetadata"];
+      }
+      // Read back the answered `ask_question` record so the answered card
+      // rehydrates from history. Validated (rather than trusted like the
+      // sibling riders) because the card renders its contents directly: a
+      // malformed rider from a hand-edited or partially-written row must
+      // degrade to no card, not to a crashing render.
+      const answeredQuestion = AnsweredQuestionSchema.safeParse(
+        block._answeredQuestion,
+      );
+      if (answeredQuestion.success) {
+        entry.answeredQuestion = answeredQuestion.data;
       }
       toolCalls.push(entry);
       if (id) {

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -200,6 +200,8 @@ describe("QuestionPrompter", () => {
 
     const result = await promise;
     expect(result).toEqual({
+      requestId: req.requestId,
+      questions: req.questions,
       entries: [{ questionId: "q1", decision: "option", optionId: "a" }],
       overall: "completed",
     });
@@ -255,6 +257,8 @@ describe("QuestionPrompter", () => {
 
     const result = await promise;
     expect(result).toEqual({
+      requestId: req.requestId,
+      questions: req.questions,
       entries: [{ questionId: "q1", decision: "free_text", text: "Cherry" }],
       overall: "completed",
     });

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import type {
+  QuestionEntry,
   QuestionOption,
   QuestionRequestEvent,
 } from "../api/events/question-request.js";
@@ -57,6 +58,18 @@ export interface QuestionPromptEntryResult {
 export interface QuestionPromptResult {
   entries: QuestionPromptEntryResult[];
   overall: "completed" | "closed" | "timed_out" | "aborted";
+}
+
+/**
+ * What {@link QuestionPrompter.prompt} returns: the resolution plus the
+ * identity of the prompt that produced it. `requestId` and `questions` are
+ * known only to the prompter (it mints the id and assigns the per-question
+ * ids), and the `ask_question` executor needs both to record the durable
+ * answered-question payload against the questions as they were asked.
+ */
+export interface QuestionPromptOutcome extends QuestionPromptResult {
+  requestId: string;
+  questions: QuestionEntry[];
 }
 
 export interface QuestionPromptParamsEntry {
@@ -170,7 +183,7 @@ export interface QuestionBatchMetadata {
  * fires when a prompt is left open with no response and no follow-up message.
  */
 export class QuestionPrompter {
-  async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
+  async prompt(params: QuestionPromptParams): Promise<QuestionPromptOutcome> {
     const { conversationId, questions, toolUseId, signal } = params;
 
     if (questions.length === 0) {
@@ -195,8 +208,12 @@ export class QuestionPrompter {
       optionsById[e.id] = e.options.map((o) => o.id);
     }
 
+    const requestId = uuid();
+
     if (signal?.aborted) {
       return {
+        requestId,
+        questions: entries,
         entries: orderedIds.map((id) => ({
           questionId: id,
           decision: "aborted",
@@ -205,9 +222,7 @@ export class QuestionPrompter {
       };
     }
 
-    const requestId = uuid();
-
-    return new Promise<QuestionPromptResult>((resolve, reject) => {
+    const settled = new Promise<QuestionPromptResult>((resolve, reject) => {
       const timeoutMs = getConfig().timeouts.questionResponseTimeoutSec * 1000;
 
       // Closure-scoped idempotency guard. Every resolution path (timeout,
@@ -318,5 +333,7 @@ export class QuestionPrompter {
       // single-question batch) lives in the promotion module.
       void createGuardianRequestForQuestion(msg, conversationId);
     });
+
+    return { ...(await settled), requestId, questions: entries };
   }
 }

--- a/assistant/src/runtime/routes/__tests__/question-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/question-routes.test.ts
@@ -394,4 +394,68 @@ describe("POST /v1/question-response", () => {
     // Pending interaction left in place.
     expect(pendingInteractions.get("req-legacy-multi")).toBeDefined();
   });
+
+  // A gone interaction must read as 404 for every body shape. Clients treat
+  // 404 as the terminal signal that retires a stale card; a 400 leaves the
+  // card on screen and surfaces a body-validation string the user cannot act
+  // on. The legacy shapes are the ones that matter here: the web client sends
+  // them for every single-question answer, which is the common prompt.
+  test("legacy option against a gone interaction is 404, not a validation 400", async () => {
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "req-gone", kind: "option", optionId: "yes" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+  });
+
+  test("legacy free-text against a gone interaction is 404, not a validation 400", async () => {
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "req-gone", kind: "free_text", text: "maybe" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+  });
+
+  test("close against a gone interaction is 404", async () => {
+    let thrown: unknown;
+    try {
+      await call({ body: { requestId: "req-gone", kind: "close" } });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+  });
+
+  test("legacy option against a confirmation requestId is 404, not a validation 400", async () => {
+    // Cross-talk safety has to hold for the legacy shapes too: the wrong-kind
+    // interaction carries no question metadata for the shim to read.
+    pendingInteractions.register("req-confirm-legacy", {
+      conversationId: "conv-1",
+      kind: "confirmation",
+    });
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: {
+          requestId: "req-confirm-legacy",
+          kind: "option",
+          optionId: "y",
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+    // The confirmation is left intact rather than consumed.
+    expect(pendingInteractions.get("req-confirm-legacy")).toBeDefined();
+  });
 });

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -18,6 +18,11 @@
  *
  * Cross-talk safety: pending interactions of other kinds (`confirmation`,
  * `secret`, host_*, etc.) return 404 here rather than being mis-resolved.
+ *
+ * Status ordering: a missing interaction is always 404, never a body-validation
+ * 400, whichever shape was submitted. Clients treat 404 as the terminal signal
+ * that retires a stale card, so a gone interaction reported as 400 would strand
+ * the card and surface a validation string the user cannot act on.
  */
 import { z } from "zod";
 
@@ -112,8 +117,25 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
   const response: QuestionResponseBody = parsed.data;
   const { requestId } = response;
 
-  // The legacy single-question shim needs the interaction's stashed metadata to
-  // synthesize a one-element batch; peek (don't consume) before resolving.
+  // Establish the interaction exists BEFORE normalizing the body. A missing or
+  // wrong-kind interaction is not-found regardless of which body shape asked,
+  // and the legacy shim below reads its stashed metadata: normalizing first
+  // would surface a gone interaction as a body-validation 400, telling the
+  // client its payload was malformed when the real answer is that there is
+  // nothing left to answer. Clients rely on 404 being the terminal signal that
+  // retires a stale card, so the status has to be right for every shape.
+  // Peek, don't consume; `resolvePendingQuestion` performs the real consume.
+  const interaction = pendingInteractions.get(requestId);
+  if (!interaction || interaction.kind !== "question") {
+    log.warn(
+      { requestId },
+      "Question response for unknown or wrong-kind requestId",
+    );
+    throw new NotFoundError(
+      "No pending question interaction found for this requestId",
+    );
+  }
+
   let input;
   try {
     input =
@@ -121,10 +143,7 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
         ? ({ kind: "close" } as const)
         : ({
             kind: "submit",
-            submissions: buildSubmissions(
-              response,
-              pendingInteractions.get(requestId),
-            ),
+            submissions: buildSubmissions(response, interaction),
           } as const);
   } catch (err) {
     if (err instanceof QuestionBatchValidationError) {
@@ -135,11 +154,10 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
 
   const outcome = resolvePendingQuestion(requestId, input);
 
+  // Still reachable: the interaction can be consumed between the peek above and
+  // the resolve (a channel answer, a timeout firing).
   if (outcome.status === "not_found") {
-    log.warn(
-      { requestId },
-      "Question response for unknown or wrong-kind requestId",
-    );
+    log.warn({ requestId }, "Question interaction resolved before submission");
     throw new NotFoundError(
       "No pending question interaction found for this requestId",
     );

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type {
+  QuestionPromptOutcome,
   QuestionPromptParams,
   QuestionPromptResult,
 } from "../../permissions/question-prompter.js";
@@ -25,16 +26,22 @@ function setNextResult(result: QuestionPromptResult): void {
 
 mock.module("../../permissions/question-prompter.js", () => ({
   QuestionPrompter: class {
-    async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
+    async prompt(params: QuestionPromptParams): Promise<QuestionPromptOutcome> {
       calls.push(params);
-      return nextResult;
+      // Mirror the real prompter: it mints the request id and assigns the
+      // per-question `q1..qN` ids, then returns them alongside the resolution.
+      return {
+        requestId: "req-stub",
+        questions: params.questions.map((q, i) => ({ id: `q${i + 1}`, ...q })),
+        ...nextResult,
+      };
     }
   },
 }));
 
 // Import after the mock so the tool's `import { QuestionPrompter }` binds
 // to the stub class above.
-const { askQuestionTool, formatQuestionsAsTextFallback } =
+const { askQuestionTool, formatQuestionsAsTextFallback, toAnsweredQuestion } =
   await import("./ask-question-tool.js");
 
 type PromptParams = QuestionPromptParams;
@@ -708,5 +715,113 @@ describe("askQuestionTool definition (batched schema)", () => {
     // The legacy flat fields are gone.
     expect(schema.properties.question).toBeUndefined();
     expect(schema.properties.options).toBeUndefined();
+  });
+});
+
+describe("answered-question record", () => {
+  test("carries the option the user chose, keyed to the questions as asked", async () => {
+    setNextResult({
+      entries: [{ questionId: "q1", decision: "option", optionId: "b" }],
+      overall: "completed",
+    });
+
+    const result = await askQuestionTool.execute(validInput, makeContext());
+
+    expect(result.answeredQuestion).toEqual({
+      requestId: "req-stub",
+      questions: [{ id: "q1", ...singleQ }],
+      responses: [{ questionId: "q1", decision: "option", optionId: "b" }],
+      overall: "completed",
+    });
+  });
+
+  test("carries a free-text answer", async () => {
+    setNextResult({
+      entries: [{ questionId: "q1", decision: "free_text", text: "Cherry" }],
+      overall: "completed",
+    });
+
+    const result = await askQuestionTool.execute(validInput, makeContext());
+
+    expect(result.answeredQuestion?.responses).toEqual([
+      { questionId: "q1", decision: "free_text", text: "Cherry" },
+    ]);
+  });
+
+  test("records a closed card as every question skipped", async () => {
+    setNextResult({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "closed",
+    });
+
+    const result = await askQuestionTool.execute(
+      { questions: [singleQ, singleQ] },
+      makeContext(),
+    );
+
+    expect(result.answeredQuestion?.overall).toBe("closed");
+    expect(result.answeredQuestion?.responses).toEqual([
+      { questionId: "q1", decision: "skipped" },
+      { questionId: "q2", decision: "skipped" },
+    ]);
+  });
+
+  test("keeps per-question skips inside an otherwise completed batch", async () => {
+    setNextResult({
+      entries: [
+        { questionId: "q1", decision: "option", optionId: "a" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "completed",
+    });
+
+    const result = await askQuestionTool.execute(
+      { questions: [singleQ, singleQ] },
+      makeContext(),
+    );
+
+    expect(result.answeredQuestion?.responses).toEqual([
+      { questionId: "q1", decision: "option", optionId: "a" },
+      { questionId: "q2", decision: "skipped" },
+    ]);
+  });
+
+  test("records nothing for a prompt that timed out or was aborted", async () => {
+    for (const overall of ["timed_out", "aborted"] as const) {
+      setNextResult({
+        entries: [{ questionId: "q1", decision: overall }],
+        overall,
+      });
+
+      const result = await askQuestionTool.execute(validInput, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.answeredQuestion).toBeUndefined();
+    }
+  });
+
+  test("records nothing when the channel degrades to the text fallback", async () => {
+    const result = await askQuestionTool.execute(
+      validInput,
+      makeContext({ supportsDynamicUi: false }),
+    );
+
+    // No card was ever shown, so there is no answered state to keep.
+    expect(result.answeredQuestion).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("toAnsweredQuestion is undefined for non-user outcomes", () => {
+    expect(
+      toAnsweredQuestion({
+        requestId: "req-1",
+        questions: [],
+        entries: [],
+        overall: "timed_out",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-import { QuestionPrompter } from "../../permissions/question-prompter.js";
+import type {
+  AnsweredQuestion,
+  AnsweredQuestionResponse,
+} from "../../api/events/question-answered.js";
+import {
+  QuestionPrompter,
+  type QuestionPromptOutcome,
+} from "../../permissions/question-prompter.js";
 import { RiskLevel } from "../../permissions/types.js";
 import {
   invalidToolInputResult,
@@ -161,6 +168,47 @@ export function formatQuestionsAsTextFallback(
   return [header, "", blocks.join("\n\n")].join("\n");
 }
 
+/**
+ * Project a settled prompt into the durable answered-question record the
+ * daemon persists on the tool call. Returns undefined for outcomes that carry
+ * no user decision (timeout, abort), which have nothing to show in history.
+ */
+export function toAnsweredQuestion(
+  outcome: QuestionPromptOutcome,
+): AnsweredQuestion | undefined {
+  if (outcome.overall !== "completed" && outcome.overall !== "closed") {
+    return undefined;
+  }
+  const responses: AnsweredQuestionResponse[] = [];
+  for (const entry of outcome.entries) {
+    if (entry.decision === "option") {
+      responses.push({
+        questionId: entry.questionId,
+        decision: "option",
+        optionId: entry.optionId,
+      });
+    } else if (entry.decision === "free_text") {
+      responses.push({
+        questionId: entry.questionId,
+        decision: "free_text",
+        text: entry.text,
+      });
+    } else {
+      // A `completed` batch can still carry per-question skips, and a `closed`
+      // card reports every question as skipped. `timed_out` / `aborted` cannot
+      // reach here: they only ever appear on a batch-wide outcome of the same
+      // name, which is filtered above.
+      responses.push({ questionId: entry.questionId, decision: "skipped" });
+    }
+  }
+  return {
+    requestId: outcome.requestId,
+    questions: outcome.questions,
+    responses,
+    overall: outcome.overall,
+  };
+}
+
 // ── Tool ────────────────────────────────────────────────────────────
 
 /**
@@ -254,15 +302,21 @@ export const askQuestionTool = {
       return `${prefix} Skipped`;
     });
 
+    // The user's decision belongs in the transcript, not just in the string
+    // handed to the model: the daemon persists this on the tool call so the
+    // answered card survives a conversation switch, reload, or history reopen.
+    const answeredQuestion = toAnsweredQuestion(result);
+
     switch (result.overall) {
       case "completed":
-        return { content: lines.join("\n"), isError: false };
+        return { content: lines.join("\n"), isError: false, answeredQuestion };
       case "closed": {
         const summary =
           "User closed the question card without answering. All questions skipped.";
         return {
           content: [summary, ...lines].join("\n"),
           isError: false,
+          answeredQuestion,
         };
       }
       case "timed_out":

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import type { AnsweredQuestion } from "../api/events/question-answered.js";
 import type { InterfaceId } from "../channels/types.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
@@ -133,6 +134,14 @@ export interface ToolExecutionResult {
   /** Structured activity metadata for client rendering (web search, web fetch, etc).
    *  Populated by daemon-internal tools; plugins must not set this. */
   activityMetadata?: ToolActivityMetadata;
+  /**
+   * Typed side channel from the `ask_question` executor to the agent loop: the
+   * questions asked and the answers the user gave. The loop forwards it on the
+   * `tool_result` event and persists it on the tool_use block, so the answered
+   * card renders live and survives a history reopen instead of the decision
+   * disappearing with the interactive prompt. Set only by `ask_question`.
+   */
+  answeredQuestion?: AnsweredQuestion;
 }
 
 export type ProxyToolResolver = (

--- a/clients/web/src/domains/chat/answered-question.test.ts
+++ b/clients/web/src/domains/chat/answered-question.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the pure answered-question projection: how a persisted record pairs
+ * questions with responses, and whether it has anything worth rendering.
+ *
+ * The card's own rendering is covered in `answered-question-card.test.tsx`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { AnsweredQuestion } from "@vellumai/assistant-api";
+
+import {
+  hasRenderableAnswer,
+  resolveAnswers,
+} from "@/domains/chat/answered-question";
+
+const ALICE_QUESTION = {
+  id: "q1",
+  question: "Which Alice?",
+  description: "Two contacts match.",
+  options: [
+    { id: "alice_work", label: "Alice (work)", description: "Acme Corp" },
+    { id: "alice_personal", label: "Alice (personal)" },
+  ],
+};
+
+function makeAnswered(overrides: Partial<AnsweredQuestion>): AnsweredQuestion {
+  return {
+    requestId: "req-1",
+    questions: [ALICE_QUESTION],
+    responses: [
+      { questionId: "q1", decision: "option", optionId: "alice_work" },
+    ],
+    overall: "completed",
+    ...overrides,
+  };
+}
+
+describe("hasRenderableAnswer", () => {
+  // Callers hide the raw tool chip in favor of this card, so "the field is
+  // set" and "the card draws something" must be the same condition. If they
+  // diverge, a tool call renders neither and drops out of the transcript.
+  test("is false for a record with no questions", () => {
+    expect(
+      hasRenderableAnswer(makeAnswered({ questions: [], responses: [] })),
+    ).toBe(false);
+  });
+
+  test("is false when the field is absent", () => {
+    expect(hasRenderableAnswer(undefined)).toBe(false);
+  });
+
+  test("is true for a record carrying questions", () => {
+    expect(hasRenderableAnswer(makeAnswered({}))).toBe(true);
+  });
+});
+
+describe("resolveAnswers", () => {
+  test("pairs answers to questions by id, not by position", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        questions: [
+          ALICE_QUESTION,
+          {
+            id: "q2",
+            question: "Which day?",
+            options: [{ id: "mon", label: "Monday" }],
+          },
+        ],
+        // Deliberately out of order relative to `questions`.
+        responses: [
+          { questionId: "q2", decision: "option", optionId: "mon" },
+          { questionId: "q1", decision: "option", optionId: "alice_work" },
+        ],
+      }),
+    );
+
+    expect(resolved.map((r) => r.answer)).toEqual(["Alice (work)", "Monday"]);
+  });
+
+  test("reads a question with no matching response as skipped", () => {
+    const resolved = resolveAnswers(makeAnswered({ responses: [] }));
+
+    expect(resolved[0]?.kind).toBe("skipped");
+    expect(resolved[0]?.answer).toBe("Skipped");
+  });
+
+  test("reads a blank free-text answer as skipped", () => {
+    // The single-question wire shape has no `skip` kind, so a skip arrives as
+    // `free_text` with empty text. Rendering it as free text would show an
+    // empty answer row, and the raw tool chip is suppressed, so the user would
+    // see the question with no answer at all.
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [{ questionId: "q1", decision: "free_text", text: "" }],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("skipped");
+    expect(resolved[0]?.answer).toBe("Skipped");
+  });
+
+  test("reads a whitespace-only free-text answer as skipped", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [{ questionId: "q1", decision: "free_text", text: "   " }],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("skipped");
+  });
+
+  test("keeps a real free-text answer verbatim, including its spacing", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [
+          { questionId: "q1", decision: "free_text", text: "the one at Acme" },
+        ],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("free_text");
+    expect(resolved[0]?.answer).toBe("the one at Acme");
+  });
+
+  test("falls back to the raw option id when the options no longer carry it", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [
+          { questionId: "q1", decision: "option", optionId: "alice_retired" },
+        ],
+      }),
+    );
+
+    expect(resolved[0]?.answer).toBe("alice_retired");
+  });
+});

--- a/clients/web/src/domains/chat/answered-question.ts
+++ b/clients/web/src/domains/chat/answered-question.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure projection of a persisted `answeredQuestion` record into the rows the
+ * transcript renders.
+ *
+ * Kept out of the card component so the transcript can ask "is there an answer
+ * to show?" without importing UI, and so the pairing rules below are testable
+ * on their own.
+ */
+
+import type { AnsweredQuestion } from "@vellumai/assistant-api";
+
+/** The rendered answer for one question, resolved against the options as asked. */
+export interface ResolvedAnswer {
+  questionId: string;
+  question: string;
+  description?: string;
+  /** What the user chose, already resolved to display text. */
+  answer: string;
+  kind: "option" | "free_text" | "skipped";
+  /** The chosen option's own description, when it had one. */
+  answerDescription?: string;
+}
+
+/**
+ * Whether an answered record has anything to show. A record with no questions
+ * renders nothing, so a caller that hides the raw tool chip in favor of the
+ * answered card must gate on this rather than on the field's presence: keying
+ * off presence alone would leave a tool call rendering neither the card nor the
+ * chip, dropping the step out of the transcript entirely. The daemon cannot
+ * write an empty record (the prompter rejects an empty batch), but a truncated
+ * or hand-edited persisted row satisfies the wire schema, which validates the
+ * shape and not the arity.
+ */
+export function hasRenderableAnswer(
+  answered: AnsweredQuestion | undefined,
+): answered is AnsweredQuestion {
+  return answered !== undefined && answered.questions.length > 0;
+}
+
+/**
+ * Pair each question with its response. Ordering follows `questions`, not
+ * `responses`, so a record whose arrays disagree (a truncated or hand-edited
+ * row) still renders every question rather than dropping the tail. A question
+ * with no matching response reads as skipped, which is what an unanswered entry
+ * in a settled batch means.
+ */
+export function resolveAnswers(answered: AnsweredQuestion): ResolvedAnswer[] {
+  const byQuestionId = new Map(
+    answered.responses.map((response) => [response.questionId, response]),
+  );
+  return answered.questions.map((question) => {
+    const response = byQuestionId.get(question.id);
+    if (response?.decision === "option") {
+      const option = question.options.find(
+        (candidate) => candidate.id === response.optionId,
+      );
+      return {
+        questionId: question.id,
+        question: question.question,
+        description: question.description,
+        kind: "option",
+        // An unresolvable option id means the persisted record and the asked
+        // options disagree; show the raw id rather than an empty row.
+        answer: option?.label ?? response.optionId ?? "Unknown option",
+        answerDescription: option?.description,
+      };
+    }
+    // Blank free text means the user skipped. The card cannot submit an empty
+    // answer (`handleSubmitFreeText` returns early on blank input), so the only
+    // way one reaches here is the legacy single-question wire shape, which has
+    // no `skip` kind and coerces a skip to `free_text` with empty text. Reading
+    // it as free text would render a blank answer row.
+    if (response?.decision === "free_text" && response.text?.trim()) {
+      return {
+        questionId: question.id,
+        question: question.question,
+        description: question.description,
+        kind: "free_text",
+        answer: response.text,
+      };
+    }
+    return {
+      questionId: question.id,
+      question: question.question,
+      description: question.description,
+      kind: "skipped",
+      answer: "Skipped",
+    };
+  });
+}

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -720,6 +720,50 @@ describe("mapRuntimeToolCalls — confirmationDecision", () => {
   });
 });
 
+describe("mapRuntimeToolCalls — answeredQuestion", () => {
+  test("rehydrates a persisted answered ask_question record", () => {
+    // GIVEN a reopened conversation whose ask_question row carries the answer
+    const wire: ConversationMessageToolCall = {
+      id: "tu_q",
+      name: "ask_question",
+      input: { questions: [{ question: "Which Alice?" }] },
+      result: "answered",
+      answeredQuestion: {
+        requestId: "req-1",
+        questions: [
+          {
+            id: "q1",
+            question: "Which Alice?",
+            options: [{ id: "alice_work", label: "Alice (work)" }],
+          },
+        ],
+        responses: [
+          { questionId: "q1", decision: "option", optionId: "alice_work" },
+        ],
+        overall: "completed",
+      },
+    };
+
+    // WHEN it is projected onto the rendered tool call
+    const [mapped] = mapRuntimeToolCalls([wire], "msg-1");
+
+    // THEN the answered card has everything it needs from history alone
+    expect(mapped!.answeredQuestion).toEqual(wire.answeredQuestion!);
+  });
+
+  test("leaves answeredQuestion absent on rows that never carried one", () => {
+    const wire: ConversationMessageToolCall = {
+      name: "bash",
+      input: {},
+      result: "ok",
+    };
+
+    const [mapped] = mapRuntimeToolCalls([wire], "msg-1");
+
+    expect(mapped!.answeredQuestion).toBeUndefined();
+  });
+});
+
 describe("mapRuntimeToolCalls — id", () => {
   test("uses the wire-provided provider tool-use id when present", () => {
     // GIVEN a history tool call carrying the provider tool-use id on the wire

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -720,7 +720,7 @@ describe("mapRuntimeToolCalls — confirmationDecision", () => {
   });
 });
 
-describe("mapRuntimeToolCalls — answeredQuestion", () => {
+describe("mapRuntimeToolCalls: answeredQuestion", () => {
   test("rehydrates a persisted answered ask_question record", () => {
     // GIVEN a reopened conversation whose ask_question row carries the answer
     const wire: ConversationMessageToolCall = {

--- a/clients/web/src/domains/chat/components/answered-question-card.test.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.test.tsx
@@ -59,13 +59,17 @@ describe("AnsweredQuestionCard", () => {
       <AnsweredQuestionCard
         answered={makeAnswered({
           responses: [
-            { questionId: "q1", decision: "free_text", text: "Alice Zhang" },
+            {
+              questionId: "q1",
+              decision: "free_text",
+              text: "The one at Acme",
+            },
           ],
         })}
       />,
     );
 
-    expect(screen.getByText("Alice Zhang")).toBeDefined();
+    expect(screen.getByText("The one at Acme")).toBeDefined();
   });
 
   test("renders a skipped question as skipped", () => {

--- a/clients/web/src/domains/chat/components/answered-question-card.test.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.test.tsx
@@ -16,6 +16,7 @@ import type { AnsweredQuestion } from "@vellumai/assistant-api";
 
 import {
   AnsweredQuestionCard,
+  hasRenderableAnswer,
   resolveAnswers,
 } from "@/domains/chat/components/answered-question-card";
 
@@ -116,6 +117,38 @@ describe("AnsweredQuestionCard", () => {
     );
 
     expect(container.textContent).toBe("");
+  });
+});
+
+describe("hasRenderableAnswer", () => {
+  // Callers hide the raw tool chip in favor of this card, so "the field is
+  // set" and "the card draws something" must be the same condition. If they
+  // diverge, a tool call renders neither and drops out of the transcript.
+  test("is false for a record with no questions", () => {
+    expect(
+      hasRenderableAnswer(makeAnswered({ questions: [], responses: [] })),
+    ).toBe(false);
+  });
+
+  test("is false when the field is absent", () => {
+    expect(hasRenderableAnswer(undefined)).toBe(false);
+  });
+
+  test("is true for a record carrying questions", () => {
+    expect(hasRenderableAnswer(makeAnswered({}))).toBe(true);
+  });
+
+  test("agrees with what the card actually renders", () => {
+    for (const answered of [
+      makeAnswered({}),
+      makeAnswered({ questions: [], responses: [] }),
+    ]) {
+      const { container } = render(
+        <AnsweredQuestionCard answered={answered} />,
+      );
+      expect(container.textContent !== "").toBe(hasRenderableAnswer(answered));
+      cleanup();
+    }
   });
 });
 

--- a/clients/web/src/domains/chat/components/answered-question-card.test.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Tests for `AnsweredQuestionCard`, the durable transcript record of an
+ * `ask_question` prompt the user answered.
+ *
+ * The interactive prompt disappears once it resolves, so this card is the only
+ * thing that keeps the user's decision readable after a conversation switch,
+ * reload, or history reopen. It renders purely from the `answeredQuestion`
+ * record on the tool call, which is identical on the live and rehydrated paths.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type { AnsweredQuestion } from "@vellumai/assistant-api";
+
+import {
+  AnsweredQuestionCard,
+  resolveAnswers,
+} from "@/domains/chat/components/answered-question-card";
+
+afterEach(cleanup);
+
+const ALICE_QUESTION = {
+  id: "q1",
+  question: "Which Alice?",
+  description: "Two contacts match.",
+  options: [
+    { id: "alice_work", label: "Alice (work)", description: "Acme Corp" },
+    { id: "alice_personal", label: "Alice (personal)" },
+  ],
+};
+
+function makeAnswered(overrides: Partial<AnsweredQuestion>): AnsweredQuestion {
+  return {
+    requestId: "req-1",
+    questions: [ALICE_QUESTION],
+    responses: [
+      { questionId: "q1", decision: "option", optionId: "alice_work" },
+    ],
+    overall: "completed",
+    ...overrides,
+  };
+}
+
+describe("AnsweredQuestionCard", () => {
+  test("renders the question and the chosen option's label", () => {
+    render(<AnsweredQuestionCard answered={makeAnswered({})} />);
+
+    expect(screen.getByText("Which Alice?")).toBeDefined();
+    expect(screen.getByText("Two contacts match.")).toBeDefined();
+    expect(screen.getByText("Alice (work)")).toBeDefined();
+    expect(screen.getByText("Acme Corp")).toBeDefined();
+  });
+
+  test("renders a free-text answer verbatim", () => {
+    render(
+      <AnsweredQuestionCard
+        answered={makeAnswered({
+          responses: [
+            { questionId: "q1", decision: "free_text", text: "Alice Zhang" },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Alice Zhang")).toBeDefined();
+  });
+
+  test("renders a skipped question as skipped", () => {
+    render(
+      <AnsweredQuestionCard
+        answered={makeAnswered({
+          responses: [{ questionId: "q1", decision: "skipped" }],
+          overall: "closed",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Skipped")).toBeDefined();
+  });
+
+  test("renders one row per question in a batch, in the order asked", () => {
+    render(
+      <AnsweredQuestionCard
+        answered={makeAnswered({
+          questions: [
+            ALICE_QUESTION,
+            {
+              id: "q2",
+              question: "Which day?",
+              options: [{ id: "mon", label: "Monday" }],
+            },
+          ],
+          responses: [
+            {
+              questionId: "q1",
+              decision: "option",
+              optionId: "alice_personal",
+            },
+            { questionId: "q2", decision: "option", optionId: "mon" },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Alice (personal)")).toBeDefined();
+    expect(screen.getByText("Monday")).toBeDefined();
+  });
+
+  test("renders nothing when the record carries no questions", () => {
+    const { container } = render(
+      <AnsweredQuestionCard
+        answered={makeAnswered({ questions: [], responses: [] })}
+      />,
+    );
+
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("resolveAnswers", () => {
+  test("pairs answers to questions by id, not by position", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        questions: [
+          ALICE_QUESTION,
+          {
+            id: "q2",
+            question: "Which day?",
+            options: [{ id: "mon", label: "Monday" }],
+          },
+        ],
+        // Deliberately out of order relative to `questions`.
+        responses: [
+          { questionId: "q2", decision: "option", optionId: "mon" },
+          { questionId: "q1", decision: "option", optionId: "alice_work" },
+        ],
+      }),
+    );
+
+    expect(resolved.map((r) => r.answer)).toEqual(["Alice (work)", "Monday"]);
+  });
+
+  test("reads a question with no matching response as skipped", () => {
+    const resolved = resolveAnswers(makeAnswered({ responses: [] }));
+
+    expect(resolved[0]?.kind).toBe("skipped");
+    expect(resolved[0]?.answer).toBe("Skipped");
+  });
+
+  test("falls back to the raw option id when the options no longer carry it", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [
+          { questionId: "q1", decision: "option", optionId: "alice_retired" },
+        ],
+      }),
+    );
+
+    expect(resolved[0]?.answer).toBe("alice_retired");
+  });
+});

--- a/clients/web/src/domains/chat/components/answered-question-card.test.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.test.tsx
@@ -186,6 +186,44 @@ describe("resolveAnswers", () => {
     expect(resolved[0]?.answer).toBe("Skipped");
   });
 
+  test("reads a blank free-text answer as skipped", () => {
+    // The single-question wire shape has no `skip` kind, so a skip arrives as
+    // `free_text` with empty text. Rendering it as free text would show an
+    // empty answer row, and the raw tool chip is suppressed, so the user would
+    // see the question with no answer at all.
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [{ questionId: "q1", decision: "free_text", text: "" }],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("skipped");
+    expect(resolved[0]?.answer).toBe("Skipped");
+  });
+
+  test("reads a whitespace-only free-text answer as skipped", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [{ questionId: "q1", decision: "free_text", text: "   " }],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("skipped");
+  });
+
+  test("keeps a real free-text answer verbatim, including its spacing", () => {
+    const resolved = resolveAnswers(
+      makeAnswered({
+        responses: [
+          { questionId: "q1", decision: "free_text", text: "the one at Acme" },
+        ],
+      }),
+    );
+
+    expect(resolved[0]?.kind).toBe("free_text");
+    expect(resolved[0]?.answer).toBe("the one at Acme");
+  });
+
   test("falls back to the raw option id when the options no longer carry it", () => {
     const resolved = resolveAnswers(
       makeAnswered({

--- a/clients/web/src/domains/chat/components/answered-question-card.test.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.test.tsx
@@ -14,11 +14,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 
 import type { AnsweredQuestion } from "@vellumai/assistant-api";
 
-import {
-  AnsweredQuestionCard,
-  hasRenderableAnswer,
-  resolveAnswers,
-} from "@/domains/chat/components/answered-question-card";
+import { hasRenderableAnswer } from "@/domains/chat/answered-question";
+import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
 
 afterEach(cleanup);
 
@@ -122,27 +119,11 @@ describe("AnsweredQuestionCard", () => {
 
     expect(container.textContent).toBe("");
   });
-});
 
-describe("hasRenderableAnswer", () => {
-  // Callers hide the raw tool chip in favor of this card, so "the field is
-  // set" and "the card draws something" must be the same condition. If they
-  // diverge, a tool call renders neither and drops out of the transcript.
-  test("is false for a record with no questions", () => {
-    expect(
-      hasRenderableAnswer(makeAnswered({ questions: [], responses: [] })),
-    ).toBe(false);
-  });
-
-  test("is false when the field is absent", () => {
-    expect(hasRenderableAnswer(undefined)).toBe(false);
-  });
-
-  test("is true for a record carrying questions", () => {
-    expect(hasRenderableAnswer(makeAnswered({}))).toBe(true);
-  });
-
-  test("agrees with what the card actually renders", () => {
+  test("renders exactly when hasRenderableAnswer says it will", () => {
+    // The transcript hides the raw tool chip based on the predicate, so if the
+    // predicate and the card ever disagree the step renders neither and drops
+    // out of the conversation. Pin them together.
     for (const answered of [
       makeAnswered({}),
       makeAnswered({ questions: [], responses: [] }),
@@ -153,86 +134,5 @@ describe("hasRenderableAnswer", () => {
       expect(container.textContent !== "").toBe(hasRenderableAnswer(answered));
       cleanup();
     }
-  });
-});
-
-describe("resolveAnswers", () => {
-  test("pairs answers to questions by id, not by position", () => {
-    const resolved = resolveAnswers(
-      makeAnswered({
-        questions: [
-          ALICE_QUESTION,
-          {
-            id: "q2",
-            question: "Which day?",
-            options: [{ id: "mon", label: "Monday" }],
-          },
-        ],
-        // Deliberately out of order relative to `questions`.
-        responses: [
-          { questionId: "q2", decision: "option", optionId: "mon" },
-          { questionId: "q1", decision: "option", optionId: "alice_work" },
-        ],
-      }),
-    );
-
-    expect(resolved.map((r) => r.answer)).toEqual(["Alice (work)", "Monday"]);
-  });
-
-  test("reads a question with no matching response as skipped", () => {
-    const resolved = resolveAnswers(makeAnswered({ responses: [] }));
-
-    expect(resolved[0]?.kind).toBe("skipped");
-    expect(resolved[0]?.answer).toBe("Skipped");
-  });
-
-  test("reads a blank free-text answer as skipped", () => {
-    // The single-question wire shape has no `skip` kind, so a skip arrives as
-    // `free_text` with empty text. Rendering it as free text would show an
-    // empty answer row, and the raw tool chip is suppressed, so the user would
-    // see the question with no answer at all.
-    const resolved = resolveAnswers(
-      makeAnswered({
-        responses: [{ questionId: "q1", decision: "free_text", text: "" }],
-      }),
-    );
-
-    expect(resolved[0]?.kind).toBe("skipped");
-    expect(resolved[0]?.answer).toBe("Skipped");
-  });
-
-  test("reads a whitespace-only free-text answer as skipped", () => {
-    const resolved = resolveAnswers(
-      makeAnswered({
-        responses: [{ questionId: "q1", decision: "free_text", text: "   " }],
-      }),
-    );
-
-    expect(resolved[0]?.kind).toBe("skipped");
-  });
-
-  test("keeps a real free-text answer verbatim, including its spacing", () => {
-    const resolved = resolveAnswers(
-      makeAnswered({
-        responses: [
-          { questionId: "q1", decision: "free_text", text: "the one at Acme" },
-        ],
-      }),
-    );
-
-    expect(resolved[0]?.kind).toBe("free_text");
-    expect(resolved[0]?.answer).toBe("the one at Acme");
-  });
-
-  test("falls back to the raw option id when the options no longer carry it", () => {
-    const resolved = resolveAnswers(
-      makeAnswered({
-        responses: [
-          { questionId: "q1", decision: "option", optionId: "alice_retired" },
-        ],
-      }),
-    );
-
-    expect(resolved[0]?.answer).toBe("alice_retired");
   });
 });

--- a/clients/web/src/domains/chat/components/answered-question-card.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.tsx
@@ -30,6 +30,22 @@ interface ResolvedAnswer {
 }
 
 /**
+ * Whether an answered record has anything to show. A record with no questions
+ * renders nothing, so a caller that hides the raw tool chip in favor of this
+ * card must gate on this rather than on the field's presence: keying off
+ * presence alone would leave a tool call rendering neither the card nor the
+ * chip, dropping the step out of the transcript entirely. The daemon cannot
+ * write an empty record (the prompter rejects an empty batch), but a truncated
+ * or hand-edited persisted row satisfies the wire schema, which validates the
+ * shape and not the arity.
+ */
+export function hasRenderableAnswer(
+  answered: AnsweredQuestion | undefined,
+): answered is AnsweredQuestion {
+  return answered !== undefined && answered.questions.length > 0;
+}
+
+/**
  * Pair each question with its response. Ordering follows `questions`, not
  * `responses`, so a record whose arrays disagree (a truncated or hand-edited
  * row) still renders every question rather than dropping the tail. A question
@@ -77,10 +93,10 @@ export function resolveAnswers(answered: AnsweredQuestion): ResolvedAnswer[] {
 }
 
 export function AnsweredQuestionCard({ answered }: AnsweredQuestionCardProps) {
-  const resolved = resolveAnswers(answered);
-  if (resolved.length === 0) {
+  if (!hasRenderableAnswer(answered)) {
     return null;
   }
+  const resolved = resolveAnswers(answered);
 
   return (
     <Card data-testid="answered-question-card">

--- a/clients/web/src/domains/chat/components/answered-question-card.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.tsx
@@ -1,0 +1,163 @@
+/**
+ * Read-only transcript record of an `ask_question` prompt the user answered.
+ *
+ * The interactive `QuestionPromptCard` lives above the composer and exists only
+ * while the prompt is outstanding. This card is what the conversation keeps:
+ * it renders from the `answeredQuestion` record the daemon persists on the
+ * `ask_question` tool call, so the question and the user's choice stay readable
+ * after switching conversations, reloading, or reopening from history.
+ */
+
+import { Check, Pencil, SkipForward } from "lucide-react";
+
+import type { AnsweredQuestion } from "@vellumai/assistant-api";
+import { Card, Typography } from "@vellumai/design-library";
+
+export interface AnsweredQuestionCardProps {
+  answered: AnsweredQuestion;
+}
+
+/** The rendered answer for one question, resolved against the options as asked. */
+interface ResolvedAnswer {
+  questionId: string;
+  question: string;
+  description?: string;
+  /** What the user chose, already resolved to display text. */
+  answer: string;
+  kind: "option" | "free_text" | "skipped";
+  /** The chosen option's own description, when it had one. */
+  answerDescription?: string;
+}
+
+/**
+ * Pair each question with its response. Ordering follows `questions`, not
+ * `responses`, so a record whose arrays disagree (a truncated or hand-edited
+ * row) still renders every question rather than dropping the tail. A question
+ * with no matching response reads as skipped, which is what an unanswered entry
+ * in a settled batch means.
+ */
+export function resolveAnswers(answered: AnsweredQuestion): ResolvedAnswer[] {
+  const byQuestionId = new Map(
+    answered.responses.map((response) => [response.questionId, response]),
+  );
+  return answered.questions.map((question) => {
+    const response = byQuestionId.get(question.id);
+    if (response?.decision === "option") {
+      const option = question.options.find(
+        (candidate) => candidate.id === response.optionId,
+      );
+      return {
+        questionId: question.id,
+        question: question.question,
+        description: question.description,
+        kind: "option",
+        // An unresolvable option id means the persisted record and the asked
+        // options disagree; show the raw id rather than an empty row.
+        answer: option?.label ?? response.optionId ?? "Unknown option",
+        answerDescription: option?.description,
+      };
+    }
+    if (response?.decision === "free_text") {
+      return {
+        questionId: question.id,
+        question: question.question,
+        description: question.description,
+        kind: "free_text",
+        answer: response.text ?? "",
+      };
+    }
+    return {
+      questionId: question.id,
+      question: question.question,
+      description: question.description,
+      kind: "skipped",
+      answer: "Skipped",
+    };
+  });
+}
+
+export function AnsweredQuestionCard({ answered }: AnsweredQuestionCardProps) {
+  const resolved = resolveAnswers(answered);
+  if (resolved.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card data-testid="answered-question-card">
+      <div className="flex flex-col gap-3">
+        {resolved.map((item) => (
+          <div key={item.questionId} className="flex flex-col gap-1.5">
+            <Typography
+              variant="body-medium-default"
+              as="div"
+              className="text-[color:var(--content-default)]"
+            >
+              {item.question}
+            </Typography>
+            {item.description && (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-[color:var(--content-tertiary)]"
+              >
+                {item.description}
+              </Typography>
+            )}
+            <AnsweredRow item={item} />
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * One answer row. The leading glyph distinguishes the three shapes at a glance
+ * and mirrors the interactive card's iconography: a check for a chosen option,
+ * a pencil for typed text, a skip arrow for a question left unanswered.
+ */
+function AnsweredRow({ item }: { item: ResolvedAnswer }) {
+  const Glyph =
+    item.kind === "option"
+      ? Check
+      : item.kind === "free_text"
+        ? Pencil
+        : SkipForward;
+  const isSkipped = item.kind === "skipped";
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-[var(--surface-base)] px-3 py-2">
+      <span
+        aria-hidden="true"
+        className={`mt-0.5 flex shrink-0 items-center justify-center ${
+          isSkipped
+            ? "text-[color:var(--content-tertiary)]"
+            : "text-[color:var(--primary-base)]"
+        }`}
+      >
+        <Glyph className="h-3.5 w-3.5" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <Typography
+          variant="body-medium-default"
+          as="span"
+          className={
+            isSkipped
+              ? "text-[color:var(--content-tertiary)]"
+              : "text-[color:var(--content-default)]"
+          }
+        >
+          {item.answer}
+        </Typography>
+        {item.answerDescription && (
+          <Typography
+            variant="body-small-default"
+            as="span"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            {item.answerDescription}
+          </Typography>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/answered-question-card.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.tsx
@@ -73,13 +73,18 @@ export function resolveAnswers(answered: AnsweredQuestion): ResolvedAnswer[] {
         answerDescription: option?.description,
       };
     }
-    if (response?.decision === "free_text") {
+    // Blank free text means the user skipped. The card cannot submit an empty
+    // answer (`handleSubmitFreeText` returns early on blank input), so the only
+    // way one reaches here is the legacy single-question wire shape, which has
+    // no `skip` kind and coerces a skip to `free_text` with empty text. Reading
+    // it as free text would render a blank answer row.
+    if (response?.decision === "free_text" && response.text?.trim()) {
       return {
         questionId: question.id,
         question: question.question,
         description: question.description,
         kind: "free_text",
-        answer: response.text ?? "",
+        answer: response.text,
       };
     }
     return {

--- a/clients/web/src/domains/chat/components/answered-question-card.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-card.tsx
@@ -8,105 +8,27 @@
  * after switching conversations, reloading, or reopening from history.
  */
 
-import { Check, Pencil, SkipForward } from "lucide-react";
-
 import type { AnsweredQuestion } from "@vellumai/assistant-api";
+import {
+  hasRenderableAnswer,
+  resolveAnswers,
+} from "@/domains/chat/answered-question";
+import { AnsweredQuestionRow } from "@/domains/chat/components/answered-question-row";
 import { Card, Typography } from "@vellumai/design-library";
 
 export interface AnsweredQuestionCardProps {
   answered: AnsweredQuestion;
 }
 
-/** The rendered answer for one question, resolved against the options as asked. */
-interface ResolvedAnswer {
-  questionId: string;
-  question: string;
-  description?: string;
-  /** What the user chose, already resolved to display text. */
-  answer: string;
-  kind: "option" | "free_text" | "skipped";
-  /** The chosen option's own description, when it had one. */
-  answerDescription?: string;
-}
-
-/**
- * Whether an answered record has anything to show. A record with no questions
- * renders nothing, so a caller that hides the raw tool chip in favor of this
- * card must gate on this rather than on the field's presence: keying off
- * presence alone would leave a tool call rendering neither the card nor the
- * chip, dropping the step out of the transcript entirely. The daemon cannot
- * write an empty record (the prompter rejects an empty batch), but a truncated
- * or hand-edited persisted row satisfies the wire schema, which validates the
- * shape and not the arity.
- */
-export function hasRenderableAnswer(
-  answered: AnsweredQuestion | undefined,
-): answered is AnsweredQuestion {
-  return answered !== undefined && answered.questions.length > 0;
-}
-
-/**
- * Pair each question with its response. Ordering follows `questions`, not
- * `responses`, so a record whose arrays disagree (a truncated or hand-edited
- * row) still renders every question rather than dropping the tail. A question
- * with no matching response reads as skipped, which is what an unanswered entry
- * in a settled batch means.
- */
-export function resolveAnswers(answered: AnsweredQuestion): ResolvedAnswer[] {
-  const byQuestionId = new Map(
-    answered.responses.map((response) => [response.questionId, response]),
-  );
-  return answered.questions.map((question) => {
-    const response = byQuestionId.get(question.id);
-    if (response?.decision === "option") {
-      const option = question.options.find(
-        (candidate) => candidate.id === response.optionId,
-      );
-      return {
-        questionId: question.id,
-        question: question.question,
-        description: question.description,
-        kind: "option",
-        // An unresolvable option id means the persisted record and the asked
-        // options disagree; show the raw id rather than an empty row.
-        answer: option?.label ?? response.optionId ?? "Unknown option",
-        answerDescription: option?.description,
-      };
-    }
-    // Blank free text means the user skipped. The card cannot submit an empty
-    // answer (`handleSubmitFreeText` returns early on blank input), so the only
-    // way one reaches here is the legacy single-question wire shape, which has
-    // no `skip` kind and coerces a skip to `free_text` with empty text. Reading
-    // it as free text would render a blank answer row.
-    if (response?.decision === "free_text" && response.text?.trim()) {
-      return {
-        questionId: question.id,
-        question: question.question,
-        description: question.description,
-        kind: "free_text",
-        answer: response.text,
-      };
-    }
-    return {
-      questionId: question.id,
-      question: question.question,
-      description: question.description,
-      kind: "skipped",
-      answer: "Skipped",
-    };
-  });
-}
-
 export function AnsweredQuestionCard({ answered }: AnsweredQuestionCardProps) {
   if (!hasRenderableAnswer(answered)) {
     return null;
   }
-  const resolved = resolveAnswers(answered);
 
   return (
     <Card data-testid="answered-question-card">
       <div className="flex flex-col gap-3">
-        {resolved.map((item) => (
+        {resolveAnswers(answered).map((item) => (
           <div key={item.questionId} className="flex flex-col gap-1.5">
             <Typography
               variant="body-medium-default"
@@ -124,61 +46,10 @@ export function AnsweredQuestionCard({ answered }: AnsweredQuestionCardProps) {
                 {item.description}
               </Typography>
             )}
-            <AnsweredRow item={item} />
+            <AnsweredQuestionRow item={item} />
           </div>
         ))}
       </div>
     </Card>
-  );
-}
-
-/**
- * One answer row. The leading glyph distinguishes the three shapes at a glance
- * and mirrors the interactive card's iconography: a check for a chosen option,
- * a pencil for typed text, a skip arrow for a question left unanswered.
- */
-function AnsweredRow({ item }: { item: ResolvedAnswer }) {
-  const Glyph =
-    item.kind === "option"
-      ? Check
-      : item.kind === "free_text"
-        ? Pencil
-        : SkipForward;
-  const isSkipped = item.kind === "skipped";
-  return (
-    <div className="flex items-start gap-2 rounded-md bg-[var(--surface-base)] px-3 py-2">
-      <span
-        aria-hidden="true"
-        className={`mt-0.5 flex shrink-0 items-center justify-center ${
-          isSkipped
-            ? "text-[color:var(--content-tertiary)]"
-            : "text-[color:var(--primary-base)]"
-        }`}
-      >
-        <Glyph className="h-3.5 w-3.5" />
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <Typography
-          variant="body-medium-default"
-          as="span"
-          className={
-            isSkipped
-              ? "text-[color:var(--content-tertiary)]"
-              : "text-[color:var(--content-default)]"
-          }
-        >
-          {item.answer}
-        </Typography>
-        {item.answerDescription && (
-          <Typography
-            variant="body-small-default"
-            as="span"
-            className="text-[color:var(--content-tertiary)]"
-          >
-            {item.answerDescription}
-          </Typography>
-        )}
-      </span>
-    </div>
   );
 }

--- a/clients/web/src/domains/chat/components/answered-question-row.tsx
+++ b/clients/web/src/domains/chat/components/answered-question-row.tsx
@@ -1,0 +1,63 @@
+/**
+ * One answered question's response row.
+ *
+ * The leading glyph distinguishes the three answer shapes at a glance and
+ * mirrors the interactive card's iconography: a check for a chosen option, a
+ * pencil for typed text, a skip arrow for a question left unanswered.
+ */
+
+import { Check, Pencil, SkipForward } from "lucide-react";
+
+import type { ResolvedAnswer } from "@/domains/chat/answered-question";
+import { Typography } from "@vellumai/design-library";
+
+export interface AnsweredQuestionRowProps {
+  item: ResolvedAnswer;
+}
+
+const GLYPH_BY_KIND = {
+  option: Check,
+  free_text: Pencil,
+  skipped: SkipForward,
+} as const;
+
+export function AnsweredQuestionRow({ item }: AnsweredQuestionRowProps) {
+  const Glyph = GLYPH_BY_KIND[item.kind];
+  const isSkipped = item.kind === "skipped";
+  const textColor = isSkipped
+    ? "text-[color:var(--content-tertiary)]"
+    : "text-[color:var(--content-default)]";
+
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-[var(--surface-base)] px-3 py-2">
+      <span
+        aria-hidden="true"
+        className={`mt-0.5 flex shrink-0 items-center justify-center ${
+          isSkipped
+            ? "text-[color:var(--content-tertiary)]"
+            : "text-[color:var(--primary-base)]"
+        }`}
+      >
+        <Glyph className="h-3.5 w-3.5" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <Typography
+          variant="body-medium-default"
+          as="span"
+          className={textColor}
+        >
+          {item.answer}
+        </Typography>
+        {item.answerDescription && (
+          <Typography
+            variant="body-small-default"
+            as="span"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            {item.answerDescription}
+          </Typography>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/interaction-store.test.ts
+++ b/clients/web/src/domains/chat/interaction-store.test.ts
@@ -256,6 +256,28 @@ describe("useInteractionStore", () => {
       expect(s.isQuestionCardDismissed).toBe(false);
     });
 
+    it("dismissQuestionIfMatches retires the card the answer belongs to", () => {
+      useInteractionStore
+        .getState()
+        .showQuestion({ requestId: "q1", entries: [] });
+      useInteractionStore.getState().dismissQuestionIfMatches("q1");
+      const s = useInteractionStore.getState();
+      expect(s.pendingQuestion).toBeNull();
+      expect(s.isSubmittingQuestion).toBe(false);
+    });
+
+    it("dismissQuestionIfMatches leaves a newer card standing", () => {
+      // An answer for a superseded prompt must not close the card the user is
+      // currently looking at.
+      useInteractionStore
+        .getState()
+        .showQuestion({ requestId: "q2", entries: [] });
+      useInteractionStore.getState().dismissQuestionIfMatches("q1");
+      expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+        "q2",
+      );
+    });
+
     it("dismissQuestionCard hides card but keeps pendingQuestion", () => {
       useInteractionStore
         .getState()

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -121,6 +121,7 @@ export interface InteractionActions {
   submitQuestionStart: () => void;
   submitQuestionEnd: () => void;
   dismissQuestion: () => void;
+  dismissQuestionIfMatches: (requestId: string) => void;
   dismissQuestionCard: () => void;
 
   // ACP Connect Claude prompt
@@ -293,6 +294,18 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
       isSubmittingQuestion: false,
       isQuestionCardDismissed: false,
     }),
+
+  dismissQuestionIfMatches: (requestId) => {
+    const { pendingQuestion } = get();
+    if (!pendingQuestion || pendingQuestion.requestId !== requestId) {
+      return;
+    }
+    set({
+      pendingQuestion: null,
+      isSubmittingQuestion: false,
+      isQuestionCardDismissed: false,
+    });
+  },
 
   dismissQuestionCard: () => set({ isQuestionCardDismissed: true }),
 

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -318,10 +318,11 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
       pendingConfirmation: null,
       isSubmittingConfirmation: false,
       inlineConfirmationToolCallId: null,
-      // Question state intentionally NOT cleared — the composer intercept
-      // (`pendingQuestion && trimmed`) only fires for text sends; clearing
-      // the question would hide the card while the daemon blocks on
-      // /question-response/.
+      // Question state is intentionally not cleared: the daemon blocks on
+      // /question-response until the prompt settles, and clearing here would
+      // hide a card that is still answerable. A question that the daemon does
+      // settle retires through `dismissQuestionIfMatches`, driven by the
+      // `interaction_resolved` handler and the 404 paths in `question-actions`.
     }),
 
   // ----- ACP Connect Claude prompt -----

--- a/clients/web/src/domains/chat/question-actions.test.ts
+++ b/clients/web/src/domains/chat/question-actions.test.ts
@@ -28,6 +28,28 @@ const submitCalls: Array<{
 /** Runs inside the in-flight POST, to simulate SSE landing mid-request. */
 let onSubmit: (() => void) | undefined;
 
+/**
+ * Per-requestId gate. A test that registers one holds that request open until
+ * it resolves the returned deferred, so two submissions can be genuinely
+ * in flight at once.
+ */
+const deferred = new Map<
+  string,
+  { promise: Promise<void>; release: () => void }
+>();
+
+function holdRequest(requestId: string): void {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  deferred.set(requestId, { promise, release });
+}
+
+function releaseRequest(requestId: string): void {
+  deferred.get(requestId)?.release();
+}
+
 mock.module("@/domains/chat/api/interactions", () => ({
   submitQuestionResponse: async (
     _assistantId: string,
@@ -36,9 +58,16 @@ mock.module("@/domains/chat/api/interactions", () => ({
   ): Promise<SubmitSecretResponseResult> => {
     submitCalls.push({ requestId, submission });
     onSubmit?.();
-    return submitQuestionResult;
+    const gate = deferred.get(requestId);
+    if (gate) {
+      await gate.promise;
+    }
+    return resultByRequestId.get(requestId) ?? submitQuestionResult;
   },
 }));
+
+/** Per-requestId results, for tests where two requests resolve differently. */
+const resultByRequestId = new Map<string, SubmitSecretResponseResult>();
 
 const capturedErrors: Array<{ context?: string }> = [];
 mock.module("@/lib/sentry/capture-error", () => ({
@@ -84,6 +113,8 @@ beforeEach(() => {
   submitCalls.length = 0;
   capturedErrors.length = 0;
   onSubmit = undefined;
+  deferred.clear();
+  resultByRequestId.clear();
   submitQuestionResult = { ok: true };
   useInteractionStore.getState().resetAll();
   useChatSessionStore.getState().setError(null);
@@ -152,6 +183,85 @@ describe("handleQuestionResponse: stale (404) interaction", () => {
     // The stale 404 must retire only the prompt it was answering.
     expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
       "q-new",
+    );
+  });
+});
+
+describe("handleQuestionResponse: a late 404 must not rewrite newer state", () => {
+  // `isSubmittingQuestion` and the session error are shared, not per-request.
+  // The daemon supersedes A with B, which is why A 404s, and `showQuestion`
+  // clears `isSubmittingQuestion` when B arrives, so B can already be in flight
+  // when A's response lands.
+  it("leaves the newer prompt's submitting state intact", async () => {
+    holdRequest("q-a");
+    resultByRequestId.set("q-a", {
+      ok: false,
+      status: 404,
+      error: "No pending question interaction found for this requestId",
+    });
+    resultByRequestId.set("q-b", { ok: true });
+    holdRequest("q-b");
+
+    seedPendingQuestion("q-a");
+    const answerA = handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+
+    // B supersedes A. `showQuestion` resets the submitting flag, so the user
+    // can answer B while A is still open.
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-b", entries: [] });
+    const answerB = handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
+
+    // Now A's 404 lands, after B is already in flight.
+    releaseRequest("q-a");
+    await answerA;
+
+    // B still owns the submitting flag, so its double-submit guard holds.
+    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
+    expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+      "q-b",
+    );
+
+    releaseRequest("q-b");
+    await answerB;
+    expect(submitCalls.map((c) => c.requestId)).toEqual(["q-a", "q-b"]);
+  });
+
+  it("leaves the newer prompt's error intact", async () => {
+    holdRequest("q-a");
+    resultByRequestId.set("q-a", { ok: false, status: 404, error: "gone" });
+    resultByRequestId.set("q-b", {
+      ok: false,
+      status: 500,
+      error: "Internal error",
+    });
+
+    seedPendingQuestion("q-a");
+    const answerA = handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-b", entries: [] });
+    await handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+    expect(useChatSessionStore.getState().error?.message).toBe(
+      "Internal error",
+    );
+
+    releaseRequest("q-a");
+    await answerA;
+
+    // A's stale cleanup must not erase the failure the user needs to see.
+    expect(useChatSessionStore.getState().error?.message).toBe(
+      "Internal error",
     );
   });
 });

--- a/clients/web/src/domains/chat/question-actions.test.ts
+++ b/clients/web/src/domains/chat/question-actions.test.ts
@@ -62,9 +62,15 @@ mock.module("@/domains/chat/api/interactions", () => ({
     if (gate) {
       await gate.promise;
     }
+    if (throwByRequestId.has(requestId)) {
+      throw new Error("network down");
+    }
     return resultByRequestId.get(requestId) ?? submitQuestionResult;
   },
 }));
+
+/** Requests that reject rather than resolve, modelling a transport failure. */
+const throwByRequestId = new Set<string>();
 
 /** Per-requestId results, for tests where two requests resolve differently. */
 const resultByRequestId = new Map<string, SubmitSecretResponseResult>();
@@ -115,6 +121,7 @@ beforeEach(() => {
   onSubmit = undefined;
   deferred.clear();
   resultByRequestId.clear();
+  throwByRequestId.clear();
   submitQuestionResult = { ok: true };
   useInteractionStore.getState().resetAll();
   useChatSessionStore.getState().setError(null);
@@ -187,71 +194,130 @@ describe("handleQuestionResponse: stale (404) interaction", () => {
   });
 });
 
-describe("handleQuestionResponse: a late 404 must not rewrite newer state", () => {
-  // `isSubmittingQuestion` and the session error are shared, not per-request.
-  // The daemon supersedes A with B, which is why A 404s, and `showQuestion`
-  // clears `isSubmittingQuestion` when B arrives, so B can already be in flight
-  // when A's response lands.
-  it("leaves the newer prompt's submitting state intact", async () => {
-    holdRequest("q-a");
+/**
+ * Start request A, let prompt B supersede it, then start request B, leaving
+ * both in flight. Returns A's promise plus a release for it.
+ *
+ * `isSubmittingQuestion` and the session error are single slots on the store.
+ * The daemon supersedes A with B, and `showQuestion` clears
+ * `isSubmittingQuestion` when B arrives, so the user can answer B while A is
+ * still open. Every completion path of A then lands after ownership has moved.
+ */
+async function startOverlappingRequests(): Promise<{
+  answerA: Promise<void>;
+  answerB: Promise<void>;
+}> {
+  holdRequest("q-a");
+  holdRequest("q-b");
+
+  seedPendingQuestion("q-a");
+  const answerA = handleQuestionResponse([
+    { questionId: "q1", kind: "option", optionId: "alice_work" },
+  ]);
+
+  useInteractionStore
+    .getState()
+    .showQuestion({ requestId: "q-b", entries: [] });
+  const answerB = handleQuestionResponse([
+    { questionId: "q1", kind: "option", optionId: "alice_work" },
+  ]);
+
+  // Both are genuinely in flight, and B owns the shared state.
+  expect(submitCalls.map((c) => c.requestId)).toEqual(["q-a", "q-b"]);
+  expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
+  return { answerA, answerB };
+}
+
+/** Assert B still owns everything after A landed late. */
+function expectBStillOwnsState(): void {
+  expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
+  expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe("q-b");
+}
+
+describe("handleQuestionResponse: a late completion must not rewrite newer state", () => {
+  it("stale A 404 leaves B's pending/submitting state intact", async () => {
     resultByRequestId.set("q-a", {
       ok: false,
       status: 404,
       error: "No pending question interaction found for this requestId",
     });
-    resultByRequestId.set("q-b", { ok: true });
-    holdRequest("q-b");
+    const { answerA, answerB } = await startOverlappingRequests();
 
-    seedPendingQuestion("q-a");
-    const answerA = handleQuestionResponse([
-      { questionId: "q1", kind: "option", optionId: "alice_work" },
-    ]);
-
-    // B supersedes A. `showQuestion` resets the submitting flag, so the user
-    // can answer B while A is still open.
-    useInteractionStore
-      .getState()
-      .showQuestion({ requestId: "q-b", entries: [] });
-    const answerB = handleQuestionResponse([
-      { questionId: "q1", kind: "option", optionId: "alice_work" },
-    ]);
-    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
-
-    // Now A's 404 lands, after B is already in flight.
     releaseRequest("q-a");
     await answerA;
 
-    // B still owns the submitting flag, so its double-submit guard holds.
-    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(true);
-    expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
-      "q-b",
+    expectBStillOwnsState();
+    expect(useChatSessionStore.getState().error).toBeNull();
+
+    releaseRequest("q-b");
+    await answerB;
+  });
+
+  it("stale A success leaves B's pending/submitting state intact", async () => {
+    // The success path is the sharpest case: its card-retiring branch compares
+    // request ids, so the fallback branch fires precisely when B owns the state.
+    resultByRequestId.set("q-a", { ok: true });
+    const { answerA, answerB } = await startOverlappingRequests();
+
+    releaseRequest("q-a");
+    await answerA;
+
+    expectBStillOwnsState();
+
+    releaseRequest("q-b");
+    await answerB;
+  });
+
+  it("stale A non-404 failure leaves B's pending/submitting state intact", async () => {
+    resultByRequestId.set("q-a", {
+      ok: false,
+      status: 500,
+      error: "A exploded",
+    });
+    const { answerA, answerB } = await startOverlappingRequests();
+
+    releaseRequest("q-a");
+    await answerA;
+
+    expectBStillOwnsState();
+    // A's failure belongs to a prompt the user can no longer see.
+    expect(useChatSessionStore.getState().error).toBeNull();
+
+    releaseRequest("q-b");
+    await answerB;
+  });
+
+  it("stale A transport failure leaves B's pending/submitting state intact", async () => {
+    throwByRequestId.add("q-a");
+    const { answerA, answerB } = await startOverlappingRequests();
+
+    releaseRequest("q-a");
+    await answerA;
+
+    expectBStillOwnsState();
+    expect(useChatSessionStore.getState().error).toBeNull();
+    // The throw is still reported: suppressing the banner is not suppressing
+    // telemetry.
+    expect(capturedErrors.map((e) => e.context)).toContain(
+      "submit_question_response",
     );
 
     releaseRequest("q-b");
     await answerB;
-    expect(submitCalls.map((c) => c.requestId)).toEqual(["q-a", "q-b"]);
   });
 
-  it("leaves the newer prompt's error intact", async () => {
-    holdRequest("q-a");
+  it("B's error survives A's late completion", async () => {
+    // B fails for real while A is still open; A must not erase the banner.
     resultByRequestId.set("q-a", { ok: false, status: 404, error: "gone" });
     resultByRequestId.set("q-b", {
       ok: false,
       status: 500,
       error: "Internal error",
     });
+    const { answerA, answerB } = await startOverlappingRequests();
 
-    seedPendingQuestion("q-a");
-    const answerA = handleQuestionResponse([
-      { questionId: "q1", kind: "option", optionId: "alice_work" },
-    ]);
-
-    useInteractionStore
-      .getState()
-      .showQuestion({ requestId: "q-b", entries: [] });
-    await handleQuestionResponse([
-      { questionId: "q1", kind: "option", optionId: "alice_work" },
-    ]);
+    releaseRequest("q-b");
+    await answerB;
     expect(useChatSessionStore.getState().error?.message).toBe(
       "Internal error",
     );
@@ -259,10 +325,27 @@ describe("handleQuestionResponse: a late 404 must not rewrite newer state", () =
     releaseRequest("q-a");
     await answerA;
 
-    // A's stale cleanup must not erase the failure the user needs to see.
     expect(useChatSessionStore.getState().error?.message).toBe(
       "Internal error",
     );
+  });
+
+  it("still cleans up its own state when no newer prompt took over", async () => {
+    // The guard must not strand the submitting flag in the ordinary case where
+    // the card was retired by `interaction_resolved` mid-flight.
+    resultByRequestId.set("q-a", { ok: false, status: 500, error: "boom" });
+    holdRequest("q-a");
+    seedPendingQuestion("q-a");
+    const answerA = handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+    useInteractionStore.getState().dismissQuestionIfMatches("q-a");
+
+    releaseRequest("q-a");
+    await answerA;
+
+    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(false);
+    expect(useChatSessionStore.getState().error?.message).toBe("boom");
   });
 });
 

--- a/clients/web/src/domains/chat/question-actions.test.ts
+++ b/clients/web/src/domains/chat/question-actions.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Reactive safety net for stale question prompts.
+ *
+ * When the daemon has already discarded a pending interaction (the prompt
+ * timed out, the turn was aborted, a newer user message superseded it, or a
+ * daemon restart dropped it), `POST /v1/question-response` returns 404. The
+ * matching `interaction_resolved` event that would normally retire the card can
+ * be missed entirely (the web / iOS SSE stream tears down on app background and
+ * has no replay), so the prompt lingers. Answering or closing it must not
+ * strand the user on an un-actionable card, nor report an expected outcome as
+ * an error.
+ *
+ * Mirrors `confirmation-actions.test.ts`, which covers the same shape for
+ * confirmations.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { SubmitSecretResponseResult } from "@/domains/chat/api/interactions";
+import type { QuestionSubmission } from "@/domains/chat/api/event-types";
+
+let submitQuestionResult: SubmitSecretResponseResult = { ok: true };
+const submitCalls: Array<{
+  requestId: string;
+  submission: QuestionSubmission;
+}> = [];
+
+/** Runs inside the in-flight POST, to simulate SSE landing mid-request. */
+let onSubmit: (() => void) | undefined;
+
+mock.module("@/domains/chat/api/interactions", () => ({
+  submitQuestionResponse: async (
+    _assistantId: string,
+    requestId: string,
+    submission: QuestionSubmission,
+  ): Promise<SubmitSecretResponseResult> => {
+    submitCalls.push({ requestId, submission });
+    onSubmit?.();
+    return submitQuestionResult;
+  },
+}));
+
+const capturedErrors: Array<{ context?: string }> = [];
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: (_err: unknown, opts?: { context?: string }) => {
+    capturedErrors.push({ context: opts?.context });
+  },
+}));
+
+const { handleQuestionResponse, handleDismissPendingQuestion } = await import(
+  "@/domains/chat/question-actions"
+);
+const { useInteractionStore } = await import(
+  "@/domains/chat/interaction-store"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { useStreamStore } = await import("@/domains/chat/stream-store");
+
+function seedPendingQuestion(requestId: string): void {
+  useStreamStore.getState().setStreamContext({
+    assistantId: "ast-1",
+    conversationId: "conv-1",
+  });
+  useInteractionStore.getState().showQuestion({
+    requestId,
+    entries: [
+      {
+        id: "q1",
+        question: "Which Alice?",
+        options: [{ id: "alice_work", label: "Alice (work)" }],
+      },
+    ],
+  });
+}
+
+/** Let the fire-and-forget close POST settle. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  submitCalls.length = 0;
+  capturedErrors.length = 0;
+  onSubmit = undefined;
+  submitQuestionResult = { ok: true };
+  useInteractionStore.getState().resetAll();
+  useChatSessionStore.getState().setError(null);
+  useStreamStore.getState().setStreamContext(null);
+});
+
+describe("handleQuestionResponse: stale (404) interaction", () => {
+  it("retires the prompt without surfacing a blocking error", async () => {
+    submitQuestionResult = {
+      ok: false,
+      status: 404,
+      error: "No pending question interaction found for this requestId",
+    };
+    seedPendingQuestion("q-stale");
+
+    await handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+
+    expect(submitCalls).toHaveLength(1);
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(false);
+    // The raw server string must never reach the error banner: it renders a
+    // "Go to Doctor" CTA for what is an expected, unactionable outcome.
+    expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("still surfaces a non-404 failure", async () => {
+    submitQuestionResult = {
+      ok: false,
+      status: 500,
+      error: "Internal error",
+    };
+    seedPendingQuestion("q-broken");
+
+    await handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+
+    // A real server failure is retryable, so the card stays and the user is told.
+    expect(useChatSessionStore.getState().error?.message).toBe(
+      "Internal error",
+    );
+    expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+      "q-broken",
+    );
+    expect(useInteractionStore.getState().isSubmittingQuestion).toBe(false);
+  });
+
+  it("leaves a newer prompt standing when a stale answer 404s", async () => {
+    submitQuestionResult = { ok: false, status: 404, error: "gone" };
+    seedPendingQuestion("q-stale");
+    // A fresh prompt arrives while the answer is in flight, which is the only
+    // way the store can hold a different prompt by the time the 404 lands:
+    // `handleQuestionResponse` snapshots the request id at entry.
+    onSubmit = () => {
+      useInteractionStore
+        .getState()
+        .showQuestion({ requestId: "q-new", entries: [] });
+    };
+
+    await handleQuestionResponse([
+      { questionId: "q1", kind: "option", optionId: "alice_work" },
+    ]);
+
+    // The stale 404 must retire only the prompt it was answering.
+    expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+      "q-new",
+    );
+  });
+});
+
+describe("handleDismissPendingQuestion: stale (404) interaction", () => {
+  it("does not report a 404 close to Sentry", async () => {
+    submitQuestionResult = {
+      ok: false,
+      status: 404,
+      error: "No pending question interaction found for this requestId",
+    };
+    seedPendingQuestion("q-stale");
+
+    handleDismissPendingQuestion();
+    await flush();
+
+    expect(submitCalls).toHaveLength(1);
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+    // Closing a prompt the daemon already settled is the expected path.
+    expect(capturedErrors).toHaveLength(0);
+  });
+
+  it("still reports a non-404 close failure", async () => {
+    submitQuestionResult = { ok: false, status: 500, error: "boom" };
+    seedPendingQuestion("q-broken");
+
+    handleDismissPendingQuestion();
+    await flush();
+
+    expect(capturedErrors).toHaveLength(1);
+    expect(capturedErrors[0]?.context).toBe("submit_question_response_close");
+  });
+});

--- a/clients/web/src/domains/chat/question-actions.ts
+++ b/clients/web/src/domains/chat/question-actions.ts
@@ -31,8 +31,21 @@ import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
  * stranded. Mirrors `clearStaleConfirmation` in `confirmation-actions.ts`,
  * minus its attention-key release: an attention key is only ever recorded for a
  * pending secret or confirmation, never a question.
+ *
+ * Bails entirely when a newer prompt has taken over. `isSubmittingQuestion` and
+ * the session error are shared, not per-request, so a late 404 must not touch
+ * them once they belong to someone else. That handoff is the norm rather than a
+ * rare race: the daemon supersedes this prompt with the newer one, which is
+ * *why* this request 404s, and `showQuestion` clears `isSubmittingQuestion` on
+ * arrival, so the newer prompt can already be in flight by the time the older
+ * response lands. Clearing it there would reopen the double-submit guard and
+ * erase a real failure the user needs to see.
  */
 function clearStaleQuestion(requestId: string): void {
+  const { pendingQuestion } = useInteractionStore.getState();
+  if (pendingQuestion && pendingQuestion.requestId !== requestId) {
+    return;
+  }
   useInteractionStore.getState().dismissQuestionIfMatches(requestId);
   useInteractionStore.getState().submitQuestionEnd();
   useChatSessionStore.getState().setError(null);

--- a/clients/web/src/domains/chat/question-actions.ts
+++ b/clients/web/src/domains/chat/question-actions.ts
@@ -15,6 +15,30 @@ import { submitQuestionResponse } from "@/domains/chat/api/interactions";
 import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
 
 /**
+ * Clear a question prompt the daemon has already discarded.
+ *
+ * A question POST comes back 404 ("No pending question interaction found for
+ * this requestId") when the server-side pending interaction is gone: the prompt
+ * timed out, the turn was aborted, a newer user message superseded it, or a
+ * daemon restart dropped it. This is terminal and non-retryable, because the
+ * answer is moot once the server has moved on. The matching
+ * `interaction_resolved` event that would normally retire the card can be
+ * missed entirely (the web / iOS SSE stream tears down on app background and
+ * has no replay), so the stale prompt lingers, leaving the user tapping options
+ * into the same 404.
+ *
+ * Retire the prompt without surfacing a blocking error so the user is never
+ * stranded. Mirrors `clearStaleConfirmation` in `confirmation-actions.ts`,
+ * minus its attention-key release: an attention key is only ever recorded for a
+ * pending secret or confirmation, never a question.
+ */
+function clearStaleQuestion(requestId: string): void {
+  useInteractionStore.getState().dismissQuestionIfMatches(requestId);
+  useInteractionStore.getState().submitQuestionEnd();
+  useChatSessionStore.getState().setError(null);
+}
+
+/**
  * Submit the user's answers to a pending question prompt.
  * Guards against a new SSE-driven `question_request` arriving mid-flight
  * by comparing request IDs before clearing state.
@@ -46,6 +70,10 @@ export async function handleQuestionResponse(
       { kind: "submit", responses },
     );
     if (!result.ok) {
+      if (result.status === 404) {
+        clearStaleQuestion(snapshot.requestId);
+        return;
+      }
       useChatSessionStore.getState().setError({ message: result.error });
       useInteractionStore.getState().submitQuestionEnd();
       return;
@@ -85,7 +113,12 @@ export function handleDismissPendingQuestion(): void {
     kind: "close",
   })
     .then((result) => {
-      if (!result.ok) {
+      // A 404 on close is the expected outcome, not a failure: the card is
+      // being dismissed precisely because the user is done with it, and the
+      // daemon may already have settled the prompt itself (timeout, abort,
+      // supersession). Reporting it produced steady Sentry noise with no
+      // actionable signal. Every other status still reports.
+      if (!result.ok && result.status !== 404) {
         captureError(
           new Error(`question-response close failed: ${result.error}`),
           {

--- a/clients/web/src/domains/chat/question-actions.ts
+++ b/clients/web/src/domains/chat/question-actions.ts
@@ -15,6 +15,29 @@ import { submitQuestionResponse } from "@/domains/chat/api/interactions";
 import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
 
 /**
+ * Whether `requestId` still owns the shared question state.
+ *
+ * `isSubmittingQuestion` and the session error are single slots on the store,
+ * not per-request. Only one in-flight submission may write them, and that is
+ * whichever request the currently pending prompt belongs to. A request whose
+ * prompt has since been replaced must leave both alone.
+ *
+ * This handoff is the norm rather than a rare race. The daemon supersedes an
+ * open prompt with a newer one, and `showQuestion` clears
+ * `isSubmittingQuestion` when the newer prompt arrives, so the user can answer
+ * it while the older request is still in flight. Every completion path of the
+ * older request then lands after ownership has already moved.
+ *
+ * A null pending prompt reads as still-owned: the card is simply gone (retired
+ * by `interaction_resolved`, or by this request's own success), and the
+ * leftover submitting/error state is this request's to clean up.
+ */
+function stillOwnsQuestionState(requestId: string): boolean {
+  const { pendingQuestion } = useInteractionStore.getState();
+  return !pendingQuestion || pendingQuestion.requestId === requestId;
+}
+
+/**
  * Clear a question prompt the daemon has already discarded.
  *
  * A question POST comes back 404 ("No pending question interaction found for
@@ -32,18 +55,12 @@ import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
  * minus its attention-key release: an attention key is only ever recorded for a
  * pending secret or confirmation, never a question.
  *
- * Bails entirely when a newer prompt has taken over. `isSubmittingQuestion` and
- * the session error are shared, not per-request, so a late 404 must not touch
- * them once they belong to someone else. That handoff is the norm rather than a
- * rare race: the daemon supersedes this prompt with the newer one, which is
- * *why* this request 404s, and `showQuestion` clears `isSubmittingQuestion` on
- * arrival, so the newer prompt can already be in flight by the time the older
- * response lands. Clearing it there would reopen the double-submit guard and
- * erase a real failure the user needs to see.
+ * Bails entirely when a newer prompt has taken over: clearing there would
+ * reopen the double-submit guard and erase a real failure the user needs to
+ * see. See {@link stillOwnsQuestionState}.
  */
 function clearStaleQuestion(requestId: string): void {
-  const { pendingQuestion } = useInteractionStore.getState();
-  if (pendingQuestion && pendingQuestion.requestId !== requestId) {
+  if (!stillOwnsQuestionState(requestId)) {
     return;
   }
   useInteractionStore.getState().dismissQuestionIfMatches(requestId);
@@ -53,8 +70,11 @@ function clearStaleQuestion(requestId: string): void {
 
 /**
  * Submit the user's answers to a pending question prompt.
- * Guards against a new SSE-driven `question_request` arriving mid-flight
- * by comparing request IDs before clearing state.
+ *
+ * A new SSE-driven `question_request` can arrive mid-flight and take over the
+ * shared submitting/error state, so every path that resumes after the POST
+ * checks {@link stillOwnsQuestionState} before writing to it. Everything before
+ * the POST runs synchronously, so ownership cannot change there.
  */
 export async function handleQuestionResponse(
   responses: QuestionResponseEntry[],
@@ -69,6 +89,8 @@ export async function handleQuestionResponse(
 
   const ctx = useStreamStore.getState().streamContext;
   if (!ctx) {
+    // No ownership check: this runs in the same synchronous block as the entry
+    // guard above, so no newer prompt can have arrived yet.
     useChatSessionStore
       .getState()
       .setError({ message: "No active session. Please try again." });
@@ -87,24 +109,35 @@ export async function handleQuestionResponse(
         clearStaleQuestion(snapshot.requestId);
         return;
       }
-      useChatSessionStore.getState().setError({ message: result.error });
-      useInteractionStore.getState().submitQuestionEnd();
+      // A retryable failure, so the card stays and the user is told. Both
+      // writes belong to whoever owns the state now.
+      if (stillOwnsQuestionState(snapshot.requestId)) {
+        useChatSessionStore.getState().setError({ message: result.error });
+        useInteractionStore.getState().submitQuestionEnd();
+      }
       return;
     }
-    if (
-      useInteractionStore.getState().pendingQuestion?.requestId ===
-      snapshot.requestId
-    ) {
+    // Success. Retire the card this answer belongs to; if it is already gone,
+    // release the submitting flag. When a newer prompt holds it instead, leave
+    // it running: releasing here would reopen the double-submit guard while
+    // that prompt's own request is still in flight.
+    const { pendingQuestion } = useInteractionStore.getState();
+    if (pendingQuestion?.requestId === snapshot.requestId) {
       useInteractionStore.getState().dismissQuestion();
-    } else {
+    } else if (!pendingQuestion) {
       useInteractionStore.getState().submitQuestionEnd();
     }
   } catch (err) {
+    // Transport failure (network drop, abort, malformed response). Always
+    // report it, but only surface it to the user when this request still owns
+    // the banner, so a dead request cannot mask a live one's failure.
     captureError(err, { context: "submit_question_response" });
-    useChatSessionStore
-      .getState()
-      .setError({ message: "Failed to submit response. Please try again." });
-    useInteractionStore.getState().submitQuestionEnd();
+    if (stillOwnsQuestionState(snapshot.requestId)) {
+      useChatSessionStore
+        .getState()
+        .setError({ message: "Failed to submit response. Please try again." });
+      useInteractionStore.getState().submitQuestionEnd();
+    }
   }
 }
 

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -7,7 +7,10 @@ import {
 } from "@/domains/chat/transcript/rolling-snapshot";
 import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import type { AssistantEvent } from "@/types/event-types";
-import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+import type {
+  AnsweredQuestion,
+  AssistantEventEnvelope,
+} from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -542,6 +545,74 @@ describe("rolling-snapshot reducer", () => {
         );
       }
     });
+  });
+});
+
+describe("answered ask_question", () => {
+  const ANSWERED: AnsweredQuestion = {
+    requestId: "req-1",
+    questions: [
+      {
+        id: "q1",
+        question: "Which Alice?",
+        options: [
+          { id: "alice_work", label: "Alice (work)" },
+          { id: "alice_personal", label: "Alice (personal)" },
+        ],
+      },
+    ],
+    responses: [
+      { questionId: "q1", decision: "option", optionId: "alice_work" },
+    ],
+    overall: "completed",
+  };
+
+  const answeredResult = (seq: number, toolUseId: string) =>
+    env(seq, {
+      type: "tool_result",
+      toolUseId,
+      result: "answered",
+      isError: false,
+      answeredQuestion: ANSWERED,
+    } as AssistantEvent);
+
+  test("folds the answered record onto the ask_question tool call", () => {
+    const history = applyEventsToHistory(SEED, [
+      toolUseStart(1, "a1", "t1", "ask_question"),
+      answeredResult(2, "t1"),
+    ]);
+
+    expect(history.messages[0]?.toolCalls?.[0]?.answeredQuestion).toEqual(
+      ANSWERED,
+    );
+  });
+
+  test("a replayed result does not duplicate the answered card", () => {
+    // The card renders one per tool call, so a re-folded event must leave the
+    // tool call count and its record untouched.
+    const events = [
+      toolUseStart(1, "a1", "t1", "ask_question"),
+      answeredResult(2, "t1"),
+    ];
+    const once = applyEventsToHistory(SEED, events);
+    const twice = applyEventsToHistory(SEED, [
+      ...events,
+      answeredResult(2, "t1"),
+    ]);
+
+    expect(twice).toEqual(once);
+    expect(twice.messages[0]?.toolCalls).toHaveLength(1);
+  });
+
+  test("leaves the tool call untouched when the result carries no answer", () => {
+    const history = applyEventsToHistory(SEED, [
+      toolUseStart(1, "a1", "t1", "bash"),
+      toolResult(2, "t1"),
+    ]);
+
+    expect(
+      history.messages[0]?.toolCalls?.[0]?.answeredQuestion,
+    ).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -168,6 +168,7 @@ export function appendEventToMessages(
           imageData: event.imageData,
           imageDataList: event.imageDataList,
           activityMetadata: event.activityMetadata,
+          answeredQuestion: event.answeredQuestion,
           errorCode: event.errorCode,
           completedAt:
             "completedAt" in event && typeof event.completedAt === "number"

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -701,6 +701,54 @@ describe("TranscriptMessageBody", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 
+  test("renders the answered question card for a settled ask_question", () => {
+    const { queryByTestId, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "answered-response",
+          role: "assistant",
+          contentBlocks: [
+            toolUseBlock({
+              id: "tc-ask",
+              name: "ask_question",
+              input: {},
+              completedAt: 1,
+              answeredQuestion: {
+                requestId: "req-1",
+                questions: [
+                  {
+                    id: "q1",
+                    question: "Which Alice?",
+                    options: [{ id: "alice_work", label: "Alice (work)" }],
+                  },
+                ],
+                responses: [
+                  {
+                    questionId: "q1",
+                    decision: "option",
+                    optionId: "alice_work",
+                  },
+                ],
+                overall: "completed",
+              },
+            }),
+            textBlock("Booking with Alice (work)."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    // The answer is content the conversation keeps, so it stays out of the
+    // collapsed "Earlier activity" run that swallows plain completed tools.
+    expect(queryByTestId("answered-question-card")).not.toBeNull();
+    expect(queryByText("Which Alice?")).not.toBeNull();
+    expect(queryByText("Alice (work)")).not.toBeNull();
+    // The card supersedes the raw chip, so the question and answer appear once.
+    expect(queryByTestId("inline-tool-link")).toBeNull();
+    expect(queryByTestId("tool-progress-card")).toBeNull();
+  });
+
   test("keeps completed assistant activity visible when the flag is disabled", () => {
     useClientFeatureFlagStore.setState({
       collapseAssistantIntermediates: false,
@@ -836,7 +884,8 @@ describe("TranscriptMessageBody", () => {
     const secondText = getByText("I will summarize it.");
     const finalText = getByText("Here are the results.");
     expect(
-      firstText.compareDocumentPosition(image!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      firstText.compareDocumentPosition(image!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(
       image!.compareDocumentPosition(secondText) &

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -749,6 +749,40 @@ describe("TranscriptMessageBody", () => {
     expect(queryByTestId("tool-progress-card")).toBeNull();
   });
 
+  test("falls back to the raw chip when an answered record has no questions", () => {
+    // The card draws nothing for an empty record, so suppression must not fire
+    // on the field's mere presence: otherwise the step renders neither a card
+    // nor a chip and disappears from the conversation. The daemon cannot write
+    // this, but a truncated persisted row satisfies the wire schema.
+    const { queryByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "empty-answer-response",
+          role: "assistant",
+          contentBlocks: [
+            toolUseBlock({
+              id: "tc-ask-empty",
+              name: "ask_question",
+              input: {},
+              completedAt: 1,
+              answeredQuestion: {
+                requestId: "req-1",
+                questions: [],
+                responses: [],
+                overall: "completed",
+              },
+            }),
+          ],
+        }}
+        onSurfaceAction={noop}
+        isStreaming
+      />,
+    );
+
+    expect(queryByTestId("answered-question-card")).toBeNull();
+    expect(queryByTestId("inline-tool-link")).not.toBeNull();
+  });
+
   test("keeps completed assistant activity visible when the flag is disabled", () => {
     useClientFeatureFlagStore.setState({
       collapseAssistantIntermediates: false,

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -42,7 +42,10 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
-import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
+import {
+  AnsweredQuestionCard,
+  hasRenderableAnswer,
+} from "@/domains/chat/components/answered-question-card";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
@@ -662,7 +665,9 @@ export function TranscriptMessageBody({
   // renders identically on both paths and cannot double up: one card per
   // answered tool call.
   const renderAnsweredQuestionCards = (toolCalls: ChatMessageToolCall[]) => {
-    const answered = toolCalls.filter((tc) => tc.answeredQuestion);
+    const answered = toolCalls.filter((tc) =>
+      hasRenderableAnswer(tc.answeredQuestion),
+    );
     if (answered.length === 0) {
       return null;
     }
@@ -760,7 +765,7 @@ export function TranscriptMessageBody({
         cardBackedWorkflowRunId(tc) === null &&
         cardBackedAcpRunId(tc) === null &&
         cardBackedBackgroundTaskId(tc) === null &&
-        tc.answeredQuestion === undefined,
+        !hasRenderableAnswer(tc.answeredQuestion),
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -797,7 +802,7 @@ export function TranscriptMessageBody({
               cardBackedWorkflowRunId(tc) !== null ||
               cardBackedAcpRunId(tc) !== null ||
               cardBackedBackgroundTaskId(tc) !== null ||
-              tc.answeredQuestion !== undefined,
+              hasRenderableAnswer(tc.answeredQuestion),
           )
           .map((tc) => tc.id),
       );
@@ -1073,7 +1078,7 @@ export function TranscriptMessageBody({
               cardBackedWorkflowRunId(toolCall) !== null ||
               cardBackedAcpRunId(toolCall) !== null ||
               cardBackedBackgroundTaskId(toolCall) !== null ||
-              toolCall.answeredQuestion !== undefined ||
+              hasRenderableAnswer(toolCall.answeredQuestion) ||
               acpConnectToolUseId === toolCall.id ||
               unknownNudgeToolCallIds?.has(toolCall.id) === true,
           );

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -42,6 +42,7 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
+import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
@@ -655,6 +656,25 @@ export function TranscriptMessageBody({
       <AcpConnectAffordance assistantId={assistantId} />
     ) : null;
 
+  // An answered `ask_question` renders its questions and the user's answers as
+  // a durable transcript row. The record rides the tool call itself (live from
+  // `tool_result`, then from the daemon's persisted copy on reload), so this
+  // renders identically on both paths and cannot double up: one card per
+  // answered tool call.
+  const renderAnsweredQuestionCards = (toolCalls: ChatMessageToolCall[]) => {
+    const answered = toolCalls.filter((tc) => tc.answeredQuestion);
+    if (answered.length === 0) {
+      return null;
+    }
+    return (
+      <div className="flex w-full flex-col gap-1.5">
+        {answered.map((tc) => (
+          <AnsweredQuestionCard key={tc.id} answered={tc.answeredQuestion!} />
+        ))}
+      </div>
+    );
+  };
+
   const renderInlineBackgroundTaskCards = (
     toolCalls: ChatMessageToolCall[],
   ) => {
@@ -731,14 +751,16 @@ export function TranscriptMessageBody({
     const renderableToolCalls = groupToolCalls.filter(
       // Suppress the raw chip only for a card-backed run_workflow / acp_spawn /
       // background bash call (see cardBackedWorkflowRunId / cardBackedAcpRunId /
-      // cardBackedBackgroundTaskId). A failed call (no id) or a run with no
-      // store entry is not card-backed, so it renders its tool result instead
-      // of vanishing.
+      // cardBackedBackgroundTaskId), or an answered ask_question whose card
+      // already shows the question and the answer. A failed call (no id) or a
+      // run with no store entry is not card-backed, so it renders its tool
+      // result instead of vanishing.
       (tc) =>
         !isSubagentSpawnCall(tc) &&
         cardBackedWorkflowRunId(tc) === null &&
         cardBackedAcpRunId(tc) === null &&
-        cardBackedBackgroundTaskId(tc) === null,
+        cardBackedBackgroundTaskId(tc) === null &&
+        tc.answeredQuestion === undefined,
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -757,6 +779,7 @@ export function TranscriptMessageBody({
           {renderInlineWorkflowCards(groupToolCalls)}
           {renderInlineAcpRunCards(groupToolCalls)}
           {renderInlineBackgroundTaskCards(groupToolCalls)}
+          {renderAnsweredQuestionCards(groupToolCalls)}
           {renderAcpConnectAffordance(groupToolCalls)}
         </Fragment>
       );
@@ -773,7 +796,8 @@ export function TranscriptMessageBody({
             (tc) =>
               cardBackedWorkflowRunId(tc) !== null ||
               cardBackedAcpRunId(tc) !== null ||
-              cardBackedBackgroundTaskId(tc) !== null,
+              cardBackedBackgroundTaskId(tc) !== null ||
+              tc.answeredQuestion !== undefined,
           )
           .map((tc) => tc.id),
       );
@@ -809,6 +833,7 @@ export function TranscriptMessageBody({
           {renderInlineWorkflowCards(groupToolCalls)}
           {renderInlineAcpRunCards(groupToolCalls)}
           {renderInlineBackgroundTaskCards(groupToolCalls)}
+          {renderAnsweredQuestionCards(groupToolCalls)}
           {renderAcpConnectAffordance(groupToolCalls)}
         </Fragment>
       );
@@ -834,6 +859,7 @@ export function TranscriptMessageBody({
         {renderInlineWorkflowCards(groupToolCalls)}
         {renderInlineAcpRunCards(groupToolCalls)}
         {renderInlineBackgroundTaskCards(groupToolCalls)}
+        {renderAnsweredQuestionCards(groupToolCalls)}
       </Fragment>
     );
   };
@@ -1047,6 +1073,7 @@ export function TranscriptMessageBody({
               cardBackedWorkflowRunId(toolCall) !== null ||
               cardBackedAcpRunId(toolCall) !== null ||
               cardBackedBackgroundTaskId(toolCall) !== null ||
+              toolCall.answeredQuestion !== undefined ||
               acpConnectToolUseId === toolCall.id ||
               unknownNudgeToolCallIds?.has(toolCall.id) === true,
           );

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -42,10 +42,8 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
-import {
-  AnsweredQuestionCard,
-  hasRenderableAnswer,
-} from "@/domains/chat/components/answered-question-card";
+import { hasRenderableAnswer } from "@/domains/chat/answered-question";
+import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -390,6 +390,22 @@ export function TranscriptMessageBody({
     const id = extractBgIdFromResult(tc);
     return id !== undefined && cardBackedBackgroundTaskIds.has(id) ? id : null;
   };
+  /**
+   * Whether a dedicated inline card renders this tool call's content, which
+   * makes the raw chip a duplicate. Each clause requires the card to actually
+   * be there: a failed call (no id), a run with no store entry, and an answered
+   * question with nothing to show are all not card-backed, so they keep the
+   * chip instead of vanishing from the transcript.
+   *
+   * Read by all three places that must agree on this: the chip filter, the
+   * group's suppression set, and the collapse guard that keeps a card-backed
+   * group out of the "Earlier activity" disclosure.
+   */
+  const isCardBacked = (tc: ChatMessageToolCall): boolean =>
+    cardBackedWorkflowRunId(tc) !== null ||
+    cardBackedAcpRunId(tc) !== null ||
+    cardBackedBackgroundTaskId(tc) !== null ||
+    hasRenderableAnswer(tc.answeredQuestion);
   const handleAcpRunClick = useCallback((acpSessionId: string) => {
     useViewerStore.getState().openAcpRunDetail(acpSessionId);
   }, []);
@@ -754,18 +770,7 @@ export function TranscriptMessageBody({
       it.kind === "thinking" ? [it.text] : [],
     );
     const renderableToolCalls = groupToolCalls.filter(
-      // Suppress the raw chip only for a card-backed run_workflow / acp_spawn /
-      // background bash call (see cardBackedWorkflowRunId / cardBackedAcpRunId /
-      // cardBackedBackgroundTaskId), or an answered ask_question whose card
-      // already shows the question and the answer. A failed call (no id) or a
-      // run with no store entry is not card-backed, so it renders its tool
-      // result instead of vanishing.
-      (tc) =>
-        !isSubagentSpawnCall(tc) &&
-        cardBackedWorkflowRunId(tc) === null &&
-        cardBackedAcpRunId(tc) === null &&
-        cardBackedBackgroundTaskId(tc) === null &&
-        !hasRenderableAnswer(tc.answeredQuestion),
+      (tc) => !isSubagentSpawnCall(tc) && !isCardBacked(tc),
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -790,21 +795,11 @@ export function TranscriptMessageBody({
       );
     }
     if (renderableToolCalls.length > 0) {
-      // A card-backed run_workflow / acp_spawn call is shown by its dedicated
-      // inline card, so drop it from the steps MultiActivityGroup renders too
-      // (the group filters subagent_spawn internally but not the others). A
-      // failed or pruned call is not card-backed and is kept, so its tool result
-      // still renders as a step; subagent spawns are left for the group to filter.
+      // A card-backed call is shown by its dedicated inline card, so drop it
+      // from the steps MultiActivityGroup renders too (the group filters
+      // subagent_spawn internally but not the others).
       const suppressedCardIds = new Set(
-        groupToolCalls
-          .filter(
-            (tc) =>
-              cardBackedWorkflowRunId(tc) !== null ||
-              cardBackedAcpRunId(tc) !== null ||
-              cardBackedBackgroundTaskId(tc) !== null ||
-              hasRenderableAnswer(tc.answeredQuestion),
-          )
-          .map((tc) => tc.id),
+        groupToolCalls.filter(isCardBacked).map((tc) => tc.id),
       );
       const groupCardToolCalls =
         suppressedCardIds.size === 0
@@ -1075,10 +1070,7 @@ export function TranscriptMessageBody({
               isToolCallRunning(toolCall) ||
               toolCall.pendingConfirmation !== undefined ||
               isSubagentSpawnCall(toolCall) ||
-              cardBackedWorkflowRunId(toolCall) !== null ||
-              cardBackedAcpRunId(toolCall) !== null ||
-              cardBackedBackgroundTaskId(toolCall) !== null ||
-              hasRenderableAnswer(toolCall.answeredQuestion) ||
+              isCardBacked(toolCall) ||
               acpConnectToolUseId === toolCall.id ||
               unknownNudgeToolCallIds?.has(toolCall.id) === true,
           );

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
@@ -186,6 +186,86 @@ describe("handleInteractionResolved", () => {
       "cr-1",
     );
   });
+
+  it("retires a question card the daemon settled without the user", () => {
+    // Timeout, abort, supersession, and daemon restart all settle the prompt
+    // as "cancelled". None of them produce an answer, so this event is the
+    // only signal the card has stopped being answerable.
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-req-1", entries: [] });
+
+    handleInteractionResolved({
+      type: "interaction_resolved",
+      requestId: "q-req-1",
+      conversationId: "conv-1",
+      kind: "question",
+      state: "cancelled",
+    });
+
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+  });
+
+  it("retires a question card on the answered state too", () => {
+    // The channel paths (a Telegram option tap, a request-code reply) resolve
+    // the prompt as "answered" while the web card is still open.
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-req-1", entries: [] });
+
+    handleInteractionResolved({
+      type: "interaction_resolved",
+      requestId: "q-req-1",
+      conversationId: "conv-1",
+      kind: "question",
+      state: "answered",
+    });
+
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+  });
+
+  it("leaves a question card raised for a different requestId alone", () => {
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-req-2", entries: [] });
+
+    handleInteractionResolved({
+      type: "interaction_resolved",
+      requestId: "q-req-1",
+      conversationId: "conv-1",
+      kind: "question",
+      state: "cancelled",
+    });
+
+    expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+      "q-req-2",
+    );
+  });
+
+  it("does not disturb a pending confirmation when a question resolves", () => {
+    useInteractionStore.getState().showConfirmation({
+      requestId: "cr-1",
+      toolName: "bash",
+      riskLevel: "high",
+      input: {},
+    });
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "q-req-1", entries: [] });
+
+    handleInteractionResolved({
+      type: "interaction_resolved",
+      requestId: "q-req-1",
+      conversationId: "conv-1",
+      kind: "question",
+      state: "cancelled",
+    });
+
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+    expect(useInteractionStore.getState().pendingConfirmation?.requestId).toBe(
+      "cr-1",
+    );
+  });
 });
 
 describe("handleContactRequest", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -70,28 +70,40 @@ export function handleConfirmationRequest(
 }
 
 /**
- * Retire an active confirmation prompt when the daemon reports its pending
- * interaction has resolved (approved, rejected, cancelled, or superseded).
+ * Retire an active confirmation or question prompt when the daemon reports its
+ * pending interaction has resolved (approved, rejected, answered, cancelled, or
+ * superseded).
  *
  * `interaction_resolved` is conversation-scoped, so by the time it reaches a
  * chat stream handler it is guaranteed to be for the active conversation.
  * Attention tracking (`use-attention-tracking`) deliberately skips the active
- * conversation and defers its confirmation card to this handler — so without
- * it, a confirmation the daemon has already discarded (e.g. an `acp_spawn`
- * that timed out) would linger on screen with no way to act on it, and tapping
- * Allow/Deny would 404.
+ * conversation and defers its card to this handler. Without it, a prompt the
+ * daemon has already discarded (e.g. an `acp_spawn` that timed out) would
+ * linger on screen with no way to act on it, and acting on it would 404.
  *
- * Only confirmation kinds render a card here; other kinds (host-proxy steps,
- * secrets, questions) own their own lifecycle. The requestId guards make a
- * mismatched or already-cleared confirmation a no-op.
+ * Both card-rendering kinds are handled here. A question card is retired by
+ * `question-actions` on the two outcomes the user drives (a submitted answer,
+ * the X), but every other settlement is invisible to the client: the prompt
+ * timed out, the turn aborted, a newer message superseded it, or the daemon
+ * restarted. Those all funnel through the prompter's `finish()`, which
+ * deregisters the interaction and broadcasts this event, making it the only
+ * signal the card has become undecidable. Host-proxy steps and secrets render
+ * no card here. The requestId guards make a mismatched or already-cleared
+ * prompt a no-op.
  */
 export function handleInteractionResolved(
   event: InteractionResolvedEvent,
 ): void {
+  const { requestId } = event;
+
+  if (event.kind === "question") {
+    useInteractionStore.getState().dismissQuestionIfMatches(requestId);
+    return;
+  }
+
   if (event.kind !== "confirmation" && event.kind !== "acp_confirmation") {
     return;
   }
-  const { requestId } = event;
   const session = useChatSessionStore.getState();
   const interaction = useInteractionStore.getState();
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleToolResult,
@@ -164,5 +165,46 @@ describe("handleToolResult", () => {
       ctx,
     );
     expect(ctx.turnActions.onToolActivityMetadata).not.toHaveBeenCalled();
+  });
+
+  describe("answered ask_question", () => {
+    const answeredQuestion = {
+      requestId: "req-1",
+      questions: [{ id: "q1", question: "Which Alice?", options: [] }],
+      responses: [{ questionId: "q1", decision: "skipped" as const }],
+      overall: "completed" as const,
+    };
+
+    const answeredResult = (requestId: string) => ({
+      type: "tool_result" as const,
+      toolName: "ask_question",
+      result: "answered",
+      toolUseId: "tc-1",
+      answeredQuestion: { ...answeredQuestion, requestId },
+    });
+
+    it("retires the interactive card for a prompt answered elsewhere", () => {
+      // A channel option tap resolves the prompt server-side; without this the
+      // web card would stay open next to the answered transcript row.
+      useInteractionStore
+        .getState()
+        .showQuestion({ requestId: "req-1", entries: [] });
+
+      handleToolResult(answeredResult("req-1"), makeCtx());
+
+      expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+    });
+
+    it("leaves a card raised for a different prompt standing", () => {
+      useInteractionStore
+        .getState()
+        .showQuestion({ requestId: "req-2", entries: [] });
+
+      handleToolResult(answeredResult("req-1"), makeCtx());
+
+      expect(useInteractionStore.getState().pendingQuestion?.requestId).toBe(
+        "req-2",
+      );
+    });
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -53,6 +53,18 @@ export function handleToolResult(
     );
   }
 
+  // The prompt has settled, so retire any interactive card still on screen for
+  // it. The submit path already clears its own card; this covers a prompt
+  // answered elsewhere (a channel option tap, a request-code reply) whose
+  // answer would otherwise leave the web card open alongside the answered
+  // transcript row. Guarded on the requestId so a card raised for a newer
+  // question is untouched.
+  if (event.answeredQuestion) {
+    useInteractionStore
+      .getState()
+      .dismissQuestionIfMatches(event.answeredQuestion.requestId);
+  }
+
   // A missing-token `acp_spawn` failure raises the inline "Connect Claude Code"
   // prompt in the interaction store. This is a LIVE-only tap: a `/messages`
   // reseed replays the event tail through the rolling-snapshot reducer, not

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
@@ -9,7 +9,10 @@
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
-import type { ConversationContentBlock } from "@vellumai/assistant-api";
+import type {
+  AnsweredQuestion,
+  ConversationContentBlock,
+} from "@vellumai/assistant-api";
 import type {
   AllowlistOption,
   DirectoryScopeOption,
@@ -165,6 +168,13 @@ export function applyToolResult(
      */
     activityMetadata?: ToolActivityMetadata;
     /**
+     * The answered `ask_question` record from the tool_result event. Persisted
+     * on the tool call so the answered card renders the moment the prompt
+     * resolves, matching what a later history reopen restores from the
+     * daemon's persisted copy.
+     */
+    answeredQuestion?: AnsweredQuestion;
+    /**
      * Stable machine-readable error classification from the tool_result event
      * (only set when `isError`). Persisted on the tool call so surfaces can
      * branch on a known failure (e.g. `acp_claude_oauth_missing`) after the
@@ -247,6 +257,9 @@ export function applyToolResult(
     ...(imageDataList !== undefined ? { imageDataList } : {}),
     ...(opts.activityMetadata !== undefined
       ? { activityMetadata: opts.activityMetadata }
+      : {}),
+    ...(opts.answeredQuestion !== undefined
+      ? { answeredQuestion: opts.answeredQuestion }
       : {}),
     ...(opts.errorCode !== undefined ? { errorCode: opts.errorCode } : {}),
     completedAt: opts.completedAt ?? Date.now(),


### PR DESCRIPTION
## TL;DR

An answered `ask_question` prompt now stays in the conversation. The questions and the user's answers are persisted on the `ask_question` tool call and rendered as a read-only card in the transcript, so the decision survives switching conversations, reloading, and reopening from history.

Closes LUM-3019. Also closes JARVIS-1064 (stale question cards), and quiets the LUM-2340 Sentry noise.

## Before / after

| Situation | Before | After |
| --- | --- | --- |
| Right after answering | The card disappears; the turn shows a generic `ask_question` tool chip | A card showing the question and the answer you gave |
| Switch to another conversation and back | No trace of the question or the answer | The same answered card |
| Reload the page or restart the app | No trace of the question or the answer | The same answered card |
| Reopen an old conversation from history | No trace of the question or the answer | The same answered card |
| Free-text answer instead of an option | Lost | Shown verbatim |
| Question skipped, or the card closed unanswered | Lost | Shown as "Skipped" |
| Question still waiting on you | Interactive card above the composer | Unchanged |
| Prompt answered on a channel while the web card is open | Web card lingers, and answering it 404s | The web card retires when the answer lands |
| Prompt times out | Card stays on screen; clicking an option shows a raw server error with a "Go to Doctor" CTA | Card retires itself; the turn's error result stands in the transcript |
| Turn aborted, or a follow-up message supersedes the prompt | Same stranded card and raw error | Card retires itself |
| Assistant restarts while a prompt is open | Same stranded card and raw error | Card retires itself |
| Answering a prompt the assistant already dropped | Raw server string in the error banner | Card retires quietly, no error surfaced |
| Closing a prompt the assistant already dropped | Silently reported to Sentry as an error | Treated as the expected outcome, not reported |
| A genuine server failure on answer or close | Error surfaced / reported | Unchanged |
| Conversations answered before this change | Nothing to show | Unchanged, no card |

## Two halves, one lifecycle

Persisting the answer only covers outcomes the **user** drives. A prompt also settles for reasons the client never sees: it times out, the turn aborts, a newer message supersedes it, or the assistant restarts. Those produce no answer to persist, so the card needs a separate retirement path, and without one it stayed on screen answering into a 404.

That path now mirrors what confirmations already had (#35612):

- **Proactive**: `handleInteractionResolved` retires a question card on any resolution state. Every daemon settlement funnels through the prompter's `finish()`, which broadcasts `interaction_resolved`, so this is the one signal that the card has stopped being answerable.
- **Reactive**: a 404 from the response endpoint is terminal in both directions. It is not redundant with the proactive half, because the web / iOS SSE stream tears down on app background with no replay, so the event can be missed entirely.

## How it works

The answer rides the tool call it belongs to, following the same path `activityMetadata` already takes:

1. When the prompt settles, the `ask_question` executor returns an `answeredQuestion` record on its `ToolExecutionResult`: the questions as asked (with their daemon-assigned ids) plus one response per question.
2. The agent loop forwards it on the `tool_result` event and stamps it onto the persisted `tool_use` block as `_answeredQuestion`.
3. `renderHistoryContent` reads it back onto the wire tool call, so `GET /messages` carries it.
4. Web folds the live event onto the tool call in the rolling-snapshot reducer, and picks up the persisted copy on a history load. Both paths produce the same field on the same tool call.

`QuestionPrompter.prompt()` now returns the `requestId` and the entries it broadcast alongside the resolution, since only the prompter knows them.

Only user-driven outcomes are recorded (`completed` and `closed`). A prompt that timed out or was aborted produced no decision, so it carries no record and its own error result stands on its own.

## Why it is safe

- **Additive wire field.** `answeredQuestion` is optional on both `tool_result` and the history tool call. An older assistant omits it, the field is absent, and the UI renders exactly as it does today. No version gate is needed: this is a read whose absent state is the feature-off state.
- **No new persistence store.** The record is a rider on the existing `tool_use` block, alongside `_startedAt`, `_riskLevel`, and `_activityMetadata`. It reuses the annotation path those already use.
- **Cannot duplicate.** The card renders one per tool call from a field that is set, not appended, so a replayed `tool_result` and a history rehydration both converge on the same single card. Covered by a reducer replay test.
- **Malformed rows degrade, they do not crash.** The read-back validates against the schema, so an unparseable rider yields no card rather than a broken render.
- **Pending prompts are untouched.** The `pendingQuestion` registry path, the interactive card, and the submit flow are unchanged. A tool call carries at most one of the two.
- **The raw tool chip is suppressed only when a card actually replaces it**, following the existing `cardBacked*` pattern. Suppression, the collapse guard, and the card itself all gate on one shared `hasRenderableAnswer` predicate, so "the field is set" and "the card draws something" cannot diverge into a tool call that renders neither. A record with no questions degrades to the plain chip.

## Notable non-obvious detail

The answered record is stamped on the persisted row **immediately** when the result lands, not only at the end-of-turn annotation. That annotation waits for every tool in the turn to finish, so a user who switches conversations while a sibling tool is still running would refetch history that had already lost their answer.

This required a third copy of the early-stamp helper, so the two existing near-identical ones (`recordToolStartOnPersistedMessage`, `recordToolPreviewStartOnPersistedMessage`) are extracted onto one `stampToolUseBlockEarly` that all three now use.

## Tests

New coverage for each behavior in the ticket:

- `assistant/src/__tests__/answered-question-persistence.test.ts` (new): stamping, immediate durability with a sibling tool still running, survival across end-of-turn annotation, no rewrite on a repeat, no stamp without an answer.
- `assistant/src/__tests__/server-history-render.test.ts`: read-back for option and free-text answers, absence on pre-change rows, malformed rider ignored.
- `assistant/src/tools/ask-question/ask-question-tool.test.ts`: option, free text, closed card, per-question skips inside a completed batch, nothing for timeout/abort, nothing for the text-fallback channel path.
- `clients/web/.../answered-question-card.test.tsx` (new): rendering for each answer shape, batches, and answer-to-question pairing by id.
- `clients/web/.../rolling-snapshot.test.ts`: the live fold, and that a replayed result does not duplicate the card.
- `clients/web/.../transcript-message-body.test.tsx`: the card renders, stays out of the collapsed "Earlier activity" run, and supersedes the raw chip.
- `clients/web/.../messages.test.ts`, `interaction-store.test.ts`, `tool-call-handlers.test.ts`: history rehydration, the request-id-guarded card retirement.
- `clients/web/.../interaction-handlers.test.ts`: `interaction_resolved` with kind `question` retires a matching card (on both `cancelled` and `answered`), leaves a non-matching requestId alone, and does not disturb a pending confirmation.
- `clients/web/.../question-actions.test.ts` (new, mirroring `confirmation-actions.test.ts`): a 404 on answer and on close both retire without surfacing an error or reporting to Sentry; non-404 statuses still do both; a prompt that arrives mid-flight is not retired by the older request's 404.

`assistant/openapi.yaml` is regenerated; the change is additive.

## Deferred

Nothing. Channel-specific terminal-message behavior (Telegram keyboard withdrawal) was scoped out by the ticket and does not share this seam: it is a delivery concern in the guardian-request pipeline, not transcript persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
