### PR TITLE
fix(assistant): persist one-shot surface completion when acting on a history-restored surface

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { UISurfaceCompleteEvent } from "../api/events/ui-surface-complete.js";
+import type { AssistantEvent } from "../api/index.js";
+
+let broadcastedMessages: AssistantEvent[] = [];
+const realEventHub = await import("../runtime/assistant-event-hub.js");
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  ...realEventHub,
+  broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
+}));
+
+// Stand-in for the persisted message store: `getMessages` reads it and
+// `updateMessageContent` writes back through JSON, so a read after a write
+// sees exactly what a client's turn-end history reseed would fetch.
+type StoredRow = {
+  id: string;
+  conversationId: string;
+  role: string;
+  content: Array<Record<string, unknown>>;
+  createdAt: number;
+  metadata: string | null;
+};
+let storedRows: StoredRow[] = [];
+let contentWrites: Array<{
+  id: string;
+  blocks: Array<Record<string, unknown>>;
+}> = [];
+
+const realCrud = await import("../persistence/conversation-crud.js");
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getMessages: (conversationId: string) =>
+    storedRows.filter((r) => r.conversationId === conversationId),
+  updateMessageContent: (id: string, content: string) => {
+    const blocks = JSON.parse(content) as Array<Record<string, unknown>>;
+    contentWrites.push({ id, blocks });
+    const row = storedRows.find((r) => r.id === id);
+    if (row) {
+      row.content = blocks;
+    }
+  },
+}));
+
+// Import must come AFTER mock.module so the surface module picks up the
+// mocked event hub and persistence functions.
+const { createSurfaceMutex, handleSurfaceAction } =
+  await import("../daemon/conversation-surfaces.js");
+
+import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
+import type { SurfaceType } from "../daemon/message-protocol.js";
+
+const CONVERSATION_ID = "conv-history-restored-1";
+
+type EnqueueResult = { queued: boolean; requestId: string; rejected?: boolean };
+
+function makeContext(
+  enqueueResult: EnqueueResult = { queued: false, requestId: "req-1" },
+): SurfaceConversationContext & { enqueuedContents: string[] } {
+  const enqueuedContents: string[] = [];
+  return {
+    conversationId: CONVERSATION_ID,
+    sendToClient: () => {},
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    pendingStandaloneSurfaces: new Map(),
+    recentlyCompletedStandaloneSurfaces: new Map(),
+    isProcessing: () => false,
+    enqueueMessage: (options) => {
+      enqueuedContents.push(options.content);
+      return enqueueResult;
+    },
+    getQueueDepth: () => 0,
+    processMessage: async () => "msg-1",
+    withSurface: createSurfaceMutex(),
+    enqueuedContents,
+  };
+}
+
+function seedSurfaceRow(surfaceId: string, surfaceType: string): void {
+  storedRows = [
+    {
+      id: "msg-with-surface",
+      conversationId: CONVERSATION_ID,
+      role: "assistant",
+      content: [
+        { type: "text", text: "Which one?" },
+        {
+          type: "ui_surface",
+          surfaceId,
+          surfaceType,
+          data: {
+            options: [
+              { id: "inbox", title: "Clean up my inbox" },
+              { id: "calendar", title: "Plan my week" },
+            ],
+          },
+        },
+      ],
+      createdAt: 0,
+      metadata: null,
+    },
+  ];
+}
+
+/** Re-read the persisted block the way a history reseed would. */
+function readPersistedSurface(
+  surfaceId: string,
+): Record<string, unknown> | undefined {
+  for (const row of storedRows) {
+    const block = row.content.find(
+      (b) => b.type === "ui_surface" && b.surfaceId === surfaceId,
+    );
+    if (block) {
+      return block;
+    }
+  }
+  return undefined;
+}
+
+function completionBroadcasts(surfaceId: string): UISurfaceCompleteEvent[] {
+  return broadcastedMessages.filter(
+    (m): m is UISurfaceCompleteEvent =>
+      m.type === "ui_surface_complete" && m.surfaceId === surfaceId,
+  );
+}
+
+// The payload the web client posts when a user picks an option.
+const CHOICE_PAYLOAD = {
+  choiceId: "inbox",
+  choiceTitle: "Clean up my inbox",
+  selectedIds: ["inbox"],
+  selectedTitles: ["Clean up my inbox"],
+};
+
+describe("history-restored surface completion", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+  });
+
+  test("one-shot choice surface with no in-memory state is completed and persisted", async () => {
+    const surfaceId = "surface-choice-history-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    expect(ctx.surfaceState.has(surfaceId)).toBe(false);
+
+    // The history-restored branch signals acceptance by returning nothing; the
+    // HTTP route maps that to `{ ok: true }`.
+    const result = await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "inbox",
+      CHOICE_PAYLOAD,
+    );
+    expect(result).toBeUndefined();
+
+    // The turn is still enqueued.
+    expect(ctx.enqueuedContents).toHaveLength(1);
+
+    // A re-read of persisted history reports the surface as answered, which is
+    // exactly what the client's turn-end reseed fetches.
+    const persisted = readPersistedSurface(surfaceId);
+    expect(persisted?.completed).toBe(true);
+    expect(persisted?.completionSummary).toBe(
+      'User chose: "Clean up my inbox"',
+    );
+
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe('User chose: "Clean up my inbox"');
+  });
+
+  test("in-memory surface state supplies the type when it is still present", async () => {
+    const surfaceId = "surface-choice-history-2";
+    // Nothing persisted: the type can only come from the live entry.
+    storedRows = [];
+    const ctx = makeContext();
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "choice",
+      data: {
+        options: [{ id: "inbox", title: "Clean up my inbox" }],
+        selectionMode: "single",
+      },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe('User chose: "Clean up my inbox"');
+  });
+
+  test("a non-one-shot persisted surface type is not auto-completed", async () => {
+    const surfaceId = "surface-page-history-1";
+    seedSurfaceRow(surfaceId, "dynamic_page");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "answer_selected", {
+      choiceId: "inbox",
+    });
+
+    expect(ctx.enqueuedContents).toHaveLength(1);
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+    expect(contentWrites).toHaveLength(0);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+  });
+
+  test("a rejected enqueue leaves the surface answerable", async () => {
+    const surfaceId = "surface-choice-history-3";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext({
+      queued: false,
+      requestId: "req-rejected",
+      rejected: true,
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+    expect(contentWrites).toHaveLength(0);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+    expect(ctx.surfaceActionRequestIds.size).toBe(0);
+  });
+
+  test("an explicit _completeSurface request completes a non-one-shot surface", async () => {
+    const surfaceId = "surface-page-history-2";
+    seedSurfaceRow(surfaceId, "dynamic_page");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "answer_selected", {
+      _completeSurface: true,
+      _completionSummary: "Answered",
+    });
+
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+    expect(readPersistedSurface(surfaceId)?.completionSummary).toBe("Answered");
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe("Answered");
+  });
+
+  test("the pending branch still completes a one-shot surface exactly as before", async () => {
+    const surfaceId = "surface-choice-pending-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "choice" });
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "choice",
+      data: {
+        options: [
+          { id: "inbox", title: "Clean up my inbox" },
+          { id: "calendar", title: "Plan my week" },
+        ],
+        selectionMode: "single",
+      },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(ctx.enqueuedContents).toHaveLength(1);
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    const completion = completions[0];
+    expect(completion.summary).toBe('User chose: "Clean up my inbox"');
+    // The pending branch carries the submitted payload on the broadcast.
+    expect(completion.submittedData).toEqual(CHOICE_PAYLOAD);
+  });
+});

