### PR TITLE
fix(web): panel tile contrast, responsive grid, and story coverage

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared `DisplayAttachment` fixtures for the attachment renderers' tests and
+ * stories. Kept free of any test-runner import so `.stories.tsx` files can use
+ * it; the `bun:test` stubs live in `attachment-test-helpers.tsx`.
+ */
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+/**
+ * Tiny generated 96x96 PNGs, one per hue, used wherever a story needs a real
+ * decodable thumbnail rather than an icon fallback.
+ */
+export const SAMPLE_PREVIEWS: string[] = [
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQ2DQBREwdcZJRA6oAW3QO80gDa25JEu3Ogl9zUd5/X6Pt/79f3bPnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnV4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgfx4N4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTzop/cPo8PkO85qWSYAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQ2DQBREwdcZBVCAE3KXQes0gDa25JEu3Ogl9zVd5/H67u/n9f3bPnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnX2PnV4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgfx4N4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTyIB/EgHsSD1OFBPIgH8SAexIN4EA9ShwfxIB7Eg3gQD+JBPMgFwIN4EA/iQTzop/cPi1d4O2QKRFUAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwdebiTsIMUsTLt8NWIsjZaSDix65r+n4nK/vur+v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8A3VnELJtLlW4AAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA7klEQVR42u3YsQ3DMBAEwS3OuTpQBW7CnasB4mIBHoDhRZvwMV2f+/i+9+/4/m2fOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOnufOjyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5I/jQTyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5ALgQTyIB/EgHsSDeBAP4kHq8CAexIN4EA/iQTyIB6nDg3gQD+JBPIgH8SAe5ALgQTyIB/EgHvTq/QMeCDpZKCPwnAAAAABJRU5ErkJggg==",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YsQnDQBREwVeWmhAG1eFE/SdqQGxs8MCFG73kPtP1OV7f/T1f37/tU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU4cH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg/xxPIgH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg1wAPIgH8SAexIN4EA/iQTxIHR7Eg3gQD+JBPIgH8SB1eBAP4kE8iAfxIB7Eg1wAPIgH8SAexIN+ev8A6As4HS9kpJoAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA7UlEQVR42u3YsQ3DMBAEwS3MVShTGU5VvRogLjbgARhetAkf0+e6j+/6Psf3b/vU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU2fvU4UE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgfxwP4kE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgFwAP4kE8iAfxIB7Eg3gQD1KHB/EgHsSDeBAP4kE8SB0exIN4EA/iQTyIB/EgFwAP4kE8iAfxoJ/ev2/xijtU5xswAAAAAElFTkSuQmCC",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwVeemTsIMU0T7twNWIsjZaSDix65r+lznK/vvr6v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8AkMfcWd+1vLwAAAAASUVORK5CYII=",
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAA70lEQVR42u3YoQ3DQBREwdeamXGYcSpw/8QNWIsjZaSDix65r+n8HK/ve1+v79/2qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qbP3qcODeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQf44HsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE8iAfxIB6kDg/iQTyIB/EgHsSDeJA6PIgH8SAexIN4EA/iQS4AHsSDeBAP4kE/vX8Au7CSHXnIoW4AAAAASUVORK5CYII=",
+];
+
+/**
+ * A display attachment with sensible PNG defaults. Pass `overrides` for the
+ * fields a test actually cares about.
+ */
+export function makeDisplayAttachment(
+  overrides: Partial<DisplayAttachment> = {},
+): DisplayAttachment {
+  const id = overrides.id ?? "att-1";
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    previewUrl: null,
+    ...overrides,
+  };
+}
+
+/** `count` distinct image attachments, named `photo-<i>.png`. */
+export function makeImageAttachments(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: `https://example.com/photo-${index}.png`,
+    }),
+  );
+}
+
+/**
+ * `count` image attachments carrying a real decodable preview, so stories
+ * render actual thumbnails instead of the icon fallback.
+ */
+export function makePreviewableImages(count: number): DisplayAttachment[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `slide-${String(index + 1).padStart(2, "0")}.png`,
+      sizeBytes: 184_320 + index * 4_096,
+      previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+    }),
+  );
+}
+
+/** A mixed media / non-media set covering each icon fallback kind. */
+export function makeMixedAttachments(): DisplayAttachment[] {
+  return [
+    makeImageAttachments(1)[0]!,
+    makeDisplayAttachment({
+      id: "deck-1",
+      filename: "deck.pptx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      sizeBytes: 4_096,
+    }),
+    makeDisplayAttachment({
+      id: "report-1",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_048,
+    }),
+    makeDisplayAttachment({
+      id: "bundle-1",
+      filename: "bundle.zip",
+      mimeType: "application/zip",
+      sizeBytes: 8_192,
+    }),
+  ];
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-strip.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-strip.stories.tsx
@@ -1,0 +1,236 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import {
+  makeDisplayAttachment,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
+
+/**
+ * The assistant-message attachment strip. Past five attachments it collapses
+ * to the first five squares plus a `+N` tile that opens the files panel. The
+ * cap is type blind: images, video, documents and archives all count toward
+ * it.
+ */
+
+const MIXED: DisplayAttachment[] = [
+  makeDisplayAttachment({
+    id: "deck-1",
+    filename: "On_Site_Safety.pptx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    sizeBytes: 4_194_304,
+  }),
+  ...makePreviewableImages(2),
+  makeDisplayAttachment({
+    id: "report-1",
+    filename: "annual-report.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_097_152,
+  }),
+  makeDisplayAttachment({
+    id: "slide-17",
+    filename: "slide-17.png",
+    sizeBytes: 192_512,
+    previewUrl: SAMPLE_PREVIEWS[3]!,
+  }),
+  makeDisplayAttachment({
+    id: "bundle-1",
+    filename: "source-bundle.zip",
+    mimeType: "application/zip",
+    sizeBytes: 8_388_608,
+  }),
+  makeDisplayAttachment({
+    id: "cover-1",
+    filename: "cover.png",
+    sizeBytes: 196_608,
+    previewUrl: SAMPLE_PREVIEWS[4]!,
+  }),
+  makeDisplayAttachment({
+    id: "sheet-1",
+    filename: "forecast.xlsx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    sizeBytes: 65_536,
+  }),
+];
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-[var(--border-base)] pb-6">
+      <span className="text-xs uppercase tracking-wide text-[var(--content-tertiary)]">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: "Chat/AttachmentStrip",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+/** Every count at which the strip changes behaviour. */
+export const Counts: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-[var(--surface-base)] p-8">
+      <Row label="3 photos - under the limit, no tile">
+        <MessageAttachments
+          attachments={makePreviewableImages(3)}
+          messageId="m-3"
+        />
+      </Row>
+      <Row label="5 photos - exactly at the limit, still no tile">
+        <MessageAttachments
+          attachments={makePreviewableImages(5)}
+          messageId="m-5"
+        />
+      </Row>
+      <Row label="6 photos - first overflow, +1">
+        <MessageAttachments
+          attachments={makePreviewableImages(6)}
+          messageId="m-6"
+        />
+      </Row>
+      <Row label="8 mixed files - pptx / pdf / zip count toward the cap, +3">
+        <MessageAttachments attachments={MIXED} messageId="m-mixed" />
+      </Row>
+      <Row label="41 photos - +36">
+        <MessageAttachments
+          attachments={makePreviewableImages(41)}
+          messageId="m-41"
+        />
+      </Row>
+    </div>
+  ),
+};
+
+/**
+ * Every state a square can land on. Only the first has a decodable preview;
+ * the rest fall back to the file-kind icon, which is the common case for large
+ * images the daemon does not inline and for attachments rehydrated from a
+ * text summary.
+ */
+export const Fallbacks: StoryObj = {
+  render: () => {
+    const cases: Array<[string, DisplayAttachment]> = [
+      [
+        "image + preview",
+        makeDisplayAttachment({
+          id: "f1",
+          filename: "photo.png",
+          sizeBytes: 184_320,
+          previewUrl: SAMPLE_PREVIEWS[0]!,
+        }),
+      ],
+      [
+        "image, no preview",
+        makeDisplayAttachment({
+          id: "f2",
+          filename: "large-photo.png",
+          sizeBytes: 24_117_248,
+        }),
+      ],
+      [
+        "image, decode fails",
+        makeDisplayAttachment({
+          id: "f3",
+          filename: "shot.heic",
+          mimeType: "image/heic",
+          sizeBytes: 3_145_728,
+          previewUrl: "data:image/heic;base64,AAAAAAAA",
+        }),
+      ],
+      [
+        "video + poster",
+        makeDisplayAttachment({
+          id: "f4",
+          filename: "clip.mp4",
+          mimeType: "video/mp4",
+          sizeBytes: 12_582_912,
+          thumbnailUrl: SAMPLE_PREVIEWS[3]!,
+        }),
+      ],
+      [
+        "video, no poster",
+        makeDisplayAttachment({
+          id: "f5",
+          filename: "raw.mov",
+          mimeType: "video/quicktime",
+          sizeBytes: 8_388_608,
+        }),
+      ],
+      [
+        "pdf",
+        makeDisplayAttachment({
+          id: "f6",
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 2_097_152,
+        }),
+      ],
+      [
+        "zip",
+        makeDisplayAttachment({
+          id: "f7",
+          filename: "bundle.zip",
+          mimeType: "application/zip",
+          sizeBytes: 8_388_608,
+        }),
+      ],
+      [
+        "spreadsheet",
+        makeDisplayAttachment({
+          id: "f8",
+          filename: "data.csv",
+          mimeType: "text/csv",
+          sizeBytes: 65_536,
+        }),
+      ],
+      [
+        "audio",
+        makeDisplayAttachment({
+          id: "f9",
+          filename: "voice.mp3",
+          mimeType: "audio/mpeg",
+          sizeBytes: 1_048_576,
+        }),
+      ],
+      [
+        "code",
+        makeDisplayAttachment({
+          id: "f10",
+          filename: "migrate.ts",
+          mimeType: "text/plain",
+          sizeBytes: 9_216,
+        }),
+      ],
+      [
+        "unknown",
+        makeDisplayAttachment({
+          id: "f11",
+          filename: "firmware.bin",
+          mimeType: "application/octet-stream",
+          sizeBytes: 524_288,
+        }),
+      ],
+    ];
+    return (
+      <div className="flex flex-wrap gap-6 bg-[var(--surface-base)] p-8">
+        {cases.map(([label, att]) => (
+          <div key={att.id} className="flex w-[110px] flex-col gap-2">
+            <MessageAttachments attachments={[att]} messageId={`fb-${att.id}`} />
+            <span className="text-[11px] uppercase tracking-wide text-[var(--content-tertiary)]">
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -3,6 +3,9 @@
  * (`BubbleAttachments`, `MessageAttachments`, `MessageFilesPanel`) and the
  * viewer store's message-files actions.
  *
+ * Fixtures live in `attachment-fixtures.ts`, which imports no test runner so
+ * stories can share them; this module adds the `bun:test` stubs on top.
+ *
  * The preview-modal stub is exported as a function rather than run on import,
  * because `mock.module` must be applied BEFORE the module under test is
  * imported and a bare side-effecting import gives the test no control over
@@ -11,62 +14,15 @@
 
 import { mock } from "bun:test";
 
-import type { DisplayAttachment } from "@/domains/chat/types/types";
-
-/**
- * A display attachment with sensible PNG defaults. Pass `overrides` for the
- * fields a test actually cares about.
- */
-export function makeDisplayAttachment(
-  overrides: Partial<DisplayAttachment> = {},
-): DisplayAttachment {
-  const id = overrides.id ?? "att-1";
-  return {
-    id,
-    filename: `${id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: null,
-    ...overrides,
-  };
-}
-
-/** `count` distinct image attachments, named `photo-<i>.png`. */
-export function makeImageAttachments(count: number): DisplayAttachment[] {
-  return Array.from({ length: count }, (_, index) =>
-    makeDisplayAttachment({
-      id: `img-${index}`,
-      filename: `photo-${index}.png`,
-      previewUrl: `https://example.com/photo-${index}.png`,
-    }),
-  );
-}
-
-/** A mixed media / non-media set covering each icon fallback kind. */
-export function makeMixedAttachments(): DisplayAttachment[] {
-  return [
-    makeImageAttachments(1)[0]!,
-    makeDisplayAttachment({
-      id: "deck-1",
-      filename: "deck.pptx",
-      mimeType:
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      sizeBytes: 4_096,
-    }),
-    makeDisplayAttachment({
-      id: "report-1",
-      filename: "report.pdf",
-      mimeType: "application/pdf",
-      sizeBytes: 2_048,
-    }),
-    makeDisplayAttachment({
-      id: "bundle-1",
-      filename: "bundle.zip",
-      mimeType: "application/zip",
-      sizeBytes: 8_192,
-    }),
-  ];
-}
+// Re-exported so existing test imports keep resolving from one place; the
+// factories themselves live in a test-runner-free module the stories share.
+export {
+  makeDisplayAttachment,
+  makeImageAttachments,
+  makeMixedAttachments,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 
 /**
  * Replace the preview modal with a probe exposing the opened attachment, its

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -76,6 +76,11 @@ export function MessageAttachmentSquare({
   // a poster fails, so an <img> would surface the browser's broken glyph.
   const backgroundImageUrl =
     kind === "video" && thumbnailUrl != null ? thumbnailUrl : null;
+  // With nothing filling the tile, its `--surface-lift` fill disappears on a
+  // container painted the same colour (the files panel's `DetailShell` body),
+  // leaving a bare glyph. A `--border-element` hairline is the one outline that
+  // reads against both `--surface-base` and `--surface-lift` in every theme.
+  const showsIcon = !hasImagePreview && backgroundImageUrl === null;
   const isClickable = onPreview != null;
   const displayName = middleTruncate(filename, 18);
   const displaySize = formatAttachmentSize(sizeBytes);
@@ -110,7 +115,7 @@ export function MessageAttachmentSquare({
     >
       <div className="relative w-fit">
         <div
-          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]`}
+          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]${showsIcon ? " border border-[var(--border-element)]" : ""}`}
           style={
             backgroundImageUrl
               ? {

--- a/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.stories.tsx
@@ -2,6 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
+import {
+  makeDisplayAttachment,
+  makePreviewableImages,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { AttachmentOverflowSquare } from "@/domains/chat/components/chat-attachments/attachment-overflow-square";
 import { MessageFilesPanel } from "./message-files-panel";
 
@@ -12,63 +17,53 @@ import { MessageFilesPanel } from "./message-files-panel";
  * attachment strip.
  */
 
-function makeAttachment(
-  overrides: Partial<DisplayAttachment> & { id: string },
-): DisplayAttachment {
-  return {
-    filename: `${overrides.id}.png`,
-    mimeType: "image/png",
-    sizeBytes: 1_024,
-    previewUrl: null,
-    ...overrides,
-  };
-}
-
 const MIXED: DisplayAttachment[] = [
-  makeAttachment({
+  makeDisplayAttachment({
     id: "img-0",
     filename: "quarterly-revenue.png",
     sizeBytes: 184_320,
+    previewUrl: SAMPLE_PREVIEWS[0]!,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "deck-1",
     filename: "board-deck.pptx",
     mimeType:
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     sizeBytes: 4_194_304,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "report-1",
     filename: "annual-report.pdf",
     mimeType: "application/pdf",
     sizeBytes: 2_097_152,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
+    id: "img-1",
+    filename: "hazard-gallery.png",
+    sizeBytes: 188_416,
+    previewUrl: SAMPLE_PREVIEWS[1]!,
+  }),
+  makeDisplayAttachment({
     id: "sheet-1",
     filename: "forecast.xlsx",
     mimeType:
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     sizeBytes: 65_536,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "bundle-1",
     filename: "source-bundle.zip",
     mimeType: "application/zip",
     sizeBytes: 8_388_608,
   }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "clip-1",
     filename: "walkthrough.mp4",
     mimeType: "video/mp4",
     sizeBytes: 12_582_912,
+    thumbnailUrl: SAMPLE_PREVIEWS[2]!,
   }),
-  makeAttachment({
-    id: "notes-1",
-    filename: "meeting-notes.md",
-    mimeType: "text/markdown",
-    sizeBytes: 3_072,
-  }),
-  makeAttachment({
+  makeDisplayAttachment({
     id: "script-1",
     filename: "migrate.ts",
     mimeType: "text/plain",
@@ -145,4 +140,19 @@ export const OverflowTileStates: StoryObj = {
       </div>
     </div>
   ),
+};
+
+/**
+ * A photo-heavy message: the grid wraps to the panel's width rather than a
+ * fixed column count, so it fills a widened drawer and the full-width mobile
+ * overlay alike.
+ */
+export const Photos: Story = {
+  args: {
+    payload: {
+      messageId: "story-photos",
+      attachments: makePreviewableImages(12),
+    },
+    onClose: () => {},
+  },
 };

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -73,8 +73,11 @@ export function MessageFilesPanel({
           No files on this message
         </Typography>
       ) : (
-        // Three across fits the drawer's 400px default width.
-        <div className="grid grid-cols-3 gap-3">
+        // Wraps rather than sitting on a fixed column count: the drawer is
+        // drag-resizable and the mobile overlay renders this same panel at
+        // full viewport width. `items-start` keeps squares with taller
+        // captions from stretching their neighbours.
+        <div className="flex flex-wrap items-start gap-3">
           {displayAttachments.map((att, index) => renderSquare(att, index))}
         </div>
       )}

--- a/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
+++ b/clients/web/src/domains/chat/hooks/reconcile-subagent-hydration.ts
@@ -39,8 +39,8 @@ export interface SubagentNotificationLike {
  *
  * Entry lifecycle cleanup is owned elsewhere: cross-conversation clearing by
  * the conversation-change reset (`use-conversation-change-effects`' layout
- * effect and `switchConversation`), staleness by reconcile's generation guard,
- * and stuck-active settling by reconcile's orphan pass.
+ * effect and `navigateToConversation`), staleness by reconcile's generation
+ * guard, and stuck-active settling by reconcile's orphan pass.
  *
  * `parentConversationId` is the conversation being hydrated, it scopes the
  * Active-Subagents overlay. A notification's own `conversationId` is the

--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -2,7 +2,7 @@
  * Consolidates side effects that fire when `activeConversationId` changes:
  *
  * - Reset subagent tracking state (needed for URL-navigation paths that
- *   bypass the `switchConversation` / `startNewConversation` wrappers)
+ *   bypass the `navigateToConversation` / `startNewConversation` wrappers)
  * - Auto-fetch detail for the subagents that can't wait for a click: the ones
  *   still running, and the stubs deferring their live events until a backfill
  *   lands
@@ -57,7 +57,7 @@ export function useConversationChangeEffects(
   // child (effects fire children-first), letting a card capture the pre-reset
   // `generation`; the reset would then bump it and the in-flight hydration
   // would discard its own result as stale — leaving the card blank with no
-  // retry. The wrapper-initiated path (`switchConversation` /
+  // retry. The wrapper-initiated path (`navigateToConversation` /
   // `startNewConversation`) also resets eagerly; the double-reset is idempotent.
   // This effect catches the URL-navigation path where wrappers don't run.
   useLayoutEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -81,8 +81,8 @@ interface UseConversationLoaderParams {
  * polling for new messages.
  *
  * Owns the primary data-fetching lifecycle for the chat sidebar and
- * transcript. Returns `switchConversation`, `startNewConversation`,
- * and `refreshConversations` for use by sibling hooks.
+ * transcript. Returns `startNewConversation` and `refreshConversations` for
+ * use by sibling hooks.
  *
  * Delegates to:
  * - `useConversationHistory` -- conversation switch, cache, and history loading
@@ -416,27 +416,6 @@ export function useConversationLoader({
   });
 
   // -------------------------------------------------------------------------
-  // switchConversation
-  // -------------------------------------------------------------------------
-  const switchConversation = useCallback(
-    (key: string) => {
-      useViewerStore.getState().setMainView("chat");
-      // Same-conversation reselect: return to the chat view but keep the
-      // per-conversation process stores — wiping them kills the inline
-      // cards of still-running subagents, which only repopulate from live
-      // SSE events (LUM-2875).
-      if (key === useConversationStore.getState().activeConversationId) {
-        return;
-      }
-      useSubagentStore.getState().reset();
-      useWorkflowStore.getState().reset();
-      useViewerStore.getState().clearTranscriptPanelPayloads();
-      void navigate(routes.conversation(key));
-    },
-    [navigate],
-  );
-
-  // -------------------------------------------------------------------------
   // startNewConversation
   // -------------------------------------------------------------------------
   const startNewConversation = useCallback(
@@ -460,7 +439,6 @@ export function useConversationLoader({
 
   return {
     refreshConversations,
-    switchConversation,
     startNewConversation,
     conversationExistsOnServer,
     historyResult,

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -4,7 +4,7 @@
  *
  * Focus: they reset stale viewer state (main view, subagent / workflow panels,
  * transcript side-panel payloads), update the active conversation, and fire
- * exactly one haptic tap — unless the caller opts out via `{ silent: true }`.
+ * exactly one haptic tap, unless the caller opts out via `{ silent: true }`.
  * The fork action taps at action start and routes navigation through this
  * helper, so it relies on `silent` to avoid a double buzz.
  */

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for the imperative `navigateToConversation` navigator.
+ * Unit tests for the imperative `navigateToConversation` and
+ * `navigateToNewConversation` navigators.
  *
- * Focus: it resets stale viewer state (main view, subagent / workflow panels),
- * updates the active conversation, and fires exactly one haptic tap — unless
- * the caller opts out via `{ silent: true }`. The fork action taps at action
- * start and routes navigation through this helper, so it relies on `silent`
- * to avoid a double buzz.
+ * Focus: they reset stale viewer state (main view, subagent / workflow panels,
+ * transcript side-panel payloads), update the active conversation, and fire
+ * exactly one haptic tap — unless the caller opts out via `{ silent: true }`.
+ * The fork action taps at action start and routes navigation through this
+ * helper, so it relies on `silent` to avoid a double buzz.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -15,9 +16,12 @@ import { routes } from "@/utils/routes";
 
 const hapticLight = mock(() => {});
 const setMainView = mock((_view: string) => {});
+const clearTranscriptPanelPayloads = mock(() => {});
 const subagentReset = mock(() => {});
 const workflowReset = mock(() => {});
 const setActiveConversationId = mock((_id: string) => {});
+const playSound = mock((_name: string) => Promise.resolve());
+const composerFocus = mock(() => {});
 
 mock.module("@/utils/haptics", () => ({
   haptic: {
@@ -28,7 +32,15 @@ mock.module("@/utils/haptics", () => ({
   },
 }));
 mock.module("@/stores/viewer-store", () => ({
-  useViewerStore: { getState: () => ({ setMainView }) },
+  useViewerStore: {
+    getState: () => ({ setMainView, clearTranscriptPanelPayloads }),
+  },
+}));
+mock.module("@/lib/sounds/sound-manager", () => ({
+  getSoundManager: () => ({ play: playSound }),
+}));
+mock.module("@/domains/chat/composer-focus", () => ({
+  requestComposerFocus: composerFocus,
 }));
 mock.module("@/domains/chat/subagent-store", () => ({
   useSubagentStore: { getState: () => ({ reset: subagentReset }) },
@@ -43,15 +55,19 @@ mock.module("@/stores/conversation-store", () => ({
   },
 }));
 
-const { navigateToConversation } =
-  await import("@/utils/conversation-navigation");
+const { navigateToConversation, navigateToNewConversation } = await import(
+  "@/utils/conversation-navigation"
+);
 
 beforeEach(() => {
   hapticLight.mockClear();
   setMainView.mockClear();
+  clearTranscriptPanelPayloads.mockClear();
   subagentReset.mockClear();
   workflowReset.mockClear();
   setActiveConversationId.mockClear();
+  playSound.mockClear();
+  composerFocus.mockClear();
   activeConversationId = null;
 });
 
@@ -104,15 +120,46 @@ describe("navigateToConversation", () => {
     expect(setMainView).toHaveBeenCalledWith("chat");
     expect(subagentReset).not.toHaveBeenCalled();
     expect(workflowReset).not.toHaveBeenCalled();
+    expect(clearTranscriptPanelPayloads).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-1"));
   });
 
-  test("genuine switch still resets subagent/workflow state", () => {
+  test("genuine switch resets subagent/workflow state and panel payloads", () => {
     activeConversationId = "conv-1";
     const navigate = mock((_to: string) => {});
     navigateToConversation(navigate as unknown as NavigateFunction, "conv-2");
 
     expect(subagentReset).toHaveBeenCalledTimes(1);
     expect(workflowReset).toHaveBeenCalledTimes(1);
+    // A files or activity-steps panel opened from the previous transcript
+    // points at a message this conversation does not contain.
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("navigateToNewConversation", () => {
+  test("resets panel payloads and process stores, taps, focuses the composer", () => {
+    activeConversationId = "conv-1";
+    const navigate = mock((_to: string) => {});
+    navigateToNewConversation(navigate as unknown as NavigateFunction);
+
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(setMainView).toHaveBeenCalledWith("chat");
+    expect(subagentReset).toHaveBeenCalledTimes(1);
+    expect(workflowReset).toHaveBeenCalledTimes(1);
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
+    expect(setActiveConversationId).toHaveBeenCalledTimes(1);
+    expect(composerFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test("silent suppresses the haptic and sound but still clears panel payloads", () => {
+    const navigate = mock((_to: string) => {});
+    navigateToNewConversation(navigate as unknown as NavigateFunction, {
+      silent: true,
+    });
+
+    expect(hapticLight).not.toHaveBeenCalled();
+    expect(playSound).not.toHaveBeenCalled();
+    expect(clearTranscriptPanelPayloads).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -23,8 +23,8 @@ export interface NavigateToConversationOptions {
 
 /**
  * Navigate to an existing conversation, resetting stale viewer state (main
- * view, subagent / workflow panels) and updating the active conversation in
- * the store.
+ * view, subagent / workflow panels, transcript side-panel payloads) and
+ * updating the active conversation in the store.
  *
  * Pure imperative function — reads stores via `.getState()`, no React hooks.
  */
@@ -46,6 +46,7 @@ export function navigateToConversation(
   ) {
     useSubagentStore.getState().reset();
     useWorkflowStore.getState().reset();
+    useViewerStore.getState().clearTranscriptPanelPayloads();
   }
   useConversationStore.getState().setActiveConversationId(conversationId);
   void navigate(
@@ -64,8 +65,9 @@ export interface NavigateToNewConversationOptions {
 /**
  * Create a fresh draft conversation and navigate to it.
  *
- * Always resets subagent state (a subagent detail panel from a prior
- * conversation must not persist into the new draft). When `silent` is true
+ * Always resets subagent state and the transcript side-panel payloads (a
+ * subagent detail or files panel from a prior conversation must not persist
+ * into the new draft). When `silent` is true
  * (e.g. fallback after archiving the active conversation), the haptic tap
  * is suppressed.
  *
@@ -86,6 +88,7 @@ export function navigateToNewConversation(
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();
+  useViewerStore.getState().clearTranscriptPanelPayloads();
   const draftId = createDraftConversationId();
   useConversationStore.getState().setActiveConversationId(draftId);
 


### PR DESCRIPTION
## Summary

Found by browser-verifying the feature in Storybook. The first two defects were missed by unit tests and four code-review passes, because both are invisible unless you look at the rendered panel.

- **Non-image tiles were invisible inside the files panel.** `MessageAttachmentSquare` fills its tile with `--surface-lift`, correct on the transcript's `--surface-base`, but `DetailShell`'s panel body is *also* `--surface-lift` — so pptx/pdf/zip/csv icons rendered as bare glyphs with no card, in both light and dark. Icon-only tiles now carry a `--border-element` hairline, the one token that reads against both surfaces in all three themes. Image and video-poster tiles are deliberately untouched; outlining every photo would change the whole transcript's look.
- **The panel grid was fixed at `grid-cols-3`**, sized for the 400px default drawer. But the drawer is drag-resizable with a persisted width, and the mobile overlay renders the same panel full-width. Now `flex flex-wrap items-start`, mirroring the inline strip.
- **`clearTranscriptPanelPayloads()` was wired into `switchConversation`, which has no callers.** `useConversationLoader`'s only consumer never destructures it. The live paths are `navigateToConversation` / `navigateToNewConversation`, which back the sidebar, the new-chat button, Cmd+N, deep links, schedules and the home page. Moved it there, and removed the dead function per AGENTS.md's dead-code rule.
- **Story coverage.** Nothing on the branch rendered a real photo, so the `<img>` + `object-cover` path added in #39881 had zero visual coverage. Adds the inline strip at every count that changes behaviour (3/5/6/8-mixed/41), a photo-heavy panel, and the full fallback matrix (image+preview, image with no preview, image whose decode fails, video with and without a poster, pdf, zip, spreadsheet, audio, code, unknown).
- Fixtures moved to a test-runner-free `attachment-fixtures.ts` so stories can share them; `attachment-test-helpers.tsx` imports `bun:test` at module scope and cannot be imported from a story.

## Verification
`bunx tsc --noEmit` clean, `bun run lint` 0 errors, `bun run test:ci` 821/821. Stories confirmed rendering in Storybook and screenshotted in both themes.