### PR TITLE
feat(inference): per-tier default-profile overrides for BYO fallback models

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14637,7 +14637,9 @@ paths:
         "404":
           description: Profile not found
         "409":
-          description: Profile is still referenced by activeProfile, advisorProfile, a call site, or a mix arm
+          description:
+            Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a
+            mix arm
     get:
       operationId: inference_profiles_by_name_get
       summary: Get an effective inference profile

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -592,7 +592,7 @@ describe("defaultProfileOverrides tier remap", () => {
       defaultProfileOverrides: { balanced: "mine" },
       ...anthropicDp,
     });
-    // `vision` has no shipped profile — it resolves through the anchor.
+    // `vision` has no shipped profile; it resolves through the anchor.
     expect(resolveCallSiteConfig("vision", llm).model).toBe("gpt-5.5");
     expect(selectWinningProfile("vision", llm).profileName).toBe("mine");
   });

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -530,3 +530,82 @@ describe("user shadows of default keys keep their intent", () => {
     expect(pinned.provider).toBe("openai");
   });
 });
+
+describe("defaultProfileOverrides tier remap", () => {
+  test("a tier remap redirects every call site on that tier, and only that tier", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      defaultProfileOverrides: { "cost-optimized": "mine" },
+      ...anthropicDp,
+    });
+    // conversationSummarization ships on the cost-optimized tier.
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    expect(resolved.model).toBe("gpt-5.5");
+    expect(resolved.provider).toBe("openai");
+    const selection = selectWinningProfile("conversationSummarization", llm);
+    expect(selection.profileName).toBe("mine");
+    expect(selection.source).toBe("default");
+    // A balanced-tier site is untouched by a cost-optimized remap.
+    expect(resolveCallSiteConfig("subagentSpawn", llm).provider).toBe(
+      "anthropic",
+    );
+  });
+
+  test("a per-call-site pin still beats the tier remap", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        mine: completeCustom,
+        pinned: { ...completeCustom, model: "gpt-5.4" },
+      },
+      defaultProfileOverrides: { "cost-optimized": "mine" },
+      callSites: { conversationSummarization: { profile: "pinned" } },
+      ...anthropicDp,
+    });
+    expect(resolveCallSiteConfig("conversationSummarization", llm).model).toBe(
+      "gpt-5.4",
+    );
+  });
+
+  test("an unusable remap target reports and falls through to the stock tier", () => {
+    const llm = LLMSchema.parse({
+      profiles: { partial: { source: "user", model: "gpt-5.5" } },
+      defaultProfileOverrides: { "cost-optimized": "partial" },
+      ...anthropicDp,
+    });
+    const { fallbacks, opts } = collect();
+    const resolved = resolveCallSiteConfig(
+      "conversationSummarization",
+      llm,
+      opts,
+    );
+    expect(resolved.provider).toBe("anthropic");
+    expect(fallbacks).toContainEqual({
+      callSite: "conversationSummarization",
+      requested: "partial",
+      reason: "incomplete",
+    });
+  });
+
+  test("the anchor consults the balanced remap for profileless call sites", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: completeCustom },
+      defaultProfileOverrides: { balanced: "mine" },
+      ...anthropicDp,
+    });
+    // `vision` has no shipped profile — it resolves through the anchor.
+    expect(resolveCallSiteConfig("vision", llm).model).toBe("gpt-5.5");
+    expect(selectWinningProfile("vision", llm).profileName).toBe("mine");
+  });
+
+  test("a self-referential remap is a no-op", () => {
+    const llm = LLMSchema.parse({
+      defaultProfileOverrides: { balanced: "balanced" },
+      ...anthropicDp,
+    });
+    const { fallbacks, opts } = collect();
+    expect(resolveCallSiteConfig("subagentSpawn", llm, opts).provider).toBe(
+      "anthropic",
+    );
+    expect(fallbacks).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -385,6 +385,7 @@ describe("resolveCallSiteConfig", () => {
       callSites: {
         mainAgent: { profile: "nonexistent" },
       },
+      defaultProfileOverrides: {},
       profileSession: { defaultTtlSeconds: 1800, maxTtlSeconds: 43200 },
       pricingOverrides: [],
     };
@@ -561,6 +562,7 @@ describe("resolveCallSiteConfig", () => {
       profileOrder: [],
       callSites: {},
       activeProfile: "nonexistent",
+      defaultProfileOverrides: {},
       profileSession: { defaultTtlSeconds: 1800, maxTtlSeconds: 43200 },
       pricingOverrides: [],
     };

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -319,4 +319,40 @@ describe("LLMSchema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  test("defaultProfileOverrides accepts custom profiles and default keys as targets", () => {
+    const parsed = LLMSchema.parse({
+      profiles: { fast: { speed: "fast", effort: "low" } },
+      defaultProfileOverrides: {
+        balanced: "fast",
+        "cost-optimized": "quality-optimized",
+      },
+    });
+    expect(parsed.defaultProfileOverrides).toEqual({
+      balanced: "fast",
+      "cost-optimized": "quality-optimized",
+    });
+    expect(LLMSchema.parse({}).defaultProfileOverrides).toEqual({});
+  });
+
+  test("a defaultProfileOverrides target naming no profile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      defaultProfileOverrides: { balanced: "no-such-profile" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual([
+        "defaultProfileOverrides",
+        "balanced",
+      ]);
+    }
+  });
+
+  test("a defaultProfileOverrides key outside the default-profile tiers is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: { fast: { speed: "fast" } },
+      defaultProfileOverrides: { turbo: "fast" },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -340,6 +340,31 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(LLMSchema.safeParse(after.llm).success).toBe(true);
   });
 
