### PR TITLE
fix(assistant): address self-review gaps in surface completion persistence

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -9,6 +9,16 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
 }));
 
+// These surfaces are shown live and asserted through their client messages, so
+// history holds nothing. Stand in an empty store: the completion path reads
+// persisted `ui_surface` blocks, and this file's DB carries no schema, so the
+// real read would throw and be indistinguishable from a persistence failure.
+const realCrud = await import("../persistence/conversation-crud.js");
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  getMessages: () => [],
+}));
+
 const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
 

--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -2,12 +2,34 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { UISurfaceCompleteEvent } from "../api/events/ui-surface-complete.js";
 import type { AssistantEvent } from "../api/index.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
+
+/** Interleaved record of persist writes and broadcasts, for ordering asserts. */
+let callOrder: string[] = [];
 
 let broadcastedMessages: AssistantEvent[] = [];
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 mock.module("../runtime/assistant-event-hub.js", () => ({
   ...realEventHub,
-  broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => {
+    callOrder.push(`broadcast:${msg.type}`);
+    broadcastedMessages.push(msg);
+  },
+}));
+
+let loggedWarnings: Array<{ fields: Record<string, unknown>; msg: string }> =
+  [];
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: (fields: Record<string, unknown>, msg: string) =>
+      loggedWarnings.push({ fields, msg }),
+    error: () => {},
+    fatal: () => {},
+    trace: () => {},
+    child: () => ({}),
+  }),
 }));
 
 // Stand-in for the persisted message store: `getMessages` reads it and
@@ -26,14 +48,26 @@ let contentWrites: Array<{
   id: string;
   blocks: Array<Record<string, unknown>>;
 }> = [];
