### PR TITLE
fix(memory): fail-closed retrospective finalization, truthful job outcomes, bounded deferrals, consolidation cancellation/ownership

### DIFF
--- a/assistant/src/__tests__/agent-loop-pre-model-call-messages.test.ts
+++ b/assistant/src/__tests__/agent-loop-pre-model-call-messages.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the `pre-model-call` hook's outbound-messages contract: a hook can
+ * rewrite the wire payload the loop sends (without touching the loop's own
+ * history bookkeeping) and can fail the model call outright via
+ * `decision: "fail"`, ending the turn through the loop's normal error path
+ * before anything reaches the provider. A throwing hook stays fail-open (the
+ * call proceeds with the original request).
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
+import type { PreModelCallContext } from "../plugin-api/types.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import { registerPlugin } from "../plugins/registry.js";
+import type { Message } from "../providers/types.js";
+import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "Hello" }],
+};
+
+function collect(events: AgentEvent[]): (event: AgentEvent) => void {
+  return (event) => events.push(event);
+}
+
+function registerPreModelCallPlugin(
+  hook: (ctx: PreModelCallContext) => void,
+): void {
+  registerPlugin({
+    manifest: { name: "test-pre-model-call", version: "0.0.0" },
+    hooks: {
+      "pre-model-call": async (ctx: PreModelCallContext) => {
+        hook(ctx);
+      },
+    },
+  });
+}
+
+describe("agent loop pre-model-call outbound messages", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+  });
+
+  test("a hook-rewritten messages array is what the provider receives", async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.messages = [
+        { role: "user", content: [{ type: "text", text: "rewritten" }] },
+      ];
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0].messages;
+    expect(sent).toHaveLength(1);
+    expect(sent[0].content).toEqual([{ type: "text", text: "rewritten" }]);
+    // Wire payload only: the loop's own history keeps the original user
+    // message untouched.
+    expect(history[0].content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  test("in-place mutation of ctx.messages reaches the wire without touching history", async () => {
+    registerPreModelCallPlugin((ctx) => {
+      for (const message of ctx.messages) {
+        for (let i = 0; i < message.content.length; i++) {
+          const block = message.content[i];
+          if (block.type === "text") {
+            message.content[i] = {
+              type: "text",
+              text: block.text.toUpperCase(),
+            };
+          }
+        }
+      }
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls[0].messages[0].content).toEqual([
+      { type: "text", text: "HELLO" },
+    ]);
+    expect(history[0].content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  test('decision "fail" ends the turn through the error path without a provider call', async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.decision = "fail";
+      ctx.failureReason = "media bound for a text-only route";
+    });
+    const { provider, calls } = createMockProvider([textResponse("never")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type !== "error") {
+      throw new Error("type narrowing");
+    }
+    expect(errorEvent.error.message).toBe("media bound for a text-only route");
+    const exitEvent = events.find((e) => e.type === "agent_loop_exit");
+    expect(exitEvent).toBeDefined();
+    if (exitEvent?.type !== "agent_loop_exit") {
+      throw new Error("type narrowing");
+    }
+    expect(exitEvent.reason).toBe("error");
+  });
+
+  test('decision "fail" without a failureReason surfaces the generic message', async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.decision = "fail";
+    });
+    const { provider, calls } = createMockProvider([textResponse("never")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    if (errorEvent?.type !== "error") {
+      throw new Error("expected an error event");
+    }
+    expect(errorEvent.error.message).toBe(
+      "A pre-model-call hook failed this model call",
+    );
+  });
+
+  test("a throwing hook is fail-open: the call proceeds with the original request", async () => {
+    registerPreModelCallPlugin(() => {
+      throw new Error("hook exploded");
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].messages[0].content).toEqual([
+      { type: "text", text: "Hello" },
+    ]);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1619,17 +1619,27 @@ export class AgentLoop {
           signal,
         };
 
-        // Let plugins edit the outbound request and opt this call into deferred
-        // output streaming. Runs for every provider call; hooks self-gate on
-        // call site / conversation. Fail-open: a throwing hook leaves the
-        // request unchanged and streaming live.
+        // Let plugins edit the outbound request (system prompt and wire
+        // messages), opt this call into deferred output streaming, or fail the
+        // call outright. Runs for every provider call; hooks self-gate on
+        // call site / conversation. Fail-open for hook THROWS: a throwing hook
+        // leaves the request unchanged and streaming live. A hook that must
+        // stop the call instead sets `decision: "fail"` on the context; the
+        // loop then ends the turn through its normal error path (below,
+        // outside this catch) instead of sending.
+        let outboundMessages = providerHistory;
+        let preModelCallFailure: Error | null = null;
         try {
           const preModelCtx: PreModelCallInputContext = {
             conversationId: this.conversationId,
             callSite: callSite ?? null,
             systemPrompt: providerOptions.systemPrompt ?? null,
             modelProfile: effectiveOverrideProfile ?? null,
+            modelProfileKey: options.modelProfileKey ?? null,
+            messages: providerHistory,
             deferAssistantOutput: false,
+            decision: "proceed",
+            failureReason: null,
           };
           const finalPreModelCtx = await traceAsyncSection(
             "agent-loop:pre-model-call-hook",
@@ -1669,11 +1679,40 @@ export class AgentLoop {
           // The hook owns the policy (it sees `callSite`/conversation and
           // self-gates); the loop honors whatever it decides.
           deferAssistantOutput = finalPreModelCtx.deferAssistantOutput;
+          // Adopt a rewritten wire payload. The hook pipeline hands hooks a
+          // deep clone of the context, so the settled array never aliases
+          // `history`: only what goes on the wire changes, the loop's own
+          // history bookkeeping is untouched. The pipeline's output schema
+          // already discarded any hook mutation carrying malformed messages.
+          if (Array.isArray(finalPreModelCtx.messages)) {
+            outboundMessages = finalPreModelCtx.messages;
+          }
+          if (finalPreModelCtx.decision === "fail") {
+            preModelCallFailure = new Error(
+              finalPreModelCtx.failureReason ??
+                "A pre-model-call hook failed this model call",
+            );
+          }
         } catch (preModelCallError) {
           rlog.error(
             { err: preModelCallError },
             "pre-model-call hook failed — proceeding with the original request",
           );
+        }
+
+        // Honor a hook-chain `decision: "fail"` before anything is sent or a
+        // persistence row is reserved. Thrown here (not inside the hook
+        // try/catch, which contains hook errors fail-open) so the turn ends
+        // through the loop's normal error path: `error` event, stop hook,
+        // exit reason "error". Background callers that retry failed runs
+        // (memory retrospective/consolidation wakes) observe an ordinary
+        // failed run.
+        if (preModelCallFailure) {
+          rlog.warn(
+            { err: preModelCallFailure, callSite },
+            "pre-model-call hook failed the model call; ending the turn without sending",
+          );
+          throw preModelCallFailure;
         }
 
         // Announce the LLM-call boundary so downstream handlers (the
@@ -1703,7 +1742,7 @@ export class AgentLoop {
         let response: ProviderResponse;
         try {
           response = await traceAsyncSection("agent-loop:provider-send", () =>
-            this.provider.sendMessage(providerHistory, providerOptions),
+            this.provider.sendMessage(outboundMessages, providerOptions),
           );
         } catch (llmCallError) {
           // Skip recording on abort — the user cancelled the request and
@@ -1721,7 +1760,7 @@ export class AgentLoop {
             // misrepresent both.
             const rawRequest = {
               provider: this.provider.name,
-              messages: providerHistory,
+              messages: outboundMessages,
               tools: providerOptions.tools,
               systemPrompt: providerOptions.systemPrompt,
               config: providerOptions.config,

--- a/assistant/src/cli/commands/memory/__tests__/memory-retrospective.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-retrospective.test.ts
@@ -1,22 +1,269 @@
 /**
- * Tests for the pure helpers behind `assistant memory retrospective run`'s
- * rewind flags: the `--from` / `--from-start` resolver and the cursor
- * formatter. The command's action wiring is exercised end-to-end by the
- * retrospective job tests plus manual CLI runs; these cover the flag
- * semantics that gate the overrideCursor replay path.
+ * Tests for `assistant memory retrospective run`:
+ *
+ *   - the pure helpers behind the rewind flags (the `--from` / `--from-start`
+ *     resolver and the cursor formatter), and
+ *   - the run action itself, exercised through the commander program with
+ *     every side-effecting dependency replaced by a recorder: the fork-based
+ *     retrospective job, the state store (reads and writes), the accounting
+ *     window counter, the config loader, and the conversation/message lookups.
+ *
+ * Every disk- or DB-touching module the action can lazily import is mocked,
+ * so the recorders plus the captured stdout/log output are the action's
+ * complete side-effect surface. The tests assert that dry runs and
+ * validation failures perform zero writes, and that real runs delegate all
+ * state mutation to the job (the CLI itself never writes).
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const noop = () => {};
-const fakeLogger = { info: noop, warn: noop, error: noop, debug: noop };
+import { Command } from "commander";
+
+import type { MemoryRetrospectiveState } from "../../../../plugins/defaults/memory/memory-retrospective-state.js";
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+interface JobCall {
+  conversationId: string;
+  config: unknown;
+  options: { overrideCursor: string | null } | undefined;
+}
+
+/** Every `runForkBasedRetrospective` invocation, in order. */
+let jobCalls: JobCall[] = [];
+
+/** Outcome the job mock returns; overridable per test. */
+let jobResult: unknown = { kind: "no_new_messages" };
+
+/** Every state-store write, in order. Must stay empty in every test. */
+let stateWrites: { fn: string; args: unknown[] }[] = [];
+
+/** Conversation ids passed to `getRetrospectiveState`, in order. */
+let stateReads: string[] = [];
+
+/** Row `getRetrospectiveState` returns (null = no row). */
+let stateRow: MemoryRetrospectiveState | null = null;
+
+/** Every `getRetrospectiveMessagesAfter` call, in order. */
+let accountingCalls: { conversationId: string; afterMessageId: unknown }[] = [];
+
+/** Rows the accounting mock returns for the unprocessed window. */
+let unprocessedMessages: unknown[] = [];
+
+/** Conversation ids `getConversation` treats as existing. */
+let knownConversationIds = new Set<string>();
+
+/** Message ids `getMessageById` treats as existing. */
+let knownMessageIds = new Set<string>();
+
+/** Conversation ids passed to `getConversation`, in order. */
+let conversationLookups: string[] = [];
+
+/** Number of `getConfig` calls (each real call reads config from disk). */
+let configCalls = 0;
+
+/** Sentinel config object the loader mock returns. */
+const sentinelConfig = { sentinel: "config" };
+
+/** Captured log output for assertion. */
+let logOutput: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module(
+  "../../../../plugins/defaults/memory/memory-retrospective-job.js",
+  () => ({
+    runForkBasedRetrospective: async (
+      conversationId: string,
+      config: unknown,
+      options?: { overrideCursor: string | null },
+    ) => {
+      jobCalls.push({ conversationId, config, options });
+      return jobResult;
+    },
+  }),
+);
+
+mock.module(
+  "../../../../plugins/defaults/memory/memory-retrospective-state.js",
+  () => ({
+    getRetrospectiveState: (conversationId: string) => {
+      stateReads.push(conversationId);
+      return stateRow;
+    },
+    listRetrospectiveStates: () => (stateRow ? [stateRow] : []),
+    upsertRetrospectiveState: async (...args: unknown[]) => {
+      stateWrites.push({ fn: "upsertRetrospectiveState", args });
+    },
+    appendToRememberedLog: (...args: unknown[]) => {
+      stateWrites.push({ fn: "appendToRememberedLog", args });
+      return [];
+    },
+    forkRetrospectiveState: (...args: unknown[]) => {
+      stateWrites.push({ fn: "forkRetrospectiveState", args });
+    },
+    bumpRetrospectiveLastRunAt: async (...args: unknown[]) => {
+      stateWrites.push({ fn: "bumpRetrospectiveLastRunAt", args });
+    },
+  }),
+);
+
+mock.module(
+  "../../../../plugins/defaults/memory/memory-retrospective-accounting.js",
+  () => ({
+    getRetrospectiveMessagesAfter: (
+      conversationId: string,
+      afterMessageId: unknown,
+    ) => {
+      accountingCalls.push({ conversationId, afterMessageId });
+      return unprocessedMessages;
+    },
+  }),
+);
+
+mock.module("../../../../persistence/conversation-crud.js", () => ({
+  getConversation: (id: string) => {
+    conversationLookups.push(id);
+    return knownConversationIds.has(id) ? { id } : null;
+  },
+  getMessageById: (messageId: string, _conversationId: string) =>
+    knownMessageIds.has(messageId) ? { id: messageId } : null,
+}));
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => {
+    configCalls += 1;
+    return sentinelConfig;
+  },
+}));
+
+const capture = (...args: unknown[]) => {
+  logOutput.push(args.map((a) => JSON.stringify(a)).join(" "));
+};
+const fakeLogger = {
+  info: capture,
+  warn: capture,
+  error: capture,
+  debug: () => {},
+};
 mock.module("../../../../util/logger.js", () => ({
   getLogger: () => fakeLogger,
   getCliLogger: () => fakeLogger,
 }));
 
-const { describeCursor, resolveRunCursorOverride } =
-  await import("../memory-retrospective.js");
+// ---------------------------------------------------------------------------
+// Import the module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const {
+  describeCursor,
+  registerMemoryRetrospectiveCommand,
+  resolveRunCursorOverride,
+} = await import("../memory-retrospective.js");
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: () => {},
+    writeOut: () => {},
+  });
+  const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
+  registerMemoryRetrospectiveCommand(memory);
+  return program;
+}
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = buildProgram();
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+  return { stdout: stdoutChunks.join(""), exitCode };
+}
+
+const INVOKED_OUTCOME = {
+  kind: "invoked",
+  backgroundConversationId: "fork-conv-1",
+  cutoffMessageId: "msg-9",
+  newMessageCount: 3,
+  followUpJobIds: [],
+};
+
+function sampleStateRow(): MemoryRetrospectiveState {
+  return {
+    conversationId: "conv-1",
+    lastProcessedMessageId: "msg-5",
+    lastRunAt: 1_720_000_000_000,
+    rememberedLog: ["fact one", "fact two"],
+  };
+}
+
+/** Asserts the action performed no writes through any recorded channel. */
+function expectNoWrites(): void {
+  expect(jobCalls).toHaveLength(0);
+  expect(stateWrites).toHaveLength(0);
+  expect(configCalls).toBe(0);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jobCalls = [];
+  jobResult = { kind: "no_new_messages" };
+  stateWrites = [];
+  stateReads = [];
+  stateRow = null;
+  accountingCalls = [];
+  unprocessedMessages = [];
+  knownConversationIds = new Set(["conv-1"]);
+  knownMessageIds = new Set(["msg-3"]);
+  conversationLookups = [];
+  configCalls = 0;
+  logOutput = [];
+  process.exitCode = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
 
 describe("resolveRunCursorOverride", () => {
   test("neither flag: default (persisted cursor is used)", () => {
@@ -74,5 +321,291 @@ describe("describeCursor", () => {
 
   test("a concrete message id renders verbatim", () => {
     expect(describeCursor("msg-123")).toBe("msg-123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run action: --dry-run
+// ---------------------------------------------------------------------------
+
+describe("run --dry-run", () => {
+  test("performs zero writes and reports cursors, window size, lastRunAt, and log size", async () => {
+    stateRow = sampleStateRow();
+    unprocessedMessages = [{}, {}, {}];
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      kind: "dry_run",
+      conversationId: "conv-1",
+      currentCursor: "msg-5",
+      overrideCursor: "msg-5",
+      unprocessedMessageCount: 3,
+      lastRunAt: 1_720_000_000_000,
+      rememberedLogEntryCount: 2,
+    });
+
+    expectNoWrites();
+    // The window is counted from the current cursor (a read-only lookup).
+    expect(accountingCalls).toEqual([
+      { conversationId: "conv-1", afterMessageId: "msg-5" },
+    ]);
+  });
+
+  test("--from-start --dry-run reports the override target without writing", async () => {
+    stateRow = sampleStateRow();
+    unprocessedMessages = [{}, {}, {}, {}, {}];
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from-start",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const report = JSON.parse(stdout);
+    expect(report.currentCursor).toBe("msg-5");
+    expect(report.overrideCursor).toBeNull();
+    expect(report.unprocessedMessageCount).toBe(5);
+
+    expectNoWrites();
+    expect(accountingCalls).toEqual([
+      { conversationId: "conv-1", afterMessageId: null },
+    ]);
+  });
+
+  test("a conversation with no state row reports null cursor and empty log", async () => {
+    stateRow = null;
+    unprocessedMessages = [{}];
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      kind: "dry_run",
+      conversationId: "conv-1",
+      currentCursor: null,
+      overrideCursor: null,
+      unprocessedMessageCount: 1,
+      lastRunAt: null,
+      rememberedLogEntryCount: 0,
+    });
+    expectNoWrites();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run action: validation failures happen before any mutation
+// ---------------------------------------------------------------------------
+
+describe("run validation", () => {
+  test("an unknown conversation id fails before any mutation", async () => {
+    knownConversationIds = new Set();
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-missing",
+      "--from",
+      "msg-3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(stdout);
+    expect(payload.kind).toBe("error");
+    expect(payload.error).toContain("Conversation not found: conv-missing");
+
+    expectNoWrites();
+    expect(stateReads).toHaveLength(0);
+    expect(accountingCalls).toHaveLength(0);
+  });
+
+  test("--from with a message id outside the conversation fails before any mutation", async () => {
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from",
+      "msg-404",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(stdout);
+    expect(payload.kind).toBe("error");
+    expect(payload.error).toContain("msg-404");
+    expect(payload.error).toContain("not found");
+
+    expectNoWrites();
+    expect(stateReads).toHaveLength(0);
+  });
+
+  test("--from together with --from-start fails before any work at all", async () => {
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from",
+      "msg-3",
+      "--from-start",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(stdout);
+    expect(payload.kind).toBe("error");
+    expect(payload.error).toContain("mutually exclusive");
+
+    expectNoWrites();
+    // Flag resolution fails before validation, so nothing is even read.
+    expect(conversationLookups).toHaveLength(0);
+    expect(stateReads).toHaveLength(0);
+    expect(accountingCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run action: job delegation
+// ---------------------------------------------------------------------------
+
+describe("run job delegation", () => {
+  test("a failed replay (no_usable_output) is reported and the CLI writes nothing on top", async () => {
+    jobResult = {
+      kind: "no_usable_output",
+      reason: "verifier rejected the transcript",
+      conversationId: "fork-conv-1",
+    };
+
+    const { exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(jobCalls).toHaveLength(1);
+    expect(jobCalls[0].conversationId).toBe("conv-1");
+    expect(jobCalls[0].options).toBeUndefined();
+    // State ownership stays with the job: the CLI adds no writes of its own.
+    expect(stateWrites).toHaveLength(0);
+    expect(logOutput.join("\n")).toContain("no usable output");
+    expect(logOutput.join("\n")).toContain("verifier rejected the transcript");
+  });
+
+  test("a plain run passes no overrideCursor and prints the outcome", async () => {
+    jobResult = INVOKED_OUTCOME;
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(jobCalls).toHaveLength(1);
+    expect(jobCalls[0].config).toBe(sentinelConfig);
+    expect(jobCalls[0].options).toBeUndefined();
+    expect(JSON.parse(stdout)).toEqual(INVOKED_OUTCOME);
+    expect(stateWrites).toHaveLength(0);
+    // A plain run defers validation to the job itself.
+    expect(conversationLookups).toHaveLength(0);
+  });
+
+  test("--from-start passes a null overrideCursor and prints the resulting state row", async () => {
+    jobResult = INVOKED_OUTCOME;
+    stateRow = sampleStateRow();
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from-start",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(jobCalls).toHaveLength(1);
+    expect(jobCalls[0].options).toEqual({ overrideCursor: null });
+    expect(JSON.parse(stdout)).toEqual({
+      outcome: INVOKED_OUTCOME,
+      state: sampleStateRow(),
+    });
+    expect(stateWrites).toHaveLength(0);
+  });
+
+  test("--from <messageId> passes that id as the overrideCursor", async () => {
+    jobResult = INVOKED_OUTCOME;
+    stateRow = sampleStateRow();
+
+    const { stdout, exitCode } = await runCommand([
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from",
+      "msg-3",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(jobCalls).toHaveLength(1);
+    expect(jobCalls[0].options).toEqual({ overrideCursor: "msg-3" });
+    // The rewind run re-reads and prints the post-run state row.
+    expect(JSON.parse(stdout).state).toEqual(sampleStateRow());
+    expect(stateWrites).toHaveLength(0);
+  });
+
+  test("repeating the same --from replay invokes the job identically and never writes state directly", async () => {
+    jobResult = INVOKED_OUTCOME;
+    stateRow = sampleStateRow();
+
+    const args = [
+      "memory",
+      "retrospective",
+      "run",
+      "conv-1",
+      "--from",
+      "msg-3",
+      "--json",
+    ];
+    const first = await runCommand(args);
+    const second = await runCommand(args);
+
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+    expect(first.stdout).toBe(second.stdout);
+    expect(jobCalls).toHaveLength(2);
+    expect(jobCalls[0].options).toEqual({ overrideCursor: "msg-3" });
+    expect(jobCalls[1].options).toEqual(jobCalls[0].options);
+    // Advancement idempotence lives in the job; the CLI adds zero writes
+    // across repeats.
+    expect(stateWrites).toHaveLength(0);
   });
 });

--- a/assistant/src/cli/commands/memory/__tests__/memory-retrospective.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-retrospective.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the pure helpers behind `assistant memory retrospective run`'s
+ * rewind flags: the `--from` / `--from-start` resolver and the cursor
+ * formatter. The command's action wiring is exercised end-to-end by the
+ * retrospective job tests plus manual CLI runs; these cover the flag
+ * semantics that gate the overrideCursor replay path.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const noop = () => {};
+const fakeLogger = { info: noop, warn: noop, error: noop, debug: noop };
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => fakeLogger,
+  getCliLogger: () => fakeLogger,
+}));
+
+const { describeCursor, resolveRunCursorOverride } =
+  await import("../memory-retrospective.js");
+
+describe("resolveRunCursorOverride", () => {
+  test("neither flag: default (persisted cursor is used)", () => {
+    expect(resolveRunCursorOverride({})).toEqual({ kind: "default" });
+  });
+
+  test("--from-start resolves to a null override (replay from the beginning)", () => {
+    expect(resolveRunCursorOverride({ fromStart: true })).toEqual({
+      kind: "override",
+      overrideCursor: null,
+    });
+  });
+
+  test("--from <messageId> resolves to that id as the override", () => {
+    expect(resolveRunCursorOverride({ from: "msg-123" })).toEqual({
+      kind: "override",
+      overrideCursor: "msg-123",
+    });
+  });
+
+  test("--from and --from-start together are rejected", () => {
+    const result = resolveRunCursorOverride({
+      from: "msg-123",
+      fromStart: true,
+    });
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("mutually exclusive");
+    }
+  });
+
+  test("an empty --from value is rejected with a pointer to --from-start", () => {
+    const result = resolveRunCursorOverride({ from: "" });
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("--from-start");
+    }
+  });
+
+  test("fromStart: false behaves as absent", () => {
+    expect(resolveRunCursorOverride({ fromStart: false })).toEqual({
+      kind: "default",
+    });
+    expect(
+      resolveRunCursorOverride({ from: "msg-123", fromStart: false }),
+    ).toEqual({ kind: "override", overrideCursor: "msg-123" });
+  });
+});
+
+describe("describeCursor", () => {
+  test("null and the empty-string sentinel render as the start of the conversation", () => {
+    expect(describeCursor(null)).toBe("(start of conversation)");
+    expect(describeCursor("")).toBe("(start of conversation)");
+  });
+
+  test("a concrete message id renders verbatim", () => {
+    expect(describeCursor("msg-123")).toBe("msg-123");
+  });
+});

--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -839,6 +839,21 @@ Examples:
           ],
           options: [
             {
+              flags: "--from <messageId>",
+              description:
+                "Rewind: review from this message id instead of the saved cursor (mutually exclusive with --from-start)",
+            },
+            {
+              flags: "--from-start",
+              description:
+                "Rewind: review the conversation from its first message",
+            },
+            {
+              flags: "--dry-run",
+              description:
+                "Read-only preview: report cursors and the unprocessed message count without running anything",
+            },
+            {
               flags: "--json",
               description: "Emit raw JSON instead of a formatted summary",
             },
@@ -849,8 +864,21 @@ retrospective instruction, and wakes the fork so the agent reviews the new
 messages and calls \`remember\` on anything worth saving. Runs entirely in the
 CLI process — no IPC round-trip to the daemon.
 
+Rewind/backfill: --from <messageId> (or --from-start) replays a window whose
+cursor already advanced, e.g. past runs that produced no usable output. The
+replay is idempotent with respect to the remembered log: the run sees every
+previously saved entry as <already_remembered> dedup context, and the saved
+cursor only advances (forward, to the window's latest real message) once the
+run persists verified usable output; a failed or interrupted replay leaves
+state exactly as it was. --dry-run previews the window (current cursor, target
+cursor, unprocessed message count, last run time, remembered-log size) with no
+writes of any kind.
+
 Examples:
-  $ assistant memory retrospective run abc123`,
+  $ assistant memory retrospective run abc123
+  $ assistant memory retrospective run abc123 --dry-run
+  $ assistant memory retrospective run abc123 --from 9f2c4f3a-3f1a-41e4-88e7-abc123 --dry-run
+  $ assistant memory retrospective run abc123 --from-start`,
         },
         {
           name: "list",

--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -8,15 +8,79 @@
  * Subcommands:
  *
  *   - `run <conversationId>` — run a fork-based retrospective on a conversation.
+ *     Supports targeted rewind/backfill via `--from <messageId>` /
+ *     `--from-start` (replay a window whose cursor already advanced) and a
+ *     read-only `--dry-run` preview.
  *   - `list` — list the most-recently-run retrospective state rows.
  */
 
 import type { Command } from "commander";
 
 import type { MemoryRetrospectiveOutcome } from "../../../plugins/defaults/memory/memory-retrospective-job.js";
+import type { MemoryRetrospectiveState } from "../../../plugins/defaults/memory/memory-retrospective-state.js";
 import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+
+interface RetrospectiveRunFlags {
+  json?: boolean;
+  from?: string;
+  fromStart?: boolean;
+  dryRun?: boolean;
+}
+
+/**
+ * Resolution of the `--from` / `--from-start` rewind flags into the
+ * `overrideCursor` value `runForkBasedRetrospective` accepts:
+ *
+ *   - `default`: neither flag passed; the run uses the persisted cursor.
+ *   - `override`: replay from `overrideCursor` (`null` means from the
+ *     conversation's beginning).
+ *   - `error`: invalid flag combination; `message` explains why.
+ */
+export type RunCursorResolution =
+  | { kind: "error"; message: string }
+  | { kind: "default" }
+  | { kind: "override"; overrideCursor: string | null };
+
+/**
+ * Pure flag resolver for the `run` subcommand's rewind options. `--from` and
+ * `--from-start` are mutually exclusive, and `--from` requires a non-empty
+ * message id (the from-start sentinel is spelled `--from-start`, never an
+ * empty `--from`).
+ */
+export function resolveRunCursorOverride(
+  opts: Pick<RetrospectiveRunFlags, "from" | "fromStart">,
+): RunCursorResolution {
+  if (opts.from !== undefined && opts.fromStart === true) {
+    return {
+      kind: "error",
+      message: "--from and --from-start are mutually exclusive.",
+    };
+  }
+  if (opts.fromStart === true) {
+    return { kind: "override", overrideCursor: null };
+  }
+  if (opts.from !== undefined) {
+    if (opts.from === "") {
+      return {
+        kind: "error",
+        message:
+          "--from requires a non-empty message id (use --from-start to replay from the beginning).",
+      };
+    }
+    return { kind: "override", overrideCursor: opts.from };
+  }
+  return { kind: "default" };
+}
+
+/** Human-readable rendering of a cursor value for dry-run/state output. */
+export function describeCursor(cursor: string | null): string {
+  if (cursor === null || cursor === "") {
+    return "(start of conversation)";
+  }
+  return cursor;
+}
 
 export function registerMemoryRetrospectiveCommand(memory: Command): void {
   const retro = subcommand(memory, "retrospective");
@@ -24,7 +88,81 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
   // ── run ───────────────────────────────────────────────────────────────
 
   subcommand(retro, "run").action(
-    async (conversationId: string, opts: { json?: boolean }, cmd: Command) => {
+    async (
+      conversationId: string,
+      opts: RetrospectiveRunFlags,
+      cmd: Command,
+    ) => {
+      const fail = (message: string): void => {
+        if (opts.json === true) {
+          writeOutput(cmd, { kind: "error", error: message });
+        } else {
+          log.error(message);
+        }
+        process.exitCode = 1;
+      };
+
+      const resolution = resolveRunCursorOverride(opts);
+      if (resolution.kind === "error") {
+        fail(resolution.message);
+        return;
+      }
+
+      // The rewind and dry-run paths validate their targets up front (both
+      // are read-only lookups); the plain run defers to the job's own
+      // missing-conversation handling.
+      if (resolution.kind === "override" || opts.dryRun === true) {
+        const { getConversation, getMessageById } =
+          await import("../../../persistence/conversation-crud.js");
+        if (!getConversation(conversationId)) {
+          fail(`Conversation not found: ${conversationId}`);
+          return;
+        }
+        if (
+          resolution.kind === "override" &&
+          resolution.overrideCursor !== null &&
+          !getMessageById(resolution.overrideCursor, conversationId)
+        ) {
+          fail(
+            `Message ${resolution.overrideCursor} not found in conversation ${conversationId}.`,
+          );
+          return;
+        }
+      }
+
+      if (opts.dryRun === true) {
+        // Purely read-only preview: no state writes, no fork, no wake.
+        const [{ getRetrospectiveState }, { getRetrospectiveMessagesAfter }] =
+          await Promise.all([
+            import("../../../plugins/defaults/memory/memory-retrospective-state.js"),
+            import("../../../plugins/defaults/memory/memory-retrospective-accounting.js"),
+          ]);
+        const state = getRetrospectiveState(conversationId);
+        const currentCursor = state?.lastProcessedMessageId ?? null;
+        const targetCursor =
+          resolution.kind === "override"
+            ? resolution.overrideCursor
+            : currentCursor;
+        const report = {
+          kind: "dry_run" as const,
+          conversationId,
+          currentCursor,
+          overrideCursor: targetCursor,
+          unprocessedMessageCount: getRetrospectiveMessagesAfter(
+            conversationId,
+            targetCursor,
+          ).length,
+          lastRunAt: state?.lastRunAt ?? null,
+          rememberedLogEntryCount: state?.rememberedLog.length ?? 0,
+        };
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, report);
+          return;
+        }
+        renderDryRun(report);
+        return;
+      }
+
       // Deferred: loads the config loader and retrospective job graph.
       const [{ getConfig }, { runForkBasedRetrospective }] = await Promise.all([
         import("../../../config/loader.js"),
@@ -33,7 +171,13 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
       const config = getConfig();
       let outcome: MemoryRetrospectiveOutcome;
       try {
-        outcome = await runForkBasedRetrospective(conversationId, config);
+        outcome = await runForkBasedRetrospective(
+          conversationId,
+          config,
+          resolution.kind === "override"
+            ? { overrideCursor: resolution.overrideCursor }
+            : undefined,
+        );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.error({ err, conversationId }, "memory-retrospective: run threw");
@@ -43,6 +187,19 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
           log.error(msg);
         }
         process.exitCode = 1;
+        return;
+      }
+
+      if (resolution.kind === "override") {
+        const { getRetrospectiveState } =
+          await import("../../../plugins/defaults/memory/memory-retrospective-state.js");
+        const state = getRetrospectiveState(conversationId);
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, { outcome, state });
+          return;
+        }
+        renderOutcome(outcome);
+        renderStateRow(state);
         return;
       }
 
@@ -87,14 +244,7 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
 // Human-readable rendering
 // ---------------------------------------------------------------------------
 
-interface RetrospectiveStateRow {
-  conversationId: string;
-  lastProcessedMessageId: string;
-  lastRunAt: number;
-  rememberedLog: string[];
-}
-
-function renderList(rows: RetrospectiveStateRow[]): void {
+function renderList(rows: MemoryRetrospectiveState[]): void {
   if (rows.length === 0) {
     log.info("No retrospective state found. Run a retrospective first with:");
     log.info("  assistant memory retrospective run <conversationId>");
@@ -135,6 +285,19 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
     case "no_new_messages":
       log.info("No new messages to review since the last retrospective.");
       break;
+    case "no_user_activity":
+      log.info(
+        "The unprocessed window has no user activity; nothing to review.",
+      );
+      break;
+    case "no_usable_output":
+      log.error(
+        `Run produced no usable output${outcome.reason ? `: ${outcome.reason}` : ""}` +
+          (outcome.conversationId ? ` (fork: ${outcome.conversationId})` : "") +
+          ". The window stays retryable; state was not advanced.",
+      );
+      process.exitCode = 1;
+      break;
     case "source_dormant":
       log.info(
         "Source conversation is dormant beyond the sweep lookback; skipping.",
@@ -164,4 +327,36 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
       );
       break;
   }
+}
+
+function renderDryRun(report: {
+  conversationId: string;
+  currentCursor: string | null;
+  overrideCursor: string | null;
+  unprocessedMessageCount: number;
+  lastRunAt: number | null;
+  rememberedLogEntryCount: number;
+}): void {
+  log.info(
+    `Dry run (no writes).\n` +
+      `  conversation:        ${report.conversationId}\n` +
+      `  current cursor:      ${describeCursor(report.currentCursor)}\n` +
+      `  target cursor:       ${describeCursor(report.overrideCursor)}\n` +
+      `  unprocessed msgs:    ${report.unprocessedMessageCount}\n` +
+      `  last run at:         ${report.lastRunAt === null ? "(never)" : new Date(report.lastRunAt).toISOString()}\n` +
+      `  remembered entries:  ${report.rememberedLogEntryCount}`,
+  );
+}
+
+function renderStateRow(state: MemoryRetrospectiveState | null): void {
+  if (!state) {
+    log.info("No retrospective state row exists for this conversation.");
+    return;
+  }
+  log.info(
+    `Resulting state:\n` +
+      `  cursor:              ${describeCursor(state.lastProcessedMessageId)}\n` +
+      `  last run at:         ${new Date(state.lastRunAt).toISOString()}\n` +
+      `  remembered entries:  ${state.rememberedLog.length}`,
+  );
 }

--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -190,6 +190,16 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
         return;
       }
 
+      // Failure outcomes exit non-zero in every output mode, so scripted
+      // callers (and the recovery runbook) can branch on the exit code
+      // without parsing the payload.
+      if (
+        outcome.kind === "wake_failed" ||
+        outcome.kind === "no_usable_output"
+      ) {
+        process.exitCode = 1;
+      }
+
       if (resolution.kind === "override") {
         const { getRetrospectiveState } =
           await import("../../../plugins/defaults/memory/memory-retrospective-state.js");

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -451,17 +451,37 @@ export interface StopContext extends StopInputContext, BaseHookContext {}
 // ─── Pre-model-call hook context ─────────────────────────────────────────────
 
 /**
+ * Outcome of the `pre-model-call` hook chain. The agent loop seeds it to
+ * `"proceed"` and acts on the value the chain settles on:
+ *
+ * - `"proceed"`: issue the provider call (with any edits the chain applied).
+ *   This is the default.
+ * - `"fail"`: do not send. The loop ends the turn through its normal error
+ *   path (an `error` event followed by the `stop` hook with exit reason
+ *   `"error"`), carrying {@link PreModelCallContext.failureReason} as the error
+ *   message. This is the fail-closed lever for a hook that determines the
+ *   outbound request must not reach the resolved model (e.g. media bound for a
+ *   model that cannot accept it, on a call site whose caller retries failures).
+ *   Because the hook pipeline contains hook throws, setting this field is the
+ *   only way a hook can fail the call; a thrown error is logged and the call
+ *   proceeds with the original request.
+ */
+export type PreModelCallDecision = "proceed" | "fail";
+
+/**
  * Context passed to the `pre-model-call` hook. Fires immediately before each
  * provider call — once per model call within a turn, including tool-result
  * follow-up calls. Because it runs for every provider call (background, subagent,
  * and compaction work can share a conversation), hooks MUST self-gate on
  * {@link callSite} / {@link conversationId} before acting.
  *
- * A hook may edit the outbound request by replacing {@link systemPrompt}, route
- * the call to a different inference profile via {@link modelProfile}, and opt
- * this turn into deferred output streaming via {@link deferAssistantOutput}.
- * Mutate the context in place or return a new one; throwing is contained by the
- * loop (the call proceeds with the original request).
+ * A hook may edit the outbound request by replacing {@link systemPrompt} or
+ * rewriting {@link messages}, route the call to a different inference profile
+ * via {@link modelProfile}, opt this turn into deferred output streaming via
+ * {@link deferAssistantOutput}, or fail the call outright via
+ * {@link PreModelCallDecision}. Mutate the context in place or return a new
+ * one; throwing is contained by the loop (the call proceeds with the original
+ * request).
  */
 export interface PreModelCallInputContext {
   /** Conversation ID the call belongs to. */
@@ -495,6 +515,26 @@ export interface PreModelCallInputContext {
    */
   modelProfile: string | null;
   /**
+   * Effective inference-profile identity for the model this run resolved at
+   * turn start: a profile key for named-profile configs, the resolved model id
+   * for profileless configs (mirrors
+   * {@link UserPromptSubmitContext.modelProfileKey}). `null` for raw loop runs
+   * that supply none. A hook judging model capabilities for THIS call should
+   * prefer {@link modelProfile} (the live per-call override, which an earlier
+   * hook in the chain may have rerouted) and fall back to this value.
+   */
+  readonly modelProfileKey: string | null;
+  /**
+   * The outbound provider-bound message history for this call, after the
+   * loop's pre-send sanitization (historical media stripped, AX trees
+   * collapsed, stale web-search results converted to text). A hook may rewrite
+   * it, in place or by returning a new context with a replacement array, and
+   * the loop sends the settled value. Wire payload only: the loop's own
+   * history bookkeeping (persistence, compaction, retries) is untouched by
+   * edits here.
+   */
+  messages: Message[];
+  /**
    * Seeded `false`. When a hook sets it `true`, the loop suppresses this turn's
    * live assistant `text_delta` stream; a `post-model-call` hook is then
    * expected to produce the text the client sees (emitted once, after the reply
@@ -502,6 +542,18 @@ export interface PreModelCallInputContext {
    * redaction that needs the full message — instead of leaking the raw stream.
    */
   deferAssistantOutput: boolean;
+  /**
+   * Seeded `"proceed"`. A hook sets it to `"fail"` to stop the loop from
+   * sending this call and end the turn through the loop's normal error path;
+   * see {@link PreModelCallDecision}. Later hooks in the chain may override it.
+   */
+  decision: PreModelCallDecision;
+  /**
+   * Error message the loop surfaces when {@link decision} settles on `"fail"`.
+   * A failing hook should name the call site, the resolved model, and the
+   * remedy. `null` (with a generic fallback message) when unset.
+   */
+  failureReason: string | null;
 }
 
 /**

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2825,6 +2825,21 @@ export function isConversationProcessing(id: string): boolean {
 }
 
 /**
+ * The persisted `processing_started_at` stamp, or null when idle or missing.
+ * Deliberately reads only the column (no in-memory fallback): consumers use
+ * it to age a flag {@link isConversationProcessing} already reported set, and
+ * the column is the only signal that carries a start time.
+ */
+export function getConversationProcessingStartedAt(id: string): number | null {
+  const row = rawGet<{ processing_started_at: number | null }>(
+    "conversation:getProcessingStartedAt",
+    "SELECT processing_started_at FROM conversations WHERE id = ?",
+    id,
+  );
+  return row?.processing_started_at ?? null;
+}
+
+/**
  * Conversations currently mid-turn, longest-running first. Throws on a read
  * failure — drain callers must distinguish "nothing processing" from "could
  * not read", so this does not degrade to an empty list.

--- a/assistant/src/persistence/conversation-plugin-facade.ts
+++ b/assistant/src/persistence/conversation-plugin-facade.ts
@@ -59,6 +59,20 @@ export async function isConversationProcessing(id: string): Promise<boolean> {
   return fn(id);
 }
 
+/**
+ * The persisted `processing_started_at` stamp for a conversation, or null
+ * when the conversation is idle (or the row does not exist). Lets background
+ * consumers age-gate the processing flag: a stamp far in the past is a
+ * stranded flag (a swallowed turn-end clear), not a live turn.
+ */
+export async function getConversationProcessingStartedAt(
+  id: string,
+): Promise<number | null> {
+  const { getConversationProcessingStartedAt: fn } =
+    await import("./conversation-crud.js");
+  return fn(id);
+}
+
 /** Parse a stored message-metadata JSON string; undefined when absent/invalid. */
 export async function parseMessageMetadata(
   metadataJson: string | null,

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -794,10 +794,19 @@ export function claimMemoryJobs(
 
 export function completeMemoryJob(id: string): void {
   const db = memoryDb();
+  // Guarded on `running` so a late return from an abandoned execution cannot
+  // overwrite a terminal state another writer already recorded (the stalled-job
+  // watchdog's `failed`, or a successor worker's re-claimed row).
   db.update(memoryJobs)
     .set({ status: "completed", updatedAt: Date.now(), lastError: null })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
+  if (rawMemoryChanges() === 0) {
+    log.warn(
+      { jobId: id },
+      "completeMemoryJob: row was not running; late completion suppressed",
+    );
+  }
 }
 
 /** Max times a job can be deferred before it is marked as failed. */
@@ -820,7 +829,17 @@ const DEFER_MAX_DELAY_MS = 5 * 60 * 1000;
  * Returns `'deferred'` if the job was put back, or `'failed'` if max deferrals
  * were exceeded and the job was marked as failed.
  */
-export function deferMemoryJob(id: string): "deferred" | "failed" {
+export function deferMemoryJob(
+  id: string,
+  options?: {
+    /**
+     * Terminal `last_error` recorded when the deferral budget is exhausted.
+     * Defaults to the backend-unavailable wording used by the worker's
+     * infrastructure deferrals.
+     */
+    exhaustedMessage?: string;
+  },
+): "deferred" | "failed" {
   const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
   if (!row) {
@@ -840,9 +859,11 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
         status: "failed",
         deferrals,
         updatedAt: now,
-        lastError: `Backend unavailable after ${deferrals} deferrals`,
+        lastError:
+          options?.exhaustedMessage ??
+          `Backend unavailable after ${deferrals} deferrals`,
       })
-      .where(eq(memoryJobs.id, id))
+      .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
       .run();
     return "failed";
   }
@@ -868,7 +889,7 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
       runAfter: now + delay,
       updatedAt: now,
     })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
   return "deferred";
 }
@@ -886,7 +907,7 @@ export function rescheduleMemoryJob(id: string, delayMs: number): void {
   memoryDb()
     .update(memoryJobs)
     .set({ status: "pending", runAfter: now + delayMs, updatedAt: now })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
 }
 
@@ -904,6 +925,9 @@ export function failMemoryJob(
   }
   const attempts = row.attempts + 1;
   const now = Date.now();
+  // Both transitions are guarded on `running` for the same reason as
+  // `completeMemoryJob`: a late writer must not overwrite a terminal state
+  // recorded by the stalled-job watchdog or a successor worker.
   if (attempts >= maxAttempts) {
     db.update(memoryJobs)
       .set({
@@ -912,7 +936,7 @@ export function failMemoryJob(
         updatedAt: now,
         lastError: truncate(error, 2000, ""),
       })
-      .where(eq(memoryJobs.id, id))
+      .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
       .run();
     return;
   }
@@ -924,7 +948,7 @@ export function failMemoryJob(
       updatedAt: now,
       lastError: truncate(error, 2000, ""),
     })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
 }
 

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -317,6 +317,7 @@ export {
   deleteConversation,
   getConversation,
   getConversationDirPath,
+  getConversationProcessingStartedAt,
   getMessages,
   hasLexicalTokens,
   isConversationProcessing,

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -113,6 +113,7 @@ export type {
   PostModelCallDecision,
   PostToolUseContext,
   PreModelCallContext,
+  PreModelCallDecision,
   ShutdownContext,
   StopContext,
   ToolContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -22,6 +22,7 @@ export type {
   PostModelCallDecision,
   PostToolUseContext,
   PreModelCallContext,
+  PreModelCallDecision,
   StopContext,
   UserPromptSubmitContext,
 } from "../hooks/types.js";

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
@@ -1,0 +1,266 @@
+/**
+ * End-to-end tests for capability-aware media routing at the AgentLoop wire
+ * boundary: the real `pre-model-call` hook registered as a plugin, driving a
+ * real `AgentLoop.run` with a recording mock provider. Covers both invocation
+ * paths' shared seam (main-turn and background wakes both traverse
+ * `AgentLoop.run`, which is where the hook fires):
+ *
+ * - vision-capable model: outbound images reach the provider untouched
+ * - non-vision model with a vision profile: the provider receives captions
+ *   with NO image blocks on the wire, proactively (no rejection round-trip)
+ * - text-only history: untouched
+ * - non-vision model, no vision profile, `memoryRetrospective` call site: the
+ *   run fails observably before any provider call (retryable fail-closed)
+ * - same, `mainAgent` call site: unchanged fall-through to the provider (the
+ *   reactive post-model-call recovery keeps ownership)
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+  ModelProfileInfo,
+} from "@vellumai/plugin-api";
+
+import type { AgentEvent } from "../../../../agent/loop.js";
+import { AgentLoop } from "../../../../agent/loop.js";
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../../../registry.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockProfiles: ModelProfileInfo[];
+let visionProfiles: Set<string>;
+let visionModelKeys: Set<string>;
+let captionProviderCalls: number;
+
+const fakeCaptionProvider = {
+  name: "mock-vision-provider",
+  async sendMessage() {
+    captionProviderCalls++;
+    return { content: [{ type: "text", text: "A bar chart of Q3 revenue." }] };
+  },
+};
+
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModelKeys.has(arg)
+      : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: (source: ImageContent["source"]) =>
+    source.type === "base64"
+      ? { data: source.data, media_type: source.media_type }
+      : null,
+  getConfiguredProvider: async () => fakeCaptionProvider,
+  lastToolResultUserMessageIndex,
+}));
+
+mock.module("../src/image-persist.js", () => ({
+  persistImage: () => "/workspace/data/attachments/mock-hash.png",
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const preModelCall = (await import("../hooks/pre-model-call.js")).default;
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "pre-model-call-loop-test-"));
+initCaptionStore(STORAGE_DIR);
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let imageSeq = 0;
+
+/** A distinct inline image block per call, so the content-hash cache never collides across cases. */
+function makeImage(): ImageContent {
+  imageSeq += 1;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from(`image-bytes-${imageSeq}`).toString("base64"),
+    },
+  };
+}
+
+function userMessage(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+/** A provider that records what it was sent and answers with plain text. */
+function makeRecordingProvider(): {
+  provider: ConstructorParameters<typeof AgentLoop>[0]["provider"];
+  calls: Message[][];
+} {
+  const calls: Message[][] = [];
+  return {
+    calls,
+    provider: {
+      name: "mock-main-provider",
+      async sendMessage(messages: Message[]) {
+        calls.push(structuredClone(messages));
+        return {
+          content: [{ type: "text", text: "done" }] as ContentBlock[],
+          model: "mock-model",
+          usage: { inputTokens: 1, outputTokens: 1 },
+          stopReason: "end_turn",
+        };
+      },
+    },
+  };
+}
+
+function hasImageBlocks(messages: Message[]): boolean {
+  return messages.some((m) =>
+    m.content.some(
+      (b) =>
+        b.type === "image" ||
+        (b.type === "tool_result" &&
+          b.contentBlocks?.some((cb) => cb.type === "image")),
+    ),
+  );
+}
+
+interface RunCase {
+  callSite?: "mainAgent" | "memoryRetrospective";
+  modelProfileKey: string;
+}
+
+async function runLoop(input: Message[], opts: RunCase) {
+  const { provider, calls } = makeRecordingProvider();
+  const loop = new AgentLoop({
+    provider,
+    systemPrompt: "system",
+    conversationId: "conv-media-routing",
+  });
+  const events: AgentEvent[] = [];
+  const result = await loop.run({
+    requestId: "test-request",
+    messages: input,
+    onEvent: (e) => {
+      events.push(e);
+    },
+    trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    callSite: opts.callSite ?? "mainAgent",
+    modelProfileKey: opts.modelProfileKey,
+  });
+  return { calls, events, result };
+}
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+  resetCaptionCacheForTests();
+  captionProviderCalls = 0;
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as ModelProfileInfo,
+    { key: "text-only-profile", isDisabled: false } as ModelProfileInfo,
+  ];
+  visionProfiles = new Set(["vision-profile"]);
+  visionModelKeys = new Set();
+  registerPlugin({
+    manifest: { name: "image-fallback-under-test", version: "0.0.0" },
+    hooks: { "pre-model-call": preModelCall },
+  });
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("agent loop capability-aware media routing (image-fallback pre-model-call)", () => {
+  test("vision-capable model receives outbound images untouched", async () => {
+    const { calls, events } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "vision-profile" },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(true);
+    expect(captionProviderCalls).toBe(0);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  test("non-vision model with a vision profile receives captions, no image blocks, proactively", async () => {
+    const { calls, result } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "text-only-profile" },
+    );
+
+    // One provider round-trip: the substitution happened before the send, not
+    // via a rejection-and-retry.
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0][0].content.some(
+        (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+      ),
+    ).toBe(true);
+    expect(captionProviderCalls).toBe(1);
+    // The loop's own history keeps the raw image (wire-only substitution).
+    expect(hasImageBlocks(result.history)).toBe(true);
+  });
+
+  test("text-only history reaches a non-vision model untouched", async () => {
+    const input = [userMessage({ type: "text", text: "just text" })];
+    const { calls } = await runLoop(structuredClone(input), {
+      modelProfileKey: "text-only-profile",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].content).toEqual(input[0].content);
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("memoryRetrospective fails closed when no vision profile can caption for a non-vision model", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const { calls, events } = await runLoop([userMessage(makeImage())], {
+      callSite: "memoryRetrospective",
+      modelProfileKey: "text-only-profile",
+    });
+
+    // The provider is never called with the media-bearing request.
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type !== "error") {
+      throw new Error("type narrowing");
+    }
+    expect(errorEvent.error.message).toContain("memoryRetrospective");
+    expect(errorEvent.error.message).toContain("text-only-profile");
+    const exitEvent = events.find((e) => e.type === "agent_loop_exit");
+    if (exitEvent?.type !== "agent_loop_exit") {
+      throw new Error("expected an agent_loop_exit event");
+    }
+    // The turn ends through the ordinary error path, which background callers
+    // treat as a failed (and therefore retryable) run.
+    expect(exitEvent.reason).toBe("error");
+  });
+
+  test("mainAgent with no vision profile falls through to the provider unchanged", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const { calls, events } = await runLoop([userMessage(makeImage())], {
+      callSite: "mainAgent",
+      modelProfileKey: "text-only-profile",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(true);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for the image-fallback plugin's `pre-model-call` hook: the
+ * wire-boundary guard that captions outbound images bound for a non-vision
+ * model, fails the background memory call sites closed when no vision profile
+ * exists to caption with, and passes everything else through untouched.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+  ModelProfileInfo,
+  PluginLogger,
+  PreModelCallContext,
+} from "@vellumai/plugin-api";
+
+// Real host helper wired into the mock so the tests exercise the shipped
+// current-turn boundary behavior rather than a stand-in.
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockProfiles: ModelProfileInfo[];
+let visionProfiles: Set<string>;
+/** Bare-string identities (model ids / profile keys) that support vision. */
+let visionModelKeys: Set<string>;
+let captionProviderCalls: number;
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage() {
+    captionProviderCalls++;
+    return { content: [{ type: "text", text: "A bar chart of Q3 revenue." }] };
+  },
+};
+
+const mockResolveMediaSourceData = (source: ImageContent["source"]) =>
+  source.type === "base64"
+    ? { data: source.data, media_type: source.media_type }
+    : null;
+
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModelKeys.has(arg)
+      : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: mockResolveMediaSourceData,
+  getConfiguredProvider: async () => fakeProvider,
+  lastToolResultUserMessageIndex,
+}));
+
+mock.module("../src/image-persist.js", () => ({
+  persistImage: () => "/workspace/data/attachments/mock-hash.png",
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const preModelCall = (await import("../hooks/pre-model-call.js")).default;
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "pre-model-call-test-"));
+initCaptionStore(STORAGE_DIR);
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+let imageSeq = 0;
+
+/** A distinct inline image block per call, so the content-hash cache never collides across cases. */
+function makeImage(): ImageContent {
+  imageSeq += 1;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from(`image-bytes-${imageSeq}`).toString("base64"),
+    },
+  };
+}
+
+function userMessage(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+function makeCtx(
+  overrides: Partial<PreModelCallContext> = {},
+): PreModelCallContext {
+  return {
+    conversationId: "conv-pre-model-call",
+    callSite: "mainAgent",
+    systemPrompt: null,
+    modelProfile: null,
+    modelProfileKey: "text-only-profile",
+    messages: [],
+    deferAssistantOutput: false,
+    decision: "proceed",
+    failureReason: null,
+    logger: noopLogger,
+    broadcast: () => {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetCaptionCacheForTests();
+  captionProviderCalls = 0;
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as ModelProfileInfo,
+    { key: "text-only-profile", isDisabled: false } as ModelProfileInfo,
+  ];
+  visionProfiles = new Set(["vision-profile"]);
+  visionModelKeys = new Set();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("image-fallback pre-model-call outbound guard", () => {
+  test("leaves outbound images untouched for a vision-capable model", async () => {
+    visionProfiles.add("text-only-profile");
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("captions outbound images proactively for a non-vision model", async () => {
+    const messages = [userMessage({ type: "text", text: "look" }, makeImage())];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    const blocks = ctx.messages[0].content;
+    expect(blocks.some((b) => b.type === "image")).toBe(false);
+    expect(
+      blocks.some(
+        (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+      ),
+    ).toBe(true);
+    expect(captionProviderCalls).toBe(1);
+  });
+
+  test("captions images nested in current-turn tool_result contentBlocks", async () => {
+    const messages = [
+      userMessage({
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        content: "screenshot taken",
+        contentBlocks: [makeImage()],
+      } as ContentBlock),
+    ];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    const nested = (
+      ctx.messages[0].content[0] as ContentBlock & {
+        contentBlocks: ContentBlock[];
+      }
+    ).contentBlocks;
+    expect(nested.some((b) => b.type === "image")).toBe(false);
+    expect(nested[0].type).toBe("text");
+  });
+
+  test("reuses the caption cache: a repeated pass over the same image runs no new vision call", async () => {
+    const image = makeImage();
+    const first = makeCtx({ messages: [userMessage(structuredClone(image))] });
+    await preModelCall(first);
+    expect(captionProviderCalls).toBe(1);
+
+    const second = makeCtx({ messages: [userMessage(structuredClone(image))] });
+    await preModelCall(second);
+
+    expect(captionProviderCalls).toBe(1);
+    expect(second.messages[0].content[0].type).toBe("text");
+  });
+
+  test("text-only outbound history is untouched, even on a fail-closed call site with no vision profile", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const messages = [userMessage({ type: "text", text: "just text" })];
+    const ctx = makeCtx({ messages, callSite: "memoryRetrospective" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages).toEqual(messages);
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test.each(["memoryRetrospective", "memoryV2Consolidation"] as const)(
+    "fails %s closed when images meet a non-vision model and no vision profile exists",
+    async (callSite) => {
+      mockProfiles = [];
+      visionProfiles = new Set();
+      const messages = [userMessage(makeImage())];
+      const ctx = makeCtx({ messages, callSite });
+
+      await preModelCall(ctx);
+
+      expect(ctx.decision).toBe("fail");
+      expect(ctx.failureReason).toContain(callSite);
+      expect(ctx.failureReason).toContain("text-only-profile");
+      expect(ctx.failureReason).toContain("vision-capable");
+      // The wire payload is not mutated; the loop never sends it.
+      expect(ctx.messages[0].content[0].type).toBe("image");
+      expect(captionProviderCalls).toBe(0);
+    },
+  );
+
+  test("mainAgent with no vision profile falls through unchanged (reactive recovery keeps ownership)", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages, callSite: "mainAgent" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.failureReason).toBeNull();
+    expect(ctx.messages[0].content[0].type).toBe("image");
+  });
+
+  test("a fail-closed call site with a vision profile captions instead of failing", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages, callSite: "memoryRetrospective" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("text");
+    expect(captionProviderCalls).toBe(1);
+  });
+
+  test("prefers the live per-call modelProfile override over the run-level modelProfileKey", async () => {
+    // The run resolved a text-only profile, but an earlier hook rerouted the
+    // call to a vision-capable profile: no captioning should run.
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({
+      messages,
+      modelProfile: "vision-profile",
+      modelProfileKey: "text-only-profile",
+    });
+
+    await preModelCall(ctx);
+
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("a bare model id resolves through doesSupportVision when no profile matches", async () => {
+    // Profileless configs carry the resolved model id as the identity.
+    visionModelKeys = new Set(["gpt-6.2-vision"]);
+    const messages = [userMessage(makeImage())];
+    const seen = makeCtx({ messages, modelProfileKey: "gpt-6.2-vision" });
+    await preModelCall(seen);
+    expect(seen.messages[0].content[0].type).toBe("image");
+
+    const textOnly = makeCtx({
+      messages: [userMessage(makeImage())],
+      modelProfileKey: "deepseek-v4-flash",
+    });
+    await preModelCall(textOnly);
+    expect(textOnly.messages[0].content[0].type).toBe("text");
+  });
+
+  test("passes through when neither modelProfile nor modelProfileKey is set", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({
+      messages,
+      callSite: null,
+      modelProfile: null,
+      modelProfileKey: null,
+    });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
@@ -1,0 +1,147 @@
+/**
+ * Default `pre-model-call` hook: the wire-boundary guard that keeps raw image
+ * blocks off requests bound for a model that cannot accept them.
+ *
+ * The `user-prompt-submit` sweep captions history images at turn start, but it
+ * only fires on the main-turn orchestrator path. Background wakes (memory
+ * retrospective forks, memory consolidation) enter `AgentLoop.run` directly
+ * and never dispatch that hook, so media-bearing history would otherwise reach
+ * the provider verbatim. This hook runs at the shared invocation boundary,
+ * once per provider call on every path, against the outbound (sanitized) wire
+ * payload in `ctx.messages`:
+ *
+ * - No image blocks outbound, or the resolved model supports vision
+ *   ({@link needsImageFallback} via the live per-call profile override or the
+ *   run's `modelProfileKey`): no-op.
+ * - Images + non-vision model + a vision-capable profile available: replace
+ *   the images with text captions via the plugin's shared outbound sweep
+ *   ({@link captionOutboundImagesInMessages}). The caption cache makes the
+ *   pass lookup-only for anything the turn-start sweep already captioned, so
+ *   keeping both hooks is cheap.
+ * - Images + non-vision model + NO vision profile: for the background memory
+ *   call sites (`memoryRetrospective`, `memoryV2Consolidation`) fail the call
+ *   closed (`decision: "fail"`) so the run surfaces a retryable failure
+ *   instead of silently sending a request the provider will reject; a failed
+ *   retrospective wake leaves the memory cursor untouched, so the work is
+ *   retried once a capable route exists. Every other call site falls through
+ *   unchanged, preserving the reactive `post-model-call` recovery and its
+ *   fail-open placeholder behavior for user-facing turns.
+ *
+ * Every non-trivial decision emits a structured log line with the call site,
+ * resolved profile/model, media count, and decision.
+ */
+
+import {
+  type HookFunction,
+  type LLMCallSite,
+  type PreModelCallContext,
+} from "@vellumai/plugin-api";
+
+import {
+  captionOutboundImagesInMessages,
+  countImageBlocksInMessages,
+  needsImageFallback,
+} from "../src/caption-blocks.js";
+import { findVisionProfile } from "../src/vision-caption.js";
+
+/**
+ * Background memory call sites whose callers own failure handling and retry:
+ * a failed run is re-attempted later, so failing closed loses no work, while
+ * silently sending media to a non-vision route would either reject the run
+ * with an opaque provider error or degrade extraction quality invisibly.
+ */
+const FAIL_CLOSED_MEMORY_CALL_SITES: ReadonlySet<LLMCallSite> = new Set([
+  "memoryRetrospective",
+  "memoryV2Consolidation",
+]);
+
+const preModelCall: HookFunction<PreModelCallContext> = async (ctx) => {
+  const mediaBlocks = countImageBlocksInMessages(ctx.messages);
+  if (mediaBlocks === 0) {
+    return;
+  }
+
+  // The live per-call override (which an earlier hook, e.g. a model router,
+  // may have set) wins over the run-level identity resolved at turn start.
+  const modelKey = ctx.modelProfile ?? ctx.modelProfileKey;
+  if (modelKey == null) {
+    // Raw loop runs (no call site, no resolved identity) carry nothing to
+    // judge capabilities against; leave the request untouched.
+    return;
+  }
+
+  if (!needsImageFallback(modelKey)) {
+    ctx.logger.debug(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        decision: "pass",
+      },
+      "Outbound media bound for a vision-capable model; sending untouched",
+    );
+    return;
+  }
+
+  const visionProfileKey = findVisionProfile();
+  if (visionProfileKey != null) {
+    const captioned = await captionOutboundImagesInMessages(
+      ctx.messages,
+      ctx.conversationId,
+      visionProfileKey,
+      ctx.logger,
+    );
+    ctx.logger.info(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        captioned,
+        decision: "captioned",
+      },
+      "Replaced outbound image blocks with text captions for text-only model",
+    );
+    return;
+  }
+
+  if (ctx.callSite != null && FAIL_CLOSED_MEMORY_CALL_SITES.has(ctx.callSite)) {
+    ctx.decision = "fail";
+    ctx.failureReason =
+      `Model call for background call site "${ctx.callSite}" carries ` +
+      `${mediaBlocks} image block(s), but its resolved model ` +
+      `("${modelKey}") does not support image input and no vision-capable ` +
+      `profile is configured to caption them. Configure a vision-capable ` +
+      `model profile, or route the "${ctx.callSite}" call site to a ` +
+      `vision-capable model; the run will be retried.`;
+    ctx.logger.error(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        decision: "fail_closed",
+      },
+      "Failing background memory model call closed: outbound media, non-vision model, and no vision profile to caption with",
+    );
+    return;
+  }
+
+  // No vision profile and not a fail-closed call site: fall through with the
+  // request untouched. The turn-start sweep has already placeholdered what it
+  // saw, and the reactive post-model-call recovery handles a provider
+  // rejection of anything that leaked past it.
+  ctx.logger.warn(
+    {
+      plugin: "image-fallback",
+      callSite: ctx.callSite,
+      modelProfileKey: modelKey,
+      mediaBlocks,
+      decision: "pass",
+    },
+    "Outbound media bound for a text-only model with no vision profile; leaving it to reactive recovery",
+  );
+};
+
+export default preModelCall;

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -182,6 +182,34 @@ export async function captionImagesInMessages(
 }
 
 /**
+ * Count every image block a provider request built from `messages` would
+ * carry: top-level image blocks plus images nested in `tool_result`
+ * `contentBlocks`. Used on an outbound (already-sanitized) history, where
+ * stale tool-result media has been stripped to markers, so the count is
+ * exactly the set {@link captionOutboundImagesInMessages} would substitute.
+ * Read-only.
+ */
+export function countImageBlocksInMessages(
+  messages: ReadonlyArray<Message>,
+): number {
+  let imageCount = 0;
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block.type === "image") {
+        imageCount++;
+      } else if (block.type === "tool_result" && block.contentBlocks != null) {
+        for (const nested of block.contentBlocks) {
+          if (nested.type === "image") {
+            imageCount++;
+          }
+        }
+      }
+    }
+  }
+  return imageCount;
+}
+
+/**
  * Caption only the image blocks a rejected model call would still carry after
  * the host's outbound media-stripping: every top-level image block (the
  * sanitizer never strips those) plus tool_result media in the current-turn

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -49,6 +49,7 @@ import imageFallbackInit from "./image-fallback/hooks/init.js";
 import imageFallbackPostCompact from "./image-fallback/hooks/post-compact.js";
 import imageFallbackPostModelCall from "./image-fallback/hooks/post-model-call.js";
 import imageFallbackPostToolUse from "./image-fallback/hooks/post-tool-use.js";
+import imageFallbackPreModelCall from "./image-fallback/hooks/pre-model-call.js";
 import imageFallbackShutdown from "./image-fallback/hooks/shutdown.js";
 import imageFallbackStop from "./image-fallback/hooks/stop.js";
 import imageFallbackUserPromptSubmit from "./image-fallback/hooks/user-prompt-submit.js";
@@ -102,13 +103,18 @@ import workspacePkg from "./workspace/package.json" with { type: "json" };
  * screenshot) nested in the tool result's `contentBlocks`; the `post-compact`
  * hook re-sweeps the rebuilt history after a mid-turn compaction, whose
  * retained images and persistence-restored tool results land after the
- * turn-start sweep. The `post-model-call` hook backstops raw images that
- * reach the provider anyway (messages joining an in-flight turn, catalog
- * entries that call a model vision-capable when its serving endpoint rejects
- * images): on a vision-not-supported rejection it captions the working
- * history and retries, bounded to one pass per turn, with the `stop` hook
- * clearing the recovery bound on a terminal stop. Fail-open with a
- * placeholder when no vision profile is configured or captioning fails. A
+ * turn-start sweep. The `pre-model-call` hook guards the wire boundary every
+ * provider call crosses (including background wakes, which skip
+ * `user-prompt-submit`): outbound images bound for a non-vision model are
+ * captioned proactively, and the background memory call sites fail closed
+ * when no vision profile exists to caption with. The `post-model-call` hook
+ * backstops raw images that reach the provider anyway (messages joining an
+ * in-flight turn, catalog entries that call a model vision-capable when its
+ * serving endpoint rejects images): on a vision-not-supported rejection it
+ * captions the working history and retries, bounded to one pass per turn,
+ * with the `stop` hook clearing the recovery bound on a terminal stop.
+ * Fail-open with a placeholder when no vision profile is configured or
+ * captioning fails (outside the fail-closed memory call sites). A
  * read-through content-hash cache (in-memory LRU over a plugin-owned SQLite
  * file, opened by `init` in the plugin's storage dir and closed by
  * `shutdown`) avoids re-captioning the same image across turns, compactions,
@@ -126,6 +132,7 @@ export const defaultImageFallbackPlugin: Plugin = {
     "user-prompt-submit": imageFallbackUserPromptSubmit,
     "post-tool-use": imageFallbackPostToolUse,
     "post-compact": imageFallbackPostCompact,
+    "pre-model-call": imageFallbackPreModelCall,
     "post-model-call": imageFallbackPostModelCall,
     stop: imageFallbackStop,
     "conversation-deleted": imageFallbackConversationDeleted,

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-outcome-contract.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-outcome-contract.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Outcome-truthfulness contract between job handlers and the jobs worker.
+ *
+ * Handlers that report failure through a RETURNED domain outcome (the
+ * retrospective's `wake_failed` / `no_usable_output` / `source_processing`,
+ * the consolidation's `run_failed`) must not leave their job rows reading
+ * `completed` with a null `last_error`. The registration-site adapters in
+ * `job-handlers.ts` translate domain outcomes into `JobQueueResolution`s and
+ * the worker applies them, so the persisted `memory_jobs.status` reflects the
+ * handler's actual outcome.
+ *
+ * Also covers the store-level late-transition guards: once the stalled-job
+ * watchdog fails a row, a late `completeMemoryJob` from the abandoned
+ * execution must not flip it back to `completed`.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import type { MemoryRetrospectiveOutcome } from "../memory-retrospective-job.js";
+import type { ConsolidationOutcome } from "../substrate/consolidation-job.js";
+
+// Scripted handler outcomes, set per-test.
+let retrospectiveOutcome: MemoryRetrospectiveOutcome = {
+  kind: "no_new_messages",
+};
+let consolidationOutcome: ConsolidationOutcome = { kind: "empty_buffer" };
+
+mock.module("../memory-retrospective-job.js", () => ({
+  memoryRetrospectiveJob: async () => retrospectiveOutcome,
+  STALE_SOURCE_PROCESSING_OVERRIDE_MS: 6 * 60 * 60 * 1000,
+}));
+
+mock.module("../substrate/consolidation-job.js", () => ({
+  memoryV2ConsolidateJob: async () => consolidationOutcome,
+  // Scheduler helpers the worker reads on every pass.
+  countBufferLines: () => 0,
+  readConsolidationFailureState: () => null,
+}));
+
+mock.module("../graph/graph-search.js", () => ({
+  embedGraphNodeDirect: async () => {},
+  embedGraphNodeJob: async (): Promise<void> => {},
+  enqueueGraphNodeEmbed: () => {},
+  embedGraphTriggerJob: async (): Promise<void> => {},
+  enqueueGraphTriggerEmbed: () => {},
+}));
+
+mock.module("../v1/graph/graph-search.js", () => ({
+  searchGraphNodes: async () => [],
+}));
+
+mock.module("../../../../persistence/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: async () => {},
+  maybeRunPassiveWalCheckpoint: async () => {},
+}));
+
+const tmpWorkspace = mkdtempSync(
+  join(tmpdir(), "jobs-worker-outcome-contract-"),
+);
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+import { getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { _resetQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
+import {
+  completeMemoryJob,
+  enqueueMemoryJob,
+  failStalledJobs,
+} from "../../../../persistence/jobs-store.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import { registerMemoryPluginJobHandlers } from "../job-handler-registration.js";
+import { runMemoryJobsOnce } from "../jobs-worker.js";
+
+function jobRow(jobId: string) {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, jobId))
+    .get();
+}
+
+describe("job outcome truthfulness", () => {
+  beforeAll(async () => {
+    registerMemoryPluginJobHandlers();
+    await initializeDb();
+  });
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+    _resetQdrantBreaker();
+    retrospectiveOutcome = { kind: "no_new_messages" };
+    consolidationOutcome = { kind: "empty_buffer" };
+  });
+
+  test("retrospective wake_failed dead-letters the row with an honest last_error", async () => {
+    retrospectiveOutcome = { kind: "wake_failed", reason: "run_error" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("retrospective wake failed");
+    expect(row?.lastError).toContain("run_error");
+  });
+
+  test("retrospective no_usable_output dead-letters the row with the failure detail", async () => {
+    retrospectiveOutcome = {
+      kind: "no_usable_output",
+      reason: "run persisted no memory-writing tool call",
+    };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("no usable output");
+  });
+
+  test("retrospective source_processing defers the SAME row on the deferral counter", async () => {
+    retrospectiveOutcome = { kind: "source_processing" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    const before = Date.now();
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("pending");
+    expect(row?.deferrals).toBe(1);
+    expect(row?.attempts).toBe(0);
+    expect(row!.runAfter).toBeGreaterThan(before);
+    // Exactly one row for the conversation: no fresh row minted per attempt.
+    const rows = getMemoryDb()!
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "memory_retrospective"))
+      .all();
+    expect(rows).toHaveLength(1);
+  });
+
+  test("source_processing deferral budget exhausts into an honest terminal failure", async () => {
+    retrospectiveOutcome = { kind: "source_processing" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+    // Spend 49 of the 50 deferrals up front; the next pass is the last one.
+    getMemoryDb()!
+      .update(memoryJobs)
+      .set({ deferrals: 49 })
+      .where(eq(memoryJobs.id, jobId))
+      .run();
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("mid-turn");
+  });
+
+  test("retrospective success and benign no-ops still complete", async () => {
+    retrospectiveOutcome = { kind: "no_new_messages" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    expect(jobRow(jobId)?.status).toBe("completed");
+  });
+
+  test("consolidation run_failed dead-letters the row with the failure reason", async () => {
+    consolidationOutcome = { kind: "run_failed", reason: "timeout" };
+    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("consolidation run failed");
+    expect(row?.lastError).toContain("timeout");
+  });
+
+  test("consolidation skips (locked/empty) still complete", async () => {
+    consolidationOutcome = { kind: "locked", holder: "1234 0 consolidation" };
+    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+
+    await runMemoryJobsOnce();
+
+    expect(jobRow(jobId)?.status).toBe("completed");
+  });
+
+  test("late completion cannot overwrite a watchdog-failed row", async () => {
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+    // Simulate a claimed row whose execution went silent long enough for the
+    // stalled-job watchdog to fail it.
+    getMemoryDb()!
+      .update(memoryJobs)
+      .set({ status: "running", startedAt: Date.now() - 60 * 60 * 1000 })
+      .where(eq(memoryJobs.id, jobId))
+      .run();
+    expect(failStalledJobs(30 * 60 * 1000)).toBe(1);
+    expect(jobRow(jobId)?.status).toBe("failed");
+
+    // The abandoned execution finally returns and reports success.
+    completeMemoryJob(jobId);
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("timed out");
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -97,6 +97,10 @@ let messagesByConversationId: Record<string, StubMessage[]> = {};
 // the real registry's semantics for conversations not in memory.
 let loadedConversations: Record<string, { processing: boolean }> = {};
 
+// Persisted `processing_started_at` stamps, keyed by conversation id, backing
+// the stale-flag override's age check. Absent ids read as null (stampless).
+let processingStartedAtById: Record<string, number | null> = {};
+
 const watchdogEvents: Array<{
   checkName: string;
   value?: number | null;
@@ -195,6 +199,8 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
     const entry = loadedConversations[id];
     return entry?.processing ?? false;
   },
+  getConversationProcessingStartedAt: (id: string) =>
+    processingStartedAtById[id] ?? null,
   forkConversationForRetrospective: async (params: {
     conversationId: string;
     throughMessageId?: string;
@@ -328,7 +334,7 @@ import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 import {
   memoryRetrospectiveJob,
   runForkBasedRetrospective,
-  SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+  STALE_SOURCE_PROCESSING_OVERRIDE_MS,
 } from "../memory-retrospective-job.js";
 
 function makeConfig(
@@ -397,6 +403,27 @@ function persistedInstructionText(): string {
   return blocks[0]!.text;
 }
 
+/**
+ * Default persisted run output for the wake's fork conversation: a single
+ * assistant `remember` tool_use with an empty batch payload. Satisfies the
+ * fail-closed advancement gate (a durable memory-writing call exists) while
+ * appending nothing to the remembered log, so pre-gate assertions about log
+ * contents hold unchanged. Tests that assert the gate itself override
+ * `messagesByConversationId` for the fork id.
+ */
+function defaultForkRunOutput() {
+  return [
+    {
+      role: "assistant",
+      content: JSON.stringify([
+        { type: "tool_use", name: "remember", input: { content: [] } },
+      ]),
+      createdAt: Date.parse("2026-05-11T10:20:00Z"),
+      metadata: null,
+    },
+  ];
+}
+
 function priorRetroMessage(rememberContents: string[]) {
   return {
     role: "assistant",
@@ -434,8 +461,9 @@ describe("memoryRetrospectiveJob", () => {
     addMessageCalls = [];
     retrospectiveJobUpserts = [];
     conversationOverrides = {};
-    messagesByConversationId = {};
+    messagesByConversationId = { "fork-conv-1": defaultForkRunOutput() };
     loadedConversations = {};
+    processingStartedAtById = {};
     mockResolvedUserSlug = "alice";
     resolveUserSlugCalls = [];
     mockV3TierActive = false;
@@ -740,6 +768,183 @@ describe("memoryRetrospectiveJob", () => {
     expect(deletedConversationIds).toEqual(["fork-conv-1"]);
   });
 
+  // -------------------------------------------------------------------------
+  // Fail-closed usable-output gate: `invoked: true` alone must not advance
+  // the cursor. The agent loop swallows provider rejections into a normal
+  // no-output return, so a wake can report success for a run that persisted
+  // nothing; advancement requires a durable memory-writing tool call on the
+  // run's own persisted tail.
+  // -------------------------------------------------------------------------
+
+  test("invoked wake with NO persisted run output: no_usable_output, cursor and log untouched, window retryable", async () => {
+    mockWakeResult = { invoked: true };
+    // The fork persisted nothing (e.g. a swallowed provider rejection or a
+    // zero-output max-tokens stop).
+    messagesByConversationId["fork-conv-1"] = [];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    // Cursor NOT advanced, remembered log NOT appended.
+    expect(stateUpserts).toHaveLength(0);
+    // Retryable: cooldown bump only, orphan fork cleaned up.
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: {
+          outcome: "no_usable_output",
+          reason: "run persisted no memory-writing tool call",
+        },
+      },
+    ]);
+  });
+
+  test("invoked wake whose run persisted only analysis text (no tool calls): no_usable_output, prior retrospective preserved", async () => {
+    mockWakeResult = { invoked: true };
+    priorRetroId = "prior-retro-1";
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new worth remembering here." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+    // Only this run's own fork is deleted; the prior retrospective (the
+    // dedup baseline for the retry) is preserved.
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+  });
+
+  test("run-message load failure classifies as no_usable_output (fail-closed), not success", async () => {
+    mockWakeResult = { invoked: true };
+    // Fork-kind conversation with no stamps and no leading instruction row:
+    // `loadRetrospectiveRunMessages` returns null (indeterminate).
+    conversationOverrides["fork-conv-1"] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: null,
+    };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "copied row" }]),
+        createdAt: 1,
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("checkpoint-persisted saves on a fork-kind tail count as usable output (rebase-after-live cannot fake no-output)", async () => {
+    mockWakeResult = { invoked: true };
+    conversationOverrides["fork-conv-1"] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: null,
+    };
+    // Copied prefix rows carry forkSourceMessageId stamps; the run's own
+    // persisted tail (from checkpoint persistence, regardless of what the
+    // in-memory history looked like after any rebase) sits after the
+    // boundary and carries the durable remember call.
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "copied source row" }]),
+        createdAt: 100,
+        metadata: JSON.stringify({ forkSourceMessageId: "m2" }),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: ["fact persisted via checkpoint"] },
+          },
+        ]),
+        createdAt: 200,
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.rememberedLog).toEqual([
+      "fact persisted via checkpoint",
+    ]);
+  });
+
+  test("scaffold_managed_skill counts as durable work even with zero remembers", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "scaffold_managed_skill",
+            input: { name: "deploy-checklist" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
+  });
+
+  test("retry after a no_usable_output run advances only once durable output exists", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [];
+
+    const first = await memoryRetrospectiveJob(makeJob(), stubConfig);
+    expect(first.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+
+    // Retry: same window, this time the run persists a real save.
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: "fact captured on retry" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:25:00Z"),
+        metadata: null,
+      },
+    ];
+    const second = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(second.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toEqual(["fact captured on retry"]);
+  });
+
   test("wake throws: lastRunAt bumped before rethrow, orphan fork deleted, error rethrown", async () => {
     mockWakeThrows = new Error("LLM provider 503");
     await expect(memoryRetrospectiveJob(makeJob(), stubConfig)).rejects.toThrow(
@@ -1012,12 +1217,10 @@ describe("memoryRetrospectiveJob", () => {
   // Mid-turn requeue gate
   // -------------------------------------------------------------------------
 
-  test("source mid-turn → skipped outcome, state fully untouched, job re-upserted with the fallback delay, no fork", async () => {
+  test("source mid-turn → source_processing outcome, state fully untouched, no self-upserted row, no fork", async () => {
     loadedConversations["src-conv-1"] = { processing: true };
 
-    const before = Date.now();
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
-    const after = Date.now();
 
     expect(outcome.kind).toBe("source_processing");
     // BOTH pointers untouched. `lastRunAt` must stay unbumped so the
@@ -1027,23 +1230,51 @@ describe("memoryRetrospectiveJob", () => {
     // forever.
     expect(stateUpserts).toHaveLength(0);
     expect(lastRunAtBumps).toHaveLength(0);
-    // Timed fallback row for a turn that aborts without indexing another
-    // message: coalescing re-upsert at the named delay.
-    expect(retrospectiveJobUpserts).toHaveLength(1);
-    expect(retrospectiveJobUpserts[0]!.payload).toEqual({
-      conversationId: "src-conv-1",
-    });
-    expect(retrospectiveJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
-      before + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-    );
-    expect(retrospectiveJobUpserts[0]!.runAfter).toBeLessThanOrEqual(
-      after + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-    );
+    // The handler no longer mints a fresh fallback row per attempt: the
+    // worker defers the SAME job row on the bounded deferral counter (see
+    // `resolveRetrospectiveOutcome`), so a stranded processing flag cannot
+    // produce an unbounded stream of job rows.
+    expect(retrospectiveJobUpserts).toHaveLength(0);
     // No fork, no instruction, no wake, no cleanup side effects.
     expect(forkCalls).toHaveLength(0);
     expect(addMessageCalls).toHaveLength(0);
     expect(wakeCalls).toHaveLength(0);
     expect(deletedConversationIds).toEqual([]);
+  });
+
+  test("source mid-turn with a fresh processing stamp → still deferred", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    processingStartedAtById["src-conv-1"] = Date.now() - 60_000;
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_processing");
+    expect(forkCalls).toHaveLength(0);
+  });
+
+  test("source mid-turn with a stamp older than the stale override → proceeds and runs normally", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    processingStartedAtById["src-conv-1"] =
+      Date.now() - STALE_SOURCE_PROCESSING_OVERRIDE_MS - 60_000;
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // A stranded flag (swallowed turn-end clear while the daemon stayed up)
+    // must not block memory formation indefinitely: past the override window
+    // the run proceeds as if idle.
+    expect(outcome.kind).toBe("invoked");
+    expect(forkCalls).toHaveLength(1);
+    expect(stateUpserts).toHaveLength(1);
+  });
+
+  test("source mid-turn with a set flag but no persisted stamp → deferred (reads as live)", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    // No processingStartedAtById entry: the stamp write may have failed, so
+    // age cannot be established. The bounded deferral budget still caps it.
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_processing");
+    expect(forkCalls).toHaveLength(0);
   });
 
   test("source loaded but idle → normal run, no requeue upsert", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -1003,6 +1003,100 @@ describe("memoryRetrospectiveJob", () => {
     expect(lastRunAtBumps).toHaveLength(1);
   });
 
+  test("explicit no-findings reply advances the cursor without fabricating a memory write", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new to save." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // A reviewed-and-no-findings pass is a legitimate success: the mandated
+    // exact reply is the positive persisted artifact, the cursor advances,
+    // and the remembered log gains nothing.
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
+  });
+
+  test("analysis prose that merely mentions the no-findings phrase does not advance", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "I reviewed the window. Nothing new to save. Here is my reasoning about why each item was already covered by prior passes.",
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("no-findings reply cannot advance a run that attempted a save and failed", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-mixed-1",
+            name: "remember",
+            input: { content: "fact that failed to land" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-mixed-1",
+            content: "write failed",
+            is_error: true,
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
+        metadata: null,
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new to save." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:02Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // The run demonstrably had findings (it attempted a save); the failed
+    // write must stay retryable rather than being papered over by a
+    // no-findings claim.
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
   test("a remember tool_use with NO persisted tool_result is not durable evidence", async () => {
     mockWakeResult = { invoked: true };
     messagesByConversationId["fork-conv-1"] = [

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -415,8 +415,9 @@ function persistedInstructionText(): string {
 
 /**
  * Default persisted run output for the wake's fork conversation: a single
- * assistant `remember` tool_use with an empty batch payload. Satisfies the
- * fail-closed advancement gate (a durable memory-writing call exists) while
+ * assistant `remember` tool_use with an empty batch payload plus its
+ * successful tool_result. Satisfies the fail-closed advancement gate (a
+ * durable memory-writing call exists AND its execution succeeded) while
  * appending nothing to the remembered log, so pre-gate assertions about log
  * contents hold unchanged. Tests that assert the gate itself override
  * `messagesByConversationId` for the fork id.
@@ -426,9 +427,22 @@ function defaultForkRunOutput() {
     {
       role: "assistant",
       content: JSON.stringify([
-        { type: "tool_use", name: "remember", input: { content: [] } },
+        {
+          type: "tool_use",
+          id: "tu-run-1",
+          name: "remember",
+          input: { content: [] },
+        },
       ]),
       createdAt: Date.parse("2026-05-11T10:20:00Z"),
+      metadata: null,
+    },
+    {
+      role: "user",
+      content: JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu-run-1", content: "Saved." },
+      ]),
+      createdAt: Date.parse("2026-05-11T10:20:01Z"),
       metadata: null,
     },
   ];
@@ -883,11 +897,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-ckpt-1",
             name: "remember",
             input: { content: ["fact persisted via checkpoint"] },
           },
         ]),
         createdAt: 200,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-ckpt-1", content: "Saved." },
+        ]),
+        createdAt: 201,
         metadata: null,
       },
     ];
@@ -909,11 +932,24 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-skill-1",
             name: "scaffold_managed_skill",
             input: { name: "deploy-checklist" },
           },
         ]),
         createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-skill-1",
+            content: "Skill scaffolded.",
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
         metadata: null,
       },
     ];
@@ -925,6 +961,72 @@ describe("memoryRetrospectiveJob", () => {
     expect(stateUpserts[0]!.rememberedLog).toEqual([]);
   });
 
+  test("a remember whose execution FAILED (is_error tool_result) is not durable evidence and its facts stay out of the log", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-fail-1",
+            name: "remember",
+            input: { content: "fact that never landed" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-fail-1",
+            content: "memory buffer write failed",
+            is_error: true,
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // The tool_use alone proves the model asked; the durable write happens
+    // in the executor, and it failed. Window stays retryable, and the failed
+    // fact must not enter <already_remembered> where it would suppress the
+    // retry's re-save.
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(1);
+  });
+
+  test("a remember tool_use with NO persisted tool_result is not durable evidence", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-noresult-1",
+            name: "remember",
+            input: { content: "fact with unproven execution" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
   test("retry after a no_usable_output run advances only once durable output exists", async () => {
     mockWakeResult = { invoked: true };
     messagesByConversationId["fork-conv-1"] = [];
@@ -933,18 +1035,28 @@ describe("memoryRetrospectiveJob", () => {
     expect(first.kind).toBe("no_usable_output");
     expect(stateUpserts).toHaveLength(0);
 
-    // Retry: same window, this time the run persists a real save.
+    // Retry: same window, this time the run persists a real save and its
+    // successful execution.
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-retry-1",
             name: "remember",
             input: { content: "fact captured on retry" },
           },
         ]),
         createdAt: Date.parse("2026-05-11T10:25:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-retry-1", content: "Saved." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:25:01Z"),
         metadata: null,
       },
     ];
@@ -1992,11 +2104,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-tail-1",
             name: "remember",
             input: { content: "post-fork tail save — included" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-tail-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];
@@ -2056,11 +2177,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-seed-1",
             name: "remember",
             input: { content: "this run's save" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-seed-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];
@@ -2101,11 +2231,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-carry-1",
             name: "remember",
             input: { content: "fork tail save" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-carry-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];
@@ -2356,11 +2495,24 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-replay-1",
             name: "remember",
             input: { content: "replayed save" },
           },
         ]),
         createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-replay-1",
+            content: "Saved.",
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
         metadata: null,
       },
     ];

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -32,6 +32,13 @@ let newMessages: Array<{
   metadata?: string | null;
 }> = [];
 
+// Recorded `getMessagesAfter` calls, so overrideCursor tests can assert which
+// cursor value actually reached the slice read.
+let messagesAfterCalls: Array<{
+  conversationId: string;
+  afterId: string | null;
+}> = [];
+
 // Prior retrospective conversation + messages. `priorRetroOwnerId` is the
 // fork-chain conversation the prior is rooted at — `findMostRecentRetrospectiveFor`
 // returns it so the GC ownership check can tell "this source's own prior"
@@ -159,7 +166,10 @@ mock.module("../find-most-recent-retrospective-for.js", () => ({
 }));
 
 mock.module("../../../../persistence/conversation-crud.js", () => ({
-  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
+  getMessagesAfter: (id: string, afterId: string | null) => {
+    messagesAfterCalls.push({ conversationId: id, afterId });
+    return newMessages;
+  },
   getMessages: (id: string) => {
     if (messagesByConversationId[id]) {
       return messagesByConversationId[id];
@@ -448,6 +458,7 @@ describe("memoryRetrospectiveJob", () => {
       { id: "m2", createdAt: Date.parse("2026-05-11T10:05:00Z") },
       { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
     ];
+    messagesAfterCalls = [];
     priorRetroId = null;
     priorRetroOwnerId = "src-conv-1";
     priorRetroMessages = [];
@@ -2230,5 +2241,140 @@ describe("memoryRetrospectiveJob", () => {
     // skill-linking directive.
     expect(instructionText).not.toContain("skill:");
     expect(instructionText).toContain("Ordinary facts still go through");
+  });
+
+  // -------------------------------------------------------------------------
+  // overrideCursor (targeted rewind/backfill replay)
+  // -------------------------------------------------------------------------
+
+  test("no overrideCursor: the slice reads from the persisted cursor", async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+    };
+
+    await runForkBasedRetrospective("src-conv-1", stubConfig);
+
+    expect(messagesAfterCalls).toEqual([
+      { conversationId: "src-conv-1", afterId: "prev-msg" },
+    ]);
+  });
+
+  test('overrideCursor "" slices from the start; the persisted cursor is untouched until success and dedup still reads the persisted log', async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+      rememberedLog: ["baseline entry"],
+    };
+
+    const outcome = await runForkBasedRetrospective("src-conv-1", stubConfig, {
+      overrideCursor: "",
+    });
+
+    // The override (not the persisted "prev-msg") reaches the slice read.
+    expect(messagesAfterCalls).toEqual([
+      { conversationId: "src-conv-1", afterId: "" },
+    ]);
+    expect(outcome.kind).toBe("invoked");
+    // The only state write is the success finalizer's forward move to the
+    // window cutoff; nothing rewrote the persisted cursor up front.
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(lastRunAtBumps).toHaveLength(0);
+    // <already_remembered> still comes from the persisted state row, so a
+    // replayed window sees prior saves as dedup context.
+    expect(persistedInstructionText()).toContain("- baseline entry");
+  });
+
+  test("overrideCursor null slices from the start (same sentinel family as the empty string)", async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+    };
+
+    await runForkBasedRetrospective("src-conv-1", stubConfig, {
+      overrideCursor: null,
+    });
+
+    expect(messagesAfterCalls).toEqual([
+      { conversationId: "src-conv-1", afterId: null },
+    ]);
+  });
+
+  test("overrideCursor with a specific message id reaches the slice call", async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+    };
+
+    await runForkBasedRetrospective("src-conv-1", stubConfig, {
+      overrideCursor: "m1",
+    });
+
+    expect(messagesAfterCalls).toEqual([
+      { conversationId: "src-conv-1", afterId: "m1" },
+    ]);
+  });
+
+  test("failed replay (no_usable_output) under overrideCursor leaves the persisted cursor unchanged", async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+      rememberedLog: ["baseline entry"],
+    };
+    mockWakeResult = { invoked: true };
+    // The replay's fork persisted nothing durable.
+    messagesByConversationId["fork-conv-1"] = [];
+
+    const outcome = await runForkBasedRetrospective("src-conv-1", stubConfig, {
+      overrideCursor: "",
+    });
+
+    expect(outcome.kind).toBe("no_usable_output");
+    // Cursor and remembered log untouched: checkpoint-safe replay.
+    expect(stateUpserts).toHaveLength(0);
+    // Cooldown bump only, orphan fork cleaned up; the window stays retryable.
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+  });
+
+  test("successful replay advances the cursor to the window cutoff and appends run remembers on top of the existing log", async () => {
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+      rememberedLog: ["older pass save"],
+    };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: "replayed save" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await runForkBasedRetrospective("src-conv-1", stubConfig, {
+      overrideCursor: "",
+    });
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toEqual([
+      "older pass save",
+      "replayed save",
+    ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
+import { MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT } from "../memory-retrospective-constants.js";
 import {
   buildForkInstruction,
   type ForkInstructionArgs,
@@ -47,7 +48,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
 `);
   });
 
@@ -120,7 +121,7 @@ For everything else in your review window, use the \`remember\` tool on facts, p
     expect(out).not.toContain("PROCEDURE");
     expect(
       out.endsWith(
-        'If nothing new is worth saving, say "Nothing new to save." and stop.\n',
+        'If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.\n',
       ),
     ).toBe(true);
   });
@@ -199,4 +200,14 @@ describe("promptOverridePath", () => {
     expect(out).toBe(buildForkInstruction(makeArgs()));
     expect(out).not.toContain("SENSITIVE FILE CONTENTS");
   });
+});
+
+// The finalizer's explicit-no-findings gate matches persisted assistant text
+// against MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT by strict equality, and the
+// bundled instruction is what teaches the model to emit it. This guard fails
+// if either side drifts.
+test("bundled template mandates the exact no-findings sentinel the finalizer matches", () => {
+  expect(RETROSPECTIVE_INSTRUCTION_TEMPLATE).toContain(
+    `reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`,
+  );
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -424,13 +424,13 @@ describe("memoryRetrospectiveJob through the real wake + real agent loop", () =>
     ];
   });
 
-  test("real provider rejection through the real agent loop leaves the window retryable", async () => {
-    // Scenario A: every provider call is rejected. Mechanism under test:
-    // `AgentLoop.run`'s outer catch swallows the throw (emits an `error`
-    // event, `stopTurn("error")`, returns the history unchanged), so the
-    // real wake's silent no-op branch reports `invoked: true`, and the
-    // handler's durable-evidence gate must still refuse to advance,
-    // classifying the run as `no_usable_output` (NOT `wake_failed`).
+  test("real provider rejection is classified at the wake layer and leaves the window retryable", async () => {
+    // The wake's exit-reason classifier fails a swallowed rejection before
+    // finalization (invoked: false, reason run_error), so the handler
+    // reports wake_failed. Full rejection-chain coverage (state
+    // preservation, prior-fork survival, retry consuming the window) lives
+    // in memory-retrospective-wake-chain.test.ts; this case pins only the
+    // layered outcome and that the finalizer was never reached.
     providerImpl = async () => {
       throw new ProviderError(
         "This model (test-model) doesn't support image input. Remove the image or switch to a vision-capable model.",
@@ -441,16 +441,14 @@ describe("memoryRetrospectiveJob through the real wake + real agent loop", () =>
 
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
 
-    expect(outcome.kind).toBe("no_usable_output");
-    // The real loop really issued the provider call.
+    expect(outcome.kind).toBe("wake_failed");
+    if (outcome.kind === "wake_failed") {
+      expect(outcome.reason).toBe("run_error");
+    }
     expect(providerCalls.length).toBeGreaterThanOrEqual(1);
-    // Cursor NOT advanced; window stays retryable.
     expect(stateUpserts).toHaveLength(0);
-    // Cooldown bump only, exactly once, and the orphan fork is cleaned up.
     expect(lastRunAtBumps).toHaveLength(1);
     expect(deletedConversationIds).toEqual([FORK_ID]);
-    // Sanity: the run staged its instruction row but persisted no tail.
-    expect(messageStores[FORK_ID]?.map((row) => row.role)).toEqual(["user"]);
   });
 
   test("durable remember persisted through the real loop advances the cursor", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -1,0 +1,485 @@
+/**
+ * LUM-3013 regression: the retrospective's fail-closed advancement gate must
+ * hold through the REAL producer chain, not just against a mocked wake.
+ *
+ * These tests run the real `memoryRetrospectiveJob` handler → the real
+ * `wakeAgentForOpportunity` (runtime/agent-wake.ts, NOT mocked) → a
+ * conversation double whose `agentLoop` is a real `AgentLoop` driven by a
+ * scripted fake `Provider`. Only the provider and the daemon/persistence
+ * boundaries are test doubles, so the chain exercises the actual mechanism
+ * behind the bug:
+ *
+ *   - `AgentLoop.run` SWALLOWS provider rejections: the outer catch
+ *     (agent/loop.ts, `onEvent({ type: "error" })` + `stopTurn("error")`)
+ *     returns normally with the history unchanged.
+ *   - The wake then finds no tail output and takes its silent no-op branch
+ *     (agent-wake.ts), returning `{ invoked: true, producedToolCalls: false }`.
+ *   - `invoked: true` alone must therefore NOT advance
+ *     `memory_retrospective_state`: the handler re-reads the fork's persisted
+ *     rows (`collectRetrospectiveRunEvidence` → `loadRetrospectiveRunMessages`
+ *     → `getMessages`) and only advances when a durable memory-writing
+ *     `tool_use` (`remember` / `scaffold_managed_skill`) was persisted by THIS
+ *     run.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state. Reset between tests.
+// ---------------------------------------------------------------------------
+
+const SOURCE_ID = "src-conv-1";
+const FORK_ID = "fork-conv-1";
+
+let stateUpserts: Array<{
+  conversationId: string;
+  lastProcessedMessageId: string;
+  lastRunAt: number;
+  rememberedLog?: string[];
+}> = [];
+let lastRunAtBumps: Array<{ conversationId: string; lastRunAt: number }> = [];
+
+let newMessages: Array<{
+  id: string;
+  createdAt: number;
+  role?: string;
+  content?: string | Array<Record<string, unknown>>;
+  metadata?: string | null;
+}> = [];
+
+/**
+ * Persisted message rows, keyed by conversation id. `addMessage` appends here
+ * and `getMessages` reads it back. The same store serves the handler's
+ * instruction staging, the wake's tail persistence, and the finalizer's
+ * durable-evidence read, so the evidence gate sees exactly what the real
+ * producer chain persisted.
+ */
+type PersistedRow = {
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+};
+let messageStores: Record<string, PersistedRow[]> = {};
+let persistedMessageCounter = 0;
+
+let deletedConversationIds: string[] = [];
+let forkCalls: Array<{ conversationId: string; throughMessageId?: string }> =
+  [];
+
+// ---------------------------------------------------------------------------
+// Retrospective-side mocks (mirroring memory-retrospective-job.test.ts, but
+// WITHOUT mocking ../../../../runtime/agent-wake.js: the wake runs real).
+// ---------------------------------------------------------------------------
+
+mock.module("../memory-retrospective-state.js", () => ({
+  getRetrospectiveState: (_id: string) => null,
+  upsertRetrospectiveState: (args: {
+    conversationId: string;
+    lastProcessedMessageId: string;
+    lastRunAt: number;
+    rememberedLog?: string[];
+  }) => {
+    stateUpserts.push(args);
+  },
+  bumpRetrospectiveLastRunAt: (conversationId: string, lastRunAt: number) => {
+    lastRunAtBumps.push({ conversationId, lastRunAt });
+  },
+  appendToRememberedLog: (existing: string[], newEntries: string[]) => [
+    ...existing,
+    ...newEntries,
+  ],
+}));
+
+mock.module("../find-most-recent-retrospective-for.js", () => ({
+  findMostRecentRetrospectiveFor: (_id: string) => null,
+}));
+
+mock.module("../../../../persistence/conversation-crud.js", () => ({
+  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
+  getMessages: (id: string) => messageStores[id] ?? [],
+  // `defaultResolveTarget` in the REAL wake reads the FORK id's row for the
+  // archived check, so both rows carry archivedAt/createdAt. The fork's
+  // "user" source makes `loadRetrospectiveRunMessages` treat every persisted
+  // row as the run's own (legacy-kind), the simplest faithful setup here.
+  getConversation: (id: string) => {
+    if (id === FORK_ID) {
+      return {
+        source: "user",
+        forkParentMessageId: null,
+        title: "Fork",
+        archivedAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
+    return {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      archivedAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+  },
+  isConversationProcessing: (_id: string) => false,
+  getConversationProcessingStartedAt: (_id: string) => null,
+  forkConversationForRetrospective: async (params: {
+    conversationId: string;
+    throughMessageId?: string;
+  }) => {
+    forkCalls.push(params);
+    return { id: FORK_ID };
+  },
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    _options: unknown,
+  ) => {
+    const store = (messageStores[conversationId] ??= []);
+    store.push({ role, content, createdAt: Date.now(), metadata: null });
+    persistedMessageCounter += 1;
+    return { id: `msg-${persistedMessageCounter}` };
+  },
+  deleteConversation: (id: string) => {
+    deletedConversationIds.push(id);
+  },
+  deleteConversationGently: async (id: string) => {
+    deletedConversationIds.push(id);
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+  resolveOverrideProfile: () => undefined,
+  getConversationOverrideProfile: () => undefined,
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: async () => ({ id: "msg-reserve" }),
+}));
+
+mock.module("../../../../daemon/trust-context.js", () => ({
+  INTERNAL_GUARDIAN_TRUST_CONTEXT: {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+  },
+}));
+
+mock.module("../../../../prompts/persona-resolver.js", () => ({
+  resolveUserSlug: (_trustContext: unknown) => "alice",
+}));
+
+mock.module("../../../../persistence/jobs-store.js", () => ({
+  enqueueMemoryJob: () => "follow-up-job-id",
+  upsertMemoryRetrospectiveJob: () => {},
+}));
+
+mock.module("../../../../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: () => {},
+}));
+
+mock.module("../../../../config/memory-v3-gate.js", () => ({
+  isMemoryEnabled: (config?: { memory?: { enabled?: boolean } }) =>
+    config?.memory?.enabled !== false,
+  isV3TierActive: () => false,
+  isMemoryV3Live: () => false,
+  usesConceptPageMemory: () => false,
+}));
+
+mock.module("../../../../daemon/conversation-registry.js", () => ({
+  findConversation: (_id: string | undefined) => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Wake-side boundary mocks (mirroring runtime/__tests__/agent-wake.test.ts,
+// with relative paths adjusted for this directory).
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+mock.module("../../../../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: () => {},
+}));
+
+mock.module("../../../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
+}));
+
+mock.module("../../../../daemon/conversation-store.js", () => ({
+  // The real wake's `defaultResolveTarget` lands here after the archived
+  // check; it must yield the live fork conversation the run executes on.
+  getOrCreateConversation: async (
+    _conversationId: string,
+    _options?: unknown,
+  ) => makeForkConversationDouble(),
+}));
+
+mock.module("../../../../config/llm-context-resolution.js", () => ({
+  resolveEffectiveContextWindow: () => ({ maxInputTokens: 200_000 }),
+}));
+
+mock.module("../../../../daemon/disk-pressure-guard.js", () => ({
+  getDiskPressureStatus: () => ({
+    enabled: false,
+    state: "disabled",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: null,
+    thresholdPercent: 95,
+    path: null,
+    lastCheckedAt: null,
+    blockedCapabilities: [],
+    error: null,
+  }),
+}));
+
+mock.module("../../../../daemon/conversation-usage.js", () => ({
+  recordUsage: () => {},
+}));
+
+mock.module("../../../../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => "log-id",
+  backfillMessageIdOnLogs: () => {},
+  setAgentLoopExitReasonOnLatestLog: () => {},
+  buildProviderErrorResponsePayload: (error: unknown) => ({
+    error: String(error),
+  }),
+}));
+
+import { AgentLoop } from "../../../../agent/loop.js";
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { MemoryJob } from "../../../../persistence/jobs-store.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../../../../providers/types.js";
+import { ProviderError } from "../../../../util/errors.js";
+import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
+
+// ---------------------------------------------------------------------------
+// Fake provider: the ONLY seam scripted per scenario. Everything between the
+// job handler and this `sendMessage` is real production code.
+// ---------------------------------------------------------------------------
+
+let providerCalls: Array<{ messages: Message[] }> = [];
+let providerImpl: (
+  messages: Message[],
+  options?: SendMessageOptions,
+) => Promise<ProviderResponse> = async () => textOnlyResponse("unused");
+
+const fakeProvider: Provider = {
+  name: "fake-provider",
+  async sendMessage(
+    messages: Message[],
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    providerCalls.push({ messages: [...messages] });
+    return providerImpl(messages, options);
+  },
+};
+
+function textOnlyResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+}
+
+function rememberToolUseResponse(): ProviderResponse {
+  return {
+    content: [
+      { type: "text", text: "Saving one fact." },
+      {
+        type: "tool_use",
+        id: "tu-1",
+        name: "remember",
+        input: { content: "provider-path fact" },
+      },
+    ],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "tool_use",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Conversation double: minimal structural stand-in for the fork the wake
+// resolves. Its `agentLoop` is a REAL AgentLoop over the fake provider; its
+// message history hydrates from the persisted store (so the instruction row
+// the handler staged is the run's baseline, exactly like a DB rehydration).
+// ---------------------------------------------------------------------------
+
+function makeForkConversationDouble(): Conversation {
+  const messages: Message[] = (messageStores[FORK_ID] ?? []).map((row) => ({
+    role: row.role as Message["role"],
+    content: JSON.parse(row.content) as Message["content"],
+  }));
+  const realLoop = new AgentLoop({
+    provider: fakeProvider,
+    systemPrompt: "test",
+    conversationId: FORK_ID,
+  });
+  const conversation = {
+    conversationId: FORK_ID,
+    messages,
+    getMessages: () => messages,
+    isProcessing: () => false,
+    setProcessing: (_on: boolean) => {},
+    waitForIdle: async (_opts: { timeoutMs: number }) => true,
+    drainQueue: async () => {},
+    maybeCompact: async () => null,
+    subagentAllowedTools: undefined,
+    setSubagentAllowedTools: (_tools: Set<string> | undefined) => {},
+    preactivatedSkillIds: undefined,
+    setPreactivatedSkillIds: (_ids: readonly string[] | undefined) => {},
+    trustContext: undefined,
+    setTrustContext: (_ctx: unknown) => {},
+    currentTurnTrustContext: undefined,
+    wakePersonaOverride: undefined,
+    contextWindowManager: { estimateInputTokens: () => 0 },
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+    buildCurrentSystemPrompt: () => "test-system-prompt",
+    provider: { name: "fake-provider" },
+    usageStats: {},
+    modelOverride: undefined,
+    agentLoop: {
+      run: (options: Parameters<AgentLoop["run"]>[0]) => realLoop.run(options),
+    },
+  };
+  return conversation as unknown as Conversation;
+}
+
+// ---------------------------------------------------------------------------
+// Job/config helpers (shape copied from memory-retrospective-job.test.ts).
+// ---------------------------------------------------------------------------
+
+function makeConfig(): Parameters<typeof memoryRetrospectiveJob>[1] {
+  return {
+    memory: {
+      v2: { enabled: true },
+      retrospective: {
+        keepSupersededRuns: false,
+        matchConversationProfile: false,
+        promptPath: null,
+        requireUserActivity: false,
+        sweepIntervalMs: 8 * 60 * 60 * 1000,
+        sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
+      },
+    },
+    ui: {
+      userTimezone: undefined,
+      detectedTimezone: undefined,
+    },
+  } as unknown as Parameters<typeof memoryRetrospectiveJob>[1];
+}
+
+const stubConfig = makeConfig();
+
+function makeJob(conversationId = SOURCE_ID): MemoryJob<{
+  conversationId?: string;
+}> {
+  return {
+    id: "job-1",
+    type: "memory_retrospective",
+    payload: { conversationId },
+    status: "pending",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("memoryRetrospectiveJob through the real wake + real agent loop", () => {
+  beforeEach(() => {
+    stateUpserts = [];
+    lastRunAtBumps = [];
+    deletedConversationIds = [];
+    forkCalls = [];
+    messageStores = {};
+    persistedMessageCounter = 0;
+    providerCalls = [];
+    providerImpl = async () => textOnlyResponse("unused");
+    newMessages = [
+      { id: "m1", createdAt: Date.parse("2026-05-11T10:00:00Z") },
+      { id: "m2", createdAt: Date.parse("2026-05-11T10:05:00Z") },
+      { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
+    ];
+  });
+
+  test("real provider rejection through the real agent loop leaves the window retryable", async () => {
+    // Scenario A: every provider call is rejected. Mechanism under test:
+    // `AgentLoop.run`'s outer catch swallows the throw (emits an `error`
+    // event, `stopTurn("error")`, returns the history unchanged), so the
+    // real wake's silent no-op branch reports `invoked: true`, and the
+    // handler's durable-evidence gate must still refuse to advance,
+    // classifying the run as `no_usable_output` (NOT `wake_failed`).
+    providerImpl = async () => {
+      throw new ProviderError(
+        "This model (test-model) doesn't support image input. Remove the image or switch to a vision-capable model.",
+        "openai",
+        400,
+      );
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    // The real loop really issued the provider call.
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    // Cursor NOT advanced; window stays retryable.
+    expect(stateUpserts).toHaveLength(0);
+    // Cooldown bump only, exactly once, and the orphan fork is cleaned up.
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(deletedConversationIds).toEqual([FORK_ID]);
+    // Sanity: the run staged its instruction row but persisted no tail.
+    expect(messageStores[FORK_ID]?.map((row) => row.role)).toEqual(["user"]);
+  });
+
+  test("durable remember persisted through the real loop advances the cursor", async () => {
+    // Scenario B: first call emits a `remember` tool_use; the loop (built
+    // without a tool executor) stops after persisting the tool-bearing
+    // assistant message, and the wake's tail persistence writes it through
+    // `addMessage`. Subsequent calls (defensive) return plain text.
+    let call = 0;
+    providerImpl = async () => {
+      call += 1;
+      return call === 1 ? rememberToolUseResponse() : textOnlyResponse("Done.");
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toContain("provider-path fact");
+    // The durable evidence really flowed through persistence: the fork store
+    // holds the instruction row plus the wake-persisted tool_use tail.
+    const persistedRoles = messageStores[FORK_ID]!.map((row) => row.role);
+    expect(persistedRoles[0]).toBe("user");
+    expect(persistedRoles).toContain("assistant");
+    expect(lastRunAtBumps).toHaveLength(0);
+  });
+
+  test("clean empty reply through the real loop does not advance", async () => {
+    // Scenario C: the model answers with analysis text and no tool calls.
+    // The wake persists the text tail (visible output), but with zero
+    // durable memory-writing tool calls the gate must refuse to advance.
+    providerImpl = async () => textOnlyResponse("Nothing worth saving.");
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stateUpserts).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -322,6 +322,15 @@ function makeForkConversationDouble(): Conversation {
     provider: fakeProvider,
     systemPrompt: "test",
     conversationId: FORK_ID,
+    // Real executor round-trip: the finalizer's durable-evidence gate
+    // requires a matching successful tool_result, so the loop must execute
+    // the remember call and persist its result exactly as production does.
+    toolExecutor: async (name: string) => {
+      if (name === "remember") {
+        return { content: "Saved.", isError: false };
+      }
+      return { content: `unknown tool ${name}`, isError: true };
+    },
   });
   const conversation = {
     conversationId: FORK_ID,

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -409,9 +409,10 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
 
     // (2) The window stays retryable: the same slice succeeds on retry.
-    providerScript = [
-      { response: textResponse("Reviewed. Nothing new worth saving.") },
-    ];
+    // The finalizer's usable-output gate accepts free text only when it is
+    // exactly the mandated no-findings sentinel; a verified remember write
+    // is the other accepted evidence. Use the sentinel for the control.
+    providerScript = [{ response: textResponse("Nothing new to save.") }];
     providerCallCount = 0;
     const retry = await runForkBasedRetrospective(
       fixture.sourceId,
@@ -459,7 +460,7 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
 
     // The window stays retryable and a usable reply consumes it.
-    providerScript = [{ response: textResponse("Reviewed; nothing new.") }];
+    providerScript = [{ response: textResponse("Nothing new to save.") }];
     providerCallCount = 0;
     const retry = await runForkBasedRetrospective(
       fixture.sourceId,

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -20,7 +20,7 @@
 import { isMemoryV1Active } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
-import type { JobHandlerEntry } from "../../types.js";
+import type { JobHandlerEntry, JobQueueResolution } from "../../types.js";
 // The all-tier graph store: `embedGraphNodeJob` serves the V1 section,
 // `embedGraphTriggerJob` the SUBSTRATE one.
 import {
@@ -31,11 +31,17 @@ import {
 import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { getLogger } from "./logging.js";
 // RETROSPECTIVE (all tiers).
-import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
+import {
+  memoryRetrospectiveJob,
+  type MemoryRetrospectiveOutcome,
+} from "./memory-retrospective-job.js";
 import { skillCardInsertJob } from "./memory-retrospective-skill-card.js";
 import { memoryRetrospectiveSweepJob } from "./memory-retrospective-sweep.js";
 // SUBSTRATE (v2+v3).
-import { memoryV2ConsolidateJob } from "./substrate/consolidation-job.js";
+import {
+  type ConsolidationOutcome,
+  memoryV2ConsolidateJob,
+} from "./substrate/consolidation-job.js";
 import { memoryV2ReembedJob } from "./substrate/reembed-job.js";
 import { memoryV2SweepJob } from "./substrate/sweep-job.js";
 // V1 — delete with v1.
@@ -269,7 +275,8 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   },
   {
     type: "memory_v2_consolidate",
-    handler: (job, config) => memoryV2ConsolidateJob(job, config),
+    handler: async (job, config) =>
+      resolveConsolidationOutcome(await memoryV2ConsolidateJob(job, config)),
   },
   {
     type: "memory_v2_reembed",
@@ -303,7 +310,8 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   // v3 but is owned by the retrospective, so it groups here.
   {
     type: "memory_retrospective",
-    handler: (job, config) => memoryRetrospectiveJob(job, config),
+    handler: async (job, config) =>
+      resolveRetrospectiveOutcome(await memoryRetrospectiveJob(job, config)),
   },
   {
     type: "memory_retrospective_sweep",
@@ -314,3 +322,77 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     handler: (job) => skillCardInsertJob(job),
   },
 ];
+
+/**
+ * Terminal `last_error` for a retrospective row whose source conversation
+ * stayed mid-turn through the whole deferral budget. Named so the dead-letter
+ * row points at the stranded `processing_started_at` flag rather than a
+ * generic backend message; the sweep re-enqueues a fresh row once the source
+ * is eligible again.
+ */
+const SOURCE_PROCESSING_EXHAUSTED_MESSAGE =
+  "source conversation stayed mid-turn through the deferral budget " +
+  "(processing_started_at may be stranded); the retrospective sweep will re-enqueue";
+
+/**
+ * Translate the retrospective handler's domain outcome into the queue
+ * resolution persisted on its job row. The domain outcome is the source of
+ * truth for what happened; this mapping owns only how the row reads
+ * afterward:
+ *
+ * - benign no-ops and successful runs complete;
+ * - a mid-turn source defers the SAME row on the bounded deferral counter
+ *   (the turn-end trigger check's upsert coalesces onto this row, so the
+ *   event-driven retry keeps its immediacy) instead of completing it and
+ *   re-upserting a fresh row per attempt;
+ * - a failed or unusable wake dead-letters the row with an honest
+ *   `last_error`. Retry stays event-driven (cooldown + re-enqueue), so the
+ *   queue's attempt budget is deliberately not double-driving it.
+ */
+function resolveRetrospectiveOutcome(
+  outcome: MemoryRetrospectiveOutcome,
+): JobQueueResolution {
+  switch (outcome.kind) {
+    case "source_processing": {
+      return {
+        queueResolution: "deferred",
+        deferralExhaustedMessage: SOURCE_PROCESSING_EXHAUSTED_MESSAGE,
+      };
+    }
+    case "wake_failed": {
+      return {
+        queueResolution: "failed",
+        errorMessage: `retrospective wake failed: ${outcome.reason ?? "unknown"}`,
+      };
+    }
+    case "no_usable_output": {
+      return {
+        queueResolution: "failed",
+        errorMessage: `retrospective run produced no usable output: ${outcome.reason ?? "unknown"}`,
+      };
+    }
+    default: {
+      return { queueResolution: "completed" };
+    }
+  }
+}
+
+/**
+ * Translate the consolidation handler's domain outcome into the queue
+ * resolution persisted on its job row. A `run_failed` dead-letters the row
+ * with the failure reason; retry cadence is owned by the durable
+ * consolidation failure-state checkpoint (`memory_v2_consolidate_failure_state`),
+ * not the queue's attempt budget. Skips (disabled / locked / empty buffer)
+ * and successful runs complete.
+ */
+function resolveConsolidationOutcome(
+  outcome: ConsolidationOutcome,
+): JobQueueResolution {
+  if (outcome.kind === "run_failed") {
+    return {
+      queueResolution: "failed",
+      errorMessage: `consolidation run failed: ${outcome.reason ?? "unknown"}`,
+    };
+  }
+  return { queueResolution: "completed" };
+}

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -59,7 +59,7 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
-import type { JobHandler } from "../../types.js";
+import { isJobQueueResolution, type JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
@@ -425,8 +425,8 @@ export async function runMemoryJobsOnce(
     let groupProcessed = 0;
     for (const job of group) {
       try {
-        await processJob(job, config);
-        completeMemoryJob(job.id);
+        const resolution = await processJob(job, config);
+        applyQueueResolution(job, resolution);
         groupProcessed += 1;
       } catch (err) {
         try {
@@ -654,10 +654,55 @@ function handleJobError(job: MemoryJob, err: unknown): void {
 
 // ── Job dispatch ───────────────────────────────────────────────────
 
+/**
+ * Apply a handler's returned {@link JobQueueResolution} to its claimed row.
+ * Handlers that return anything else resolve as `completed` (the historical
+ * contract: failure is signaled by throwing). This is the worker's half of
+ * the outcome-truthfulness boundary: the persisted `memory_jobs.status` must
+ * reflect the handler's actual outcome, so a handler that reports failure
+ * through a returned value (e.g. the retrospective's `wake_failed`, the
+ * consolidation's `run_failed`) dead-letters or retries instead of silently
+ * completing.
+ */
+function applyQueueResolution(job: MemoryJob, resolution: unknown): void {
+  if (!isJobQueueResolution(resolution)) {
+    completeMemoryJob(job.id);
+    return;
+  }
+  switch (resolution.queueResolution) {
+    case "completed": {
+      completeMemoryJob(job.id);
+      return;
+    }
+    case "failed": {
+      failMemoryJob(job.id, resolution.errorMessage ?? "handler failed", {
+        maxAttempts: 1,
+      });
+      return;
+    }
+    case "retryable": {
+      failMemoryJob(job.id, resolution.errorMessage ?? "handler failed", {
+        retryDelayMs:
+          resolution.retryDelayMs ?? retryDelayForAttempt(job.attempts + 1),
+        maxAttempts: RETRY_MAX_ATTEMPTS,
+      });
+      return;
+    }
+    case "deferred": {
+      deferMemoryJob(job.id, {
+        ...(resolution.deferralExhaustedMessage
+          ? { exhaustedMessage: resolution.deferralExhaustedMessage }
+          : {}),
+      });
+      return;
+    }
+  }
+}
+
 async function processJob(
   job: MemoryJob,
   config: AssistantConfig,
-): Promise<void> {
+): Promise<unknown> {
   // Dispatch-level half of the v1-staleness guard, on the same condition the
   // handler-level half uses (`isStaleV1GraphJob` in `job-handlers.ts`): v1 work
   // runs only while v1 is the live tier, which memory being off is not (see
@@ -674,8 +719,7 @@ async function processJob(
   }
   const handler = jobHandlers.get(job.type);
   if (handler) {
-    await handler(job, config);
-    return;
+    return await handler(job, config);
   }
 
   const rawType = (job as { type: string }).type;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
@@ -78,3 +78,14 @@ export const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
  * set from turn 1, and matched by the permission checker's origin-scoped grant.
  */
 export const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
+
+/**
+ * The exact reply the fork instruction mandates when a reviewed window
+ * contains nothing worth saving. The finalizer treats a persisted assistant
+ * text block that trims to exactly this phrase (with no memory-writing tool
+ * attempts in the run) as the positive artifact of a legitimate no-findings
+ * review, advancing the cursor without fabricating a memory write. Compared
+ * by strict whole-block equality so analysis prose that merely mentions the
+ * phrase does not qualify.
+ */
+export const MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT = "Nothing new to save.";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -227,6 +227,19 @@ export async function runForkBasedRetrospective(
      * request overrides the gate.
      */
     enforceUserActivityGate?: boolean;
+    /**
+     * Rewind/backfill override for the review window's start. When provided,
+     * the source window is sliced from this message id (or from the
+     * conversation's beginning when `""` / `null`) instead of the persisted
+     * `lastProcessedMessageId`. The persisted cursor is not modified up
+     * front: a usable-output run advances it to the run's cutoff (the latest
+     * real message) via the normal finalizer, which is always a
+     * forward-or-equal move, so an interrupted or failed replay leaves state
+     * exactly as it was. The `rememberedLog` dedup baseline is still read
+     * from the persisted state row, so `<already_remembered>` applies to
+     * replayed windows and duplicate saves are suppressed.
+     */
+    overrideCursor?: string | null;
   },
 ): Promise<MemoryRetrospectiveOutcome> {
   // Start stamp for the retrospective's end-to-end wall time, surfaced as
@@ -309,7 +322,10 @@ export async function runForkBasedRetrospective(
   }
 
   const state = getRetrospectiveState(sourceConversationId);
-  const lastProcessedMessageId = state?.lastProcessedMessageId ?? null;
+  const lastProcessedMessageId =
+    opts?.overrideCursor !== undefined
+      ? opts.overrideCursor
+      : (state?.lastProcessedMessageId ?? null);
   // Kind-aware slice: a prior run's own `skill-authored-card` message lands
   // AFTER the cursor that run persisted, so the raw slice would treat the
   // card as new work — a card-only tail must be `no_new_messages`, and a

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -1052,7 +1052,20 @@ async function collectPriorRetrospectiveRemembers(
 async function extractRetrospectiveRunRemembers(
   conversationId: string,
 ): Promise<string[]> {
-  return (await collectRetrospectiveRunEvidence(conversationId)).remembers;
+  const conv = await getConversation(conversationId);
+  const runMessages = await loadRetrospectiveRunMessages(
+    conversationId,
+    conv?.source ?? null,
+  );
+  if (runMessages == null) {
+    return [];
+  }
+  // Deliberately unfiltered by execution success: this reads a PRIOR run for
+  // the <already_remembered> dedup baseline, where over-inclusion is the
+  // safe direction (worst case a fact is not re-saved) and old runs predate
+  // result-verified evidence. The CURRENT run's log append goes through
+  // `collectRetrospectiveRunEvidence`, which does verify execution.
+  return extractRememberContents(runMessages);
 }
 
 /**
@@ -1070,9 +1083,15 @@ const DURABLE_RETROSPECTIVE_TOOLS: ReadonlySet<string> = new Set([
 /**
  * Read the durable evidence a retrospective run persisted: its `remember`
  * contents plus a count of every memory-writing tool call on the run's
- * post-boundary tail. A load failure (`runMessages == null`) reports zero
- * durable calls, which the advancement gate treats as "not proven usable"
- * (fail-closed, the window stays retryable).
+ * post-boundary tail whose EXECUTION succeeded. A `tool_use` block alone
+ * proves only that the model asked; the durable write happens inside the
+ * executor, so a call counts (and its facts feed the remembered log) only
+ * when a matching non-error `tool_result` is persisted on the same tail. A
+ * failed or missing execution therefore leaves the window retryable, and a
+ * failed `remember`'s facts never enter the `<already_remembered>` baseline
+ * where they would suppress the retry's re-save. A load failure
+ * (`runMessages == null`) reports zero durable calls, which the advancement
+ * gate treats as "not proven usable" (fail-closed).
  */
 async function collectRetrospectiveRunEvidence(
   conversationId: string,
@@ -1085,18 +1104,61 @@ async function collectRetrospectiveRunEvidence(
   if (runMessages == null) {
     return { remembers: [], durableToolCallCount: 0 };
   }
+  const succeededIds = collectSuccessfulToolResultIds(runMessages);
   return {
-    remembers: extractRememberContents(runMessages),
-    durableToolCallCount: countDurableToolUses(runMessages),
+    remembers: extractRememberContents(runMessages, succeededIds),
+    durableToolCallCount: countDurableToolUses(runMessages, succeededIds),
   };
 }
 
 /**
- * Count persisted `tool_use` blocks whose `name` is in
- * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows.
- * Robust to malformed content JSON the same way `extractRememberContents` is.
+ * Ids of `tool_result` blocks on the run's user rows whose execution did not
+ * report an error. Robust to malformed content JSON the same way
+ * `extractRememberContents` is.
  */
-function countDurableToolUses(messages: MessageLike[]): number {
+function collectSuccessfulToolResultIds(messages: MessageLike[]): Set<string> {
+  const ids = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "user") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "tool_result" &&
+        typeof b.tool_use_id === "string" &&
+        b.is_error !== true
+      ) {
+        ids.add(b.tool_use_id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Count persisted `tool_use` blocks whose `name` is in
+ * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows and
+ * whose id has a matching successful `tool_result` in `succeededIds`.
+ */
+function countDurableToolUses(
+  messages: MessageLike[],
+  succeededIds: ReadonlySet<string>,
+): number {
   let count = 0;
   for (const msg of messages) {
     if (msg.role !== "assistant") {
@@ -1120,7 +1182,9 @@ function countDurableToolUses(messages: MessageLike[]): number {
       const b = block as Record<string, unknown>;
       if (
         b.type === "tool_use" &&
-        DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name))
+        DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name)) &&
+        typeof b.id === "string" &&
+        succeededIds.has(b.id)
       ) {
         count += 1;
       }
@@ -1139,7 +1203,10 @@ interface MessageLike {
  * `"remember"` and return the `input.content` strings in order. Robust to
  * malformed content JSON — unparseable rows are skipped, not propagated.
  */
-function extractRememberContents(messages: MessageLike[]): string[] {
+function extractRememberContents(
+  messages: MessageLike[],
+  succeededIds?: ReadonlySet<string>,
+): string[] {
   const contents: string[] = [];
   for (const msg of messages) {
     if (msg.role !== "assistant") {
@@ -1165,6 +1232,16 @@ function extractRememberContents(messages: MessageLike[]): string[] {
         continue;
       }
       if (b.name !== "remember") {
+        continue;
+      }
+      // When a success set is provided, only executions that reported a
+      // non-error tool_result contribute facts: a failed remember never
+      // wrote the buffer, and logging its facts would suppress the retry's
+      // re-save via <already_remembered>.
+      if (
+        succeededIds !== undefined &&
+        (typeof b.id !== "string" || !succeededIds.has(b.id))
+      ) {
         continue;
       }
       const input = b.input;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -88,6 +88,7 @@ import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+  MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT,
   MEMORY_RETROSPECTIVE_ORIGIN,
   MEMORY_RETROSPECTIVE_SOURCE,
   SKILL_MANAGEMENT_SKILL_ID,
@@ -572,25 +573,36 @@ export async function runForkBasedRetrospective(
     // provider rejections into a normal no-output return, an exhausted output
     // budget can stop a run before any visible text or tool call, and a
     // model may reply with analysis (or nothing) without saving. Advancement
-    // past the window therefore requires POSITIVE durable evidence from THIS
-    // run: at least one memory-writing tool call persisted on the fork's
-    // post-boundary tail. The evidence read is run-specific by construction
+    // past the window therefore requires POSITIVE evidence from THIS run,
+    // one of:
+    //   - a memory-writing tool call on the fork's post-boundary tail whose
+    //     execution verifiably succeeded (matching non-error tool_result), or
+    //   - the explicit no-findings reply the instruction mandates (an
+    //     assistant text block that is exactly the sentinel phrase), with no
+    //     memory-writing tool attempts at all; a run that attempted a save
+    //     and failed cannot advance by also claiming no findings.
+    // The evidence read is run-specific by construction
     // (`loadRetrospectiveRunMessages` scopes to rows after the fork
     // boundary), so a prior run's persisted saves can never satisfy it, and
     // it reads the DB rather than the returned history, so a checkpoint that
     // went live and persisted saves counts even when a later in-loop repair
-    // rebased the returned tail. A run with no durable evidence follows the
-    // wake-failure path: cursor, remembered log, and the prior retrospective
-    // (the dedup baseline) stay untouched and the window remains retryable.
+    // rebased the returned tail. A run with neither evidence kind follows
+    // the wake-failure path: cursor, remembered log, and the prior
+    // retrospective (the dedup baseline) stay untouched and the window
+    // remains retryable.
     const runEvidence = await collectRetrospectiveRunEvidence(forkId);
-    if (runEvidence.durableToolCallCount === 0) {
+    const reviewedNoFindings =
+      runEvidence.explicitNoFindings &&
+      runEvidence.durableToolAttemptCount === 0;
+    if (runEvidence.durableToolCallCount === 0 && !reviewedNoFindings) {
       log.warn(
         {
           sourceConversationId,
           forkId,
           newMessageCount: newMessages.length,
+          durableToolAttempts: runEvidence.durableToolAttemptCount,
         },
-        "memory-retrospective (fork): run produced no durable memory writes; leaving window retryable",
+        "memory-retrospective (fork): run produced neither a verified durable write nor an explicit no-findings reply; leaving window retryable",
       );
     } else {
       return await finalizeSuccessfulRetrospective({
@@ -606,6 +618,7 @@ export async function runForkBasedRetrospective(
           kind: "fork",
           windowStartTimestamp,
           durationMs: Date.now() - startedAtMs,
+          noFindings: reviewedNoFindings,
         },
       });
     }
@@ -1095,20 +1108,80 @@ const DURABLE_RETROSPECTIVE_TOOLS: ReadonlySet<string> = new Set([
  */
 async function collectRetrospectiveRunEvidence(
   conversationId: string,
-): Promise<{ remembers: string[]; durableToolCallCount: number }> {
+): Promise<{
+  remembers: string[];
+  /** Memory-writing tool calls whose execution verifiably succeeded. */
+  durableToolCallCount: number;
+  /** Memory-writing tool calls the run attempted, regardless of outcome. */
+  durableToolAttemptCount: number;
+  /**
+   * The run replied with exactly the mandated no-findings sentinel text
+   * ({@link MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}) in a persisted assistant
+   * text block. Strict whole-block equality: prose that merely mentions the
+   * phrase does not qualify, so an analysis-only reply stays unusable.
+   */
+  explicitNoFindings: boolean;
+}> {
   const conv = await getConversation(conversationId);
   const runMessages = await loadRetrospectiveRunMessages(
     conversationId,
     conv?.source ?? null,
   );
   if (runMessages == null) {
-    return { remembers: [], durableToolCallCount: 0 };
+    return {
+      remembers: [],
+      durableToolCallCount: 0,
+      durableToolAttemptCount: 0,
+      explicitNoFindings: false,
+    };
   }
   const succeededIds = collectSuccessfulToolResultIds(runMessages);
   return {
     remembers: extractRememberContents(runMessages, succeededIds),
     durableToolCallCount: countDurableToolUses(runMessages, succeededIds),
+    durableToolAttemptCount: countDurableToolUses(runMessages, null),
+    explicitNoFindings: hasExplicitNoFindingsReply(runMessages),
   };
+}
+
+/**
+ * Whether any persisted assistant row on the run's tail carries a text block
+ * that is exactly the no-findings sentinel (after trimming). The instruction
+ * template mandates this exact reply for a reviewed-and-nothing-to-save
+ * pass, making it the positive persisted artifact that distinguishes a
+ * legitimate no-findings review from an empty or unusable response.
+ */
+function hasExplicitNoFindingsReply(messages: MessageLike[]): boolean {
+  for (const msg of messages) {
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "text" &&
+        typeof b.text === "string" &&
+        b.text.trim() === MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -1152,12 +1225,14 @@ function collectSuccessfulToolResultIds(messages: MessageLike[]): Set<string> {
 
 /**
  * Count persisted `tool_use` blocks whose `name` is in
- * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows and
- * whose id has a matching successful `tool_result` in `succeededIds`.
+ * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows.
+ * With a `succeededIds` set, only calls whose id has a matching successful
+ * `tool_result` count (verified executions); with `null`, every attempt
+ * counts regardless of outcome.
  */
 function countDurableToolUses(
   messages: MessageLike[],
-  succeededIds: ReadonlySet<string>,
+  succeededIds: ReadonlySet<string> | null,
 ): number {
   let count = 0;
   for (const msg of messages) {
@@ -1183,8 +1258,8 @@ function countDurableToolUses(
       if (
         b.type === "tool_use" &&
         DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name)) &&
-        typeof b.id === "string" &&
-        succeededIds.has(b.id)
+        (succeededIds === null ||
+          (typeof b.id === "string" && succeededIds.has(b.id)))
       ) {
         count += 1;
       }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -46,6 +46,7 @@ import {
   type ConversationRow,
   deleteConversation,
   getConversation,
+  getConversationProcessingStartedAt,
   isConversationProcessing,
 } from "@vellumai/plugin-api";
 
@@ -72,7 +73,6 @@ import {
   enqueueMemoryJob,
   type MemoryJob,
   type MemoryJobType,
-  upsertMemoryRetrospectiveJob,
 } from "../../../persistence/jobs-store.js";
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
@@ -112,15 +112,17 @@ const log = getLogger("memory-retrospective-job");
 const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [] as const;
 
 /**
- * Fallback delay for re-upserting a run that was skipped because the source
- * conversation was mid-turn. The PRIMARY requeue is event-driven: the
- * mid-turn skip leaves `lastRunAt` unbumped, so the message-indexing pass on
- * the turn's final assistant message re-enqueues immediately. This timed row
- * only covers a turn that aborts without ever persisting another message.
- * Each retried attempt re-checks the processing flag and re-upserts at the
- * same cadence, so the loop self-resolves when the turn ends.
+ * Age past which a source conversation's persisted `processing_started_at`
+ * stamp is treated as stranded rather than live, and the retrospective
+ * proceeds despite it. A turn-end flag clear can fail and be swallowed under
+ * DB-lock contention while the daemon stays up, and the monitor-process
+ * reaper only clears flags older than the daemon's boot time, so an
+ * in-process stranded flag otherwise blocks a conversation's retrospectives
+ * indefinitely. Proceeding risks only forking a half-finished display turn
+ * (a review-quality concern; the fork copies complete persisted turns), which
+ * is strictly better than never forming memories for the conversation again.
  */
-export const SOURCE_PROCESSING_REQUEUE_DELAY_MS = 60_000;
+export const STALE_SOURCE_PROCESSING_OVERRIDE_MS = 6 * 60 * 60 * 1000;
 
 /** Watchdog check_name for the per-run retrospective outcome counter. */
 const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
@@ -132,6 +134,7 @@ export type MemoryRetrospectiveOutcome =
   | { kind: "source_dormant" }
   | { kind: "source_processing" }
   | { kind: "wake_failed"; reason?: string; conversationId?: string }
+  | { kind: "no_usable_output"; reason?: string; conversationId?: string }
   | {
       kind: "invoked";
       backgroundConversationId: string;
@@ -186,7 +189,9 @@ export async function memoryRetrospectiveJob(
   }
   emitRunOutcome(
     outcome.kind,
-    outcome.kind === "wake_failed" ? outcome.reason : undefined,
+    outcome.kind === "wake_failed" || outcome.kind === "no_usable_output"
+      ? outcome.reason
+      : undefined,
   );
   return outcome;
 }
@@ -271,34 +276,36 @@ export async function runForkBasedRetrospective(
   // persisted message — including the turn's final assistant message — so an
   // unbumped `lastRunAt` lets that turn-end pass re-enqueue with no cooldown
   // suppression. That is the primary, event-driven requeue: the retrospective
-  // runs right after the colliding turn completes. Mid-turn attempts are
-  // cheap no-ops (existence + processing check) that recur at most once per
-  // persisted message and coalesce into a single pending row via the upsert.
-  // The timed re-upsert below is a fallback for a turn that aborts without
-  // ever indexing another message (the lifecycle/disposal enqueue remains
-  // the last-resort net). Both state pointers stay untouched, so nothing is
-  // lost. Returning (not throwing) keeps the jobs-worker from
-  // retry-with-backoff.
+  // runs right after the colliding turn completes. The `source_processing`
+  // outcome maps to a bounded deferral of the SAME job row at the worker
+  // (see `resolveRetrospectiveOutcome` in `job-handlers.ts`); turn-end
+  // trigger upserts coalesce onto that pending row, so the event-driven
+  // retry keeps its immediacy while a stranded flag can no longer mint an
+  // unbounded stream of fresh rows. Both state pointers stay untouched, so
+  // nothing is lost.
+  //
+  // Stranded-flag override: a swallowed turn-end flag clear leaves the
+  // persisted stamp set while the daemon stays up, where the monitor
+  // process's boot-time-fenced reaper never touches it. A stamp older than
+  // `STALE_SOURCE_PROCESSING_OVERRIDE_MS` is treated as stranded and the run
+  // proceeds; a set-but-stampless flag reads as live (deferral bounds it).
   if (await isConversationProcessing(sourceConversationId)) {
-    try {
-      upsertMemoryRetrospectiveJob(
-        { conversationId: sourceConversationId },
-        Date.now() + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-      );
+    const processingStartedAt =
+      await getConversationProcessingStartedAt(sourceConversationId);
+    const stale =
+      processingStartedAt != null &&
+      startedAtMs - processingStartedAt > STALE_SOURCE_PROCESSING_OVERRIDE_MS;
+    if (!stale) {
       log.info(
-        {
-          sourceConversationId,
-          requeueDelayMs: SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-        },
-        "memory-retrospective (fork): source conversation is mid-turn; requeued",
+        { sourceConversationId, processingStartedAt },
+        "memory-retrospective (fork): source conversation is mid-turn; deferring",
       );
-    } catch (err) {
-      log.warn(
-        { err, sourceConversationId },
-        "memory-retrospective (fork): mid-turn fallback requeue failed; relying on the turn-end trigger check",
-      );
+      return { kind: "source_processing" };
     }
-    return { kind: "source_processing" };
+    log.warn(
+      { sourceConversationId, processingStartedAt },
+      "memory-retrospective (fork): processing flag is stale beyond the override window; proceeding despite it",
+    );
   }
 
   const state = getRetrospectiveState(sourceConversationId);
@@ -544,25 +551,53 @@ export async function runForkBasedRetrospective(
   }
 
   if (wakeSucceeded) {
-    return await finalizeSuccessfulRetrospective({
-      config,
-      sourceConversationId,
-      retrospectiveConversationId: forkId,
-      cutoffMessageId,
-      newMessageCount: newMessages.length,
-      prior,
-      priorRemembers,
-      logFields: {
-        kind: "fork",
-        windowStartTimestamp,
-        durationMs: Date.now() - startedAtMs,
-      },
-    });
+    // Fail-closed finalization: `invoked: true` proves only that the wake
+    // went live, not that the run produced anything. The agent loop swallows
+    // provider rejections into a normal no-output return, an exhausted output
+    // budget can stop a run before any visible text or tool call, and a
+    // model may reply with analysis (or nothing) without saving. Advancement
+    // past the window therefore requires POSITIVE durable evidence from THIS
+    // run: at least one memory-writing tool call persisted on the fork's
+    // post-boundary tail. The evidence read is run-specific by construction
+    // (`loadRetrospectiveRunMessages` scopes to rows after the fork
+    // boundary), so a prior run's persisted saves can never satisfy it, and
+    // it reads the DB rather than the returned history, so a checkpoint that
+    // went live and persisted saves counts even when a later in-loop repair
+    // rebased the returned tail. A run with no durable evidence follows the
+    // wake-failure path: cursor, remembered log, and the prior retrospective
+    // (the dedup baseline) stay untouched and the window remains retryable.
+    const runEvidence = await collectRetrospectiveRunEvidence(forkId);
+    if (runEvidence.durableToolCallCount === 0) {
+      log.warn(
+        {
+          sourceConversationId,
+          forkId,
+          newMessageCount: newMessages.length,
+        },
+        "memory-retrospective (fork): run produced no durable memory writes; leaving window retryable",
+      );
+    } else {
+      return await finalizeSuccessfulRetrospective({
+        config,
+        sourceConversationId,
+        retrospectiveConversationId: forkId,
+        cutoffMessageId,
+        newMessageCount: newMessages.length,
+        prior,
+        priorRemembers,
+        runRemembers: runEvidence.remembers,
+        logFields: {
+          kind: "fork",
+          windowStartTimestamp,
+          durationMs: Date.now() - startedAtMs,
+        },
+      });
+    }
   }
 
-  // Wake failed. Bump `lastRunAt` only so the cooldown gate applies, leave
-  // `lastProcessedMessageId` alone so the next attempt re-processes the
-  // same messages. Then clean up the orphan fork.
+  // Wake failed or produced no usable output. Bump `lastRunAt` only so the
+  // cooldown gate applies, leave `lastProcessedMessageId` alone so the next
+  // attempt re-processes the same messages. Then clean up the orphan fork.
   await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
   await safeDeleteRetrospectiveConversation(
     forkId,
@@ -573,6 +608,13 @@ export async function runForkBasedRetrospective(
     throw threw;
   }
 
+  if (wakeSucceeded) {
+    return {
+      kind: "no_usable_output",
+      reason: failureReason ?? "run persisted no memory-writing tool call",
+      conversationId: forkId,
+    };
+  }
   return {
     kind: "wake_failed",
     reason: failureReason,
@@ -781,6 +823,12 @@ async function finalizeSuccessfulRetrospective(args: {
   newMessageCount: number;
   prior: PriorRetrospective | null;
   priorRemembers: string[];
+  /**
+   * The `remember` contents extracted from this run's persisted tail by the
+   * caller's usable-output check; passed through so the evidence that gated
+   * advancement is exactly the evidence folded into the log.
+   */
+  runRemembers: string[];
   /** Per-kind extras for the success log line (e.g. `kind`, fork anchor). */
   logFields: Record<string, unknown>;
 }): Promise<MemoryRetrospectiveOutcome> {
@@ -792,12 +840,10 @@ async function finalizeSuccessfulRetrospective(args: {
     newMessageCount,
     prior,
     priorRemembers,
+    runRemembers,
     logFields,
   } = args;
 
-  const runRemembers = await extractRetrospectiveRunRemembers(
-    retrospectiveConversationId,
-  );
   await upsertRetrospectiveState({
     conversationId: sourceConversationId,
     lastProcessedMessageId: cutoffMessageId,
@@ -990,15 +1036,81 @@ async function collectPriorRetrospectiveRemembers(
 async function extractRetrospectiveRunRemembers(
   conversationId: string,
 ): Promise<string[]> {
+  return (await collectRetrospectiveRunEvidence(conversationId)).remembers;
+}
+
+/**
+ * Tool names whose persisted `tool_use` blocks count as durable memory work
+ * for the fail-closed advancement gate: `remember` writes the memory buffer,
+ * `scaffold_managed_skill` writes a managed skill. Read-only tools on the
+ * retrospective allowlist (`skill_load`, `find_similar_skills`) deliberately
+ * do not qualify: a run that only browsed produced nothing durable.
+ */
+const DURABLE_RETROSPECTIVE_TOOLS: ReadonlySet<string> = new Set([
+  "remember",
+  "scaffold_managed_skill",
+]);
+
+/**
+ * Read the durable evidence a retrospective run persisted: its `remember`
+ * contents plus a count of every memory-writing tool call on the run's
+ * post-boundary tail. A load failure (`runMessages == null`) reports zero
+ * durable calls, which the advancement gate treats as "not proven usable"
+ * (fail-closed, the window stays retryable).
+ */
+async function collectRetrospectiveRunEvidence(
+  conversationId: string,
+): Promise<{ remembers: string[]; durableToolCallCount: number }> {
   const conv = await getConversation(conversationId);
   const runMessages = await loadRetrospectiveRunMessages(
     conversationId,
     conv?.source ?? null,
   );
   if (runMessages == null) {
-    return [];
+    return { remembers: [], durableToolCallCount: 0 };
   }
-  return extractRememberContents(runMessages);
+  return {
+    remembers: extractRememberContents(runMessages),
+    durableToolCallCount: countDurableToolUses(runMessages),
+  };
+}
+
+/**
+ * Count persisted `tool_use` blocks whose `name` is in
+ * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows.
+ * Robust to malformed content JSON the same way `extractRememberContents` is.
+ */
+function countDurableToolUses(messages: MessageLike[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "tool_use" &&
+        DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name))
+      ) {
+        count += 1;
+      }
+    }
+  }
+  return count;
 }
 
 interface MessageLike {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -63,7 +63,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
 {{SKILL_AUTHORING_SECTION}}`;
 
 /** Placeholder names recognized in the bundled template and overrides. */

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
@@ -28,6 +28,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -71,6 +72,8 @@ let runnerImpl: () => Promise<{
   errorKind?: string;
   failureCode?: string;
   skipReason?: string;
+  workStopped?: boolean;
+  workSettled?: Promise<void>;
 }> = runnerTrimsBuffer;
 
 mock.module("../../../../../runtime/background-job-runner.js", () => ({
@@ -745,6 +748,83 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     // Lock must still be released on the failure path so the next
     // scheduled consolidation can re-attempt.
     expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("timeout whose turn stopped cooperatively releases the lock", async () => {
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: true,
+    });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("run_failed");
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("timeout whose turn is STILL RUNNING keeps the lock held, then releases on late settlement", async () => {
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    let settleLateWork: (() => void) | undefined;
+    const workSettled = new Promise<void>((resolve) => {
+      settleLateWork = resolve;
+    });
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: false,
+      workSettled,
+    });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("run_failed");
+    // The abandoned turn may still be writing memory files: the lock must
+    // outlive the handler so no overlapping consolidation can start.
+    expect(existsSync(lockPath())).toBe(true);
+
+    // Late settlement frees the lock without waiting for the stale TTL.
+    settleLateWork!();
+    await workSettled;
+    // The release continuation runs on the microtask queue after settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("late settlement release is owner-verified: a taken-over lock is not clobbered", async () => {
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    let settleLateWork: (() => void) | undefined;
+    const workSettled = new Promise<void>((resolve) => {
+      settleLateWork = resolve;
+    });
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: false,
+      workSettled,
+    });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(result.kind).toBe("run_failed");
+    expect(existsSync(lockPath())).toBe(true);
+
+    // Simulate a stale-TTL takeover by a newer run while the zombie lingers.
+    const newerHolder = `${process.pid} ${Date.now()} consolidation-newer\n`;
+    writeFileSync(lockPath(), newerHolder);
+
+    settleLateWork!();
+    await workSettled;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // The zombie's late release must NOT unlink the newer holder's lock.
+    expect(existsSync(lockPath())).toBe(true);
+    expect(readFileSync(lockPath(), "utf-8")).toBe(newerHolder);
   });
 
   test("does NOT emit a notification signal when the runner fails (suppression honored)", async () => {

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-lock.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-lock.test.ts
@@ -29,6 +29,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   getConsolidationLockPath,
+  readLockHolder,
   releaseLock,
   STALE_LOCK_TTL_MS,
   tryAcquireLock,
@@ -132,5 +133,50 @@ describe("releaseLock", () => {
   test("is a no-op when the lock file is absent", () => {
     expect(existsSync(lockPath)).toBe(false);
     expect(() => releaseLock(lockPath)).not.toThrow();
+  });
+
+  test("owner-verified release removes the lock while the payload still matches", () => {
+    expect(tryAcquireLock(lockPath, "consolidation")).toBeNull();
+    const ownerToken = readLockHolder(lockPath);
+    expect(ownerToken).not.toBeNull();
+
+    releaseLock(lockPath, ownerToken!);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("owner-verified release refuses to unlink a lock held by a different owner", () => {
+    expect(tryAcquireLock(lockPath, "consolidation")).toBeNull();
+    const ownerToken = readLockHolder(lockPath)!;
+
+    // A takeover re-wrote the lock: the original owner's token no longer
+    // matches, so its release must be a no-op.
+    const newerHolder = `${process.pid} ${Date.now()} consolidation-newer`;
+    writeFileSync(lockPath, `${newerHolder}\n`);
+
+    releaseLock(lockPath, ownerToken);
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe(newerHolder);
+  });
+
+  test("owner-verified release is a no-op when the lock is already gone", () => {
+    expect(tryAcquireLock(lockPath)).toBeNull();
+    const ownerToken = readLockHolder(lockPath)!;
+    releaseLock(lockPath);
+    expect(() => releaseLock(lockPath, ownerToken)).not.toThrow();
+  });
+});
+
+describe("readLockHolder", () => {
+  test("returns the trimmed payload of a held lock", () => {
+    expect(tryAcquireLock(lockPath, "consolidation")).toBeNull();
+    const holder = readLockHolder(lockPath);
+    expect(holder).toStartWith(`${process.pid} `);
+    expect(holder).toEndWith(" consolidation");
+  });
+
+  test("returns null for a missing or empty lock file", () => {
+    expect(readLockHolder(lockPath)).toBeNull();
+    writeFileSync(lockPath, "");
+    expect(readLockHolder(lockPath)).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
@@ -97,6 +97,7 @@ import { getWorkspaceDir } from "../paths.js";
 import {
   CONSOLIDATION_TIMEOUT_MS,
   getConsolidationLockPath,
+  readLockHolder,
   releaseLock,
   tryAcquireLock,
 } from "./consolidation-lock.js";
@@ -319,6 +320,16 @@ export async function memoryV2ConsolidateJob(
     log.warn({ lockPath, holder }, "consolidation skipped: lock already held");
     return { kind: "locked", holder };
   }
+  // Read our own payload back as the owner token: `releaseLock` below is
+  // owner-verified, so a lock that was stale-classified and taken over by a
+  // newer run mid-execution is never unlinked out from under that newer run.
+  const ownerToken = readLockHolder(lockPath) ?? undefined;
+  // Set when the run timed out and the underlying turn did NOT stop within
+  // the abort grace window: the abandoned turn can still be writing
+  // `memory/**`, so releasing the lock would let a second consolidation run
+  // concurrently with it. The lock is deliberately left held; the stale-lock
+  // TTL (or the zombie process exiting) reclaims it.
+  let abandonedRunStillWriting = false;
 
   try {
     // Step 2: bail on empty buffer. Nothing for the agent to consolidate.
@@ -458,6 +469,27 @@ export async function memoryV2ConsolidateJob(
     });
 
     if (!runResult.ok) {
+      // A timed-out run is cooperatively aborted by the runner; when the
+      // turn still refused to stop within the grace window it may keep
+      // writing memory files, so the lock must outlive this handler (see
+      // `abandonedRunStillWriting` above).
+      if (
+        runResult.errorKind === "timeout" &&
+        runResult.workStopped === false
+      ) {
+        abandonedRunStillWriting = true;
+        // Free the lock promptly (owner-verified) once the zombie finally
+        // settles, instead of waiting out the stale-lock TTL. If the TTL
+        // reaper (or a takeover) got there first, the owner check makes
+        // this a no-op.
+        void runResult.workSettled?.then(() => {
+          log.info(
+            { lockPath },
+            "consolidation: timed-out run settled late; releasing its lock",
+          );
+          releaseLock(lockPath, ownerToken);
+        });
+      }
       // Billing turn failures (`PROVIDER_BILLING` covers both exhausted
       // managed credits and BYOK provider-account credits) are
       // non-retryable and select the scheduler's long backoff curve;
@@ -471,6 +503,7 @@ export async function memoryV2ConsolidateJob(
           errorKind: runResult.errorKind,
           failureCode: runResult.failureCode,
           failureKind,
+          abandonedRunStillWriting,
           err: runResult.error?.message,
         },
         "consolidation run failed; follow-ups skipped",
@@ -576,7 +609,18 @@ export async function memoryV2ConsolidateJob(
       noProgress: false,
     };
   } finally {
-    releaseLock(lockPath);
+    if (abandonedRunStillWriting) {
+      // The timed-out turn is still executing: keep the lock so no second
+      // consolidation overlaps its writes. Reclamation is the stale-lock
+      // classifier's job (PID death, or the TTL for a wedged-but-alive
+      // process).
+      log.warn(
+        { lockPath },
+        "consolidation: leaving lock held for a timed-out run that has not stopped",
+      );
+    } else {
+      releaseLock(lockPath, ownerToken);
+    }
   }
 }
 

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
@@ -228,13 +228,47 @@ function holderStaleReason(holder: string): StaleReason | null {
 }
 
 /**
+ * Read the lock file's current holder payload (trimmed), or `null` when the
+ * file is missing or unreadable. An acquirer reads its own payload back right
+ * after a successful `tryAcquireLock` to obtain the owner token it must
+ * present to `releaseLock`.
+ */
+export function readLockHolder(lockPath: string): string | null {
+  try {
+    const holder = readFileSync(lockPath, "utf-8").trim();
+    return holder.length > 0 ? holder : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Idempotent unlink of the lock file. Called from the caller's `finally`
  * block so a crash in the run path doesn't leave the lock stranded. ENOENT is
  * swallowed
  * because the lock may have been released by an operator or never created
  * (acquire failed before reaching the lock-write step).
+ *
+ * `expectedHolder` makes the release owner-verified: when provided, the lock
+ * is unlinked only while its current payload still matches, so a caller
+ * whose lock was taken over (stale-classified and re-acquired by a newer
+ * run) cannot release the newer holder's lock. Omitting it preserves the
+ * unconditional unlink for callers that positively own the file.
  */
-export function releaseLock(lockPath: string): void {
+export function releaseLock(lockPath: string, expectedHolder?: string): void {
+  if (expectedHolder !== undefined) {
+    const current = readLockHolder(lockPath);
+    if (current === null) {
+      return;
+    }
+    if (current !== expectedHolder) {
+      log.warn(
+        { lockPath, expectedHolder, currentHolder: current },
+        "consolidation: skipping lock release; lock is now held by a different owner",
+      );
+      return;
+    }
+  }
   try {
     unlinkSync(lockPath);
   } catch (err) {

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -207,6 +207,9 @@ const HOOK_OUTPUT_SCHEMAS: Partial<
   [HOOKS.POST_COMPACT]: z.looseObject({
     history: z.array(MessageSchema).optional(),
   }),
+  [HOOKS.PRE_MODEL_CALL]: z.looseObject({
+    messages: z.array(MessageSchema).optional(),
+  }),
   [HOOKS.POST_MODEL_CALL]: z.looseObject({
     messages: z.array(MessageSchema).optional(),
     content: z.array(ContentBlockSchema).optional(),

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -334,9 +334,67 @@ export interface Injector {
 // than wired through the loader, so they carry no `Plugin` contribution slot.
 
 /**
+ * How the worker resolves a claimed job row after its handler returns
+ * without throwing. Handlers that report failure through a returned domain
+ * outcome (rather than a throw) translate that outcome into one of these at
+ * the registration site, so the persisted `memory_jobs.status` reflects what
+ * actually happened instead of unconditionally reading `completed`.
+ *
+ * - `completed`: the work succeeded (or was a legitimate no-op).
+ * - `failed`: terminal failure; the row is dead-lettered with
+ *   `errorMessage` as `last_error`. Use when retry is owned elsewhere
+ *   (event-driven re-enqueue, durable backoff checkpoints).
+ * - `retryable`: transient failure; the row re-enters the queue's
+ *   attempt-budgeted retry machinery with `errorMessage` recorded.
+ * - `deferred`: the work could not run yet for a reason external to the
+ *   job (e.g. its source conversation is mid-turn); the row goes back to
+ *   pending on the deferral counter's backoff curve and dead-letters with
+ *   `deferralExhaustedMessage` once the deferral budget is spent.
+ */
+export interface JobQueueResolution {
+  queueResolution: "completed" | "failed" | "retryable" | "deferred";
+  /** Persisted to `memory_jobs.last_error` for `failed` / `retryable`. */
+  errorMessage?: string;
+  /** Retry delay override for `retryable`. */
+  retryDelayMs?: number;
+  /** Terminal `last_error` when a `deferred` job exhausts its budget. */
+  deferralExhaustedMessage?: string;
+}
+
+const QUEUE_RESOLUTIONS = new Set([
+  "completed",
+  "failed",
+  "retryable",
+  "deferred",
+]);
+
+/**
+ * Narrow an arbitrary handler return value to a {@link JobQueueResolution}.
+ * Anything else (including `undefined` and legacy domain outcomes) resolves
+ * as `completed`, preserving the historical contract for handlers that only
+ * signal failure by throwing.
+ */
+export function isJobQueueResolution(
+  value: unknown,
+): value is JobQueueResolution {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "queueResolution" in value &&
+    typeof (value as { queueResolution: unknown }).queueResolution ===
+      "string" &&
+    QUEUE_RESOLUTIONS.has(
+      (value as { queueResolution: string }).queueResolution,
+    )
+  );
+}
+
+/**
  * Processes one claimed background job: receives the claimed job row and the
- * live assistant config. The return value is ignored — a handler signals
- * failure by throwing, which the worker records against the job.
+ * live assistant config. A handler signals failure by throwing (recorded
+ * against the job's attempt budget) or by returning a
+ * {@link JobQueueResolution}; any other return value resolves the row as
+ * `completed`.
  */
 export type JobHandler = (job: MemoryJob, config: AssistantConfig) => unknown;
 

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -94,6 +94,27 @@ mock.module("../pre-first-message-gate.js", () => ({
   hasReceivedUserMessage: () => preFirstMessageGateOpen,
 }));
 
+// Conversation registry stub for the timeout-cancellation path: the runner
+// looks up the live conversation to signal its abort controller. Tests
+// register an abort recorder here; absent ids mean "not resident" (no-op).
+const abortCalls: Array<{ conversationId: string; reason: unknown }> = [];
+let registeredAbortableConversation:
+  | { conversationId: string; onAbort?: () => void }
+  | undefined;
+mock.module("../../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string) => {
+    if (registeredAbortableConversation?.conversationId !== id) {
+      return undefined;
+    }
+    return {
+      abort: (reason: unknown) => {
+        abortCalls.push({ conversationId: id, reason });
+        registeredAbortableConversation?.onAbort?.();
+      },
+    };
+  },
+}));
+
 // Import after mocks are in place.
 const { runBackgroundJob } = await import("../background-job-runner.js");
 const { bufferIfDeferred, resetDeferredForTest } =
@@ -125,6 +146,8 @@ beforeEach(() => {
   processMessageCalls.length = 0;
   emitCalls.length = 0;
   addMessageCalls.length = 0;
+  abortCalls.length = 0;
+  registeredAbortableConversation = undefined;
   resetDeferredForTest();
   preFirstMessageGateOpen = true;
   processMessageImpl = async () => ({ messageId: "msg-1" });
@@ -310,7 +333,9 @@ describe("runBackgroundJob", () => {
     // Never resolve — force timeout to win the race.
     processMessageImpl = () => new Promise(() => {});
 
-    const result = await runBackgroundJob(baseOpts({ timeoutMs: 50 }));
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 20 }),
+    );
 
     expect(result.ok).toBe(false);
     expect(result.errorKind).toBe("timeout");
@@ -320,6 +345,67 @@ describe("runBackgroundJob", () => {
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("timeout");
+  });
+
+  test("timeout: signals the live conversation's abort controller and reports workStopped=true when the turn settles", async () => {
+    // The turn hangs until it observes the abort, then settles: the
+    // cooperative-cancellation contract.
+    let settleWork: (() => void) | undefined;
+    processMessageImpl = () =>
+      new Promise((resolve) => {
+        settleWork = () => resolve({ messageId: "msg-aborted" });
+      });
+    registeredAbortableConversation = {
+      conversationId: STUB_CONVERSATION_ID,
+      onAbort: () => settleWork?.(),
+    };
+
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 500 }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("timeout");
+    expect(result.workStopped).toBe(true);
+    expect(result.workSettled).toBeUndefined();
+    expect(abortCalls).toHaveLength(1);
+    expect(abortCalls[0]!.conversationId).toBe(STUB_CONVERSATION_ID);
+    expect(abortCalls[0]!.reason).toMatchObject({
+      kind: "signal_cancel",
+      source: "backgroundJobTimeout:test-job",
+    });
+  });
+
+  test("timeout: a turn that ignores the abort reports workStopped=false and exposes workSettled", async () => {
+    let settleWork: (() => void) | undefined;
+    processMessageImpl = () =>
+      new Promise((resolve) => {
+        settleWork = () => resolve({ messageId: "msg-late" });
+      });
+    registeredAbortableConversation = {
+      conversationId: STUB_CONVERSATION_ID,
+      // No onAbort: the turn keeps running through the grace window.
+    };
+
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 20 }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("timeout");
+    expect(result.workStopped).toBe(false);
+    expect(result.workSettled).toBeDefined();
+    expect(abortCalls).toHaveLength(1);
+
+    // The late settlement is observable through the exposed handle.
+    let settled = false;
+    const settledProbe = result.workSettled!.then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+    settleWork!();
+    await settledProbe;
+    expect(settled).toBe(true);
   });
 
   test("suppressFailureNotifications: failure returns ok=false but emits nothing", async () => {
@@ -520,7 +606,11 @@ describe("runBackgroundJob", () => {
       };
 
       const result = await runBackgroundJob(
-        baseOpts({ deferNotifications: true, timeoutMs: 30 }),
+        baseOpts({
+          deferNotifications: true,
+          timeoutMs: 30,
+          timeoutAbortGraceMs: 20,
+        }),
       );
 
       expect(result.ok).toBe(false);
@@ -556,7 +646,11 @@ describe("runBackgroundJob", () => {
       processMessageImpl = () => new Promise(() => {});
 
       const result = await runBackgroundJob(
-        baseOpts({ deferNotifications: true, timeoutMs: 20 }),
+        baseOpts({
+          deferNotifications: true,
+          timeoutMs: 20,
+          timeoutAbortGraceMs: 20,
+        }),
       );
       expect(result.ok).toBe(false);
 

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -103,6 +103,12 @@ export interface RunBackgroundJobOptions {
   /** Hard timeout for `processMessage` in milliseconds. */
   timeoutMs: number;
   /**
+   * Post-timeout cooperative-cancellation grace window override in
+   * milliseconds. Defaults to {@link TIMEOUT_ABORT_GRACE_MS}; tests shrink it
+   * so the still-running branch is observable without a 30s wait.
+   */
+  timeoutAbortGraceMs?: number;
+  /**
    * When true, failures do NOT emit an `activity.failed` notification.
    * Use for jobs that own their own failure UX (e.g. heartbeat's alerter)
    * or for "quiet" scheduled jobs that the user has explicitly asked to
@@ -209,6 +215,22 @@ export interface RunBackgroundJobResult {
   error?: Error;
   errorKind?: BackgroundJobErrorKind;
   /**
+   * Present only on `errorKind: "timeout"` failures: whether the underlying
+   * turn was observed to STOP (settle) within the post-abort grace window
+   * after the runner signalled the conversation's abort controller. `false`
+   * means the turn is still executing; callers that guard a shared resource
+   * (e.g. the consolidation lock) must treat the resource as still in use by
+   * the abandoned run.
+   */
+  workStopped?: boolean;
+  /**
+   * Present only when `workStopped` is `false`: settles (never rejects) when
+   * the abandoned turn finally stops. Lets a caller holding a shared
+   * resource for the zombie release it promptly on late settlement instead
+   * of waiting for a staleness TTL.
+   */
+  workSettled?: Promise<void>;
+  /**
    * Stable classified error code (`ConversationErrorCode`, e.g.
    * `"PROVIDER_BILLING"`) when the turn failed without throwing. Absent for
    * timeouts and thrown exceptions. Lets callers branch on the failure class
@@ -225,6 +247,74 @@ export interface RunBackgroundJobResult {
    *   was bootstrapped; `conversationId` is the empty string.
    */
   skipReason?: "pre_first_user_message";
+}
+
+/**
+ * How long the runner waits, after signalling the abort controller of a
+ * timed-out turn, for the underlying `processMessage` promise to settle
+ * before reporting the work as still running. Cooperative cancellation
+ * normally unwinds within seconds (the AbortSignal reaches the in-flight
+ * provider call and the tool loop); the grace window only bounds the wait,
+ * it does not kill anything.
+ */
+export const TIMEOUT_ABORT_GRACE_MS = 30_000;
+
+/**
+ * Cooperatively cancel a timed-out background turn and report whether it
+ * actually stopped. Signals the live conversation's abort controller (the
+ * same rail user Stop uses, so the abort reaches the in-flight provider call
+ * and tool loop), then waits up to {@link TIMEOUT_ABORT_GRACE_MS} for the
+ * `processMessage` promise to settle. Returns `true` when the work settled
+ * (stopped), `false` when it is still executing past the grace window.
+ */
+async function cancelTimedOutWork(
+  conversationId: string | undefined,
+  work: Promise<unknown> | undefined,
+  jobName: string,
+  graceMs: number,
+): Promise<boolean> {
+  if (conversationId) {
+    try {
+      const { findConversation } =
+        await import("../daemon/conversation-registry.js");
+      const { createAbortReason } = await import("../util/abort-reasons.js");
+      findConversation(conversationId)?.abort(
+        createAbortReason(
+          "signal_cancel",
+          `backgroundJobTimeout:${jobName}`,
+          conversationId,
+        ),
+      );
+    } catch (abortErr) {
+      log.warn(
+        {
+          err: abortErr instanceof Error ? abortErr.message : String(abortErr),
+          jobName,
+          conversationId,
+        },
+        "Failed to signal abort for timed-out background job",
+      );
+    }
+  }
+  if (!work) {
+    return true;
+  }
+  let graceTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        graceTimer = setTimeout(() => resolve(false), graceMs);
+      }),
+    ]);
+  } finally {
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+    }
+  }
 }
 
 function classifyError(err: unknown): BackgroundJobErrorKind {
@@ -290,6 +380,7 @@ export async function runBackgroundJob(
     | Awaited<ReturnType<typeof bootstrapConversation>>
     | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let work: ReturnType<typeof processMessage> | undefined;
   try {
     // Bootstrap inside the try so that a `createConversation` /
     // `queueGenerateConversationTitle` failure is caught and surfaced as a
@@ -353,7 +444,7 @@ export async function runBackgroundJob(
       );
     }
 
-    const work = processMessage(conversation.id, opts.prompt, {
+    work = processMessage(conversation.id, opts.prompt, {
       trustContext: opts.trustContext,
       callSite: opts.callSite,
       ...(opts.overrideProfile
@@ -411,6 +502,34 @@ export async function runBackgroundJob(
     // so the structured failure result still flows to the caller.
     const conversationId = conversation?.id ?? "";
 
+    // A timeout must not silently abandon a still-running turn: signal the
+    // conversation's abort controller (cooperative cancellation on the same
+    // rail as user Stop) and report whether the work actually stopped, so
+    // callers guarding shared resources can act on the truth instead of
+    // assuming the timed-out run is gone.
+    let workStopped: boolean | undefined;
+    let workSettled: Promise<void> | undefined;
+    if (err instanceof BackgroundJobTimeoutError) {
+      workStopped = await cancelTimedOutWork(
+        conversation?.id,
+        work,
+        opts.jobName,
+        opts.timeoutAbortGraceMs ?? TIMEOUT_ABORT_GRACE_MS,
+      );
+      if (workStopped === false && work) {
+        workSettled = work.then(
+          () => undefined,
+          () => undefined,
+        );
+      }
+      log.warn(
+        { jobName: opts.jobName, conversationId, workStopped },
+        workStopped
+          ? "Timed-out background job cancelled cooperatively"
+          : "Timed-out background job did NOT stop within the abort grace window; treating its resources as still in use",
+      );
+    }
+
     if (opts.deferNotifications && conversationId) {
       discardDeferredConversation(conversationId);
     }
@@ -467,6 +586,8 @@ export async function runBackgroundJob(
       error,
       errorKind,
       ...(failureCode !== undefined ? { failureCode } : {}),
+      ...(workStopped !== undefined ? { workStopped } : {}),
+      ...(workSettled !== undefined ? { workSettled } : {}),
     };
   } finally {
     if (timer) {


### PR DESCRIPTION
## TL;DR

Hardens the memory subsystem's derived-memory pipeline end to end: a finalizer-side durable-evidence contract layered over the wake-level classifier that merged in #39877, truthful job-row outcomes, bounded mid-turn deferrals with a stranded-flag override, consolidation cancellation and lock ownership, capability-aware media routing for background memory call sites, and a supported rewind/dry-run recovery command.

Part of LUM-3016. Part of LUM-3017. Part of LUM-3018. Hardens the finalization contract beyond the merged fix for LUM-3013 (closed by #39877).

## Layering vs #39877 (which guard is load-bearing where)

#39877 fixed LUM-3013 at the agent-wake seam: a no-output run with an abnormal terminal exit fails the wake, and the retrospective's `requireUsableOutput: true` also fails clean-stop runs that committed nothing. That layer is load-bearing for classifying HOW the run ended.

This PR's finalizer layer is load-bearing for WHAT the run durably produced, which the wake classifier cannot see:

- Advancement requires a memory-writing tool call (`remember` / `scaffold_managed_skill`) whose matching `tool_result` persisted without `is_error` on the fork's post-boundary tail, read from the DB (immune to post-live history rebases). A model that asked but whose execution failed does not advance, and the failed facts stay out of `<already_remembered>` where they would suppress the retry's re-save.
- A run with visible prose but no saves is usable output to the wake; the finalizer still refuses it unless it is the explicit no-findings artifact below.
- A legitimate reviewed-and-nothing-to-save pass now has a positive persisted artifact: the instruction mandates replying with exactly "Nothing new to save.", and the finalizer advances on that exact persisted text (with zero memory-writing attempts) without fabricating a write. A run that attempted a save and failed cannot advance by also claiming no findings. A guard test pins the template wording to the finalizer's constant.

Test coverage is deduped accordingly: `memory-retrospective-wake-chain.test.ts` (from #39877) owns the wake-classification chain; `memory-retrospective-provider-path.test.ts` owns the finalizer-evidence seam (real tool-executor round-trip, prose-only refusal) and pins the layered rejection outcome.

## Truthful job outcomes, and the retry-path interaction

Handlers that report failure through returned outcomes no longer persist as `completed` with a null `last_error`: registration-site adapters map `wake_failed` / `no_usable_output` / consolidation `run_failed` to dead-lettered rows with honest errors. Deliberate interaction with the designed retry path: these rows dead-letter with `maxAttempts: 1`, so the jobs-worker's backoff never double-drives the cooldown + event-driven re-enqueue that owns retrospective retries (the concern #39877 documented when it left rows completing). The row status changes; the retry cadence does not. A mid-turn source now defers the SAME row on the bounded deferral counter instead of minting a fresh row every 60s (a live instance had accumulated 3,112 rows for one stranded conversation), and store transitions are guarded on `running` so a late return cannot overwrite a watchdog-failed row.

## Stranded-flag override (scope ratified here)

A persisted `processing_started_at` older than 6 hours is treated as stranded and the retrospective proceeds. Relation to JARVIS-1237 (canceled): that ticket described a swallowed turn-end flag clear stranding a conversation forever, and its "no reaper" claim is now half-fixed upstream; the monitor-process reaper only clears flags older than daemon boot, so a flag stranded while the daemon stays up is unreachable by it. This override is the memory-side mitigation; the daemon-side clear-retry remains a follow-up outside this plugin. Genuinely-long-running-operation case: a real turn older than 6h loses only fork QUALITY, not correctness. The fork copies complete persisted turns, the cursor still advances only on verified durable output, and the alternative (never forming memories again for that conversation) is strictly worse. Deferral stays bounded either way: without the override the deferral budget dead-letters the row honestly and the sweep re-enqueues later.

## Consolidation cancellation and lock ownership (LUM-3018)

Timeouts signal the conversation's abort controller (the user-Stop rail, so cancellation reaches the in-flight provider call and tool loop), wait a bounded grace, and report `workStopped` truthfully. Consolidation holds its lock while a zombie writer lives, releases owner-verified on late settlement, and never unlinks a lock a takeover re-acquired. Residual guarantees, stated honestly: the stale-lock TTL (60 min) can still reclaim a lock whose holder is alive but has ignored the cooperative abort for the full hour, so overlap is narrowed from "begins at minute 15 unconditionally" to "requires surviving an abort signal and outliving the TTL", not eliminated; and the owner-verified release is read-then-unlink, not atomic, leaving a microseconds-wide window that only matters if two processes release concurrently (the worker is single-process per workspace). Closing both fully needs abort-honoring guarantees in every tool executor and an atomic rename-based lock; deferred with this rationale.

## Capability-aware media routing (LUM-3016)

The pre-model-call hook contract now carries the outbound wire messages and a proceed/fail decision; the image-fallback plugin captions media bound for `supportsVision: false` models proactively (cache-deduped) at the one boundary both main turns and background wakes traverse. When no vision-capable profile exists, background memory call sites fail observably and retryably instead of sending media the route cannot process; interactive call sites keep today's reactive recovery.

## Supported rewind and dry-run (LUM-3017, implemented here, not deferred)

`assistant memory retrospective run <id> [--from <messageId> | --from-start] [--dry-run]`. Dry-run is purely read-only (zero DB/file/job/fork writes, covered by action-level tests). Replay changes only where the window starts; the persisted cursor advances exclusively through the finalizer's evidence gate to the window cutoff (forward-or-equal), so failed or interrupted replays change nothing, `remembered_log` suppresses duplicate saves across repeats, invalid inputs fail before any mutation, and failure outcomes exit non-zero in every output mode.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Retrospective whose remember EXECUTION failed | Cursor advanced; failed facts entered the dedup log and suppressed re-saves | Window retryable; facts excluded from the log |
| Reviewed window with genuinely nothing to save | Advanced on any silent no-op (indistinguishable from failures) | Advances only on the explicit mandated reply; empty/analysis-only runs stay retryable |
| Queue visibility of failed retrospectives/consolidations | `completed`, no `last_error` | `failed` with the reason; retry cadence unchanged |
| Conversation with a stranded mid-turn flag | One new job row per minute, forever; no memory formation | Bounded deferrals on one row; after 6h the pass proceeds |
| Timed-out consolidation | Work kept running unobserved; lock released; overlap possible immediately | Cooperative abort; lock held until the work provably stopped |
| Image-bearing window on a non-vision route | Provider round-trip burned, then placeholder fall-open or failure | Proactive captioning, or an observable retryable failure when no vision route exists |
| Skipped/suspect windows | Unrecoverable without SQL edits | Targeted `--from` replay with `--dry-run` preview |

## Deferred

- Daemon-side turn-end `setProcessing(false)` clear-retry (root cause of stranded flags).
- Atomic lock release + executor-level abort guarantees (see residual guarantees above).
- v1 `memoryExtraction` can also send raw images on a direct provider call (`v1/graph/extraction.ts:1225`), but the path is inactive under V3-live and the tier is in retirement; no change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
