### PR TITLE
Verify Android HTTPS App Links

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -54,6 +54,35 @@ origin and native auth host agree.
 Launcher and splash colors also distinguish production, staging, and dev
 installs.
 
+## HTTPS App Links
+
+Each flavor claims only its own web host. The verified routes are the app root,
+pairing, conversations, voice settings, OAuth completion, and billing pages.
+Other paths stay in the browser. Incoming links navigate the existing WebView
+with their query string and fragment intact.
+
+Android verifies a claim only after the matching host serves
+`/.well-known/assetlinks.json` with HTTP 200, `application/json`, and no
+redirect. Each statement must use the application ID in the Build Variants
+table and real SHA-256 fingerprints for every certificate that signs that
+flavor. Play App Signing fingerprints must come from Play Console. Do not use
+an upload-certificate fingerprint as a substitute.
+
+The existing custom schemes remain supported for native auth, pairing, billing
+completion, and voice commands. HTTPS App Links are additive.
+
+After the Digital Asset Links file is deployed, install the matching build on
+a physical device and check verification with:
+
+```bash
+adb shell pm get-app-links ai.vellum.assistant
+adb shell am start -a android.intent.action.VIEW \
+  -c android.intent.category.BROWSABLE \
+  -d 'https://www.vellum.ai/assistant/conversations/conv-xyz?message=message-123#reply'
+```
+
+Use the suffixed application ID and matching host when checking staging or dev.
+
 ## Native Auth
 
 The `NativeAuth` Capacitor plugin opens WorkOS AuthKit in the system browser,

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -61,6 +61,10 @@ pairing, conversations, voice settings, OAuth completion, and billing pages.
 Other paths stay in the browser. Incoming links navigate the existing WebView
 with their query string and fragment intact.
 
+A shell paired to a self-hosted assistant keeps its current server when a
+Vellum Cloud App Link arrives. App Links do not interrupt pairing or switch a
+self-hosted WebView to Vellum Cloud.
+
 Android verifies a claim only after the matching host serves
 `/.well-known/assetlinks.json` with HTTP 200, `application/json`, and no
 redirect. Each statement must use the application ID in the Build Variants

--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -27,6 +27,11 @@ def buildValue = { String name, String fallback = '' ->
         .getOrElse(fallback)
 }
 def buildText = { String name, String fallback = '' -> buildValue(name, fallback).trim() }
