### PR TITLE
fix(memory): fail-closed retrospective finalization and truthful job outcomes

### DIFF
--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -135,6 +135,11 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
     case "no_new_messages":
       log.info("No new messages to review since the last retrospective.");
       break;
+    case "no_user_activity":
+      log.info(
+        "No user activity in the window since the last retrospective; skipping.",
+      );
+      break;
     case "source_dormant":
       log.info(
         "Source conversation is dormant beyond the sweep lookback; skipping.",
@@ -152,6 +157,15 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
       );
       process.exitCode = 1;
       break;
+    case "no_usable_output":
+      log.error(
+        `Run produced no usable output` +
+          `${outcome.reason ? `: ${outcome.reason}` : ""}` +
+          (outcome.conversationId ? ` (fork: ${outcome.conversationId})` : "") +
+          `. The window stays retryable.`,
+      );
+      process.exitCode = 1;
+      break;
     case "invoked":
       log.info(
         `Retrospective invoked.\n` +
@@ -163,5 +177,9 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
             : ""),
       );
       break;
+    default: {
+      const _exhaustive: never = outcome;
+      break;
+    }
   }
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2825,6 +2825,21 @@ export function isConversationProcessing(id: string): boolean {
 }
 
 /**
+ * The persisted `processing_started_at` stamp, or null when idle or missing.
+ * Deliberately reads only the column (no in-memory fallback): consumers use
+ * it to age a flag {@link isConversationProcessing} already reported set, and
+ * the column is the only signal that carries a start time.
+ */
+export function getConversationProcessingStartedAt(id: string): number | null {
+  const row = rawGet<{ processing_started_at: number | null }>(
+    "conversation:getProcessingStartedAt",
+    "SELECT processing_started_at FROM conversations WHERE id = ?",
+    id,
+  );
+  return row?.processing_started_at ?? null;
+}
+
+/**
  * Conversations currently mid-turn, longest-running first. Throws on a read
  * failure — drain callers must distinguish "nothing processing" from "could
  * not read", so this does not degrade to an empty list.

--- a/assistant/src/persistence/conversation-plugin-facade.ts
+++ b/assistant/src/persistence/conversation-plugin-facade.ts
@@ -59,6 +59,20 @@ export async function isConversationProcessing(id: string): Promise<boolean> {
   return fn(id);
 }
 
+/**
+ * The persisted `processing_started_at` stamp for a conversation, or null
+ * when the conversation is idle (or the row does not exist). Lets background
+ * consumers age-gate the processing flag: a stamp far in the past is a
+ * stranded flag (a swallowed turn-end clear), not a live turn.
+ */
+export async function getConversationProcessingStartedAt(
+  id: string,
+): Promise<number | null> {
+  const { getConversationProcessingStartedAt: fn } =
+    await import("./conversation-crud.js");
+  return fn(id);
+}
+
 /** Parse a stored message-metadata JSON string; undefined when absent/invalid. */
 export async function parseMessageMetadata(
   metadataJson: string | null,

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -794,10 +794,19 @@ export function claimMemoryJobs(
 
 export function completeMemoryJob(id: string): void {
   const db = memoryDb();
+  // Guarded on `running` so a late return from an abandoned execution cannot
+  // overwrite a terminal state another writer already recorded (the stalled-job
+  // watchdog's `failed`, or a successor worker's re-claimed row).
   db.update(memoryJobs)
     .set({ status: "completed", updatedAt: Date.now(), lastError: null })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
+  if (rawMemoryChanges() === 0) {
+    log.warn(
+      { jobId: id },
+      "completeMemoryJob: row was not running; late completion suppressed",
+    );
+  }
 }
 
 /** Max times a job can be deferred before it is marked as failed. */
@@ -820,7 +829,17 @@ const DEFER_MAX_DELAY_MS = 5 * 60 * 1000;
  * Returns `'deferred'` if the job was put back, or `'failed'` if max deferrals
  * were exceeded and the job was marked as failed.
  */
-export function deferMemoryJob(id: string): "deferred" | "failed" {
+export function deferMemoryJob(
+  id: string,
+  options?: {
+    /**
+     * Terminal `last_error` recorded when the deferral budget is exhausted.
+     * Defaults to the backend-unavailable wording used by the worker's
+     * infrastructure deferrals.
+     */
+    exhaustedMessage?: string;
+  },
+): "deferred" | "failed" {
   const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
   if (!row) {
@@ -840,9 +859,11 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
         status: "failed",
         deferrals,
         updatedAt: now,
-        lastError: `Backend unavailable after ${deferrals} deferrals`,
+        lastError:
+          options?.exhaustedMessage ??
+          `Backend unavailable after ${deferrals} deferrals`,
       })
-      .where(eq(memoryJobs.id, id))
+      .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
       .run();
     return "failed";
   }
@@ -868,7 +889,7 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
       runAfter: now + delay,
       updatedAt: now,
     })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
   return "deferred";
 }
@@ -886,7 +907,7 @@ export function rescheduleMemoryJob(id: string, delayMs: number): void {
   memoryDb()
     .update(memoryJobs)
     .set({ status: "pending", runAfter: now + delayMs, updatedAt: now })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
 }
 
@@ -904,6 +925,9 @@ export function failMemoryJob(
   }
   const attempts = row.attempts + 1;
   const now = Date.now();
+  // Both transitions are guarded on `running` for the same reason as
+  // `completeMemoryJob`: a late writer must not overwrite a terminal state
+  // recorded by the stalled-job watchdog or a successor worker.
   if (attempts >= maxAttempts) {
     db.update(memoryJobs)
       .set({
@@ -912,7 +936,7 @@ export function failMemoryJob(
         updatedAt: now,
         lastError: truncate(error, 2000, ""),
       })
-      .where(eq(memoryJobs.id, id))
+      .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
       .run();
     return;
   }
@@ -924,7 +948,7 @@ export function failMemoryJob(
       updatedAt: now,
       lastError: truncate(error, 2000, ""),
     })