--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -111,6 +111,25 @@ function seedSurfaceRow(surfaceId: string, surfaceType: string): void {
   ];
 }
 
+function seedConfirmationRow(
+  surfaceId: string,
+  data: Record<string, unknown>,
+): void {
+  storedRows = [
+    {
+      id: "msg-with-confirmation",
+      conversationId: CONVERSATION_ID,
+      role: "assistant",
+      content: [
+        { type: "text", text: "Are you sure?" },
+        { type: "ui_surface", surfaceId, surfaceType: "confirmation", data },
+      ],
+      createdAt: 0,
+      metadata: null,
+    },
+  ];
+}
+
 /** Re-read the persisted block the way a history reseed would. */
 function readPersistedSurface(
   surfaceId: string,
@@ -180,6 +199,45 @@ describe("history-restored surface completion", () => {
     const completions = completionBroadcasts(surfaceId);
     expect(completions).toHaveLength(1);
     expect(completions[0].summary).toBe('User chose: "Clean up my inbox"');
+  });
+
+  test("a history-restored confirmation quotes its persisted confirmLabel", async () => {
+    const surfaceId = "surface-confirm-history-1";
+    seedConfirmationRow(surfaceId, {
+      message: "Delete this project?",
+      confirmLabel: "Delete forever",
+      cancelLabel: "Keep it",
+    });
+    const ctx = makeContext();
+
+    // Neither live map has anything: the labels can only come from history.
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    expect(ctx.surfaceState.has(surfaceId)).toBe(false);
+
+    await handleSurfaceAction(ctx, surfaceId, "confirm", {});
+
+    expect(readPersistedSurface(surfaceId)?.completionSummary).toBe(
+      'User chose: "Delete forever"',
+    );
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe('User chose: "Delete forever"');
+  });
+
+  test("a history-restored confirmation quotes its persisted cancelLabel", async () => {
+    const surfaceId = "surface-confirm-history-2";
+    seedConfirmationRow(surfaceId, {
+      message: "Delete this project?",
+      confirmLabel: "Delete forever",
+      cancelLabel: "Keep it",
+    });
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "cancel", {});
+
+    expect(readPersistedSurface(surfaceId)?.completionSummary).toBe(
+      'User chose: "Keep it"',
+    );
   });
 
   test("in-memory surface state supplies the type when it is still present", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
@@ -20,10 +20,10 @@ mock.module("../persistence/conversation-crud.js", () => ({
 
 // Import must come AFTER mock.module so the surface module picks up the
 // mocked persistence functions.
-const { findPersistedSurfaceType } =
+const { findPersistedSurfaceInfo } =
   await import("../daemon/conversation-surfaces.js");
 
-const CONVERSATION_ID = "conv-persisted-type-1";
+const CONVERSATION_ID = "conv-persisted-info-1";
 
 function seedRows(rows: Array<{ id: string; content: unknown[] }>): void {
   getMessagesImpl = () =>
@@ -37,7 +37,7 @@ function seedRows(rows: Array<{ id: string; content: unknown[] }>): void {
     }));
 }
 
-describe("findPersistedSurfaceType", () => {
+describe("findPersistedSurfaceInfo", () => {
   beforeEach(() => {
     getMessagesImpl = () => [];
   });
@@ -58,9 +58,52 @@ describe("findPersistedSurfaceType", () => {
       },
     ]);
 
-    expect(findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1")).toBe(
-      "choice",
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1")
+        ?.surfaceType,
+    ).toBe("choice");
+  });
+
+  test("returns the data of a persisted ui_surface block", () => {
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-confirm-1",
+            surfaceType: "confirmation",
+            data: { message: "Delete it?", confirmLabel: "Delete forever" },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-confirm-1")?.data,
+    ).toEqual({ message: "Delete it?", confirmLabel: "Delete forever" });
+  });
+
+  test("reports no data when the block carries no object data", () => {
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-dataless-1",
+            surfaceType: "choice",
+          },
+        ],
+      },
+    ]);
+
+    const info = findPersistedSurfaceInfo(
+      CONVERSATION_ID,
+      "surface-dataless-1",
     );
