### PR TITLE
fix(web): hide Vellum-managed credentials outside developer mode

### DIFF
--- a/clients/web/src/domains/settings/credentials/credentials-page.test.tsx
+++ b/clients/web/src/domains/settings/credentials/credentials-page.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+
+let developerMode = false;
+let ownCredentials: Array<{ service: string; field: string }> = [];
+let managedCredentials: Array<{
+  handle: string;
+  provider: string;
+  accountInfo: string | null;
+  status: string;
+}> = [];
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => "assistant-123",
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
+
+mock.module("@/lib/backwards-compat/use-supports-credentials-settings", () => ({
+  useSupportsCredentialsSettings: () => true,
+}));
+
+mock.module("@/stores/assistant-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    settingsDeveloperNav: () => developerMode,
+  };
+  return { useAssistantFeatureFlagStore: store };
+});
+
+mock.module("@/stores/assistant-identity-store", () => {
+  const store = () => null;
+  store.use = {
+    assistantId: () => "assistant-123",
+    version: () => "0.11.0",
+  };
+  return { useAssistantIdentityStore: store };
+});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  credentialsListPost: async () => ({
+    data: { credentials: ownCredentials, managedCredentials },
+  }),
+}));
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  useCredentialsDeletePostMutation: () => ({
+    mutate: () => {},
+    isPending: false,
+    variables: undefined,
+  }),
+}));
+
+mock.module("@/components/add-credential-modal", () => ({
+  AddCredentialModal: () => null,
+  credentialsListQueryKey: (assistantId: string) => [
+    "credentials",
+    assistantId,
+  ],
+}));
+
+mock.module("./credential-row", () => ({
+  CredentialRow: ({
+    credential,
+  }: {
+    credential: { service: string; field: string };
+  }) => <div>{`${credential.service}:${credential.field}`}</div>,
+}));
+
+const { CredentialsPage } = await import("./credentials-page");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  developerMode = false;
+  ownCredentials = [];
+  managedCredentials = [];
+});
+
+describe("CredentialsPage", () => {
+  test("hides managed credentials and the source split outside developer mode", async () => {
+    ownCredentials = [{ service: "stripe", field: "api_key" }];
+    managedCredentials = [
+      {
+        handle: "managed-google",
+        provider: "Google",
+        accountInfo: "user@example.com",
+        status: "connected",
+      },
+    ];
+
+    render(<CredentialsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("stripe:api_key")).not.toBeNull();
+    });
+    expect(screen.queryByLabelText("Credential source")).toBeNull();
+    expect(screen.queryByText("Google")).toBeNull();
+  });
+
+  test("shows the source split and managed credentials in developer mode", async () => {
+    developerMode = true;
+    ownCredentials = [{ service: "stripe", field: "api_key" }];
+    managedCredentials = [
+      {
+        handle: "managed-google",
+        provider: "Google",
+        accountInfo: "user@example.com",
+        status: "connected",
+      },
+    ];
+
+    render(<CredentialsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Credential source")).not.toBeNull();
+    });
+    expect(screen.getByText("stripe:api_key")).not.toBeNull();
+  });
+
+  test("shows the empty state instead of managed credentials outside developer mode", async () => {
+    managedCredentials = [
+      {
+        handle: "managed-google",
+        provider: "Google",
+        accountInfo: "user@example.com",
+        status: "connected",
+      },
+    ];
+
+    render(<CredentialsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("No credentials yet")).not.toBeNull();
+    });
+    expect(screen.queryByLabelText("Credential source")).toBeNull();
+    expect(screen.queryByText("Google")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/credentials/credentials-page.tsx
+++ b/clients/web/src/domains/settings/credentials/credentials-page.tsx
@@ -14,6 +14,7 @@ import { credentialsListPost } from "@/generated/daemon/sdk.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useSupportsCredentialsSettings } from "@/lib/backwards-compat/use-supports-credentials-settings";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { shouldRetryDaemonError } from "@/utils/daemon-errors";
 import { Button } from "@vellumai/design-library/components/button";
@@ -106,9 +107,14 @@ function CredentialsPageInner() {
     () => listQuery.data?.credentials ?? [],
     [listQuery.data],
   );
+  // Managed credentials are provisioned by Vellum and can only be read here, so
+  // the list and the managed/personal split are developer-mode surfaces.
+  // Standard users see just the credentials they can act on.
+  const isDeveloperMode =
+    useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const managedCredentials = useMemo(
-    () => listQuery.data?.managedCredentials ?? [],
-    [listQuery.data],
+    () => (isDeveloperMode ? (listQuery.data?.managedCredentials ?? []) : []),
+    [isDeveloperMode, listQuery.data],
   );
 
   const deleteMutation = useCredentialsDeletePostMutation({


### PR DESCRIPTION
## What

Hide Vellum-managed credentials, and the managed/personal split UI, from the credentials settings page unless developer mode is on.

## Why

Managed credentials are provisioned by the platform and are strictly read-only in this page: no reveal, no replace, no delete, no one-time link. Showing them to a standard user adds a "Your own" / "Managed" segment control and a list of rows nobody can act on, and the auto-switch effect could even land a user with zero personal credentials directly on that read-only tab. Standard users should see only the credentials they can actually manage.

## Behavior change

- **Standard users**: the credentials page shows only their own vault credentials. No "Credential source" segment control, no managed rows, no auto-switch to the managed view. A user with no personal credentials sees the existing "No credentials yet" empty state plus the Add affordance instead of a read-only managed list.
- **Developer mode** (`settings-developer-nav`, the 7-tap version unlock): unchanged. Segment control, managed list, subtitle copy and auto-switch all behave exactly as before.

## Implementation

One choke point in `clients/web/src/domains/settings/credentials/credentials-page.tsx`: `managedCredentials` resolves to an empty array when the `settingsDeveloperNav` flag is off. Everything downstream already derives from it (`hasManaged`, `showManaged`, the segment control, the subtitle, the auto-switch effect), so no other branch needed touching. Flag is read via the existing `useAssistantFeatureFlagStore.use.settingsDeveloperNav()` selector, matching how `settings-layout.tsx` and the LLM inspector gate.

The list request is unchanged: the daemon still returns both arrays and the query stays a single source of truth, we just don't render the managed half.

## Files changed

- `clients/web/src/domains/settings/credentials/credentials-page.tsx` (gate)
- `clients/web/src/domains/settings/credentials/credentials-page.test.tsx` (new; first test coverage for this page)

## Test notes

New `credentials-page.test.tsx` follows the `settings-layout.test.tsx` / `mcp-page.test.tsx` pattern (bun:test + Testing Library, `mock.module` for the flag store and daemon SDK). Three cases:

1. Flag off with both personal and managed credentials: personal rows render, no "Credential source" control, no managed provider row.
2. Flag on: segment control renders alongside the personal rows.
3. Flag off with zero personal credentials and managed credentials present: the empty state renders instead of the managed list (regression guard for the auto-switch effect).

```
cd clients/web && bun test src/domains/settings/credentials/credentials-page.test.tsx   # 3 pass
cd clients/web && bunx tsc --noEmit                                                     # clean
cd clients/web && bun run lint                                                          # no new warnings (0 errors)
```

## Note for review

The flag store hydrates asynchronously and reads `false` until `/feature-flags` lands, so a developer-mode user can see a brief moment without the segment control on first paint. That matches the existing `settings-layout.tsx` gate, which also does not consult `hasHydrated()`, and it fails closed (hidden) rather than flashing managed credentials at a standard user. Happy to add a `hasHydrated()` guard if reviewers prefer the loading-shaped variant used by `inspect-page.tsx`.

Fixes LUM-2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->