### PR TITLE
fix(memory): capability-aware media routing at the shared model-call boundary

### DIFF
--- a/assistant/src/__tests__/agent-loop-pre-model-call-messages.test.ts
+++ b/assistant/src/__tests__/agent-loop-pre-model-call-messages.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the `pre-model-call` hook's outbound-messages contract: a hook can
+ * rewrite the wire payload the loop sends (without touching the loop's own
+ * history bookkeeping) and can fail the model call outright via
+ * `decision: "fail"`, ending the turn through the loop's normal error path
+ * before anything reaches the provider. A throwing hook stays fail-open (the
+ * call proceeds with the original request).
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
+import type { PreModelCallContext } from "../plugin-api/types.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import { registerPlugin } from "../plugins/registry.js";
+import type { Message } from "../providers/types.js";
+import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "Hello" }],
+};
+
+function collect(events: AgentEvent[]): (event: AgentEvent) => void {
+  return (event) => events.push(event);
+}
+
+function registerPreModelCallPlugin(
+  hook: (ctx: PreModelCallContext) => void,
+): void {
+  registerPlugin({
+    manifest: { name: "test-pre-model-call", version: "0.0.0" },
+    hooks: {
+      "pre-model-call": async (ctx: PreModelCallContext) => {
+        hook(ctx);
+      },
+    },
+  });
+}
+
+describe("agent loop pre-model-call outbound messages", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+  });
+
+  test("a hook-rewritten messages array is what the provider receives", async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.messages = [
+        { role: "user", content: [{ type: "text", text: "rewritten" }] },
+      ];
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0].messages;
+    expect(sent).toHaveLength(1);
+    expect(sent[0].content).toEqual([{ type: "text", text: "rewritten" }]);
+    // Wire payload only: the loop's own history keeps the original user
+    // message untouched.
+    expect(history[0].content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  test("in-place mutation of ctx.messages reaches the wire without touching history", async () => {
+    registerPreModelCallPlugin((ctx) => {
+      for (const message of ctx.messages) {
+        for (let i = 0; i < message.content.length; i++) {
+          const block = message.content[i];
+          if (block.type === "text") {
+            message.content[i] = {
+              type: "text",
+              text: block.text.toUpperCase(),
+            };
+          }
+        }
+      }
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls[0].messages[0].content).toEqual([
+      { type: "text", text: "HELLO" },
+    ]);
+    expect(history[0].content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  test('decision "fail" ends the turn through the error path without a provider call', async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.decision = "fail";
+      ctx.failureReason = "media bound for a text-only route";
+    });
+    const { provider, calls } = createMockProvider([textResponse("never")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type !== "error") {
+      throw new Error("type narrowing");
+    }
+    expect(errorEvent.error.message).toBe("media bound for a text-only route");
+    const exitEvent = events.find((e) => e.type === "agent_loop_exit");
+    expect(exitEvent).toBeDefined();
+    if (exitEvent?.type !== "agent_loop_exit") {
+      throw new Error("type narrowing");
+    }
+    expect(exitEvent.reason).toBe("error");
+  });
+
+  test('decision "fail" without a failureReason surfaces the generic message', async () => {
+    registerPreModelCallPlugin((ctx) => {
+      ctx.decision = "fail";
+    });
+    const { provider, calls } = createMockProvider([textResponse("never")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    if (errorEvent?.type !== "error") {
+      throw new Error("expected an error event");
+    }
+    expect(errorEvent.error.message).toBe(
+      "A pre-model-call hook failed this model call",
+    );
+  });
+
+  test("a throwing hook is fail-open: the call proceeds with the original request", async () => {
+    registerPreModelCallPlugin(() => {
+      throw new Error("hook exploded");
+    });
+    const { provider, calls } = createMockProvider([textResponse("ok")]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collect(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].messages[0].content).toEqual([
+      { type: "text", text: "Hello" },
+    ]);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -626,6 +626,14 @@ describe("web_search_tool_result structural guard", () => {
     // (stripHistoricalWebSearchResults), so nothing is silently dropped.
     "context/outbound-sanitize.ts",
 
+    // Send-boundary media guard: walks `tool_result.contentBlocks` to replace
+    // image blocks bound for a text-only model. Same rationale as the
+    // media-strip transform above: `web_search_tool_result` carries opaque
+    // provider content (`content: unknown`, encrypted search results), never
+    // a `contentBlocks` array, so there is no nested image for this pass to
+    // reach and nothing is silently dropped.
+    "context/outbound-media-guard.ts",
+
     // Anthropic provider type guards define API-specific discriminants.
     // It has a separate isWebSearchToolResultBlock for the other type.
     "providers/anthropic/client.ts",

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -29,6 +29,11 @@ import {
 import { HOOKS } from "../plugin-api/constants.js";
 import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
+import {
+  captionOutboundImagesInMessages,
+  countImageBlocksInMessages,
+  needsImageFallback,
+} from "../plugins/defaults/image-fallback/src/caption-blocks.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { CompactionCircuitEvent } from "../plugins/types.js";
 import { isMaxTokensStopReason } from "../providers/stop-reasons.js";
@@ -1713,6 +1718,51 @@ export class AgentLoop {
             "pre-model-call hook failed the model call; ending the turn without sending",
           );
           throw preModelCallFailure;
+        }
+
+        // FINAL media-capability enforcement, at the authoritative send
+        // boundary. The image-fallback `pre-model-call` hook handles this
+        // proactively (captioning via a vision profile when one exists), but
+        // two paths can defeat it: the pipeline discards a hook's mutation
+        // when it times out or throws (fail-open), and a hook registered
+        // after it can reroute the call to a text-only profile. Whatever the
+        // settled chain produced, raw image blocks must not be sent to a
+        // model that cannot accept them, so any that remain are replaced
+        // with the plugin's deterministic static placeholders here. No
+        // captioning at this boundary: the proactive pass had its chance,
+        // and this pass must be cheap, bounded, and provider-call-free.
+        // Substitution happens on a clone, so only the wire payload changes
+        // and the loop's history bookkeeping is untouched (the same
+        // wire-only contract the hook has).
+        const finalModelKey =
+          (typeof providerConfig.overrideProfile === "string"
+            ? providerConfig.overrideProfile
+            : undefined) ??
+          options.modelProfileKey ??
+          null;
+        if (finalModelKey != null && needsImageFallback(finalModelKey)) {
+          const residualMediaBlocks =
+            countImageBlocksInMessages(outboundMessages);
+          if (residualMediaBlocks > 0) {
+            const wireClone = structuredClone(outboundMessages);
+            const placeholdered = await captionOutboundImagesInMessages(
+              wireClone,
+              this.conversationId,
+              null,
+              rlog,
+            );
+            outboundMessages = wireClone;
+            rlog.warn(
+              {
+                callSite,
+                modelProfileKey: finalModelKey,
+                residualMediaBlocks,
+                placeholdered,
+                decision: "boundary_placeholdered",
+              },
+              "Outbound media survived the settled pre-model-call chain bound for a text-only model; replaced with static placeholders at the send boundary",
+            );
+          }
         }
 
         // Announce the LLM-call boundary so downstream handlers (the

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -2,6 +2,10 @@ import { getConfig } from "../config/loader.js";
 import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { recordEstimate } from "../context/estimator-calibration.js";
+import {
+  modelLacksVisionSupport,
+  replaceOutboundImagesWithPlaceholders,
+} from "../context/outbound-media-guard.js";
 import { preModelCallSanitize } from "../context/outbound-sanitize.js";
 import {
   estimatePromptTokensRaw,
@@ -29,11 +33,6 @@ import {
 import { HOOKS } from "../plugin-api/constants.js";
 import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
-import {
-  captionOutboundImagesInMessages,
-  countImageBlocksInMessages,
-  needsImageFallback,
-} from "../plugins/defaults/image-fallback/src/caption-blocks.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { CompactionCircuitEvent } from "../plugins/types.js";
 import { isMaxTokensStopReason } from "../providers/stop-reasons.js";
@@ -1728,35 +1727,38 @@ export class AgentLoop {
         // after it can reroute the call to a text-only profile. Whatever the
         // settled chain produced, raw image blocks must not be sent to a
         // model that cannot accept them, so any that remain are replaced
-        // with the plugin's deterministic static placeholders here. No
-        // captioning at this boundary: the proactive pass had its chance,
-        // and this pass must be cheap, bounded, and provider-call-free.
+        // with deterministic static placeholders here (the host-side
+        // `outbound-media-guard`, so the guarantee holds even with the
+        // plugin disabled). No captioning at this boundary: the proactive
+        // pass had its chance, and this pass must be cheap, bounded, and
+        // provider-call-free.
         // Substitution happens on a clone, so only the wire payload changes
         // and the loop's history bookkeeping is untouched (the same
         // wire-only contract the hook has).
-        const finalModelKey =
-          (typeof providerConfig.overrideProfile === "string"
-            ? providerConfig.overrideProfile
-            : undefined) ??
-          options.modelProfileKey ??
-          null;
-        if (finalModelKey != null && needsImageFallback(finalModelKey)) {
-          const residualMediaBlocks =
-            countImageBlocksInMessages(outboundMessages);
-          if (residualMediaBlocks > 0) {
+        const outboundHasMedia = outboundMessages.some((m) =>
+          m.content.some(
+            (b) =>
+              b.type === "image" ||
+              (b.type === "tool_result" &&
+                b.contentBlocks?.some((cb) => cb.type === "image")),
+          ),
+        );
+        if (outboundHasMedia) {
+          const finalModelKey =
+            (typeof providerConfig.overrideProfile === "string"
+              ? providerConfig.overrideProfile
+              : undefined) ??
+            options.modelProfileKey ??
+            null;
+          if (finalModelKey != null && modelLacksVisionSupport(finalModelKey)) {
             const wireClone = structuredClone(outboundMessages);
-            const placeholdered = await captionOutboundImagesInMessages(
-              wireClone,
-              this.conversationId,
-              null,
-              rlog,
-            );
+            const placeholdered =
+              replaceOutboundImagesWithPlaceholders(wireClone);
             outboundMessages = wireClone;
             rlog.warn(
               {
                 callSite,
                 modelProfileKey: finalModelKey,
-                residualMediaBlocks,
                 placeholdered,
                 decision: "boundary_placeholdered",
               },

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1619,17 +1619,27 @@ export class AgentLoop {
           signal,
         };
 
-        // Let plugins edit the outbound request and opt this call into deferred
-        // output streaming. Runs for every provider call; hooks self-gate on
-        // call site / conversation. Fail-open: a throwing hook leaves the
-        // request unchanged and streaming live.
+        // Let plugins edit the outbound request (system prompt and wire
+        // messages), opt this call into deferred output streaming, or fail the
+        // call outright. Runs for every provider call; hooks self-gate on
+        // call site / conversation. Fail-open for hook THROWS: a throwing hook
+        // leaves the request unchanged and streaming live. A hook that must
+        // stop the call instead sets `decision: "fail"` on the context; the
+        // loop then ends the turn through its normal error path (below,
+        // outside this catch) instead of sending.
+        let outboundMessages = providerHistory;
+        let preModelCallFailure: Error | null = null;
         try {
           const preModelCtx: PreModelCallInputContext = {
             conversationId: this.conversationId,
             callSite: callSite ?? null,
             systemPrompt: providerOptions.systemPrompt ?? null,
             modelProfile: effectiveOverrideProfile ?? null,
+            modelProfileKey: options.modelProfileKey ?? null,
+            messages: providerHistory,
             deferAssistantOutput: false,
+            decision: "proceed",
+            failureReason: null,
           };
           const finalPreModelCtx = await traceAsyncSection(
             "agent-loop:pre-model-call-hook",
@@ -1669,11 +1679,40 @@ export class AgentLoop {
           // The hook owns the policy (it sees `callSite`/conversation and
           // self-gates); the loop honors whatever it decides.
           deferAssistantOutput = finalPreModelCtx.deferAssistantOutput;
+          // Adopt a rewritten wire payload. The hook pipeline hands hooks a
+          // deep clone of the context, so the settled array never aliases
+          // `history`: only what goes on the wire changes, the loop's own
+          // history bookkeeping is untouched. The pipeline's output schema
+          // already discarded any hook mutation carrying malformed messages.
+          if (Array.isArray(finalPreModelCtx.messages)) {
+            outboundMessages = finalPreModelCtx.messages;
+          }
+          if (finalPreModelCtx.decision === "fail") {
+            preModelCallFailure = new Error(
+              finalPreModelCtx.failureReason ??
+                "A pre-model-call hook failed this model call",
+            );
+          }
         } catch (preModelCallError) {
           rlog.error(
             { err: preModelCallError },
             "pre-model-call hook failed — proceeding with the original request",
           );
+        }
+
+        // Honor a hook-chain `decision: "fail"` before anything is sent or a
+        // persistence row is reserved. Thrown here (not inside the hook
+        // try/catch, which contains hook errors fail-open) so the turn ends
+        // through the loop's normal error path: `error` event, stop hook,
+        // exit reason "error". Background callers that retry failed runs
+        // (memory retrospective/consolidation wakes) observe an ordinary
+        // failed run.
+        if (preModelCallFailure) {
+          rlog.warn(
+            { err: preModelCallFailure, callSite },
+            "pre-model-call hook failed the model call; ending the turn without sending",
+          );
+          throw preModelCallFailure;
         }
 
         // Announce the LLM-call boundary so downstream handlers (the
@@ -1703,7 +1742,7 @@ export class AgentLoop {
         let response: ProviderResponse;
         try {
           response = await traceAsyncSection("agent-loop:provider-send", () =>
-            this.provider.sendMessage(providerHistory, providerOptions),
+            this.provider.sendMessage(outboundMessages, providerOptions),
           );
         } catch (llmCallError) {
           // Skip recording on abort — the user cancelled the request and
@@ -1721,7 +1760,7 @@ export class AgentLoop {
             // misrepresent both.
             const rawRequest = {
               provider: this.provider.name,
-              messages: providerHistory,
+              messages: outboundMessages,
               tools: providerOptions.tools,
               systemPrompt: providerOptions.systemPrompt,
               config: providerOptions.config,

--- a/assistant/src/context/outbound-media-guard.ts
+++ b/assistant/src/context/outbound-media-guard.ts
@@ -1,0 +1,85 @@
+/**
+ * Host-side media-capability guard for the agent loop's final send boundary.
+ *
+ * The image-fallback plugin's `pre-model-call` hook is the proactive quality
+ * pass (captioning via a vision profile when one exists), but the plugin
+ * pipeline discards a hook's mutation when it throws or times out, and a hook
+ * registered later in the chain can reroute the call to a text-only profile
+ * after the guard has passed. The loop therefore enforces the invariant
+ * itself, immediately before provider send: raw image blocks must not reach a
+ * model that cannot accept them.
+ *
+ * This module lives in host code (not the plugin) deliberately: the loop may
+ * not reach into a plugin's internals (see
+ * `plugin-import-boundary-reverse-guard.test.ts`), and the guarantee must
+ * hold even with the plugin disabled or replaced. The substitution here is
+ * intentionally dumber than the plugin's: static placeholder text only, no
+ * captioning, no persistence, no provider calls. The plugin remains the
+ * quality pass; this is the backstop.
+ *
+ * The placeholder text matches the plugin's no-vision-profile placeholder so
+ * downstream consumers (and tests) observe one consistent degraded form
+ * regardless of which layer substituted it.
+ */
+
+import { getModelProfiles } from "../plugin-api/model-profiles.js";
+import { doesSupportVision } from "../plugin-api/vision-support.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+/**
+ * Text substituted for an image block that cannot be captioned. Kept
+ * byte-identical to the image-fallback plugin's no-vision placeholder (its
+ * `captionImageBlocks` null-profile branch) so both layers degrade to the
+ * same observable form.
+ */
+export const NO_VISION_PLACEHOLDER_TEXT =
+  "[Image: no vision-capable model configured to describe it]";
+
+/**
+ * Whether the model identity a call will actually run under lacks vision
+ * support. Mirrors the plugin's `needsImageFallback`: resolve a profile key
+ * through the configured profiles first, and fall back to treating the key
+ * as a concrete model id for profileless configs.
+ */
+export function modelLacksVisionSupport(modelProfileKey: string): boolean {
+  const profile = getModelProfiles().find((p) => p.key === modelProfileKey);
+  if (profile == null) {
+    return !doesSupportVision(modelProfileKey);
+  }
+  return !doesSupportVision(profile);
+}
+
+/**
+ * Replace every image block in `messages` (in place) with the static
+ * placeholder text block: top-level image blocks and images nested in
+ * `tool_result` `contentBlocks`. Returns the number of blocks replaced.
+ *
+ * Callers own the wire-only contract: pass a clone, never the loop's history.
+ * The walk is deliberately exhaustive rather than mirroring the plugin
+ * sweep's current-turn scoping. The boundary runs on the sanitized outbound
+ * payload, where stale tool-result media has already been stripped to
+ * markers, so anything image-shaped that remains was about to go on the wire
+ * and a text-only model can do nothing with any of it.
+ */
+export function replaceOutboundImagesWithPlaceholders(
+  messages: Message[],
+): number {
+  let replaced = 0;
+  const substitute = (blocks: ContentBlock[]): void => {
+    for (let i = 0; i < blocks.length; i++) {
+      if (blocks[i].type === "image") {
+        blocks[i] = { type: "text", text: NO_VISION_PLACEHOLDER_TEXT };
+        replaced++;
+      }
+    }
+  };
+  for (const message of messages) {
+    substitute(message.content);
+    for (const block of message.content) {
+      if (block.type === "tool_result" && block.contentBlocks != null) {
+        substitute(block.contentBlocks);
+      }
+    }
+  }
+  return replaced;
+}

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -451,17 +451,37 @@ export interface StopContext extends StopInputContext, BaseHookContext {}
 // ─── Pre-model-call hook context ─────────────────────────────────────────────
 
 /**
+ * Outcome of the `pre-model-call` hook chain. The agent loop seeds it to
+ * `"proceed"` and acts on the value the chain settles on:
+ *
+ * - `"proceed"`: issue the provider call (with any edits the chain applied).
+ *   This is the default.
+ * - `"fail"`: do not send. The loop ends the turn through its normal error
+ *   path (an `error` event followed by the `stop` hook with exit reason
+ *   `"error"`), carrying {@link PreModelCallContext.failureReason} as the error
+ *   message. This is the fail-closed lever for a hook that determines the
+ *   outbound request must not reach the resolved model (e.g. media bound for a
+ *   model that cannot accept it, on a call site whose caller retries failures).
+ *   Because the hook pipeline contains hook throws, setting this field is the
+ *   only way a hook can fail the call; a thrown error is logged and the call
+ *   proceeds with the original request.
+ */
+export type PreModelCallDecision = "proceed" | "fail";
+
+/**
  * Context passed to the `pre-model-call` hook. Fires immediately before each
  * provider call — once per model call within a turn, including tool-result
  * follow-up calls. Because it runs for every provider call (background, subagent,
  * and compaction work can share a conversation), hooks MUST self-gate on
  * {@link callSite} / {@link conversationId} before acting.
  *
- * A hook may edit the outbound request by replacing {@link systemPrompt}, route
- * the call to a different inference profile via {@link modelProfile}, and opt
- * this turn into deferred output streaming via {@link deferAssistantOutput}.
- * Mutate the context in place or return a new one; throwing is contained by the
- * loop (the call proceeds with the original request).
+ * A hook may edit the outbound request by replacing {@link systemPrompt} or
+ * rewriting {@link messages}, route the call to a different inference profile
+ * via {@link modelProfile}, opt this turn into deferred output streaming via
+ * {@link deferAssistantOutput}, or fail the call outright via
+ * {@link PreModelCallDecision}. Mutate the context in place or return a new
+ * one; throwing is contained by the loop (the call proceeds with the original
+ * request).
  */
 export interface PreModelCallInputContext {
   /** Conversation ID the call belongs to. */
@@ -495,6 +515,26 @@ export interface PreModelCallInputContext {
    */
   modelProfile: string | null;
   /**
+   * Effective inference-profile identity for the model this run resolved at
+   * turn start: a profile key for named-profile configs, the resolved model id
+   * for profileless configs (mirrors
+   * {@link UserPromptSubmitContext.modelProfileKey}). `null` for raw loop runs
+   * that supply none. A hook judging model capabilities for THIS call should
+   * prefer {@link modelProfile} (the live per-call override, which an earlier
+   * hook in the chain may have rerouted) and fall back to this value.
+   */
+  readonly modelProfileKey: string | null;
+  /**
+   * The outbound provider-bound message history for this call, after the
+   * loop's pre-send sanitization (historical media stripped, AX trees
+   * collapsed, stale web-search results converted to text). A hook may rewrite
+   * it, in place or by returning a new context with a replacement array, and
+   * the loop sends the settled value. Wire payload only: the loop's own
+   * history bookkeeping (persistence, compaction, retries) is untouched by
+   * edits here.
+   */
+  messages: Message[];
+  /**
    * Seeded `false`. When a hook sets it `true`, the loop suppresses this turn's
    * live assistant `text_delta` stream; a `post-model-call` hook is then
    * expected to produce the text the client sees (emitted once, after the reply
@@ -502,6 +542,18 @@ export interface PreModelCallInputContext {
    * redaction that needs the full message — instead of leaking the raw stream.
    */
   deferAssistantOutput: boolean;
+  /**
+   * Seeded `"proceed"`. A hook sets it to `"fail"` to stop the loop from
+   * sending this call and end the turn through the loop's normal error path;
+   * see {@link PreModelCallDecision}. Later hooks in the chain may override it.
+   */
+  decision: PreModelCallDecision;
+  /**
+   * Error message the loop surfaces when {@link decision} settles on `"fail"`.
+   * A failing hook should name the call site, the resolved model, and the
+   * remedy. `null` (with a generic fallback message) when unset.
+   */
+  failureReason: string | null;
 }
 
 /**

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -113,6 +113,7 @@ export type {
   PostModelCallDecision,
   PostToolUseContext,
   PreModelCallContext,
+  PreModelCallDecision,
   ShutdownContext,
   StopContext,
   ToolContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -22,6 +22,7 @@ export type {
   PostModelCallDecision,
   PostToolUseContext,
   PreModelCallContext,
+  PreModelCallDecision,
   StopContext,
   UserPromptSubmitContext,
 } from "../hooks/types.js";

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
@@ -1,0 +1,266 @@
+/**
+ * End-to-end tests for capability-aware media routing at the AgentLoop wire
+ * boundary: the real `pre-model-call` hook registered as a plugin, driving a
+ * real `AgentLoop.run` with a recording mock provider. Covers both invocation
+ * paths' shared seam (main-turn and background wakes both traverse
+ * `AgentLoop.run`, which is where the hook fires):
+ *
+ * - vision-capable model: outbound images reach the provider untouched
+ * - non-vision model with a vision profile: the provider receives captions
+ *   with NO image blocks on the wire, proactively (no rejection round-trip)
+ * - text-only history: untouched
+ * - non-vision model, no vision profile, `memoryRetrospective` call site: the
+ *   run fails observably before any provider call (retryable fail-closed)
+ * - same, `mainAgent` call site: unchanged fall-through to the provider (the
+ *   reactive post-model-call recovery keeps ownership)
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+  ModelProfileInfo,
+} from "@vellumai/plugin-api";
+
+import type { AgentEvent } from "../../../../agent/loop.js";
+import { AgentLoop } from "../../../../agent/loop.js";
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../../../registry.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockProfiles: ModelProfileInfo[];
+let visionProfiles: Set<string>;
+let visionModelKeys: Set<string>;
+let captionProviderCalls: number;
+
+const fakeCaptionProvider = {
+  name: "mock-vision-provider",
+  async sendMessage() {
+    captionProviderCalls++;
+    return { content: [{ type: "text", text: "A bar chart of Q3 revenue." }] };
+  },
+};
+
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModelKeys.has(arg)
+      : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: (source: ImageContent["source"]) =>
+    source.type === "base64"
+      ? { data: source.data, media_type: source.media_type }
+      : null,
+  getConfiguredProvider: async () => fakeCaptionProvider,
+  lastToolResultUserMessageIndex,
+}));
+
+mock.module("../src/image-persist.js", () => ({
+  persistImage: () => "/workspace/data/attachments/mock-hash.png",
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const preModelCall = (await import("../hooks/pre-model-call.js")).default;
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "pre-model-call-loop-test-"));
+initCaptionStore(STORAGE_DIR);
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let imageSeq = 0;
+
+/** A distinct inline image block per call, so the content-hash cache never collides across cases. */
+function makeImage(): ImageContent {
+  imageSeq += 1;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from(`image-bytes-${imageSeq}`).toString("base64"),
+    },
+  };
+}
+
+function userMessage(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+/** A provider that records what it was sent and answers with plain text. */
+function makeRecordingProvider(): {
+  provider: ConstructorParameters<typeof AgentLoop>[0]["provider"];
+  calls: Message[][];
+} {
+  const calls: Message[][] = [];
+  return {
+    calls,
+    provider: {
+      name: "mock-main-provider",
+      async sendMessage(messages: Message[]) {
+        calls.push(structuredClone(messages));
+        return {
+          content: [{ type: "text", text: "done" }] as ContentBlock[],
+          model: "mock-model",
+          usage: { inputTokens: 1, outputTokens: 1 },
+          stopReason: "end_turn",
+        };
+      },
+    },
+  };
+}
+
+function hasImageBlocks(messages: Message[]): boolean {
+  return messages.some((m) =>
+    m.content.some(
+      (b) =>
+        b.type === "image" ||
+        (b.type === "tool_result" &&
+          b.contentBlocks?.some((cb) => cb.type === "image")),
+    ),
+  );
+}
+
+interface RunCase {
+  callSite?: "mainAgent" | "memoryRetrospective";
+  modelProfileKey: string;
+}
+
+async function runLoop(input: Message[], opts: RunCase) {
+  const { provider, calls } = makeRecordingProvider();
+  const loop = new AgentLoop({
+    provider,
+    systemPrompt: "system",
+    conversationId: "conv-media-routing",
+  });
+  const events: AgentEvent[] = [];
+  const result = await loop.run({
+    requestId: "test-request",
+    messages: input,
+    onEvent: (e) => {
+      events.push(e);
+    },
+    trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    callSite: opts.callSite ?? "mainAgent",
+    modelProfileKey: opts.modelProfileKey,
+  });
+  return { calls, events, result };
+}
+
+beforeEach(() => {
+  resetPluginRegistryForTests();
+  resetCaptionCacheForTests();
+  captionProviderCalls = 0;
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as ModelProfileInfo,
+    { key: "text-only-profile", isDisabled: false } as ModelProfileInfo,
+  ];
+  visionProfiles = new Set(["vision-profile"]);
+  visionModelKeys = new Set();
+  registerPlugin({
+    manifest: { name: "image-fallback-under-test", version: "0.0.0" },
+    hooks: { "pre-model-call": preModelCall },
+  });
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("agent loop capability-aware media routing (image-fallback pre-model-call)", () => {
+  test("vision-capable model receives outbound images untouched", async () => {
+    const { calls, events } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "vision-profile" },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(true);
+    expect(captionProviderCalls).toBe(0);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  test("non-vision model with a vision profile receives captions, no image blocks, proactively", async () => {
+    const { calls, result } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "text-only-profile" },
+    );
+
+    // One provider round-trip: the substitution happened before the send, not
+    // via a rejection-and-retry.
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0][0].content.some(
+        (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+      ),
+    ).toBe(true);
+    expect(captionProviderCalls).toBe(1);
+    // The loop's own history keeps the raw image (wire-only substitution).
+    expect(hasImageBlocks(result.history)).toBe(true);
+  });
+
+  test("text-only history reaches a non-vision model untouched", async () => {
+    const input = [userMessage({ type: "text", text: "just text" })];
+    const { calls } = await runLoop(structuredClone(input), {
+      modelProfileKey: "text-only-profile",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].content).toEqual(input[0].content);
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("memoryRetrospective fails closed when no vision profile can caption for a non-vision model", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const { calls, events } = await runLoop([userMessage(makeImage())], {
+      callSite: "memoryRetrospective",
+      modelProfileKey: "text-only-profile",
+    });
+
+    // The provider is never called with the media-bearing request.
+    expect(calls).toHaveLength(0);
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type !== "error") {
+      throw new Error("type narrowing");
+    }
+    expect(errorEvent.error.message).toContain("memoryRetrospective");
+    expect(errorEvent.error.message).toContain("text-only-profile");
+    const exitEvent = events.find((e) => e.type === "agent_loop_exit");
+    if (exitEvent?.type !== "agent_loop_exit") {
+      throw new Error("expected an agent_loop_exit event");
+    }
+    // The turn ends through the ordinary error path, which background callers
+    // treat as a failed (and therefore retryable) run.
+    expect(exitEvent.reason).toBe("error");
+  });
+
+  test("mainAgent with no vision profile falls through to the provider unchanged", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const { calls, events } = await runLoop([userMessage(makeImage())], {
+      callSite: "mainAgent",
+      modelProfileKey: "text-only-profile",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(true);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
@@ -10,7 +10,8 @@
  *   with NO image blocks on the wire, proactively (no rejection round-trip)
  * - text-only history: untouched
  * - non-vision model, no vision profile, `memoryRetrospective` call site: the
- *   run fails observably before any provider call (retryable fail-closed)
+ *   provider receives static placeholders with NO image blocks on the wire,
+ *   and the run completes (a text-only workspace keeps forming memories)
  * - same, `mainAgent` call site: unchanged fall-through to the provider (the
  *   reactive post-model-call recovery keeps ownership)
  */
@@ -225,7 +226,11 @@ describe("agent loop capability-aware media routing (image-fallback pre-model-ca
     expect(captionProviderCalls).toBe(0);
   });
 
-  test("memoryRetrospective fails closed when no vision profile can caption for a non-vision model", async () => {
+  test("memoryRetrospective gets static placeholders when no vision profile can caption for a non-vision model", async () => {
+    // A failed call here would be a deterministic permanent stall for the
+    // conversation's memory cursor (no retry can succeed until a vision
+    // profile is configured), so the boundary substitutes the fail-open
+    // placeholders and lets the pass extract the window's text.
     mockProfiles = [];
     visionProfiles = new Set();
     const { calls, events } = await runLoop([userMessage(makeImage())], {
@@ -233,22 +238,22 @@ describe("agent loop capability-aware media routing (image-fallback pre-model-ca
       modelProfileKey: "text-only-profile",
     });
 
-    // The provider is never called with the media-bearing request.
-    expect(calls).toHaveLength(0);
-    const errorEvent = events.find((e) => e.type === "error");
-    expect(errorEvent).toBeDefined();
-    if (errorEvent?.type !== "error") {
-      throw new Error("type narrowing");
-    }
-    expect(errorEvent.error.message).toContain("memoryRetrospective");
-    expect(errorEvent.error.message).toContain("text-only-profile");
-    const exitEvent = events.find((e) => e.type === "agent_loop_exit");
-    if (exitEvent?.type !== "agent_loop_exit") {
-      throw new Error("expected an agent_loop_exit event");
-    }
-    // The turn ends through the ordinary error path, which background callers
-    // treat as a failed (and therefore retryable) run.
-    expect(exitEvent.reason).toBe("error");
+    // The provider is called exactly once, with no image blocks on the wire
+    // and the static placeholder in their place.
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0].some((m) =>
+        m.content.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.includes("[Image: no vision-capable model configured"),
+        ),
+      ),
+    ).toBe(true);
+    // No vision call was burned producing the placeholders.
+    expect(captionProviderCalls).toBe(0);
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
   });
 
   test("mainAgent with no vision profile falls through to the provider unchanged", async () => {

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
@@ -12,8 +12,12 @@
  * - non-vision model, no vision profile, `memoryRetrospective` call site: the
  *   provider receives static placeholders with NO image blocks on the wire,
  *   and the run completes (a text-only workspace keeps forming memories)
- * - same, `mainAgent` call site: unchanged fall-through to the provider (the
- *   reactive post-model-call recovery keeps ownership)
+ * - same, `mainAgent` call site: the send-boundary enforcement placeholders
+ *   proactively instead of burning a guaranteed provider rejection
+ * - REGRESSIONS for the two hook-chain escapes: a failed/timed-out captioning
+ *   hook (the pipeline discards its mutation) and a later model-router hook
+ *   downgrading to a text-only profile. Both are caught by the loop's final
+ *   send-boundary enforcement: raw media never reaches a text-only model.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -256,7 +260,12 @@ describe("agent loop capability-aware media routing (image-fallback pre-model-ca
     expect(events.find((e) => e.type === "error")).toBeUndefined();
   });
 
-  test("mainAgent with no vision profile falls through to the provider unchanged", async () => {
+  test("mainAgent with no vision profile gets boundary placeholders instead of a guaranteed rejection", async () => {
+    // The hook itself falls through for non-memory call sites when no vision
+    // profile exists, but the loop's send-boundary enforcement now keeps the
+    // raw images off the wire: the provider receives static placeholders in
+    // a single round trip rather than rejecting the request first and
+    // relying on the reactive recovery to retry.
     mockProfiles = [];
     visionProfiles = new Set();
     const { calls, events } = await runLoop([userMessage(makeImage())], {
@@ -265,7 +274,96 @@ describe("agent loop capability-aware media routing (image-fallback pre-model-ca
     });
 
     expect(calls).toHaveLength(1);
-    expect(hasImageBlocks(calls[0])).toBe(true);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0].some((m) =>
+        m.content.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.includes("[Image: no vision-capable model configured"),
+        ),
+      ),
+    ).toBe(true);
     expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  // ── Send-boundary regressions (review blockers) ───────────────────────────
+
+  test("REGRESSION: a failed or timed-out captioning hook cannot fail open into raw-media delivery", async () => {
+    // The pipeline time-boxes each hook and contains its throws in the SAME
+    // catch (`pipeline.ts`: "plugin hook failed" / timed-out hooks reject
+    // through `callWithTimeout` into that catch), so timeout and throw both
+    // produce the identical observable state: the hook's mutation is
+    // discarded and the chain proceeds with the prior context. Register a
+    // hook that dies in place of the real one to produce exactly that state
+    // with a vision profile available: before the boundary enforcement, the
+    // raw images sailed to the text-only provider.
+    resetPluginRegistryForTests();
+    registerPlugin({
+      manifest: { name: "image-fallback-under-test", version: "0.0.0" },
+      hooks: {
+        "pre-model-call": async () => {
+          throw new Error("caption sweep exceeded the hook budget");
+        },
+      },
+    });
+
+    const { calls, result } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "text-only-profile" },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0].some((m) =>
+        m.content.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.includes("[Image: no vision-capable model configured"),
+        ),
+      ),
+    ).toBe(true);
+    // The boundary pass is deterministic: no captioning round-trip is burned
+    // recovering from the dead hook.
+    expect(captionProviderCalls).toBe(0);
+    // Wire-only: the loop's own history keeps the raw image.
+    expect(hasImageBlocks(result.history)).toBe(true);
+  });
+
+  test("REGRESSION: a later model-router hook downgrading to a text-only profile cannot re-expose raw media", async () => {
+    // The real image-fallback hook runs first, sees a vision-capable model,
+    // and passes the images through untouched. A router hook registered
+    // AFTER it then reroutes the call to a text-only profile. The settled
+    // chain previously sent the still-image-bearing payload to the
+    // downgraded model; the send boundary must judge the FINAL profile.
+    registerPlugin({
+      manifest: { name: "model-router-under-test", version: "0.0.0" },
+      hooks: {
+        "pre-model-call": async (ctx) => {
+          (ctx as { modelProfile: string | null }).modelProfile =
+            "text-only-profile";
+        },
+      },
+    });
+
+    const { calls, result } = await runLoop(
+      [userMessage({ type: "text", text: "see" }, makeImage())],
+      { modelProfileKey: "vision-profile" },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(hasImageBlocks(calls[0])).toBe(false);
+    expect(
+      calls[0].some((m) =>
+        m.content.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.includes("[Image: no vision-capable model configured"),
+        ),
+      ),
+    ).toBe(true);
+    expect(captionProviderCalls).toBe(0);
+    expect(hasImageBlocks(result.history)).toBe(true);
   });
 });

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call-loop.test.ts
@@ -73,6 +73,21 @@ mock.module("../src/image-persist.js", () => ({
   persistImage: () => "/workspace/data/attachments/mock-hash.png",
 }));
 
+// The loop's host-side send-boundary guard (`context/outbound-media-guard.ts`)
+// imports these capability modules directly rather than through the
+// "@vellumai/plugin-api" barrel mocked above, so the same fakes are wired at
+// those specifiers too. Both layers must judge capabilities identically for
+// the boundary regressions to be meaningful.
+mock.module("../../../../plugin-api/model-profiles.js", () => ({
+  getModelProfiles: () => mockProfiles,
+}));
+mock.module("../../../../plugin-api/vision-support.js", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModelKeys.has(arg)
+      : visionProfiles.has(arg.key),
+}));
+
 // ─── Imports (after mocks are registered) ───────────────────────────────────
 
 const preModelCall = (await import("../hooks/pre-model-call.js")).default;

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for the image-fallback plugin's `pre-model-call` hook: the
+ * wire-boundary guard that captions outbound images bound for a non-vision
+ * model, fails the background memory call sites closed when no vision profile
+ * exists to caption with, and passes everything else through untouched.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+  ModelProfileInfo,
+  PluginLogger,
+  PreModelCallContext,
+} from "@vellumai/plugin-api";
+
+// Real host helper wired into the mock so the tests exercise the shipped
+// current-turn boundary behavior rather than a stand-in.
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockProfiles: ModelProfileInfo[];
+let visionProfiles: Set<string>;
+/** Bare-string identities (model ids / profile keys) that support vision. */
+let visionModelKeys: Set<string>;
+let captionProviderCalls: number;
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage() {
+    captionProviderCalls++;
+    return { content: [{ type: "text", text: "A bar chart of Q3 revenue." }] };
+  },
+};
+
+const mockResolveMediaSourceData = (source: ImageContent["source"]) =>
+  source.type === "base64"
+    ? { data: source.data, media_type: source.media_type }
+    : null;
+
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModelKeys.has(arg)
+      : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  resolveMediaSourceData: mockResolveMediaSourceData,
+  getConfiguredProvider: async () => fakeProvider,
+  lastToolResultUserMessageIndex,
+}));
+
+mock.module("../src/image-persist.js", () => ({
+  persistImage: () => "/workspace/data/attachments/mock-hash.png",
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const preModelCall = (await import("../hooks/pre-model-call.js")).default;
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "pre-model-call-test-"));
+initCaptionStore(STORAGE_DIR);
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+let imageSeq = 0;
+
+/** A distinct inline image block per call, so the content-hash cache never collides across cases. */
+function makeImage(): ImageContent {
+  imageSeq += 1;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from(`image-bytes-${imageSeq}`).toString("base64"),
+    },
+  };
+}
+
+function userMessage(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+function makeCtx(
+  overrides: Partial<PreModelCallContext> = {},
+): PreModelCallContext {
+  return {
+    conversationId: "conv-pre-model-call",
+    callSite: "mainAgent",
+    systemPrompt: null,
+    modelProfile: null,
+    modelProfileKey: "text-only-profile",
+    messages: [],
+    deferAssistantOutput: false,
+    decision: "proceed",
+    failureReason: null,
+    logger: noopLogger,
+    broadcast: () => {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetCaptionCacheForTests();
+  captionProviderCalls = 0;
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as ModelProfileInfo,
+    { key: "text-only-profile", isDisabled: false } as ModelProfileInfo,
+  ];
+  visionProfiles = new Set(["vision-profile"]);
+  visionModelKeys = new Set();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("image-fallback pre-model-call outbound guard", () => {
+  test("leaves outbound images untouched for a vision-capable model", async () => {
+    visionProfiles.add("text-only-profile");
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("captions outbound images proactively for a non-vision model", async () => {
+    const messages = [userMessage({ type: "text", text: "look" }, makeImage())];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    const blocks = ctx.messages[0].content;
+    expect(blocks.some((b) => b.type === "image")).toBe(false);
+    expect(
+      blocks.some(
+        (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+      ),
+    ).toBe(true);
+    expect(captionProviderCalls).toBe(1);
+  });
+
+  test("captions images nested in current-turn tool_result contentBlocks", async () => {
+    const messages = [
+      userMessage({
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        content: "screenshot taken",
+        contentBlocks: [makeImage()],
+      } as ContentBlock),
+    ];
+    const ctx = makeCtx({ messages });
+
+    await preModelCall(ctx);
+
+    const nested = (
+      ctx.messages[0].content[0] as ContentBlock & {
+        contentBlocks: ContentBlock[];
+      }
+    ).contentBlocks;
+    expect(nested.some((b) => b.type === "image")).toBe(false);
+    expect(nested[0].type).toBe("text");
+  });
+
+  test("reuses the caption cache: a repeated pass over the same image runs no new vision call", async () => {
+    const image = makeImage();
+    const first = makeCtx({ messages: [userMessage(structuredClone(image))] });
+    await preModelCall(first);
+    expect(captionProviderCalls).toBe(1);
+
+    const second = makeCtx({ messages: [userMessage(structuredClone(image))] });
+    await preModelCall(second);
+
+    expect(captionProviderCalls).toBe(1);
+    expect(second.messages[0].content[0].type).toBe("text");
+  });
+
+  test("text-only outbound history is untouched, even on a fail-closed call site with no vision profile", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const messages = [userMessage({ type: "text", text: "just text" })];
+    const ctx = makeCtx({ messages, callSite: "memoryRetrospective" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages).toEqual(messages);
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test.each(["memoryRetrospective", "memoryV2Consolidation"] as const)(
+    "fails %s closed when images meet a non-vision model and no vision profile exists",
+    async (callSite) => {
+      mockProfiles = [];
+      visionProfiles = new Set();
+      const messages = [userMessage(makeImage())];
+      const ctx = makeCtx({ messages, callSite });
+
+      await preModelCall(ctx);
+
+      expect(ctx.decision).toBe("fail");
+      expect(ctx.failureReason).toContain(callSite);
+      expect(ctx.failureReason).toContain("text-only-profile");
+      expect(ctx.failureReason).toContain("vision-capable");
+      // The wire payload is not mutated; the loop never sends it.
+      expect(ctx.messages[0].content[0].type).toBe("image");
+      expect(captionProviderCalls).toBe(0);
+    },
+  );
+
+  test("mainAgent with no vision profile falls through unchanged (reactive recovery keeps ownership)", async () => {
+    mockProfiles = [];
+    visionProfiles = new Set();
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages, callSite: "mainAgent" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.failureReason).toBeNull();
+    expect(ctx.messages[0].content[0].type).toBe("image");
+  });
+
+  test("a fail-closed call site with a vision profile captions instead of failing", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({ messages, callSite: "memoryRetrospective" });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("text");
+    expect(captionProviderCalls).toBe(1);
+  });
+
+  test("prefers the live per-call modelProfile override over the run-level modelProfileKey", async () => {
+    // The run resolved a text-only profile, but an earlier hook rerouted the
+    // call to a vision-capable profile: no captioning should run.
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({
+      messages,
+      modelProfile: "vision-profile",
+      modelProfileKey: "text-only-profile",
+    });
+
+    await preModelCall(ctx);
+
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+
+  test("a bare model id resolves through doesSupportVision when no profile matches", async () => {
+    // Profileless configs carry the resolved model id as the identity.
+    visionModelKeys = new Set(["gpt-6.2-vision"]);
+    const messages = [userMessage(makeImage())];
+    const seen = makeCtx({ messages, modelProfileKey: "gpt-6.2-vision" });
+    await preModelCall(seen);
+    expect(seen.messages[0].content[0].type).toBe("image");
+
+    const textOnly = makeCtx({
+      messages: [userMessage(makeImage())],
+      modelProfileKey: "deepseek-v4-flash",
+    });
+    await preModelCall(textOnly);
+    expect(textOnly.messages[0].content[0].type).toBe("text");
+  });
+
+  test("passes through when neither modelProfile nor modelProfileKey is set", async () => {
+    const messages = [userMessage(makeImage())];
+    const ctx = makeCtx({
+      messages,
+      callSite: null,
+      modelProfile: null,
+      modelProfileKey: null,
+    });
+
+    await preModelCall(ctx);
+
+    expect(ctx.decision).toBe("proceed");
+    expect(ctx.messages[0].content[0].type).toBe("image");
+    expect(captionProviderCalls).toBe(0);
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/pre-model-call.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for the image-fallback plugin's `pre-model-call` hook: the
  * wire-boundary guard that captions outbound images bound for a non-vision
- * model, fails the background memory call sites closed when no vision profile
- * exists to caption with, and passes everything else through untouched.
+ * model, substitutes static placeholders for the background memory call
+ * sites when no vision profile exists to caption with, and passes everything
+ * else through untouched.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -198,7 +199,7 @@ describe("image-fallback pre-model-call outbound guard", () => {
     expect(second.messages[0].content[0].type).toBe("text");
   });
 
-  test("text-only outbound history is untouched, even on a fail-closed call site with no vision profile", async () => {
+  test("text-only outbound history is untouched, even on a background memory call site with no vision profile", async () => {
     mockProfiles = [];
     visionProfiles = new Set();
     const messages = [userMessage({ type: "text", text: "just text" })];
@@ -212,8 +213,11 @@ describe("image-fallback pre-model-call outbound guard", () => {
   });
 
   test.each(["memoryRetrospective", "memoryV2Consolidation"] as const)(
-    "fails %s closed when images meet a non-vision model and no vision profile exists",
+    "substitutes static placeholders for %s when images meet a non-vision model and no vision profile exists",
     async (callSite) => {
+      // Failing the call here instead would stall the conversation's memory
+      // cursor permanently: the trigger (no vision profile configured) is
+      // deterministic, so every retry would fail identically.
       mockProfiles = [];
       visionProfiles = new Set();
       const messages = [userMessage(makeImage())];
@@ -221,12 +225,18 @@ describe("image-fallback pre-model-call outbound guard", () => {
 
       await preModelCall(ctx);
 
-      expect(ctx.decision).toBe("fail");
-      expect(ctx.failureReason).toContain(callSite);
-      expect(ctx.failureReason).toContain("text-only-profile");
-      expect(ctx.failureReason).toContain("vision-capable");
-      // The wire payload is not mutated; the loop never sends it.
-      expect(ctx.messages[0].content[0].type).toBe("image");
+      expect(ctx.decision).toBe("proceed");
+      expect(ctx.failureReason).toBeNull();
+      const blocks = ctx.messages[0].content;
+      expect(blocks.some((b) => b.type === "image")).toBe(false);
+      expect(
+        blocks.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.includes("[Image: no vision-capable model configured"),
+        ),
+      ).toBe(true);
+      // Deterministic preprocessing: no provider round-trip is burned.
       expect(captionProviderCalls).toBe(0);
     },
   );
@@ -244,7 +254,7 @@ describe("image-fallback pre-model-call outbound guard", () => {
     expect(ctx.messages[0].content[0].type).toBe("image");
   });
 
-  test("a fail-closed call site with a vision profile captions instead of failing", async () => {
+  test("a background memory call site with a vision profile captions instead of placeholdering", async () => {
     const messages = [userMessage(makeImage())];
     const ctx = makeCtx({ messages, callSite: "memoryRetrospective" });
 

--- a/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
@@ -1,0 +1,147 @@
+/**
+ * Default `pre-model-call` hook: the wire-boundary guard that keeps raw image
+ * blocks off requests bound for a model that cannot accept them.
+ *
+ * The `user-prompt-submit` sweep captions history images at turn start, but it
+ * only fires on the main-turn orchestrator path. Background wakes (memory
+ * retrospective forks, memory consolidation) enter `AgentLoop.run` directly
+ * and never dispatch that hook, so media-bearing history would otherwise reach
+ * the provider verbatim. This hook runs at the shared invocation boundary,
+ * once per provider call on every path, against the outbound (sanitized) wire
+ * payload in `ctx.messages`:
+ *
+ * - No image blocks outbound, or the resolved model supports vision
+ *   ({@link needsImageFallback} via the live per-call profile override or the
+ *   run's `modelProfileKey`): no-op.
+ * - Images + non-vision model + a vision-capable profile available: replace
+ *   the images with text captions via the plugin's shared outbound sweep
+ *   ({@link captionOutboundImagesInMessages}). The caption cache makes the
+ *   pass lookup-only for anything the turn-start sweep already captioned, so
+ *   keeping both hooks is cheap.
+ * - Images + non-vision model + NO vision profile: for the background memory
+ *   call sites (`memoryRetrospective`, `memoryV2Consolidation`) fail the call
+ *   closed (`decision: "fail"`) so the run surfaces a retryable failure
+ *   instead of silently sending a request the provider will reject; a failed
+ *   retrospective wake leaves the memory cursor untouched, so the work is
+ *   retried once a capable route exists. Every other call site falls through
+ *   unchanged, preserving the reactive `post-model-call` recovery and its
+ *   fail-open placeholder behavior for user-facing turns.
+ *
+ * Every non-trivial decision emits a structured log line with the call site,
+ * resolved profile/model, media count, and decision.
+ */
+
+import {
+  type HookFunction,
+  type LLMCallSite,
+  type PreModelCallContext,
+} from "@vellumai/plugin-api";
+
+import {
+  captionOutboundImagesInMessages,
+  countImageBlocksInMessages,
+  needsImageFallback,
+} from "../src/caption-blocks.js";
+import { findVisionProfile } from "../src/vision-caption.js";
+
+/**
+ * Background memory call sites whose callers own failure handling and retry:
+ * a failed run is re-attempted later, so failing closed loses no work, while
+ * silently sending media to a non-vision route would either reject the run
+ * with an opaque provider error or degrade extraction quality invisibly.
+ */
+const FAIL_CLOSED_MEMORY_CALL_SITES: ReadonlySet<LLMCallSite> = new Set([
+  "memoryRetrospective",
+  "memoryV2Consolidation",
+]);
+
+const preModelCall: HookFunction<PreModelCallContext> = async (ctx) => {
+  const mediaBlocks = countImageBlocksInMessages(ctx.messages);
+  if (mediaBlocks === 0) {
+    return;
+  }
+
+  // The live per-call override (which an earlier hook, e.g. a model router,
+  // may have set) wins over the run-level identity resolved at turn start.
+  const modelKey = ctx.modelProfile ?? ctx.modelProfileKey;
+  if (modelKey == null) {
+    // Raw loop runs (no call site, no resolved identity) carry nothing to
+    // judge capabilities against; leave the request untouched.
+    return;
+  }
+
+  if (!needsImageFallback(modelKey)) {
+    ctx.logger.debug(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        decision: "pass",
+      },
+      "Outbound media bound for a vision-capable model; sending untouched",
+    );
+    return;
+  }
+
+  const visionProfileKey = findVisionProfile();
+  if (visionProfileKey != null) {
+    const captioned = await captionOutboundImagesInMessages(
+      ctx.messages,
+      ctx.conversationId,
+      visionProfileKey,
+      ctx.logger,
+    );
+    ctx.logger.info(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        captioned,
+        decision: "captioned",
+      },
+      "Replaced outbound image blocks with text captions for text-only model",
+    );
+    return;
+  }
+
+  if (ctx.callSite != null && FAIL_CLOSED_MEMORY_CALL_SITES.has(ctx.callSite)) {
+    ctx.decision = "fail";
+    ctx.failureReason =
+      `Model call for background call site "${ctx.callSite}" carries ` +
+      `${mediaBlocks} image block(s), but its resolved model ` +
+      `("${modelKey}") does not support image input and no vision-capable ` +
+      `profile is configured to caption them. Configure a vision-capable ` +
+      `model profile, or route the "${ctx.callSite}" call site to a ` +
+      `vision-capable model; the run will be retried.`;
+    ctx.logger.error(
+      {
+        plugin: "image-fallback",
+        callSite: ctx.callSite,
+        modelProfileKey: modelKey,
+        mediaBlocks,
+        decision: "fail_closed",
+      },
+      "Failing background memory model call closed: outbound media, non-vision model, and no vision profile to caption with",
+    );
+    return;
+  }
+
+  // No vision profile and not a fail-closed call site: fall through with the
+  // request untouched. The turn-start sweep has already placeholdered what it
+  // saw, and the reactive post-model-call recovery handles a provider
+  // rejection of anything that leaked past it.
+  ctx.logger.warn(
+    {
+      plugin: "image-fallback",
+      callSite: ctx.callSite,
+      modelProfileKey: modelKey,
+      mediaBlocks,
+      decision: "pass",
+    },
+    "Outbound media bound for a text-only model with no vision profile; leaving it to reactive recovery",
+  );
+};
+
+export default preModelCall;

--- a/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
@@ -31,10 +31,14 @@
  *
  * The preventive check reads the profile override as settled at THIS hook's
  * position in the chain; a later user-land hook that reroutes the call to a
- * text-only profile bypasses it (default hooks dispatch before user hooks).
- * That leak is caught by the reactive `post-model-call` recovery, which
- * placeholders the rejected media and retries, so the boundary stays
- * defense-in-depth rather than a single gate.
+ * text-only profile bypasses it (default hooks dispatch before user hooks),
+ * and the pipeline discards this hook's mutation entirely when it throws or
+ * times out. Both escapes are closed by the loop's final send-boundary
+ * enforcement (`agent/loop.ts`), which judges the settled chain's FINAL
+ * profile and statically placeholders any media still bound for a text-only
+ * model. This hook stays the quality pass (captions when a vision profile
+ * exists); the boundary is the guarantee, and the reactive
+ * `post-model-call` recovery remains the net for provider-side surprises.
  *
  * Every non-trivial decision emits a structured log line with the call site,
  * resolved profile/model, media count, and decision.

--- a/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
@@ -19,13 +19,22 @@
  *   pass lookup-only for anything the turn-start sweep already captioned, so
  *   keeping both hooks is cheap.
  * - Images + non-vision model + NO vision profile: for the background memory
- *   call sites (`memoryRetrospective`, `memoryV2Consolidation`) fail the call
- *   closed (`decision: "fail"`) so the run surfaces a retryable failure
- *   instead of silently sending a request the provider will reject; a failed
- *   retrospective wake leaves the memory cursor untouched, so the work is
- *   retried once a capable route exists. Every other call site falls through
- *   unchanged, preserving the reactive `post-model-call` recovery and its
- *   fail-open placeholder behavior for user-facing turns.
+ *   call sites (`memoryRetrospective`, `memoryV2Consolidation`) substitute
+ *   the fail-open text placeholders (deterministic preprocessing: the same
+ *   stand-ins the reactive recovery produces, minus the wasted provider
+ *   round-trip). The pass still runs, so a workspace whose only models are
+ *   text-only keeps forming memories from the window's text; the trigger is
+ *   deterministic, so failing the call instead would stall that
+ *   conversation's memory cursor permanently. Every other call site falls
+ *   through unchanged, preserving the reactive `post-model-call` recovery
+ *   and its fail-open placeholder behavior for user-facing turns.
+ *
+ * The preventive check reads the profile override as settled at THIS hook's
+ * position in the chain; a later user-land hook that reroutes the call to a
+ * text-only profile bypasses it (default hooks dispatch before user hooks).
+ * That leak is caught by the reactive `post-model-call` recovery, which
+ * placeholders the rejected media and retries, so the boundary stays
+ * defense-in-depth rather than a single gate.
  *
  * Every non-trivial decision emits a structured log line with the call site,
  * resolved profile/model, media count, and decision.
@@ -45,12 +54,12 @@ import {
 import { findVisionProfile } from "../src/vision-caption.js";
 
 /**
- * Background memory call sites whose callers own failure handling and retry:
- * a failed run is re-attempted later, so failing closed loses no work, while
- * silently sending media to a non-vision route would either reject the run
- * with an opaque provider error or degrade extraction quality invisibly.
+ * Background memory call sites that get deterministic media preprocessing at
+ * this boundary even when no vision profile exists: their runs enter
+ * `AgentLoop.run` without the turn-start sweep, so this hook is the only
+ * placeholder pass their outbound payload gets before the provider call.
  */
-const FAIL_CLOSED_MEMORY_CALL_SITES: ReadonlySet<LLMCallSite> = new Set([
+const BACKGROUND_MEMORY_CALL_SITES: ReadonlySet<LLMCallSite> = new Set([
   "memoryRetrospective",
   "memoryV2Consolidation",
 ]);
@@ -106,29 +115,34 @@ const preModelCall: HookFunction<PreModelCallContext> = async (ctx) => {
     return;
   }
 
-  if (ctx.callSite != null && FAIL_CLOSED_MEMORY_CALL_SITES.has(ctx.callSite)) {
-    ctx.decision = "fail";
-    ctx.failureReason =
-      `Model call for background call site "${ctx.callSite}" carries ` +
-      `${mediaBlocks} image block(s), but its resolved model ` +
-      `("${modelKey}") does not support image input and no vision-capable ` +
-      `profile is configured to caption them. Configure a vision-capable ` +
-      `model profile, or route the "${ctx.callSite}" call site to a ` +
-      `vision-capable model; the run will be retried.`;
-    ctx.logger.error(
+  if (ctx.callSite != null && BACKGROUND_MEMORY_CALL_SITES.has(ctx.callSite)) {
+    // No vision profile anywhere: substitute the fail-open placeholders (a
+    // null vision profile makes the sweep emit its static stand-in text
+    // instead of captions). The pass proceeds and still extracts the
+    // window's text; failing the call here would be a deterministic
+    // permanent stall for the conversation's memory cursor, since a retry
+    // can never do better until the configuration itself changes.
+    const placeholdered = await captionOutboundImagesInMessages(
+      ctx.messages,
+      ctx.conversationId,
+      null,
+      ctx.logger,
+    );
+    ctx.logger.warn(
       {
         plugin: "image-fallback",
         callSite: ctx.callSite,
         modelProfileKey: modelKey,
         mediaBlocks,
-        decision: "fail_closed",
+        placeholdered,
+        decision: "placeholdered",
       },
-      "Failing background memory model call closed: outbound media, non-vision model, and no vision profile to caption with",
+      "Replaced outbound image blocks with static placeholders for background memory call: no vision-capable profile is configured to caption them",
     );
     return;
   }
 
-  // No vision profile and not a fail-closed call site: fall through with the
+  // No vision profile and not a background memory call site: fall through with the
   // request untouched. The turn-start sweep has already placeholdered what it
   // saw, and the reactive post-model-call recovery handles a provider
   // rejection of anything that leaked past it.

--- a/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/pre-model-call.ts
@@ -34,11 +34,12 @@
  * text-only profile bypasses it (default hooks dispatch before user hooks),
  * and the pipeline discards this hook's mutation entirely when it throws or
  * times out. Both escapes are closed by the loop's final send-boundary
- * enforcement (`agent/loop.ts`), which judges the settled chain's FINAL
- * profile and statically placeholders any media still bound for a text-only
- * model. This hook stays the quality pass (captions when a vision profile
- * exists); the boundary is the guarantee, and the reactive
- * `post-model-call` recovery remains the net for provider-side surprises.
+ * enforcement (the host-side `context/outbound-media-guard.ts`, applied in
+ * `agent/loop.ts`), which judges the settled chain's FINAL profile and
+ * statically placeholders any media still bound for a text-only model. This
+ * hook stays the quality pass (captions when a vision profile exists); the
+ * boundary is the guarantee, and the reactive `post-model-call` recovery
+ * remains the net for provider-side surprises.
  *
  * Every non-trivial decision emits a structured log line with the call site,
  * resolved profile/model, media count, and decision.

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -182,6 +182,34 @@ export async function captionImagesInMessages(
 }
 
 /**
+ * Count every image block a provider request built from `messages` would
+ * carry: top-level image blocks plus images nested in `tool_result`
+ * `contentBlocks`. Used on an outbound (already-sanitized) history, where
+ * stale tool-result media has been stripped to markers, so the count is
+ * exactly the set {@link captionOutboundImagesInMessages} would substitute.
+ * Read-only.
+ */
+export function countImageBlocksInMessages(
+  messages: ReadonlyArray<Message>,
+): number {
+  let imageCount = 0;
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block.type === "image") {
+        imageCount++;
+      } else if (block.type === "tool_result" && block.contentBlocks != null) {
+        for (const nested of block.contentBlocks) {
+          if (nested.type === "image") {
+            imageCount++;
+          }
+        }
+      }
+    }
+  }
+  return imageCount;
+}
+
+/**
  * Caption only the image blocks a rejected model call would still carry after
  * the host's outbound media-stripping: every top-level image block (the
  * sanitizer never strips those) plus tool_result media in the current-turn

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -49,6 +49,7 @@ import imageFallbackInit from "./image-fallback/hooks/init.js";
 import imageFallbackPostCompact from "./image-fallback/hooks/post-compact.js";
 import imageFallbackPostModelCall from "./image-fallback/hooks/post-model-call.js";
 import imageFallbackPostToolUse from "./image-fallback/hooks/post-tool-use.js";
+import imageFallbackPreModelCall from "./image-fallback/hooks/pre-model-call.js";
 import imageFallbackShutdown from "./image-fallback/hooks/shutdown.js";
 import imageFallbackStop from "./image-fallback/hooks/stop.js";
 import imageFallbackUserPromptSubmit from "./image-fallback/hooks/user-prompt-submit.js";
@@ -102,13 +103,18 @@ import workspacePkg from "./workspace/package.json" with { type: "json" };
  * screenshot) nested in the tool result's `contentBlocks`; the `post-compact`
  * hook re-sweeps the rebuilt history after a mid-turn compaction, whose
  * retained images and persistence-restored tool results land after the
- * turn-start sweep. The `post-model-call` hook backstops raw images that
- * reach the provider anyway (messages joining an in-flight turn, catalog
- * entries that call a model vision-capable when its serving endpoint rejects
- * images): on a vision-not-supported rejection it captions the working
- * history and retries, bounded to one pass per turn, with the `stop` hook
- * clearing the recovery bound on a terminal stop. Fail-open with a
- * placeholder when no vision profile is configured or captioning fails. A
+ * turn-start sweep. The `pre-model-call` hook guards the wire boundary every
+ * provider call crosses (including background wakes, which skip
+ * `user-prompt-submit`): outbound images bound for a non-vision model are
+ * captioned proactively, and the background memory call sites fail closed
+ * when no vision profile exists to caption with. The `post-model-call` hook
+ * backstops raw images that reach the provider anyway (messages joining an
+ * in-flight turn, catalog entries that call a model vision-capable when its
+ * serving endpoint rejects images): on a vision-not-supported rejection it
+ * captions the working history and retries, bounded to one pass per turn,
+ * with the `stop` hook clearing the recovery bound on a terminal stop.
+ * Fail-open with a placeholder when no vision profile is configured or
+ * captioning fails (outside the fail-closed memory call sites). A
  * read-through content-hash cache (in-memory LRU over a plugin-owned SQLite
  * file, opened by `init` in the plugin's storage dir and closed by
  * `shutdown`) avoids re-captioning the same image across turns, compactions,
@@ -126,6 +132,7 @@ export const defaultImageFallbackPlugin: Plugin = {
     "user-prompt-submit": imageFallbackUserPromptSubmit,
     "post-tool-use": imageFallbackPostToolUse,
     "post-compact": imageFallbackPostCompact,
+    "pre-model-call": imageFallbackPreModelCall,
     "post-model-call": imageFallbackPostModelCall,
     stop: imageFallbackStop,
     "conversation-deleted": imageFallbackConversationDeleted,

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -106,15 +106,16 @@ import workspacePkg from "./workspace/package.json" with { type: "json" };
  * turn-start sweep. The `pre-model-call` hook guards the wire boundary every
  * provider call crosses (including background wakes, which skip
  * `user-prompt-submit`): outbound images bound for a non-vision model are
- * captioned proactively, and the background memory call sites fail closed
- * when no vision profile exists to caption with. The `post-model-call` hook
+ * captioned proactively, and the background memory call sites get static
+ * placeholders when no vision profile exists to caption with, so those
+ * passes complete on text-only workspaces. The `post-model-call` hook
  * backstops raw images that reach the provider anyway (messages joining an
  * in-flight turn, catalog entries that call a model vision-capable when its
  * serving endpoint rejects images): on a vision-not-supported rejection it
  * captions the working history and retries, bounded to one pass per turn,
  * with the `stop` hook clearing the recovery bound on a terminal stop.
  * Fail-open with a placeholder when no vision profile is configured or
- * captioning fails (outside the fail-closed memory call sites). A
+ * captioning fails. A
  * read-through content-hash cache (in-memory LRU over a plugin-owned SQLite
  * file, opened by `init` in the plugin's storage dir and closed by
  * `shutdown`) avoids re-captioning the same image across turns, compactions,

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -207,6 +207,9 @@ const HOOK_OUTPUT_SCHEMAS: Partial<
   [HOOKS.POST_COMPACT]: z.looseObject({
     history: z.array(MessageSchema).optional(),
   }),
+  [HOOKS.PRE_MODEL_CALL]: z.looseObject({
+    messages: z.array(MessageSchema).optional(),
+  }),
   [HOOKS.POST_MODEL_CALL]: z.looseObject({
     messages: z.array(MessageSchema).optional(),
     content: z.array(ContentBlockSchema).optional(),


### PR DESCRIPTION
## TL;DR

Media is no longer sent to a model that declares `supportsVision: false`, from either the main turn or a background wake, enforced once at the boundary every path traverses: the shared pre-model-call hook in `AgentLoop`. Part of LUM-3016; part 3 of a 4-PR series (finalization/outcomes #39914, consolidation ownership #39915, rewind CLI #39917).

## Why this is needed

Verified on a live workspace: the shipped `memoryRetrospective` default resolves to a non-vision model, and background wakes bypass the main turn's reactive image sweep — so every image-bearing memory window burned a guaranteed provider rejection (39 explicit `vision_unsupported` failures across eight conversations in one day, LUM-3016). The exposure is any Vellum-default workspace on v0.10.3–v0.11.1 with memory enabled and an image-bearing window, and the failure is *configuration-deterministic*: retrying the same window against the same model can never succeed.

## Why this approach

- **One guard at the shared boundary, not per-caller patches.** Main turns, retrospective wakes, and consolidation wakes all pass through the model call in `AgentLoop`. `PreModelCallInputContext` now carries the outbound wire `messages` (rewritable) and a proceed/fail `decision`, mirroring the existing post-model-call flow — a capability the hook contract needed anyway, rather than a special case for memory.
- **Degrade deterministically instead of failing deterministically.** With a vision-capable profile available, media is captioned proactively through the existing caption cache (no provider round-trip burned). With no vision profile anywhere (text-only BYOK), background memory call sites replace image blocks with the plugin's static fail-open placeholder so the pass completes and the window's *text* still becomes memory. Failing the call instead would stall the conversation's memory cursor permanently — the trigger is configuration, not transient state.
- **Wire-only rewriting.** The hook rewrites only what is sent to the provider; persisted history is untouched, so nothing the user sees changes and nothing is lost if the guard's decision improves later (e.g. a vision profile is configured).
- **Interactive turns keep today's reactive recovery** — their model is user-chosen and a rejection is visible and recoverable in-place; the deterministic path is reserved for the background call sites where nobody is watching.

## The invariant is enforced at the send boundary, not just the hook

The hook is a best-effort quality pass with two structural escapes: the pipeline discards a hook's mutation when it throws or times out (both funnel through the same fail-open catch), and a hook registered later in the chain can reroute the call to a text-only profile after the guard has passed. Both are closed where they terminate: after the hook chain settles, immediately before provider send, the loop judges the **final** profile identity and replaces any image blocks still bound for a text-only model with deterministic static placeholders, on a clone of the wire payload. The enforcement lives in host code (`context/outbound-media-guard.ts`), not the plugin, so the guarantee holds even with the plugin disabled and the host/plugin import boundary stays clean; the placeholder text is byte-identical across both layers. No captioning happens at the boundary (cheap, bounded, provider-call-free); the hook remains the captioning quality pass, the boundary owns the guarantee, and every boundary substitution logs call site, final model identity, and residual media count. A side benefit: a `mainAgent` turn with no vision profile now gets proactive placeholders in one round trip instead of a guaranteed provider rejection followed by the reactive retry.

Classified, no code change: v1 `memoryExtraction` can send raw images on a direct provider call, but that path is inactive under V3-live and the tier is in retirement.

## Why this is safe

The hook only rewrites the wire payload (never persisted history); it reuses the existing caption sweep and cache rather than introducing a second captioning path; hook throws remain fail-open with the reactive post-model-call recovery as the net; and the `PRE_MODEL_CALL` output schema rejects malformed mutations. Every decision logs call site, resolved model identity, media count, and outcome, so the guard's behavior is auditable per call.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Image-bearing conversation, retrospective on the shipped non-vision default, a vision profile exists | Provider rejects the window; no derived memory, ever | Images are captioned; full-fidelity memory pass |
| Same, but no vision-capable profile configured anywhere (text-only BYOK) | Provider rejects the window; no derived memory, ever | Images become static text placeholders; memory still forms from the window's text |
| Interactive turns | Reactive post-model-call recovery | Unchanged |

## Coverage

Decision-matrix suite 12/12, end-to-end real-AgentLoop suite 7/7 (proactive single round-trip, wire-only substitution, placeholder substitution with a single provider call, plus the two send-boundary regressions: a dead captioning hook and a later text-only downgrade both keep raw media off the wire), loop-mechanics suite 5/5, plus existing image-fallback (31), vision-recovery (10), agent-loop (59), caption-cache (12) suites green per-file; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
