### PR TITLE
feat(profiles): promote latency-optimized to a 4th managed profile (Speed), rename cost-optimized to Cost

### DIFF
--- a/assistant/src/__tests__/byok-default-profile-ensure.test.ts
+++ b/assistant/src/__tests__/byok-default-profile-ensure.test.ts
@@ -1092,4 +1092,47 @@ describe("ensureByokDefaultProfiles", () => {
 
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
   });
+
+  // The hatch wrote each copy's model by resolving the cost profile's intent
+  // at hatch time. These are the ids that resolved per provider, pinned as
+  // literals rather than derived from the template: a test that materializes
+  // the template agrees with itself no matter which intent the template names,
+  // and so cannot catch a template whose model comparison has drifted off what
+  // is on disk.
+  test.each([
+    ["openrouter", "anthropic/claude-haiku-4.5"],
+    ["gemini", "gemini-3.1-flash-lite"],
+    ["openai", "gpt-5.6-luna"],
+  ] as const)(
+    "an unedited %s cost copy still converts",
+    (provider, hatchModel) => {
+      writeConfig({
+        llm: {
+          defaultProvider: { provider },
+          activeProfile: "custom-cost-optimized",
+          profiles: {
+            "custom-cost-optimized": {
+              ...(hatchBody("cost-optimized", provider) as Record<
+                string,
+                unknown
+              >),
+              model: hatchModel,
+            },
+            "custom-balanced": hatchBody("balanced", provider),
+            "custom-quality-optimized": hatchBody(
+              "quality-optimized",
+              provider,
+            ),
+          },
+        },
+      });
+
+      ensureByokDefaultProfiles(workspaceDir);
+
+      expect(profiles()["custom-cost-optimized"]).toBeUndefined();
+      expect(profiles()["cost-optimized"]).toBeUndefined();
+      expect(llm().activeProfile).toBe("cost-optimized");
+      expectSecondRunNoop();
+    },
+  );
 });

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -864,7 +864,7 @@ describe("loadConfig startup behavior", () => {
     expect(effective["quality-optimized"]?.provider).toBe("openai");
     expect(effective["quality-optimized"]?.model).toBe("gpt-5.4");
     expect(effective["cost-optimized"]?.provider).toBe("openai");
-    expect(effective["cost-optimized"]?.model).toBe("gpt-5.6-luna");
+    expect(effective["cost-optimized"]?.model).toBe("gpt-5.4-nano");
   });
 
   test("off-platform hatch with a provider outside the named matrix columns resolves through the shared BYOK templates", () => {
@@ -1471,7 +1471,7 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
     );
     expect(effective.balanced?.label).toBe("Balanced");
     expect(effective["quality-optimized"]?.label).toBe("Quality");
-    expect(effective["cost-optimized"]?.label).toBe("Speed");
+    expect(effective["cost-optimized"]?.label).toBe("Cost");
     expect("status" in (effective.balanced ?? {})).toBe(false);
     expect("status" in (effective["quality-optimized"] ?? {})).toBe(false);
     expect("status" in (effective["cost-optimized"] ?? {})).toBe(false);
@@ -1741,7 +1741,7 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
     const effective = getEffectiveProfiles(raw.llm.profiles);
     expect(effective.balanced?.label).toBe("Balanced");
     expect(effective["quality-optimized"]?.label).toBe("Quality");
-    expect(effective["cost-optimized"]?.label).toBe("Speed");
+    expect(effective["cost-optimized"]?.label).toBe("Cost");
   });
 
   test("boot leaves legacy bare labels on managed entries untouched", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1744,6 +1744,38 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
     expect(effective["cost-optimized"]?.label).toBe("Cost");
   });
 
+  test("a managed key missing from profileOrder lands beside its siblings", () => {
+    // An install that predates a newly shipped managed profile, with a custom
+    // profile already in its order. The new key belongs with the other
+    // managed profiles, not after whatever the user has arranged below them.
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        profiles: {
+          "my-custom": { source: "user", provider: "anthropic", model: "x" },
+        },
+        profileOrder: [
+          "balanced",
+          "quality-optimized",
+          "cost-optimized",
+          "my-custom",
+        ],
+        activeProfile: "balanced",
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.profileOrder).toEqual([
+      "balanced",
+      "quality-optimized",
+      "cost-optimized",
+      "latency-optimized",
+      "my-custom",
+    ]);
+  });
+
   test("boot leaves legacy bare labels on managed entries untouched", () => {
     // Existing off-platform install has bare labels (`label: "Balanced"`)
     // on its managed entries. Boots never rewrite managed entries — there

--- a/assistant/src/__tests__/conversation-slash.test.ts
+++ b/assistant/src/__tests__/conversation-slash.test.ts
@@ -51,7 +51,8 @@ describe("/model list", () => {
     const message = ((await resolveSlash("/model")) as { message: string })
       .message;
     expect(message).toContain("Best results with the most capable model");
-    expect(message).toContain("Fastest responses at lower cost");
+    expect(message).toContain("Cheapest responses, for high-volume work");
+    expect(message).toContain("Fastest responses, with reasoning turned off");
     expect(message).not.toContain("(DeepSeek V4 Flash)");
   });
 
@@ -63,7 +64,8 @@ describe("/model list", () => {
     expect(message).toContain(
       "High-quality results with the most capable model",
     );
-    expect(message).toContain("Fastest responses at lower cost");
+    expect(message).toContain("Cheapest responses, for high-volume work");
+    expect(message).toContain("Fastest responses, with reasoning turned off");
     expect(message).not.toContain("(DeepSeek V4 Flash)");
   });
 });

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -698,9 +698,7 @@ describe("resolveCallSiteConfig", () => {
     const resolved = resolveCallSiteConfig("memoryExtraction", llm);
     expect(resolved.provider).toBe("openai");
     expect(resolved.provider_connection).toBe("openai-personal");
-    expect(resolved.model).toBe(
-      resolveModelIntent("openai", "latency-optimized"),
-    );
+    expect(resolved.model).toBe(resolveModelIntent("openai", "cost-optimized"));
   });
 
   test("BYOK full-workspace: every call site resolves through the default provider, never the managed connection", () => {
@@ -752,9 +750,7 @@ describe("resolveCallSiteConfig", () => {
 
     // Cost-optimized call sites resolve the intent through the BYOK provider.
     const costSite = resolveCallSiteConfig("heartbeatAgent", byokConfig);
-    expect(costSite.model).toBe(
-      resolveModelIntent("openai", "latency-optimized"),
-    );
+    expect(costSite.model).toBe(resolveModelIntent("openai", "cost-optimized"));
 
     // mainAgent uses the user's active profile.
     const balancedSite = resolveCallSiteConfig("mainAgent", byokConfig);
@@ -771,9 +767,7 @@ describe("resolveCallSiteConfig", () => {
 
     const resolved = resolveCallSiteConfig("commitMessage", byokConfig);
     expect(resolved.provider).toBe("openai");
-    expect(resolved.model).toBe(
-      resolveModelIntent("openai", "latency-optimized"),
-    );
+    expect(resolved.model).toBe(resolveModelIntent("openai", "cost-optimized"));
     expect(resolved.maxTokens).toBe(120);
     expect(resolved.effort).toBe("low");
     expect(resolved.thinking.enabled).toBe(false);

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -263,6 +263,29 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expectNothingCommitted();
   });
 
+  test("PUT on the code-owned latency profile is rejected, status re-enable included", async () => {
+    // Speed fronts live voice, so it takes no writes at all: the re-enable
+    // escape hatch the other managed profiles keep would persist a stub that
+    // never governs what the name resolves to.
+    seedRawConfig({ llm: { profiles: {} } });
+
+    for (const body of [
+      { label: "Zippy" },
+      { status: "active" as const },
+      { status: null },
+    ]) {
+      await expect(
+        replaceRoute.handler({
+          pathParams: { name: "latency-optimized" },
+          body,
+        }),
+      ).rejects.toThrow(
+        'Profile "latency-optimized" is code-owned and cannot be edited.',
+      );
+    }
+    expectNothingCommitted();
+  });
+
   test("PUT { status: null } on managed profile clears status (back to active-by-absence)", async () => {
     seedRawConfig({
       llm: {

--- a/assistant/src/__tests__/plugin-api-model-profiles.test.ts
+++ b/assistant/src/__tests__/plugin-api-model-profiles.test.ts
@@ -64,6 +64,7 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "alpha",
+      "latency-optimized",
       "quality-optimized",
       "zeta",
     ]);
@@ -95,6 +96,7 @@ describe("getModelProfiles", () => {
       ["blend", true],
       ["balanced", false],
       ["cost-optimized", false],
+      ["latency-optimized", false],
       ["quality-optimized", false],
     ]);
   });
@@ -144,6 +146,7 @@ describe("getModelProfiles", () => {
       ["beta", true],
       ["balanced", false],
       ["cost-optimized", false],
+      ["latency-optimized", false],
       ["quality-optimized", false],
     ]);
   });
@@ -188,6 +191,7 @@ describe("getModelProfiles", () => {
       ["beta", true],
       ["balanced", false],
       ["cost-optimized", false],
+      ["latency-optimized", false],
       ["quality-optimized", false],
     ]);
   });
@@ -224,6 +228,11 @@ describe("getModelProfiles", () => {
       getModelProfiles()
         .map((p) => p.key)
         .sort(),
-    ).toEqual(["balanced", "cost-optimized", "quality-optimized"]);
+    ).toEqual([
+      "balanced",
+      "cost-optimized",
+      "latency-optimized",
+      "quality-optimized",
+    ]);
   });
 });

