### PR TITLE
feat(assistant): add findPersistedSurfaceType for compaction-independent block lookup

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-persisted-type.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-persisted-type.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the persistence layer the surface helpers read from so tests can seed
+// rows without touching SQLite. Swapped per test via the closure below.
+let getMessagesImpl: (conversationId: string) => Array<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: unknown;
+  createdAt: number;
+  metadata: string | null;
+}> = () => [];
+
+const realCrud = await import("../persistence/conversation-crud.js");
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getMessages: (conversationId: string) => getMessagesImpl(conversationId),
+}));
+
+// Import must come AFTER mock.module so the surface module picks up the
+// mocked persistence functions.
+const { findPersistedSurfaceType } =
+  await import("../daemon/conversation-surfaces.js");
+
+const CONVERSATION_ID = "conv-persisted-type-1";
+
+function seedRows(rows: Array<{ id: string; content: unknown[] }>): void {
+  getMessagesImpl = () =>
+    rows.map((r) => ({
+      id: r.id,
+      conversationId: CONVERSATION_ID,
+      role: "assistant",
+      content: r.content,
+      createdAt: 0,
+      metadata: null,
+    }));
+}
+
+describe("findPersistedSurfaceType", () => {
+  beforeEach(() => {
+    getMessagesImpl = () => [];
+  });
+
+  test("returns the surfaceType of a persisted ui_surface block", () => {
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          { type: "text", text: "pick one" },
+          {
+            type: "ui_surface",
+            surfaceId: "surface-choice-1",
+            surfaceType: "choice",
+            data: { options: [] },
+          },
+        ],
+      },
+    ]);
+
+    expect(findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1")).toBe(
+      "choice",
+    );
+  });
+
+  test("returns undefined for an unknown surfaceId", () => {
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-choice-1",
+            surfaceType: "choice",
+            data: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceType(CONVERSATION_ID, "surface-missing"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for a conversation with no messages", () => {
+    seedRows([]);
+
+    expect(
+      findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1"),
+    ).toBeUndefined();
+  });
+
+  test("returns the type for a block behind the compaction boundary", () => {
+    // The surface sits in the oldest row, with three newer rows after it. A
+    // conversation compacted to `contextCompactedMessageCount: 3` hides this
+    // row from `findPersistedSurfaceState`, whose scan is bounded by
+    // `rn > liveHistoryStartRow`. This helper consults no boundary at all.
+    seedRows([
+      {
+        id: "msg-compacted",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-compacted-1",
+            surfaceType: "choice",
+            data: {},
+          },
+        ],
+      },
+      { id: "msg-2", content: [{ type: "text", text: "later" }] },
+      { id: "msg-3", content: [{ type: "text", text: "later" }] },
+      { id: "msg-4", content: [{ type: "text", text: "later" }] },
+    ]);
+
+    expect(
+      findPersistedSurfaceType(CONVERSATION_ID, "surface-compacted-1"),
+    ).toBe("choice");
+  });
+
+  test("returns undefined when the block carries no string surfaceType", () => {
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          { type: "ui_surface", surfaceId: "surface-typeless-1", data: {} },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceType(CONVERSATION_ID, "surface-typeless-1"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined rather than throwing when the DB read fails", () => {
+    getMessagesImpl = () => {
+      throw new Error("database is locked");
+    };
+
+    expect(
+      findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1"),
+    ).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -363,6 +363,46 @@ export function markSurfaceCompleted(
 }
 
 /**
+ * Read a `ui_surface` block's `surfaceType` out of persisted history.
+ *
+ * This must NOT be routed through `findPersistedSurfaceState`
+ * (`runtime/routes/surface-conversation-resolver.ts`): that helper is bounded
+ * by `liveHistoryStartRow` / `contextCompactedMessageCount` and by design will
+ * not see a surface behind the compaction boundary, which is exactly the case
+ * this lookup exists to serve. The write scan in {@link markSurfaceCompleted}
+ * is likewise unbounded, so the two stay consistent.
+ *
+ * Hits are deliberately not memoized into `conversation.surfaceState`; see
+ * `runtime/routes/surface-content-routes.ts` for why that shared map must not
+ * absorb scan results.
+ */
+export function findPersistedSurfaceType(
+  conversationId: string,
+  surfaceId: string,
+): string | undefined {
+  try {
+    const rows = getMessages(conversationId);
+    for (let r = rows.length - 1; r >= 0; r--) {
+      const parsed: unknown[] = rows[r].content;
+      for (const pb of parsed) {
+        const rb = pb as Record<string, unknown>;
+        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
+          return typeof rb.surfaceType === "string"
+            ? rb.surfaceType
+            : undefined;
+        }
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err, conversationId, surfaceId },
+      "Failed to read persisted surface type from DB",
+    );
+  }
+  return undefined;
+}
+
+/**
  * Complete a `ui_surface` card and notify live clients, addressed only by
  * conversation + surface id.
  *

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -175,11 +175,57 @@ const pendingSurfacePersists = new Map<
   }
 >();
 
+/** A located `ui_surface` block plus everything needed to write it back. */
+type PersistedSurfaceHit = {
+  /** Message row the block lives in, for `updateMessageContent`. */
+  rowId: string;
+  /** The row's full content block array, mutated in place then re-serialized. */
+  blocks: unknown[];
+  /** The matching `ui_surface` block, a live reference into `blocks`. */
+  block: Record<string, unknown>;
+  /** Index of `block` within `blocks`. */
+  blockIndex: number;
+};
+
 /**
- * Persist the latest `data` for a `ui_surface` content block by
- * scanning the conversation's messages for one containing the given
- * `surfaceId` and patching its `data` field. Mirrors the scan-and-patch
- * pattern in `markSurfaceCompleted`.
+ * Locate the persisted `ui_surface` content block for `surfaceId`.
+ *
+ * The single owner of how a persisted surface block is resolved: newest
+ * message row first, first matching block within that row, stopping at the
+ * first hit. Every persisted read and write goes through here so a change to
+ * storage resolution, ordering, or matching can never make them target
+ * different blocks.
+ *
+ * The scan is deliberately unbounded by compaction (see
+ * {@link findPersistedSurfaceType}), and it throws rather than swallowing DB
+ * errors so each caller keeps its own logging.
+ */
+function findPersistedSurfaceBlock(
+  conversationId: string,
+  surfaceId: string,
+): PersistedSurfaceHit | undefined {
+  const rows = getMessages(conversationId);
+  for (let r = rows.length - 1; r >= 0; r--) {
+    const blocks: unknown[] = rows[r].content;
+    const blockIndex = blocks.findIndex((pb) => {
+      const rb = pb as Record<string, unknown>;
+      return rb.type === "ui_surface" && rb.surfaceId === surfaceId;
+    });
+    if (blockIndex !== -1) {
+      return {
+        rowId: rows[r].id,
+        blocks,
+        block: blocks[blockIndex] as Record<string, unknown>,
+        blockIndex,
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Persist the latest `data` for a `ui_surface` content block by locating it
+ * with {@link findPersistedSurfaceBlock} and patching its `data` field.
  *
  * Safe to call before the assistant message has been persisted (mid-stream):
  * the scan simply finds nothing and bails. The next update after
@@ -191,23 +237,12 @@ function persistSurfaceData(
   data: SurfaceData,
 ): void {
   try {
-    const rows = getMessages(conversationId);
-    for (let r = rows.length - 1; r >= 0; r--) {
-      const parsed: unknown[] = rows[r].content;
-      let found = false;
-      for (const pb of parsed) {
-        const rb = pb as Record<string, unknown>;
-        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
-          rb.data = data;
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        updateMessageContent(rows[r].id, JSON.stringify(parsed));
-        return;
-      }
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId);
+    if (!hit) {
+      return;
     }
+    hit.block.data = data;
+    updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
   } catch (err) {
     log.debug(
       { err, surfaceId, conversationId },
@@ -339,23 +374,11 @@ export function markSurfaceCompleted(
 
   // Persist to DB.
   try {
-    const rows = getMessages(ctx.conversationId);
-    for (let r = rows.length - 1; r >= 0; r--) {
-      const parsed: unknown[] = rows[r].content;
-      let found = false;
-      for (const pb of parsed) {
-        const rb = pb as Record<string, unknown>;
-        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
-          rb.completed = true;
-          rb.completionSummary = summary;
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        updateMessageContent(rows[r].id, JSON.stringify(parsed));
-        return;
-      }
+    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId);
+    if (hit) {
+      hit.block.completed = true;
+      hit.block.completionSummary = summary;
+      updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
     }
   } catch (err) {
     // Error, not warn: a silent failure here presents as the user's answer being discarded.
@@ -373,8 +396,8 @@ export function markSurfaceCompleted(
  * (`runtime/routes/surface-conversation-resolver.ts`): that helper is bounded
  * by `liveHistoryStartRow` / `contextCompactedMessageCount` and by design will
  * not see a surface behind the compaction boundary, which is exactly the case
- * this lookup exists to serve. The write scan in {@link markSurfaceCompleted}
- * is likewise unbounded, so the two stay consistent.
+ * this lookup exists to serve. {@link findPersistedSurfaceBlock}, which also
+ * backs the write paths, is unbounded, so reads and writes stay consistent.
  *
  * Hits are deliberately not memoized into `conversation.surfaceState`; see
  * `runtime/routes/surface-content-routes.ts` for why that shared map must not
@@ -385,17 +408,9 @@ export function findPersistedSurfaceType(
   surfaceId: string,
 ): string | undefined {
   try {
-    const rows = getMessages(conversationId);
-    for (let r = rows.length - 1; r >= 0; r--) {
-      const parsed: unknown[] = rows[r].content;
-      for (const pb of parsed) {
-        const rb = pb as Record<string, unknown>;
-        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
-          return typeof rb.surfaceType === "string"
-            ? rb.surfaceType
-            : undefined;
-        }
-      }
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId);
+    if (hit && typeof hit.block.surfaceType === "string") {
+      return hit.block.surfaceType;
     }
   } catch (err) {
     log.warn(
@@ -463,18 +478,10 @@ export function removeSurfaceBlock(
   }
 
   try {
-    const rows = getMessages(ctx.conversationId);
-    for (let r = rows.length - 1; r >= 0; r--) {
-      const parsed: unknown[] = rows[r].content;
-      const idx = parsed.findIndex((pb) => {
-        const rb = pb as Record<string, unknown>;
-        return rb.type === "ui_surface" && rb.surfaceId === surfaceId;
-      });
-      if (idx !== -1) {
-        parsed.splice(idx, 1);
-        updateMessageContent(rows[r].id, JSON.stringify(parsed));
-        return;
-      }
+    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId);
+    if (hit) {
+      hit.blocks.splice(hit.blockIndex, 1);
+      updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
     }
   } catch (err) {
     log.warn({ err, surfaceId }, "Failed to remove dismissed surface from DB");


### PR DESCRIPTION
## Summary
- Add `findPersistedSurfaceType`, a read-only scan of persisted `ui_surface` blocks that returns a surface's type
- Deliberately unbounded, mirroring `markSurfaceCompleted`'s write scan, so it can see surfaces behind the context-compaction boundary that `findPersistedSurfaceState` skips by design

Groundwork for persisting one-shot surface completion on the history-restored action path.

Part of plan: choice-surface-completion-persist.md (PR 2 of 3)