### PR TITLE
fix(assistant): log surface completion persist failures at error with conversation context

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -358,7 +358,11 @@ export function markSurfaceCompleted(
       }
     }
   } catch (err) {
-    log.warn({ err, surfaceId }, "Failed to persist surface completion to DB");
+    // Error, not warn: a silent failure here presents as the user's answer being discarded.
+    log.error(
+      { err, conversationId: ctx.conversationId, surfaceId },
+      "Failed to persist surface completion to DB",
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Escalate the swallowed `markSurfaceCompleted` DB-persist failure from warn to error
- Add `conversationId` to the log context so the failure is traceable to a conversation

A silent failure here presents to the user as their answer being discarded, and is otherwise indistinguishable from the history-restored branch never attempting the write.

Part of plan: choice-surface-completion-persist.md (PR 1 of 3)