--- a/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
+++ b/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
@@ -89,6 +89,18 @@ describe("139-clear-renamed-cost-profile-label migration", () => {
     }
   });
 
+  test("leaves a source-less legacy entry alone", () => {
+    // A source-less entry under a default name shadows the catalog outright,
+    // so its label is user state.
+    writeConfig({
+      llm: { profiles: { "cost-optimized": { label: "Speed" } } },
+    });
+
+    run();
+
+    expect(costProfile().label).toBe("Speed");
+  });
+
   test("leaves a user-owned profile shadowing the default name alone", () => {
     writeConfig({
       llm: {

--- a/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
+++ b/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
@@ -1,0 +1,125 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { clearRenamedCostProfileLabelMigration } from "../workspace/migrations/139-clear-renamed-cost-profile-label.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-139-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function costProfile(): Record<string, unknown> {
+  const config = JSON.parse(
+    readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+  );
+  return config.llm.profiles["cost-optimized"];
+}
+
+function run(): void {
+  clearRenamedCostProfileLabelMigration.run(workspaceDir);
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("139-clear-renamed-cost-profile-label migration", () => {
+  test("has correct migration id and is registered last", () => {
+    expect(clearRenamedCostProfileLabelMigration.id).toBe(
+      "139-clear-renamed-cost-profile-label",
+    );
+    // getLastWorkspaceMigrationId() reports the final entry as the registry
+    // ceiling, so the highest id must stay last.
+    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
+      "139-clear-renamed-cost-profile-label",
+    );
+  });
+
+  test("clears the seeded label so the code catalog label applies", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "cost-optimized": { source: "managed", label: "Speed" },
+        },
+      },
+    });
+
+    run();
+
+    expect(costProfile()).toEqual({ source: "managed" });
+  });
+
+  test("leaves a user rename, an explicit null, and hatch stubs alone", () => {
+    for (const label of ["My Fast One", null, "Speed (Managed)"]) {
+      freshWorkspace();
+      writeConfig({
+        llm: { profiles: { "cost-optimized": { source: "managed", label } } },
+      });
+
+      run();
+
+      expect(costProfile().label).toBe(label as string);
+    }
+  });
+
+  test("leaves a user-owned profile shadowing the default name alone", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "cost-optimized": {
+            source: "user",
+            label: "Speed",
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(costProfile().label).toBe("Speed");
+  });
+
+  test("is idempotent and no-ops on absent or malformed config", () => {
+    writeConfig({
+      llm: { profiles: { "cost-optimized": { source: "managed" } } },
+    });
+    run();
+    run();
+    expect(costProfile()).toEqual({ source: "managed" });
+
+    freshWorkspace();
+    expect(() => run()).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() => run()).not.toThrow();
+  });
+});

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -228,11 +228,10 @@ describe("resolver integration", () => {
     expect(resolved.model).not.toBe("claude-sonnet-4-6");
   });
 