+def appLinkHosts = [
+    production: "www.vellum.ai",
+    staging: "staging-assistant.vellum.ai",
+    dev: "dev-assistant.vellum.ai",
+]
 
 def versionCodeInput = buildText('VELLUM_ANDROID_VERSION_CODE', '1')
 if (!(versionCodeInput ==~ /[1-9][0-9]*/) || versionCodeInput.toBigInteger() > 2100000000) {
@@ -70,27 +75,30 @@ android {
         production {
             dimension "environment"
             manifestPlaceholders = [
+                vellumAppLinkHost: appLinkHosts.production,
                 vellumAuthScheme: "vellum-assistant"
             ]
-            resValue "string", "vellum_auth_host", "www.vellum.ai"
+            resValue "string", "vellum_auth_host", appLinkHosts.production
             resValue "string", "vellum_auth_scheme", "vellum-assistant"
         }
         staging {
             dimension "environment"
             applicationIdSuffix ".staging"
             manifestPlaceholders = [
+                vellumAppLinkHost: appLinkHosts.staging,
                 vellumAuthScheme: "vellum-assistant-staging"
             ]
-            resValue "string", "vellum_auth_host", "staging-assistant.vellum.ai"
+            resValue "string", "vellum_auth_host", appLinkHosts.staging
             resValue "string", "vellum_auth_scheme", "vellum-assistant-staging"
         }
         dev {
             dimension "environment"
             applicationIdSuffix ".dev"
             manifestPlaceholders = [
+                vellumAppLinkHost: appLinkHosts.dev,
                 vellumAuthScheme: "vellum-assistant-dev"
             ]
-            resValue "string", "vellum_auth_host", "dev-assistant.vellum.ai"
+            resValue "string", "vellum_auth_host", appLinkHosts.dev
             resValue "string", "vellum_auth_scheme", "vellum-assistant-dev"
         }
     }

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -108,10 +108,6 @@
                 <data
                     android:scheme="https"
                     android:host="${vellumAppLinkHost}"
-                    android:path="/assistant/conversations" />
-                <data
-                    android:scheme="https"
-                    android:host="${vellumAppLinkHost}"
                     android:pathPrefix="/assistant/conversations/" />
                 <data
                     android:scheme="https"

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -91,6 +91,58 @@
                     android:host="voice" />
             </intent-filter>
 
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/pair" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/conversations" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:pathPrefix="/assistant/conversations/" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/settings/voice" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/account/oauth/complete" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/checkout" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/plans" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/settings/billing" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:pathPrefix="/assistant/settings/billing/" />
+                <data
+                    android:scheme="https"
+                    android:host="${vellumAppLinkHost}"
+                    android:path="/assistant/settings/usage" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
@@ -17,6 +17,7 @@ final class AndroidAppLink {
         } catch (URISyntaxException exception) {
             return null;
         }
+        String path = uri.getRawPath();
 
         if (
             !"https".equalsIgnoreCase(uri.getScheme())
@@ -24,10 +25,33 @@ final class AndroidAppLink {
                 || !expectedHost.equalsIgnoreCase(uri.getHost())
                 || uri.getRawUserInfo() != null
                 || (uri.getPort() != -1 && uri.getPort() != 443)
+                || path == null
+                || !path.equals(uri.normalize().getRawPath())
+                || !ownsPath(path)
         ) {
             return null;
         }
 
         return uri;
+    }
+
+    private static boolean ownsPath(String path) {
+        if (path == null || path.indexOf('%') >= 0) {
+            return false;
+        }
+        switch (path) {
+            case "/assistant":
+            case "/assistant/pair":
+            case "/assistant/settings/voice":
+            case "/account/oauth/complete":
+            case "/assistant/checkout":
+            case "/assistant/plans":
+            case "/assistant/settings/billing":
+            case "/assistant/settings/usage":
+                return true;
+            default:
+                return path.startsWith("/assistant/conversations/")
+                    || path.startsWith("/assistant/settings/billing/");
+        }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
@@ -1,0 +1,33 @@
+package ai.vellum.assistant;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+final class AndroidAppLink {
+    private AndroidAppLink() {}
+
+    static URI parse(String raw, String expectedHost) {
+        if (raw == null || expectedHost == null) {
+            return null;
+        }
+
+        final URI uri;
+        try {
+            uri = new URI(raw);
+        } catch (URISyntaxException exception) {
+            return null;
+        }
+
+        if (
+            !"https".equalsIgnoreCase(uri.getScheme())
+                || uri.getHost() == null
+                || !expectedHost.equalsIgnoreCase(uri.getHost())
+                || uri.getRawUserInfo() != null
+                || (uri.getPort() != -1 && uri.getPort() != 443)
+        ) {
+            return null;
+        }
+
+        return uri;
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -44,8 +44,8 @@ public class MainActivity extends BridgeActivity {
         if (pendingConnect == null) {
             pendingConnect = consumeConnectIntent(getIntent());
         }
-        pendingAppLink = consumeAppLinkIntent(getIntent());
         configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
+        pendingAppLink = consumeAppLinkIntent(getIntent());
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
@@ -153,7 +153,12 @@ public class MainActivity extends BridgeActivity {
     }
 
     private URI consumeAppLinkIntent(Intent intent) {
-        if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
+        if (
+            intent == null
+                || !Intent.ACTION_VIEW.equals(intent.getAction())
+                || effectiveServer != null
+                || pendingConnect != null
+        ) {
             return null;
         }
         URI appLink = AndroidAppLink.parse(
@@ -183,6 +188,10 @@ public class MainActivity extends BridgeActivity {
 
     private void deliverPendingAppLink() {
         if (pendingAppLink == null || bridge == null) {
+            return;
+        }
+        if (effectiveServer != null || pendingConnect != null) {
+            pendingAppLink = null;
             return;
         }
         URI appLink = pendingAppLink;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -23,6 +23,7 @@ public class MainActivity extends BridgeActivity {
 
     private AlertDialog unreachableDialog;
     private URI effectiveServer;
+    private URI pendingAppLink;
     private ConnectDeepLink pendingConnect;
     private boolean pendingNewChat;
     private Intent pendingVoiceLaunch;
@@ -43,6 +44,7 @@ public class MainActivity extends BridgeActivity {
         if (pendingConnect == null) {
             pendingConnect = consumeConnectIntent(getIntent());
         }
+        pendingAppLink = consumeAppLinkIntent(getIntent());
         configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
@@ -54,12 +56,21 @@ public class MainActivity extends BridgeActivity {
         if (bridge != null) {
             bridge.setWebViewClient(new SelfHostedWebViewClient(bridge, this));
         }
+        deliverPendingAppLink();
         deliverPendingConnect();
         deliverPendingNewChat();
     }
 
     @Override
     protected void onNewIntent(Intent intent) {
+        URI appLink = consumeAppLinkIntent(intent);
+        if (appLink != null) {
+            super.onNewIntent(withoutData(intent));
+            pendingAppLink = appLink;
+            deliverPendingAppLink();
+            return;
+        }
+
         VoiceDeepLink.Command voiceCommand = VoiceDeepLink.parse(
             intent,
             getString(R.string.vellum_auth_scheme)
@@ -141,6 +152,22 @@ public class MainActivity extends BridgeActivity {
             && ConnectDeepLink.handles(intent.getDataString(), getString(R.string.vellum_auth_scheme));
     }
 
+    private URI consumeAppLinkIntent(Intent intent) {
+        if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
+            return null;
+        }
+        URI appLink = AndroidAppLink.parse(
+            intent.getDataString(),
+            getString(R.string.vellum_auth_host)
+        );
+        if (appLink == null) {
+            return null;
+        }
+        intent.setData(null);
+        setIntent(withoutData(intent));
+        return appLink;
+    }
+
     private Intent withoutData(Intent intent) {
         Intent sanitized = intent == null ? new Intent() : new Intent(intent);
         sanitized.setData(null);
@@ -152,6 +179,15 @@ public class MainActivity extends BridgeActivity {
             return;
         }
         bridge.getWebView().loadUrl(pendingConnect.pairPage().toASCIIString());
+    }
+
+    private void deliverPendingAppLink() {
+        if (pendingAppLink == null || bridge == null) {
+            return;
+        }
+        URI appLink = pendingAppLink;
+        pendingAppLink = null;
+        bridge.getWebView().loadUrl(appLink.toASCIIString());
     }
 
     private void finishPendingConnect(String loadedUrl) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
@@ -1,0 +1,53 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class AndroidAppLinkTest {
+    private static final String HOST = "dev-assistant.vellum.ai";
+
+    @Test
+    public void acceptsTheFlavorHostAndPreservesTheFullUrl() {
+        String raw =
+            "https://dev-assistant.vellum.ai/assistant/conversations/conv-xyz?next=%2Fassistant%2Fplans#reply%2Fmessage-123";
+
+        URI appLink = AndroidAppLink.parse(raw, HOST);
+
+        assertEquals(raw, appLink.toASCIIString());
+        assertEquals(
+            "https://dev-assistant.vellum.ai/assistant/pair?deviceCode=device-123#approval",
+            AndroidAppLink.parse(
+                "https://dev-assistant.vellum.ai/assistant/pair?deviceCode=device-123#approval",
+                HOST
+            ).toASCIIString()
+        );
+        assertEquals(
+            "https://dev-assistant.vellum.ai/account/oauth/complete?requestId=request-123",
+            AndroidAppLink.parse(
+                "https://dev-assistant.vellum.ai/account/oauth/complete?requestId=request-123",
+                HOST
+            ).toASCIIString()
+        );
+        assertEquals(
+            "https://dev-assistant.vellum.ai/assistant/settings/billing/upgrade/success",
+            AndroidAppLink.parse(
+                "https://dev-assistant.vellum.ai/assistant/settings/billing/upgrade/success",
+                HOST
+            ).toASCIIString()
+        );
+    }
+
+    @Test
+    public void rejectsOtherFlavorsAndNonHttpsUrls() {
+        assertNull(
+            AndroidAppLink.parse("https://www.vellum.ai/assistant/conversations/conv-xyz", HOST)
+        );
+        assertNull(AndroidAppLink.parse("http://dev-assistant.vellum.ai/assistant", HOST));
+        assertNull(
+            AndroidAppLink.parse("https://dev-assistant.vellum.ai:444/assistant", HOST)
+        );
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
@@ -50,4 +50,24 @@ public class AndroidAppLinkTest {
             AndroidAppLink.parse("https://dev-assistant.vellum.ai:444/assistant", HOST)
         );
     }
+
+    @Test
+    public void rejectsUnownedAndEncodedPaths() {
+        assertNull(AndroidAppLink.parse("https://dev-assistant.vellum.ai/assistant/logs", HOST));
+        assertNull(
+            AndroidAppLink.parse("https://dev-assistant.vellum.ai/assistant/pairing", HOST)
+        );
+        assertNull(
+            AndroidAppLink.parse(
+                "https://dev-assistant.vellum.ai/assistant/conversations/../logs",
+                HOST
+            )
+        );
+        assertNull(
+            AndroidAppLink.parse(
+                "https://dev-assistant.vellum.ai/assistant/conversations/%2e%2e/logs",
+                HOST
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary\n\n- Add flavor-specific, auto-verified HTTPS App Link filters for the narrow Vellum routes Android owns.\n- Route verified cold and warm links into the existing WebView without duplicating or dropping query strings and fragments.\n- Preserve all custom-scheme fallbacks and document the real Digital Asset Links deployment and physical-device verification prerequisites.\n\n## Original prompt\n\nComplete the standalone Android HTTPS App Links PR from the iOS and Android parity plan while preserving existing iOS behavior and custom-scheme fallbacks. Keep each flavor isolated under its current ai.vellum.assistant package ID, do not fabricate Play signing fingerprints, and leave production verification explicitly blocked until the matching Digital Asset Links files are deployed with real certificates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->