-    .where(eq(memoryJobs.id, id))
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "running")))
     .run();
 }
 

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -317,6 +317,7 @@ export {
   deleteConversation,
   getConversation,
   getConversationDirPath,
+  getConversationProcessingStartedAt,
   getMessages,
   hasLexicalTokens,
   isConversationProcessing,

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-outcome-contract.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-outcome-contract.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Outcome-truthfulness contract between job handlers and the jobs worker.
+ *
+ * Handlers that report failure through a RETURNED domain outcome (the
+ * retrospective's `wake_failed` / `no_usable_output` / `source_processing`,
+ * the consolidation's `run_failed`) must not leave their job rows reading
+ * `completed` with a null `last_error`. The registration-site adapters in
+ * `job-handlers.ts` translate domain outcomes into `JobQueueResolution`s and
+ * the worker applies them, so the persisted `memory_jobs.status` reflects the
+ * handler's actual outcome.
+ *
+ * Also covers the store-level late-transition guards: once the stalled-job
+ * watchdog fails a row, a late `completeMemoryJob` from the abandoned
+ * execution must not flip it back to `completed`.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import type { MemoryRetrospectiveOutcome } from "../memory-retrospective-job.js";
+import type { ConsolidationOutcome } from "../substrate/consolidation-job.js";
+
+// Scripted handler outcomes, set per-test.
+let retrospectiveOutcome: MemoryRetrospectiveOutcome = {
+  kind: "no_new_messages",
+};
+let consolidationOutcome: ConsolidationOutcome = { kind: "empty_buffer" };
+
+mock.module("../memory-retrospective-job.js", () => ({
+  memoryRetrospectiveJob: async () => retrospectiveOutcome,
+  STALE_SOURCE_PROCESSING_OVERRIDE_MS: 6 * 60 * 60 * 1000,
+}));
+
+mock.module("../substrate/consolidation-job.js", () => ({
+  memoryV2ConsolidateJob: async () => consolidationOutcome,
+  // Scheduler helpers the worker reads on every pass.
+  countBufferLines: () => 0,
+  readConsolidationFailureState: () => null,
+}));
+
+mock.module("../graph/graph-search.js", () => ({
+  embedGraphNodeDirect: async () => {},
+  embedGraphNodeJob: async (): Promise<void> => {},
+  enqueueGraphNodeEmbed: () => {},
+  embedGraphTriggerJob: async (): Promise<void> => {},
+  enqueueGraphTriggerEmbed: () => {},
+}));
+
+mock.module("../v1/graph/graph-search.js", () => ({
+  searchGraphNodes: async () => [],
+}));
+
+mock.module("../../../../persistence/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: async () => {},
+  maybeRunPassiveWalCheckpoint: async () => {},
+}));
+
+const tmpWorkspace = mkdtempSync(
+  join(tmpdir(), "jobs-worker-outcome-contract-"),
+);
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+import { getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { _resetQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
+import {
+  completeMemoryJob,
+  enqueueMemoryJob,
+  failStalledJobs,
+} from "../../../../persistence/jobs-store.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import { registerMemoryPluginJobHandlers } from "../job-handler-registration.js";
+import { runMemoryJobsOnce } from "../jobs-worker.js";
+
+function jobRow(jobId: string) {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, jobId))
+    .get();
+}
+
+describe("job outcome truthfulness", () => {
+  beforeAll(async () => {
+    registerMemoryPluginJobHandlers();
+    await initializeDb();
+  });
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+    _resetQdrantBreaker();
+    retrospectiveOutcome = { kind: "no_new_messages" };
+    consolidationOutcome = { kind: "empty_buffer" };
+  });
+
+  test("retrospective wake_failed dead-letters the row with an honest last_error", async () => {
+    retrospectiveOutcome = { kind: "wake_failed", reason: "run_error" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("retrospective wake failed");
+    expect(row?.lastError).toContain("run_error");
+  });
+
+  test("retrospective no_usable_output dead-letters the row with the failure detail", async () => {
+    retrospectiveOutcome = {
+      kind: "no_usable_output",
+      reason: "run persisted no memory-writing tool call",
+    };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("no usable output");
+  });
+
+  test("retrospective source_processing defers the SAME row on the deferral counter", async () => {
+    retrospectiveOutcome = { kind: "source_processing" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    const before = Date.now();
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("pending");
+    expect(row?.deferrals).toBe(1);
+    expect(row?.attempts).toBe(0);
+    expect(row!.runAfter).toBeGreaterThan(before);
+    // Exactly one row for the conversation: no fresh row minted per attempt.
+    const rows = getMemoryDb()!
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "memory_retrospective"))
+      .all();
+    expect(rows).toHaveLength(1);
+  });
+
+  test("source_processing deferral budget exhausts into an honest terminal failure", async () => {
+    retrospectiveOutcome = { kind: "source_processing" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+    // Spend 49 of the 50 deferrals up front; the next pass is the last one.
+    getMemoryDb()!
+      .update(memoryJobs)
+      .set({ deferrals: 49 })
+      .where(eq(memoryJobs.id, jobId))
+      .run();
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("mid-turn");
+  });
+
+  test("retrospective success and benign no-ops still complete", async () => {
+    retrospectiveOutcome = { kind: "no_new_messages" };
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    expect(jobRow(jobId)?.status).toBe("completed");
+  });
+
+  test("consolidation run_failed dead-letters the row with the failure reason", async () => {
+    consolidationOutcome = { kind: "run_failed", reason: "timeout" };
+    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("consolidation run failed");
+    expect(row?.lastError).toContain("timeout");
+  });
+
+  test("consolidation skips (locked/empty) still complete", async () => {
+    consolidationOutcome = { kind: "locked", holder: "1234 0 consolidation" };
+    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+
+    await runMemoryJobsOnce();
+
+    expect(jobRow(jobId)?.status).toBe("completed");
+  });
+
+  test("late completion cannot overwrite a watchdog-failed row", async () => {
+    const jobId = enqueueMemoryJob("memory_retrospective", {
+      conversationId: "conv-1",
+    });
+    // Simulate a claimed row whose execution went silent long enough for the
+    // stalled-job watchdog to fail it.
+    getMemoryDb()!
+      .update(memoryJobs)
+      .set({ status: "running", startedAt: Date.now() - 60 * 60 * 1000 })
+      .where(eq(memoryJobs.id, jobId))
+      .run();
+    expect(failStalledJobs(30 * 60 * 1000)).toBe(1);
+    expect(jobRow(jobId)?.status).toBe("failed");
+
+    // The abandoned execution finally returns and reports success.
+    completeMemoryJob(jobId);
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("failed");
+    expect(row?.lastError).toContain("timed out");
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -32,6 +32,13 @@ let newMessages: Array<{
   metadata?: string | null;
 }> = [];
 
+// Recorded `getMessagesAfter` calls, so overrideCursor tests can assert which
+// cursor value actually reached the slice read.
+let messagesAfterCalls: Array<{
+  conversationId: string;
+  afterId: string | null;
+}> = [];
+
 // Prior retrospective conversation + messages. `priorRetroOwnerId` is the
 // fork-chain conversation the prior is rooted at — `findMostRecentRetrospectiveFor`
 // returns it so the GC ownership check can tell "this source's own prior"
@@ -97,6 +104,10 @@ let messagesByConversationId: Record<string, StubMessage[]> = {};
 // the real registry's semantics for conversations not in memory.
 let loadedConversations: Record<string, { processing: boolean }> = {};
 
+// Persisted `processing_started_at` stamps, keyed by conversation id, backing
+// the stale-flag override's age check. Absent ids read as null (stampless).
+let processingStartedAtById: Record<string, number | null> = {};
+
 const watchdogEvents: Array<{
   checkName: string;
   value?: number | null;
@@ -155,7 +166,10 @@ mock.module("../find-most-recent-retrospective-for.js", () => ({
 }));
 
 mock.module("../../../../persistence/conversation-crud.js", () => ({
-  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
+  getMessagesAfter: (id: string, afterId: string | null) => {
+    messagesAfterCalls.push({ conversationId: id, afterId });
+    return newMessages;
+  },
   getMessages: (id: string) => {
     if (messagesByConversationId[id]) {
       return messagesByConversationId[id];
@@ -195,6 +209,8 @@ mock.module("../../../../persistence/conversation-crud.js", () => ({
     const entry = loadedConversations[id];
     return entry?.processing ?? false;
   },
+  getConversationProcessingStartedAt: (id: string) =>
+    processingStartedAtById[id] ?? null,
   forkConversationForRetrospective: async (params: {
     conversationId: string;
     throughMessageId?: string;
@@ -328,7 +344,7 @@ import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 import {
   memoryRetrospectiveJob,
   runForkBasedRetrospective,
-  SOURCE_PROCESSING_REQUEUE_DELAY_MS,
+  STALE_SOURCE_PROCESSING_OVERRIDE_MS,
 } from "../memory-retrospective-job.js";
 
 function makeConfig(
@@ -397,6 +413,41 @@ function persistedInstructionText(): string {
   return blocks[0]!.text;
 }
 
+/**
+ * Default persisted run output for the wake's fork conversation: a single
+ * assistant `remember` tool_use with an empty batch payload plus its
+ * successful tool_result. Satisfies the fail-closed advancement gate (a
+ * durable memory-writing call exists AND its execution succeeded) while
+ * appending nothing to the remembered log, so pre-gate assertions about log
+ * contents hold unchanged. Tests that assert the gate itself override
+ * `messagesByConversationId` for the fork id.
+ */
+function defaultForkRunOutput() {
+  return [
+    {
+      role: "assistant",
+      content: JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tu-run-1",
+          name: "remember",
+          input: { content: [] },
+        },
+      ]),
+      createdAt: Date.parse("2026-05-11T10:20:00Z"),
+      metadata: null,
+    },
+    {
+      role: "user",
+      content: JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu-run-1", content: "Saved." },
+      ]),
+      createdAt: Date.parse("2026-05-11T10:20:01Z"),
+      metadata: null,
+    },
+  ];
+}
+
 function priorRetroMessage(rememberContents: string[]) {
   return {
     role: "assistant",
@@ -421,6 +472,7 @@ describe("memoryRetrospectiveJob", () => {
       { id: "m2", createdAt: Date.parse("2026-05-11T10:05:00Z") },
       { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
     ];
+    messagesAfterCalls = [];
     priorRetroId = null;
     priorRetroOwnerId = "src-conv-1";
     priorRetroMessages = [];
@@ -434,8 +486,9 @@ describe("memoryRetrospectiveJob", () => {
     addMessageCalls = [];
     retrospectiveJobUpserts = [];
     conversationOverrides = {};
-    messagesByConversationId = {};
+    messagesByConversationId = { "fork-conv-1": defaultForkRunOutput() };
     loadedConversations = {};
+    processingStartedAtById = {};
     mockResolvedUserSlug = "alice";
     resolveUserSlugCalls = [];
     mockV3TierActive = false;
@@ -740,6 +793,375 @@ describe("memoryRetrospectiveJob", () => {
     expect(deletedConversationIds).toEqual(["fork-conv-1"]);
   });
 
+  // -------------------------------------------------------------------------
+  // Fail-closed usable-output gate: `invoked: true` alone must not advance
+  // the cursor. The agent loop swallows provider rejections into a normal
+  // no-output return, so a wake can report success for a run that persisted
+  // nothing; advancement requires a durable memory-writing tool call on the
+  // run's own persisted tail.
+  // -------------------------------------------------------------------------
+
+  test("invoked wake with NO persisted run output: no_usable_output, cursor and log untouched, window retryable", async () => {
+    mockWakeResult = { invoked: true };
+    // The fork persisted nothing (e.g. a swallowed provider rejection or a
+    // zero-output max-tokens stop).
+    messagesByConversationId["fork-conv-1"] = [];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    // Cursor NOT advanced, remembered log NOT appended.
+    expect(stateUpserts).toHaveLength(0);
+    // Retryable: cooldown bump only, orphan fork cleaned up.
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: {
+          outcome: "no_usable_output",
+          reason: "run persisted no memory-writing tool call",
+        },
+      },
+    ]);
+  });
+
+  test("invoked wake whose run persisted only analysis text (no tool calls): no_usable_output, prior retrospective preserved", async () => {
+    mockWakeResult = { invoked: true };
+    priorRetroId = "prior-retro-1";
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new worth remembering here." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+    // Only this run's own fork is deleted; the prior retrospective (the
+    // dedup baseline for the retry) is preserved.
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+  });
+
+  test("run-message load failure classifies as no_usable_output (fail-closed), not success", async () => {
+    mockWakeResult = { invoked: true };
+    // Fork-kind conversation with no stamps and no leading instruction row:
+    // `loadRetrospectiveRunMessages` returns null (indeterminate).
+    conversationOverrides["fork-conv-1"] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: null,
+    };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "copied row" }]),
+        createdAt: 1,
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("checkpoint-persisted saves on a fork-kind tail count as usable output (rebase-after-live cannot fake no-output)", async () => {
+    mockWakeResult = { invoked: true };
+    conversationOverrides["fork-conv-1"] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: null,
+    };
+    // Copied prefix rows carry forkSourceMessageId stamps; the run's own
+    // persisted tail (from checkpoint persistence, regardless of what the
+    // in-memory history looked like after any rebase) sits after the
+    // boundary and carries the durable remember call.
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "copied source row" }]),
+        createdAt: 100,
+        metadata: JSON.stringify({ forkSourceMessageId: "m2" }),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-ckpt-1",
+            name: "remember",
+            input: { content: ["fact persisted via checkpoint"] },
+          },
+        ]),
+        createdAt: 200,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-ckpt-1", content: "Saved." },
+        ]),
+        createdAt: 201,
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.rememberedLog).toEqual([
+      "fact persisted via checkpoint",
+    ]);
+  });
+
+  test("scaffold_managed_skill counts as durable work even with zero remembers", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-skill-1",
+            name: "scaffold_managed_skill",
+            input: { name: "deploy-checklist" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-skill-1",
+            content: "Skill scaffolded.",
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
+  });
+
+  test("a remember whose execution FAILED (is_error tool_result) is not durable evidence and its facts stay out of the log", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-fail-1",
+            name: "remember",
+            input: { content: "fact that never landed" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-fail-1",
+            content: "memory buffer write failed",
+            is_error: true,
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // The tool_use alone proves the model asked; the durable write happens
+    // in the executor, and it failed. Window stays retryable, and the failed
+    // fact must not enter <already_remembered> where it would suppress the
+    // retry's re-save.
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(1);
+  });
+
+  test("explicit no-findings reply advances the cursor without fabricating a memory write", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new to save." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // A reviewed-and-no-findings pass is a legitimate success: the mandated
+    // exact reply is the positive persisted artifact, the cursor advances,
+    // and the remembered log gains nothing.
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
+  });
+
+  test("analysis prose that merely mentions the no-findings phrase does not advance", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "I reviewed the window. Nothing new to save. Here is my reasoning about why each item was already covered by prior passes.",
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("no-findings reply cannot advance a run that attempted a save and failed", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-mixed-1",
+            name: "remember",
+            input: { content: "fact that failed to land" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "tu-mixed-1",
+            content: "write failed",
+            is_error: true,
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:01Z"),
+        metadata: null,
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Nothing new to save." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:02Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // The run demonstrably had findings (it attempted a save); the failed
+    // write must stay retryable rather than being papered over by a
+    // no-findings claim.
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("a remember tool_use with NO persisted tool_result is not durable evidence", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-noresult-1",
+            name: "remember",
+            input: { content: "fact with unproven execution" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("retry after a no_usable_output run advances only once durable output exists", async () => {
+    mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [];
+
+    const first = await memoryRetrospectiveJob(makeJob(), stubConfig);
+    expect(first.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+
+    // Retry: same window, this time the run persists a real save and its
+    // successful execution.
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-retry-1",
+            name: "remember",
+            input: { content: "fact captured on retry" },
+          },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:25:00Z"),
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-retry-1", content: "Saved." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:25:01Z"),
+        metadata: null,
+      },
+    ];
+    const second = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(second.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toEqual(["fact captured on retry"]);
+  });
+
   test("wake throws: lastRunAt bumped before rethrow, orphan fork deleted, error rethrown", async () => {
     mockWakeThrows = new Error("LLM provider 503");
     await expect(memoryRetrospectiveJob(makeJob(), stubConfig)).rejects.toThrow(
@@ -1012,12 +1434,10 @@ describe("memoryRetrospectiveJob", () => {
   // Mid-turn requeue gate
   // -------------------------------------------------------------------------
 
-  test("source mid-turn → skipped outcome, state fully untouched, job re-upserted with the fallback delay, no fork", async () => {
+  test("source mid-turn → source_processing outcome, state fully untouched, no self-upserted row, no fork", async () => {
     loadedConversations["src-conv-1"] = { processing: true };
 
-    const before = Date.now();
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
-    const after = Date.now();
 
     expect(outcome.kind).toBe("source_processing");
     // BOTH pointers untouched. `lastRunAt` must stay unbumped so the
@@ -1027,23 +1447,51 @@ describe("memoryRetrospectiveJob", () => {
     // forever.
     expect(stateUpserts).toHaveLength(0);
     expect(lastRunAtBumps).toHaveLength(0);
-    // Timed fallback row for a turn that aborts without indexing another
-    // message: coalescing re-upsert at the named delay.
-    expect(retrospectiveJobUpserts).toHaveLength(1);
-    expect(retrospectiveJobUpserts[0]!.payload).toEqual({
-      conversationId: "src-conv-1",
-    });
-    expect(retrospectiveJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
-      before + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-    );
-    expect(retrospectiveJobUpserts[0]!.runAfter).toBeLessThanOrEqual(
-      after + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-    );
+    // The handler no longer mints a fresh fallback row per attempt: the
+    // worker defers the SAME job row on the bounded deferral counter (see
+    // `resolveRetrospectiveOutcome`), so a stranded processing flag cannot
+    // produce an unbounded stream of job rows.
+    expect(retrospectiveJobUpserts).toHaveLength(0);
     // No fork, no instruction, no wake, no cleanup side effects.
     expect(forkCalls).toHaveLength(0);
     expect(addMessageCalls).toHaveLength(0);
     expect(wakeCalls).toHaveLength(0);
     expect(deletedConversationIds).toEqual([]);
+  });
+
+  test("source mid-turn with a fresh processing stamp → still deferred", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    processingStartedAtById["src-conv-1"] = Date.now() - 60_000;
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_processing");
+    expect(forkCalls).toHaveLength(0);
+  });
+
+  test("source mid-turn with a stamp older than the stale override → proceeds and runs normally", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    processingStartedAtById["src-conv-1"] =
+      Date.now() - STALE_SOURCE_PROCESSING_OVERRIDE_MS - 60_000;
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // A stranded flag (swallowed turn-end clear while the daemon stayed up)
+    // must not block memory formation indefinitely: past the override window
+    // the run proceeds as if idle.
+    expect(outcome.kind).toBe("invoked");
+    expect(forkCalls).toHaveLength(1);
+    expect(stateUpserts).toHaveLength(1);
+  });
+
+  test("source mid-turn with a set flag but no persisted stamp → deferred (reads as live)", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+    // No processingStartedAtById entry: the stamp write may have failed, so
+    // age cannot be established. The bounded deferral budget still caps it.
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_processing");
+    expect(forkCalls).toHaveLength(0);
   });
 
   test("source loaded but idle → normal run, no requeue upsert", async () => {
@@ -1750,11 +2198,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-tail-1",
             name: "remember",
             input: { content: "post-fork tail save — included" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-tail-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];
@@ -1814,11 +2271,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-seed-1",
             name: "remember",
             input: { content: "this run's save" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-seed-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];
@@ -1859,11 +2325,20 @@ describe("memoryRetrospectiveJob", () => {
         content: JSON.stringify([
           {
             type: "tool_use",
+            id: "tu-carry-1",
             name: "remember",
             input: { content: "fork tail save" },
           },
         ]),
         createdAt: 2000,
+        metadata: null,
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-carry-1", content: "Saved." },
+        ]),
+        createdAt: 2001,
         metadata: null,
       },
     ];

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -176,7 +176,32 @@ describe("promptOverridePath", () => {
     writeFileSync(overridePath, "Just remember the good parts.\n");
     expect(
       buildForkInstruction(makeArgs({ promptOverridePath: overridePath })),
-    ).toBe("Just remember the good parts.\n");
+    ).toBe(
+      "Just remember the good parts.\n\n\n" +
+        `If nothing new is worth saving, reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`,
+    );
+  });
+
+  test("an override that drops the no-findings mandate still carries the finalizer's exact-reply contract", () => {
+    // The finalizer advances a no-findings window only on a persisted reply
+    // that trims to exactly MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT. An
+    // override author who never read that code would otherwise stall every
+    // no-findings window forever, so the mandate must survive any override.
+    const overridePath = join(dir, "mandate-free.md");
+    writeFileSync(
+      overridePath,
+      "Review the window and save what matters. If nothing matters, do nothing.\n",
+    );
+    const out = buildForkInstruction(
+      makeArgs({ promptOverridePath: overridePath }),
+    );
+    expect(out).toContain(
+      `reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}"`,
+    );
+    // The mandate references the same constant the finalizer compares
+    // against, so the two cannot drift; guard the constant's exact value here
+    // to make an accidental rewording loud.
+    expect(MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT).toBe("Nothing new to save.");
   });
 
   test("missing override file falls back to the bundled rendering", () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
+import { MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT } from "../memory-retrospective-constants.js";
 import {
   buildForkInstruction,
   type ForkInstructionArgs,
@@ -47,7 +48,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
 `);
   });
 
@@ -120,7 +121,7 @@ For everything else in your review window, use the \`remember\` tool on facts, p
     expect(out).not.toContain("PROCEDURE");
     expect(
       out.endsWith(
-        'If nothing new is worth saving, say "Nothing new to save." and stop.\n',
+        'If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.\n',
       ),
     ).toBe(true);
   });
@@ -199,4 +200,14 @@ describe("promptOverridePath", () => {
     expect(out).toBe(buildForkInstruction(makeArgs()));
     expect(out).not.toContain("SENSITIVE FILE CONTENTS");
   });
+});
+
+// The finalizer's explicit-no-findings gate matches persisted assistant text
+// against MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT by strict equality, and the
+// bundled instruction is what teaches the model to emit it. This guard fails
+// if either side drifts.
+test("bundled template mandates the exact no-findings sentinel the finalizer matches", () => {
+  expect(RETROSPECTIVE_INSTRUCTION_TEMPLATE).toContain(
+    `reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`,
+  );
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -1,0 +1,492 @@
+/**
+ * LUM-3013 regression: the retrospective's fail-closed advancement gate must
+ * hold through the REAL producer chain, not just against a mocked wake.
+ *
+ * These tests run the real `memoryRetrospectiveJob` handler → the real
+ * `wakeAgentForOpportunity` (runtime/agent-wake.ts, NOT mocked) → a
+ * conversation double whose `agentLoop` is a real `AgentLoop` driven by a
+ * scripted fake `Provider`. Only the provider and the daemon/persistence
+ * boundaries are test doubles, so the chain exercises the actual mechanism
+ * behind the bug:
+ *
+ *   - `AgentLoop.run` SWALLOWS provider rejections: the outer catch
+ *     (agent/loop.ts, `onEvent({ type: "error" })` + `stopTurn("error")`)
+ *     returns normally with the history unchanged.
+ *   - The wake then finds no tail output and takes its silent no-op branch
+ *     (agent-wake.ts), returning `{ invoked: true, producedToolCalls: false }`.
+ *   - `invoked: true` alone must therefore NOT advance
+ *     `memory_retrospective_state`: the handler re-reads the fork's persisted
+ *     rows (`collectRetrospectiveRunEvidence` → `loadRetrospectiveRunMessages`
+ *     → `getMessages`) and only advances when a durable memory-writing
+ *     `tool_use` (`remember` / `scaffold_managed_skill`) was persisted by THIS
+ *     run.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state. Reset between tests.
+// ---------------------------------------------------------------------------
+
+const SOURCE_ID = "src-conv-1";
+const FORK_ID = "fork-conv-1";
+
+let stateUpserts: Array<{
+  conversationId: string;
+  lastProcessedMessageId: string;
+  lastRunAt: number;
+  rememberedLog?: string[];
+}> = [];
+let lastRunAtBumps: Array<{ conversationId: string; lastRunAt: number }> = [];
+
+let newMessages: Array<{
+  id: string;
+  createdAt: number;
+  role?: string;
+  content?: string | Array<Record<string, unknown>>;
+  metadata?: string | null;
+}> = [];
+
+/**
+ * Persisted message rows, keyed by conversation id. `addMessage` appends here
+ * and `getMessages` reads it back. The same store serves the handler's
+ * instruction staging, the wake's tail persistence, and the finalizer's
+ * durable-evidence read, so the evidence gate sees exactly what the real
+ * producer chain persisted.
+ */
+type PersistedRow = {
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+};
+let messageStores: Record<string, PersistedRow[]> = {};
+let persistedMessageCounter = 0;
+
+let deletedConversationIds: string[] = [];
+let forkCalls: Array<{ conversationId: string; throughMessageId?: string }> =
+  [];
+
+// ---------------------------------------------------------------------------
+// Retrospective-side mocks (mirroring memory-retrospective-job.test.ts, but
+// WITHOUT mocking ../../../../runtime/agent-wake.js: the wake runs real).
+// ---------------------------------------------------------------------------
+
+mock.module("../memory-retrospective-state.js", () => ({
+  getRetrospectiveState: (_id: string) => null,
+  upsertRetrospectiveState: (args: {
+    conversationId: string;
+    lastProcessedMessageId: string;
+    lastRunAt: number;
+    rememberedLog?: string[];
+  }) => {
+    stateUpserts.push(args);
+  },
+  bumpRetrospectiveLastRunAt: (conversationId: string, lastRunAt: number) => {
+    lastRunAtBumps.push({ conversationId, lastRunAt });
+  },
+  appendToRememberedLog: (existing: string[], newEntries: string[]) => [
+    ...existing,
+    ...newEntries,
+  ],
+}));
+
+mock.module("../find-most-recent-retrospective-for.js", () => ({
+  findMostRecentRetrospectiveFor: (_id: string) => null,
+}));
+
+mock.module("../../../../persistence/conversation-crud.js", () => ({
+  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
+  getMessages: (id: string) => messageStores[id] ?? [],
+  // `defaultResolveTarget` in the REAL wake reads the FORK id's row for the
+  // archived check, so both rows carry archivedAt/createdAt. The fork's
+  // "user" source makes `loadRetrospectiveRunMessages` treat every persisted
+  // row as the run's own (legacy-kind), the simplest faithful setup here.
+  getConversation: (id: string) => {
+    if (id === FORK_ID) {
+      return {
+        source: "user",
+        forkParentMessageId: null,
+        title: "Fork",
+        archivedAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    }
+    return {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      archivedAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+  },
+  isConversationProcessing: (_id: string) => false,
+  getConversationProcessingStartedAt: (_id: string) => null,
+  forkConversationForRetrospective: async (params: {
+    conversationId: string;
+    throughMessageId?: string;
+  }) => {
+    forkCalls.push(params);
+    return { id: FORK_ID };
+  },
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    _options: unknown,
+  ) => {
+    const store = (messageStores[conversationId] ??= []);
+    store.push({ role, content, createdAt: Date.now(), metadata: null });
+    persistedMessageCounter += 1;
+    return { id: `msg-${persistedMessageCounter}` };
+  },
+  deleteConversation: (id: string) => {
+    deletedConversationIds.push(id);
+  },
+  deleteConversationGently: async (id: string) => {
+    deletedConversationIds.push(id);
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+  resolveOverrideProfile: () => undefined,
+  getConversationOverrideProfile: () => undefined,
+  provenanceFromTrustContext: () => ({}),
+  reserveMessage: async () => ({ id: "msg-reserve" }),
+}));
+
+mock.module("../../../../daemon/trust-context.js", () => ({
+  INTERNAL_GUARDIAN_TRUST_CONTEXT: {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+  },
+}));
+
+mock.module("../../../../prompts/persona-resolver.js", () => ({
+  resolveUserSlug: (_trustContext: unknown) => "alice",
+}));
+
+mock.module("../../../../persistence/jobs-store.js", () => ({
+  enqueueMemoryJob: () => "follow-up-job-id",
+  upsertMemoryRetrospectiveJob: () => {},
+}));
+
+mock.module("../../../../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: () => {},
+}));
+
+mock.module("../../../../config/memory-v3-gate.js", () => ({
+  isMemoryEnabled: (config?: { memory?: { enabled?: boolean } }) =>
+    config?.memory?.enabled !== false,
+  isV3TierActive: () => false,
+  isMemoryV3Live: () => false,
+  usesConceptPageMemory: () => false,
+}));
+
+mock.module("../../../../daemon/conversation-registry.js", () => ({
+  findConversation: (_id: string | undefined) => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Wake-side boundary mocks (mirroring runtime/__tests__/agent-wake.test.ts,
+// with relative paths adjusted for this directory).
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+mock.module("../../../../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: () => {},
+}));
+
+mock.module("../../../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
+}));
+
+mock.module("../../../../daemon/conversation-store.js", () => ({
+  // The real wake's `defaultResolveTarget` lands here after the archived
+  // check; it must yield the live fork conversation the run executes on.
+  getOrCreateConversation: async (
+    _conversationId: string,
+    _options?: unknown,
+  ) => makeForkConversationDouble(),
+}));
+
+mock.module("../../../../config/llm-context-resolution.js", () => ({
+  resolveEffectiveContextWindow: () => ({ maxInputTokens: 200_000 }),
+}));
+
+mock.module("../../../../daemon/disk-pressure-guard.js", () => ({
+  getDiskPressureStatus: () => ({
+    enabled: false,
+    state: "disabled",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: null,
+    thresholdPercent: 95,
+    path: null,
+    lastCheckedAt: null,
+    blockedCapabilities: [],
+    error: null,
+  }),
+}));
+
+mock.module("../../../../daemon/conversation-usage.js", () => ({
+  recordUsage: () => {},
+}));
+
+mock.module("../../../../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => "log-id",
+  backfillMessageIdOnLogs: () => {},
+  setAgentLoopExitReasonOnLatestLog: () => {},
+  buildProviderErrorResponsePayload: (error: unknown) => ({
+    error: String(error),
+  }),
+}));
+
+import { AgentLoop } from "../../../../agent/loop.js";
+import type { Conversation } from "../../../../daemon/conversation.js";
+import type { MemoryJob } from "../../../../persistence/jobs-store.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../../../../providers/types.js";
+import { ProviderError } from "../../../../util/errors.js";
+import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
+
+// ---------------------------------------------------------------------------
+// Fake provider: the ONLY seam scripted per scenario. Everything between the
+// job handler and this `sendMessage` is real production code.
+// ---------------------------------------------------------------------------
+
+let providerCalls: Array<{ messages: Message[] }> = [];
+let providerImpl: (
+  messages: Message[],
+  options?: SendMessageOptions,
+) => Promise<ProviderResponse> = async () => textOnlyResponse("unused");
+
+const fakeProvider: Provider = {
+  name: "fake-provider",
+  async sendMessage(
+    messages: Message[],
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    providerCalls.push({ messages: [...messages] });
+    return providerImpl(messages, options);
+  },
+};
+
+function textOnlyResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+}
+
+function rememberToolUseResponse(): ProviderResponse {
+  return {
+    content: [
+      { type: "text", text: "Saving one fact." },
+      {
+        type: "tool_use",
+        id: "tu-1",
+        name: "remember",
+        input: { content: "provider-path fact" },
+      },
+    ],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "tool_use",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Conversation double: minimal structural stand-in for the fork the wake
+// resolves. Its `agentLoop` is a REAL AgentLoop over the fake provider; its
+// message history hydrates from the persisted store (so the instruction row
+// the handler staged is the run's baseline, exactly like a DB rehydration).
+// ---------------------------------------------------------------------------
+
+function makeForkConversationDouble(): Conversation {
+  const messages: Message[] = (messageStores[FORK_ID] ?? []).map((row) => ({
+    role: row.role as Message["role"],
+    content: JSON.parse(row.content) as Message["content"],
+  }));
+  const realLoop = new AgentLoop({
+    provider: fakeProvider,
+    systemPrompt: "test",
+    conversationId: FORK_ID,
+    // Real executor round-trip: the finalizer's durable-evidence gate
+    // requires a matching successful tool_result, so the loop must execute
+    // the remember call and persist its result exactly as production does.
+    toolExecutor: async (name: string) => {
+      if (name === "remember") {
+        return { content: "Saved.", isError: false };
+      }
+      return { content: `unknown tool ${name}`, isError: true };
+    },
+  });
+  const conversation = {
+    conversationId: FORK_ID,
+    messages,
+    getMessages: () => messages,
+    isProcessing: () => false,
+    setProcessing: (_on: boolean) => {},
+    waitForIdle: async (_opts: { timeoutMs: number }) => true,
+    drainQueue: async () => {},
+    maybeCompact: async () => null,
+    subagentAllowedTools: undefined,
+    setSubagentAllowedTools: (_tools: Set<string> | undefined) => {},
+    preactivatedSkillIds: undefined,
+    setPreactivatedSkillIds: (_ids: readonly string[] | undefined) => {},
+    trustContext: undefined,
+    setTrustContext: (_ctx: unknown) => {},
+    currentTurnTrustContext: undefined,
+    wakePersonaOverride: undefined,
+    contextWindowManager: { estimateInputTokens: () => 0 },
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+    buildCurrentSystemPrompt: () => "test-system-prompt",
+    provider: { name: "fake-provider" },
+    usageStats: {},
+    modelOverride: undefined,
+    agentLoop: {
+      run: (options: Parameters<AgentLoop["run"]>[0]) => realLoop.run(options),
+    },
+  };
+  return conversation as unknown as Conversation;
+}
+
+// ---------------------------------------------------------------------------
+// Job/config helpers (shape copied from memory-retrospective-job.test.ts).
+// ---------------------------------------------------------------------------
+
+function makeConfig(): Parameters<typeof memoryRetrospectiveJob>[1] {
+  return {
+    memory: {
+      v2: { enabled: true },
+      retrospective: {
+        keepSupersededRuns: false,
+        matchConversationProfile: false,
+        promptPath: null,
+        requireUserActivity: false,
+        sweepIntervalMs: 8 * 60 * 60 * 1000,
+        sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
+      },
+    },
+    ui: {
+      userTimezone: undefined,
+      detectedTimezone: undefined,
+    },
+  } as unknown as Parameters<typeof memoryRetrospectiveJob>[1];
+}
+
+const stubConfig = makeConfig();
+
+function makeJob(conversationId = SOURCE_ID): MemoryJob<{
+  conversationId?: string;
+}> {
+  return {
+    id: "job-1",
+    type: "memory_retrospective",
+    payload: { conversationId },
+    status: "pending",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("memoryRetrospectiveJob through the real wake + real agent loop", () => {
+  beforeEach(() => {
+    stateUpserts = [];
+    lastRunAtBumps = [];
+    deletedConversationIds = [];
+    forkCalls = [];
+    messageStores = {};
+    persistedMessageCounter = 0;
+    providerCalls = [];
+    providerImpl = async () => textOnlyResponse("unused");
+    newMessages = [
+      { id: "m1", createdAt: Date.parse("2026-05-11T10:00:00Z") },
+      { id: "m2", createdAt: Date.parse("2026-05-11T10:05:00Z") },
+      { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
+    ];
+  });
+
+  test("real provider rejection is classified at the wake layer and leaves the window retryable", async () => {
+    // The wake's exit-reason classifier fails a swallowed rejection before
+    // finalization (invoked: false, reason run_error), so the handler
+    // reports wake_failed. Full rejection-chain coverage (state
+    // preservation, prior-fork survival, retry consuming the window) lives
+    // in memory-retrospective-wake-chain.test.ts; this case pins only the
+    // layered outcome and that the finalizer was never reached.
+    providerImpl = async () => {
+      throw new ProviderError(
+        "This model (test-model) doesn't support image input. Remove the image or switch to a vision-capable model.",
+        "openai",
+        400,
+      );
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("wake_failed");
+    if (outcome.kind === "wake_failed") {
+      expect(outcome.reason).toBe("run_error");
+    }
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(deletedConversationIds).toEqual([FORK_ID]);
+  });
+
+  test("durable remember persisted through the real loop advances the cursor", async () => {
+    // Scenario B: first call emits a `remember` tool_use; the loop (built
+    // without a tool executor) stops after persisting the tool-bearing
+    // assistant message, and the wake's tail persistence writes it through
+    // `addMessage`. Subsequent calls (defensive) return plain text.
+    let call = 0;
+    providerImpl = async () => {
+      call += 1;
+      return call === 1 ? rememberToolUseResponse() : textOnlyResponse("Done.");
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(stateUpserts[0]!.rememberedLog).toContain("provider-path fact");
+    // The durable evidence really flowed through persistence: the fork store
+    // holds the instruction row plus the wake-persisted tool_use tail.
+    const persistedRoles = messageStores[FORK_ID]!.map((row) => row.role);
+    expect(persistedRoles[0]).toBe("user");
+    expect(persistedRoles).toContain("assistant");
+    expect(lastRunAtBumps).toHaveLength(0);
+  });
+
+  test("clean empty reply through the real loop does not advance", async () => {
+    // Scenario C: the model answers with analysis text and no tool calls.
+    // The wake persists the text tail (visible output), but with zero
+    // durable memory-writing tool calls the gate must refuse to advance.
+    providerImpl = async () => textOnlyResponse("Nothing worth saving.");
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(providerCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stateUpserts).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -409,9 +409,10 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
 
     // (2) The window stays retryable: the same slice succeeds on retry.
-    providerScript = [
-      { response: textResponse("Reviewed. Nothing new worth saving.") },
-    ];
+    // The finalizer's usable-output gate accepts free text only when it is
+    // exactly the mandated no-findings sentinel; a verified remember write
+    // is the other accepted evidence. Use the sentinel for the control.
+    providerScript = [{ response: textResponse("Nothing new to save.") }];
     providerCallCount = 0;
     const retry = await runForkBasedRetrospective(
       fixture.sourceId,
@@ -459,7 +460,7 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
 
     // The window stays retryable and a usable reply consumes it.
-    providerScript = [{ response: textResponse("Reviewed; nothing new.") }];
+    providerScript = [{ response: textResponse("Nothing new to save.") }];
     providerCallCount = 0;
     const retry = await runForkBasedRetrospective(
       fixture.sourceId,

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -20,7 +20,7 @@
 import { isMemoryV1Active } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
-import type { JobHandlerEntry } from "../../types.js";
+import type { JobHandlerEntry, JobQueueResolution } from "../../types.js";
 // The all-tier graph store: `embedGraphNodeJob` serves the V1 section,
 // `embedGraphTriggerJob` the SUBSTRATE one.
 import {
@@ -31,11 +31,17 @@ import {
 import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { getLogger } from "./logging.js";
 // RETROSPECTIVE (all tiers).
-import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
+import {
+  memoryRetrospectiveJob,
+  type MemoryRetrospectiveOutcome,
+} from "./memory-retrospective-job.js";
 import { skillCardInsertJob } from "./memory-retrospective-skill-card.js";
 import { memoryRetrospectiveSweepJob } from "./memory-retrospective-sweep.js";
 // SUBSTRATE (v2+v3).
-import { memoryV2ConsolidateJob } from "./substrate/consolidation-job.js";
+import {
+  type ConsolidationOutcome,
+  memoryV2ConsolidateJob,
+} from "./substrate/consolidation-job.js";
 import { memoryV2ReembedJob } from "./substrate/reembed-job.js";
 import { memoryV2SweepJob } from "./substrate/sweep-job.js";
 // V1 — delete with v1.
@@ -269,7 +275,8 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   },
   {
     type: "memory_v2_consolidate",
-    handler: (job, config) => memoryV2ConsolidateJob(job, config),
+    handler: async (job, config) =>
+      resolveConsolidationOutcome(await memoryV2ConsolidateJob(job, config)),
   },
   {
     type: "memory_v2_reembed",
@@ -303,7 +310,8 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   // v3 but is owned by the retrospective, so it groups here.
   {
     type: "memory_retrospective",
-    handler: (job, config) => memoryRetrospectiveJob(job, config),
+    handler: async (job, config) =>
+      resolveRetrospectiveOutcome(await memoryRetrospectiveJob(job, config)),
   },
   {
     type: "memory_retrospective_sweep",
@@ -314,3 +322,77 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     handler: (job) => skillCardInsertJob(job),
   },
 ];
+
+/**
+ * Terminal `last_error` for a retrospective row whose source conversation
+ * stayed mid-turn through the whole deferral budget. Named so the dead-letter
+ * row points at the stranded `processing_started_at` flag rather than a
+ * generic backend message; the sweep re-enqueues a fresh row once the source
+ * is eligible again.
+ */
+const SOURCE_PROCESSING_EXHAUSTED_MESSAGE =
+  "source conversation stayed mid-turn through the deferral budget " +
+  "(processing_started_at may be stranded); the retrospective sweep will re-enqueue";
+
+/**
+ * Translate the retrospective handler's domain outcome into the queue
+ * resolution persisted on its job row. The domain outcome is the source of
+ * truth for what happened; this mapping owns only how the row reads
+ * afterward:
+ *
+ * - benign no-ops and successful runs complete;
+ * - a mid-turn source defers the SAME row on the bounded deferral counter
+ *   (the turn-end trigger check's upsert coalesces onto this row, so the
+ *   event-driven retry keeps its immediacy) instead of completing it and
+ *   re-upserting a fresh row per attempt;
+ * - a failed or unusable wake dead-letters the row with an honest
+ *   `last_error`. Retry stays event-driven (cooldown + re-enqueue), so the
+ *   queue's attempt budget is deliberately not double-driving it.
+ */
+function resolveRetrospectiveOutcome(
+  outcome: MemoryRetrospectiveOutcome,
+): JobQueueResolution {
+  switch (outcome.kind) {
+    case "source_processing": {
+      return {
+        queueResolution: "deferred",
+        deferralExhaustedMessage: SOURCE_PROCESSING_EXHAUSTED_MESSAGE,
+      };
+    }
+    case "wake_failed": {
+      return {
+        queueResolution: "failed",
+        errorMessage: `retrospective wake failed: ${outcome.reason ?? "unknown"}`,
+      };
+    }
+    case "no_usable_output": {
+      return {
+        queueResolution: "failed",
+        errorMessage: `retrospective run produced no usable output: ${outcome.reason ?? "unknown"}`,
+      };
+    }
+    default: {
+      return { queueResolution: "completed" };
+    }
+  }
+}
+
+/**
+ * Translate the consolidation handler's domain outcome into the queue
+ * resolution persisted on its job row. A `run_failed` dead-letters the row
+ * with the failure reason; retry cadence is owned by the durable
+ * consolidation failure-state checkpoint (`memory_v2_consolidate_failure_state`),
+ * not the queue's attempt budget. Skips (disabled / locked / empty buffer)
+ * and successful runs complete.
+ */
+function resolveConsolidationOutcome(
+  outcome: ConsolidationOutcome,
+): JobQueueResolution {
+  if (outcome.kind === "run_failed") {
+    return {
+      queueResolution: "failed",
+      errorMessage: `consolidation run failed: ${outcome.reason ?? "unknown"}`,
+    };
+  }
+  return { queueResolution: "completed" };
+}

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -59,7 +59,7 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
-import type { JobHandler } from "../../types.js";
+import { isJobQueueResolution, type JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
@@ -425,8 +425,8 @@ export async function runMemoryJobsOnce(
     let groupProcessed = 0;
     for (const job of group) {
       try {
-        await processJob(job, config);
-        completeMemoryJob(job.id);
+        const resolution = await processJob(job, config);
+        applyQueueResolution(job, resolution);
         groupProcessed += 1;
       } catch (err) {
         try {
@@ -654,10 +654,55 @@ function handleJobError(job: MemoryJob, err: unknown): void {
 
 // ── Job dispatch ───────────────────────────────────────────────────
 
+/**
+ * Apply a handler's returned {@link JobQueueResolution} to its claimed row.
+ * Handlers that return anything else resolve as `completed` (the historical
+ * contract: failure is signaled by throwing). This is the worker's half of
+ * the outcome-truthfulness boundary: the persisted `memory_jobs.status` must
+ * reflect the handler's actual outcome, so a handler that reports failure
+ * through a returned value (e.g. the retrospective's `wake_failed`, the
+ * consolidation's `run_failed`) dead-letters or retries instead of silently
+ * completing.
+ */
+function applyQueueResolution(job: MemoryJob, resolution: unknown): void {
+  if (!isJobQueueResolution(resolution)) {
+    completeMemoryJob(job.id);
+    return;
+  }
+  switch (resolution.queueResolution) {
+    case "completed": {
+      completeMemoryJob(job.id);
+      return;
+    }
+    case "failed": {
+      failMemoryJob(job.id, resolution.errorMessage ?? "handler failed", {
+        maxAttempts: 1,
+      });
+      return;
+    }
+    case "retryable": {
+      failMemoryJob(job.id, resolution.errorMessage ?? "handler failed", {
+        retryDelayMs:
+          resolution.retryDelayMs ?? retryDelayForAttempt(job.attempts + 1),
+        maxAttempts: RETRY_MAX_ATTEMPTS,
+      });
+      return;
+    }
+    case "deferred": {
+      deferMemoryJob(job.id, {
+        ...(resolution.deferralExhaustedMessage
+          ? { exhaustedMessage: resolution.deferralExhaustedMessage }
+          : {}),
+      });
+      return;
+    }
+  }
+}
+
 async function processJob(
   job: MemoryJob,
   config: AssistantConfig,
-): Promise<void> {
+): Promise<unknown> {
   // Dispatch-level half of the v1-staleness guard, on the same condition the
   // handler-level half uses (`isStaleV1GraphJob` in `job-handlers.ts`): v1 work
   // runs only while v1 is the live tier, which memory being off is not (see
@@ -674,8 +719,7 @@ async function processJob(
   }
   const handler = jobHandlers.get(job.type);
   if (handler) {
-    await handler(job, config);
-    return;
+    return await handler(job, config);
   }
 
   const rawType = (job as { type: string }).type;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
@@ -78,3 +78,14 @@ export const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
  * set from turn 1, and matched by the permission checker's origin-scoped grant.
  */
 export const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
+
+/**
+ * The exact reply the fork instruction mandates when a reviewed window
+ * contains nothing worth saving. The finalizer treats a persisted assistant
+ * text block that trims to exactly this phrase (with no memory-writing tool
+ * attempts in the run) as the positive artifact of a legitimate no-findings
+ * review, advancing the cursor without fabricating a memory write. Compared
+ * by strict whole-block equality so analysis prose that merely mentions the
+ * phrase does not qualify.
+ */
+export const MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT = "Nothing new to save.";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -46,6 +46,7 @@ import {
   type ConversationRow,
   deleteConversation,
   getConversation,
+  getConversationProcessingStartedAt,
   isConversationProcessing,
 } from "@vellumai/plugin-api";
 
@@ -72,7 +73,6 @@ import {
   enqueueMemoryJob,
   type MemoryJob,
   type MemoryJobType,
-  upsertMemoryRetrospectiveJob,
 } from "../../../persistence/jobs-store.js";
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
@@ -88,6 +88,7 @@ import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+  MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT,
   MEMORY_RETROSPECTIVE_ORIGIN,
   MEMORY_RETROSPECTIVE_SOURCE,
   SKILL_MANAGEMENT_SKILL_ID,
@@ -112,15 +113,17 @@ const log = getLogger("memory-retrospective-job");
 const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [] as const;
 
 /**
- * Fallback delay for re-upserting a run that was skipped because the source
- * conversation was mid-turn. The PRIMARY requeue is event-driven: the
- * mid-turn skip leaves `lastRunAt` unbumped, so the message-indexing pass on
- * the turn's final assistant message re-enqueues immediately. This timed row
- * only covers a turn that aborts without ever persisting another message.
- * Each retried attempt re-checks the processing flag and re-upserts at the
- * same cadence, so the loop self-resolves when the turn ends.
+ * Age past which a source conversation's persisted `processing_started_at`
+ * stamp is treated as stranded rather than live, and the retrospective
+ * proceeds despite it. A turn-end flag clear can fail and be swallowed under
+ * DB-lock contention while the daemon stays up, and the monitor-process
+ * reaper only clears flags older than the daemon's boot time, so an
+ * in-process stranded flag otherwise blocks a conversation's retrospectives
+ * indefinitely. Proceeding risks only forking a half-finished display turn
+ * (a review-quality concern; the fork copies complete persisted turns), which
+ * is strictly better than never forming memories for the conversation again.
  */
-export const SOURCE_PROCESSING_REQUEUE_DELAY_MS = 60_000;
+export const STALE_SOURCE_PROCESSING_OVERRIDE_MS = 6 * 60 * 60 * 1000;
 
 /** Watchdog check_name for the per-run retrospective outcome counter. */
 const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
@@ -132,6 +135,7 @@ export type MemoryRetrospectiveOutcome =
   | { kind: "source_dormant" }
   | { kind: "source_processing" }
   | { kind: "wake_failed"; reason?: string; conversationId?: string }
+  | { kind: "no_usable_output"; reason?: string; conversationId?: string }
   | {
       kind: "invoked";
       backgroundConversationId: string;
@@ -186,7 +190,9 @@ export async function memoryRetrospectiveJob(
   }
   emitRunOutcome(
     outcome.kind,
-    outcome.kind === "wake_failed" ? outcome.reason : undefined,
+    outcome.kind === "wake_failed" || outcome.kind === "no_usable_output"
+      ? outcome.reason
+      : undefined,
   );
   return outcome;
 }
@@ -271,34 +277,36 @@ export async function runForkBasedRetrospective(
   // persisted message — including the turn's final assistant message — so an
   // unbumped `lastRunAt` lets that turn-end pass re-enqueue with no cooldown
   // suppression. That is the primary, event-driven requeue: the retrospective
-  // runs right after the colliding turn completes. Mid-turn attempts are
-  // cheap no-ops (existence + processing check) that recur at most once per
-  // persisted message and coalesce into a single pending row via the upsert.
-  // The timed re-upsert below is a fallback for a turn that aborts without
-  // ever indexing another message (the lifecycle/disposal enqueue remains
-  // the last-resort net). Both state pointers stay untouched, so nothing is
-  // lost. Returning (not throwing) keeps the jobs-worker from
-  // retry-with-backoff.
+  // runs right after the colliding turn completes. The `source_processing`
+  // outcome maps to a bounded deferral of the SAME job row at the worker
+  // (see `resolveRetrospectiveOutcome` in `job-handlers.ts`); turn-end
+  // trigger upserts coalesce onto that pending row, so the event-driven
+  // retry keeps its immediacy while a stranded flag can no longer mint an
+  // unbounded stream of fresh rows. Both state pointers stay untouched, so
+  // nothing is lost.
+  //
+  // Stranded-flag override: a swallowed turn-end flag clear leaves the
+  // persisted stamp set while the daemon stays up, where the monitor
+  // process's boot-time-fenced reaper never touches it. A stamp older than
+  // `STALE_SOURCE_PROCESSING_OVERRIDE_MS` is treated as stranded and the run
+  // proceeds; a set-but-stampless flag reads as live (deferral bounds it).
   if (await isConversationProcessing(sourceConversationId)) {
-    try {
-      upsertMemoryRetrospectiveJob(
-        { conversationId: sourceConversationId },
-        Date.now() + SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-      );
+    const processingStartedAt =
+      await getConversationProcessingStartedAt(sourceConversationId);
+    const stale =
+      processingStartedAt != null &&
+      startedAtMs - processingStartedAt > STALE_SOURCE_PROCESSING_OVERRIDE_MS;
+    if (!stale) {
       log.info(
-        {
-          sourceConversationId,
-          requeueDelayMs: SOURCE_PROCESSING_REQUEUE_DELAY_MS,
-        },
-        "memory-retrospective (fork): source conversation is mid-turn; requeued",
+        { sourceConversationId, processingStartedAt },
+        "memory-retrospective (fork): source conversation is mid-turn; deferring",
       );
-    } catch (err) {
-      log.warn(
-        { err, sourceConversationId },
-        "memory-retrospective (fork): mid-turn fallback requeue failed; relying on the turn-end trigger check",
-      );
+      return { kind: "source_processing" };
     }
-    return { kind: "source_processing" };
+    log.warn(
+      { sourceConversationId, processingStartedAt },
+      "memory-retrospective (fork): processing flag is stale beyond the override window; proceeding despite it",
+    );
   }
 
   const state = getRetrospectiveState(sourceConversationId);
@@ -549,25 +557,65 @@ export async function runForkBasedRetrospective(
   }
 
   if (wakeSucceeded) {
-    return await finalizeSuccessfulRetrospective({
-      config,
-      sourceConversationId,
-      retrospectiveConversationId: forkId,
-      cutoffMessageId,
-      newMessageCount: newMessages.length,
-      prior,
-      priorRemembers,
-      logFields: {
-        kind: "fork",
-        windowStartTimestamp,
-        durationMs: Date.now() - startedAtMs,
-      },
-    });
+    // Fail-closed finalization: `invoked: true` proves only that the wake
+    // went live, not that the run produced anything. The agent loop swallows
+    // provider rejections into a normal no-output return, an exhausted output
+    // budget can stop a run before any visible text or tool call, and a
+    // model may reply with analysis (or nothing) without saving. Advancement
+    // past the window therefore requires POSITIVE evidence from THIS run,
+    // one of:
+    //   - a memory-writing tool call on the fork's post-boundary tail whose
+    //     execution verifiably succeeded (matching non-error tool_result), or
+    //   - the explicit no-findings reply the instruction mandates (an
+    //     assistant text block that is exactly the sentinel phrase), with no
+    //     memory-writing tool attempts at all; a run that attempted a save
+    //     and failed cannot advance by also claiming no findings.
+    // The evidence read is run-specific by construction
+    // (`loadRetrospectiveRunMessages` scopes to rows after the fork
+    // boundary), so a prior run's persisted saves can never satisfy it, and
+    // it reads the DB rather than the returned history, so a checkpoint that
+    // went live and persisted saves counts even when a later in-loop repair
+    // rebased the returned tail. A run with neither evidence kind follows
+    // the wake-failure path: cursor, remembered log, and the prior
+    // retrospective (the dedup baseline) stay untouched and the window
+    // remains retryable.
+    const runEvidence = await collectRetrospectiveRunEvidence(forkId);
+    const reviewedNoFindings =
+      runEvidence.explicitNoFindings &&
+      runEvidence.durableToolAttemptCount === 0;
+    if (runEvidence.durableToolCallCount === 0 && !reviewedNoFindings) {
+      log.warn(
+        {
+          sourceConversationId,
+          forkId,
+          newMessageCount: newMessages.length,
+          durableToolAttempts: runEvidence.durableToolAttemptCount,
+        },
+        "memory-retrospective (fork): run produced neither a verified durable write nor an explicit no-findings reply; leaving window retryable",
+      );
+    } else {
+      return await finalizeSuccessfulRetrospective({
+        config,
+        sourceConversationId,
+        retrospectiveConversationId: forkId,
+        cutoffMessageId,
+        newMessageCount: newMessages.length,
+        prior,
+        priorRemembers,
+        runRemembers: runEvidence.remembers,
+        logFields: {
+          kind: "fork",
+          windowStartTimestamp,
+          durationMs: Date.now() - startedAtMs,
+          noFindings: reviewedNoFindings,
+        },
+      });
+    }
   }
 
-  // Wake failed. Bump `lastRunAt` only so the cooldown gate applies, leave
-  // `lastProcessedMessageId` alone so the next attempt re-processes the
-  // same messages. Then clean up the orphan fork.
+  // Wake failed or produced no usable output. Bump `lastRunAt` only so the
+  // cooldown gate applies, leave `lastProcessedMessageId` alone so the next
+  // attempt re-processes the same messages. Then clean up the orphan fork.
   await bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
   await safeDeleteRetrospectiveConversation(
     forkId,
@@ -578,6 +626,13 @@ export async function runForkBasedRetrospective(
     throw threw;
   }
 
+  if (wakeSucceeded) {
+    return {
+      kind: "no_usable_output",
+      reason: failureReason ?? "run persisted no memory-writing tool call",
+      conversationId: forkId,
+    };
+  }
   return {
     kind: "wake_failed",
     reason: failureReason,
@@ -786,6 +841,12 @@ async function finalizeSuccessfulRetrospective(args: {
   newMessageCount: number;
   prior: PriorRetrospective | null;
   priorRemembers: string[];
+  /**
+   * The `remember` contents extracted from this run's persisted tail by the
+   * caller's usable-output check; passed through so the evidence that gated
+   * advancement is exactly the evidence folded into the log.
+   */
+  runRemembers: string[];
   /** Per-kind extras for the success log line (e.g. `kind`, fork anchor). */
   logFields: Record<string, unknown>;
 }): Promise<MemoryRetrospectiveOutcome> {
@@ -797,12 +858,10 @@ async function finalizeSuccessfulRetrospective(args: {
     newMessageCount,
     prior,
     priorRemembers,
+    runRemembers,
     logFields,
   } = args;
 
-  const runRemembers = await extractRetrospectiveRunRemembers(
-    retrospectiveConversationId,
-  );
   await upsertRetrospectiveState({
     conversationId: sourceConversationId,
     lastProcessedMessageId: cutoffMessageId,
@@ -1003,7 +1062,199 @@ async function extractRetrospectiveRunRemembers(
   if (runMessages == null) {
     return [];
   }
+  // Deliberately unfiltered by execution success: this reads a PRIOR run for
+  // the <already_remembered> dedup baseline, where over-inclusion is the
+  // safe direction (worst case a fact is not re-saved) and old runs predate
+  // result-verified evidence. The CURRENT run's log append goes through
+  // `collectRetrospectiveRunEvidence`, which does verify execution.
   return extractRememberContents(runMessages);
+}
+
+/**
+ * Tool names whose persisted `tool_use` blocks count as durable memory work
+ * for the fail-closed advancement gate: `remember` writes the memory buffer,
+ * `scaffold_managed_skill` writes a managed skill. Read-only tools on the
+ * retrospective allowlist (`skill_load`, `find_similar_skills`) deliberately
+ * do not qualify: a run that only browsed produced nothing durable.
+ */
+const DURABLE_RETROSPECTIVE_TOOLS: ReadonlySet<string> = new Set([
+  "remember",
+  "scaffold_managed_skill",
+]);
+
+/**
+ * Read the durable evidence a retrospective run persisted: its `remember`
+ * contents plus a count of every memory-writing tool call on the run's
+ * post-boundary tail whose EXECUTION succeeded. A `tool_use` block alone
+ * proves only that the model asked; the durable write happens inside the
+ * executor, so a call counts (and its facts feed the remembered log) only
+ * when a matching non-error `tool_result` is persisted on the same tail. A
+ * failed or missing execution therefore leaves the window retryable, and a
+ * failed `remember`'s facts never enter the `<already_remembered>` baseline
+ * where they would suppress the retry's re-save. A load failure
+ * (`runMessages == null`) reports zero durable calls, which the advancement
+ * gate treats as "not proven usable" (fail-closed).
+ */
+async function collectRetrospectiveRunEvidence(
+  conversationId: string,
+): Promise<{
+  remembers: string[];
+  /** Memory-writing tool calls whose execution verifiably succeeded. */
+  durableToolCallCount: number;
+  /** Memory-writing tool calls the run attempted, regardless of outcome. */
+  durableToolAttemptCount: number;
+  /**
+   * The run replied with exactly the mandated no-findings sentinel text
+   * ({@link MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}) in a persisted assistant
+   * text block. Strict whole-block equality: prose that merely mentions the
+   * phrase does not qualify, so an analysis-only reply stays unusable.
+   */
+  explicitNoFindings: boolean;
+}> {
+  const conv = await getConversation(conversationId);
+  const runMessages = await loadRetrospectiveRunMessages(
+    conversationId,
+    conv?.source ?? null,
+  );
+  if (runMessages == null) {
+    return {
+      remembers: [],
+      durableToolCallCount: 0,
+      durableToolAttemptCount: 0,
+      explicitNoFindings: false,
+    };
+  }
+  const succeededIds = collectSuccessfulToolResultIds(runMessages);
+  return {
+    remembers: extractRememberContents(runMessages, succeededIds),
+    durableToolCallCount: countDurableToolUses(runMessages, succeededIds),
+    durableToolAttemptCount: countDurableToolUses(runMessages, null),
+    explicitNoFindings: hasExplicitNoFindingsReply(runMessages),
+  };
+}
+
+/**
+ * Whether any persisted assistant row on the run's tail carries a text block
+ * that is exactly the no-findings sentinel (after trimming). The instruction
+ * template mandates this exact reply for a reviewed-and-nothing-to-save
+ * pass, making it the positive persisted artifact that distinguishes a
+ * legitimate no-findings review from an empty or unusable response.
+ */
+function hasExplicitNoFindingsReply(messages: MessageLike[]): boolean {
+  for (const msg of messages) {
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "text" &&
+        typeof b.text === "string" &&
+        b.text.trim() === MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Ids of `tool_result` blocks on the run's user rows whose execution did not
+ * report an error. Robust to malformed content JSON the same way
+ * `extractRememberContents` is.
+ */
+function collectSuccessfulToolResultIds(messages: MessageLike[]): Set<string> {
+  const ids = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "user") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "tool_result" &&
+        typeof b.tool_use_id === "string" &&
+        b.is_error !== true
+      ) {
+        ids.add(b.tool_use_id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Count persisted `tool_use` blocks whose `name` is in
+ * {@link DURABLE_RETROSPECTIVE_TOOLS} across the run's assistant rows.
+ * With a `succeededIds` set, only calls whose id has a matching successful
+ * `tool_result` count (verified executions); with `null`, every attempt
+ * counts regardless of outcome.
+ */
+function countDurableToolUses(
+  messages: MessageLike[],
+  succeededIds: ReadonlySet<string> | null,
+): number {
+  let count = 0;
+  for (const msg of messages) {
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    let blocks: unknown = msg.content;
+    if (typeof blocks === "string") {
+      try {
+        blocks = JSON.parse(blocks);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (
+        b.type === "tool_use" &&
+        DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name)) &&
+        (succeededIds === null ||
+          (typeof b.id === "string" && succeededIds.has(b.id)))
+      ) {
+        count += 1;
+      }
+    }
+  }
+  return count;
 }
 
 interface MessageLike {
@@ -1016,7 +1267,10 @@ interface MessageLike {
  * `"remember"` and return the `input.content` strings in order. Robust to
  * malformed content JSON — unparseable rows are skipped, not propagated.
  */
-function extractRememberContents(messages: MessageLike[]): string[] {
+function extractRememberContents(
+  messages: MessageLike[],
+  succeededIds?: ReadonlySet<string>,
+): string[] {
   const contents: string[] = [];
   for (const msg of messages) {
     if (msg.role !== "assistant") {
@@ -1042,6 +1296,16 @@ function extractRememberContents(messages: MessageLike[]): string[] {
         continue;
       }
       if (b.name !== "remember") {
+        continue;
+      }
+      // When a success set is provided, only executions that reported a
+      // non-error tool_result contribute facts: a failed remember never
+      // wrote the buffer, and logging its facts would suppress the retry's
+      // re-save via <already_remembered>.
+      if (
+        succeededIds !== undefined &&
+        (typeof b.id !== "string" || !succeededIds.has(b.id))
+      ) {
         continue;
       }
       const input = b.input;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -1200,6 +1200,9 @@ function collectSuccessfulToolResultIds(messages: MessageLike[]): Set<string> {
         continue;
       }
       const b = block as Record<string, unknown>;
+      // guard:allow-tool-result-only: success evidence for locally-executed
+      // durable memory tools; server-side web_search_tool_result never
+      // corresponds to a durable write and carries no is_error flag.
       if (
         b.type === "tool_result" &&
         typeof b.tool_use_id === "string" &&

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -63,7 +63,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
 {{SKILL_AUTHORING_SECTION}}`;
 
 /** Placeholder names recognized in the bundled template and overrides. */

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -27,6 +27,7 @@
  */
 
 import { getLogger } from "./logging.js";
+import { MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT } from "./memory-retrospective-constants.js";
 import { getWorkspaceDir } from "./paths.js";
 import { loadPromptOverride } from "./prompt-override.js";
 
@@ -42,6 +43,13 @@ function neutralizeSentinels(s: string): string {
     "<\u200B/already_remembered>",
   );
 }
+
+/**
+ * The sentence mandating the exact no-findings reply. Built from
+ * {@link MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT} so the instruction and the
+ * finalizer's acceptance check can never drift apart.
+ */
+const NO_FINDINGS_MANDATE = `If nothing new is worth saving, reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`;
 
 /**
  * Bundled fork-instruction template. Exported so tests (and any future
@@ -63,7 +71,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. ${NO_FINDINGS_MANDATE}
 {{SKILL_AUTHORING_SECTION}}`;
 
 /** Placeholder names recognized in the bundled template and overrides. */
@@ -140,7 +148,9 @@ export interface ForkInstructionArgs {
  * override resolves to a usable file (bounded to a regular file under 1 MiB by
  * the shared {@link loadPromptOverride}), else the bundled
  * {@link RETROSPECTIVE_INSTRUCTION_TEMPLATE}; both get the same placeholder
- * substitution.
+ * substitution. An override additionally gets the no-findings mandate
+ * appended after its body: the exact-reply sentinel is the finalizer's
+ * advancement contract, so it holds regardless of what the override says.
  */
 export function buildForkInstruction({
   windowStartTimestamp,
@@ -175,7 +185,7 @@ export function buildForkInstruction({
     label: "retrospective prompt",
   });
 
-  return substituteInstructionParts(
+  const rendered = substituteInstructionParts(
     override ?? RETROSPECTIVE_INSTRUCTION_TEMPLATE,
     {
       AVAILABLE_TOOLS_LINE: availableToolsLine,
@@ -186,6 +196,16 @@ export function buildForkInstruction({
         : "",
     },
   );
+  if (override == null) {
+    return rendered;
+  }
+  // The finalizer recognizes a no-findings review only by the exact
+  // MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT reply, so the mandate is part of
+  // the advancement contract, not prompt styling: an override body that
+  // drops it would leave every no-findings window permanently retryable.
+  // Appended outside the override so a custom prompt cannot break the
+  // contract.
+  return `${rendered}\n\n${NO_FINDINGS_MANDATE}`;
 }
 
 /**

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -351,9 +351,67 @@ export interface Injector {
 // than wired through the loader, so they carry no `Plugin` contribution slot.
 
 /**
+ * How the worker resolves a claimed job row after its handler returns
+ * without throwing. Handlers that report failure through a returned domain
+ * outcome (rather than a throw) translate that outcome into one of these at
+ * the registration site, so the persisted `memory_jobs.status` reflects what
+ * actually happened instead of unconditionally reading `completed`.
+ *
+ * - `completed`: the work succeeded (or was a legitimate no-op).
+ * - `failed`: terminal failure; the row is dead-lettered with
+ *   `errorMessage` as `last_error`. Use when retry is owned elsewhere
+ *   (event-driven re-enqueue, durable backoff checkpoints).
+ * - `retryable`: transient failure; the row re-enters the queue's
+ *   attempt-budgeted retry machinery with `errorMessage` recorded.
+ * - `deferred`: the work could not run yet for a reason external to the
+ *   job (e.g. its source conversation is mid-turn); the row goes back to
+ *   pending on the deferral counter's backoff curve and dead-letters with
+ *   `deferralExhaustedMessage` once the deferral budget is spent.
+ */
+export interface JobQueueResolution {
+  queueResolution: "completed" | "failed" | "retryable" | "deferred";
+  /** Persisted to `memory_jobs.last_error` for `failed` / `retryable`. */
+  errorMessage?: string;
+  /** Retry delay override for `retryable`. */
+  retryDelayMs?: number;
+  /** Terminal `last_error` when a `deferred` job exhausts its budget. */
+  deferralExhaustedMessage?: string;
+}
+
+const QUEUE_RESOLUTIONS = new Set([
+  "completed",
+  "failed",
+  "retryable",
+  "deferred",
+]);
+
+/**
+ * Narrow an arbitrary handler return value to a {@link JobQueueResolution}.
+ * Anything else (including `undefined` and legacy domain outcomes) resolves
+ * as `completed`, preserving the historical contract for handlers that only
+ * signal failure by throwing.
+ */
+export function isJobQueueResolution(
+  value: unknown,
+): value is JobQueueResolution {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "queueResolution" in value &&
+    typeof (value as { queueResolution: unknown }).queueResolution ===
+      "string" &&
+    QUEUE_RESOLUTIONS.has(
+      (value as { queueResolution: string }).queueResolution,
+    )
+  );
+}
+
+/**
  * Processes one claimed background job: receives the claimed job row and the
- * live assistant config. The return value is ignored — a handler signals
- * failure by throwing, which the worker records against the job.
+ * live assistant config. A handler signals failure by throwing (recorded
+ * against the job's attempt budget) or by returning a
+ * {@link JobQueueResolution}; any other return value resolves the row as
+ * `completed`.
  */
 export type JobHandler = (job: MemoryJob, config: AssistantConfig) => unknown;
 


### PR DESCRIPTION
## TL;DR

Two truthfulness fixes at one seam. **Finalization:** a retrospective window's cursor now advances only on positive, durable, run-specific evidence — a memory-writing tool call whose execution verifiably succeeded, or the explicit mandated no-findings reply. **Job ledger:** memory job rows now record what the handler actually reported — a failed retrospective or consolidation run dead-letters with an honest `last_error` instead of reading `completed`, and a mid-turn source defers one bounded row instead of minting a new row every minute.

Layers over the wake-level exit classifier from #39877: the wake owns *how* the run ended; this finalizer owns *what* the run verifiably produced. Part 1 of a 4-PR series (consolidation ownership, media routing, and the rewind CLI follow separately; the rewind PR is stacked on this branch).

## Why this is needed

All three failure shapes are verified on a live workspace, not hypothetical:

- **Windows advanced past failed work.** The agent loop swallows provider rejections into a normal no-output return, so `invoked: true` proved only that the wake went live. An image-bearing window routed to a non-vision model produced 39 explicit failures — and the checkpoint still advanced, permanently skipping those windows' derived memory (LUM-3013).
- **The ledger lied.** Retrospective `wake_failed` and consolidation `run_failed` are *returned* values, not throws, so the worker marked those rows `completed` with `last_error = NULL`. Failed runs were indistinguishable from successful ones in the only queue-level record that exists.
- **Unbounded row minting.** The mid-turn skip path re-upserted a fresh timed row per attempt. One conversation with a stranded `processing_started_at` flag accumulated **3,112 retrospective job rows** on a live instance, with zero memory formation — the stranded flag also blocked that conversation's retrospectives indefinitely, because the monitor reaper is boot-time-fenced and can never clear a flag stranded while the daemon stays up.

## Why this approach

- **Evidence at the finalizer, not trust in the loop.** The exit classifier (#39877) cannot know whether a "clean" run did durable work. The finalizer reads the fork's post-boundary tail **from the DB**: a `tool_use` counts only with a matching non-error `tool_result` (the write happens in the executor, not at the call), a prior run's saves can never satisfy the check (run-scoped by the fork boundary), and a checkpoint whose saves persisted counts even if a later in-loop repair rebased the returned history.
- **A no-findings review must leave a positive artifact.** "Advance on silence" is exactly the failure being fixed, so a legitimately empty review must say so: the instruction mandates replying with exactly the sentinel phrase, accepted only when the run attempted zero saves — a run that tried a save and failed cannot paper over it with a no-findings claim, and failed facts stay out of `<already_remembered>` so the retry's re-save is not suppressed. The mandate is rendered from the same constant the finalizer compares against (they cannot drift) and is appended outside any `memory.retrospective.promptPath` override body, so a customized prompt cannot break the acceptance contract.
- **The worker owns the outcome boundary, generically.** Handlers may now return a typed `JobQueueResolution` (`completed | failed | retryable | deferred`) which `applyQueueResolution` maps onto the existing store primitives. Every other handler is untouched: anything that isn't a resolution narrows to `completed`, preserving the historical throw-to-fail contract — no handler rewrite, no second mechanism.
- **Dead-letter at `maxAttempts: 1`, deliberately.** Retrospective and consolidation retries are domain-owned (cooldown + event-driven re-enqueue; the consolidation failure-state checkpoint). Letting the queue's attempt budget also retry them would double-drive the same work — the interaction #39877 documented. The row's job is to *tell the truth*, not to schedule the retry.
- **Defer the same row instead of minting rows.** `source_processing` now maps to the bounded deferral counter on the claimed row; turn-end trigger upserts coalesce onto it, so the event-driven retry keeps its immediacy while a stranded flag can no longer grow the table. A stamp older than 6h is treated as stranded and the pass proceeds — a bounded mitigation of the swallowed turn-end flag-clear (the JARVIS-1237 mechanism). That root cause is documented at the override site, and the worst case of proceeding is fork quality, never cursor integrity.

## Why this is safe

- **No behavior change for healthy runs**: verified-output runs finalize exactly as before; benign no-ops (`disabled`, `no_new_messages`, `source_dormant`) are unchanged.
- **No retry-cadence change**: only the terminal status a row carries changes; the claim path and `hasActiveJobOfType` read only `pending`/`running`, so scheduling is provably unaffected. (Terminal rows were never pruned before this PR either — the honest `failed` status makes that pre-existing retention gap visible; LUM-3044 tracks the sweep.)
- **Store transitions are CAS-guarded on `running`**: a late return from an abandoned execution cannot overwrite a terminal state written by the stalled-job watchdog or a successor worker.
- **Fail-closed on uncertainty**: an evidence-load failure reports zero durable calls, which leaves the window retryable — the error direction is "retry later", never "skip forever".
- **Reviewed**: both bot-review bugs (override prompts missing the sentinel mandate; CLI silently succeeding on `no_usable_output`) are fixed with regression tests; the content-ref concern was verified non-applicable (the evidence read goes through the facade's `getMessages`, whose rows are already resolved `ContentBlock[]`).
- **Tested**: retrospective job suite (82), real-chain wake suite (4), finalizer-seam provider-path suite (3, real AgentLoop + real tool executor), outcome-contract suite (8, real SQLite rows), prompt suite (14) — green per-file; typecheck and full CI green.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| A memory save fails during review | Window skipped forever; failed facts suppressed future re-saves | Window stays retryable; facts excluded from the dedup log so the retry re-saves them |
| Review genuinely finds nothing | Advanced on any silent no-op | Advances only on the explicit mandated reply; silence stays retryable |
| Review fails (provider error, no output) | Job row reads `completed`, nothing to diagnose | Row reads `failed` with the reason in `last_error`; retry timing unchanged |
| Conversation stuck mid-turn | A new job row every minute, forever; memories never form again | One bounded row; after 6h the flag is treated as stranded and memory formation resumes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
