### PR TITLE
feat(voice): let a live-voice call show surfaces, and reveal them deterministically

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -485,9 +485,10 @@ describe("startVoiceTurn triage-and-escalate control prompt", () => {
 });
 
 describe("startVoiceTurn channel capabilities", () => {
-  // Voice calls are non-interactive: the bridge forces supportsDynamicUi off
-  // for every voice turn so ui-surface tools never reach the model mid-call,
-  // while leaving the rest of the channel's resolved capabilities intact.
+  // Whether a call can show a surface is a property of its channel, not of
+  // calls in general, so the bridge applies no voice-specific override: a
+  // phone call has no screen and resolves false on its own, while a live-voice
+  // call is a screen the user is holding and resolves true.
 
   // The turn installs its capabilities, then cleanup resets them to null — so
   // capture every applied value and read the installed (non-null) one.
@@ -507,7 +508,7 @@ describe("startVoiceTurn channel capabilities", () => {
       );
   }
 
-  test("a vellum/macos (live-voice) turn forces supportsDynamicUi off, other fields untouched", async () => {
+  test("a vellum/macos (live-voice) turn keeps its channel's dynamic UI", async () => {
     const installed = captureInstalledCapabilities();
     await startVoiceTurn({
       ...makeTurnOptions(),
@@ -515,14 +516,16 @@ describe("startVoiceTurn channel capabilities", () => {
       userMessageInterface: "macos",
     });
     const caps = installed();
-    expect(caps?.supportsDynamicUi).toBe(false);
-    // The override is surgical: live-voice keeps identifying as vellum/macos.
+    expect(caps?.supportsDynamicUi).toBe(true);
+    // Nothing else about the channel is rewritten either.
     expect(caps?.dashboardCapable).toBe(true);
     expect(caps?.supportsVoiceInput).toBe(true);
     expect(caps?.clientOS).toBe("macos");
   });
 
-  test("phone defaults (no channel overrides) also yield supportsDynamicUi false", async () => {
+  // The case the removed override existed for, still covered: a phone call has
+  // no screen to show a surface on, and says so through its channel.
+  test("phone defaults yield supportsDynamicUi false", async () => {
     const installed = captureInstalledCapabilities();
     await startVoiceTurn(makeTurnOptions());
     const caps = installed();

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -367,11 +367,16 @@ export interface VoiceTurnHandle {
  * provides assistant identity) and guardian context (injected separately).
  */
 /**
- * Steering shared by every voice channel. Voice turns exclude the ui-surface
- * tools, but the model can still reach OAuth/sign-in flows through shell or
- * CLI tools (e.g. `assistant oauth connect`), which open a browser window
- * mid-call that the caller may be unable to see or complete. Tell it to speak
- * the limitation and defer the flow to text chat instead.
+ * Steering shared by every voice channel. A sign-in flow opens a browser
+ * window mid-call that the caller may be unable to see or complete, whether it
+ * is reached through a ui-surface tool or through shell and CLI tools (e.g.
+ * `assistant oauth connect`). Tell the model to speak the limitation and defer
+ * the flow to text chat instead.
+ *
+ * This outlives the ui-surface restriction it was written alongside: a
+ * live-voice call can now show surfaces, but a browser window handing control
+ * to a third party mid-call is a different problem, and one a minimized room
+ * does not solve.
  */
 export const VOICE_NO_SETUP_FLOWS_RULE =
   "Never start account connections, OAuth or sign-in flows, or any other action that opens a browser window or needs the user's screen during this call — not even through shell or CLI tools. If the task needs one, say so briefly and offer to finish it in text chat after the call.";
@@ -897,21 +902,22 @@ export async function startVoiceTurn(
     trustContext: opts.trustContext ?? null,
     turnChannelContext,
     turnInterfaceContext,
-    channelCapabilities: {
-      ...resolveChannelCapabilities(
-        turnChannelContext.userMessageChannel,
-        turnInterfaceContext.userMessageInterface,
-      ),
-      // Voice calls are non-interactive: no surface can be shown, read, or
-      // clicked mid-call, so `ui_show`/`ui_update`/`ui_dismiss` (and thus
-      // `oauth_connect`, a ui_show surface_type) must never reach the model.
-      // Phone already resolves to false via its channel; live-voice resolves
-      // vellum/macos → true, so force it off here for every voice turn. This
-      // also flips the runtime-context `supports_dynamic_ui` line the prompt
-      // advertises, the secret-prompter's dynamic-UI branch, and the
-      // task-progress-nudge hook — all correctly non-UI during a call.
-      supportsDynamicUi: false,
-    },
+    // Resolved from the channel, with no voice-specific override.
+    //
+    // Whether a call can show a surface is a property of the call's channel,
+    // not of calls in general. A phone call has no screen at all and resolves
+    // to `supportsDynamicUi: false` on its own; a live-voice call is a screen
+    // the user is holding, temporarily covered by the room overlay, and the
+    // session minimizes that overlay when a surface is shown (see the ui-tool
+    // branch of the live-voice session's `tool_use_start`).
+    //
+    // This one flag also drives the runtime-context `supports_dynamic_ui`
+    // line, the secret-prompter's dynamic-UI branch, and the
+    // task-progress-nudge hook, so a live-voice turn now reaches all of them.
+    channelCapabilities: resolveChannelCapabilities(
+      turnChannelContext.userMessageChannel,
+      turnInterfaceContext.userMessageInterface,
+    ),
     voiceCallControlPrompt,
   };
   const installVoiceTurnState = () => {
@@ -1196,11 +1202,14 @@ export async function startVoiceTurn(
       return;
     }
     if (msg.type === "secret_request") {
-      // Defense-in-depth: SecretPrompter.prompt fails fast with
-      // `unsupported_channel` on voice turns (supportsDynamicUi is forced
-      // off above), so a secret_request should never reach this handler.
-      // Resolve immediately anyway in case an emitter bypasses the
-      // prompter's channel check or races a capability install.
+      // Auto-resolved rather than prompted, on every voice channel.
+      //
+      // A phone call cannot render a secret field at all. A live-voice call
+      // now can (its channel resolves `supportsDynamicUi` true), so this is
+      // where the prompt would surface, and it deliberately does not yet:
+      // typing a credential into a screen you reached by minimizing a call is
+      // a flow that needs designing, not a flag flip. Resolving with no secret
+      // leaves the tool to fail the way it does today.
       log.info(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -672,13 +672,27 @@ describe("LiveVoiceSession room reveal", () => {
     };
   }
 
+  /** Run a ui tool to completion, as the agent loop would. */
+  function runUiTool(
+    getCallbacks: () => VoiceTurnCallbacks | undefined,
+    toolName: string,
+    opts?: { isError?: boolean },
+  ): void {
+    getCallbacks()?.tool_use_start?.(toolName);
+    getCallbacks()?.tool_result?.({
+      toolName,
+      resultPreview: "",
+      ...(opts?.isError === true ? { isError: true } : {}),
+    });
+  }
+
   // Showing a surface is what reveals the screen. Nothing the model says does,
   // so the user never loses the reveal to a forgotten token.
   test("a ui tool emits minimize_room after tts_done", async () => {
     const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
-    getCallbacks()?.tool_use_start?.("ui_show");
+    runUiTool(getCallbacks, "ui_show");
     emitTextDelta(getCallbacks, "Here is the summary.");
     emitMessageComplete(getCallbacks);
     await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
@@ -700,11 +714,53 @@ describe("LiveVoiceSession room reveal", () => {
     ).toHaveLength(1);
   });
 
+  // The reveal follows the surface, not the attempt: a rejected call (no
+  // surface_type, an empty card, a client that never acks) rendered nothing,
+  // and minimizing to show nothing is worse than staying put.
+  test("a failed ui call reveals nothing", async () => {
+    const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    runUiTool(getCallbacks, "ui_show", { isError: true });
+    emitTextDelta(getCallbacks, "I could not show that.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  test("a surface taken away before the reply ends reveals nothing", async () => {
+    const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    runUiTool(getCallbacks, "ui_show");
+    runUiTool(getCallbacks, "ui_dismiss");
+    emitTextDelta(getCallbacks, "Never mind, sorted it.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  // Opening an app puts something on screen just as a card does; a list keyed
+  // on "ui_" would have missed it.
+  test("opening an app reveals the screen", async () => {
+    const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    runUiTool(getCallbacks, "app_open");
+    emitTextDelta(getCallbacks, "Opened it up.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(true);
+  });
+
   test("dismissing a surface does not reveal the screen", async () => {
     const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
-    getCallbacks()?.tool_use_start?.("ui_dismiss");
+    runUiTool(getCallbacks, "ui_dismiss");
     emitTextDelta(getCallbacks, "Cleared that away.");
     emitMessageComplete(getCallbacks);
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
@@ -768,7 +824,7 @@ describe("LiveVoiceSession room reveal", () => {
     const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
-    getCallbacks()?.tool_use_start?.("ui_show");
+    runUiTool(getCallbacks, "ui_show");
     emitTextDelta(getCallbacks, "Showing you now.");
     await flushAsyncCallbacks();
 

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -618,7 +618,7 @@ describe("LiveVoiceSession tool-use spoken ack", () => {
   });
 });
 
-describe("LiveVoiceSession minimize-room marker", () => {
+describe("LiveVoiceSession room reveal", () => {
   function createMarkerHarness() {
     const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
     const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
@@ -633,11 +633,10 @@ describe("LiveVoiceSession minimize-room marker", () => {
   }
 
   /**
-   * Marker-command harness for the leg that can actually put something on
-   * screen: routing fronts every turn with the fast leg, so the front-door
-   * call is scripted to escalate ("[1] Working on it.") and the returned
-   * callbacks drive the ESCALATED leg — the only leg whose completion may
-   * latch `minimizeRequested`.
+   * Harness for the leg that can actually put something on screen: routing
+   * fronts every turn with the fast leg, so the front-door call is scripted to
+   * escalate ("[1] Working on it.") and the returned callbacks drive the
+   * ESCALATED leg; the toolless front door can never run a ui tool.
    */
   function createEscalatedMarkerHarness() {
     let escalatedCallbacks: VoiceTurnCallbacks | undefined;
@@ -673,35 +672,67 @@ describe("LiveVoiceSession minimize-room marker", () => {
     };
   }
 
-  test("strips a terminal [-1] from deltas and TTS and emits minimize_room after tts_done", async () => {
+  // Showing a surface is what reveals the screen. Nothing the model says does,
+  // so the user never loses the reveal to a forgotten token.
+  test("a ui tool emits minimize_room after tts_done", async () => {
+    const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    getCallbacks()?.tool_use_start?.("ui_show");
+    emitTextDelta(getCallbacks, "Here is the summary.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+
+    const ttsDoneIndex = frames.findIndex((frame) => frame.type === "tts_done");
+    const minimizeIndex = frames.findIndex(
+      (frame) => frame.type === "minimize_room",
+    );
+    expect(ttsDoneIndex).toBeGreaterThanOrEqual(0);
+    // After the speech drains, never mid-sentence.
+    expect(minimizeIndex).toBeGreaterThan(ttsDoneIndex);
+    expect(frames[minimizeIndex]).toMatchObject({
+      type: "minimize_room",
+      turnId: "live-turn-1",
+    });
+    // At most once, however many surfaces the turn touched.
+    expect(
+      frames.filter((frame) => frame.type === "minimize_room"),
+    ).toHaveLength(1);
+  });
+
+  test("dismissing a surface does not reveal the screen", async () => {
+    const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
+
+    await startReleasedTurn(session, getCallbacks);
+    getCallbacks()?.tool_use_start?.("ui_dismiss");
+    emitTextDelta(getCallbacks, "Cleared that away.");
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Minimizing to show the user something that is no longer there is the
+    // opposite of the point.
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
+  });
+
+  // The marker is no longer taught to any leg, so this is about a model that
+  // emits one anyway: it must not be spoken, and it must not move the room.
+  test("a terminal [-1] is stripped from deltas and TTS and reveals nothing", async () => {
     const { frames, session, getCallbacks, ttsTexts } =
       createEscalatedMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
     emitTextDelta(getCallbacks, "hello world. [-1]");
     emitMessageComplete(getCallbacks);
-    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
     const joined = assistantDeltaTexts(frames).join("");
     expect(joined).toContain("hello world. ");
     expect(joined).not.toContain("[-1]");
     expect(ttsTexts.join(" ")).not.toContain("[-1]");
-    const ttsDoneIndex = frames.findIndex((frame) => frame.type === "tts_done");
-    const minimizeIndex = frames.findIndex(
-      (frame) => frame.type === "minimize_room",
-    );
-    expect(ttsDoneIndex).toBeGreaterThanOrEqual(0);
-    expect(minimizeIndex).toBeGreaterThan(ttsDoneIndex);
-    expect(frames[minimizeIndex]).toMatchObject({
-      type: "minimize_room",
-      turnId: "live-turn-1",
-    });
-    expect(
-      frames.filter((frame) => frame.type === "minimize_room"),
-    ).toHaveLength(1);
+    expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
   });
 
-  test("holds a marker split across deltas, never leaks the partial, and still emits", async () => {
+  test("holds a marker split across deltas and never leaks the partial", async () => {
     const { frames, session, getCallbacks, ttsTexts } =
       createEscalatedMarkerHarness();
 
@@ -712,14 +743,14 @@ describe("LiveVoiceSession minimize-room marker", () => {
 
     emitTextDelta(getCallbacks, "1]");
     emitMessageComplete(getCallbacks);
-    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
     const joined = assistantDeltaTexts(frames).join("");
     expect(joined).not.toContain("[-");
     expect(ttsTexts.join(" ")).not.toContain("[-");
   });
 
-  test("a mid-reply [-1] (content, not command) is stripped from speech but never minimizes", async () => {
+  test("a mid-reply [-1] is stripped from speech and never minimizes", async () => {
     const { frames, session, getCallbacks } = createMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
@@ -737,7 +768,8 @@ describe("LiveVoiceSession minimize-room marker", () => {
     const { frames, session, getCallbacks } = createEscalatedMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);
-    emitTextDelta(getCallbacks, "Minimizing now. [-1]");
+    getCallbacks()?.tool_use_start?.("ui_show");
+    emitTextDelta(getCallbacks, "Showing you now.");
     await flushAsyncCallbacks();
 
     await session.handleClientFrame({ type: "interrupt" });
@@ -747,7 +779,7 @@ describe("LiveVoiceSession minimize-room marker", () => {
     expect(frames.some((frame) => frame.type === "minimize_room")).toBe(false);
   });
 
-  test("a turn without the marker emits no minimize_room frame", async () => {
+  test("a turn that shows nothing emits no minimize_room frame", async () => {
     const { frames, session, getCallbacks } = createMarkerHarness();
 
     await startReleasedTurn(session, getCallbacks);

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -254,13 +254,13 @@ describe("LiveVoiceSession archive and metrics events", () => {
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
       // Pins the full production control prompt for the FRONT-DOOR leg (the
-      // first leg of every routed turn): the no-UI rule (voice turns are
-      // non-interactive — everything is conveyed in speech) and the shared
-      // no-setup-flows rule (no OAuth/browser flows mid-call). The [-1]
+      // first leg of every routed turn): the speech-first rule (which now
+      // permits a surface, since the room reveals one by itself) and the
+      // shared no-setup-flows rule (no OAuth/browser flows mid-call). The [-1]
       // room-minimize teaching is deliberately absent — only the escalated
       // leg learns it (see live-voice-triage-escalate.test.ts).
       voiceControlPrompt:
-        "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. " +
+        "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. " +
         VOICE_NO_SETUP_FLOWS_RULE,
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -190,7 +190,7 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);
   });
 
-  test("the [-1] teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
+  test("the screen-reveal teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],
       escalated: ["The detailed answer is 42."],
@@ -205,10 +205,14 @@ describe("live-voice triage-and-escalate routing", () => {
       starter.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
     const escalatedPrompt =
       starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
-    // The toolless fast leg has nothing to show and its decision rule promises
-    // verbatim speech — it must never learn the marker.
+    // The toolless fast leg has nothing to show, so it is never told the
+    // screen will be revealed.
+    expect(frontDoorPrompt).not.toContain("the overlay minimizes");
+    expect(escalatedPrompt).toContain("the overlay minimizes");
+    // No leg is taught a marker any more: the reveal is decided by whether a
+    // ui tool ran, never by anything the model emits.
     expect(frontDoorPrompt).not.toContain("[-1]");
-    expect(escalatedPrompt).toContain("[-1]");
+    expect(escalatedPrompt).not.toContain("[-1]");
   });
 
   test("the verdict token and any text past the bridge cap never reach the transcript", async () => {

--- a/assistant/src/live-voice/activity-label.ts
+++ b/assistant/src/live-voice/activity-label.ts
@@ -27,6 +27,24 @@
  */
 
 /**
+ * The tools that put something on screen worth looking at.
+ *
+ * `ui_dismiss` is deliberately absent: it retires a surface, and revealing the
+ * screen to show the user something that is no longer there is the opposite of
+ * the point. A turn that only dismisses leaves the room where it is.
+ */
+const UI_REVEAL_TOOLS: ReadonlySet<string> = new Set(["ui_show", "ui_update"]);
+
+/**
+ * Whether running `toolName` leaves something on screen the user should be
+ * shown, which is what makes a live-voice turn reveal the screen behind the
+ * call overlay.
+ */
+export function revealsUiSurface(toolName: string): boolean {
+  return UI_REVEAL_TOOLS.has(toolName);
+}
+
+/**
  * Present-participle phrases for the built-in tools, by exact name.
  *
  * Grouped by what the user would say is happening, not by how the tool is

--- a/assistant/src/live-voice/activity-label.ts
+++ b/assistant/src/live-voice/activity-label.ts
@@ -29,11 +29,22 @@
 /**
  * The tools that put something on screen worth looking at.
  *
- * `ui_dismiss` is deliberately absent: it retires a surface, and revealing the
- * screen to show the user something that is no longer there is the opposite of
- * the point. A turn that only dismisses leaves the room where it is.
+ * `app_open` belongs here with the ui-surface tools: it proxies to a connected
+ * client to bring an app up, which is the same thing from the user's side, and
+ * a list keyed on "ui_" would have missed it.
+ *
+ * `ui_dismiss` is deliberately absent, and is handled as its own case: it
+ * retires a surface, and revealing the screen to show the user something that
+ * is no longer there is the opposite of the point.
  */
-const UI_REVEAL_TOOLS: ReadonlySet<string> = new Set(["ui_show", "ui_update"]);
+const UI_REVEAL_TOOLS: ReadonlySet<string> = new Set([
+  "ui_show",
+  "ui_update",
+  "app_open",
+]);
+
+/** The tool that takes a surface away again. */
+const UI_DISMISS_TOOL = "ui_dismiss";
 
 /**
  * Whether running `toolName` leaves something on screen the user should be
@@ -42,6 +53,11 @@ const UI_REVEAL_TOOLS: ReadonlySet<string> = new Set(["ui_show", "ui_update"]);
  */
 export function revealsUiSurface(toolName: string): boolean {
   return UI_REVEAL_TOOLS.has(toolName);
+}
+
+/** Whether `toolName` takes a surface off the screen. */
+export function dismissesUiSurface(toolName: string): boolean {
+  return toolName === UI_DISMISS_TOOL;
 }
 
 /**
@@ -72,6 +88,7 @@ const TOOL_ACTIVITY_LABELS: Readonly<Record<string, string>> = {
   schedule: "Checking the schedule",
   ui_show: "Putting something on screen",
   ui_update: "Putting something on screen",
+  app_open: "Opening an app",
 };
 
 /**

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -8,7 +8,6 @@ import {
 import { sanitizeForTts } from "../calls/tts-text-sanitizer.js";
 import {
   isIncompleteControlMarkerTail,
-  MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "../calls/voice-control-protocol.js";
 import type {
@@ -59,7 +58,7 @@ import { getToolOwner } from "../tools/registry.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
-import { activityLabelForTool } from "./activity-label.js";
+import { activityLabelForTool, revealsUiSurface } from "./activity-label.js";
 import {
   createVoiceFrontDecider,
   type VoiceFrontDecider,
@@ -479,8 +478,10 @@ interface ActiveAssistantTurn {
   progress: TurnProgressState;
   assistantCompleted: boolean;
   ttsDone: boolean;
-  // Latched when the leg's stream contains MINIMIZE_ROOM_MARKER; consumed
+  // Latched when the turn puts something on screen (a ui tool ran); consumed
   // once at TTS drain, where the minimize_room frame goes out after tts_done.
+  // Never set from anything the model says: the reveal is a consequence of
+  // showing a surface, not a token the model has to remember.
   minimizeRequested: boolean;
   // The activity label the client was last told about, so a run of tools that
   // map to the same line sends one frame rather than one per call. Empty means
@@ -604,13 +605,16 @@ interface ActiveAssistantTurn {
  * runs forward from the emitted boundary — not from the last "[" — so
  * brackets INSIDE a streaming marker body (a JSON array or "]"-bearing string
  * in ASK_GUARDIAN_APPROVAL) can neither mask the marker's start nor pass as
- * its terminator. As a side effect the force flush latches the turn's
- * `minimizeRequested` when the completed stream ENDS with
- * MINIMIZE_ROOM_MARKER — terminal position only, matching the prompt's
- * "end the reply with it" contract, so a reply whose CONTENT happens to
- * contain "[-1]" (an array literal, a temperature) never minimizes the
- * room. The marker itself is stripped wherever it appears (the shared
- * marker-strip convention), so the latch is the only observable.
+ * its terminator.
+ *
+ * **Markers are stripped, never acted on.** Nothing the model can say
+ * minimizes the room any more: that is decided by whether a ui tool ran (see
+ * the `tool_use_start` handler), so the reveal cannot depend on the model
+ * remembering a token, and a reply whose content happens to contain "[-1]" (an
+ * array literal, a temperature) cannot move the room either. No prompt teaches
+ * a marker, so this stripping is defense against a model that emits one
+ * regardless: an unspoken, unpersisted "[-1]" is the correct handling of a
+ * token that now means nothing.
  */
 function createControlMarkerHoldback(
   turn: ActiveAssistantTurn,
@@ -618,13 +622,6 @@ function createControlMarkerHoldback(
 ): (raw: string, opts?: { force?: boolean }) => void {
   let emitted = 0;
   return (raw, opts) => {
-    if (
-      opts?.force === true &&
-      !turn.minimizeRequested &&
-      raw.trimEnd().endsWith(MINIMIZE_ROOM_MARKER)
-    ) {
-      turn.minimizeRequested = true;
-    }
     let safeEnd = raw.length;
     if (opts?.force !== true) {
       for (
@@ -650,29 +647,23 @@ function createControlMarkerHoldback(
 // buildInterruptionMergeNote) so the model reconciles the interrupted request
 // with the new utterance.
 const LIVE_VOICE_CONTROL_PROMPT_BASE =
-  "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech. ";
+  "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. ";
 
-// MINIMIZE_ROOM_MARKER teaching, appended for the legs that can actually put
-// something on screen — the main leg and the escalated leg. The front-door
-// (fast) leg never receives it: that leg is toolless, so it has nothing to
-// show, and its decision rule promises that apart from a leading verdict
-// token every character is spoken verbatim — teaching it the marker would
-// contradict that rule and could only produce spurious minimizes.
+// Appended for the legs that can actually put something on screen: the main
+// leg and the escalated leg. The front-door (fast) leg never receives it, for
+// the same reason it never received the marker this replaces: that leg is
+// toolless, so it has nothing to show.
 //
-// The teaching deliberately keeps the no-interactive-UI rule intact
-// (live-voice turns are non-interactive, JARVIS-1291): the marker does not
-// render UI — it asks the client to reveal the screen the call overlay
-// covers. The gate in createControlMarkerHoldback strips it from speech, and
-// completeTtsForTurn sends the minimize_room frame only after the reply's
-// TTS drains, so "end your reply with it" is the whole contract the model
-// needs.
-//
-// The narration guidance is load-bearing: without it, the base prompt's
-// convey-everything-in-speech rule reads to the model as "the user can never
-// see the screen", and it minimizes the room while telling the user it has
-// no way to show them anything ("check it from the app later").
-const LIVE_VOICE_MINIMIZE_MARKER_TEACHING =
-  "The call renders as a full-screen overlay covering the app. If this reply created or changed something on screen worth looking at (an app, a page, a document), you may end the reply with the marker [-1]: after you finish speaking, the overlay minimizes so the user can see the screen while the call continues. The user is in the app and sees what you made the moment the overlay minimizes, so when you end with the marker, speak as if you are showing it to them right now (for example, close with something like: take a look) — never say you cannot show it, that you cannot display it because this is a voice call, or that they should check it later. Use it at most once per reply, only when there is genuinely something new to show, never speak the marker aloud or mention it, and never emit any other bracketed marker. ";
+// **The model no longer asks for the minimize; it is told one is coming.**
+// Revealing the screen used to be a marker the model emitted at the end of a
+// reply, which made "did the user see it" depend on the model remembering a
+// token. It is now a consequence of showing a surface at all: the session
+// latches the minimize when a ui tool runs, and the room opens after the
+// reply's speech drains. What is left for the prompt is the part only the
+// model can get right, which is speaking as though the thing is already in
+// front of the user, because by the time it stops talking it is.
+const LIVE_VOICE_SCREEN_REVEAL_TEACHING =
+  "The call renders as a full-screen overlay covering the app. Whenever you put something on screen, the overlay minimizes by itself as soon as you finish speaking, and the user is looking at what you made. So speak as if you are showing it to them right now (for example, close with something like: take a look), and never say you cannot show it, that this is a voice call, or that they should check it later. Never emit bracketed markers of any kind. ";
 
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut
@@ -731,8 +722,8 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
 }
 
 // Assemble a leg's model-facing control prompt: the base live-voice rules,
-// the [-1] minimize teaching (withheld from the front-door leg — see
-// LIVE_VOICE_MINIMIZE_MARKER_TEACHING), the shared no-setup-flows rule, plus
+// the screen-reveal teaching (withheld from the front-door leg, see
+// LIVE_VOICE_SCREEN_REVEAL_TEACHING), the shared no-setup-flows rule, plus
 // any pending barge-in merge context, completed-continuation context, and/or
 // the announcement instruction. A turn can carry several (a barge-in follow-up
 // that also has a continuation result waiting); the notes are model-only and
@@ -743,7 +734,7 @@ function buildVoiceControlPrompt(
 ): string {
   let prompt =
     LIVE_VOICE_CONTROL_PROMPT_BASE +
-    (leg.frontDoor === true ? "" : LIVE_VOICE_MINIMIZE_MARKER_TEACHING) +
+    (leg.frontDoor === true ? "" : LIVE_VOICE_SCREEN_REVEAL_TEACHING) +
     VOICE_NO_SETUP_FLOWS_RULE;
   if (turn.interruptedRequest) {
     prompt = `${prompt}\n\n${buildInterruptionMergeNote(turn.interruptedRequest)}`;
@@ -3885,6 +3876,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             });
             current.progress.opsSinceNarration += 1;
             current.progress.stateEpoch += 1;
+            // Showing a surface implies revealing it. The room is a
+            // full-screen overlay, so a surface rendered behind it is a
+            // surface nobody sees, and asking the model to also remember the
+            // minimize marker makes that the model's problem instead of the
+            // system's. Latching here reuses the marker's own machinery, so
+            // the reveal still happens where it always has: after the reply's
+            // speech drains, never mid-sentence, at most once per turn.
+            if (revealsUiSurface(toolName)) {
+              current.minimizeRequested = true;
+            }
             this.publishActivity(current, this.currentActivityLabel(current));
             log.debug({ turnId, toolName }, "Live voice turn started tool use");
             // Definitive tool use means the turn is guaranteed slow: speak

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -58,7 +58,11 @@ import { getToolOwner } from "../tools/registry.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
-import { activityLabelForTool, revealsUiSurface } from "./activity-label.js";
+import {
+  activityLabelForTool,
+  dismissesUiSurface,
+  revealsUiSurface,
+} from "./activity-label.js";
 import {
   createVoiceFrontDecider,
   type VoiceFrontDecider,
@@ -3876,16 +3880,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             });
             current.progress.opsSinceNarration += 1;
             current.progress.stateEpoch += 1;
-            // Showing a surface implies revealing it. The room is a
-            // full-screen overlay, so a surface rendered behind it is a
-            // surface nobody sees, and asking the model to also remember the
-            // minimize marker makes that the model's problem instead of the
-            // system's. Latching here reuses the marker's own machinery, so
-            // the reveal still happens where it always has: after the reply's
-            // speech drains, never mid-sentence, at most once per turn.
-            if (revealsUiSurface(toolName)) {
-              current.minimizeRequested = true;
-            }
             this.publishActivity(current, this.currentActivityLabel(current));
             log.debug({ turnId, toolName }, "Live voice turn started tool use");
             // Definitive tool use means the turn is guaranteed slow: speak
@@ -3940,6 +3934,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               }
             }
             current.progress.stateEpoch += 1;
+            // Showing a surface implies revealing it: the room is a
+            // full-screen overlay, so a surface rendered behind it is a
+            // surface nobody sees.
+            //
+            // **Latched on the result, not the tool start.** A ui call can be
+            // rejected (no `surface_type`, an empty card, a client that never
+            // acks), and a reveal driven by the attempt would minimize the room
+            // to show nothing at all. Only a call that came back without an
+            // error actually put something on screen.
+            //
+            // A dismissal clears it again, so a turn that shows a surface and
+            // then takes it away does not reveal an empty screen. Last write
+            // wins, which is the right reading of "what did this turn leave up"
+            // without tracking surfaces individually.
+            if (event.isError !== true) {
+              if (revealsUiSurface(event.toolName)) {
+                current.minimizeRequested = true;
+              } else if (dismissesUiSurface(event.toolName)) {
+                current.minimizeRequested = false;
+              }
+            }
             this.publishActivity(current, this.currentActivityLabel(current));
             this.maybeNarrateProgress(current, trigger);
           },


### PR DESCRIPTION
A live-voice call could not put anything on screen. The prompt said so, but the enforcement was `supportsDynamicUi: false`, forced on every voice turn in the bridge — which also took out the runtime-context line, the secret prompter, and the task-progress nudge.

## The change

**Whether a call can show a surface is a property of its channel, not of calls in general.** A phone call has no screen and already resolves `false` on its own; a live-voice call is a screen the user is holding, temporarily covered by the room overlay. So the blanket override is gone and the channel decides. Phone is unchanged, and still covered by a test.

**The overlay is now handled by the system, not the model.** Running a `ui_show`/`ui_update` latches the room minimize, which the session already consumes after the reply's speech drains — so a surface is revealed exactly when there is one, at most once per turn, never mid-sentence. `ui_dismiss` deliberately does not count: revealing the screen to show something that is no longer there is the opposite of the point.

**The `[-1]` marker is retired.** No leg is taught it any more. Nothing the model emits moves the room, so the reveal can't be lost to a token the model forgot, and a reply whose content happens to contain `[-1]` (an array literal, a temperature) can't move it either. The stripping and the split-across-deltas holdback stay as defense: an untaught model that emits one anyway must not have it spoken or persisted. What the prompt teaches instead is the part only the model can get right — speaking as though the thing is already in front of the user, because by the time it stops talking it is.

## Deliberately not in scope

- **Secrets stay auto-resolved** on every voice channel. A live-voice call can render a secret field now, but typing a credential into a screen you reached by minimizing a call is a flow that needs designing, not a flag flip. The bridge comment says so at the handler.
- **`VOICE_NO_SETUP_FLOWS_RULE` stays.** It was written alongside the ui-surface restriction but outlives it: a browser window handing control to a third party mid-call is a different problem, and one a minimized room does not solve.
- **`userMessageInterface` is still hardcoded to `"macos"`** for every live-voice session, including iOS and web. Pre-existing, and it happens to be why this works uniformly across clients; plumbing the real interface through is its own change (and would need `"ios"` teaching the capability resolver that a WKWebView is web).

## Testing

Typecheck plus every live-voice and calls test file, per-file as CI runs them. Rewritten rather than deleted where the contract changed: the caps test now asserts live-voice keeps its channel's dynamic UI and phone still resolves false, and the marker tests now assert a ui tool triggers the reveal, `ui_dismiss` does not, and a stray `[-1]` is stripped while moving nothing.

Part of JARVIS-1404 (3 of 4); does not close it. PR 4 is interactive approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)