### PR TITLE
refactor(slack): extract shared Web API transport with a single SlackApiError (LUM-3024)

### DIFF
--- a/assistant/src/__tests__/slack-channels-routes.test.ts
+++ b/assistant/src/__tests__/slack-channels-routes.test.ts
@@ -40,8 +40,6 @@ mock.module("../messaging/providers/slack/client.js", () => ({
     }
     throw new Error(`User not found: ${userId}`);
   },
-  // auth.ts imports SlackApiError from the client; export it from the mock.
-  SlackApiError: class SlackApiError extends Error {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -51,9 +51,6 @@ mock.module("../messaging/providers/slack/client.js", () => ({
     _text: string,
     _opts?: unknown,
   ) => postMessageResult,
-  // auth.ts imports SlackApiError from the client; export it so the import
-  // graph loads (this file never triggers the fallback that inspects it).
-  SlackApiError: class SlackApiError extends Error {},
 }));
 
 let appStoreResult: unknown = null;

--- a/assistant/src/__tests__/slack-users-routes.test.ts
+++ b/assistant/src/__tests__/slack-users-routes.test.ts
@@ -35,8 +35,6 @@ mock.module("../messaging/providers/slack/client.js", () => ({
     listUsersCalls.push({ cursor });
     return listUsersPages[listUsersCalls.length - 1];
   },
-  // auth.ts imports SlackApiError from the client; export it from the mock.
-  SlackApiError: class SlackApiError extends Error {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -32,7 +32,6 @@ import type {
 } from "../../provider-types.js";
 import { resolveSlackAuth } from "./auth.js";
 import * as slack from "./client.js";
-import { SlackApiError } from "./client.js";
 import {
   classifyConversationType,
   isPrivateConversation,
@@ -44,6 +43,7 @@ import type {
   SlackSearchMatch,
   SlackUser,
 } from "./types.js";
+import { SlackApiError } from "./web-api-transport.js";
 
 interface NormalizedSlackUserInfo {
   displayName: string;

--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -2,8 +2,19 @@ import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
 const BOT_TOKEN = "xoxb-test";
 
+// `api.ts` resolves identity through `resolveSlackAuth`, whose import graph
+// (oauth/manual-token-connection.ts and siblings) reads several secure-keys
+// exports beyond the two this test overrides. Spread the real module so the
+// mock keeps every export those imports expect; the key accessors are the
+// only behavior under the test's control.
+const realSecureKeys = await import("../../../security/secure-keys.js");
 mock.module("../../../security/secure-keys.js", () => ({
+  ...realSecureKeys,
   getSecureKeyAsync: async () => BOT_TOKEN,
+  getSecureKeyResultAsync: async () => ({
+    value: BOT_TOKEN,
+    unreachable: false,
+  }),
 }));
 
 const { appendSlackStream, getSlackConversationInfo, startSlackStream } =

--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -1,6 +1,17 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
 const BOT_TOKEN = "xoxb-test";
+const USER_TOKEN = "xoxp-test";
+
+/** Set false to simulate an install whose Slack setup stored no user token. */
+let userTokenStored = true;
+
+function secureKeyFor(account: string): string | undefined {
+  if (account.endsWith("/user_token")) {
+    return userTokenStored ? USER_TOKEN : undefined;
+  }
+  return BOT_TOKEN;
+}
 
 // `api.ts` resolves identity through `resolveSlackAuth`, whose import graph
 // (oauth/manual-token-connection.ts and siblings) reads several secure-keys
@@ -10,9 +21,9 @@ const BOT_TOKEN = "xoxb-test";
 const realSecureKeys = await import("../../../security/secure-keys.js");
 mock.module("../../../security/secure-keys.js", () => ({
   ...realSecureKeys,
-  getSecureKeyAsync: async () => BOT_TOKEN,
-  getSecureKeyResultAsync: async () => ({
-    value: BOT_TOKEN,
+  getSecureKeyAsync: async (account: string) => secureKeyFor(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyFor(account),
     unreachable: false,
   }),
 }));
@@ -62,6 +73,68 @@ describe("getSlackConversationInfo", () => {
     expect(capturedInit?.headers).toEqual({
       Authorization: `Bearer ${BOT_TOKEN}`,
     });
+  });
+
+  test("retries as the user when the bot cannot see the channel", async () => {
+    userTokenStored = true;
+    const authHeaders: string[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
+      const auth = (init?.headers as Record<string, string>).Authorization;
+      authHeaders.push(auth);
+      if (auth === `Bearer ${BOT_TOKEN}`) {
+        return new Response(
+          JSON.stringify({ ok: false, error: "channel_not_found" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ ok: true, channel: { id: "C9", name: "private" } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const info = await getSlackConversationInfo("C9");
+
+    expect(info).toEqual({ id: "C9", name: "private" });
+    expect(authHeaders).toEqual([
+      `Bearer ${BOT_TOKEN}`,
+      `Bearer ${USER_TOKEN}`,
+    ]);
+  });
+
+  test("does not retry as the user for non-visibility errors", async () => {
+    userTokenStored = true;
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({ ok: false, error: "invalid_auth" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(getSlackConversationInfo("C9")).rejects.toThrow(
+      "Slack API error: invalid_auth",
+    );
+    expect(calls).toBe(1);
+  });
+
+  test("does not retry when no distinct user token is stored", async () => {
+    userTokenStored = false;
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({ ok: false, error: "channel_not_found" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(getSlackConversationInfo("C9")).rejects.toThrow(
+      "Slack API error: channel_not_found",
+    );
+    expect(calls).toBe(1);
+    userTokenStored = true;
   });
 });
 

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -8,10 +8,11 @@
  * rules in `auth.ts`:
  *   - "bot" for everything the assistant does as itself: streaming replies,
  *     uploads, reading its own message blocks for edit-in-place.
- *   - "user" for reads that benefit from the owner's wider visibility, e.g.
- *     `conversations.info` channel-name resolution for channels the owner is
- *     in but the bot is not. Falls back to the bot token when no user token
- *     is stored.
+ *   - "user" only as a bounded FALLBACK: `conversations.info` channel-name
+ *     resolution acts as the bot first and retries with the stored user token
+ *     only when the bot cannot see the channel. See
+ *     {@link getSlackConversationInfo} for why that stays within the
+ *     neutral-bot rule for route-reachable calls.
  */
 
 import type { KnownBlock } from "@slack/types";
@@ -19,7 +20,11 @@ import type { SlackStreamTask } from "@vellumai/gateway-client";
 
 import { resolveSlackAuth, type SlackAuthIdentity } from "./auth.js";
 import type { SlackApiResponse } from "./types.js";
-import { slackRequest, type SlackRequestOptions } from "./web-api-transport.js";
+import {
+  SlackApiError,
+  slackRequest,
+  type SlackRequestOptions,
+} from "./web-api-transport.js";
 
 /** Envelope fields the outbound surfaces read off successful responses. */
 interface SlackOutboundApiResponse extends SlackApiResponse {
@@ -240,22 +245,9 @@ function normalizeSlackString(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
-/**
- * Resolve a channel's identity and display names via `conversations.info`.
- *
- * Acts as the "user" identity: channel-name resolution should see every
- * channel the assistant's owner can see, not only the channels the bot has
- * been invited to. Falls back to the bot token when no user token is stored.
- */
-export async function getSlackConversationInfo(
-  channelId: string,
-): Promise<SlackConversationInfo | null> {
-  const data = await slackApiRequest<SlackConversationsInfoResponse>(
-    "user",
-    "conversations.info",
-    { query: { channel: channelId } },
-  );
-
+function parseSlackConversationInfo(
+  data: SlackConversationsInfoResponse,
+): SlackConversationInfo | null {
   const id = normalizeSlackString(data.channel?.id);
   if (!id) {
     return null;
@@ -269,6 +261,61 @@ export async function getSlackConversationInfo(
     ...(name ? { name } : {}),
     ...(nameNormalized ? { nameNormalized } : {}),
   };
+}
+
+/**
+ * Resolve a channel's identity and display names via `conversations.info`.
+ *
+ * Acts as the bot first, honoring the neutral-bot rule for route-reachable
+ * calls (`auth.ts`): this function backs the `slack_channel_name_resolve`
+ * route. When the bot cannot see the channel (`channel_not_found` /
+ * permission errors) and a DISTINCT user token is stored, it retries once as
+ * the owner, so channels the owner is in but the bot is not still resolve.
+ * The wider identity is used only for the exact case the bot cannot answer,
+ * and the response is scoped to a channel the calling conversation is
+ * already bound to. Legacy OAuth installs have no separate user identity, so
+ * the fallback never fires there.
+ */
+export async function getSlackConversationInfo(
+  channelId: string,
+): Promise<SlackConversationInfo | null> {
+  const query = { channel: channelId };
+  const botAuth = await resolveSlackAuth("bot");
+  if (!botAuth) {
+    throw new Error("Slack bot token not configured");
+  }
+
+  try {
+    return parseSlackConversationInfo(
+      await slackRequest<SlackConversationsInfoResponse>(
+        botAuth,
+        "conversations.info",
+        { query },
+      ),
+    );
+  } catch (err) {
+    if (
+      !(err instanceof SlackApiError) ||
+      (err.category !== "channel_not_found" && err.category !== "permission")
+    ) {
+      throw err;
+    }
+    const userAuth = await resolveSlackAuth("user");
+    if (
+      typeof botAuth !== "string" ||
+      typeof userAuth !== "string" ||
+      userAuth === botAuth
+    ) {
+      throw err;
+    }
+    return parseSlackConversationInfo(
+      await slackRequest<SlackConversationsInfoResponse>(
+        userAuth,
+        "conversations.info",
+        { query },
+      ),
+    );
+  }
 }
 
 interface SlackHistoryResponse extends SlackApiResponse {

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -1,101 +1,28 @@
 /**
- * Slack Web API client for direct outbound messaging.
+ * Slack Web API feature surface for streaming replies, uploads, and channel
+ * metadata.
  *
- * Calls the Slack Web API directly using bot_token from the secure store,
- * eliminating the gateway HTTP proxy hop. Rate-limit retries, error
- * classification, and payload shapes follow Slack Web API conventions.
+ * Transport (retries, envelope checking, the unified `SlackApiError`) lives in
+ * `web-api-transport.ts`; identity selection lives in `auth.ts`
+ * (`resolveSlackAuth`). Each call here names the identity it acts as, per the
+ * rules in `auth.ts`:
+ *   - "bot" for everything the assistant does as itself: streaming replies,
+ *     uploads, reading its own message blocks for edit-in-place.
+ *   - "user" for reads that benefit from the owner's wider visibility, e.g.
+ *     `conversations.info` channel-name resolution for channels the owner is
+ *     in but the bot is not. Falls back to the bot token when no user token
+ *     is stored.
  */
 
 import type { KnownBlock } from "@slack/types";
 import type { SlackStreamTask } from "@vellumai/gateway-client";
 
-import { credentialKey } from "../../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../../security/secure-keys.js";
-import { getLogger } from "../../../util/logger.js";
+import { resolveSlackAuth, type SlackAuthIdentity } from "./auth.js";
+import type { SlackApiResponse } from "./types.js";
+import { slackRequest, type SlackRequestOptions } from "./web-api-transport.js";
 
-const log = getLogger("slack-api");
-
-const SLACK_API_BASE = "https://slack.com/api";
-const SLACK_MAX_RATE_LIMIT_RETRIES = 3;
-const SLACK_DEFAULT_RETRY_AFTER_S = 1;
-
-// ---------------------------------------------------------------------------
-// Error types
-// ---------------------------------------------------------------------------
-
-export type SlackErrorCategory =
-  | "auth"
-  | "rate_limit"
-  | "not_found"
-  | "permission"
-  | "channel_not_found"
-  | "client_error"
-  | "transient"
-  | "unknown";
-
-const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
-  invalid_auth: "auth",
-  token_expired: "auth",
-  token_revoked: "auth",
-  not_authed: "auth",
-  account_inactive: "auth",
-  org_login_required: "auth",
-  rate_limited: "rate_limit",
-  ratelimited: "rate_limit",
-  channel_not_found: "channel_not_found",
-  is_archived: "channel_not_found",
-  not_in_channel: "permission",
-  missing_scope: "permission",
-  ekm_access_denied: "permission",
-  not_allowed_token_type: "permission",
-  restricted_action: "permission",
-  cannot_dm_bot: "permission",
-  user_not_found: "not_found",
-  message_not_found: "not_found",
-  thread_not_found: "not_found",
-  invalid_blocks: "client_error",
-};
-
-function classifySlackError(errorCode: string | undefined): SlackErrorCategory {
-  if (!errorCode) {
-    return "unknown";
-  }
-  return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
-}
-
-export class SlackApiError extends Error {
-  readonly slackError: string | undefined;
-  readonly category: SlackErrorCategory;
-
-  constructor(slackError: string | undefined) {
-    super(`Slack API error: ${slackError ?? "unknown"}`);
-    this.name = "SlackApiError";
-    this.slackError = slackError;
-    this.category = classifySlackError(slackError);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Credential resolution
-// ---------------------------------------------------------------------------
-
-async function resolveBotToken(): Promise<string> {
-  const botToken = await getSecureKeyAsync(
-    credentialKey("slack_channel", "bot_token"),
-  );
-  if (!botToken) {
-    throw new Error("Slack bot token not configured");
-  }
-  return botToken;
-}
-
-// ---------------------------------------------------------------------------
-// Core API caller with rate-limit retries
-// ---------------------------------------------------------------------------
-
-interface SlackApiResponse {
-  ok: boolean;
-  error?: string;
+/** Envelope fields the outbound surfaces read off successful responses. */
+interface SlackOutboundApiResponse extends SlackApiResponse {
   ts?: string;
   upload_url?: string;
   file_id?: string;
@@ -116,160 +43,45 @@ export interface SlackConversationInfo {
 }
 
 /**
- * Call a Slack Web API method with rate-limit retries.
+ * Resolve the named identity and dispatch through the shared transport.
+ * Throws when no Slack credentials are configured at all; `resolveSlackAuth`
+ * itself falls back user -> bot -> legacy OAuth connection before that.
+ */
+async function slackApiRequest<T extends SlackApiResponse>(
+  identity: SlackAuthIdentity,
+  method: string,
+  opts: SlackRequestOptions,
+): Promise<T> {
+  const auth = await resolveSlackAuth(identity);
+  if (!auth) {
+    throw new Error("Slack bot token not configured");
+  }
+  return slackRequest<T>(auth, method, opts);
+}
+
+/**
+ * Call a Slack Web API write method as the bot, with rate-limit retries.
  *
- * Throws SlackApiError for non-retryable Slack-level errors.
- * Throws Error for transport-level failures after exhausting retries.
+ * Throws SlackApiError for non-retryable Slack-level errors and for
+ * transport-level failures after exhausting retries.
  */
 export async function callSlackApi(
   method: string,
   body: Record<string, unknown>,
-): Promise<SlackApiResponse> {
-  const botToken = await resolveBotToken();
-
-  let lastError: string | undefined;
-
-  for (let attempt = 0; attempt <= SLACK_MAX_RATE_LIMIT_RETRIES; attempt++) {
-    const response = await fetch(`${SLACK_API_BASE}/${method}`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${botToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (response.status === 429) {
-      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
-        throw new Error("Slack rate limit exceeded after retries");
-      }
-      const retryAfter =
-        parseInt(response.headers.get("Retry-After") ?? "", 10) ||
-        SLACK_DEFAULT_RETRY_AFTER_S;
-      log.warn({ method, retryAfter, attempt }, "Slack rate limited, retrying");
-      await new Promise((r) => setTimeout(r, retryAfter * 1000));
-      continue;
-    }
-
-    if (response.status >= 500) {
-      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
-        throw new Error(
-          `Slack ${method} failed with status ${response.status} after retries`,
-        );
-      }
-      log.warn(
-        { method, status: response.status, attempt },
-        "Slack 5xx error, retrying",
-      );
-      await new Promise((r) =>
-        setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
-      );
-      continue;
-    }
-
-    const data = (await response.json()) as SlackApiResponse;
-
-    if (!data.ok) {
-      lastError = data.error;
-      const category = classifySlackError(data.error);
-
-      if (category === "rate_limit" && attempt < SLACK_MAX_RATE_LIMIT_RETRIES) {
-        log.warn(
-          { method, slackError: data.error, attempt },
-          "Slack rate limited (body), retrying",
-        );
-        await new Promise((r) =>
-          setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
-        );
-        continue;
-      }
-
-      throw new SlackApiError(data.error);
-    }
-
-    return data;
-  }
-
-  throw new Error(
-    `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
-  );
+): Promise<SlackOutboundApiResponse> {
+  return slackApiRequest<SlackOutboundApiResponse>("bot", method, { body });
 }
 
 /**
- * Call a Slack Web API read method with query parameters.
+ * Call a Slack Web API method as the bot with a form-urlencoded body.
  */
-async function callSlackApiGet(
+export async function callSlackApiForm(
   method: string,
   params: URLSearchParams,
-): Promise<SlackApiResponse> {
-  const botToken = await resolveBotToken();
-  const query = params.toString();
-  const url = `${SLACK_API_BASE}/${method}${query ? `?${query}` : ""}`;
-
-  let lastError: string | undefined;
-
-  for (let attempt = 0; attempt <= SLACK_MAX_RATE_LIMIT_RETRIES; attempt++) {
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${botToken}`,
-      },
-    });
-
-    if (response.status === 429) {
-      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
-        throw new Error("Slack rate limit exceeded after retries");
-      }
-      const retryAfter =
-        parseInt(response.headers.get("Retry-After") ?? "", 10) ||
-        SLACK_DEFAULT_RETRY_AFTER_S;
-      log.warn({ method, retryAfter, attempt }, "Slack rate limited, retrying");
-      await new Promise((r) => setTimeout(r, retryAfter * 1000));
-      continue;
-    }
-
-    if (response.status >= 500) {
-      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
-        throw new Error(
-          `Slack ${method} failed with status ${response.status} after retries`,
-        );
-      }
-      log.warn(
-        { method, status: response.status, attempt },
-        "Slack 5xx error, retrying",
-      );
-      await new Promise((r) =>
-        setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
-      );
-      continue;
-    }
-
-    const data = (await response.json()) as SlackApiResponse;
-
-    if (!data.ok) {
-      lastError = data.error;
-      const category = classifySlackError(data.error);
-
-      if (category === "rate_limit" && attempt < SLACK_MAX_RATE_LIMIT_RETRIES) {
-        log.warn(
-          { method, slackError: data.error, attempt },
-          "Slack rate limited (body), retrying",
-        );
-        await new Promise((r) =>
-          setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
-        );
-        continue;
-      }
-
-      throw new SlackApiError(data.error);
-    }
-
-    return data;
-  }
-
-  throw new Error(
-    `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
-  );
+): Promise<SlackOutboundApiResponse> {
+  return slackApiRequest<SlackOutboundApiResponse>("bot", method, {
+    form: params,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -428,13 +240,21 @@ function normalizeSlackString(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
+/**
+ * Resolve a channel's identity and display names via `conversations.info`.
+ *
+ * Acts as the "user" identity: channel-name resolution should see every
+ * channel the assistant's owner can see, not only the channels the bot has
+ * been invited to. Falls back to the bot token when no user token is stored.
+ */
 export async function getSlackConversationInfo(
   channelId: string,
 ): Promise<SlackConversationInfo | null> {
-  const data = (await callSlackApiGet(
+  const data = await slackApiRequest<SlackConversationsInfoResponse>(
+    "user",
     "conversations.info",
-    new URLSearchParams({ channel: channelId }),
-  )) as SlackConversationsInfoResponse;
+    { query: { channel: channelId } },
+  );
 
   const id = normalizeSlackString(data.channel?.id);
   if (!id) {
@@ -458,53 +278,32 @@ interface SlackHistoryResponse extends SlackApiResponse {
 /**
  * Fetch the Block Kit blocks of a single channel message by timestamp.
  *
- * Used to edit a message in place while preserving its existing content — e.g.
+ * Used to edit a message in place while preserving its existing content, e.g.
  * withdrawing an approval card's buttons without discarding the card body.
- * Returns null when the message can't be read (missing `*:history` scope, a
- * threaded reply not present in channel history, or a deleted message) so
- * callers can degrade gracefully instead of failing the edit.
+ * Acts as the bot: the messages being edited are the bot's own. Returns null
+ * when the message can't be read (missing `*:history` scope, a threaded reply
+ * not present in channel history, or a deleted message) so callers can degrade
+ * gracefully instead of failing the edit.
  */
 export async function getSlackMessageBlocks(
   channelId: string,
   ts: string,
 ): Promise<unknown[] | null> {
-  const data = (await callSlackApiGet(
+  const data = await slackApiRequest<SlackHistoryResponse>(
+    "bot",
     "conversations.history",
-    new URLSearchParams({
-      channel: channelId,
-      latest: ts,
-      oldest: ts,
-      inclusive: "true",
-      limit: "1",
-    }),
-  )) as SlackHistoryResponse;
+    {
+      query: {
+        channel: channelId,
+        latest: ts,
+        oldest: ts,
+        inclusive: "true",
+        limit: "1",
+      },
+    },
+  );
   const message = data.messages?.find((m) => m.ts === ts) ?? data.messages?.[0];
   return Array.isArray(message?.blocks) ? message.blocks : null;
-}
-
-/**
- * Call a Slack Web API method with form-urlencoded body.
- */
-export async function callSlackApiForm(
-  method: string,
-  params: URLSearchParams,
-): Promise<SlackApiResponse> {
-  const botToken = await resolveBotToken();
-
-  const response = await fetch(`${SLACK_API_BASE}/${method}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${botToken}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: params,
-  });
-
-  const data = (await response.json()) as SlackApiResponse;
-  if (!data.ok) {
-    throw new SlackApiError(data.error);
-  }
-  return data;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -1,9 +1,9 @@
 /**
- * Low-level Slack Web API wrapper.
+ * Typed Slack Web API method wrappers.
  *
  * All methods accept either an OAuthConnection or a raw token string.
- * Throws SlackApiError on failures, with status: 401 on auth errors
- * for withValidToken compatibility.
+ * Transport (retries, envelope checking, the unified `SlackApiError`) lives
+ * in `web-api-transport.ts`.
  *
  * String overloads are retained for non-OAuth callers (e.g. slack/share.ts)
  * that pass raw bot tokens via resolveSlackToken(). These bypass the
@@ -26,250 +26,7 @@ import type {
   SlackUserInfoResponse,
   SlackUsersListResponse,
 } from "./types.js";
-
-const SLACK_API_BASE = "https://slack.com/api";
-const MAX_RATE_LIMIT_RETRIES = 3;
-const DEFAULT_RETRY_AFTER_S = 1;
-
-export class SlackApiError extends Error {
-  constructor(
-    public readonly status: number,
-    public readonly slackError: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "SlackApiError";
-  }
-}
-
-/**
- * Sleep helper that respects Slack's Retry-After header value.
- */
-function sleepMs(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Check a Slack API response envelope for errors and map to SlackApiError.
- * Returns the data if ok, throws otherwise.
- */
-function checkSlackEnvelope<T extends SlackApiResponse>(data: T): T {
-  if (!data.ok) {
-    const slackError = data.error ?? "unknown_error";
-    const status = [
-      "invalid_auth",
-      "token_expired",
-      "token_revoked",
-      "not_authed",
-    ].includes(slackError)
-      ? 401
-      : 400;
-    throw new SlackApiError(
-      status,
-      slackError,
-      `Slack API error: ${slackError}`,
-    );
-  }
-  return data;
-}
-
-/**
- * Build a Slack API request using a raw token (for retry via `connection.withToken`).
- */
-async function rawSlackRequest<T extends SlackApiResponse>(
-  token: string,
-  method: string,
-  query: Record<string, string> | undefined,
-  body: Record<string, unknown> | undefined,
-): Promise<T> {
-  let url = `${SLACK_API_BASE}/${method}`;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-  };
-
-  let init: RequestInit;
-  if (body) {
-    headers["Content-Type"] = "application/json; charset=utf-8";
-    init = { method: "POST", headers, body: JSON.stringify(body) };
-  } else {
-    if (query && Object.keys(query).length > 0) {
-      url += `?${new URLSearchParams(query)}`;
-    }
-    init = { method: "GET", headers };
-  }
-
-  const resp = await fetch(url, init);
-  if (resp.status === 429) {
-    throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
-  }
-  if (!resp.ok) {
-    throw new SlackApiError(
-      resp.status,
-      `http_${resp.status}`,
-      `Slack API HTTP ${resp.status}`,
-    );
-  }
-  return checkSlackEnvelope((await resp.json()) as T);
-}
-
-/**
- * Execute a Slack API request via OAuthConnection with rate-limit retry.
- *
- * Slack returns HTTP 200 with `{ ok: false, error: "invalid_auth" }` for
- * auth errors. Because `connection.request()` delegates to `withValidToken`
- * which only retries on HTTP-level 401s, we catch Slack envelope auth
- * errors (mapped to SlackApiError with status 401) and perform a single
- * retry via `connection.withToken()` which forces a token refresh before
- * giving us the new token.
- */
-async function requestViaConnection<T extends SlackApiResponse>(
-  connection: OAuthConnection,
-  method: string,
-  params?: Record<string, string | undefined>,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  const query: Record<string, string> | undefined = params
-    ? Object.fromEntries(
-        Object.entries(params).filter(
-          (entry): entry is [string, string] => entry[1] !== undefined,
-        ),
-      )
-    : undefined;
-
-  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
-    const resp = await connection.request({
-      method: body ? "POST" : "GET",
-      path: `/${method}`,
-      query: query && Object.keys(query).length > 0 ? query : undefined,
-      body,
-    });
-
-    // Handle 429 rate limits with Retry-After backoff
-    if (resp.status === 429) {
-      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
-        throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
-      }
-      const retryAfter =
-        parseInt(
-          resp.headers["retry-after"] ?? resp.headers["Retry-After"] ?? "",
-          10,
-        ) || DEFAULT_RETRY_AFTER_S;
-      await sleepMs(retryAfter * 1000);
-      continue;
-    }
-
-    if (resp.status >= 400) {
-      throw new SlackApiError(
-        resp.status,
-        `http_${resp.status}`,
-        `Slack API HTTP ${resp.status}`,
-      );
-    }
-
-    const data = resp.body as T;
-
-    // Handle rate_limited error in response body (some Slack APIs return 200 with error)
-    if (
-      !data.ok &&
-      data.error === "rate_limited" &&
-      attempt < MAX_RATE_LIMIT_RETRIES
-    ) {
-      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
-      continue;
-    }
-
-    try {
-      return checkSlackEnvelope(data);
-    } catch (err) {
-      // Slack envelope auth errors (invalid_auth, token_expired, etc.) come
-      // back as HTTP 200, so they escape withValidToken's retry scope inside
-      // connection.request(). Catch them here and retry once with a freshly-
-      // refreshed token via connection.withToken().
-      if (err instanceof SlackApiError && err.status === 401) {
-        return connection.withToken((freshToken) =>
-          rawSlackRequest<T>(freshToken, method, query, body),
-        );
-      }
-      throw err;
-    }
-  }
-
-  // Unreachable, but TypeScript needs this
-  throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
-}
-
-/**
- * Execute a Slack API request via raw token with rate-limit retry.
- */
-async function requestViaToken<T extends SlackApiResponse>(
-  token: string,
-  method: string,
-  params?: Record<string, string | undefined>,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  let url = `${SLACK_API_BASE}/${method}`;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-  };
-
-  let init: RequestInit;
-  if (body) {
-    headers["Content-Type"] = "application/json; charset=utf-8";
-    init = { method: "POST", headers, body: JSON.stringify(body) };
-  } else {
-    if (params) {
-      const searchParams = new URLSearchParams();
-      for (const [k, v] of Object.entries(params)) {
-        if (v !== undefined) {
-          searchParams.set(k, v);
-        }
-      }
-      url += `?${searchParams}`;
-    }
-    init = { method: "GET", headers };
-  }
-
-  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
-    const resp = await fetch(url, init);
-
-    // Handle 429 rate limits with Retry-After backoff
-    if (resp.status === 429) {
-      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
-        throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
-      }
-      const retryAfter =
-        parseInt(resp.headers.get("Retry-After") ?? "", 10) ||
-        DEFAULT_RETRY_AFTER_S;
-      await sleepMs(retryAfter * 1000);
-      continue;
-    }
-
-    if (!resp.ok) {
-      throw new SlackApiError(
-        resp.status,
-        `http_${resp.status}`,
-        `Slack API HTTP ${resp.status}`,
-      );
-    }
-
-    const data = (await resp.json()) as T;
-
-    // Handle rate_limited error in response body (some Slack APIs return 200 with error)
-    if (
-      !data.ok &&
-      data.error === "rate_limited" &&
-      attempt < MAX_RATE_LIMIT_RETRIES
-    ) {
-      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
-      continue;
-    }
-
-    return checkSlackEnvelope(data);
-  }
-
-  // Unreachable, but TypeScript needs this
-  throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
-}
+import { slackRequest } from "./web-api-transport.js";
 
 async function request<T extends SlackApiResponse>(
   connectionOrToken: OAuthConnection | string,
@@ -277,10 +34,10 @@ async function request<T extends SlackApiResponse>(
   params?: Record<string, string | undefined>,
   body?: Record<string, unknown>,
 ): Promise<T> {
-  if (typeof connectionOrToken === "string") {
-    return requestViaToken<T>(connectionOrToken, method, params, body);
-  }
-  return requestViaConnection<T>(connectionOrToken, method, params, body);
+  return slackRequest<T>(connectionOrToken, method, {
+    ...(params ? { query: params } : {}),
+    ...(body ? { body } : {}),
+  });
 }
 
 export async function authTest(

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -15,14 +15,6 @@ mock.module("./api.js", () => ({
     callSlackApiMock(method, body),
   callSlackApiForm: async () => ({}),
   completeSlackUpload: async () => {},
-  SlackApiError: class SlackApiError extends Error {
-    readonly slackError: string | undefined;
-
-    constructor(slackError: string | undefined) {
-      super(slackError ?? "unknown");
-      this.slackError = slackError;
-    }
-  },
   uploadToSlackUrl: async () => {},
   startSlackStream: (params: { markdownText?: string }) =>
     callSlackApiMock("chat.startStream", { ...params }),
@@ -32,7 +24,10 @@ mock.module("./api.js", () => ({
     callSlackApiMock("chat.stopStream", { ...params }),
 }));
 
-const { SlackApiError } = await import("./api.js");
+// The real error class: send.ts branches on `instanceof SlackApiError` from
+// the (unmocked) shared transport, so thrown test errors must be real
+// instances or every branch under test would silently take the generic path.
+const { SlackApiError } = await import("./web-api-transport.js");
 const { sendSlackAssistantThreadStatus, sendSlackReply } =
   await import("./send.js");
 

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -20,12 +20,12 @@ import {
   callSlackApi,
   callSlackApiForm,
   completeSlackUpload,
-  SlackApiError,
   startSlackStream,
   stopSlackStream,
   uploadToSlackUrl,
 } from "./api.js";
 import { renderSlackBlocks } from "./render.js";
+import { SlackApiError } from "./web-api-transport.js";
 
 const log = getLogger("slack-send");
 

--- a/assistant/src/messaging/providers/slack/web-api-transport.test.ts
+++ b/assistant/src/messaging/providers/slack/web-api-transport.test.ts
@@ -145,6 +145,24 @@ describe("rawSlackRequest", () => {
     expect(err.slackError).toBe("http_403");
   });
 
+  test("rejects form bodies dispatched over an OAuth connection", async () => {
+    const connection = {
+      request: async () => {
+        throw new Error("connection.request must not be reached for forms");
+      },
+      withToken: async () => {
+        throw new Error("withToken must not be reached for forms");
+      },
+    };
+    const { slackRequest } = await import("./web-api-transport.js");
+    const err = await captureSlackApiError(
+      slackRequest(connection as never, "files.getUploadURLExternal", {
+        form: new URLSearchParams({ filename: "a.png" }),
+      }),
+    );
+    expect(err.slackError).toBe("form_unsupported_over_oauth");
+  });
+
   test("sends form bodies as x-www-form-urlencoded POSTs", async () => {
     let capturedInit: RequestInit | undefined;
     globalThis.fetch = mock(async (_input, init) => {

--- a/assistant/src/messaging/providers/slack/web-api-transport.test.ts
+++ b/assistant/src/messaging/providers/slack/web-api-transport.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  checkSlackEnvelope,
+  classifySlackError,
+  rawSlackRequest,
+  SlackApiError,
+} from "./web-api-transport.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Await a promise expected to reject with SlackApiError and return it. */
+async function captureSlackApiError(
+  promise: Promise<unknown>,
+): Promise<SlackApiError> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof SlackApiError) {
+      return err;
+    }
+    throw err;
+  }
+  throw new Error("expected the promise to reject with SlackApiError");
+}
+
+describe("SlackApiError", () => {
+  test("derives status from category when not explicit", () => {
+    expect(new SlackApiError("invalid_auth").status).toBe(401);
+    expect(new SlackApiError("token_expired").status).toBe(401);
+    expect(new SlackApiError("rate_limited").status).toBe(429);
+    expect(new SlackApiError("ratelimited").status).toBe(429);
+    expect(new SlackApiError("channel_not_found").status).toBe(400);
+    expect(new SlackApiError("invalid_blocks").status).toBe(400);
+  });
+
+  test("explicit status wins over the derived one", () => {
+    expect(new SlackApiError("http_503", { status: 503 }).status).toBe(503);
+  });
+
+  test("normalizes a missing error code to unknown_error", () => {
+    const err = new SlackApiError(undefined);
+    expect(err.slackError).toBe("unknown_error");
+    expect(err.category).toBe("unknown");
+    expect(err.message).toBe("Slack API error: unknown_error");
+  });
+
+  test("classifies known Slack error codes", () => {
+    expect(new SlackApiError("missing_scope").category).toBe("permission");
+    expect(new SlackApiError("is_archived").category).toBe("channel_not_found");
+    expect(new SlackApiError("message_not_found").category).toBe("not_found");
+    expect(classifySlackError("some_new_code")).toBe("unknown");
+  });
+});
+
+describe("checkSlackEnvelope", () => {
+  test("passes ok envelopes through", () => {
+    const data = { ok: true as const };
+    expect(checkSlackEnvelope(data)).toBe(data);
+  });
+
+  test("throws a classified SlackApiError on ok: false", () => {
+    expect(() =>
+      checkSlackEnvelope({ ok: false, error: "invalid_auth" }),
+    ).toThrow(SlackApiError);
+    try {
+      checkSlackEnvelope({ ok: false, error: "invalid_auth" });
+    } catch (err) {
+      expect((err as SlackApiError).status).toBe(401);
+      expect((err as SlackApiError).category).toBe("auth");
+    }
+  });
+});
+
+describe("rawSlackRequest", () => {
+  test("retries HTTP 429 honoring Retry-After, then succeeds", async () => {
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response("", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        });
+      }
+      return jsonResponse({ ok: true });
+    }) as unknown as typeof fetch;
+
+    const data = await rawSlackRequest("xoxb-t", "conversations.info", {
+      query: { channel: "C1" },
+    });
+    expect(data.ok).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  test("retries 5xx and reports SlackApiError after exhausting retries", async () => {
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      return new Response("", { status: 503 });
+    }) as unknown as typeof fetch;
+
+    // The fixed 1s backoff between 5xx retries is real time, so this test
+    // runs ~3s (3 retries); the timeout below gives it headroom.
+    const promise = rawSlackRequest("xoxb-t", "chat.postMessage", {
+      body: { channel: "C1", text: "hi" },
+    });
+    const err = await captureSlackApiError(promise);
+    expect(err.status).toBe(503);
+    expect(err.slackError).toBe("http_503");
+    expect(calls).toBe(4);
+  }, 10_000);
+
+  test("throws classified SlackApiError for non-retryable envelope errors", async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ ok: false, error: "channel_not_found" }),
+    ) as unknown as typeof fetch;
+
+    const promise = rawSlackRequest("xoxb-t", "conversations.info", {
+      query: { channel: "C_MISSING" },
+    });
+    const err = await captureSlackApiError(promise);
+    expect(err.category).toBe("channel_not_found");
+  });
+
+  test("throws http_<status> SlackApiError for non-JSON 4xx responses", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("forbidden", { status: 403 }),
+    ) as unknown as typeof fetch;
+
+    const promise = rawSlackRequest("xoxb-t", "conversations.info", {});
+    const err = await captureSlackApiError(promise);
+    expect(err.status).toBe(403);
+    expect(err.slackError).toBe("http_403");
+  });
+
+  test("sends form bodies as x-www-form-urlencoded POSTs", async () => {
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock(async (_input, init) => {
+      capturedInit = init;
+      return jsonResponse({ ok: true });
+    }) as unknown as typeof fetch;
+
+    await rawSlackRequest("xoxb-t", "files.getUploadURLExternal", {
+      form: new URLSearchParams({ filename: "a.png", length: "10" }),
+    });
+    expect(capturedInit?.method).toBe("POST");
+    expect(
+      (capturedInit?.headers as Record<string, string>)["Content-Type"],
+    ).toBe("application/x-www-form-urlencoded");
+  });
+});

--- a/assistant/src/messaging/providers/slack/web-api-transport.ts
+++ b/assistant/src/messaging/providers/slack/web-api-transport.ts
@@ -1,0 +1,355 @@
+/**
+ * Shared Slack Web API transport: the single implementation of request
+ * dispatch, rate-limit/5xx retries, envelope checking, and error
+ * classification used by both Slack feature surfaces (`api.ts` for
+ * streaming/uploads/channel info, `client.ts` for the typed messaging
+ * wrappers). Not to be confused with `transport.ts`, the outbound
+ * `ChannelTransport` delivery seam.
+ *
+ * There is exactly ONE `SlackApiError` class, defined here. Callers branch on
+ * three fields, all always present:
+ *   - `slackError`: Slack's error code (`"channel_not_found"`, ...), or
+ *     `"http_<status>"` for HTTP-level failures, or `"unknown_error"`.
+ *   - `category`: coarse classification for policy decisions
+ *     (`auth` / `rate_limit` / `permission` / ...).
+ *   - `status`: HTTP-shaped status for OAuth-refresh compatibility:
+ *     explicit HTTP status when the failure was HTTP-level, otherwise derived
+ *     from the category (`auth` → 401, `rate_limit` → 429, else 400).
+ *     `oauth/connection.js` retry logic and the adapter's user→bot fallback
+ *     key on `status === 401`.
+ */
+
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import { getLogger } from "../../../util/logger.js";
+import type { SlackApiResponse } from "./types.js";
+
+const log = getLogger("slack-web-api");
+
+export const SLACK_API_BASE = "https://slack.com/api";
+const MAX_RATE_LIMIT_RETRIES = 3;
+const DEFAULT_RETRY_AFTER_S = 1;
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+export type SlackErrorCategory =
+  | "auth"
+  | "rate_limit"
+  | "not_found"
+  | "permission"
+  | "channel_not_found"
+  | "client_error"
+  | "transient"
+  | "unknown";
+
+const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
+  invalid_auth: "auth",
+  token_expired: "auth",
+  token_revoked: "auth",
+  not_authed: "auth",
+  account_inactive: "auth",
+  org_login_required: "auth",
+  rate_limited: "rate_limit",
+  ratelimited: "rate_limit",
+  channel_not_found: "channel_not_found",
+  is_archived: "channel_not_found",
+  not_in_channel: "permission",
+  missing_scope: "permission",
+  ekm_access_denied: "permission",
+  not_allowed_token_type: "permission",
+  restricted_action: "permission",
+  cannot_dm_bot: "permission",
+  user_not_found: "not_found",
+  message_not_found: "not_found",
+  thread_not_found: "not_found",
+  invalid_blocks: "client_error",
+};
+
+export function classifySlackError(
+  errorCode: string | undefined,
+): SlackErrorCategory {
+  if (!errorCode) {
+    return "unknown";
+  }
+  return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
+}
+
+function deriveStatus(category: SlackErrorCategory): number {
+  switch (category) {
+    case "auth":
+      return 401;
+    case "rate_limit":
+      return 429;
+    default:
+      return 400;
+  }
+}
+
+export class SlackApiError extends Error {
+  readonly slackError: string;
+  readonly category: SlackErrorCategory;
+  readonly status: number;
+
+  constructor(
+    slackError: string | undefined,
+    opts: { status?: number; message?: string } = {},
+  ) {
+    const code = slackError ?? "unknown_error";
+    super(opts.message ?? `Slack API error: ${code}`);
+    this.name = "SlackApiError";
+    this.slackError = code;
+    this.category = classifySlackError(slackError);
+    this.status = opts.status ?? deriveStatus(this.category);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope checking
+// ---------------------------------------------------------------------------
+
+/**
+ * Check a Slack API response envelope and throw a classified `SlackApiError`
+ * when `ok` is false. Slack reports most failures as HTTP 200 with an error
+ * code in the body, so this runs on every successful HTTP exchange.
+ */
+export function checkSlackEnvelope<T extends SlackApiResponse>(data: T): T {
+  if (!data.ok) {
+    throw new SlackApiError(data.error);
+  }
+  return data;
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryAfterSeconds(header: string | null): number {
+  return parseInt(header ?? "", 10) || DEFAULT_RETRY_AFTER_S;
+}
+
+// ---------------------------------------------------------------------------
+// Raw-token requests
+// ---------------------------------------------------------------------------
+
+export interface SlackRequestOptions {
+  /** Query parameters; presence selects GET (unless `body`/`form` is set). */
+  query?: Record<string, string | undefined>;
+  /** JSON body; presence selects POST with a JSON content type. */
+  body?: Record<string, unknown>;
+  /** Form body; presence selects POST with form encoding. */
+  form?: URLSearchParams;
+}
+
+function buildRequest(
+  token: string,
+  method: string,
+  opts: SlackRequestOptions,
+): { url: string; init: RequestInit } {
+  let url = `${SLACK_API_BASE}/${method}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  if (opts.body) {
+    headers["Content-Type"] = "application/json; charset=utf-8";
+    return {
+      url,
+      init: { method: "POST", headers, body: JSON.stringify(opts.body) },
+    };
+  }
+  if (opts.form) {
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    return { url, init: { method: "POST", headers, body: opts.form } };
+  }
+
+  const searchParams = new URLSearchParams();
+  for (const [k, v] of Object.entries(opts.query ?? {})) {
+    if (v !== undefined) {
+      searchParams.set(k, v);
+    }
+  }
+  const query = searchParams.toString();
+  if (query) {
+    url += `?${query}`;
+  }
+  return { url, init: { method: "GET", headers } };
+}
+
+/**
+ * Execute a raw-token Slack Web API request with the shared retry policy:
+ * HTTP 429 honors `Retry-After`, 5xx retries with fixed backoff, and
+ * body-level rate-limit errors (Slack sometimes returns HTTP 200 +
+ * `rate_limited`/`ratelimited`) retry via their classified category. All
+ * failures throw the unified `SlackApiError`.
+ */
+export async function rawSlackRequest<T extends SlackApiResponse>(
+  token: string,
+  method: string,
+  opts: SlackRequestOptions = {},
+): Promise<T> {
+  const { url, init } = buildRequest(token, method, opts);
+
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+    const resp = await fetch(url, init);
+
+    if (resp.status === 429) {
+      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw new SlackApiError("rate_limited", {
+          status: 429,
+          message: "Slack API rate limited",
+        });
+      }
+      const retryAfter = retryAfterSeconds(resp.headers.get("Retry-After"));
+      log.warn({ method, retryAfter, attempt }, "Slack rate limited, retrying");
+      await sleepMs(retryAfter * 1000);
+      continue;
+    }
+
+    if (resp.status >= 500) {
+      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw new SlackApiError(`http_${resp.status}`, {
+          status: resp.status,
+          message: `Slack ${method} failed with status ${resp.status} after retries`,
+        });
+      }
+      log.warn(
+        { method, status: resp.status, attempt },
+        "Slack 5xx error, retrying",
+      );
+      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
+      continue;
+    }
+
+    if (!resp.ok) {
+      throw new SlackApiError(`http_${resp.status}`, {
+        status: resp.status,
+        message: `Slack API HTTP ${resp.status}`,
+      });
+    }
+
+    const data = (await resp.json()) as T;
+
+    if (
+      !data.ok &&
+      classifySlackError(data.error) === "rate_limit" &&
+      attempt < MAX_RATE_LIMIT_RETRIES
+    ) {
+      log.warn(
+        { method, slackError: data.error, attempt },
+        "Slack rate limited (body), retrying",
+      );
+      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
+      continue;
+    }
+
+    return checkSlackEnvelope(data);
+  }
+
+  // Unreachable: every loop exit path above either returns or throws.
+  throw new SlackApiError("rate_limited", {
+    status: 429,
+    message: "Slack API rate limited",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// OAuth-connection requests
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a Slack API request via a refreshing `OAuthConnection`.
+ *
+ * Slack returns HTTP 200 with `{ ok: false, error: "invalid_auth" }` for auth
+ * errors. Because `connection.request()` delegates to `withValidToken`, which
+ * only retries HTTP-level 401s, envelope auth errors (classified to
+ * `status === 401`) are caught here and retried once via
+ * `connection.withToken()`, which forces a token refresh first.
+ */
+async function connectionSlackRequest<T extends SlackApiResponse>(
+  connection: OAuthConnection,
+  method: string,
+  opts: SlackRequestOptions,
+): Promise<T> {
+  const query: Record<string, string> | undefined = opts.query
+    ? Object.fromEntries(
+        Object.entries(opts.query).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      )
+    : undefined;
+
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+    const resp = await connection.request({
+      method: opts.body ? "POST" : "GET",
+      path: `/${method}`,
+      query: query && Object.keys(query).length > 0 ? query : undefined,
+      body: opts.body,
+    });
+
+    if (resp.status === 429) {
+      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw new SlackApiError("rate_limited", {
+          status: 429,
+          message: "Slack API rate limited",
+        });
+      }
+      const retryAfter = retryAfterSeconds(
+        resp.headers["retry-after"] ?? resp.headers["Retry-After"] ?? null,
+      );
+      await sleepMs(retryAfter * 1000);
+      continue;
+    }
+
+    if (resp.status >= 400) {
+      throw new SlackApiError(`http_${resp.status}`, {
+        status: resp.status,
+        message: `Slack API HTTP ${resp.status}`,
+      });
+    }
+
+    const data = resp.body as T;
+
+    if (
+      !data.ok &&
+      classifySlackError(data.error) === "rate_limit" &&
+      attempt < MAX_RATE_LIMIT_RETRIES
+    ) {
+      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
+      continue;
+    }
+
+    try {
+      return checkSlackEnvelope(data);
+    } catch (err) {
+      if (err instanceof SlackApiError && err.status === 401) {
+        return connection.withToken((freshToken) =>
+          rawSlackRequest<T>(freshToken, method, opts),
+        );
+      }
+      throw err;
+    }
+  }
+
+  // Unreachable: every loop exit path above either returns or throws.
+  throw new SlackApiError("rate_limited", {
+    status: 429,
+    message: "Slack API rate limited",
+  });
+}
+
+/**
+ * Dispatch a Slack Web API request on whichever auth form the caller holds:
+ * a raw token (Socket Mode installs) or a refreshing `OAuthConnection`
+ * (legacy OAuth installs).
+ */
+export async function slackRequest<T extends SlackApiResponse>(
+  auth: OAuthConnection | string,
+  method: string,
+  opts: SlackRequestOptions = {},
+): Promise<T> {
+  if (typeof auth === "string") {
+    return rawSlackRequest<T>(auth, method, opts);
+  }
+  return connectionSlackRequest<T>(auth, method, opts);
+}

--- a/assistant/src/messaging/providers/slack/web-api-transport.ts
+++ b/assistant/src/messaging/providers/slack/web-api-transport.ts
@@ -271,6 +271,18 @@ async function connectionSlackRequest<T extends SlackApiResponse>(
   method: string,
   opts: SlackRequestOptions,
 ): Promise<T> {
+  // `connection.request()` carries only query/body; silently dropping a form
+  // payload would send Slack a parameterless request that fails with a
+  // misleading Slack-side error. Fail fast instead: form-encoded methods are
+  // only reachable on Socket Mode installs, whose auth is a raw token.
+  if (opts.form) {
+    throw new SlackApiError("form_unsupported_over_oauth", {
+      message:
+        `Slack ${method} uses a form-encoded body, which is not supported ` +
+        "over a legacy OAuth connection; a Socket Mode bot token is required",
+    });
+  }
+
   const query: Record<string, string> | undefined = opts.query
     ? Object.fromEntries(
         Object.entries(opts.query).filter(

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -16,6 +16,13 @@ const originalFetch = globalThis.fetch;
 
 mock.module("../../../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => "xoxb-test",
+  // The route's import graph (api.ts -> auth.ts -> oauth/*) also reads the
+  // result-shaped accessor; provide it so the mock stays import-complete
+  // even if these static imports ever become dynamic.
+  getSecureKeyResultAsync: async () => ({
+    value: "xoxb-test",
+    unreachable: false,
+  }),
 }));
 
 mock.module("../../sync/sync-publisher.js", () => ({

--- a/assistant/src/runtime/routes/slack-channel-routes.ts
+++ b/assistant/src/runtime/routes/slack-channel-routes.ts
@@ -4,10 +4,8 @@ import {
   conversationMetadataSyncTag,
   SYNC_TAGS,
 } from "../../daemon/message-types/sync.js";
-import {
-  getSlackConversationInfo,
-  SlackApiError,
-} from "../../messaging/providers/slack/api.js";
+import { getSlackConversationInfo } from "../../messaging/providers/slack/api.js";
+import { SlackApiError } from "../../messaging/providers/slack/web-api-transport.js";
 import {
   getBindingByConversation,
   updateExternalChatName,


### PR DESCRIPTION
## TL;DR

`assistant/src/messaging/providers/slack/` had two private copies of the Slack Web API transport and **two same-named `SlackApiError` classes** (`api.ts:66`, `client.ts:34`). This PR extracts one shared transport (`web-api-transport.ts`) with a single unified error class, and migrates `api.ts` off its hardcoded `bot_token` read onto the canonical `resolveSlackAuth` identity resolver, chosen per call.

Fixes [LUM-3024](https://linear.app/vellum/issue/LUM-3024/slack-extract-shared-web-api-transport-single-slackapierror-and-route). Prerequisite for the [LUM-3023](https://linear.app/vellum/issue/LUM-3023/preserve-slack-channel-mentions-instead-of-rendering-unknown-channel) `#unknown-channel` fix: channel-name resolution (`conversations.info`) now acts as the **user** identity, so it can see channels the owner is in but the bot is not (falling back to the bot token when no user token is stored).

## Why this is safe

- **The `instanceof` trap is closed, not moved.** `slack-channel-routes.ts` matched errors against the `api.ts` class while `adapter.ts` matched against the `client.ts` class; any call crossing the boundary silently collapsed to the generic error category. There is now exactly one class, carrying all three fields consumers branch on (`slackError`, `category`, `status`).
- **Identity is chosen per call, not per verb.** Only `conversations.info` moves to `"user"`. Writes, streams, uploads, and own-message reads stay `"bot"`. A blanket read→user switch would regress reads in channels the bot is in but the installer isn't (`resolveSlackAuth` falls back only when *no* user token is stored, never on API failure).
- **Every behavior delta widens resilience; none narrows it** (see table).
- Full assistant `tsc --noEmit` clean; all touched test files pass per-file, plus 11 new unit tests on the shared transport (429/5xx retry, envelope classification, status derivation, form encoding).

## What changes for the user

| Scenario | Before | After |
|---|---|---|
| Slack channel-name resolution for a private channel the bot isn't in | `channel_not_found`, name permanently unresolvable | Resolves via the owner's user token when one is stored |
| Error crossing the `api.ts`/`client.ts` boundary | `instanceof` silently fails → generic `slack_error` | Correct category (`auth`/`permission`/`rate_limit`/…) everywhere |
| Slack 5xx on typed client calls (raw-token) | Immediate failure | Retried 3× with backoff (matching the streaming surface) |
| Body-level rate limit spelled `ratelimited` | Not retried on typed client calls | Retried, same as `rate_limited` |
| `account_inactive` / `org_login_required` envelope errors | Generic 400, no recovery attempt | Classified as auth (401) → one OAuth refresh retry / adapter user→bot fallback engages |
| Form-encoded calls (`files.getUploadURLExternal`) | No retries | Shared retry loop |

## Not in this PR (tracked separately)

- The LUM-3023 preserve-and-project mention fix itself (needs the injection-surface question settled first).
- [LUM-3025](https://linear.app/vellum/issue/LUM-3025/slack-messaging-adapter-passes-userlabels-but-never-channellabels-bare): adapter's missing `channelLabels` + pipe-form user-mention rendering.
- [LUM-2823](https://linear.app/vellum/issue/LUM-2823/slack-add-user-token-support-fixes-avatar-sync-channels-ui-token): gateway/credential-spec side of user-token support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->