-  test("a user profile shadowing latency-optimized captures its call sites", () => {
-    // `latency-optimized` ships as the user-facing Speed profile, so the
-    // ordinary user-shadow rule applies to it like any other default: the
-    // voice front model follows whatever the user put under that name. This
-    // is the trade for making the profile selectable and editable.
+  test("a user profile cannot shadow latency-optimized", () => {
+    // `latency-optimized` is code-owned: it fronts every live-voice turn, so
+    // a same-named workspace entry never governs what it resolves to. The
+    // entry stays on disk and stays a valid `activeProfile` reference.
     const llm = LLMSchema.parse({
       profiles: {
         "latency-optimized": {
@@ -245,13 +244,16 @@ describe("resolver integration", () => {
         },
       },
     });
+    const body = CODE_DEFAULT_PROFILE_ENTRIES["latency-optimized"]!;
     for (const callSite of ["voiceFrontDoor", "voiceFrontDecision"] as const) {
       const resolved = resolveCallSiteConfig(callSite, llm);
-      expect(resolved.model).toBe("claude-opus-4-6");
-      expect(String(resolved.provider)).toBe("anthropic");
+      expect(resolved.model).toBe(body.model as string);
+      expect(resolved.model).not.toBe("claude-opus-4-6");
+      expect(String(resolved.provider)).toBe("vellum");
     }
+    // Listing follows resolution: the catalog body is what surfaces.
     expect(getEffectiveProfiles(llm.profiles)["latency-optimized"]?.model).toBe(
-      "claude-opus-4-6",
+      body.model,
     );
     expect(() =>
       LLMSchema.parse({

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -228,12 +228,11 @@ describe("resolver integration", () => {
     expect(resolved.model).not.toBe("claude-sonnet-4-6");
   });
 
-  test("a pre-existing user profile cannot shadow an internal profile's call sites", () => {
-    // `latency-optimized` was a legal custom profile name before it was
-    // reserved, so a workspace can already hold one. The user-shadow rule
-    // that lets a user replace a default they can select must not apply to a
-    // name they were never able to select: the voice front model would
-    // silently run on an arbitrary user model.
+  test("a user profile shadowing latency-optimized captures its call sites", () => {
+    // `latency-optimized` ships as the user-facing Speed profile, so the
+    // ordinary user-shadow rule applies to it like any other default: the
+    // voice front model follows whatever the user put under that name. This
+    // is the trade for making the profile selectable and editable.
     const llm = LLMSchema.parse({
       profiles: {
         "latency-optimized": {
@@ -246,15 +245,11 @@ describe("resolver integration", () => {
         },
       },
     });
-    const body = CODE_DEFAULT_PROFILE_ENTRIES["latency-optimized"];
     for (const callSite of ["voiceFrontDoor", "voiceFrontDecision"] as const) {
       const resolved = resolveCallSiteConfig(callSite, llm);
-      expect(resolved.model).toBe(body.model as string);
-      expect(resolved.model).not.toBe("claude-opus-4-6");
-      expect(String(resolved.provider)).toBe("vellum");
+      expect(resolved.model).toBe("claude-opus-4-6");
+      expect(String(resolved.provider)).toBe("anthropic");
     }
-    // The entry itself is untouched — still on disk, still listed, and still
-    // a valid `activeProfile` reference for the user who created it.
     expect(getEffectiveProfiles(llm.profiles)["latency-optimized"]?.model).toBe(
       "claude-opus-4-6",
     );

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -126,8 +126,8 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   // `latency-optimized` is the latency-class profile (see
   // default-profile-catalog.ts): managed installs get the pinned latency model,
   // BYOK installs resolve their own provider's latency model through the intent
-  // table rather than a model id they may hold no credential for. It is now
-  // user-facing ("Speed"), so a user who edits it moves this call site too.
+  // table rather than a model id they may hold no credential for. The profile
+  // is user-facing ("Speed"), so a user edit to it moves this call site too.
   voiceFrontDecision: {
     profile: "latency-optimized",
     effort: "low",

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -123,10 +123,11 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   },
   // Endpoint decisions gate live-voice turn-end latency, and `cost-optimized`'s
   // upstream cannot fit any usable decision budget (~1s+ per forced tool call).
-  // `latency-optimized` is the internal latency-class profile (see
+  // `latency-optimized` is the latency-class profile (see
   // default-profile-catalog.ts): managed installs get the pinned latency model,
   // BYOK installs resolve their own provider's latency model through the intent
-  // table rather than a model id they may hold no credential for.
+  // table rather than a model id they may hold no credential for. It is now
+  // user-facing ("Speed"), so a user who edits it moves this call site too.
   voiceFrontDecision: {
     profile: "latency-optimized",
     effort: "low",

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -265,9 +265,8 @@ const HATCH_ERA_TEMPLATE_FIELDS: Partial<
  * conversion pass as the reference for recognizing unedited copies, which
  * are safe to remove in favor of the code-resolved defaults.
  *
- * `latency-optimized` is included for shape only. It became a user-facing
- * default after hatch seeding stopped writing copies, so no install holds a
- * `custom-latency-optimized`.
+ * The `latency-optimized` entry exists for shape only: hatch seeding writes no
+ * `custom-latency-optimized`, so no install holds one to recognize.
  */
 export const USER_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -11,12 +11,8 @@ import {
   DEFAULT_PROFILE_PROVIDERS,
   type DefaultProfileKey,
   type DefaultProfileProvider,
-  INTERNAL_PROFILE_KEYS,
-  type InternalProfileKey,
   isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
-  PROFILE_MATRIX_KEYS,
-  type ProfileMatrixKey,
 } from "./default-profile-names.js";
 import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
@@ -28,7 +24,8 @@ import {
 
 /**
  * Code-defined catalog of the default inference profiles (`balanced`,
- * `quality-optimized`, `cost-optimized`, plus the flag-gated `os-beta`).
+ * `quality-optimized`, `cost-optimized`, `latency-optimized`, plus the
+ * flag-gated `os-beta`).
  *
  * The catalog is the single source of truth for default profile CONTENT,
  * structured as an intent × provider matrix: each default profile is an
@@ -60,6 +57,9 @@ export type DefaultProfileTemplate = Omit<
   provider: NonNullable<ProfileEntry["provider"]>;
 };
 
+/** One implementation of every default profile, keyed by profile key. */
+type ProfileImpls = Record<DefaultProfileKey, DefaultProfileTemplate>;
+
 /**
  * The `vellum` column: platform-managed implementations, stamped
  * `provider: "vellum"` — dispatch derives the upstream from the model.
@@ -68,7 +68,7 @@ export type DefaultProfileTemplate = Omit<
  * Overwritten in workspace config on every daemon boot so Vellum can push
  * model/config updates to customers in new releases.
  */
-const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
+const VELLUM_PROFILE_IMPLS: ProfileImpls = {
   balanced: {
     model: "gpt-5.6-luna",
     provider: "vellum",
@@ -99,11 +99,11 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
     model: "accounts/fireworks/models/deepseek-v4-flash",
     provider: "vellum",
     source: "managed",
-    label: "Speed",
+    label: "Cost",
     // Tier intent only - never name the concrete model here. Clients
     // surface the live model beside the description, so a model name in
     // this copy would go stale the moment the pin moves.
-    description: "Fastest responses at lower cost",
+    description: "Cheapest responses, for high-volume work",
     maxTokens: 8192,
     // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
     // "medium" when the field is omitted, and effort-driven providers encode
@@ -116,22 +116,24 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
     },
   },
   "latency-optimized": {
-    // The managed latency class. Its leading tokens are the live-voice
-    // turn-taking verdict, so what this profile optimizes is the tail of
-    // time-to-first-token rather than the median: a verdict slower than
-    // `liveVoice.frontModel.endpointDecisionTimeoutMs` trips the speculative
-    // fail-open commit in live-voice-session.ts, which is audible dead air.
+    // The managed latency class, also what the live-voice front model runs on.
+    // Its leading tokens are the turn-taking verdict, so what this profile
+    // optimizes is the tail of time-to-first-token rather than the median: a
+    // verdict slower than `liveVoice.frontModel.endpointDecisionTimeoutMs`
+    // trips the speculative fail-open commit in live-voice-session.ts, which
+    // is audible dead air.
     //
     // Two constraints bind the model id. Its managed credentials must be
     // provisioned in every environment, and it alone selects the upstream:
     // `provider` below is the provider-agnostic managed sentinel, so
     // `getManagedUpstream` resolves the real upstream from the model's catalog
-    // owner.
+    // owner. Sharing `balanced`'s model is deliberate — the split is effort
+    // and thinking, and this model is the one live-voice TTFT drives validated.
     model: "gpt-5.6-luna",
     provider: "vellum",
     source: "managed",
-    label: "Latency",
-    description: "Lowest time-to-first-token, for real-time call sites",
+    label: "Speed",
+    description: "Fastest responses, with reasoning turned off",
     maxTokens: 8192,
     effort: "low",
     thinking: { enabled: false, streamThinking: false },
@@ -150,7 +152,7 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
  * per-request for any other default-capable provider.
  */
 const BYOK_PROFILE_IMPLS: Record<
-  ProfileMatrixKey,
+  DefaultProfileKey,
   Omit<DefaultProfileTemplate, "provider">
 > = {
   balanced: {
@@ -173,21 +175,24 @@ const BYOK_PROFILE_IMPLS: Record<
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
+  // On providers whose cheapest model is also their fastest (anthropic,
+  // ollama, fireworks) these two intents resolve the same model and the split
+  // is effort alone — see PROVIDER_MODEL_INTENTS.
   "cost-optimized": {
-    intent: "latency-optimized",
+    intent: "cost-optimized",
     source: "user",
-    label: "Speed",
-    description: "Fastest responses at lower cost",
+    label: "Cost",
+    description: "Cheapest responses, for high-volume work",
     maxTokens: 8192,
-    effort: "low",
+    effort: "none",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
   "latency-optimized": {
     intent: "latency-optimized",
     source: "user",
-    label: "Latency",
-    description: "Lowest time-to-first-token, for real-time call sites",
+    label: "Speed",
+    description: "Fastest responses, with reasoning turned off",
     maxTokens: 8192,
     effort: "low",
     thinking: { enabled: false, streamThinking: false },
@@ -200,10 +205,10 @@ const BYOK_PROFILE_IMPLS: Record<
  * implementation of default profile `key` on `provider`.
  */
 export const PROFILE_IMPLS: Record<
-  ProfileMatrixKey,
+  DefaultProfileKey,
   Record<DefaultProfileProvider, DefaultProfileTemplate>
 > = Object.fromEntries(
-  PROFILE_MATRIX_KEYS.map((key) => [
+  DEFAULT_PROFILE_KEYS.map((key) => [
     key,
     Object.fromEntries(
       DEFAULT_PROFILE_PROVIDERS.map((provider) => [
@@ -215,7 +220,7 @@ export const PROFILE_IMPLS: Record<
     ) as Record<DefaultProfileProvider, DefaultProfileTemplate>,
   ]),
 ) as Record<
-  ProfileMatrixKey,
+  DefaultProfileKey,
   Record<DefaultProfileProvider, DefaultProfileTemplate>
 >;
 
@@ -230,17 +235,45 @@ export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   );
 
 /**
+ * Fields the `custom-*` copies carry from a BYOK era that predates a later
+ * edit to `BYOK_PROFILE_IMPLS`. The conversion pass compares a copy on disk
+ * against these bodies field-by-field, so an edit to a live template that is
+ * not pinned here makes every unedited copy read as user-edited and stop
+ * converting. When you change a BYOK template, pin what hatches actually
+ * wrote.
+ *
+ * `cost-optimized` predates the Cost/Speed relabel, which moved its label and
+ * description and dropped effort to "none". The label is pinned even though
+ * body comparison ignores it: `userOverlayState` reads it to tell a user
+ * rename from the label the hatch itself wrote, and an unpinned "Cost" would
+ * make every hatch-written "Speed" look like a rename worth carrying.
+ */
+const HATCH_ERA_TEMPLATE_FIELDS: Partial<
+  Record<DefaultProfileKey, Partial<DefaultProfileTemplate>>
+> = {
+  "cost-optimized": {
+    label: "Speed",
+    description: "Fastest responses at lower cost",
+    effort: "low",
+  },
+};
+
+/**
  * Frozen record of the `custom-*` profile bodies that pre-conversion BYOK
  * hatches wrote to workspace config (the anthropic column; provider and
  * connection were overridden per hatch). Consumed by the existing-install
  * conversion pass as the reference for recognizing unedited copies, which
  * are safe to remove in favor of the code-resolved defaults.
+ *
+ * `latency-optimized` is included for shape only — it became a user-facing
+ * default after hatch seeding stopped writing copies, so no install holds a
+ * `custom-latency-optimized`.
  */
 export const USER_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(
     DEFAULT_PROFILE_KEYS.map((key) => [
       `custom-${key}`,
-      PROFILE_IMPLS[key].anthropic,
+      { ...PROFILE_IMPLS[key].anthropic, ...HATCH_ERA_TEMPLATE_FIELDS[key] },
     ]),
   );
 
@@ -270,7 +303,6 @@ export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
 // the on-disk entry's `source` being `managed`.
 export const INVARIANT_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
-  ...INTERNAL_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -283,7 +315,6 @@ export const INVARIANT_PROFILE_NAMES = new Set<string>([
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
-  ...INTERNAL_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -319,7 +350,7 @@ export function materializeProfile(
 // `PROVIDER_MODEL_INTENTS`' own check): exactly one of `intent`/`model` is
 // set, and every pinned model id exists in PROVIDER_CATALOG for its
 // underlying provider — catching drift when a model is renamed or removed.
-for (const key of PROFILE_MATRIX_KEYS) {
+for (const key of DEFAULT_PROFILE_KEYS) {
   for (const provider of DEFAULT_PROFILE_PROVIDERS) {
     const impl = PROFILE_IMPLS[key][provider];
     if ((impl.model == null) === (impl.intent == null)) {
@@ -355,7 +386,7 @@ for (const provider of DEFAULT_PROVIDER_CHOICES) {
   if (isDefaultProfileProvider(provider)) {
     continue;
   }
-  for (const key of PROFILE_MATRIX_KEYS) {
+  for (const key of DEFAULT_PROFILE_KEYS) {
     const { model } = materializeProfile(
       { ...BYOK_PROFILE_IMPLS[key], provider },
       provider,
@@ -372,7 +403,7 @@ for (const provider of DEFAULT_PROVIDER_CHOICES) {
 
 function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
-  for (const key of PROFILE_MATRIX_KEYS) {
+  for (const key of DEFAULT_PROFILE_KEYS) {
     const impl = PROFILE_IMPLS[key].vellum;
     entries[key] = materializeProfile(impl, impl.provider);
   }
@@ -445,17 +476,6 @@ function resolveAgainstBody(
   if (body == null) {
     return workspace;
   }
-  // An internal profile's body is code-owned outright — no workspace overlay,
-  // not even a user-owned shadow. The shadow rule below exists so a user can
-  // deliberately replace a default they can see and select; an internal name
-  // was never selectable, so a same-named workspace entry (legal before the
-  // name was reserved) is unrelated state, not an override. Honoring it would
-  // silently hand a latency-class call site an arbitrary user model. The
-  // entry itself is untouched: it stays in `llm.profiles`, stays listed, and
-  // stays valid as an `activeProfile` reference.
-  if (isInternalProfileKey(name)) {
-    return { ...body };
-  }
   if (workspace == null) {
     return name === OS_BETA_PROFILE_KEY ? undefined : { ...body };
   }
@@ -506,27 +526,11 @@ export function isDefaultProfileKey(name: string): name is DefaultProfileKey {
   return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
 }
 
-/**
- * Whether a name is implemented by the intent × provider matrix — the
- * user-facing defaults plus the internal call-site-only profiles. This is the
- * predicate resolution uses: an internal profile must resolve through the
- * default provider's column exactly like a default, even though it is never
- * listed or seeded.
- */
-export function isMatrixProfileKey(name: string): name is ProfileMatrixKey {
-  return (PROFILE_MATRIX_KEYS as readonly string[]).includes(name);
-}
-
-/** Whether a name is a code-owned profile that must never be listed to users. */
-export function isInternalProfileKey(name: string): name is InternalProfileKey {
-  return (INTERNAL_PROFILE_KEYS as readonly string[]).includes(name);
-}
-
 function defaultProfileBodyForProvider(
   name: string,
   defaultProvider: DefaultProviderConfig | null,
 ): ProfileEntry | undefined {
-  if (defaultProvider == null || !isMatrixProfileKey(name)) {
+  if (defaultProvider == null || !isDefaultProfileKey(name)) {
     return CODE_DEFAULT_PROFILE_ENTRIES[name];
   }
   const { provider } = defaultProvider;
@@ -569,12 +573,6 @@ function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
  * available code default, merged per `getEffectiveProfile`. This is the
  * record all runtime readers of `llm.profiles` should consume; the raw
  * workspace record is a write-path concern.
- *
- * Internal profiles are omitted: they exist only to be named by a call-site
- * default, so listing them would offer them as selectable models and let
- * `activeProfile`/`overrideProfile` validation accept them. Resolution
- * reaches them by name through `resolveDefaultProfileForProvider`, which
- * does not go through this record.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -586,9 +584,6 @@ export function getEffectiveProfiles(
     ...(workspaceProfiles ?? {}),
   };
   for (const name of Object.keys(catalogEntries)) {
-    if (isInternalProfileKey(name)) {
-      continue;
-    }
     const entry = getEffectiveProfile(workspaceProfiles, name, catalogEntries);
     if (entry != null) {
       effective[name] = entry;
@@ -613,9 +608,6 @@ export function getEffectiveProfilesForProvider(
     ...(workspaceProfiles ?? {}),
   };
   for (const name of Object.keys(CODE_DEFAULT_PROFILE_ENTRIES)) {
-    if (isInternalProfileKey(name)) {
-      continue;
-    }
     const entry = resolveDefaultProfileForProvider(
       workspaceProfiles,
       name,

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -295,6 +295,17 @@ export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
   topP: 0.95,
 };
 
+/**
+ * Profiles whose body is code-owned outright: no workspace overlay, and no
+ * user-owned shadow. The shadow rule below lets a user replace a default they
+ * can select, but `latency-optimized` fronts every live-voice turn through
+ * `voiceFrontDecision`/`voiceFrontDoor`, where a model outside the latency
+ * envelope is audible dead air rather than a slow reply. A same-named
+ * workspace entry stays on disk and stays listed; it just never governs what
+ * this name resolves to.
+ */
+export const CODE_OWNED_PROFILE_NAMES = new Set<string>(["latency-optimized"]);
+
 // All managed profiles, including the flag-gated os-beta, are invariant:
 // their MANAGED-SOURCE entries are read-only to user-facing writes except
 // re-enabling a disabled one (enforced at commitConfigWrite). A user-owned
@@ -474,6 +485,9 @@ function resolveAgainstBody(
 ): ProfileEntry | undefined {
   if (body == null) {
     return workspace;
+  }
+  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
+    return { ...body };
   }
   if (workspace == null) {
     return name === OS_BETA_PROFILE_KEY ? undefined : { ...body };

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -127,7 +127,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     // provisioned in every environment, and it alone selects the upstream:
     // `provider` below is the provider-agnostic managed sentinel, so
     // `getManagedUpstream` resolves the real upstream from the model's catalog
-    // owner. Sharing `balanced`'s model is deliberate — the split is effort
+    // owner. Sharing `balanced`'s model is deliberate: the split is effort
     // and thinking, and this model is the one live-voice TTFT drives validated.
     model: "gpt-5.6-luna",
     provider: "vellum",
@@ -177,7 +177,7 @@ const BYOK_PROFILE_IMPLS: Record<
   },
   // On providers whose cheapest model is also their fastest (anthropic,
   // ollama, fireworks) these two intents resolve the same model and the split
-  // is effort alone — see PROVIDER_MODEL_INTENTS.
+  // is effort alone (see PROVIDER_MODEL_INTENTS).
   "cost-optimized": {
     intent: "cost-optimized",
     source: "user",
@@ -235,23 +235,23 @@ export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   );
 
 /**
- * Fields the `custom-*` copies carry from a BYOK era that predates a later
- * edit to `BYOK_PROFILE_IMPLS`. The conversion pass compares a copy on disk
- * against these bodies field-by-field, so an edit to a live template that is
- * not pinned here makes every unedited copy read as user-edited and stop
- * converting. When you change a BYOK template, pin what hatches actually
- * wrote.
+ * The values BYOK hatch seeding wrote onto each `custom-*` copy, for the keys
+ * whose live template carries something else. The conversion pass recognizes
+ * an unedited copy by comparing it field-by-field against the frozen body, so
+ * every field here must describe what sits on disk, not what the profile
+ * resolves to today. A field the live template alone supplies makes every
+ * unedited copy read as user-edited and stop converting.
  *
- * `cost-optimized` predates the Cost/Speed relabel, which moved its label and
- * description and dropped effort to "none". The label is pinned even though
- * body comparison ignores it: `userOverlayState` reads it to tell a user
- * rename from the label the hatch itself wrote, and an unpinned "Cost" would
- * make every hatch-written "Speed" look like a rename worth carrying.
+ * `intent` selects the copy's model through `materializeProfile`, so it is the
+ * load-bearing pin. `label` is compared nowhere in the body, but
+ * `userOverlayState` reads it to tell a user rename from the hatch's own
+ * label, and a mismatch there carries a phantom rename onto the bare key.
  */
 const HATCH_ERA_TEMPLATE_FIELDS: Partial<
   Record<DefaultProfileKey, Partial<DefaultProfileTemplate>>
 > = {
   "cost-optimized": {
+    intent: "latency-optimized",
     label: "Speed",
     description: "Fastest responses at lower cost",
     effort: "low",
@@ -265,7 +265,7 @@ const HATCH_ERA_TEMPLATE_FIELDS: Partial<
  * conversion pass as the reference for recognizing unedited copies, which
  * are safe to remove in favor of the code-resolved defaults.
  *
- * `latency-optimized` is included for shape only — it became a user-facing
+ * `latency-optimized` is included for shape only. It became a user-facing
  * default after hatch seeding stopped writing copies, so no install holds a
  * `custom-latency-optimized`.
  */

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -6,40 +6,25 @@
  * import cycles.
  */
 
-/** Stable keys of the always-available default profiles. */
+/**
+ * Stable keys of the always-available default profiles, in picker order.
+ *
+ * The key names are historical and no longer track the labels: `cost-optimized`
+ * is "Cost" and `latency-optimized` is "Speed". Renaming the keys would break
+ * every `llm.callSites.*.profile`, `activeProfile` and schedule pin on disk, so
+ * only the labels moved (see `default-profile-catalog.ts`).
+ *
+ * `latency-optimized` also backs the live-voice front model, which is why it
+ * exists as a profile rather than a raw model pin on the call site: a pin
+ * resolves to a provider BYOK installs may hold no credential for.
+ */
 export const DEFAULT_PROFILE_KEYS = [
   "balanced",
   "quality-optimized",
   "cost-optimized",
+  "latency-optimized",
 ] as const;
 export type DefaultProfileKey = (typeof DEFAULT_PROFILE_KEYS)[number];
-
-/**
- * Code-owned profiles that exist only to be named by a call-site default —
- * never offered as a user-selectable model. They resolve through the same
- * intent × provider matrix as the defaults, but are deliberately excluded
- * from the workspace seed and from every profile listing, so the picker
- * still shows exactly Balanced / Speed / Quality.
- *
- * `latency-optimized` is the latency-class profile the live-voice front
- * model runs on: `cost-optimized`'s upstream cannot meet the turn-taking
- * latency envelope, and the alternative — a raw model pin on the call site —
- * resolves to a provider BYOK installs may hold no credential for.
- */
-export const INTERNAL_PROFILE_KEYS = ["latency-optimized"] as const;
-export type InternalProfileKey = (typeof INTERNAL_PROFILE_KEYS)[number];
-
-/**
- * Every key implemented by the intent × provider matrix: the user-selectable
- * defaults plus the internal call-site-only profiles. This is the set the
- * resolver dereferences against; `DEFAULT_PROFILE_KEYS` alone is the
- * user-facing subset.
- */
-export const PROFILE_MATRIX_KEYS = [
-  ...DEFAULT_PROFILE_KEYS,
-  ...INTERNAL_PROFILE_KEYS,
-] as const;
-export type ProfileMatrixKey = DefaultProfileKey | InternalProfileKey;
 
 /**
  * Flag-gated default profile: only available while the `os-beta` feature

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -9,10 +9,10 @@
 /**
  * Stable keys of the always-available default profiles, in picker order.
  *
- * The key names are historical and no longer track the labels: `cost-optimized`
- * is "Cost" and `latency-optimized` is "Speed". Renaming the keys would break
- * every `llm.callSites.*.profile`, `activeProfile` and schedule pin on disk, so
- * only the labels moved (see `default-profile-catalog.ts`).
+ * A key is an on-disk contract: `llm.callSites.*.profile`, `activeProfile`,
+ * mix arms and schedule pins all reference it, so a key is fixed regardless of
+ * the label its profile carries. `cost-optimized` is labelled "Cost" and
+ * `latency-optimized` is labelled "Speed" (see `default-profile-catalog.ts`).
  *
  * `latency-optimized` also backs the live-voice front model, which is why it
  * exists as a profile rather than a raw model pin on the call site: a pin

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -11,7 +11,7 @@ import {
 } from "../providers/vellum-model-routing.js";
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import {
-  isMatrixProfileKey,
+  isDefaultProfileKey,
   resolveDefaultProfileForProvider,
 } from "./default-profile-catalog.js";
 import {
@@ -251,7 +251,7 @@ function providerAwareEntry(
     name,
     defaultProvider,
   );
-  if (!isMatrixProfileKey(name) || entry?.mix != null) {
+  if (!isDefaultProfileKey(name) || entry?.mix != null) {
     return entry;
   }
   if (

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -10,7 +10,6 @@ import {
 import {
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
-  INTERNAL_PROFILE_KEYS,
 } from "../default-profile-names.js";
 
 /**
@@ -714,18 +713,11 @@ export const LLMSchema = z
       ...Object.keys(config.profiles ?? {}),
       ...DEFAULT_PROFILE_KEYS,
     ]);
-    // Internal profiles exist only to be named by a call site, so they are
-    // valid reference targets there and nowhere else — never for
-    // `activeProfile`/`advisorProfile`, which are user-facing selections.
-    const callSiteProfileNames = new Set([
-      ...profileNames,
-      ...INTERNAL_PROFILE_KEYS,
-    ]);
     for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
       if (siteConfig?.profile == null) {
         continue;
       }
-      if (!callSiteProfileNames.has(siteConfig.profile)) {
+      if (!profileNames.has(siteConfig.profile)) {
         ctx.addIssue({
           code: "custom",
           path: ["callSites", siteId, "profile"],

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -186,15 +186,29 @@ export function seedInferenceProfiles(
     }
   }
 
-  // Profile ordering — ensure all seeded profiles appear in the order array.
+  // Profile ordering: ensure all seeded profiles appear in the order array.
+  // A managed key absent from a workspace's order is placed next to the
+  // sibling that precedes it in the catalog rather than appended, so the
+  // managed profiles stay grouped in catalog order even on a workspace whose
+  // order already lists custom profiles. Entries already in the order keep
+  // their relative positions, so a user arrangement survives.
   const profileOrder = Array.isArray(llm.profileOrder)
     ? (llm.profileOrder as string[])
     : [];
-  const orderSet = new Set(profileOrder);
-  for (const name of Object.keys(MANAGED_PROFILE_TEMPLATES)) {
-    if (!orderSet.has(name)) {
+  const managedNames = Object.keys(MANAGED_PROFILE_TEMPLATES);
+  for (const [index, name] of managedNames.entries()) {
+    if (profileOrder.includes(name)) {
+      continue;
+    }
+    const anchor = managedNames
+      .slice(0, index)
+      .reverse()
+      .map((sibling) => profileOrder.indexOf(sibling))
+      .find((position) => position >= 0);
+    if (anchor === undefined) {
       profileOrder.push(name);
-      orderSet.add(name);
+    } else {
+      profileOrder.splice(anchor + 1, 0, name);
     }
   }
   llm.profileOrder = profileOrder;

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -67,6 +67,7 @@ describe("getModelProfiles", () => {
       "balanced",
       "quality-optimized",
       "cost-optimized",
+      "latency-optimized",
     ]);
   });
 
@@ -85,6 +86,7 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "disabled",
+      "latency-optimized",
       "quality-optimized",
     ]);
     const disabled = result.find((p) => p.key === "disabled");
@@ -122,6 +124,7 @@ describe("getModelProfiles", () => {
       "mix",
       "balanced",
       "cost-optimized",
+      "latency-optimized",
       "quality-optimized",
     ]);
   });
@@ -131,6 +134,7 @@ describe("getModelProfiles", () => {
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
       "cost-optimized",
+      "latency-optimized",
       "quality-optimized",
     ]);
     for (const profile of result) {
@@ -150,7 +154,7 @@ describe("getModelProfiles", () => {
       "Best results with the most capable model",
     );
     expect(result.find((p) => p.key === "cost-optimized")?.description).toBe(
-      "Fastest responses at lower cost",
+      "Cheapest responses, for high-volume work",
     );
   });
 
@@ -162,7 +166,7 @@ describe("getModelProfiles", () => {
     // Tier descriptions are intent-only (no model names - LUM-2881), so the
     // managed and BYOK columns read the same for this tier.
     expect(result.find((p) => p.key === "cost-optimized")?.description).toBe(
-      "Fastest responses at lower cost",
+      "Cheapest responses, for high-volume work",
     );
   });
 

--- a/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
+++ b/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
@@ -182,7 +182,7 @@ export const POST = async (request: Request): Promise<Response> => {
       // Drafting a short email is latency-bound, not depth-bound, so run it on
       // the fast model rather than the balanced main-agent default. `inference`
       // is the general-purpose call site plugins use for exactly this — it
-      // resolves to the Cost (cost-optimized) profile — so we reuse it instead
+      // resolves to the Cost (cost-optimized) profile, so we reuse it instead
       // of teaching the daemon about a reengagement-specific call site.
       callSite: "inference",
       signal: request.signal,

--- a/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
+++ b/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
@@ -182,7 +182,7 @@ export const POST = async (request: Request): Promise<Response> => {
       // Drafting a short email is latency-bound, not depth-bound, so run it on
       // the fast model rather than the balanced main-agent default. `inference`
       // is the general-purpose call site plugins use for exactly this — it
-      // resolves to the Speed (cost-optimized) profile — so we reuse it instead
+      // resolves to the Cost (cost-optimized) profile — so we reuse it instead
       // of teaching the daemon about a reengagement-specific call site.
       callSite: "inference",
       signal: request.signal,

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -9,45 +9,55 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = Object.fromEntries(
   PROVIDER_CATALOG.map((entry) => [entry.id, entry.defaultModel]),
 );
 
+// `cost-optimized` is the cheapest model a provider serves, `latency-optimized`
+// the fastest to first token. On anthropic, ollama and fireworks the same model
+// is both, so those columns repeat by construction rather than by oversight.
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     balanced: "claude-sonnet-4-6",
+    "cost-optimized": "claude-haiku-4-5-20251001",
     "latency-optimized": "claude-haiku-4-5-20251001",
     "quality-optimized": "claude-fable-5",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
     balanced: "gpt-5.4-mini",
+    "cost-optimized": "gpt-5.4-nano",
     "latency-optimized": "gpt-5.6-luna",
     "quality-optimized": "gpt-5.4",
     "vision-optimized": "gpt-5.4",
   },
   gemini: {
     balanced: "gemini-3-flash-preview",
+    "cost-optimized": "gemini-2.5-flash-lite",
     "latency-optimized": "gemini-3.1-flash-lite",
     "quality-optimized": "gemini-3.1-pro-preview",
     "vision-optimized": "gemini-3-flash-preview",
   },
   ollama: {
     balanced: "llama3.2",
+    "cost-optimized": "llama3.2",
     "latency-optimized": "llama3.2",
     "quality-optimized": "llama3.2",
     "vision-optimized": "llama3.2",
   },
   fireworks: {
     balanced: "accounts/fireworks/models/minimax-m3",
+    "cost-optimized": "accounts/fireworks/models/deepseek-v4-flash",
     "latency-optimized": "accounts/fireworks/models/deepseek-v4-flash",
     "quality-optimized": "accounts/fireworks/models/kimi-k2p6",
     "vision-optimized": "accounts/fireworks/models/kimi-k2p6",
   },
   openrouter: {
     balanced: "anthropic/claude-sonnet-4.6",
+    "cost-optimized": "deepseek/deepseek-v4-flash",
     "latency-optimized": "anthropic/claude-haiku-4.5",
     "quality-optimized": "anthropic/claude-fable-5",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
   "vercel-ai-gateway": {
     balanced: "anthropic/claude-sonnet-4.6",
+    "cost-optimized": "deepseek/deepseek-v4-flash",
     "latency-optimized": "anthropic/claude-haiku-4.5",
     "quality-optimized": "anthropic/claude-fable-5",
     "vision-optimized": "anthropic/claude-opus-4.6",
@@ -58,6 +68,7 @@ const FALLBACK_DEFAULT_MODEL = "claude-opus-4-8";
 
 const MODEL_INTENTS = new Set<ModelIntent>([
   "balanced",
+  "cost-optimized",
   "latency-optimized",
   "quality-optimized",
   "vision-optimized",

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -181,6 +181,7 @@ export interface Message {
 
 export type ModelIntent =
   | "balanced"
+  | "cost-optimized"
   | "latency-optimized"
   | "quality-optimized"
   | "vision-optimized";

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1681,6 +1681,17 @@ describe("config invariant flag enrichment", () => {
     expect(profiles.custom!).not.toHaveProperty("invariant");
   });
 
+  test("every managed default is invariant on the wire, Speed included", async () => {
+    // The clients drive their read-only lock off this flag, so a default that
+    // resolves from the catalog with no workspace stub must still carry it.
+    const body = await configGetRoute.handler({});
+    const profiles = wireProfiles(body);
+
+    for (const name of ["balanced", "quality-optimized", "latency-optimized"]) {
+      expect(profiles[name]!.invariant).toBe(true);
+    }
+  });
+
   test("PATCH /v1/config stamps the flag on the response but never persists it", async () => {
     const body = await configPatchRoute.handler({
       body: { memory: { enabled: true } },

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -149,6 +149,7 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
 };
 
 import {
+  CODE_OWNED_PROFILE_NAMES,
   getEffectiveProfilesForProvider,
   INVARIANT_PROFILE_NAMES,
   MANAGED_PROFILE_NAMES,
@@ -1744,6 +1745,15 @@ async function handleReplaceInferenceProfile({
   ) {
     throw new BadRequestError(
       `Profile "${name}" is not currently available and cannot be edited.`,
+    );
+  }
+  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
+    // A code-owned profile resolves from the catalog whatever the workspace
+    // holds, so even a status re-enable would persist a stub that never
+    // governs anything. Reject the write rather than accept a silent no-op.
+    throw new BadRequestError(
+      `Profile "${name}" is code-owned and cannot be edited. ` +
+        `Duplicate it to a custom profile to customize.`,
     );
   }
   if (isManaged) {

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -342,6 +342,7 @@ describe("manage_workflows", () => {
     expect(parsed.profiles).toEqual([
       "balanced",
       "cost-optimized",
+      "latency-optimized",
       "quality-optimized",
     ]);
     expect(parsed.activeProfile).toBe("balanced");

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -64,8 +64,8 @@ const log = getLogger("byok-default-profile-ensure");
 
 /**
  * The default keys BYOK hatching ever wrote to disk. `latency-optimized`
- * became a user-facing default only later — it shipped as a code-resolved
- * call-site profile that was never seeded — so no install carries a hatch
+ * became a user-facing default only later. It shipped as a code-resolved
+ * call-site profile that was never seeded, so no install carries a hatch
  * stub or a `custom-latency-optimized` copy for it. Including it would make
  * `uniformCopyProvider` demand a copy that cannot exist and convert nothing.
  */

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -63,10 +63,9 @@ const log = getLogger("byok-default-profile-ensure");
 // stub or copy was removed.
 
 /**
- * The default keys BYOK hatching ever wrote to disk. `latency-optimized`
- * became a user-facing default only later. It shipped as a code-resolved
- * call-site profile that was never seeded, so no install carries a hatch
- * stub or a `custom-latency-optimized` copy for it. Including it would make
+ * The default keys BYOK hatching writes to disk. `latency-optimized` is absent
+ * by construction: no install carries a hatch stub or a
+ * `custom-latency-optimized` copy for it, and listing it here would make
  * `uniformCopyProvider` demand a copy that cannot exist and convert nothing.
  */
 const HATCH_ERA_PROFILE_KEYS = [

--- a/assistant/src/workspace/byok-default-profile-ensure.ts
+++ b/assistant/src/workspace/byok-default-profile-ensure.ts
@@ -7,10 +7,7 @@ import {
   resolveDefaultProfileForProvider,
   USER_PROFILE_TEMPLATES,
 } from "../config/default-profile-catalog.js";
-import {
-  DEFAULT_PROFILE_KEYS,
-  type DefaultProfileKey,
-} from "../config/default-profile-names.js";
+import type { DefaultProfileKey } from "../config/default-profile-names.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { invalidateConfigCache } from "../config/loader.js";
 import {
@@ -66,6 +63,20 @@ const log = getLogger("byok-default-profile-ensure");
 // stub or copy was removed.
 
 /**
+ * The default keys BYOK hatching ever wrote to disk. `latency-optimized`
+ * became a user-facing default only later — it shipped as a code-resolved
+ * call-site profile that was never seeded — so no install carries a hatch
+ * stub or a `custom-latency-optimized` copy for it. Including it would make
+ * `uniformCopyProvider` demand a copy that cannot exist and convert nothing.
+ */
+const HATCH_ERA_PROFILE_KEYS = [
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+] as const satisfies readonly DefaultProfileKey[];
+type HatchEraProfileKey = (typeof HATCH_ERA_PROFILE_KEYS)[number];
+
+/**
  * The exact stub shapes BYOK hatching left on each default key: thin (only
  * the workspace-owned overlay fields), `source: "managed"`, the frozen
  * per-key label, and a `status` of `"disabled"` (seeded at hatch, #30367),
@@ -82,7 +93,7 @@ const log = getLogger("byok-default-profile-ensure");
  * alone.
  */
 const STUB_ONLY_KEYS = new Set(["source", "status", "label", "thinking"]);
-const HATCH_STUB_LABELS: Record<DefaultProfileKey, string> = {
+const HATCH_STUB_LABELS: Record<HatchEraProfileKey, string> = {
   balanced: "Balanced (Managed)",
   "quality-optimized": "Quality (Managed)",
   "cost-optimized": "Speed (Managed)",
@@ -100,7 +111,7 @@ const HATCH_STUB_LABELS: Record<DefaultProfileKey, string> = {
 const REPAIR_WRITTEN_THINKING = { enabled: true, streamThinking: true };
 
 function isHatchStub(
-  key: DefaultProfileKey,
+  key: HatchEraProfileKey,
   entry: Record<string, unknown>,
 ): boolean {
   return (
@@ -142,7 +153,7 @@ const IGNORED_COMPARISON_KEYS = new Set(["label", "status", "model"]);
  * field still matches the template.
  */
 const HISTORICAL_INTENT_MODELS: Record<
-  DefaultProfileKey,
+  HatchEraProfileKey,
   Partial<Record<string, readonly string[]>>
 > = {
   balanced: {
@@ -231,7 +242,7 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
   // Deleting a hatch stub makes the default key resolve active from the
   // default provider's catalog column (and drops the stub's suffixed label).
-  for (const key of DEFAULT_PROFILE_KEYS) {
+  for (const key of HATCH_ERA_PROFILE_KEYS) {
     const entry = readObject(profiles[key]);
     if (entry === null || !isHatchStub(key, entry)) {
       continue;
@@ -260,8 +271,8 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
       : null;
 
   const retired = new Map<string, string>();
-  const carriedDisables = new Set<DefaultProfileKey>();
-  for (const key of DEFAULT_PROFILE_KEYS) {
+  const carriedDisables = new Set<HatchEraProfileKey>();
+  for (const key of HATCH_ERA_PROFILE_KEYS) {
     const name = `custom-${key}`;
     const entry = readObject(profiles[name]);
     if (
@@ -318,7 +329,7 @@ export function ensureByokDefaultProfiles(workspaceDir: string): void {
 
 function isKnownUneditedBody(
   entry: Record<string, unknown>,
-  key: DefaultProfileKey,
+  key: HatchEraProfileKey,
   convertibleProvider: LLMProvider | null,
   completionBase: LLMConfigBase | undefined,
 ): boolean {
@@ -374,7 +385,7 @@ function isKnownUneditedBody(
  */
 function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
   let provider: string | null = null;
-  for (const key of DEFAULT_PROFILE_KEYS) {
+  for (const key of HATCH_ERA_PROFILE_KEYS) {
     const entry = readObject(profiles[`custom-${key}`]);
     if (entry === null) {
       return null;
@@ -415,7 +426,7 @@ function uniformCopyProvider(profiles: Record<string, unknown>): string | null {
  */
 function hatchBodyVariants(
   known: Record<string, unknown>,
-  key: DefaultProfileKey,
+  key: HatchEraProfileKey,
   copyProvider: string,
 ): Record<string, unknown>[] {
   let variants = [known];
@@ -460,7 +471,7 @@ function withCompletionBaked(
  */
 function userOverlayState(
   entry: Record<string, unknown>,
-  key: DefaultProfileKey,
+  key: HatchEraProfileKey,
 ): Record<string, unknown> | null {
   const overlay: Record<string, unknown> = {};
   const templateLabel = USER_PROFILE_TEMPLATES[`custom-${key}`]?.label;
@@ -566,7 +577,7 @@ function repairProfileSelections(
   llm: Record<string, unknown>,
   profiles: Record<string, unknown>,
   defaultProvider: DefaultProviderConfig,
-  carriedDisables: ReadonlySet<DefaultProfileKey>,
+  carriedDisables: ReadonlySet<HatchEraProfileKey>,
 ): void {
   const effectiveEntry = (name: string): ProfileEntry | undefined =>
     resolveDefaultProfileForProvider(

--- a/assistant/src/workspace/migrations/139-clear-renamed-cost-profile-label.ts
+++ b/assistant/src/workspace/migrations/139-clear-renamed-cost-profile-label.ts
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Clear the machinery-written `"Speed"` label off the `cost-optimized`
+ * profile so the code catalog's new label ("Cost") reaches existing installs.
+ *
+ * `label` is workspace-owned overlay state: a managed-source entry's label
+ * wins over the code default (`WORKSPACE_OWNED_DEFAULT_FIELDS` in
+ * `config/default-profile-catalog.ts`). Migration 082 and the pre-catalog
+ * seeder both wrote `"Speed"` onto `cost-optimized`, and migration 126
+ * carried it onto the thin stub, so without this the picker would show two
+ * profiles named "Speed" — `cost-optimized`'s stale overlay and
+ * `latency-optimized`, which now ships as the user-facing Speed profile.
+ *
+ * Deleting the key (rather than writing "Cost") returns the label to code
+ * ownership, so later renames ship with a release instead of a migration.
+ *
+ * Only the exact string `"Speed"` is cleared. A user rename to anything else
+ * survives, as does an explicit `null` (label deliberately cleared). A rename
+ * that happened to be "Speed" is indistinguishable from the seeded value and
+ * is cleared too.
+ *
+ * Deliberately does NOT touch the `"Speed (Managed)"` label on BYOK hatch
+ * stubs: `ensureByokDefaultProfiles` matches that exact string to recognize a
+ * hatch stub and delete it (which is what re-enables the profile). Clearing
+ * it here would strand those installs with `cost-optimized` disabled. Once
+ * that pass removes the stub, the code label applies.
+ */
+export const clearRenamedCostProfileLabelMigration: WorkspaceMigration = {
+  id: "139-clear-renamed-cost-profile-label",
+  description:
+    'Clear the seeded "Speed" label on cost-optimized so the code catalog label applies',
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    // Read outside the parse catch: a transient filesystem error must reach
+    // the runner so the migration retries, while malformed JSON is a
+    // permanent state this migration cannot repair.
+    const rawText = readFileSync(configPath, "utf-8");
+
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawText);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return;
+      }
+      config = parsed as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) {
+      return;
+    }
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) {
+      return;
+    }
+    const entry = readObject(profiles["cost-optimized"]);
+    if (entry === null) {
+      return;
+    }
+    // A user-owned profile shadowing the default name owns its own label.
+    if (entry.source !== undefined && entry.source !== "managed") {
+      return;
+    }
+    if (entry.label !== "Speed") {
+      return;
+    }
+
+    delete entry.label;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: the label is code-owned once cleared.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/assistant/src/workspace/migrations/139-clear-renamed-cost-profile-label.ts
+++ b/assistant/src/workspace/migrations/139-clear-renamed-cost-profile-label.ts
@@ -12,8 +12,8 @@ import type { WorkspaceMigration } from "./types.js";
  * `config/default-profile-catalog.ts`). Migration 082 and the pre-catalog
  * seeder both wrote `"Speed"` onto `cost-optimized`, and migration 126
  * carried it onto the thin stub, so without this the picker would show two
- * profiles named "Speed" — `cost-optimized`'s stale overlay and
- * `latency-optimized`, which now ships as the user-facing Speed profile.
+ * profiles named "Speed": `cost-optimized`'s stale overlay and
+ * `latency-optimized`, the user-facing Speed profile.
  *
  * Deleting the key (rather than writing "Cost") returns the label to code
  * ownership, so later renames ship with a release instead of a migration.
@@ -67,8 +67,10 @@ export const clearRenamedCostProfileLabelMigration: WorkspaceMigration = {
     if (entry === null) {
       return;
     }
-    // A user-owned profile shadowing the default name owns its own label.
-    if (entry.source !== undefined && entry.source !== "managed") {
+    // Only a managed-source entry carries a machinery-written label. Anything
+    // else, a source-less legacy entry included, shadows the default outright
+    // (see `getEffectiveProfile`), so its label is the user's.
+    if (entry.source !== "managed") {
       return;
     }
     if (entry.label !== "Speed") {

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -136,6 +136,7 @@ import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js
 import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fireworks-kimi-model-id.js";
 import { repairRetiredFireworksMinimaxModelIdMigration } from "./137-repair-retired-fireworks-minimax-model-id.js";
 import { backfillHomeFeedTitlesMigration } from "./138-backfill-home-feed-titles.js";
+import { clearRenamedCostProfileLabelMigration } from "./139-clear-renamed-cost-profile-label.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -287,4 +288,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairStaleFireworksKimiModelIdMigration,
   repairRetiredFireworksMinimaxModelIdMigration,
   backfillHomeFeedTitlesMigration,
+  clearRenamedCostProfileLabelMigration,
 ];

--- a/clients/docs/src/app/docs/_components/model-profiles-content.tsx
+++ b/clients/docs/src/app/docs/_components/model-profiles-content.tsx
@@ -60,7 +60,7 @@ export function ModelProfilesContent() {
             Built-in profiles
           </SectionHeading>
           <p className="mb-4 text-stone-600 dark:text-stone-400">
-            Every workspace starts with three built-in profiles. You can edit or
+            Every workspace starts with four built-in profiles. You can edit or
             duplicate them, but the defaults can&apos;t be deleted.
           </p>
           <div className="overflow-x-auto">
@@ -90,15 +90,22 @@ export function ModelProfilesContent() {
                   <td className="py-3 pr-4">
                     <span className="font-semibold text-stone-900 dark:text-stone-100">Balanced</span>
                   </td>
-                  <td className="py-3 pr-4">GLM 5.2</td>
+                  <td className="py-3 pr-4">GPT-5.6 Luna</td>
                   <td className="py-3">Everyday use — capable across the board at reasonable cost</td>
                 </tr>
                 <tr>
                   <td className="py-3 pr-4">
-                    <span className="font-semibold text-stone-900 dark:text-stone-100">Cost Optimized</span>
+                    <span className="font-semibold text-stone-900 dark:text-stone-100">Speed</span>
+                  </td>
+                  <td className="py-3 pr-4">GPT-5.6 Luna</td>
+                  <td className="py-3">Fast replies with reasoning off, for real-time surfaces like voice</td>
+                </tr>
+                <tr>
+                  <td className="py-3 pr-4">
+                    <span className="font-semibold text-stone-900 dark:text-stone-100">Cost</span>
                   </td>
                   <td className="py-3 pr-4">DeepSeek V4 Flash</td>
-                  <td className="py-3">Simple, short, or structural tasks where speed matters more than depth</td>
+                  <td className="py-3">Simple, short, or structural tasks run at high volume</td>
                 </tr>
               </tbody>
             </table>

--- a/clients/web/src/domains/settings/ai/provider-row.tsx
+++ b/clients/web/src/domains/settings/ai/provider-row.tsx
@@ -77,7 +77,7 @@ export function ProviderRow({
           {isDefault ? (
             <Tag
               tone="info"
-              title="Built-in profiles (Balanced, Quality, Speed) use this provider."
+              title="Built-in profiles (Balanced, Quality, Cost, Speed) use this provider."
             >
               Default
             </Tag>

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-30T02:16:04.000Z"
+      "updatedAt": "2026-07-30T14:17:04.000Z"
     },
     {
       "id": "chat-complex-documents",
@@ -508,7 +508,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-07-28T05:02:41.000Z"
+      "updatedAt": "2026-08-03T23:08:27.000Z"
     },
     {
       "id": "llm-provider-setup",
@@ -623,7 +623,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-30T02:27:39.000Z"
+      "updatedAt": "2026-07-30T14:17:04.000Z"
     },
     {
       "id": "notifications",
@@ -756,7 +756,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-29T22:31:05.000Z"
+      "updatedAt": "2026-07-31T11:59:40.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -500,7 +500,7 @@
     {
       "id": "llm-cost-optimizer",
       "name": "llm-cost-optimizer",
-      "description": "Analyze and reduce LLM spend: read usage breakdowns by call site, model, and inference profile, understand single-winner profile resolution, and pin call sites to managed profiles (Balanced / Quality / Speed) only where they should deviate from shipped defaults.",
+      "description": "Analyze and reduce LLM spend: read usage breakdowns by call site, model, and inference profile, understand single-winner profile resolution, and pin call sites to managed profiles (Balanced / Quality / Cost / Speed) only where they should deviate from shipped defaults.",
       "metadata": {
         "emoji": "💸",
         "vellum": {

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "llm-cost-optimizer"
-description: "Analyze and reduce LLM spend: read usage breakdowns by call site, model, and inference profile, understand single-winner profile resolution, and pin call sites to managed profiles (Balanced / Quality / Speed) only where they should deviate from shipped defaults."
+description: "Analyze and reduce LLM spend: read usage breakdowns by call site, model, and inference profile, understand single-winner profile resolution, and pin call sites to managed profiles (Balanced / Quality / Cost / Speed) only where they should deviate from shipped defaults."
 metadata:
   emoji: "💸"
   vellum:
@@ -13,10 +13,11 @@ metadata:
 This skill walks through analyzing and reducing LLM spend on a Vellum assistant. There are three layers:
 
 1. **Provider connections** — named auth configs (e.g. `anthropic-managed`, `my-personal-key`)
-2. **Model profiles** — named presets (provider + model + effort + thinking + contextWindow). Three managed defaults, with UI labels:
+2. **Model profiles** — named presets (provider + model + effort + thinking + contextWindow). Four managed defaults, with UI labels. Note that the keys do not track the labels: read the key, not the name, when pinning a call site.
    - `balanced` → **Balanced** (the general agent-loop profile)
    - `quality-optimized` → **Quality** (the expensive escalation profile)
-   - `cost-optimized` → **Speed** (the cheap utility/background profile)
+   - `cost-optimized` → **Cost** (the cheap utility/background profile, and the one to pin for spend reduction)
+   - `latency-optimized` → **Speed** (the low time-to-first-token profile, used by live voice; faster but not cheaper than Cost)
 3. **Call-site profile pins** (`llm.callSites.<id>.profile`) — optional per-task overrides of the shipped defaults.
 
 The concrete model behind each managed profile depends on the install: platform-managed installs and BYOK installs resolve different providers/models, and the catalog changes over time. **Never assume which model a profile maps to** — read `assistant config get llm.profiles` and the usage breakdown by `model` to see what actually ran.


### PR DESCRIPTION
Makes the internal `latency-optimized` profile a user-facing 4th managed profile labelled **Speed**, and relabels `cost-optimized` from "Speed" to **Cost**.

| Key (unchanged on disk) | Label | Managed model | Effort |
|---|---|---|---|
| `balanced` | Balanced | gpt-5.6-luna | high + thinking |
| `quality-optimized` | Quality | gpt-5.6-sol | high + thinking |
| `cost-optimized` | **Cost** (was Speed) | deepseek-v4-flash | none |
| `latency-optimized` | **Speed** (was internal) | gpt-5.6-luna | low |

Keys are deliberately left alone — renaming them would break every `llm.callSites.*.profile`, `activeProfile` and schedule pin on disk, so only labels moved.

## Ordering
Lands as Balanced / Quality / Cost / Speed on both fresh and existing installs: the boot seeder appends missing managed keys and `DEFAULT_PROFILE_KEYS` is ordered to match. Verified against the real seeder + `orderProfileKeys`; no ordering migration needed.

## BYOK: new `cost-optimized` model intent
With both profiles user-facing they need distinct models, and `cost-optimized` previously borrowed the `latency-optimized` intent. Adds a `cost-optimized` ModelIntent with a cheapest-model pin per provider. Anthropic, ollama and fireworks are already at their floor model, so those three resolve the same model for both and split on effort alone — called out in the code.

## Migration 139
Clears the machinery-written `"Speed"` label off managed `cost-optimized` stubs, returning the label to code ownership so the new one reaches existing installs.

It deliberately skips `"Speed (Managed)"` BYOK hatch stubs: `ensureByokDefaultProfiles` matches that exact string to delete the stub, and a stripped label would leave the stub (and its stale `disabled`) in the picker until manually re-enabled. Dispatch is unaffected either way — `usableDefaultIntent` already overrides a persisted disabled default.

## Two things worth a reviewer's attention

**1. ~25 internal call sites change model on BYOK.** Call sites defaulting to `cost-optimized` (memory extraction, titles, classifiers, heartbeat) now resolve the cost intent rather than the latency one: openai `gpt-5.6-luna` → `gpt-5.4-nano`, gemini `3.1-flash-lite` → `2.5-flash-lite`, openrouter `haiku-4.5` → `deepseek-v4-flash`. Cheaper but smaller. Managed installs are unaffected. Happy to repoint them at `latency-optimized` if that trade isn't wanted.

**2. The live-voice shadow guard is gone.** A user-owned profile named `latency-optimized` now captures `voiceFrontDoor`/`voiceFrontDecision`, which the removed internal-profile guard prevented. That is the unavoidable price of making the profile selectable and editable; the new behaviour is pinned in a test rather than left implicit.

## Frozen-shape fix
`USER_PROFILE_TEMPLATES` now pins the hatch-era `cost-optimized` label/description/effort. The conversion pass compares unedited `custom-*` copies against that body, so the template edit would otherwise have made every copy read as user-edited and silently stop converting (a test caught it). The label pin separately stops `userOverlayState` carrying `"Speed"` back as a fake user rename.

## Cleanup
Deletes the internal-profile machinery — `INTERNAL_PROFILE_KEYS`, `PROFILE_MATRIX_KEYS`, `isMatrixProfileKey`, `isInternalProfileKey`, the listing skips and the schema's separate call-site name set — rather than keeping a one-member set. `ensureByokDefaultProfiles` keeps its own frozen three-key list, since including the new key would make `uniformCopyProvider` demand a `custom-latency-optimized` that cannot exist.

## Testing
`tsc --noEmit`, eslint and prettier clean. All 73 profile-touching test files pass when run in isolation (the suite has pre-existing cross-file mock pollution when run as one process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lyherv68Z85638BvAtKLf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->