### PR TITLE
[LUM-3020] Ship attachment payloads once; strip bulk base64 from feedback captures

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -193,6 +193,93 @@ describe("handleListMessages attachments", () => {
     expect(docAtt!.data).toBeUndefined();
   });
 
+  test("contentBlocks attachment blocks are metadata-only references", async () => {
+    // The flat `attachments` array is the sole payload carrier. An inline
+    // file-block ref places an `attachment` block in `contentBlocks`, but
+    // that block must reference the row by id without repeating its base64:
+    // duplicating it doubles every image in the response and in client
+    // memory.
+    const conv = createConversation();
+    const stored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "check this image" },
+        {
+          type: "file",
+          source: { type: "workspace_ref", attachmentId: stored.id },
+          filename: "photo.png",
+          media_type: "image/png",
+        },
+      ]),
+    );
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const response = handleListMessages(createTestArgs(conv.id));
+    const body = response as {
+      messages: {
+        attachments?: AttachmentPayload[];
+        contentBlocks?: Array<{
+          type: string;
+          attachment?: {
+            id: string;
+            data?: string;
+            thumbnailData?: string;
+          };
+        }>;
+      }[];
+    };
+
+    expect(body.messages).toHaveLength(1);
+    const row = body.messages[0];
+
+    // Payload ships on the flat array.
+    expect(row.attachments).toHaveLength(1);
+    expect(row.attachments![0].data).toBe(IMAGE_BASE64);
+
+    // The inline block references the same row without the payload.
+    const blocks = (row.contentBlocks ?? []).filter(
+      (b) => b.type === "attachment",
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].attachment!.id).toBe(stored.id);
+    expect(blocks[0].attachment!.data).toBeUndefined();
+    expect(blocks[0].attachment!.thumbnailData).toBeUndefined();
+  });
+
+  test("synthesized attachment blocks are metadata-only references", async () => {
+    // Directive attachments take the appendix path (no file-block ref), which
+    // must strip the payload the same way the inline path does.
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "" }]),
+    );
+    const stored = uploadAttachment("output.png", "image/png", IMAGE_BASE64);
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const response = handleListMessages(createTestArgs(conv.id));
+    const body = response as {
+      messages: {
+        attachments?: AttachmentPayload[];
+        contentBlocks?: Array<{
+          type: string;
+          attachment?: { id: string; data?: string };
+        }>;
+      }[];
+    };
+
+    const row = body.messages[0];
+    expect(row.attachments![0].data).toBe(IMAGE_BASE64);
+    const blocks = (row.contentBlocks ?? []).filter(
+      (b) => b.type === "attachment",
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].attachment!.data).toBeUndefined();
+  });
+
   test("attachment-only assistant message synthesizes contentBlocks", async () => {
     // When the assistant's entire response was a <vellum-attachment/> tag,
     // parseDirectives strips it → cleanText is empty → renderHistoryContent

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -415,7 +415,14 @@ export type ConversationSurfaceBlock = z.infer<
   typeof ConversationSurfaceBlockSchema
 >;
 
-/** A vellum attachment projection (no provider analog). */
+/**
+ * A vellum attachment projection (no provider analog).
+ *
+ * The inlined `attachment` is a metadata-only positional reference:
+ * `data`/`thumbnailData` are never populated here. The payload ships once,
+ * on the message's flat `attachments` array (joinable by `attachment.id`),
+ * or on demand via the attachment content endpoint.
+ */
 export const ConversationAttachmentBlockSchema = z.object({
   type: z.literal("attachment"),
   attachment: ConversationMessageAttachmentSchema,
@@ -491,10 +498,13 @@ export const ConversationMessageSchema = z.object({
   /** Display timestamp as an ISO-8601 string. */
   timestamp: z.string(),
   /**
-   * Flat list of attachment metadata for the row. Not yet supersedable by
-   * `contentBlocks`: `renderHistoryContent` emits an `attachment` content
+   * Flat list of attachment metadata for the row, and the sole carrier of
+   * inline attachment payloads: image rows populate `data`/`thumbnailData`
+   * here, while the `attachment` blocks in `contentBlocks` stay metadata-only
+   * references joinable by id. Not supersedable by `contentBlocks` for a
+   * second reason: `renderHistoryContent` emits an `attachment` content
    * block only for file-block refs with an inline placement, so orphan rows
-   * (unmatched ids, count mismatch, no DB rows — see `alignAttachments`) ship
+   * (unmatched ids, count mismatch, no DB rows; see `alignAttachments`) ship
    * here alone. Kept non-deprecated until `contentBlocks` reaches attachment
    * parity, so clients that migrate off the positional arrays don't drop those
    * chips.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -214,6 +214,21 @@ interface AlignedAttachments {
 }
 
 /**
+ * Metadata-only projection of an attachment for inline `contentBlocks`
+ * placement. The flat `attachments` array is the payload carrier: it keeps
+ * `data`/`thumbnailData`, and `/v1/assistants/:id/attachments/:id/content`
+ * serves stored bytes on demand. Attachment blocks are positional references
+ * the renderer resolves against that array by id, so inlining the base64 here
+ * would ship every image twice in the same response.
+ */
+function toAttachmentBlockRef(
+  a: RuntimeAttachmentMetadata,
+): RuntimeAttachmentMetadata {
+  const { data: _data, thumbnailData: _thumbnailData, ...meta } = a;
+  return meta;
+}
+
+/**
  * Align DB-hydrated attachment rows with the file-block refs `renderHistoryContent`
  * captured. When a file block carries an attachment id (user-message uploads —
  * on `source.attachmentId` for reference blocks, or the legacy top-level
@@ -1093,9 +1108,10 @@ export function handleListMessages({
     const attachmentRefs = collectAttachmentRefs(m.content);
     const aligned = alignAttachments(attachmentRefs, msgAttachments);
     msgAttachments = aligned.attachments;
-    const attachmentBlocks = attachmentRefs.map(
-      (_ref, refIdx) => aligned.refIndexToAttachment.get(refIdx) ?? null,
-    );
+    const attachmentBlocks = attachmentRefs.map((_ref, refIdx) => {
+      const att = aligned.refIndexToAttachment.get(refIdx);
+      return att ? toAttachmentBlockRef(att) : null;
+    });
     const rendered = renderHistoryContent(
       m.content,
       attachmentBlocks,
@@ -1172,7 +1188,10 @@ export function handleListMessages({
     );
     for (const att of msgAttachments) {
       if (!existingAttachmentIds.has(att.id)) {
-        contentBlocks.push({ type: "attachment", attachment: att });
+        contentBlocks.push({
+          type: "attachment",
+          attachment: toAttachmentBlockRef(att),
+        });
       }
     }
 

--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -193,8 +193,14 @@ describe("diagnostics capture base64 stripping", () => {
     expect(logsText).not.toContain(bigBase64);
     expect(logsText).toContain("[stripped data URI image/png,");
     expect(logsText).toContain("[stripped base64,");
-    // The diagnostic signal survives.
-    expect(logsText).toContain("look at this photo");
+    // The diagnostic signal survives IN BOTH SURFACES: transcript items
+    // embed the same message objects clientMessages lists, and a shared
+    // reference is not a cycle. Each capture surface must carry the full
+    // message, so the text and both stripped markers appear twice.
+    expect(logsText).not.toContain("[cyclic]");
+    expect(logsText.split("look at this photo").length - 1).toBe(4);
+    expect(logsText.split("[stripped data URI image/png,").length - 1).toBe(2);
+    expect(logsText.split("[stripped base64,").length - 1).toBe(2);
     expect(logsText).toContain('"photo.png"');
   });
 
@@ -241,6 +247,29 @@ describe("stripBulkBase64", () => {
   test("preserves long prose", () => {
     const prose = "The quick brown fox jumps over the lazy dog. ".repeat(500);
     expect(stripBulkBase64(prose)).toBe(prose);
+  });
+
+  test("traverses shared references in full; flags only true cycles", () => {
+    // The capture's real shape: the same message object referenced from two
+    // sibling arrays. Both occurrences must survive intact.
+    const message = { id: "m1", text: "hello" };
+    const shared = stripBulkBase64({
+      clientMessages: [message],
+      transcriptItems: [{ kind: "message", message }],
+    }) as {
+      clientMessages: unknown[];
+      transcriptItems: { message: unknown }[];
+    };
+    expect(shared.clientMessages[0]).toEqual({ id: "m1", text: "hello" });
+    expect(shared.transcriptItems[0].message).toEqual({
+      id: "m1",
+      text: "hello",
+    });
+
+    // A genuine cycle is replaced instead of recursing forever.
+    const cyclic: Record<string, unknown> = { id: "c1" };
+    cyclic.self = cyclic;
+    expect(stripBulkBase64(cyclic)).toEqual({ id: "c1", self: "[cyclic]" });
   });
 
   test("strips long pure-base64 strings", () => {

--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -23,13 +23,44 @@ mock.module("@/stores/auth-store", () => ({
   },
 }));
 
-const { ShareFeedbackModal } =
+const { ShareFeedbackModal, stripBulkBase64 } =
   await import("@/components/share-feedback-modal");
 
 afterEach(() => {
   cleanup();
   feedbackRequests.length = 0;
+  delete (window as unknown as { _vellumDebug?: unknown })._vellumDebug;
 });
+
+/** Decompress a logs_file and return the raw tar text. */
+async function decompressLogs(logsFile: File): Promise<string> {
+  return new Response(
+    logsFile.stream().pipeThrough(new DecompressionStream("gzip")),
+  ).text();
+}
+
+async function submitAndGetLogsText(): Promise<string> {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ShareFeedbackModal
+        open
+        onClose={() => {}}
+        initialReason="bug_report"
+        initialMessage="Streaming froze."
+      />
+    </QueryClientProvider>,
+  );
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Email"), "user@example.com");
+  await user.click(screen.getByRole("button", { name: "Submit" }));
+  await waitFor(() => expect(feedbackRequests).toHaveLength(1));
+  const request = feedbackRequests[0] as { body: { logs_file?: File } };
+  expect(request.body.logs_file).toBeInstanceOf(File);
+  return decompressLogs(request.body.logs_file!);
+}
 
 describe("ShareFeedbackModal", () => {
   test("prefills the feedback message", () => {
@@ -119,5 +150,106 @@ describe("ShareFeedbackModal", () => {
     };
     expect(request.body.doctor_session_id).toBe("doctor-session-123");
     expect(request.body.logs_file).toBeUndefined();
+  });
+});
+
+describe("diagnostics capture base64 stripping", () => {
+  test("strips data URIs and inline base64 from the triage capture", async () => {
+    // A message row shaped like real client state: the same image carried as
+    // a derived preview data URI and as inline attachment base64, embedded in
+    // both capture surfaces (clientMessages and transcriptItems reference the
+    // same objects). ~140 KB of base64 per copy.
+    const bigBase64 = "iVBORw0KGgoAAAANSUhEUg".repeat(6400);
+    const message = {
+      id: "msg-1",
+      role: "user",
+      textSegments: ["look at this photo"],
+      attachments: [
+        {
+          id: "att-1",
+          filename: "photo.png",
+          previewUrl: `data:image/png;base64,${bigBase64}`,
+        },
+      ],
+      contentBlocks: [
+        { type: "text", text: "look at this photo" },
+        {
+          type: "attachment",
+          attachment: { id: "att-1", data: bigBase64 },
+        },
+      ],
+    };
+    (window as unknown as { _vellumDebug?: unknown })._vellumDebug = {
+      chat: {
+        getClientMessages: () => [message],
+        getTranscriptItems: () => [{ kind: "message", key: "m1", message }],
+      },
+    };
+
+    const logsText = await submitAndGetLogsText();
+
+    expect(logsText).toContain("web-chat-debug-api-triage.json");
+    // No copy of the payload survives, in either shape or either surface.
+    expect(logsText).not.toContain(bigBase64);
+    expect(logsText).toContain("[stripped data URI image/png,");
+    expect(logsText).toContain("[stripped base64,");
+    // The diagnostic signal survives.
+    expect(logsText).toContain("look at this photo");
+    expect(logsText).toContain('"photo.png"');
+  });
+
+  test("normal captures pass through untouched", async () => {
+    // Realistic long assistant prose: sentence-shaped, well past the length
+    // floor. Spaces and punctuation fail the base64 test, so it survives.
+    const prose =
+      "Here is a very long explanation of the failure mode. ".repeat(500);
+    const message = {
+      id: "msg-1",
+      role: "assistant",
+      textSegments: [prose],
+      contentBlocks: [{ type: "text", text: prose }],
+    };
+    (window as unknown as { _vellumDebug?: unknown })._vellumDebug = {
+      chat: {
+        getClientMessages: () => [message],
+        getTranscriptItems: () => [{ kind: "message", key: "m1", message }],
+      },
+    };
+
+    const logsText = await submitAndGetLogsText();
+
+    expect(logsText).toContain(prose);
+    expect(logsText).not.toContain("[stripped");
+  });
+});
+
+describe("stripBulkBase64", () => {
+  test("preserves short base64-looking strings (ids, hashes, tokens)", () => {
+    const input = {
+      id: "dGhpc2lzYXJlYWxpZA",
+      sha: "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+    };
+    expect(stripBulkBase64(input)).toEqual(input);
+  });
+
+  test("strips data URIs regardless of length", () => {
+    expect(stripBulkBase64("data:image/jpeg;base64,abc123")).toBe(
+      "[stripped data URI image/jpeg, 29 chars]",
+    );
+  });
+
+  test("preserves long prose", () => {
+    const prose = "The quick brown fox jumps over the lazy dog. ".repeat(500);
+    expect(stripBulkBase64(prose)).toBe(prose);
+  });
+
+  test("strips long pure-base64 strings", () => {
+    const b64 = "QUJDREVGR0g=".repeat(1000);
+    // Padding mid-string fails the pure test; unpadded runs match.
+    const unpadded = "QUJDREVGR0g".repeat(1000);
+    expect(stripBulkBase64(unpadded)).toBe(
+      `[stripped base64, ${unpadded.length} chars]`,
+    );
+    expect(stripBulkBase64(b64)).toBe(b64);
   });
 });

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -177,6 +177,53 @@ function isAllowedFile(file: File): boolean {
   return false;
 }
 
+/** Strings at or past this length are candidates for base64 stripping. */
+const BULK_BASE64_MIN_CHARS = 8192;
+
+const DATA_URI_RE = /^data:([^;,]+);base64,/i;
+const PURE_BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Replace bulk binary payloads in a diagnostics snapshot with size markers.
+ *
+ * Message state carries image bytes in two shapes: `data:` URIs (derived
+ * preview URLs) and long raw base64 fields (inline attachment data). Neither
+ * is diagnostic signal, and a handful of photos otherwise dominates the
+ * bundle the platform accepts. Matching is content-based, not field-name
+ * based, so any future field that carries a data URI or a long pure-base64
+ * string is stripped too. Prose is never touched: text with spaces or
+ * punctuation fails the base64 test, and short strings (ids, hashes,
+ * tokens) are below the length floor. The marker keeps the mime type and
+ * length, which is the diagnostically useful part.
+ */
+export function stripBulkBase64(value: unknown, seen = new WeakSet()): unknown {
+  if (typeof value === "string") {
+    const dataUri = DATA_URI_RE.exec(value);
+    if (dataUri) {
+      return `[stripped data URI ${dataUri[1]}, ${value.length} chars]`;
+    }
+    if (value.length >= BULK_BASE64_MIN_CHARS && PURE_BASE64_RE.test(value)) {
+      return `[stripped base64, ${value.length} chars]`;
+    }
+    return value;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[cyclic]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((v) => stripBulkBase64(v, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    out[k] = stripBulkBase64(v, seen);
+  }
+  return out;
+}
+
 function buildTarEntry(filename: string, data: Uint8Array): Uint8Array {
   const blockSize = 512;
   const dataBlocks = Math.ceil(data.length / blockSize);
@@ -403,8 +450,11 @@ async function buildClientLogsFile(
         reconciliationDiagnostics:
           debugApi.getReconciliationDiagnostics?.() ?? null,
       };
+      // Message state embeds attachment previews as data URIs and inline
+      // base64; strip them to size markers so the capture scales with the
+      // conversation's text, not its images.
       const triageBytes = new TextEncoder().encode(
-        JSON.stringify(triagePayload, null, 2),
+        JSON.stringify(stripBulkBase64(triagePayload), null, 2),
       );
       tarParts.push(
         buildTarEntry("web-chat-debug-api-triage.json", triageBytes),
@@ -451,8 +501,10 @@ async function buildClientLogsFile(
         })),
         events: eventsApi.getEvents(),
       };
+      // SSE event payloads can quote message deltas that embed inline
+      // base64; the same strip keeps this member text-sized.
       const triageBytes = new TextEncoder().encode(
-        JSON.stringify(triagePayload, null, 2),
+        JSON.stringify(stripBulkBase64(triagePayload), null, 2),
       );
       tarParts.push(buildTarEntry("web-sse-liveness-triage.json", triageBytes));
     }

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -196,7 +196,7 @@ const PURE_BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
  * tokens) are below the length floor. The marker keeps the mime type and
  * length, which is the diagnostically useful part.
  */
-export function stripBulkBase64(value: unknown, seen = new WeakSet()): unknown {
+export function stripBulkBase64(value: unknown, path = new WeakSet()): unknown {
   if (typeof value === "string") {
     const dataUri = DATA_URI_RE.exec(value);
     if (dataUri) {
@@ -210,17 +210,26 @@ export function stripBulkBase64(value: unknown, seen = new WeakSet()): unknown {
   if (value === null || typeof value !== "object") {
     return value;
   }
-  if (seen.has(value)) {
+  // `path` holds only the current recursion ancestry, so a true cycle is
+  // replaced while shared (sibling) references are traversed in full. The
+  // capture leans on shared references by construction: transcript items
+  // embed the same message objects `clientMessages` lists, and both copies
+  // must survive. JSON.stringify duplicates shared references the same way.
+  if (path.has(value)) {
     return "[cyclic]";
   }
-  seen.add(value);
+  path.add(value);
+  let out: unknown;
   if (Array.isArray(value)) {
-    return value.map((v) => stripBulkBase64(v, seen));
+    out = value.map((v) => stripBulkBase64(v, path));
+  } else {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      obj[k] = stripBulkBase64(v, path);
+    }
+    out = obj;
   }
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value)) {
-    out[k] = stripBulkBase64(v, seen);
-  }
+  path.delete(value);
   return out;
 }
 


### PR DESCRIPTION
## TL;DR

Feedback diagnostic bundles were inflated by the same image bytes carried **four times**: the GET /messages serializer ships each attachment's base64 twice (flat `attachments` array + inlined `contentBlocks` attachment blocks), and the feedback capture serializes that message state twice (`getClientMessages()` + `getTranscriptItems()`, which embed the same objects). Six ~1.4 MB photos → 6 × ~1.87 MB base64 × 4 ≈ 45 MB of JSON, matching the 48.3 MB capture in the recovered LUM-2913 bundle almost exactly. Past the platform's decompressed ceiling, the tar sanitizer keeps head members and silently drops the tail — which is where the daemon logs live.

Two root fixes, one per layer:

1. **Daemon** (`abd4470ef4`): attachment blocks in `contentBlocks` are now metadata-only references. The flat `attachments` array is the sole payload carrier. Halves the wire size and client memory of every image-bearing conversation, feedback or not.
2. **Web capture** (`e7e11bd841`): the triage captures pass through `stripBulkBase64` — data URIs and long pure-base64 strings become `[stripped … N chars]` markers; prose, ids, filenames, and structure survive verbatim. Capture size now scales with conversation text, not images.

No budgets, no per-member ceilings, no truncation of diagnostic content.

Fixes LUM-3020

## Why the daemon change is safe

- **No client has ever read payload from the block copy.** `groupContentBlocks` skips attachment blocks by documented design ("attachments render in their own region from `message.attachments`", `message-content.ts`); `git log -S "block.attachment"` over `clients/web` finds no reader in any released bundle. The projection was introduced as explicitly additive in #33235.
- **The consumed copy is untouched.** Every render path (`runtimeAttachmentsToDisplay`, `toDisplayAttachments`) reads the flat array, which keeps `data`/`thumbnailData` exactly as before.
- **Pre-0.8.8 daemons' rebuild path is irrelevant here** — it reconstructs blocks *from* the flat array client-side, and this change is daemon-side anyway.
- **Schema-valid with no shape change**: both fields are optional in `ConversationMessageAttachmentSchema`. No version gate needed under `BACKWARDS_COMPAT.md` — old cached web bundles keep working because the copy they read still ships.
- The live SSE path (`message_complete`) already ships a single copy and documents id-based hydration; it is unchanged.

## Why the capture change is safe

- Matching is content-based and precise: `data:` URI prefix, or ≥ 8 KiB of unbroken base64 alphabet. Sentence-shaped text can never match (spaces/punctuation); ids, hashes, and tokens are below the length floor. Markers preserve mime type and length — the diagnostically useful part.
- Applied at the feedback capture boundary only. The DevTools `_vellumDebug` API itself is untouched and stays full-fidelity for interactive use.

## Before / after

| Situation | Before | After |
|---|---|---|
| GET /messages, image-bearing conversation | Every image's base64 twice per message | Once; blocks reference by id |
| Client memory per image-bearing conversation | 2 full copies per image in message state | 1 copy |
| Feedback capture, 6-photo conversation (LUM-2913 shape) | ~48 MB triage JSON | ~100 KB-scale: text + markers |
| Oversized bundle at the platform | Tail members (daemon logs) silently dropped | Bundle no longer scales with image bytes |
| Inline previews, thumbnails, preview modal, downloads | — | Unchanged (render from flat array / content endpoint) |
| DevTools `_vellumDebug` interactive use | — | Unchanged |

## What this corrects from the earlier attempts

- PR #39891 (closed) bounded the bundle client-side with budgets/truncation; the close was right — the size was symptom, duplication was cause.
- The close comment attributed the fix to dedup alone ("drops to ~10 MB on its own"). The verified math says dedup removes 2 of the 4 copies (~48 MB → ~23 MB): under the ceiling for this incident, but still linearly coupled to image count. The capture strip removes the coupling entirely. Both changes are needed; neither alone is the root fix.
- `electron-main-logs.txt` was misattributed in the original ticket: it is rotation-capped at 10 MB (`electron-log` `maxSize`, verified against live state) and measured ~8.5 MB in the recovered bundle.

## Verification

- New daemon tests prove blocks are metadata-only on both construction paths (inline file-block and directive-appendix) while the flat array keeps payload; both fail without the fix (checked by reverting).
- New web tests prove a LUM-2913-shaped capture (same image as preview data URI + inline data, embedded in both capture surfaces) strips every copy while keeping text and filenames; the strip test fails when the strip is bypassed (checked). Plus `stripBulkBase64` unit tests: ids/hashes/prose survive, data URIs and long base64 stripped.
- Full web suite: 835 files, 0 failures. All serializer-adjacent daemon suites green (`list-messages-*`, `server-history-render`, `conversation-queue`, `conversation-attachments`, `http-user-message-parity`). Both packages typecheck clean; `generate:openapi` produces no drift.

## Deferred

1. **Preview data URIs still hold one full-res copy per image in renderer memory** (`previewUrl`). The `fileBacked` + lazy-fetch pattern from the live path is the eventual fix; it changes inline-preview UX and deserves its own ticket.
2. **`vellum.old.log` is never collected** — a freeze just before the 10 MB rotation loses its evidence. Out of scope here (Electron main-process collection change).
3. **The platform's decompressed ceiling is still unpublished**; clients can't validate against it. Platform-repo work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->