+    expect(info?.surfaceType).toBe("choice");
+    expect(info?.data).toBeUndefined();
   });
 
   test("returns undefined for an unknown surfaceId", () => {
@@ -79,7 +122,7 @@ describe("findPersistedSurfaceType", () => {
     ]);
 
     expect(
-      findPersistedSurfaceType(CONVERSATION_ID, "surface-missing"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-missing"),
     ).toBeUndefined();
   });
 
@@ -87,7 +130,7 @@ describe("findPersistedSurfaceType", () => {
     seedRows([]);
 
     expect(
-      findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1"),
     ).toBeUndefined();
   });
 
@@ -114,11 +157,12 @@ describe("findPersistedSurfaceType", () => {
     ]);
 
     expect(
-      findPersistedSurfaceType(CONVERSATION_ID, "surface-compacted-1"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-compacted-1")
+        ?.surfaceType,
     ).toBe("choice");
   });
 
-  test("returns undefined when the block carries no string surfaceType", () => {
+  test("reports no surfaceType when the block carries no string one", () => {
     seedRows([
       {
         id: "msg-1",
@@ -128,9 +172,12 @@ describe("findPersistedSurfaceType", () => {
       },
     ]);
 
-    expect(
-      findPersistedSurfaceType(CONVERSATION_ID, "surface-typeless-1"),
-    ).toBeUndefined();
+    const info = findPersistedSurfaceInfo(
+      CONVERSATION_ID,
+      "surface-typeless-1",
+    );
+    expect(info).toBeDefined();
+    expect(info?.surfaceType).toBeUndefined();
   });
 
   test("returns undefined rather than throwing when the DB read fails", () => {
@@ -139,7 +186,7 @@ describe("findPersistedSurfaceType", () => {
     };
 
     expect(
-      findPersistedSurfaceType(CONVERSATION_ID, "surface-choice-1"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1"),
     ).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -425,7 +425,7 @@ export function findPersistedSurfaceType(
  * Complete a `ui_surface` card and notify live clients, addressed only by
  * conversation + surface id.
  *
- * Unlike {@link completeSurfaceFromAction}, this needs no live `Conversation`
+ * Unlike {@link maybeCompleteSurfaceAfterAction}, this needs no live `Conversation`
  * instance, so it can run from flows that don't own one — projecting a
  * terminal guardian-request status onto its in-app approval card when the
  * request was resolved on another surface (or by the expiry sweep). Persists
@@ -1766,20 +1766,6 @@ function maybeEmitActivationMoment(
   recordActivationMoment(ctx, moment);
 }
 
-function completeSurfaceFromAction(
-  ctx: SurfaceConversationContext,
-  surfaceId: string,
-  summary: string,
-): void {
-  broadcastMessage({
-    type: "ui_surface_complete",
-    conversationId: ctx.conversationId,
-    surfaceId,
-    summary,
-  });
-  markSurfaceCompleted(ctx, surfaceId, summary);
-}
-
 // One-shot interactive surfaces auto-complete once their action message is
 // accepted (they never accept further actions).
 const ONE_SHOT_SURFACE_TYPES = [
@@ -1790,6 +1776,44 @@ const ONE_SHOT_SURFACE_TYPES = [
   "file_upload",
   "task_preferences",
 ];
+
+/**
+ * The completion rule for an accepted surface action: complete when the client
+ * asked for it explicitly (`_completeSurface`), or when the surface is a
+ * one-shot type. No-op otherwise.
+ *
+ * Both `handleSurfaceAction` branches (pending and history-restored) route
+ * completion through here, and both call it only after `enqueueMessage`
+ * accepted the turn, so a rejected enqueue leaves the surface answerable.
+ * Broadcasts `ui_surface_complete` so live clients converge, and persists the
+ * completion so a history reseed reports the surface as answered.
+ */
+function maybeCompleteSurfaceAfterAction(
+  ctx: SurfaceConversationContext,
+  surfaceId: string,
+  opts: {
+    surfaceType: string | undefined;
+    requestedSummary: string | null;
+    fallbackSummary: string;
+    submittedData?: Record<string, unknown>;
+  },
+): void {
+  const isOneShot =
+    opts.surfaceType !== undefined &&
+    ONE_SHOT_SURFACE_TYPES.includes(opts.surfaceType);
+  if (!opts.requestedSummary && !isOneShot) {
+    return;
+  }
+  const summary = opts.requestedSummary ?? opts.fallbackSummary;
+  broadcastMessage({
+    type: "ui_surface_complete",
+    conversationId: ctx.conversationId,
+    surfaceId,
+    summary,
+    submittedData: opts.submittedData,
+  });
+  markSurfaceCompleted(ctx, surfaceId, summary);
+}
 
 export async function handleSurfaceAction(
   ctx: SurfaceConversationContext,
@@ -2117,11 +2141,34 @@ export async function handleSurfaceAction(
     // (and the one-shot tag stays intact for the user's retry).
     maybeEmitActivationMoment(ctx, surfaceId);
 
-    const requestedCompletionSummary =
-      getRequestedSurfaceCompletionSummary(mergedData);
-    if (requestedCompletionSummary) {
-      completeSurfaceFromAction(ctx, surfaceId, requestedCompletionSummary);
+    // In-memory state is absent whenever the surface outlived its live entry
+    // (client reload, daemon restart), so the persisted block is the only
+    // remaining source for the surface type.
+    const resolvedSurfaceType =
+      stored?.surfaceType ??
+      findPersistedSurfaceType(ctx.conversationId, surfaceId);
+    if (!stored) {
+      log.info(
+        {
+          conversationId: ctx.conversationId,
+          surfaceId,
+          actionId,
+          resolvedSurfaceType,
+        },
+        "Surface action handled with no in-memory surface state",
+      );
     }
+
+    maybeCompleteSurfaceAfterAction(ctx, surfaceId, {
+      surfaceType: resolvedSurfaceType,
+      requestedSummary: getRequestedSurfaceCompletionSummary(mergedData),
+      fallbackSummary: buildCompletionSummary(
+        resolvedSurfaceType,
+        actionId,
+        mergedData,
+        stored?.data as Record<string, unknown> | undefined,
+      ),
+    });
 
     // One-shot: clear accumulated state now that the message has been accepted.
     // Deferred until after rejection check so state is preserved for retry on rejection.
@@ -2362,26 +2409,12 @@ export async function handleSurfaceAction(
   // one-shot tag stays intact for the user's retry).
   maybeEmitActivationMoment(ctx, surfaceId);
 
-  const requestedCompletionSummary =
-    getRequestedSurfaceCompletionSummary(mergedData);
-
-  // One-shot interactive surfaces — auto-complete now that the message has
-  // been accepted. Deferred until after rejection check so the surface stays
-  // active and retryable if the queue was full.
-  if (
-    requestedCompletionSummary ||
-    ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)
-  ) {
-    const completionSummary = requestedCompletionSummary ?? summary;
-    broadcastMessage({
-      type: "ui_surface_complete",
-      conversationId: ctx.conversationId,
-      surfaceId,
-      summary: completionSummary,
-      submittedData: mergedDataForText,
-    });
-    markSurfaceCompleted(ctx, surfaceId, completionSummary);
-  }
+  maybeCompleteSurfaceAfterAction(ctx, surfaceId, {
+    surfaceType: pending.surfaceType,
+    requestedSummary: getRequestedSurfaceCompletionSummary(mergedData),
+    fallbackSummary: summary,
+    submittedData: mergedDataForText,
+  });
 
   // One-shot: clear accumulated state now that the message has been accepted.
   // Deferred until after rejection check so state is preserved for retry on rejection.

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -197,7 +197,7 @@ type PersistedSurfaceHit = {
  * different blocks.
  *
  * The scan is deliberately unbounded by compaction (see
- * {@link findPersistedSurfaceType}), and it throws rather than swallowing DB
+ * {@link findPersistedSurfaceInfo}), and it throws rather than swallowing DB
  * errors so each caller keeps its own logging.
  */
 function findPersistedSurfaceBlock(
@@ -389,8 +389,19 @@ export function markSurfaceCompleted(
   }
 }
 
+/** What a persisted `ui_surface` block can still tell us once it is cold. */
+export type PersistedSurfaceInfo = {
+  /** The block's `surfaceType`, absent when it carries no string type. */
+  surfaceType: string | undefined;
+  /** The block's `data`, absent when it carries no plain-object data. */
+  data: Record<string, unknown> | undefined;
+};
+
 /**
- * Read a `ui_surface` block's `surfaceType` out of persisted history.
+ * Read a `ui_surface` block's `surfaceType` and `data` out of persisted
+ * history. Both travel together because every caller that has lost the live
+ * entry needs both: the type to decide completion, the data for the labels a
+ * completion summary quotes.
  *
  * This must NOT be routed through `findPersistedSurfaceState`
  * (`runtime/routes/surface-conversation-resolver.ts`): that helper is bounded
@@ -403,19 +414,30 @@ export function markSurfaceCompleted(
  * `runtime/routes/surface-content-routes.ts` for why that shared map must not
  * absorb scan results.
  */
-export function findPersistedSurfaceType(
+export function findPersistedSurfaceInfo(
   conversationId: string,
   surfaceId: string,
-): string | undefined {
+): PersistedSurfaceInfo | undefined {
   try {
     const hit = findPersistedSurfaceBlock(conversationId, surfaceId);
-    if (hit && typeof hit.block.surfaceType === "string") {
-      return hit.block.surfaceType;
+    if (!hit) {
+      return undefined;
     }
+    const data = hit.block.data;
+    return {
+      surfaceType:
+        typeof hit.block.surfaceType === "string"
+          ? hit.block.surfaceType
+          : undefined,
+      data:
+        typeof data === "object" && data !== null && !Array.isArray(data)
+          ? (data as Record<string, unknown>)
+          : undefined,
+    };
   } catch (err) {
     log.warn(
       { err, conversationId, surfaceId },
-      "Failed to read persisted surface type from DB",
+      "Failed to read persisted surface info from DB",
     );
   }
   return undefined;
@@ -2143,10 +2165,16 @@ export async function handleSurfaceAction(
 
     // In-memory state is absent whenever the surface outlived its live entry
     // (client reload, daemon restart), so the persisted block is the only
-    // remaining source for the surface type.
-    const resolvedSurfaceType =
-      stored?.surfaceType ??
-      findPersistedSurfaceType(ctx.conversationId, surfaceId);
+    // remaining source for both the surface type and the labels the completion
+    // summary quotes. One lookup serves both, and is skipped entirely while
+    // live state still covers them.
+    const persisted = stored
+      ? undefined
+      : findPersistedSurfaceInfo(ctx.conversationId, surfaceId);
+    const resolvedSurfaceType = stored?.surfaceType ?? persisted?.surfaceType;
+    const resolvedSurfaceData = (stored?.data ?? persisted?.data) as
+      | Record<string, unknown>
+      | undefined;
     if (!stored) {
       log.info(
         {
@@ -2166,7 +2194,7 @@ export async function handleSurfaceAction(
         resolvedSurfaceType,
         actionId,
         mergedData,
-        stored?.data as Record<string, unknown> | undefined,
+        resolvedSurfaceData,
       ),
     });
 


### PR DESCRIPTION
## Summary
- Complete one-shot surfaces (choice, form, confirmation, etc.) when the action arrives for a surface with no in-memory pending entry, matching what the pending branch already does
- Resolve the surface type from the persisted block when in-memory state is gone, which is the case this path exists to serve
- Log when an action is handled for a surface with no in-memory state, so the condition is greppable

Without this, the daemon accepts the action and enqueues the turn but never records the completion, so the client's turn-end history reseed reverts the card to un-answered and the user answers twice.

Part of plan: choice-surface-completion-persist.md (PR 3 of 3)