+  test("flag off clears a tier override targeting os-beta", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    (raw.llm as Record<string, unknown>).defaultProfileOverrides = {
+      balanced: "os-beta",
+      "cost-optimized": "quality-optimized",
+    };
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(
+      (after.llm as Record<string, unknown>).defaultProfileOverrides,
+    ).toEqual({ "cost-optimized": "quality-optimized" });
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
   test("a user-owned os-beta profile is never touched", () => {
     process.env.IS_PLATFORM = "true";
     writeConfig({

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -38,10 +38,10 @@ import {
  *   2. `llm.activeProfile` — `mainAgent` only, since it IS that call site's
  *      user-facing chat-model selection
  *   3. `llm.callSites[callSite].profile` (the call site's named profile)
- *   4. `CALL_SITE_DEFAULTS[callSite].profile` intent — remapped through
+ *   4. `CALL_SITE_DEFAULTS[callSite].profile` intent, remapped through
  *      `llm.defaultProfileOverrides[intent]` when set, otherwise resolved
  *      through `llm.defaultProvider`
- *   5. balanced intent (same remap consult) through `llm.defaultProvider` —
+ *   5. balanced intent (same remap consult) through `llm.defaultProvider`:
  *      the code-owned anchor for profileless call sites, or when nothing
  *      above is usable
  *
@@ -149,7 +149,7 @@ export function resolveCallSiteConfig(
 //   1. `opts.overrideProfile` (conversation/schedule/per-turn pin)
 //   2. `llm.activeProfile` (mainAgent only — it IS that call site's selection)
 //   3. `llm.callSites[callSite].profile`
-//   4. `CALL_SITE_DEFAULTS[callSite].profile` intent — remapped via
+//   4. `CALL_SITE_DEFAULTS[callSite].profile` intent, remapped via
 //      `llm.defaultProfileOverrides[intent]` when set, else intent × default
 //      provider
 //   5. balanced intent (same remap consult) × default provider (profileless
@@ -246,9 +246,9 @@ export function selectWinningProfile(
   // Anchor: profileless call sites (`vision`, `workflowLeaf`) and any
   // resolution whose every named rung was unusable land on balanced intent
   // through the default provider. The anchor consults the balanced remap
-  // first — a profileless call site follows the user's balanced choice like
-  // any balanced-tier site — but bottoms out on the code-owned catalog, so
-  // it always resolves. `profileName` stays null on the catalog path — the
+  // first (a profileless call site follows the user's balanced choice like
+  // any balanced-tier site) but bottoms out on the code-owned catalog, so
+  // it always resolves. `profileName` stays null on the catalog path: the
   // anchor itself is not a selection.
   const anchorRemap = remappedIntent("balanced");
   if (anchorRemap) {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -38,10 +38,12 @@ import {
  *   2. `llm.activeProfile` — `mainAgent` only, since it IS that call site's
  *      user-facing chat-model selection
  *   3. `llm.callSites[callSite].profile` (the call site's named profile)
- *   4. `CALL_SITE_DEFAULTS[callSite].profile` intent resolved through
- *      `llm.defaultProvider`
- *   5. balanced intent through `llm.defaultProvider` — the code-owned anchor
- *      for profileless call sites, or when nothing above is usable
+ *   4. `CALL_SITE_DEFAULTS[callSite].profile` intent — remapped through
+ *      `llm.defaultProfileOverrides[intent]` when set, otherwise resolved
+ *      through `llm.defaultProvider`
+ *   5. balanced intent (same remap consult) through `llm.defaultProvider` —
+ *      the code-owned anchor for profileless call sites, or when nothing
+ *      above is usable
  *
  * A winner must carry its own `provider` AND `model`: the base layer's schema
  * default identity never stands in for a selected profile. The anchor is
@@ -147,9 +149,11 @@ export function resolveCallSiteConfig(
 //   1. `opts.overrideProfile` (conversation/schedule/per-turn pin)
 //   2. `llm.activeProfile` (mainAgent only — it IS that call site's selection)
 //   3. `llm.callSites[callSite].profile`
-//   4. `CALL_SITE_DEFAULTS[callSite].profile` intent × default provider
-//   5. balanced intent × default provider (profileless sites, or nothing
-//      above usable)
+//   4. `CALL_SITE_DEFAULTS[callSite].profile` intent — remapped via
+//      `llm.defaultProfileOverrides[intent]` when set, else intent × default
+//      provider
+//   5. balanced intent (same remap consult) × default provider (profileless
+//      sites, or nothing above usable)
 // A winner must carry its own `provider` AND `model`: the base layer's
 // schema-default identity must never stand in for a selected profile (that
 // would be merge inheritance by the back door). A fallback anchor must be
@@ -212,8 +216,28 @@ export function selectWinningProfile(
       entry: sitePin.entry,
     };
   }
+  // A tier remap (`llm.defaultProfileOverrides`) redirects the intent rung
+  // to a named profile. Resolved through the same `usableEntry` gate as
+  // every other rung, so an unusable target reports and falls through to
+  // the stock tier resolution. A self-reference is skipped rather than
+  // resolved: the stock rung's handling of unusable user shadows differs
+  // from the named-rung path, and a no-op remap must not change behavior.
+  const remappedIntent = (intent: string) => {
+    if (!isDefaultProfileKey(intent)) {
+      return undefined;
+    }
+    const target = llm.defaultProfileOverrides?.[intent];
+    return target === intent
+      ? undefined
+      : usableEntry(target, llm, opts, report);
+  };
+
   const intent = CALL_SITE_DEFAULTS[callSite]?.profile;
   if (intent != null) {
+    const remap = remappedIntent(intent);
+    if (remap) {
+      return { profileName: remap.name, source: "default", entry: remap.entry };
+    }
     const entry = usableDefaultIntent(intent, llm, opts, report);
     if (entry) {
       return { profileName: intent, source: "default", entry };
@@ -221,8 +245,19 @@ export function selectWinningProfile(
   }
   // Anchor: profileless call sites (`vision`, `workflowLeaf`) and any
   // resolution whose every named rung was unusable land on balanced intent
-  // through the default provider. `profileName` stays null — the anchor is
-  // not a selection.
+  // through the default provider. The anchor consults the balanced remap
+  // first — a profileless call site follows the user's balanced choice like
+  // any balanced-tier site — but bottoms out on the code-owned catalog, so
+  // it always resolves. `profileName` stays null on the catalog path — the
+  // anchor itself is not a selection.
+  const anchorRemap = remappedIntent("balanced");
+  if (anchorRemap) {
+    return {
+      profileName: anchorRemap.name,
+      source: "default",
+      entry: anchorRemap.entry,
+    };
+  }
   return {
     profileName: null,
     source: "default",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -657,6 +657,15 @@ export const LLMSchema = z
     // are seeded into the user's on-disk config by migration 040, not at
     // schema level, so `LLMSchema.parse({})` yields an empty map.
     callSites: z.partialRecord(LLMCallSiteEnum, LLMCallSiteConfig).default({}),
+    // Per-tier remap of the shipped call-site defaults: every call site whose
+    // `CALL_SITE_DEFAULTS` profile is <tier> resolves through the named
+    // profile instead of the tier's intent × provider matrix body. A
+    // per-call-site pin (`llm.callSites.*.profile`) still wins over the
+    // remap, and an unusable remap target falls through to the stock tier
+    // resolution (see `selectWinningProfile`).
+    defaultProfileOverrides: z
+      .partialRecord(z.enum(DEFAULT_PROFILE_KEYS), z.string().min(1))
+      .default({}),
     activeProfile: z.string().min(1).optional(),
     // The profile the advisor role consults when spawned as a subagent (chosen
     // under Models & Services). It is excluded from the chat-profile pickers so
@@ -722,6 +731,17 @@ export const LLMSchema = z
           code: "custom",
           path: ["callSites", siteId, "profile"],
           message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
+        });
+      }
+    }
+    for (const [tier, profileName] of Object.entries(
+      config.defaultProfileOverrides ?? {},
+    )) {
+      if (profileName != null && !profileNames.has(profileName)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["defaultProfileOverrides", tier],
+          message: `Profile "${profileName}" referenced by llm.defaultProfileOverrides.${tier} is not defined in llm.profiles`,
         });
       }
     }

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -221,7 +221,7 @@ function disableProfile(
     }
   }
 
-  // Clear any tier override targeting a removed profile — the cleared tier
+  // Clear any tier override targeting a removed profile; the cleared tier
   // falls back to its stock intent resolution.
   const tierOverrides = readObject(llm.defaultProfileOverrides);
   if (tierOverrides) {

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -221,5 +221,16 @@ function disableProfile(
     }
   }
 
+  // Clear any tier override targeting a removed profile — the cleared tier
+  // falls back to its stock intent resolution.
+  const tierOverrides = readObject(llm.defaultProfileOverrides);
+  if (tierOverrides) {
+    for (const [tier, target] of Object.entries(tierOverrides)) {
+      if (typeof target === "string" && removed.has(target)) {
+        delete tierOverrides[tier];
+      }
+    }
+  }
+
   return true;
 }

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -277,6 +277,10 @@ describe("collectProfileReferences", () => {
         memoryExtraction: { profile: "my-fast" },
         recall: { profile: "other" },
       },
+      defaultProfileOverrides: {
+        balanced: "my-fast",
+        "cost-optimized": "other",
+      },
       profiles: {
         "my-fast": { source: "user", provider: "anthropic" },
         "my-mix": {
@@ -290,6 +294,7 @@ describe("collectProfileReferences", () => {
         "llm.activeProfile",
         "llm.advisorProfile",
         "llm.callSites.memoryExtraction",
+        "llm.defaultProfileOverrides.balanced",
         "llm.profiles.my-mix.mix",
       ].sort(),
     );

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -296,7 +296,8 @@ function fragmentFromBody(
 
 /**
  * Enumerate every live reference to profile `name` in the raw `llm` config
- * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`, and
+ * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`,
+ * each `defaultProfileOverrides.<tier>`, and
  * every mix arm (`profiles.<mix>.mix[].profile`). Deleting a profile while any
  * of these point at it would leave a dangling reference that `LLMSchema`'s
  * superRefine rejects on the next load — silently resetting the user's chat
@@ -321,6 +322,14 @@ export function collectProfileReferences(
     for (const [siteId, siteConfig] of Object.entries(callSites)) {
       if (asPlainObject(siteConfig)?.profile === name) {
         refs.push(`llm.callSites.${siteId}`);
+      }
+    }
+  }
+  const tierOverrides = asPlainObject(llm.defaultProfileOverrides);
+  if (tierOverrides) {
+    for (const [tier, target] of Object.entries(tierOverrides)) {
+      if (target === name) {
+        refs.push(`llm.defaultProfileOverrides.${tier}`);
       }
     }
   }
@@ -741,7 +750,7 @@ export const ROUTES: RouteDefinition[] = [
       "404": { description: "Profile not found" },
       "409": {
         description:
-          "Profile is still referenced by activeProfile, advisorProfile, a call site, or a mix arm",
+          "Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a mix arm",
       },
     },
     handler: handleDeleteProfile,


### PR DESCRIPTION
## Summary
- New `llm.defaultProfileOverrides` map (`balanced` / `quality-optimized` / `cost-optimized` / `latency-optimized` → profile name): the resolver's default-intent rung consults it before the intent × provider matrix, so all call sites on a tier can be redirected to one custom profile. Per-call-site pins (`llm.callSites.*.profile`) still take precedence, and an unusable remap target reports via `onResolutionFallback` and falls through to the stock tier resolution: a broken target can never brick a call site.
- The anchor rung (profileless call sites like `vision`) consults the balanced remap the same way but still bottoms out on the code-owned catalog, so it always resolves.
- Schema validation rejects remap targets that name no profile (mirroring call-site profile refs), and `collectProfileReferences` counts remap references so profile deletion can't strand a dangling key.

No new endpoints: the field rides the existing `PATCH /v1/config` pipe, so it is testable end-to-end today via config patch + `GET inference/callsites`.

## Original prompt
Users on BYO providers want per-tier fallback models in the Models & Services Action Overrides sheet: instead of one profile override for all ~40 actions, remap all balanced-default call sites to profile A, all quality-default ones to profile B, etc. This is PR 1 of 2 (daemon resolver + schema, inert until written); PR 2 adds the web UI Defaults group, version-gated on the daemon release containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H68iCJ2sedJyhFMYTnBQkh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
