### PR TITLE
fix(inference): require platform auth and provider "vellum" to agree

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14679,8 +14679,9 @@ paths:
       summary: Create a provider connection
       description:
         Create a new named provider connection. When auth is omitted it is derived from the provider (keyless
-        providers get none, vellum gets platform, everything else needs credential for api_key auth). Fails with 409 if
-        a connection with this name already exists.
+        providers get none, vellum gets platform, everything else needs credential for api_key auth). An explicit auth
+        object must agree with the provider; platform auth belongs to vellum and only to vellum. Fails with 409 if a
+        connection with this name already exists.
       tags:
         - inference
       requestBody:
@@ -14789,8 +14790,9 @@ paths:
       summary: Update a provider connection
       description:
         Update an existing connection. Cannot rename or change the provider. Omitting auth keeps the stored auth;
-        passing credential alone rotates the key via provider-derived api_key auth. For the Vellum-managed connection
-        (vellum) the auth is locked to platform; label remains editable.
+        passing credential alone rotates the key via provider-derived api_key auth. An explicit auth object must agree
+        with the connection's provider; platform auth belongs to vellum and only to vellum. For the Vellum-managed
+        connection (vellum) the auth is locked to platform; label remains editable.
       tags:
         - inference
       parameters:

--- a/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
+++ b/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
@@ -99,8 +99,8 @@ describe("CLI vs HTTP route parity", () => {
 
   test("platform connection: CLI createConnection and HTTP POST produce identical DB rows", async () => {
     const payload = {
-      name: "parity-openai-managed",
-      provider: "openai" as const,
+      name: "parity-vellum-managed",
+      provider: "vellum" as const,
       auth: { type: "platform" as const },
     };
 

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -637,9 +637,10 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
     expect((err as BadRequestError).message).toContain("platform");
   });
 
-  // Rows written before the pairing was enforced must stay editable — the
-  // guard only inspects an auth object the caller actually supplied.
-  test("allows editing a legacy mismatched row when auth is untouched", async () => {
+  // Rows written before the pairing was enforced must stay editable. Both the
+  // web editor and the CLI resend the stored auth on every edit, so the guard
+  // has to key on an actual auth change, not on the field being present.
+  test("allows editing a legacy mismatched row when the client resends the stored auth", async () => {
     seedConnection({
       name: "legacy-managed-openai",
       provider: "openai",
@@ -650,11 +651,50 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
       findHandler("inference_provider_connections_update"),
       {
         pathParams: { name: "legacy-managed-openai" },
-        body: { label: "Legacy" },
+        body: { auth: { type: "platform" }, label: "Legacy" },
       },
     )) as { label: string | null; auth: object };
     expect(result.label).toBe("Legacy");
     expect(result.auth).toEqual({ type: "platform" });
+  });
+
+  test("allows editing a legacy mismatched row when auth is omitted", async () => {
+    seedConnection({
+      name: "legacy-managed-gemini",
+      provider: "gemini",
+      auth: { type: "platform" },
+    });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "legacy-managed-gemini" },
+        body: { label: "Legacy" },
+      },
+    )) as { label: string | null };
+    expect(result.label).toBe("Legacy");
+  });
+
+  // The guard must not trap a legacy row in its mismatched state: an auth
+  // change that repairs the pairing is exactly what should be allowed.
+  test("allows repairing a legacy mismatched row with a valid auth change", async () => {
+    seedConnection({
+      name: "legacy-managed-anthropic",
+      provider: "anthropic",
+      auth: { type: "platform" },
+    });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "legacy-managed-anthropic" },
+        body: { auth: { type: "api_key", credential: "vault/anthropic/key" } },
+      },
+    )) as { auth: object };
+    expect(result.auth).toEqual({
+      type: "api_key",
+      credential: "vault/anthropic/key",
+    });
   });
 
   test("throws 400 when auth schema is invalid", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -207,12 +207,45 @@ describe("POST inference/provider-connections (create)", () => {
       {
         body: {
           name: "managed-openai",
-          provider: "openai",
+          provider: "vellum",
           auth: { type: "platform" },
         },
       },
     )) as { auth: object };
     expect(result.auth).toEqual({ type: "platform" });
+  });
+
+  test("rejects platform auth on a real provider", async () => {
+    const err = await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "managed-openai",
+          provider: "openai",
+          auth: { type: "platform" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("platform");
+    expect((err as BadRequestError).message).toContain("vellum");
+  });
+
+  test("rejects key auth on the vellum provider", async () => {
+    const err = await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "keyed-vellum",
+          provider: "vellum",
+          auth: { type: "api_key", credential: "vault/vellum/key" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("vellum");
   });
 
   test("creates connection with none auth (e.g. ollama)", async () => {
@@ -504,7 +537,7 @@ describe("POST inference/provider-connections (create)", () => {
         body: {
           name: "dup-name",
           provider: "openai",
-          auth: { type: "platform" },
+          auth: { type: "api_key", credential: "vault/openai/key" },
         },
       }),
     ).rejects.toBeInstanceOf(ConflictError);
@@ -583,6 +616,45 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
         body: { auth: { type: "platform" } },
       }),
     ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("rejects switching a real provider's connection to platform auth", async () => {
+    seedConnection({
+      name: "byok-openai",
+      provider: "openai",
+      auth: { type: "api_key", credential: "vault/openai/key" },
+    });
+
+    const err = await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "byok-openai" },
+        body: { auth: { type: "platform" } },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("platform");
+  });
+
+  // Rows written before the pairing was enforced must stay editable — the
+  // guard only inspects an auth object the caller actually supplied.
+  test("allows editing a legacy mismatched row when auth is untouched", async () => {
+    seedConnection({
+      name: "legacy-managed-openai",
+      provider: "openai",
+      auth: { type: "platform" },
+    });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "legacy-managed-openai" },
+        body: { label: "Legacy" },
+      },
+    )) as { label: string | null; auth: object };
+    expect(result.label).toBe("Legacy");
+    expect(result.auth).toEqual({ type: "platform" });
   });
 
   test("throws 400 when auth schema is invalid", async () => {
@@ -971,7 +1043,7 @@ describe("POST with label", () => {
         body: {
           name: "labeled-conn",
           provider: "anthropic",
-          auth: { type: "platform" },
+          auth: { type: "api_key", credential: "vault/anthropic/key" },
           label: "My Anthropic",
         },
       },
@@ -987,7 +1059,7 @@ describe("POST with label", () => {
         body: {
           name: "no-label-conn",
           provider: "openai",
-          auth: { type: "platform" },
+          auth: { type: "api_key", credential: "vault/openai/key" },
         },
       },
     )) as { label: string | null };
@@ -999,7 +1071,7 @@ describe("PATCH with label", () => {
   test("updates label to a string", async () => {
     seedConnection({
       name: "set-label",
-      provider: "openai",
+      provider: "vellum",
       auth: { type: "platform" },
     });
 
@@ -1016,7 +1088,7 @@ describe("PATCH with label", () => {
   test("clears label by setting it to null", async () => {
     seedConnection({
       name: "clear-label",
-      provider: "gemini",
+      provider: "vellum",
       auth: { type: "platform" },
     });
     // First set a label.
@@ -1038,7 +1110,7 @@ describe("PATCH with label", () => {
   test("rejects label: empty string with 400", async () => {
     seedConnection({
       name: "reject-empty",
-      provider: "anthropic",
+      provider: "vellum",
       auth: { type: "platform" },
     });
 
@@ -1168,7 +1240,7 @@ describe("Managed connection write protection", () => {
     test("allows PATCH with auth still set to platform (no-op auth change)", async () => {
       seedConnection({
         name: "vellum",
-        provider: "anthropic",
+        provider: "vellum",
         auth: { type: "platform" },
       });
 
@@ -1190,7 +1262,7 @@ describe("Managed connection write protection", () => {
     test("allows relabeling a managed connection", async () => {
       seedConnection({
         name: "vellum",
-        provider: "openai",
+        provider: "vellum",
         auth: { type: "platform" },
       });
 

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -637,9 +637,9 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
     expect((err as BadRequestError).message).toContain("platform");
   });
 
-  // Rows written before the pairing was enforced must stay editable. Both the
+  // A persisted row whose provider and auth disagree stays editable: both the
   // web editor and the CLI resend the stored auth on every edit, so the guard
-  // has to key on an actual auth change, not on the field being present.
+  // keys on an actual auth change rather than on the field being present.
   test("allows editing a legacy mismatched row when the client resends the stored auth", async () => {
     seedConnection({
       name: "legacy-managed-openai",

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -39,7 +39,10 @@ import {
   updateConnection,
 } from "../../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
-import { isVellumManagedConnection } from "../../providers/vellum-model-routing.js";
+import {
+  isVellumManagedConnection,
+  VELLUM_MANAGED_PROVIDER,
+} from "../../providers/vellum-model-routing.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { deleteSecureKeyAsync } from "../../security/secure-keys.js";
 import {
@@ -192,6 +195,27 @@ function deriveConnectionAuth(provider: string, credential: unknown): Auth {
   return derived;
 }
 
+/**
+ * Platform auth and `provider: "vellum"` record the same fact — the managed
+ * route — in two columns, and derivation always sets them together. Only an
+ * explicit `auth` object can split them, producing a row dispatch bills to
+ * the platform while every provider-keyed check reads it as BYOK (or the
+ * reverse). Applied only when the caller supplies `auth`, so rows written
+ * before this guard stay editable.
+ */
+function assertAuthMatchesProvider(provider: string, auth: Auth): void {
+  const managedAuth = auth.type === "platform";
+  const managedProvider = provider === VELLUM_MANAGED_PROVIDER;
+  if (managedAuth === managedProvider) {
+    return;
+  }
+  throw new BadRequestError(
+    managedAuth
+      ? `Auth type "platform" is only valid for provider "${VELLUM_MANAGED_PROVIDER}", not "${provider}". Vellum-managed routing is selected by the provider — omit "auth" to derive it.`
+      : `Provider "${VELLUM_MANAGED_PROVIDER}" is always platform-authenticated; "${auth.type}" auth is not valid for it. Omit "auth" to derive it, or name a real provider for key-based auth.`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -300,6 +324,9 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
   }
+  if (auth !== undefined) {
+    assertAuthMatchesProvider(providerResult.data, authResult.data);
+  }
 
   const labelRaw = body.label;
   if (
@@ -394,6 +421,9 @@ async function handleUpdateConnection({
   const authResult = AuthSchema.safeParse(auth);
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
+  }
+  if (body.auth !== undefined) {
+    assertAuthMatchesProvider(existing.provider, authResult.data);
   }
 
   const labelRaw = body.label;
@@ -643,7 +673,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Create a provider connection",
     description:
-      "Create a new named provider connection. When auth is omitted it is derived from the provider (keyless providers get none, vellum gets platform, everything else needs credential for api_key auth). Fails with 409 if a connection with this name already exists.",
+      "Create a new named provider connection. When auth is omitted it is derived from the provider (keyless providers get none, vellum gets platform, everything else needs credential for api_key auth). An explicit auth object must agree with the provider: platform auth belongs to vellum and only to vellum. Fails with 409 if a connection with this name already exists.",
     tags: ["inference"],
     requestBody: z.object({
       name: z.string().min(1),
@@ -672,7 +702,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Update a provider connection",
     description:
-      "Update an existing connection. Cannot rename or change the provider. Omitting auth keeps the stored auth; passing credential alone rotates the key via provider-derived api_key auth. For the Vellum-managed connection (vellum) the auth is locked to platform; label remains editable.",
+      "Update an existing connection. Cannot rename or change the provider. Omitting auth keeps the stored auth; passing credential alone rotates the key via provider-derived api_key auth. An explicit auth object must agree with the connection's provider: platform auth belongs to vellum and only to vellum. For the Vellum-managed connection (vellum) the auth is locked to platform; label remains editable.",
     tags: ["inference"],
     pathParams: [{ name: "name", description: "Connection name" }],
     requestBody: z.object({

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -196,12 +196,11 @@ function deriveConnectionAuth(provider: string, credential: unknown): Auth {
 }
 
 /**
- * Platform auth and `provider: "vellum"` record the same fact — the managed
- * route — in two columns, and derivation always sets them together. Only an
+ * Platform auth and `provider: "vellum"` record the same fact (the managed
+ * route) in two columns, and derivation always sets them together. Only an
  * explicit `auth` object can split them, producing a row dispatch bills to
- * the platform while every provider-keyed check reads it as BYOK (or the
- * reverse). Applied only when the caller supplies `auth`, so rows written
- * before this guard stay editable.
+ * the platform while every provider-keyed check reads it as BYOK, or the
+ * reverse.
  */
 function assertAuthMatchesProvider(provider: string, auth: Auth): void {
   const managedAuth = auth.type === "platform";
@@ -211,8 +210,21 @@ function assertAuthMatchesProvider(provider: string, auth: Auth): void {
   }
   throw new BadRequestError(
     managedAuth
-      ? `Auth type "platform" is only valid for provider "${VELLUM_MANAGED_PROVIDER}", not "${provider}". Vellum-managed routing is selected by the provider — omit "auth" to derive it.`
+      ? `Auth type "platform" is only valid for provider "${VELLUM_MANAGED_PROVIDER}", not "${provider}". Vellum-managed routing is selected by the provider, so omit "auth" to derive it.`
       : `Provider "${VELLUM_MANAGED_PROVIDER}" is always platform-authenticated; "${auth.type}" auth is not valid for it. Omit "auth" to derive it, or name a real provider for key-based auth.`,
+  );
+}
+
+/**
+ * Stable form of an auth object for equality checks. Auth values are flat, so
+ * sorting the entries is enough to make two encodings of the same auth
+ * compare equal regardless of key order.
+ */
+function authFingerprint(auth: Auth): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(auth).sort(([a], [b]) => a.localeCompare(b)),
+    ),
   );
 }
 
@@ -422,7 +434,14 @@ async function handleUpdateConnection({
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
   }
-  if (body.auth !== undefined) {
+  // Both clients resend the stored auth on every edit (the web editor and the
+  // CLI both build their PATCH body that way), so enforcing on presence alone
+  // would make a row whose columns already disagree impossible to relabel or
+  // re-point. Enforce on an actual auth change instead.
+  if (
+    body.auth !== undefined &&
+    authFingerprint(authResult.data) !== authFingerprint(existing.auth)
+  ) {
     assertAuthMatchesProvider(existing.provider, authResult.data);
   }
 
@@ -673,7 +692,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Create a provider connection",
     description:
-      "Create a new named provider connection. When auth is omitted it is derived from the provider (keyless providers get none, vellum gets platform, everything else needs credential for api_key auth). An explicit auth object must agree with the provider: platform auth belongs to vellum and only to vellum. Fails with 409 if a connection with this name already exists.",
+      "Create a new named provider connection. When auth is omitted it is derived from the provider (keyless providers get none, vellum gets platform, everything else needs credential for api_key auth). An explicit auth object must agree with the provider; platform auth belongs to vellum and only to vellum. Fails with 409 if a connection with this name already exists.",
     tags: ["inference"],
     requestBody: z.object({
       name: z.string().min(1),
@@ -702,7 +721,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Update a provider connection",
     description:
-      "Update an existing connection. Cannot rename or change the provider. Omitting auth keeps the stored auth; passing credential alone rotates the key via provider-derived api_key auth. An explicit auth object must agree with the connection's provider: platform auth belongs to vellum and only to vellum. For the Vellum-managed connection (vellum) the auth is locked to platform; label remains editable.",
+      "Update an existing connection. Cannot rename or change the provider. Omitting auth keeps the stored auth; passing credential alone rotates the key via provider-derived api_key auth. An explicit auth object must agree with the connection's provider; platform auth belongs to vellum and only to vellum. For the Vellum-managed connection (vellum) the auth is locked to platform; label remains editable.",
     tags: ["inference"],
     pathParams: [{ name: "name", description: "Connection name" }],
     requestBody: z.object({

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -434,10 +434,10 @@ async function handleUpdateConnection({
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
   }
-  // Both clients resend the stored auth on every edit (the web editor and the
-  // CLI both build their PATCH body that way), so enforcing on presence alone
-  // would make a row whose columns already disagree impossible to relabel or
-  // re-point. Enforce on an actual auth change instead.
+  // The pairing is enforced on an actual auth change, not on the field being
+  // present: the web editor and the CLI both resend the stored auth on every
+  // edit, so a row whose columns already disagree stays relabelable and
+  // re-pointable.
   if (
     body.auth !== undefined &&
     authFingerprint(authResult.data) !== authFingerprint(existing.auth)


### PR DESCRIPTION
## Summary

Auth derivation always pairs platform auth with `provider: "vellum"`, but an explicit `auth` object on create/PATCH was handed straight to `AuthSchema.safeParse` with no cross-check against the provider. That let a row be written platform-billed at dispatch (`adapter-factory.ts` keys the managed-proxy transport off `auth.type`) while every provider-keyed check, including `isVellumManagedConnection` and the route attribution added in #39829, read it as BYOK. The reverse split was possible too.

Both directions are now rejected, so *platform auth is equivalent to provider vellum* becomes an enforced invariant rather than a convention.

## Scope

- **Create:** enforced whenever an explicit `auth` is supplied. Derived auth is correct by construction.
- **PATCH:** enforced only when the supplied auth actually differs from the stored auth. Both clients resend the stored auth on every edit (`provider-editor-content.tsx` and `attachUpdateSubcommand` in `inference-providers.ts`), so keying on presence alone would make a row whose columns already disagree impossible to relabel or re-point. Keying on a real change still blocks writing a new mismatch, and lets a legacy row be repaired.
- Normalizing existing mismatched rows belongs to the connection-removal migration, not here.
- The route is the write boundary for every user-facing path, since the CLI calls `inference_provider_connections_create` rather than the DB helper, so the guard is not duplicated into `connections.ts`. Boot seeding writes derived auth. The later change that collapses the two columns should move the check down or normalize on read.

## Why now

This is the remaining half of PR 8 in `.private/plans/connection-removal-vellum-provider.md`, and it is the precondition for deleting `auth.type` later: that deletion collapses five sites onto `connection.provider === "vellum"`, which is only safe once the two columns cannot disagree.

Two existing tests asserted on the split shape (`{provider: "openai", auth: {type: "platform"}}`), a shape the product never produces. Those fixtures now use the real pairing, plus new coverage for both rejection directions, for a legacy row staying editable through the real client shape, and for repairing a legacy row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma7ZMzsQkJCG4t4uSGLoLT