### PR TITLE
fix(slack): render inline channel mentions in adapter reads; honor pipe-form user labels (LUM-3025)

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -31,12 +31,13 @@ mock.module("../../../../contacts/contacts-write.js", () => ({
 }));
 
 import {
-  __resetSlackUserInfoCacheForTests,
+  __resetSlackMentionCachesForTests,
   slackProvider,
 } from "../adapter.js";
 
 const originalFetch = globalThis.fetch;
 let userInfoCalls: string[] = [];
+let channelInfoCalls: string[] = [];
 
 function installFetchStub() {
   globalThis.fetch = (async (
@@ -63,7 +64,49 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   const parsed = new URL(url);
   const method = parsed.pathname.split("/").at(-1);
 
+  if (method === "conversations.info") {
+    const channelId = parsed.searchParams.get("channel") ?? "";
+    channelInfoCalls.push(channelId);
+    if (channelId === "CPRODMODELS1") {
+      return {
+        ok: true,
+        channel: { id: "CPRODMODELS1", name: "prod-models" },
+      };
+    }
+    return { ok: false, error: "channel_not_found" };
+  }
+
   if (method === "conversations.history") {
+    if (parsed.searchParams.get("channel") === "C_CHANNEL_MENTIONS") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            ts: "1700000009.001000",
+            user: "USENDER",
+            text: "post in <#CPRODMODELS1> and <#COTHER1|other-name> please",
+          },
+        ],
+      };
+    }
+
+    if (parsed.searchParams.get("channel") === "C_PRIVATE_MENTION") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            ts: "1700000010.001100",
+            user: "USENDER",
+            text: "see <#CINVISIBLE1> for details",
+          },
+        ],
+      };
+    }
+
     if (parsed.searchParams.get("channel") === "C_USERINFO_FAIL") {
       return {
         ok: true,
@@ -318,8 +361,9 @@ function makeOAuthConnection(
 
 describe("Slack adapter mention rendering", () => {
   beforeEach(async () => {
-    __resetSlackUserInfoCacheForTests();
+    __resetSlackMentionCachesForTests();
     userInfoCalls = [];
+    channelInfoCalls = [];
     getSecureKeyAsyncMock.mockReset();
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
       if (key === credentialKey("slack_channel", "bot_token")) {
@@ -514,6 +558,44 @@ describe("Slack adapter mention rendering", () => {
       actorTimezoneLabel: "Greenwich Mean Time",
       actorTimezoneOffsetSeconds: 0,
     });
+  });
+
+  test("getHistory renders inline channel mentions without rebinding the message's own channel", async () => {
+    // A message read from channel A that mentions channels B and C: the
+    // message stays attributed to A while the inline mentions render B/C.
+    const messages = await slackProvider.getHistory(
+      undefined,
+      "C_CHANNEL_MENTIONS",
+    );
+
+    expect(messages).toHaveLength(1);
+    // Bare token resolves via conversations.info; pipe token uses its own
+    // embedded label with no lookup.
+    expect(messages[0].text).toBe(
+      "post in #prod-models and #other-name please",
+    );
+    expect(messages[0].conversationId).toBe("C_CHANNEL_MENTIONS");
+    expect(channelInfoCalls).toEqual(["CPRODMODELS1"]);
+  });
+
+  test("getHistory falls back to #unknown-channel for channels this auth cannot see, and caches the failure", async () => {
+    const first = await slackProvider.getHistory(
+      undefined,
+      "C_PRIVATE_MENTION",
+    );
+    const second = await slackProvider.getHistory(
+      undefined,
+      "C_PRIVATE_MENTION",
+    );
+
+    expect(first[0].text).toBe("see #unknown-channel for details");
+    expect(second[0].text).toBe("see #unknown-channel for details");
+    expect(first[0].text).not.toContain("CINVISIBLE1");
+    // channel_not_found is a definitive answer for this auth: one lookup,
+    // not one per history read.
+    expect(channelInfoCalls.filter((id) => id === "CINVISIBLE1")).toHaveLength(
+      1,
+    );
   });
 
   test("getThreadReplies renders Slack user mentions for model-facing text without changing sender identity", async () => {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -8,6 +8,7 @@
 import { createHash } from "node:crypto";
 
 import {
+  buildSlackChannelLabelMap,
   buildSlackUserLabelMap,
   renderSlackTextForModel,
 } from "@vellumai/slack-text";
@@ -68,6 +69,15 @@ const PERMANENT_USER_INFO_SLACK_ERRORS = new Set([
 
 // Cache normalized Slack user facts to avoid repeated API calls within a session.
 const userInfoCache = new Map<string, Promise<SlackUserInfoLookupResult>>();
+
+/**
+ * Cache resolved channel names for inline `<#C…>` mention rendering, same
+ * lifetime and keying discipline as {@link userInfoCache}. Holds `undefined`
+ * for channels this auth provably cannot resolve (not found / no permission)
+ * so a wall of history mentioning an inaccessible channel doesn't re-fire a
+ * doomed lookup per message batch.
+ */
+const channelNameCache = new Map<string, Promise<string | undefined>>();
 
 /**
  * Cached auth resolved during resolveConnection(), split by direction.
@@ -307,15 +317,54 @@ function isPermanentSlackUserInfoFailure(err: unknown): boolean {
   );
 }
 
+function slackAuthCacheScope(auth: OAuthConnection | string): string {
+  return typeof auth === "string"
+    ? `token:${createHash("sha256").update(auth).digest("hex")}`
+    : `connection:${auth.id}:${auth.accountInfo ?? ""}`;
+}
+
 function slackUserInfoCacheKey(
   auth: OAuthConnection | string,
   userId: string,
 ): string {
-  const authScope =
-    typeof auth === "string"
-      ? `token:${createHash("sha256").update(auth).digest("hex")}`
-      : `connection:${auth.id}:${auth.accountInfo ?? ""}`;
-  return `${authScope}:user:${userId}`;
+  return `${slackAuthCacheScope(auth)}:user:${userId}`;
+}
+
+/**
+ * Resolve a channel's display name for inline mention rendering, cached per
+ * auth scope. Returns undefined when the channel has no name (DMs) or this
+ * auth cannot see it; transient failures are not cached so a later batch
+ * retries.
+ */
+async function resolveChannelName(
+  auth: OAuthConnection | string,
+  channelId: string,
+): Promise<string | undefined> {
+  if (!channelId) {
+    return undefined;
+  }
+  const cacheKey = `${slackAuthCacheScope(auth)}:channel:${channelId}`;
+  const cached = channelNameCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const resolved = slack.conversationInfo(auth, channelId).then(
+    (resp) => trimNonEmpty(resp.channel.name),
+    (err: unknown) => {
+      // Cache the definitive "this auth cannot resolve it" answers; drop
+      // everything else so transient failures retry on the next batch.
+      const permanent =
+        err instanceof SlackApiError &&
+        (err.category === "channel_not_found" || err.category === "permission");
+      if (!permanent) {
+        channelNameCache.delete(cacheKey);
+      }
+      return undefined;
+    },
+  );
+  channelNameCache.set(cacheKey, resolved);
+  return resolved;
 }
 
 function normalizeSlackUserInfo(
@@ -346,8 +395,9 @@ function trimNonEmpty(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function __resetSlackUserInfoCacheForTests(): void {
+export function __resetSlackMentionCachesForTests(): void {
   userInfoCache.clear();
+  channelNameCache.clear();
 }
 
 function slackUserInfoMetadata(
@@ -460,13 +510,13 @@ function mapMessage(
 
 function mapSearchMatch(
   match: SlackSearchMatch,
-  userLabels: Record<string, string>,
+  labels: SlackMentionLabels,
 ): Message {
   return {
     id: match.ts,
     conversationId: match.channel.id,
     sender: { id: match.user ?? "unknown", name: match.username ?? "unknown" },
-    text: renderSlackTextForModel(match.text, { userLabels }),
+    text: renderSlackTextForModel(match.text, labels),
     timestamp: parseFloat(match.ts) * 1000,
     threadId: match.thread_ts,
     platform: "slack",
@@ -479,7 +529,7 @@ async function mapSlackMessages(
   channelId: string,
   slackMessages: SlackMessage[],
 ): Promise<Message[]> {
-  const userLabels = await buildMentionUserLabels(
+  const labels = await buildMentionLabels(
     auth,
     slackMessages.map((msg) => msg.text),
   );
@@ -491,31 +541,48 @@ async function mapSlackMessages(
         msg,
         channelId,
         senderInfo,
-        renderSlackTextForModel(msg.text, { userLabels }),
+        renderSlackTextForModel(msg.text, labels),
       ),
     );
   }
   return messages;
 }
 
-async function buildMentionUserLabels(
+interface SlackMentionLabels {
+  userLabels: Record<string, string>;
+  channelLabels: Record<string, string>;
+}
+
+/**
+ * Resolve display labels for every user and channel mentioned inline in the
+ * given texts, so bare `<@U…>` / `<#C…>` tokens render as names instead of
+ * falling back to `@unknown-user` / `#unknown-channel`. Pipe-form tokens
+ * carry their own label and are skipped by the map builders.
+ */
+async function buildMentionLabels(
   auth: OAuthConnection | string,
-  textValues: Iterable<string | undefined>,
-): Promise<Record<string, string>> {
-  return buildSlackUserLabelMap(textValues, (userId) =>
-    resolveUserName(auth, userId),
-  );
+  textValues: readonly (string | undefined)[],
+): Promise<SlackMentionLabels> {
+  const [userLabels, channelLabels] = await Promise.all([
+    buildSlackUserLabelMap(textValues, (userId) =>
+      resolveUserName(auth, userId),
+    ),
+    buildSlackChannelLabelMap(textValues, (channelId) =>
+      resolveChannelName(auth, channelId),
+    ),
+  ]);
+  return { userLabels, channelLabels };
 }
 
 async function mapSearchMatches(
   auth: OAuthConnection | string,
   matches: SlackSearchMatch[],
 ): Promise<Message[]> {
-  const userLabels = await buildMentionUserLabels(
+  const labels = await buildMentionLabels(
     auth,
     matches.map((match) => match.text),
   );
-  return matches.map((match) => mapSearchMatch(match, userLabels));
+  return matches.map((match) => mapSearchMatch(match, labels));
 }
 
 export const slackProvider: MessagingProvider = {

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -19,7 +19,11 @@ import type { KnownBlock } from "@slack/types";
 import type { SlackStreamTask } from "@vellumai/gateway-client";
 
 import { resolveSlackAuth, type SlackAuthIdentity } from "./auth.js";
-import type { SlackApiResponse } from "./types.js";
+import { conversationInfo } from "./client.js";
+import type {
+  SlackApiResponse,
+  SlackConversationInfoResponse,
+} from "./types.js";
 import {
   SlackApiError,
   slackRequest,
@@ -31,14 +35,6 @@ interface SlackOutboundApiResponse extends SlackApiResponse {
   ts?: string;
   upload_url?: string;
   file_id?: string;
-}
-
-interface SlackConversationsInfoResponse extends SlackApiResponse {
-  channel?: {
-    id?: unknown;
-    name?: unknown;
-    name_normalized?: unknown;
-  };
 }
 
 export interface SlackConversationInfo {
@@ -246,7 +242,7 @@ function normalizeSlackString(value: unknown): string | undefined {
 }
 
 function parseSlackConversationInfo(
-  data: SlackConversationsInfoResponse,
+  data: SlackConversationInfoResponse,
 ): SlackConversationInfo | null {
   const id = normalizeSlackString(data.channel?.id);
   if (!id) {
@@ -279,7 +275,6 @@ function parseSlackConversationInfo(
 export async function getSlackConversationInfo(
   channelId: string,
 ): Promise<SlackConversationInfo | null> {
-  const query = { channel: channelId };
   const botAuth = await resolveSlackAuth("bot");
   if (!botAuth) {
     throw new Error("Slack bot token not configured");
@@ -287,11 +282,7 @@ export async function getSlackConversationInfo(
 
   try {
     return parseSlackConversationInfo(
-      await slackRequest<SlackConversationsInfoResponse>(
-        botAuth,
-        "conversations.info",
-        { query },
-      ),
+      await conversationInfo(botAuth, channelId),
     );
   } catch (err) {
     if (
@@ -309,11 +300,7 @@ export async function getSlackConversationInfo(
       throw err;
     }
     return parseSlackConversationInfo(
-      await slackRequest<SlackConversationsInfoResponse>(
-        userAuth,
-        "conversations.info",
-        { query },
-      ),
+      await conversationInfo(userAuth, channelId),
     );
   }
 }

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -16,6 +16,7 @@ import type {
   SlackAuthTestResponse,
   SlackBotsInfoResponse,
   SlackConversationHistoryResponse,
+  SlackConversationInfoResponse,
   SlackConversationMarkResponse,
   SlackConversationRepliesResponse,
   SlackConversationsListResponse,
@@ -151,6 +152,17 @@ export async function conversationsOpen(
     {
       users: userId,
     },
+  );
+}
+
+export async function conversationInfo(
+  connectionOrToken: OAuthConnection | string,
+  channel: string,
+): Promise<SlackConversationInfoResponse> {
+  return request<SlackConversationInfoResponse>(
+    connectionOrToken,
+    "conversations.info",
+    { channel },
   );
 }
 

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -45,6 +45,10 @@ export interface SlackConversation {
   is_user_deleted?: boolean;
 }
 
+export interface SlackConversationInfoResponse extends SlackApiResponse {
+  channel: SlackConversation;
+}
+
 export interface SlackConversationsListResponse extends SlackApiResponse {
   channels: SlackConversation[];
   response_metadata?: { next_cursor?: string };

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -27,6 +27,7 @@ export interface SlackBotsInfoResponse extends SlackApiResponse {
 export interface SlackConversation {
   id: string;
   name?: string;
+  name_normalized?: string;
   is_channel?: boolean;
   is_group?: boolean;
   is_im?: boolean;

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -14,6 +14,36 @@ describe("extractSlackUserMentionIds", () => {
       extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again"),
     ).toEqual(["U123", "W456"]);
   });
+
+  test("includes pipe-form user mention IDs", () => {
+    expect(extractSlackUserMentionIds("<@U123|jane> and <@W456|>")).toEqual([
+      "U123",
+      "W456",
+    ]);
+  });
+});
+
+describe("buildSlackUserLabelMap", () => {
+  test("skips pipe-form mentions with usable embedded labels, queues the rest", async () => {
+    const requested: string[] = [];
+    const labels = await buildSlackUserLabelMap(
+      ["<@U123|jane> <@U456|> <@U789|U789> <@U999>"],
+      async (id) => {
+        requested.push(id);
+        return `name-${id}`;
+      },
+    );
+
+    // Usable embedded label: rendered from the token, no lookup.
+    expect(requested).not.toContain("U123");
+    // Empty or ID-shaped embedded labels still need resolution.
+    expect(requested.sort()).toEqual(["U456", "U789", "U999"]);
+    expect(labels).toEqual({
+      U456: "name-U456",
+      U789: "name-U789",
+      U999: "name-U999",
+    });
+  });
 });
 
 describe("extractSlackChannelReferenceIds", () => {

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -52,6 +52,24 @@ describe("renderSlackTextForModel", () => {
     ).toBe("hello @unknown-user");
   });
 
+  test("prefers embedded pipe-form user labels over lookups", () => {
+    expect(renderSlackTextForModel("hi <@U123|jane>")).toBe("hi @jane");
+    expect(
+      renderSlackTextForModel("hi <@U123|jane>", {
+        userLabels: { U123: "Jane Doe" },
+      }),
+    ).toBe("hi @jane");
+  });
+
+  test("falls back past ID-shaped embedded user labels to resolved ones", () => {
+    expect(
+      renderSlackTextForModel("hi <@U123|U123>", {
+        userLabels: { U123: "Jane Doe" },
+      }),
+    ).toBe("hi @Jane Doe");
+    expect(renderSlackTextForModel("hi <@U123|U123>")).toBe("hi @unknown-user");
+  });
+
   test("renders channel references with labels and fallbacks", () => {
     expect(
       renderSlackTextForModel("<#C123|general> <#C456>", {

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -175,17 +175,29 @@ function renderUserMention(
   content: string,
   options: RenderSlackTextOptions,
 ): string {
-  const id = content.slice(1);
+  const [idWithPrefix, label] = splitSlackLabel(content);
+  const id = idWithPrefix.slice(1);
   if (!isSlackUserId(id)) {
     return `<${content}>`;
   }
 
+  // Slack's legacy pipe form (`<@U123|username>`) carries its own label:
+  // prefer it over a lookup, mirroring renderChannelReference. The embedded
+  // label is Slack-sourced (part of the token), so entities decode before
+  // sanitization; the caller-resolved label below is not.
+  const embeddedLabel = sanitizeOptionalLabel(
+    label === undefined ? undefined : decodeSlackHtmlEntities(label),
+  );
+  if (embeddedLabel && embeddedLabel !== id) {
+    return `@${embeddedLabel}`;
+  }
+
   const fallback = sanitizeLabel(options.userFallbackLabel, "unknown-user");
-  const label = sanitizeLabel(options.userLabels?.[id], fallback);
-  if (label === id) {
+  const resolvedLabel = sanitizeLabel(options.userLabels?.[id], fallback);
+  if (resolvedLabel === id) {
     return `@${fallback}`;
   }
-  return `@${label}`;
+  return `@${resolvedLabel}`;
 }
 
 function renderChannelReference(

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -5,7 +5,7 @@ export interface RenderSlackTextOptions {
   channelFallbackLabel?: string;
 }
 
-const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
+const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g;
 const SLACK_CHANNEL_REFERENCE_RE = /<#([CDG][A-Z0-9]+)(?:\|[^>]*)?>/g;
 
 export function extractSlackUserMentionIds(text: string): string[] {
@@ -107,7 +107,14 @@ export async function buildSlackUserLabelMap(
 
   for (const text of texts) {
     if (!text) continue;
-    for (const id of extractSlackUserMentionIds(text)) {
+    for (const match of text.matchAll(SLACK_USER_MENTION_RE)) {
+      const id = match[1];
+      // A pipe-form mention carrying a usable embedded label renders from
+      // that label directly; only queue a lookup when the label is missing,
+      // empty, or ID-shaped. Mirrors the channel builder below.
+      const [, embeddedLabel] = splitSlackLabel(match[0].slice(1, -1));
+      const sanitizedEmbeddedLabel = sanitizeOptionalLabel(embeddedLabel);
+      if (sanitizedEmbeddedLabel && sanitizedEmbeddedLabel !== id) continue;
       if (seen.has(id)) continue;
       seen.add(id);
       ids.push(id);


### PR DESCRIPTION
## TL;DR

Two rendering defects in the Slack read path, both surfacing as wrong mention text in model-facing content:

1. The messaging adapter passed `userLabels` but never `channelLabels` to the shared renderer, so **every bare `<#C…>` mention in history/search reads rendered `#unknown-channel`, deterministically** — no cache or cold-start involved.
2. `renderUserMention` in `@vellumai/slack-text` ignored Slack's legacy pipe form: `<@U123|name>` passed through as raw markup instead of rendering `@name`.

Fixes [LUM-3025](https://linear.app/vellum/issue/LUM-3025/slack-messaging-adapter-passes-userlabels-but-never-channellabels-bare). Part of the [LUM-3023](https://linear.app/vellum/issue/LUM-3023/preserve-slack-channel-mentions-instead-of-rendering-unknown-channel) `#unknown-channel` family; builds on the transport consolidation from #39895.

## Why this is safe

- Channel names resolve through a new typed `client.conversationInfo` wrapper on the adapter's **existing read auth** (`resolveSlackAuth("user")`, already wired) — no new identity surface.
- The channel-name cache mirrors the adapter's proven user-info cache discipline: keyed per auth scope, definitive failures (`channel_not_found`/permission) pinned so a wall of history can't re-fire doomed lookups, transient failures retried next batch.
- The pipe-form change only *adds* rendering for tokens that previously leaked raw markup; embedded labels take precedence exactly as `renderChannelReference` already does. All 31 slack-text tests and all 129 gateway normalize tests pass — no pinned behavior changed.
- Full `tsc --noEmit` clean in both `assistant/` and `gateway/`.

## What changes for the user

| Scenario | Before | After |
|---|---|---|
| Assistant reads Slack history containing a bare `<#C…>` mention | `#unknown-channel`, always | `#prod-models` (resolved + cached) |
| Mention of a channel the read auth cannot see | `#unknown-channel` | `#unknown-channel` (unchanged fallback, lookup cached once) |
| Legacy pipe-form user mention `<@U123|jane>` in any rendered Slack text (adapter reads *and* gateway replay ingress) | raw `<@U123|jane>` leaks to the model/UI | `@jane` |
| Message in channel A mentioning channel B | — | Stays attributed to A; inline mention renders B (regression-tested) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->