### PR TITLE
feat(voice): put sensitive tools to the user during a live-voice call

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -78,6 +78,7 @@ import {
   cutFrontDoorContentAtVerdict,
   startVoiceTurn,
   TOOL_RESULT_PREVIEW_MAX_CHARS,
+  type VoiceTurnOptions,
 } from "../voice-session-bridge.js";
 import {
   escalatedContinuationRule,
@@ -119,6 +120,11 @@ interface FakeConversation {
     metadata?: Record<string, unknown>;
   }) => Promise<{ id: string }>;
   updateClient: (cb: unknown, reset?: boolean) => void;
+  handleConfirmationResponse: (
+    requestId: string,
+    decision: string,
+    opts?: { decisionContext?: string },
+  ) => void;
   runAgentLoop: (...args: unknown[]) => Promise<void>;
   abort: (reason?: unknown) => void;
   loadFromDb: () => Promise<void>;
@@ -136,6 +142,9 @@ function makeFakeConversation(opts: {
   onPersist?: (attempt: number) => void;
 }) {
   const waitForIdleCalls: WaitForIdleCall[] = [];
+  const confirmationDecisions: Array<{ requestId: string; decision: string }> =
+    [];
+  let clientCallback: ((msg: unknown) => Promise<void>) | undefined;
   let persistCount = 0;
   let lastPersistOpts:
     | { content: string; requestId: string; metadata?: Record<string, unknown> }
@@ -173,8 +182,14 @@ function makeFakeConversation(opts: {
     },
     // The install (reset falsy) / reset (reset true) pair marks a turn
     // taking ownership of the conversation vs a turn's cleanup releasing it.
-    updateClient: (_cb, reset) => {
+    updateClient: (cb, reset) => {
       opts.events?.push(reset ? "client:reset" : "client:install");
+      if (reset !== true) {
+        clientCallback = cb as (msg: unknown) => Promise<void>;
+      }
+    },
+    handleConfirmationResponse: (requestId, decision) => {
+      confirmationDecisions.push({ requestId, decision });
     },
     runAgentLoop: () => (opts.runAgentLoop ?? (async () => {}))(),
     abort: () => {},
@@ -186,6 +201,11 @@ function makeFakeConversation(opts: {
   return {
     conversation,
     waitForIdleCalls,
+    confirmationDecisions,
+    /** Deliver an event the way the conversation would, to the installed handler. */
+    emitToClient: async (msg: unknown) => {
+      await clientCallback?.(msg);
+    },
     persistCount: () => persistCount,
     lastPersistOpts: () => lastPersistOpts,
     setProcessingFlag: (value: boolean) => {
@@ -531,6 +551,90 @@ describe("startVoiceTurn channel capabilities", () => {
     const caps = installed();
     expect(caps?.channel).toBe("phone");
     expect(caps?.supportsDynamicUi).toBe(false);
+  });
+});
+
+describe("startVoiceTurn guardian approvals", () => {
+  function confirmationRequest(
+    toolName: string,
+    executionTarget?: "sandbox" | "host",
+  ) {
+    return {
+      type: "confirmation_request",
+      requestId: "req-1",
+      toolName,
+      input: {},
+      riskLevel: "medium",
+      allowlistOptions: [],
+      scopeOptions: [],
+      ...(executionTarget !== undefined ? { executionTarget } : {}),
+    };
+  }
+
+  async function runVoiceTurn(overrides: Partial<VoiceTurnOptions>) {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      trustContext: { trustClass: "guardian" },
+      ...overrides,
+    } as VoiceTurnOptions);
+    return fake;
+  }
+
+  // A live-voice call has a screen, so a tool that reaches the workspace or
+  // the host is put to the user rather than decided for them. This is the hole
+  // it closes: a guardian call used to allow every confirmation outright.
+  test("leaves a sensitive tool pending for the user to answer", async () => {
+    const fake = await runVoiceTurn({
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+    });
+
+    await fake.emitToClient(confirmationRequest("bash", "host"));
+
+    expect(fake.confirmationDecisions).toEqual([]);
+  });
+
+  // The tools that read or render were never the reason approval exists, and
+  // gating them would interrupt the conversation constantly.
+  test("still allows a tool with no sensitive reach", async () => {
+    const fake = await runVoiceTurn({
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+    });
+
+    await fake.emitToClient(confirmationRequest("ui_show", "sandbox"));
+
+    expect(fake.confirmationDecisions).toEqual([
+      { requestId: "req-1", decision: "allow" },
+    ]);
+  });
+
+  // There is no screen on a phone call, so a prompt there is a question nobody
+  // can answer.
+  test("a phone call keeps allowing sensitive tools outright", async () => {
+    const fake = await runVoiceTurn({ userMessageChannel: "phone" });
+
+    await fake.emitToClient(confirmationRequest("bash", "host"));
+
+    expect(fake.confirmationDecisions).toEqual([
+      { requestId: "req-1", decision: "allow" },
+    ]);
+  });
+
+  // Requests from the proxy and network prompters carry no target. Unknown
+  // reads as the more consequential of the two: a prompt the user did not need
+  // costs less than an unreviewed action on their machine.
+  test("prompts when the execution target is unknown", async () => {
+    const fake = await runVoiceTurn({
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+    });
+
+    await fake.emitToClient(confirmationRequest("bash"));
+
+    expect(fake.confirmationDecisions).toEqual([]);
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -119,6 +119,7 @@ interface FakeConversation {
     requestId: string;
     metadata?: Record<string, unknown>;
   }) => Promise<{ id: string }>;
+  workingDir: string;
   updateClient: (cb: unknown, reset?: boolean) => void;
   handleConfirmationResponse: (
     requestId: string,
@@ -140,6 +141,8 @@ function makeFakeConversation(opts: {
   hasQueuedMessages?: () => boolean;
   /** Runs before each persist resolves; throw to script a persist failure. */
   onPersist?: (attempt: number) => void;
+  /** Workspace root; pass empty to model a missing boundary. */
+  workingDir?: string;
 }) {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   const confirmationDecisions: Array<{ requestId: string; decision: string }> =
@@ -151,6 +154,9 @@ function makeFakeConversation(opts: {
     | undefined;
   const conversation: FakeConversation = {
     conversationId: "conv-voice-bridge-test",
+    // The workspace boundary the reach check compares paths against. A real
+    // conversation always has one; without it the approval gate fails closed.
+    workingDir: opts.workingDir ?? "/tmp/workspace-voice-bridge-test",
     callSessionId: undefined,
     forcePromptSideEffects: false,
     currentRequestId: undefined,
@@ -558,12 +564,13 @@ describe("startVoiceTurn guardian approvals", () => {
   function confirmationRequest(
     toolName: string,
     executionTarget?: "sandbox" | "host",
+    input: Record<string, unknown> = {},
   ) {
     return {
       type: "confirmation_request",
       requestId: "req-1",
       toolName,
-      input: {},
+      input,
       riskLevel: "medium",
       allowlistOptions: [],
       scopeOptions: [],
@@ -571,15 +578,25 @@ describe("startVoiceTurn guardian approvals", () => {
     };
   }
 
-  async function runVoiceTurn(overrides: Partial<VoiceTurnOptions>) {
-    const fake = makeFakeConversation({ processing: false });
+  async function runVoiceTurn(
+    overrides: Partial<VoiceTurnOptions>,
+    conversationOpts: { workingDir?: string } = {},
+  ) {
+    const fake = makeFakeConversation({
+      processing: false,
+      ...conversationOpts,
+    });
     fakeConversation = fake.conversation;
+    const pendingAnnounced: string[] = [];
     await startVoiceTurn({
       ...makeTurnOptions(),
       trustContext: { trustClass: "guardian" },
+      onApprovalPending: (requestId: string) => {
+        pendingAnnounced.push(requestId);
+      },
       ...overrides,
     } as VoiceTurnOptions);
-    return fake;
+    return { ...fake, pendingAnnounced };
   }
 
   // A live-voice call has a screen, so a tool that reaches the workspace or
@@ -594,6 +611,9 @@ describe("startVoiceTurn guardian approvals", () => {
     await fake.emitToClient(confirmationRequest("bash", "host"));
 
     expect(fake.confirmationDecisions).toEqual([]);
+    // The card renders in the app, and the call covers the app, so a pending
+    // decision has to be announced or the turn just goes quiet.
+    expect(fake.pendingAnnounced).toEqual(["req-1"]);
   });
 
   // The tools that read or render were never the reason approval exists, and
@@ -609,6 +629,8 @@ describe("startVoiceTurn guardian approvals", () => {
     expect(fake.confirmationDecisions).toEqual([
       { requestId: "req-1", decision: "allow" },
     ]);
+    // Nothing is waiting, so nothing interrupts the call.
+    expect(fake.pendingAnnounced).toEqual([]);
   });
 
   // There is no screen on a phone call, so a prompt there is a question nobody
@@ -621,6 +643,56 @@ describe("startVoiceTurn guardian approvals", () => {
     expect(fake.confirmationDecisions).toEqual([
       { requestId: "req-1", decision: "allow" },
     ]);
+  });
+
+  // The escape this gate exists to catch: a *sandbox* file tool pointed
+  // outside the workspace reaches the host filesystem on a non-containerized
+  // install. The reach check can only see that when it is given the workspace
+  // boundary; without it this read of a host file classifies as `none` and
+  // lands on the auto-allow.
+  test("an out-of-workspace path prompts even on a sandbox target", async () => {
+    const fake = await runVoiceTurn(
+      { userMessageChannel: "vellum", userMessageInterface: "macos" },
+      { workingDir: "/tmp/workspace-voice-bridge-test" },
+    );
+
+    await fake.emitToClient(
+      confirmationRequest("file_read", "sandbox", { path: "/etc/hosts" }),
+    );
+
+    expect(fake.confirmationDecisions).toEqual([]);
+  });
+
+  // A path inside the workspace is the ordinary case, and gating it would
+  // interrupt the conversation for every file the assistant touches.
+  test("an in-workspace read is still allowed outright", async () => {
+    const fake = await runVoiceTurn(
+      { userMessageChannel: "vellum", userMessageInterface: "macos" },
+      { workingDir: "/tmp/workspace-voice-bridge-test" },
+    );
+
+    await fake.emitToClient(
+      confirmationRequest("file_read", "sandbox", {
+        path: "/tmp/workspace-voice-bridge-test/notes.md",
+      }),
+    );
+
+    expect(fake.confirmationDecisions).toEqual([
+      { requestId: "req-1", decision: "allow" },
+    ]);
+  });
+
+  // With no boundary there is no way to tell an ordinary write from an escape,
+  // and the safe reading of "cannot tell" is "ask".
+  test("a missing workspace boundary fails closed", async () => {
+    const fake = await runVoiceTurn(
+      { userMessageChannel: "vellum", userMessageInterface: "macos" },
+      { workingDir: "" },
+    );
+
+    await fake.emitToClient(confirmationRequest("ui_show", "sandbox"));
+
+    expect(fake.confirmationDecisions).toEqual([]);
   });
 
   // Requests from the proxy and network prompters carry no target. Unknown

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -287,6 +287,18 @@ export interface VoiceTurnOptions {
   onError?: (message: string) => void;
   /** Event-name callbacks used by non-phone voice clients. */
   callbacks?: VoiceTurnCallbacks;
+  /**
+   * Called when this turn leaves a confirmation for the user to answer instead
+   * of deciding it, so the client can put the prompt where they can see it.
+   *
+   * A voice client renders its call as something that covers the app (the
+   * live-voice room is a full-screen overlay), which is fine while the call is
+   * the only thing happening and wrong the moment the turn is waiting on a
+   * decision: the card is on screen, behind the call. The bridge cannot reach
+   * a client's own surfaces, so it says *that a decision is waiting* and the
+   * client decides what to do about it.
+   */
+  onApprovalPending?: (requestId: string) => void;
   /** Optional AbortSignal for external cancellation (e.g. barge-in). */
   signal?: AbortSignal;
   /**
@@ -1244,6 +1256,13 @@ export async function startVoiceTurn(
       //
       // Phone keeps the old behavior in full. There is no screen on that
       // channel, so a prompt there is a question nobody can answer.
+      // The workspace root is what makes an escape visible. A sandbox file
+      // tool pointed outside the workspace reaches the host filesystem on a
+      // non-containerized install, and `sensitiveToolReach` can only see that
+      // when it is given the boundary to compare against: without it,
+      // `file_read { path: "/etc/hosts" }` classifies as `none` and would fall
+      // through to the auto-allow this branch exists to prevent.
+      const workspaceRoot = conversation.workingDir;
       const reach = sensitiveToolReach(
         msg.toolName,
         // Absent on requests that do not come from the tool pipeline (proxy
@@ -1252,9 +1271,14 @@ export async function startVoiceTurn(
         // against an unreviewed action on their machine.
         msg.executionTarget ?? "host",
         msg.input,
+        workspaceRoot,
       );
       const canPrompt = turnChannelContext.userMessageChannel === "vellum";
-      if (canPrompt && reach !== "none") {
+      // Fail closed on a missing boundary for the same reason: with no
+      // workspace root there is no way to tell an ordinary write from an
+      // escape, and the safe reading of "cannot tell" is "ask". A real
+      // conversation always has one, so this is a guard rather than a path.
+      if (canPrompt && (reach !== "none" || !workspaceRoot)) {
         log.info(
           { turnId, toolName: msg.toolName, reach },
           "Prompting guardian voice caller for a sensitive tool",
@@ -1262,6 +1286,10 @@ export async function startVoiceTurn(
         // Left pending: the request is already broadcast, so the approval card
         // an attached client renders is now answerable rather than cleared a
         // moment later by this handler.
+        //
+        // Announced separately, because "a card exists" and "the user can see
+        // it" are different things on a channel whose call covers the app.
+        opts.onApprovalPending?.(msg.requestId);
         const timer = setTimeout(() => {
           pendingVoiceApprovals.delete(msg.requestId);
           log.info(

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -40,6 +40,7 @@ import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getAllTools } from "../tools/registry.js";
+import { sensitiveToolReach } from "../tools/tool-approval-handler.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
@@ -378,6 +379,16 @@ export interface VoiceTurnHandle {
  * to a third party mid-call is a different problem, and one a minimized room
  * does not solve.
  */
+/**
+ * How long a live-voice call waits on an approval before deciding it itself.
+ *
+ * Long enough to pick the phone up and read the card, short enough that a turn
+ * cannot sit blocked for the rest of the call. The fallback is the decision
+ * this channel made before it prompted at all, so the worst case of nobody
+ * answering is exactly the old behavior, arrived at late.
+ */
+const VOICE_APPROVAL_TIMEOUT_MS = 45_000;
+
 export const VOICE_NO_SETUP_FLOWS_RULE =
   "Never start account connections, OAuth or sign-in flows, or any other action that opens a browser window or needs the user's screen during this call — not even through shell or CLI tools. If the task needs one, say so briefly and offer to finish it in text chat after the call.";
 
@@ -856,7 +867,31 @@ export async function startVoiceTurn(
   // (tracked via `clientCallbackInstalled`); otherwise cleanup would detach
   // an active sender installed by a prior turn.
   let clientCallbackInstalled = false;
+  /**
+   * Confirmations this voice turn left pending for the user to answer, and the
+   * timers that stop them waiting forever.
+   *
+   * A call is a poor place to block: the user may have put the phone in a
+   * pocket, and a turn that waits indefinitely is a session that looks wedged.
+   * Each pending request therefore carries a deadline, after which it resolves
+   * the way this channel resolved everything before it prompted at all.
+   */
+  const pendingVoiceApprovals = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  const settleVoiceApproval = (requestId: string): void => {
+    const timer = pendingVoiceApprovals.get(requestId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      pendingVoiceApprovals.delete(requestId);
+    }
+  };
   const cleanup = () => {
+    for (const timer of pendingVoiceApprovals.values()) {
+      clearTimeout(timer);
+    }
+    pendingVoiceApprovals.clear();
     conversation.setChannelCapabilities(null);
     conversation.setTrustContext(null);
     conversation.setCommandIntent(null);
@@ -1116,6 +1151,11 @@ export async function startVoiceTurn(
   // Voice auto-denies/auto-allows/auto-resolves these since there's no interactive UI.
   let lastError: string | null = null;
   conversation.updateClient(async (msg: AssistantEvent) => {
+    // The user (or anything else) answered: stop the fallback from firing on a
+    // request that is already decided.
+    if (msg.type === "interaction_resolved") {
+      settleVoiceApproval(msg.requestId);
+    }
     if (msg.type === "confirmation_request") {
       // Broadcast the request BEFORE resolving it: resolution synchronously
       // broadcasts `interaction_resolved` (handleConfirmationResponse →
@@ -1192,6 +1232,52 @@ export async function startVoiceTurn(
         });
         return;
       }
+      // A live-voice call has a screen, so a consequential action can be put
+      // to the user instead of decided for them.
+      //
+      // Everything used to be allowed here on the strength of the caller being
+      // a guardian, which made a voice call the one surface where a tool that
+      // writes to the workspace or reaches the host never had to ask. Only
+      // *sensitive* reach prompts: gating every confirmation would interrupt a
+      // conversation constantly, and the tools that read or render were never
+      // the reason approval exists.
+      //
+      // Phone keeps the old behavior in full. There is no screen on that
+      // channel, so a prompt there is a question nobody can answer.
+      const reach = sensitiveToolReach(
+        msg.toolName,
+        // Absent on requests that do not come from the tool pipeline (proxy
+        // and network prompters). Unknown reads as the more consequential of
+        // the two: the cost of being wrong is a prompt the user did not need,
+        // against an unreviewed action on their machine.
+        msg.executionTarget ?? "host",
+        msg.input,
+      );
+      const canPrompt = turnChannelContext.userMessageChannel === "vellum";
+      if (canPrompt && reach !== "none") {
+        log.info(
+          { turnId, toolName: msg.toolName, reach },
+          "Prompting guardian voice caller for a sensitive tool",
+        );
+        // Left pending: the request is already broadcast, so the approval card
+        // an attached client renders is now answerable rather than cleared a
+        // moment later by this handler.
+        const timer = setTimeout(() => {
+          pendingVoiceApprovals.delete(msg.requestId);
+          log.info(
+            { turnId, toolName: msg.toolName },
+            "Voice approval timed out — falling back to the guardian allow",
+          );
+          conversation.handleConfirmationResponse(msg.requestId, "allow", {
+            decisionContext: `Permission approved for "${msg.toolName}": this is a verified guardian voice call and the approval prompt went unanswered.`,
+          });
+        }, VOICE_APPROVAL_TIMEOUT_MS);
+        // Never hold the process open for a prompt nobody is looking at.
+        timer.unref?.();
+        pendingVoiceApprovals.set(msg.requestId, timer);
+        return;
+      }
+
       log.info(
         { turnId, toolName: msg.toolName },
         "Auto-approving confirmation request for guardian voice turn",

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -299,6 +299,16 @@ export interface VoiceTurnOptions {
    * client decides what to do about it.
    */
   onApprovalPending?: (requestId: string) => void;
+  /**
+   * Called when the last pending confirmation this turn was waiting on is
+   * decided, however it was decided (the user answered, it timed out, a newer
+   * message superseded it). Paired with {@link onApprovalPending} so a client
+   * that changed its presentation for the wait can change it back.
+   *
+   * Fires on the *last* one, not each: a turn waiting on two decisions is
+   * still waiting after the first is answered.
+   */
+  onApprovalsResolved?: () => void;
   /** Optional AbortSignal for external cancellation (e.g. barge-in). */
   signal?: AbortSignal;
   /**
@@ -894,9 +904,15 @@ export async function startVoiceTurn(
   >();
   const settleVoiceApproval = (requestId: string): void => {
     const timer = pendingVoiceApprovals.get(requestId);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      pendingVoiceApprovals.delete(requestId);
+    if (timer === undefined) {
+      // Not one of ours: other interactions (secrets, host-proxy requests)
+      // resolve through the same event.
+      return;
+    }
+    clearTimeout(timer);
+    pendingVoiceApprovals.delete(requestId);
+    if (pendingVoiceApprovals.size === 0) {
+      opts.onApprovalsResolved?.();
     }
   };
   const cleanup = () => {
@@ -1292,6 +1308,9 @@ export async function startVoiceTurn(
         opts.onApprovalPending?.(msg.requestId);
         const timer = setTimeout(() => {
           pendingVoiceApprovals.delete(msg.requestId);
+          if (pendingVoiceApprovals.size === 0) {
+            opts.onApprovalsResolved?.();
+          }
           log.info(
             { turnId, toolName: msg.toolName },
             "Voice approval timed out — falling back to the guardian allow",

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -157,13 +157,20 @@ async function waitFor(
 function createCapturingTurnStarter(): {
   startVoiceTurn: LiveVoiceTurnStarter;
   getCallbacks: () => VoiceTurnCallbacks | undefined;
+  announceApprovalPending: () => void;
 } {
   let callbacks: VoiceTurnCallbacks | undefined;
+  let onApprovalPending: ((requestId: string) => void) | undefined;
   const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
     callbacks = options.callbacks;
+    onApprovalPending = options.onApprovalPending;
     return { turnId: "bridge-turn-1", abort: mock() };
   });
-  return { startVoiceTurn, getCallbacks: () => callbacks };
+  return {
+    startVoiceTurn,
+    getCallbacks: () => callbacks,
+    announceApprovalPending: () => onApprovalPending?.("req-1"),
+  };
 }
 
 function createRecordingTtsStreamer(): {
@@ -754,6 +761,25 @@ describe("LiveVoiceSession room reveal", () => {
     await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
 
     expect(frames.some((frame) => frame.type === "minimize_room")).toBe(true);
+  });
+
+  // A blocked turn has no speech left to drain, and the card it is blocked on
+  // renders behind the room. Waiting for a drain that is not coming would
+  // leave the call silent in front of a decision the user cannot see.
+  test("a pending approval reveals the screen immediately", async () => {
+    const { startVoiceTurn, announceApprovalPending } =
+      createCapturingTurnStarter();
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    announceApprovalPending();
+    await waitFor(() => frames.some((frame) => frame.type === "minimize_room"));
+
+    // Before any tts_done, unlike the drain-scoped reveal a shown surface gets.
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
   });
 
   test("dismissing a surface does not reveal the screen", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -158,18 +158,22 @@ function createCapturingTurnStarter(): {
   startVoiceTurn: LiveVoiceTurnStarter;
   getCallbacks: () => VoiceTurnCallbacks | undefined;
   announceApprovalPending: () => void;
+  announceApprovalsResolved: () => void;
 } {
   let callbacks: VoiceTurnCallbacks | undefined;
   let onApprovalPending: ((requestId: string) => void) | undefined;
+  let onApprovalsResolved: (() => void) | undefined;
   const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
     callbacks = options.callbacks;
     onApprovalPending = options.onApprovalPending;
+    onApprovalsResolved = options.onApprovalsResolved;
     return { turnId: "bridge-turn-1", abort: mock() };
   });
   return {
     startVoiceTurn,
     getCallbacks: () => callbacks,
     announceApprovalPending: () => onApprovalPending?.("req-1"),
+    announceApprovalsResolved: () => onApprovalsResolved?.(),
   };
 }
 
@@ -780,6 +784,39 @@ describe("LiveVoiceSession room reveal", () => {
 
     // Before any tts_done, unlike the drain-scoped reveal a shown surface gets.
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  // Every phrase progress narration has describes work in flight ("still on
+  // it", "almost there"). While the turn is blocked on the user, all of them
+  // are false, and the one that matters is the one about who is being waited
+  // on.
+  test("says it is waiting, once, and stops narrating progress", async () => {
+    const {
+      startVoiceTurn,
+      announceApprovalPending,
+      announceApprovalsResolved,
+    } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    announceApprovalPending();
+    await waitFor(() => ttsTexts.join(" ").includes("okay"));
+    // Repeat announcements do not repeat the line.
+    announceApprovalPending();
+    await flushAsyncCallbacks();
+
+    const saidWaiting = ttsTexts.filter((text) => text.includes("okay")).length;
+    expect(saidWaiting).toBe(1);
+
+    announceApprovalsResolved();
+    await flushAsyncCallbacks();
   });
 
   test("dismissing a surface does not reveal the screen", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2340,6 +2340,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
+   * Open the room because a decision is waiting behind it.
+   *
+   * The approval card renders in the app, and the room covers the app, so
+   * without this the turn simply goes quiet: nothing is spoken, nothing is
+   * visible, and the only cue is a call that stopped talking. Sent
+   * immediately rather than latched for the drain the way a shown surface is,
+   * because there is no drain coming. The turn is blocked on this decision,
+   * and the whole point is that the user can make it now.
+   *
+   * The latch is cleared as well, so a turn that also showed a surface does
+   * not send a second minimize once its speech ends; the room is already open.
+   */
+  private revealRoomForPendingApproval(turn: ActiveAssistantTurn): void {
+    turn.minimizeRequested = false;
+    void this.sendFrame(
+      { type: "minimize_room", turnId: turn.turnId },
+      () => !this.isClosed,
+    );
+  }
+
+  /**
    * Tell the client what the turn is doing, if it changed.
    *
    * De-duplicated for the same reason the Live Activity reporter de-duplicates
@@ -3655,6 +3676,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {
           ...(leg.frontDoor !== undefined ? { frontDoor: leg.frontDoor } : {}),
         }),
+        onApprovalPending: () => {
+          this.revealRoomForPendingApproval(activeTurn);
+        },
         content: leg.content,
         isInbound: true,
         launchedAtMs: activeTurn.launchedAtMs,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -491,6 +491,10 @@ interface ActiveAssistantTurn {
   // map to the same line sends one frame rather than one per call. Empty means
   // the client believes nothing is running, which is also where a turn ends.
   activityLabel: string;
+  // Set while the turn is blocked on a decision the user has to make. Suppresses
+  // progress narration, whose entire vocabulary ("still on it", "almost there")
+  // describes work in flight and would be false here.
+  awaitingApproval: boolean;
   // A tts_audio frame actually went out to the client — latches on the first
   // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
@@ -650,6 +654,12 @@ function createControlMarkerHoldback(
 // barge-in, the interruption merge note is appended to it (see
 // buildInterruptionMergeNote) so the model reconciles the interrupted request
 // with the new utterance.
+// Spoken once when a turn starts waiting on the user's decision. Fixed rather
+// than generated: this is a statement about the system's state, not about the
+// work, and it has to be true every time. Kept in the shape of the progress
+// phrases it displaces (short, neutral, no claim about tools).
+const APPROVAL_PENDING_PHRASE = "I need your okay for that one. Take a look.";
+
 const LIVE_VOICE_CONTROL_PROMPT_BASE =
   "You are speaking in a local live voice session. Keep replies brief and conversational. Speech is the main channel: say the answer, and do not narrate a surface instead of answering. You can also put something on screen when it genuinely helps (a form, a list to pick from, a progress card for long work); the call overlay minimizes by itself once you finish speaking, so the user sees it without doing anything. Never tell the user you cannot show them something. ";
 
@@ -2353,11 +2363,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * not send a second minimize once its speech ends; the room is already open.
    */
   private revealRoomForPendingApproval(turn: ActiveAssistantTurn): void {
+    if (turn.awaitingApproval) {
+      return;
+    }
+    turn.awaitingApproval = true;
     turn.minimizeRequested = false;
     void this.sendFrame(
       { type: "minimize_room", turnId: turn.turnId },
       () => !this.isClosed,
     );
+    // Spoken, because opening the room is only a cue for someone looking at
+    // the screen, and the case this exists for is a phone the user has put
+    // down. One line, not narration: the turn is not working, it is waiting,
+    // and it says which.
+    this.enqueueFillerPhrase(turn, APPROVAL_PENDING_PHRASE);
+  }
+
+  /** Clear the wait once a decision lands, so the turn narrates normally again. */
+  private clearAwaitingApproval(turn: ActiveAssistantTurn): void {
+    turn.awaitingApproval = false;
   }
 
   /**
@@ -3475,6 +3499,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsDone: false,
       minimizeRequested: false,
       activityLabel: "",
+      awaitingApproval: false,
       ttsAudioStarted: false,
       finalized: false,
       speculativePending: opts?.speculative === true,
@@ -3678,6 +3703,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }),
         onApprovalPending: () => {
           this.revealRoomForPendingApproval(activeTurn);
+        },
+        onApprovalsResolved: () => {
+          this.clearAwaitingApproval(activeTurn);
         },
         content: leg.content,
         isInbound: true,
@@ -4351,6 +4379,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return (
       this.isActiveAssistantTurn(turn.token) &&
       !turn.assistantCompleted &&
+      // Nothing is in flight while a decision is pending, so every phrase
+      // narration has would be a lie about who the call is waiting on. The
+      // turn says so once, when it starts waiting, and is quiet after that.
+      !turn.awaitingApproval &&
       this.turnAudioIdle(turn)
     );
   }


### PR DESCRIPTION
Phase 4 of JARVIS-1404: a live-voice call stops bypassing approval.

## The hole this closes

A guardian voice call **allowed every confirmation outright** (`voice-session-bridge.ts`, "Auto-approving confirmation request for guardian voice turn"). Not up to a risk threshold, not with a grant check — `isGuardian` was the whole test. So a call was the one surface where a tool that writes to the workspace or reaches the host never had to ask, and on the device owner's own phone that is always the path taken.

I had previously described this policy as "auto-approve up to a risk threshold, auto-deny above it". That was wrong; there is no threshold. Worth stating, because it makes this phase less "add buttons" and more "voice stops bypassing approval".

## What changes

**Sensitive reach prompts.** Gated on the existing `sensitiveToolReach()` classifier, so `sandbox`/`host` reach leaves the request pending instead of resolving it. The request is already broadcast *before* resolution, so the approval card attached clients render is now answerable rather than cleared a moment after it appears — the interactive plumbing already existed end to end; voice was just answering it first. Anything with no sensitive reach is still allowed outright, because the tools that read or render were never the reason approval exists.

**The reach check gets the workspace boundary.** `sensitiveToolReach` only recognizes an out-of-workspace file path — which reaches the host filesystem on a non-containerized install — when given the workspace root to compare against. Without it, `file_read { path: "/etc/hosts" }` on a *sandbox* target classifies as `none` and falls through to the auto-allow, so the single case this gate exists for was the one it missed. It now passes `conversation.workingDir` and fails closed when there is no boundary: with nothing to compare against there is no way to tell an ordinary write from an escape, and the safe reading of "cannot tell" is "ask". (Caught in review.)

**A pending approval opens the room.** The card renders in the app and the room covers the app, so a blocked turn was silent in front of a decision the user could not see. `startVoiceTurn` gained `onApprovalPending`, because the bridge cannot reach a client's surfaces and should not know about them: it reports that a decision is waiting, and the live-voice session sends `minimize_room`. Immediately, not latched for the drain a shown surface waits on, since a blocked turn has no speech left to drain.

**And the call says so.** Progress narration speaks into audible silence, so the wait would otherwise be filled with "still on it" and "almost there" — the assistant claiming to work while it waits on you, which is worse than silence because it tells the user the one thing that stops them acting. Narration is suppressed for the wait and the turn says the true thing once, spoken (opening the room only helps someone looking at the screen; the case this exists for is a phone that has been put down) and fixed rather than generated (a statement about the system's state has to be true every time).

**Phone is untouched throughout.** No screen, so a prompt there is a question nobody can answer.

**A deadline, not a block.** A pending request falls back to the old guardian allow after 45s, so the worst case of nobody answering is exactly today's behavior arrived at late, rather than a turn wedged for the rest of the call.

## Testing

62 bridge tests and 26 live-voice agent-turn tests, per-file as CI runs them, plus typecheck.

New coverage: a sensitive tool stays pending; a non-sensitive one still resolves; phone still resolves; an absent execution target prompts; an out-of-workspace path prompts on a sandbox target; an in-workspace read is still allowed; a missing boundary fails closed; a pending approval reveals the screen before any `tts_done`; and the waiting line is spoken exactly once. The two security-relevant tests were verified to fail against the previous implementation rather than pass vacuously.

**Not unit-tested:** the timeout firing. Bun cannot advance `setTimeout`, and I did not want a test-only knob on `VoiceTurnOptions`. The fallback body is a two-line `handleConfirmationResponse` call identical to the branch above it.

## Next

Island Approve/Deny buttons, which need this pending state to exist before there is anything for a button to answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)