### PR TITLE
docs(mcp-setup): clarify web client OAuth auth flow

### DIFF
--- a/assistant/src/cli/commands/mcp.help.ts
+++ b/assistant/src/cli/commands/mcp.help.ts
@@ -128,8 +128,10 @@ Arguments:
   name   Name of a configured MCP server to authenticate with
 
 Only works with sse or streamable-http transports (stdio servers do not use
-OAuth). Opens a browser for OAuth authorization with the remote server. The
-running assistant handles the OAuth callback and token exchange.
+OAuth). On desktop, opens a browser for OAuth authorization with the remote
+server. On web, prints the OAuth URL to the terminal — copy and open it in a
+new browser tab manually. The running assistant handles the OAuth callback
+and token exchange in both cases.
 
 The command waits up to 2.5 minutes for the user to complete the browser-based
 OAuth flow. If the server already has valid cached tokens, the command succeeds


### PR DESCRIPTION
## What

The `assistant mcp auth` help text says "Opens a browser for OAuth authorization" without distinguishing desktop from web.

- **Desktop:** the platform auto-opens the browser ✅
- **Web:** the URL is printed to the terminal — user must copy and open it manually ⚠️

## Fix

Updated the help text to describe both behaviors explicitly:

```
Only works with sse or streamable-http transports (stdio servers do not use
OAuth). On desktop, opens a browser for OAuth authorization with the remote
server. On web, prints the OAuth URL to the terminal — copy and open it in a
new browser tab manually. The running assistant handles the OAuth callback
and token exchange in both cases.
```

## How it was found

Discovered during Linear MCP server setup when `assistant mcp auth linear` printed the URL and exited without opening a browser (web client, Jun 29 2026).

## Verification

`assistant mcp auth --help` prints the updated text. No other files reference this string.

---

*AI-assisted PR. Submitted by AgentSlo on behalf of @shaneslo.*