+/**
+ * Full-history scans this action cost. `getMessages` is the dominant per-turn
+ * main-thread cost on large conversations, so the counts are pinned.
+ */
+let getMessagesCalls = 0;
 
 const realCrud = await import("../persistence/conversation-crud.js");
 mock.module("../persistence/conversation-crud.js", () => ({
   ...realCrud,
-  getMessages: (conversationId: string) =>
-    storedRows.filter((r) => r.conversationId === conversationId),
+  getMessages: (conversationId: string) => {
+    getMessagesCalls++;
+    // Fresh copies per call, like the real row mapper: a hit held across a
+    // write must not alias the store.
+    return storedRows
+      .filter((r) => r.conversationId === conversationId)
+      .map((r) => ({ ...r, content: structuredClone(r.content) }));
+  },
   updateMessageContent: (id: string, content: string) => {
     const blocks = JSON.parse(content) as Array<Record<string, unknown>>;
+    callOrder.push("persist");
     contentWrites.push({ id, blocks });
     const row = storedRows.find((r) => r.id === id);
     if (row) {
@@ -44,22 +78,34 @@ mock.module("../persistence/conversation-crud.js", () => ({
 
 // Import must come AFTER mock.module so the surface module picks up the
 // mocked event hub and persistence functions.
-const { createSurfaceMutex, handleSurfaceAction } =
-  await import("../daemon/conversation-surfaces.js");
+const {
+  createSurfaceMutex,
+  handleSurfaceAction,
+  markSurfaceCompleted,
+  surfaceProxyResolver,
+} = await import("../daemon/conversation-surfaces.js");
 
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType } from "../daemon/message-protocol.js";
 
 const CONVERSATION_ID = "conv-history-restored-1";
 
+/** The trust the surface-action route stamps on for a local guardian caller. */
+const GUARDIAN_TRUST: TrustContext = {
+  trustClass: "guardian",
+  sourceChannel: "vellum",
+};
+
 type EnqueueResult = { queued: boolean; requestId: string; rejected?: boolean };
 
 function makeContext(
   enqueueResult: EnqueueResult = { queued: false, requestId: "req-1" },
+  overrides: { trustContext?: TrustContext; queueDepth?: number } = {},
 ): SurfaceConversationContext & { enqueuedContents: string[] } {
   const enqueuedContents: string[] = [];
   return {
     conversationId: CONVERSATION_ID,
+    trustContext: overrides.trustContext ?? GUARDIAN_TRUST,
     sendToClient: () => {},
     pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
     lastSurfaceAction: new Map<
@@ -78,14 +124,18 @@ function makeContext(
       enqueuedContents.push(options.content);
       return enqueueResult;
     },
-    getQueueDepth: () => 0,
+    getQueueDepth: () => overrides.queueDepth ?? 0,
     processMessage: async () => "msg-1",
     withSurface: createSurfaceMutex(),
     enqueuedContents,
   };
 }
 
-function seedSurfaceRow(surfaceId: string, surfaceType: string): void {
+function seedSurfaceRow(
+  surfaceId: string,
+  surfaceType: string,
+  metadata: string | null = null,
+): void {
   storedRows = [
     {
       id: "msg-with-surface",
@@ -106,7 +156,7 @@ function seedSurfaceRow(surfaceId: string, surfaceType: string): void {
         },
       ],
       createdAt: 0,
-      metadata: null,
+      metadata,
     },
   ];
 }
@@ -130,12 +180,15 @@ function seedConfirmationRow(
   ];
 }
 
-/** Re-read the persisted block the way a history reseed would. */
+/**
+ * Re-read the persisted block the way a history reseed would. Newest row
+ * first, matching the production scan.
+ */
 function readPersistedSurface(
   surfaceId: string,
 ): Record<string, unknown> | undefined {
-  for (const row of storedRows) {
-    const block = row.content.find(
+  for (let i = storedRows.length - 1; i >= 0; i--) {
+    const block = storedRows[i].content.find(
       (b) => b.type === "ui_surface" && b.surfaceId === surfaceId,
     );
     if (block) {
@@ -165,6 +218,9 @@ describe("history-restored surface completion", () => {
     broadcastedMessages = [];
     contentWrites = [];
     storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
   });
 
   test("one-shot choice surface with no in-memory state is completed and persisted", async () => {
@@ -337,5 +393,345 @@ describe("history-restored surface completion", () => {
     expect(completion.summary).toBe('User chose: "Clean up my inbox"');
     // The pending branch carries the submitted payload on the broadcast.
     expect(completion.submittedData).toEqual(CHOICE_PAYLOAD);
+  });
+
+  test("the history-restored branch carries the submitted payload too", async () => {
+    const surfaceId = "surface-choice-history-4";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(completionBroadcasts(surfaceId)[0].submittedData).toEqual(
+      CHOICE_PAYLOAD,
+    );
+  });
+
+  test("the completion omits submittedData entirely when there is none", async () => {
+    const surfaceId = "surface-confirm-history-3";
+    seedConfirmationRow(surfaceId, { message: "Delete?" });
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "confirm");
+
+    expect(completionBroadcasts(surfaceId)[0]).not.toHaveProperty(
+      "submittedData",
+    );
+  });
+
+  test("the completion is persisted before it is broadcast", async () => {
+    const surfaceId = "surface-choice-history-5";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    // A broadcast that outran a failed persist would leave the client showing
+    // a completed card the next reseed reverts.
+    expect(callOrder).toEqual(["persist", "broadcast:ui_surface_complete"]);
+  });
+});
+
+describe("history-restored surface completion: requester provenance", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
+  });
+
+  test("an untrusted requester cannot complete a guardian-provenance surface", async () => {
+    const surfaceId = "surface-choice-guardian-1";
+    seedSurfaceRow(
+      surfaceId,
+      "choice",
+      JSON.stringify({ provenanceTrustClass: "guardian" }),
+    );
+    const ctx = makeContext(undefined, {
+      trustContext: { trustClass: "unknown", sourceChannel: "vellum" },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    // The live path hides this row from this actor, so the persisted fallback
+    // must not hand back its type or its labels.
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+    expect(contentWrites).toHaveLength(0);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+  });
+
+  test("an untrusted requester completes a contact-provenance surface", async () => {
+    const surfaceId = "surface-choice-contact-1";
+    seedSurfaceRow(
+      surfaceId,
+      "choice",
+      JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+    );
+    const ctx = makeContext(undefined, {
+      trustContext: { trustClass: "unknown", sourceChannel: "vellum" },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(1);
+  });
+});
+
+describe("history-restored surface completion: scan cost", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
+  });
+
+  test("a one-shot action with no live state costs one full scan", async () => {
+    const surfaceId = "surface-scan-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    // One read that resolves the type and the labels, reused by the write.
+    expect(getMessagesCalls).toBe(1);
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+  });
+
+  test("an explicit completion request with no live state costs one full scan", async () => {
+    const surfaceId = "surface-scan-2";
+    seedSurfaceRow(surfaceId, "dynamic_page");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "answer_selected", {
+      _completeSurface: true,
+      _completionSummary: "Answered",
+    });
+
+    // The request carries its own summary, so only the write scans.
+    expect(getMessagesCalls).toBe(1);
+    expect(readPersistedSurface(surfaceId)?.completionSummary).toBe("Answered");
+  });
+
+  test("a non-one-shot action with live state costs no scan at all", async () => {
+    const surfaceId = "surface-scan-3";
+    seedSurfaceRow(surfaceId, "dynamic_page");
+    const ctx = makeContext();
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "dynamic_page",
+      data: { html: "<p>page</p>" },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "answer_selected", {
+      choiceId: "inbox",
+    });
+
+    expect(getMessagesCalls).toBe(0);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+  });
+
+  test("a non-one-shot action with no live state costs one decisive scan", async () => {
+    const surfaceId = "surface-scan-4";
+    seedSurfaceRow(surfaceId, "dynamic_page");
+    const ctx = makeContext();
+
+    await handleSurfaceAction(ctx, surfaceId, "answer_selected", {
+      choiceId: "inbox",
+    });
+
+    // The persisted type is the only thing that can rule out completion here,
+    // so this read is the decision input, not a discarded one.
+    expect(getMessagesCalls).toBe(1);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+    expect(contentWrites).toHaveLength(0);
+  });
+
+  test("a rejected action scans nothing", async () => {
+    const surfaceId = "surface-scan-5";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext({
+      queued: false,
+      requestId: "req-rejected",
+      rejected: true,
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(getMessagesCalls).toBe(0);
+  });
+
+  test("a pending one-shot action costs one full scan", async () => {
+    const surfaceId = "surface-scan-6";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "choice" });
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "choice",
+      data: {
+        options: [{ id: "inbox", title: "Clean up my inbox" }],
+        selectionMode: "single",
+      },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    // The pending entry supplies the type, so only the write scans.
+    expect(getMessagesCalls).toBe(1);
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+  });
+});
+
+describe("surface action queue rejection", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
+  });
+
+  test("a rejected history-restored action is logged with queue depth", async () => {
+    const surfaceId = "surface-rejected-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext(
+      { queued: false, requestId: "req-rejected", rejected: true },
+      { queueDepth: 7 },
+    );
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    const rejection = loggedWarnings.find((w) =>
+      w.msg.startsWith("Surface action rejected by the message queue"),
+    );
+    expect(rejection).toBeDefined();
+    expect(rejection?.fields).toMatchObject({
+      conversationId: CONVERSATION_ID,
+      surfaceId,
+      actionId: "inbox",
+      queueDepth: 7,
+    });
+  });
+
+  test("a rejected pending action is logged with queue depth", async () => {
+    const surfaceId = "surface-rejected-2";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext(
+      { queued: false, requestId: "req-rejected", rejected: true },
+      { queueDepth: 3 },
+    );
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "choice" });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    const rejection = loggedWarnings.find((w) =>
+      w.msg.startsWith("Surface action rejected by the message queue"),
+    );
+    expect(rejection?.fields).toMatchObject({
+      surfaceId,
+      actionId: "inbox",
+      surfaceType: "choice",
+      queueDepth: 3,
+    });
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+  });
+});
+
+describe("surfaces completed without ever awaiting an action", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
+  });
+
+  test("a one-shot surface shown with await_action false completes on its first action", async () => {
+    const ctx = makeContext();
+
+    const shown = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "choice",
+      await_action: false,
+      title: "Pick one",
+      data: {
+        options: [
+          { id: "inbox", title: "Clean up my inbox" },
+          { id: "calendar", title: "Plan my week" },
+        ],
+      },
+    });
+    expect(shown.isError).toBe(false);
+    const { surfaceId } = JSON.parse(shown.content) as { surfaceId: string };
+
+    // `ui_show` registers no pending entry when it is not awaiting an action,
+    // so the action lands on the no-pending branch.
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    expect(ctx.surfaceState.has(surfaceId)).toBe(true);
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe('User chose: "Clean up my inbox"');
+  });
+
+  test("a retried action after a pending completion completes the surface again", async () => {
+    const surfaceId = "surface-retry-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "choice" });
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "choice",
+      data: {
+        options: [{ id: "inbox", title: "Clean up my inbox" }],
+        selectionMode: "single",
+      },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+    // The pending entry is consumed, but `surfaceState` survives, so a
+    // duplicate POST re-runs the completion instead of being dropped.
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(completionBroadcasts(surfaceId)).toHaveLength(2);
+    expect(contentWrites).toHaveLength(2);
+    expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
+  });
+});
+
+describe("markSurfaceCompleted in-memory patching", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+    contentWrites = [];
+    storedRows = [];
+    callOrder = [];
+    loggedWarnings = [];
+    getMessagesCalls = 0;
+  });
+
+  test("marks only the newest in-memory copy of a duplicated surfaceId", () => {
+    const surfaceId = "surface-duplicated-1";
+    const older = { type: "ui_surface", surfaceId } as Record<string, unknown>;
+    const newer = { type: "ui_surface", surfaceId } as Record<string, unknown>;
+    const messages = [{ content: [older] }, { content: [newer] }];
+
+    markSurfaceCompleted(
+      { conversationId: CONVERSATION_ID, messages },
+      surfaceId,
+      "Done",
+    );
+
+    // The DB half patches the newest row only; marking every in-memory copy
+    // would make a reseed revert the extras.
+    expect(newer.completed).toBe(true);
+    expect(newer.completionSummary).toBe("Done");
+    expect(older.completed).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -53,6 +53,8 @@ let contentWrites: Array<{
  * main-thread cost on large conversations, so the counts are pinned.
  */
 let getMessagesCalls = 0;
+/** When set, every persisted write throws it, standing in for a SQLite lock. */
+let persistError: Error | null = null;
 
 const realCrud = await import("../persistence/conversation-crud.js");
 mock.module("../persistence/conversation-crud.js", () => ({
@@ -66,6 +68,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
       .map((r) => ({ ...r, content: structuredClone(r.content) }));
   },
   updateMessageContent: (id: string, content: string) => {
+    if (persistError) {
+      throw persistError;
+    }
     const blocks = JSON.parse(content) as Array<Record<string, unknown>>;
     callOrder.push("persist");
     contentWrites.push({ id, blocks });
@@ -75,6 +80,16 @@ mock.module("../persistence/conversation-crud.js", () => ({
     }
   },
 }));
+
+function resetSurfaceState(): void {
+  broadcastedMessages = [];
+  contentWrites = [];
+  storedRows = [];
+  callOrder = [];
+  loggedWarnings = [];
+  getMessagesCalls = 0;
+  persistError = null;
+}
 
 // Import must come AFTER mock.module so the surface module picks up the
 // mocked event hub and persistence functions.
@@ -214,14 +229,7 @@ const CHOICE_PAYLOAD = {
 };
 
 describe("history-restored surface completion", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("one-shot choice surface with no in-memory state is completed and persisted", async () => {
     const surfaceId = "surface-choice-history-1";
@@ -433,14 +441,7 @@ describe("history-restored surface completion", () => {
 });
 
 describe("history-restored surface completion: requester provenance", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("an untrusted requester cannot complete a guardian-provenance surface", async () => {
     const surfaceId = "surface-choice-guardian-1";
@@ -481,14 +482,7 @@ describe("history-restored surface completion: requester provenance", () => {
 });
 
 describe("history-restored surface completion: scan cost", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("a one-shot action with no live state costs one full scan", async () => {
     const surfaceId = "surface-scan-1";
@@ -586,14 +580,7 @@ describe("history-restored surface completion: scan cost", () => {
 });
 
 describe("surface action queue rejection", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("a rejected history-restored action is logged with queue depth", async () => {
     const surfaceId = "surface-rejected-1";
@@ -642,14 +629,7 @@ describe("surface action queue rejection", () => {
 });
 
 describe("surfaces completed without ever awaiting an action", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("a one-shot surface shown with await_action false completes on its first action", async () => {
     const ctx = makeContext();
@@ -707,14 +687,7 @@ describe("surfaces completed without ever awaiting an action", () => {
 });
 
 describe("markSurfaceCompleted in-memory patching", () => {
-  beforeEach(() => {
-    broadcastedMessages = [];
-    contentWrites = [];
-    storedRows = [];
-    callOrder = [];
-    loggedWarnings = [];
-    getMessagesCalls = 0;
-  });
+  beforeEach(resetSurfaceState);
 
   test("marks only the newest in-memory copy of a duplicated surfaceId", () => {
     const surfaceId = "surface-duplicated-1";
@@ -733,5 +706,52 @@ describe("markSurfaceCompleted in-memory patching", () => {
     expect(newer.completed).toBe(true);
     expect(newer.completionSummary).toBe("Done");
     expect(older.completed).toBeUndefined();
+  });
+});
+
+describe("surface completion when the persisted write does not land", () => {
+  beforeEach(resetSurfaceState);
+
+  test("a completion whose write throws is not broadcast", async () => {
+    const surfaceId = "surface-persist-throws-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const ctx = makeContext();
+    persistError = new Error("database is locked");
+
+    const result = await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "inbox",
+      CHOICE_PAYLOAD,
+    );
+
+    // A persistence hiccup must not fail the action or drop the user's turn.
+    expect(result).toBeUndefined();
+    expect(ctx.enqueuedContents).toHaveLength(1);
+
+    // The persisted block is still pending, so a client told the card was
+    // completed would watch the next reseed revert it.
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+    expect(completionBroadcasts(surfaceId)).toHaveLength(0);
+  });
+
+  test("a completion with no persisted block is still broadcast", async () => {
+    const surfaceId = "surface-no-persisted-block-1";
+    // Nothing in history: the write is a no-op because there is nothing to
+    // write, and nothing can revert the client's completed card.
+    const ctx = makeContext();
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "choice",
+      data: {
+        options: [{ id: "inbox", title: "Clean up my inbox" }],
+        selectionMode: "single",
+      },
+    });
+
+    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+
+    expect(readPersistedSurface(surfaceId)).toBeUndefined();
+    expect(contentWrites).toHaveLength(0);
+    expect(completionBroadcasts(surfaceId)).toHaveLength(1);
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
@@ -25,7 +25,14 @@ const { findPersistedSurfaceInfo } =
 
 const CONVERSATION_ID = "conv-persisted-info-1";
 
-function seedRows(rows: Array<{ id: string; content: unknown[] }>): void {
+/** A guardian requester: sees every row, so no provenance filtering applies. */
+const GUARDIAN = { requesterCanAccessMemory: true };
+/** An untrusted requester: only non-guardian-provenance rows are visible. */
+const UNTRUSTED = { requesterCanAccessMemory: false };
+
+function seedRows(
+  rows: Array<{ id: string; content: unknown[]; metadata?: string }>,
+): void {
   getMessagesImpl = () =>
     rows.map((r) => ({
       id: r.id,
@@ -33,7 +40,7 @@ function seedRows(rows: Array<{ id: string; content: unknown[] }>): void {
       role: "assistant",
       content: r.content,
       createdAt: 0,
-      metadata: null,
+      metadata: r.metadata ?? null,
     }));
 }
 
@@ -59,7 +66,7 @@ describe("findPersistedSurfaceInfo", () => {
     ]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1")
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1", GUARDIAN)
         ?.surfaceType,
     ).toBe("choice");
   });
@@ -80,7 +87,8 @@ describe("findPersistedSurfaceInfo", () => {
     ]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-confirm-1")?.data,
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-confirm-1", GUARDIAN)
+        ?.data,
     ).toEqual({ message: "Delete it?", confirmLabel: "Delete forever" });
   });
 
@@ -101,6 +109,7 @@ describe("findPersistedSurfaceInfo", () => {
     const info = findPersistedSurfaceInfo(
       CONVERSATION_ID,
       "surface-dataless-1",
+      GUARDIAN,
     );
     expect(info?.surfaceType).toBe("choice");
     expect(info?.data).toBeUndefined();
@@ -122,7 +131,7 @@ describe("findPersistedSurfaceInfo", () => {
     ]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-missing"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-missing", GUARDIAN),
     ).toBeUndefined();
   });
 
@@ -130,7 +139,7 @@ describe("findPersistedSurfaceInfo", () => {
     seedRows([]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1", GUARDIAN),
     ).toBeUndefined();
   });
 
@@ -157,7 +166,7 @@ describe("findPersistedSurfaceInfo", () => {
     ]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-compacted-1")
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-compacted-1", GUARDIAN)
         ?.surfaceType,
     ).toBe("choice");
   });
@@ -175,6 +184,7 @@ describe("findPersistedSurfaceInfo", () => {
     const info = findPersistedSurfaceInfo(
       CONVERSATION_ID,
       "surface-typeless-1",
+      GUARDIAN,
     );
     expect(info).toBeDefined();
     expect(info?.surfaceType).toBeUndefined();
@@ -186,7 +196,121 @@ describe("findPersistedSurfaceInfo", () => {
     };
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1"),
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-choice-1", GUARDIAN),
     ).toBeUndefined();
+  });
+
+  test("hides a guardian-provenance row from an untrusted requester", () => {
+    seedRows([
+      {
+        id: "msg-guardian",
+        metadata: JSON.stringify({ provenanceTrustClass: "guardian" }),
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-guardian-1",
+            surfaceType: "confirmation",
+            data: { confirmLabel: "Wire the money" },
+          },
+        ],
+      },
+    ]);
+
+    // The same row the live history filter drops for this actor.
+    expect(
+      findPersistedSurfaceInfo(
+        CONVERSATION_ID,
+        "surface-guardian-1",
+        UNTRUSTED,
+      ),
+    ).toBeUndefined();
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-guardian-1", GUARDIAN)
+        ?.data,
+    ).toEqual({ confirmLabel: "Wire the money" });
+  });
+
+  test("hides a provenance-less row from an untrusted requester", () => {
+    seedRows([
+      {
+        id: "msg-no-metadata",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-unstamped-1",
+            surfaceType: "choice",
+            data: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceInfo(
+        CONVERSATION_ID,
+        "surface-unstamped-1",
+        UNTRUSTED,
+      ),
+    ).toBeUndefined();
+  });
+
+  test("serves a contact-provenance row to an untrusted requester", () => {
+    seedRows([
+      {
+        id: "msg-contact",
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-contact-1",
+            surfaceType: "choice",
+            data: { options: [] },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-contact-1", UNTRUSTED)
+        ?.surfaceType,
+    ).toBe("choice");
+  });
+
+  test("skips a filtered newer row and serves the visible older one", () => {
+    seedRows([
+      {
+        id: "msg-contact",
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-dup-1",
+            surfaceType: "choice",
+            data: { options: [{ id: "visible" }] },
+          },
+        ],
+      },
+      {
+        id: "msg-guardian",
+        metadata: JSON.stringify({ provenanceTrustClass: "guardian" }),
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: "surface-dup-1",
+            surfaceType: "confirmation",
+            data: { options: [{ id: "hidden" }] },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-dup-1", UNTRUSTED)
+        ?.data,
+    ).toEqual({ options: [{ id: "visible" }] });
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-dup-1", GUARDIAN)
+        ?.data,
+    ).toEqual({ options: [{ id: "hidden" }] });
   });
 });

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -372,6 +372,30 @@ export function flushPendingSurfaceDataPersists(conversationId?: string): void {
 }
 
 /**
+ * How the persisted half of {@link markSurfaceCompleted} went.
+ *
+ * `"not_found"` and `"failed"` both wrote nothing, and the difference decides
+ * whether a caller may still broadcast `ui_surface_complete`: `"not_found"`
+ * leaves no persisted block that could revert to pending on the next history
+ * reseed, while `"failed"` leaves one that will.
+ */
+export type SurfaceCompletionPersistResult =
+  | "persisted"
+  | "not_found"
+  | "failed";
+
+/**
+ * Whether a completion may be announced to clients given how its persist went.
+ * Every completion broadcast site asks this, so the rule cannot drift between
+ * them.
+ */
+function canBroadcastCompletion(
+  result: SurfaceCompletionPersistResult,
+): boolean {
+  return result !== "failed";
+}
+
+/**
  * Mark a `ui_surface` content block as completed in the database so that
  * history reconstruction preserves the completion state.  Also updates
  * in-memory messages when available.
@@ -379,13 +403,17 @@ export function flushPendingSurfaceDataPersists(conversationId?: string): void {
  * `prelocated` lets a caller that already scanned for the block (the
  * completion path's persisted read) reuse that hit instead of paying a second
  * full-history scan.
+ *
+ * Never throws: a persistence hiccup must not fail the surface action that
+ * triggered it. The outcome comes back in the return value instead, so a
+ * caller about to announce the completion can withhold it.
  */
 export function markSurfaceCompleted(
   ctx: { conversationId: string; messages?: Array<{ content: unknown }> },
   surfaceId: string,
   summary: string,
   prelocated?: PersistedSurfaceHit,
-): void {
+): SurfaceCompletionPersistResult {
   // Force-flush any pending debounced data persist so the completion
   // patch lands on top of the latest data instead of racing with it.
   const flushed = flushSurfaceDataPersist(surfaceId);
@@ -419,17 +447,20 @@ export function markSurfaceCompleted(
       prelocated && !flushed
         ? prelocated
         : findPersistedSurfaceBlock(ctx.conversationId, surfaceId, "write");
-    if (hit) {
-      hit.block.completed = true;
-      hit.block.completionSummary = summary;
-      updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
+    if (!hit) {
+      return "not_found";
     }
+    hit.block.completed = true;
+    hit.block.completionSummary = summary;
+    updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
+    return "persisted";
   } catch (err) {
     // Error, not warn: a silent failure here presents as the user's answer being discarded.
     log.error(
       { err, conversationId: ctx.conversationId, surfaceId },
       "Failed to persist surface completion to DB",
     );
+    return "failed";
   }
 }
 
@@ -509,16 +540,22 @@ export function findPersistedSurfaceInfo(
  * instance, so it can run from flows that don't own one — projecting a
  * terminal guardian-request status onto its in-app approval card when the
  * request was resolved on another surface (or by the expiry sweep). Persists
- * the completion (reload-safe) and broadcasts `ui_surface_complete` so every
- * connected client of this guardian converges. No-ops when the surface block
- * isn't found in the conversation.
+ * the completion (reload-safe) first, then broadcasts `ui_surface_complete` so
+ * every connected client of this guardian converges.
  */
 export function completeSurfaceAndNotify(
   conversationId: string,
   surfaceId: string,
   summary: string,
 ): void {
-  markSurfaceCompleted({ conversationId }, surfaceId, summary);
+  const persisted = markSurfaceCompleted(
+    { conversationId },
+    surfaceId,
+    summary,
+  );
+  if (!canBroadcastCompletion(persisted)) {
+    return;
+  }
   broadcastMessage({
     type: "ui_surface_complete",
     conversationId,
@@ -1895,9 +1932,9 @@ const ONE_SHOT_SURFACE_TYPES = [
  *
  * Called from both `handleSurfaceAction` branches, one holding a pending entry
  * and one with none, always after `enqueueMessage` accepted the turn so a
- * rejected enqueue leaves the surface answerable. Persists first and
- * broadcasts `ui_surface_complete` second: a failed persist must not leave a
- * client rendering a card the next history reseed reverts.
+ * rejected enqueue leaves the surface answerable. Persists first and broadcasts
+ * `ui_surface_complete` only once that write is known not to have failed: a
+ * client must not render a card the next history reseed reverts.
  *
  * "No pending entry" is broader than "restored from history", and with
  * `pendingSurfaceActions` empty the two cannot be told apart: a surface shown
@@ -1947,7 +1984,10 @@ function maybeCompleteSurfaceAfterAction(
   const summary =
     requestedSummary ??
     buildCompletionSummary(surfaceType, actionId, actionData, surfaceData);
-  markSurfaceCompleted(ctx, surfaceId, summary, hit);
+  const persisted = markSurfaceCompleted(ctx, surfaceId, summary, hit);
+  if (!canBroadcastCompletion(persisted)) {
+    return;
+  }
   broadcastMessage({
     type: "ui_surface_complete",
     conversationId: ctx.conversationId,
@@ -2019,6 +2059,9 @@ export async function handleSurfaceAction(
       return { accepted: true, conversationId: ctx.conversationId };
     }
 
+    // Broadcast unconditionally: `showStandaloneSurface` renders straight to
+    // the client without appending a `ui_surface` block, so there is no
+    // persisted state a failed completion write could contradict.
     broadcastMessage({
       type: "ui_surface_complete",
       conversationId: ctx.conversationId,
@@ -3614,14 +3657,18 @@ export async function surfaceProxyResolver(
         lastAction.data,
         stored?.data,
       );
-      ctx.sendToClient({
-        type: "ui_surface_complete",
-        conversationId: ctx.conversationId,
-        surfaceId,
-        summary,
-        submittedData: lastAction.data,
-      });
-      markSurfaceCompleted(ctx, surfaceId, summary);
+      // A `ui_show` surface owns a persisted block, so the completion has to
+      // land before the client is told the card is answered.
+      const persisted = markSurfaceCompleted(ctx, surfaceId, summary);
+      if (canBroadcastCompletion(persisted)) {
+        ctx.sendToClient({
+          type: "ui_surface_complete",
+          conversationId: ctx.conversationId,
+          surfaceId,
+          summary,
+          submittedData: lastAction.data,
+        });
+      }
     } else {
       ctx.sendToClient({
         type: "ui_surface_dismiss",

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -43,6 +43,7 @@ import {
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
 import type { AuthContext } from "../runtime/auth/types.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import type {
   InteractiveUiRequest,
   InteractiveUiResult,
@@ -86,6 +87,7 @@ import type {
   UiSurfaceShow,
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
+import { isRowVisibleToUntrustedActor } from "./message-provenance.js";
 export {
   buildSurfaceShowPair,
   type CurrentTurnSurface,
@@ -188,13 +190,33 @@ type PersistedSurfaceHit = {
 };
 
 /**
+ * Provenance scoping for a persisted-surface scan.
+ *
+ * A read hands the block's content back to the requester, so it passes that
+ * requester's memory capability and the scan applies
+ * {@link isRowVisibleToUntrustedActor} per row. That is the identical
+ * predicate `loadFromDb` applies when building `messages`, which
+ * `restoreSurfaceStateFromHistory` turns into `surfaceState`, so the
+ * persisted fallback can never surface a row the live path deliberately hid
+ * from this actor.
+ *
+ * A write passes `"write"` and scans unfiltered on purpose: it addresses a
+ * block by an id the caller already holds and returns nothing about it, so
+ * there is no content for the filter to protect.
+ */
+type PersistedSurfaceScope = { requesterCanAccessMemory: boolean } | "write";
+
+/**
  * Locate the persisted `ui_surface` content block for `surfaceId`.
  *
- * The single owner of how a persisted surface block is resolved: newest
- * message row first, first matching block within that row, stopping at the
- * first hit. Every persisted read and write goes through here so a change to
- * storage resolution, ordering, or matching can never make them target
- * different blocks.
+ * The single owner of how a persisted surface block is resolved *in this
+ * module*: newest message row first, first matching block within that row,
+ * stopping at the first hit. Every persisted read and write here goes through
+ * it so a change to storage resolution, ordering, or matching can never make
+ * them target different blocks. `findPersistedSurfaceState`
+ * (`runtime/routes/surface-conversation-resolver.ts`) is the other persisted
+ * `ui_surface` reader and deliberately does not: it runs its own SQL scan,
+ * bounded by the compaction boundary, for the read-only content route.
  *
  * The scan is deliberately unbounded by compaction (see
  * {@link findPersistedSurfaceInfo}), and it throws rather than swallowing DB
@@ -203,9 +225,15 @@ type PersistedSurfaceHit = {
 function findPersistedSurfaceBlock(
   conversationId: string,
   surfaceId: string,
+  scope: PersistedSurfaceScope,
 ): PersistedSurfaceHit | undefined {
+  const filterByProvenance =
+    scope !== "write" && !scope.requesterCanAccessMemory;
   const rows = getMessages(conversationId);
   for (let r = rows.length - 1; r >= 0; r--) {
+    if (filterByProvenance && !isRowVisibleToUntrustedActor(rows[r].metadata)) {
+      continue;
+    }
     const blocks: unknown[] = rows[r].content;
     const blockIndex = blocks.findIndex((pb) => {
       const rb = pb as Record<string, unknown>;
@@ -237,7 +265,7 @@ function persistSurfaceData(
   data: SurfaceData,
 ): void {
   try {
-    const hit = findPersistedSurfaceBlock(conversationId, surfaceId);
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, "write");
     if (!hit) {
       return;
     }
@@ -276,15 +304,19 @@ export function scheduleSurfaceDataPersist(
  * Force-flush any pending debounced persist for `surfaceId`. Called on
  * surface completion so the final state is durable before the surface
  * record transitions to `completed`.
+ *
+ * Returns whether a write actually landed, so a caller holding a block
+ * located before the flush knows to discard it and re-locate.
  */
-export function flushSurfaceDataPersist(surfaceId: string): void {
+export function flushSurfaceDataPersist(surfaceId: string): boolean {
   const pending = pendingSurfacePersists.get(surfaceId);
   if (!pending) {
-    return;
+    return false;
   }
   clearTimeout(pending.timer);
   pendingSurfacePersists.delete(surfaceId);
   persistSurfaceData(pending.conversationId, surfaceId, pending.data);
+  return true;
 }
 
 /**
@@ -343,20 +375,28 @@ export function flushPendingSurfaceDataPersists(conversationId?: string): void {
  * Mark a `ui_surface` content block as completed in the database so that
  * history reconstruction preserves the completion state.  Also updates
  * in-memory messages when available.
+ *
+ * `prelocated` lets a caller that already scanned for the block (the
+ * completion path's persisted read) reuse that hit instead of paying a second
+ * full-history scan.
  */
 export function markSurfaceCompleted(
   ctx: { conversationId: string; messages?: Array<{ content: unknown }> },
   surfaceId: string,
   summary: string,
+  prelocated?: PersistedSurfaceHit,
 ): void {
   // Force-flush any pending debounced data persist so the completion
   // patch lands on top of the latest data instead of racing with it.
-  flushSurfaceDataPersist(surfaceId);
+  const flushed = flushSurfaceDataPersist(surfaceId);
 
   // Update in-memory messages when available so subsequent reads within
-  // this session see the change without waiting for DB.
+  // this session see the change without waiting for DB. Newest match only,
+  // matching the persisted patch below: marking every copy of a duplicated
+  // surfaceId would make memory and history disagree, and a reseed would
+  // revert the extras.
   if (ctx.messages) {
-    for (let i = ctx.messages.length - 1; i >= 0; i--) {
+    outer: for (let i = ctx.messages.length - 1; i >= 0; i--) {
       const msg = ctx.messages[i];
       if (!Array.isArray(msg.content)) {
         continue;
@@ -366,15 +406,19 @@ export function markSurfaceCompleted(
         if (b.type === "ui_surface" && b.surfaceId === surfaceId) {
           b.completed = true;
           b.completionSummary = summary;
-          break;
+          break outer;
         }
       }
     }
   }
 
-  // Persist to DB.
+  // Persist to DB. A flush above re-read and rewrote the row, so any block
+  // located before it is stale and has to be re-located.
   try {
-    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId);
+    const hit =
+      prelocated && !flushed
+        ? prelocated
+        : findPersistedSurfaceBlock(ctx.conversationId, surfaceId, "write");
     if (hit) {
       hit.block.completed = true;
       hit.block.completionSummary = summary;
@@ -390,11 +434,16 @@ export function markSurfaceCompleted(
 }
 
 /** What a persisted `ui_surface` block can still tell us once it is cold. */
-export type PersistedSurfaceInfo = {
+type PersistedSurfaceInfo = {
   /** The block's `surfaceType`, absent when it carries no string type. */
   surfaceType: string | undefined;
   /** The block's `data`, absent when it carries no plain-object data. */
   data: Record<string, unknown> | undefined;
+  /**
+   * The block this was read from, so a completion write can patch it without
+   * scanning the conversation a second time.
+   */
+  hit: PersistedSurfaceHit;
 };
 
 /**
@@ -402,6 +451,13 @@ export type PersistedSurfaceInfo = {
  * history. Both travel together because every caller that has lost the live
  * entry needs both: the type to decide completion, the data for the labels a
  * completion summary quotes.
+ *
+ * `requesterCanAccessMemory` is the REQUESTER's memory capability, not the
+ * trust class whatever conversation happens to be loaded under. The live path
+ * this falls back from hides guardian-provenance rows from an untrusted actor
+ * (`loadFromDb` → `restoreSurfaceStateFromHistory`), so the live entry is
+ * missing precisely when the row was filtered out. The scan therefore applies
+ * the same per-row predicate rather than handing back what the filter dropped.
  *
  * This must NOT be routed through `findPersistedSurfaceState`
  * (`runtime/routes/surface-conversation-resolver.ts`): that helper is bounded
@@ -413,13 +469,17 @@ export type PersistedSurfaceInfo = {
  * Hits are deliberately not memoized into `conversation.surfaceState`; see
  * `runtime/routes/surface-content-routes.ts` for why that shared map must not
  * absorb scan results.
+ *
+ * Exported for its unit test only, and not a supported read API. In-repo callers
+ * go through `handleSurfaceAction`.
  */
 export function findPersistedSurfaceInfo(
   conversationId: string,
   surfaceId: string,
+  opts: { requesterCanAccessMemory: boolean },
 ): PersistedSurfaceInfo | undefined {
   try {
-    const hit = findPersistedSurfaceBlock(conversationId, surfaceId);
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, opts);
     if (!hit) {
       return undefined;
     }
@@ -429,10 +489,8 @@ export function findPersistedSurfaceInfo(
         typeof hit.block.surfaceType === "string"
           ? hit.block.surfaceType
           : undefined,
-      data:
-        typeof data === "object" && data !== null && !Array.isArray(data)
-          ? (data as Record<string, unknown>)
-          : undefined,
+      data: isPlainObject(data) ? data : undefined,
+      hit,
     };
   } catch (err) {
     log.warn(
@@ -500,7 +558,11 @@ export function removeSurfaceBlock(
   }
 
   try {
-    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId);
+    const hit = findPersistedSurfaceBlock(
+      ctx.conversationId,
+      surfaceId,
+      "write",
+    );
     if (hit) {
       hit.blocks.splice(hit.blockIndex, 1);
       updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
@@ -1788,6 +1850,32 @@ function maybeEmitActivationMoment(
   recordActivationMoment(ctx, moment);
 }
 
+/**
+ * Record a surface action the message queue refused.
+ *
+ * The route answers `{ ok: true }` for a rejected enqueue and the client
+ * optimistically completes the card on that, so the user sees an answered card
+ * that the next history reseed reverts. Nothing else on this path logs, so
+ * without this the only user-visible cause of a reverted card leaves no trace.
+ */
+function logSurfaceActionRejected(
+  ctx: SurfaceConversationContext,
+  surfaceId: string,
+  actionId: string,
+  surfaceType: string | undefined,
+): void {
+  log.warn(
+    {
+      conversationId: ctx.conversationId,
+      surfaceId,
+      actionId,
+      surfaceType,
+      queueDepth: ctx.getQueueDepth(),
+    },
+    "Surface action rejected by the message queue",
+  );
+}
+
 // One-shot interactive surfaces auto-complete once their action message is
 // accepted (they never accept further actions).
 const ONE_SHOT_SURFACE_TYPES = [
@@ -1802,39 +1890,71 @@ const ONE_SHOT_SURFACE_TYPES = [
 /**
  * The completion rule for an accepted surface action: complete when the client
  * asked for it explicitly (`_completeSurface`), or when the surface is a
- * one-shot type. No-op otherwise.
+ * one-shot type. No-op otherwise. Owns the whole rule, including reading the
+ * `_completeSurface` request out of the raw action data.
  *
- * Both `handleSurfaceAction` branches (pending and history-restored) route
- * completion through here, and both call it only after `enqueueMessage`
- * accepted the turn, so a rejected enqueue leaves the surface answerable.
- * Broadcasts `ui_surface_complete` so live clients converge, and persists the
- * completion so a history reseed reports the surface as answered.
+ * Called from both `handleSurfaceAction` branches, one holding a pending entry
+ * and one with none, always after `enqueueMessage` accepted the turn so a
+ * rejected enqueue leaves the surface answerable. Persists first and
+ * broadcasts `ui_surface_complete` second: a failed persist must not leave a
+ * client rendering a card the next history reseed reverts.
+ *
+ * "No pending entry" is broader than "restored from history", and with
+ * `pendingSurfaceActions` empty the two cannot be told apart: a surface shown
+ * with `await_action: false` never registered a pending entry, and a daemon
+ * restart drops the entry of one that did. So a one-shot surface that never
+ * awaited an action does complete on its first action.
+ *
+ * `liveSurfaceType` / `liveSurfaceData` come from in-memory state. When the
+ * type is missing the persisted block supplies both, read at most once per
+ * action, only once the decision actually needs it, and reused for the write.
  */
 function maybeCompleteSurfaceAfterAction(
   ctx: SurfaceConversationContext,
   surfaceId: string,
+  actionId: string,
+  actionData: Record<string, unknown> | undefined,
   opts: {
-    surfaceType: string | undefined;
-    requestedSummary: string | null;
-    fallbackSummary: string;
+    liveSurfaceType: string | undefined;
+    liveSurfaceData: Record<string, unknown> | undefined;
+    requesterCanAccessMemory: boolean;
     submittedData?: Record<string, unknown>;
   },
 ): void {
+  const requestedSummary = getRequestedSurfaceCompletionSummary(actionData);
+
+  let surfaceType = opts.liveSurfaceType;
+  let surfaceData = opts.liveSurfaceData;
+  let hit: PersistedSurfaceHit | undefined;
+  // Only the type-driven one-shot rule needs history: an explicit request
+  // carries its own summary and decides on its own. Type and labels come from
+  // the same read so the decision and the summary can never disagree.
+  if (surfaceType === undefined && !requestedSummary) {
+    const persisted = findPersistedSurfaceInfo(ctx.conversationId, surfaceId, {
+      requesterCanAccessMemory: opts.requesterCanAccessMemory,
+    });
+    surfaceType = persisted?.surfaceType;
+    surfaceData = persisted?.data;
+    hit = persisted?.hit;
+  }
+
   const isOneShot =
-    opts.surfaceType !== undefined &&
-    ONE_SHOT_SURFACE_TYPES.includes(opts.surfaceType);
-  if (!opts.requestedSummary && !isOneShot) {
+    surfaceType !== undefined && ONE_SHOT_SURFACE_TYPES.includes(surfaceType);
+  if (!requestedSummary && !isOneShot) {
     return;
   }
-  const summary = opts.requestedSummary ?? opts.fallbackSummary;
+
+  const summary =
+    requestedSummary ??
+    buildCompletionSummary(surfaceType, actionId, actionData, surfaceData);
+  markSurfaceCompleted(ctx, surfaceId, summary, hit);
   broadcastMessage({
     type: "ui_surface_complete",
     conversationId: ctx.conversationId,
     surfaceId,
     summary,
-    submittedData: opts.submittedData,
+    ...(opts.submittedData ? { submittedData: opts.submittedData } : {}),
   });
-  markSurfaceCompleted(ctx, surfaceId, summary);
 }
 
 export async function handleSurfaceAction(
@@ -2008,6 +2128,16 @@ export async function handleSurfaceAction(
     return { accepted: true, conversationId };
   }
 
+  // Trust of the actor committing THIS action. `POST /v1/surface-actions`
+  // stamps the verified requester's trust onto the conversation before
+  // dispatching here, and `loadFromDb` derives the live history filter from
+  // the same value, so the completion path's persisted read stays scoped to
+  // exactly what this actor's live view would have held. Unresolvable trust
+  // fails closed to the untrusted filter.
+  const requesterCanAccessMemory = resolveCapabilities(
+    ctx.trustContext?.trustClass,
+  ).canAccessMemory;
+
   const pending = ctx.pendingSurfaceActions.get(surfaceId);
 
   // When surfaces are restored from history (e.g. onboarding cards), there is
@@ -2116,8 +2246,12 @@ export async function handleSurfaceAction(
 
     log.info(
       {
+        conversationId: ctx.conversationId,
         surfaceId,
         actionId,
+        // False means the surface type and the labels its completion summary
+        // quotes can only come from persisted history.
+        hasLiveState: stored !== undefined,
         contentLength: content.length,
         contentPreview: content.slice(0, 200),
         attachmentCount: attachments.length,
@@ -2154,6 +2288,7 @@ export async function handleSurfaceAction(
 
     if (result.rejected) {
       ctx.surfaceActionRequestIds.delete(requestId);
+      logSurfaceActionRejected(ctx, surfaceId, actionId, stored?.surfaceType);
       return;
     }
 
@@ -2163,39 +2298,11 @@ export async function handleSurfaceAction(
     // (and the one-shot tag stays intact for the user's retry).
     maybeEmitActivationMoment(ctx, surfaceId);
 
-    // In-memory state is absent whenever the surface outlived its live entry
-    // (client reload, daemon restart), so the persisted block is the only
-    // remaining source for both the surface type and the labels the completion
-    // summary quotes. One lookup serves both, and is skipped entirely while
-    // live state still covers them.
-    const persisted = stored
-      ? undefined
-      : findPersistedSurfaceInfo(ctx.conversationId, surfaceId);
-    const resolvedSurfaceType = stored?.surfaceType ?? persisted?.surfaceType;
-    const resolvedSurfaceData = (stored?.data ?? persisted?.data) as
-      | Record<string, unknown>
-      | undefined;
-    if (!stored) {
-      log.info(
-        {
-          conversationId: ctx.conversationId,
-          surfaceId,
-          actionId,
-          resolvedSurfaceType,
-        },
-        "Surface action handled with no in-memory surface state",
-      );
-    }
-
-    maybeCompleteSurfaceAfterAction(ctx, surfaceId, {
-      surfaceType: resolvedSurfaceType,
-      requestedSummary: getRequestedSurfaceCompletionSummary(mergedData),
-      fallbackSummary: buildCompletionSummary(
-        resolvedSurfaceType,
-        actionId,
-        mergedData,
-        resolvedSurfaceData,
-      ),
+    maybeCompleteSurfaceAfterAction(ctx, surfaceId, actionId, mergedData, {
+      liveSurfaceType: stored?.surfaceType,
+      liveSurfaceData: stored?.data as Record<string, unknown> | undefined,
+      requesterCanAccessMemory,
+      submittedData: actionDataForText,
     });
 
     // One-shot: clear accumulated state now that the message has been accepted.
@@ -2428,6 +2535,7 @@ export async function handleSurfaceAction(
   });
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
+    logSurfaceActionRejected(ctx, surfaceId, actionId, pending.surfaceType);
     return;
   }
 
@@ -2437,10 +2545,10 @@ export async function handleSurfaceAction(
   // one-shot tag stays intact for the user's retry).
   maybeEmitActivationMoment(ctx, surfaceId);
 
-  maybeCompleteSurfaceAfterAction(ctx, surfaceId, {
-    surfaceType: pending.surfaceType,
-    requestedSummary: getRequestedSurfaceCompletionSummary(mergedData),
-    fallbackSummary: summary,
+  maybeCompleteSurfaceAfterAction(ctx, surfaceId, actionId, mergedData, {
+    liveSurfaceType: pending.surfaceType,
+    liveSurfaceData: surfaceData,
+    requesterCanAccessMemory,
     submittedData: mergedDataForText,
   });
 


### PR DESCRIPTION
## Summary
- Apply the untrusted-actor provenance filter to the new persisted surface read, matching the sibling resolver
- Collapse the per-action persisted scans so one surface action costs at most one full conversation read, and zero when no completion happens
- Log the rejected-enqueue path, which reproduces the same user-visible revert and was previously silent
- Persist before broadcasting, so a failed write cannot leave a client showing a completed card
- Align the in-memory completion scan with its own persistence, and correct doc claims

Addresses gaps found by the plan's self-review passes.

Part of plan: choice-surface-completion-persist.md (self-review remediation)