### PR TITLE
fix(persistence): project the grouped tool-result row once per turn

### DIFF
--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -29,6 +29,7 @@ import {
   createConversation,
   deleteConversation,
   updateConversationTitle,
+  updateMessageContent,
 } from "../persistence/conversation-crud.js";
 import {
   getConversationDirPath,
@@ -145,6 +146,114 @@ describe("addMessage + syncMessageToDisk → disk view", () => {
       .split("\n");
     const record = JSON.parse(lines[0]);
     expect(record.attachments).toEqual(["screenshot.png"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync idempotency: one DB row projects to one JSONL record
+// ---------------------------------------------------------------------------
+
+describe("syncMessageToDisk idempotency", () => {
+  beforeEach(() => {
+    resetTables();
+    resetConversationsDir();
+  });
+
+  function readJsonlLines(convId: string, createdAt: number): string[] {
+    const jsonlPath = join(
+      getConversationDirPath(convId, createdAt),
+      "messages.jsonl",
+    );
+    return readFileSync(jsonlPath, "utf-8").trim().split("\n");
+  }
+
+  test("re-syncing an unchanged row does not append a duplicate record", async () => {
+    const conv = createConversation("Idempotent Sync");
+    const msg = await addMessage(conv.id, "user", "Hello once", {
+      skipIndexing: true,
+    });
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const lines = readJsonlLines(conv.id, conv.createdAt);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).content).toBe("Hello once");
+  });
+
+  // The grouped tool-result row is written to the DB as each result arrives
+  // and projected to JSONL only at finalize. The agent loop used to sync the
+  // row once per arriving result AND once at finalize, so a turn with N tool
+  // results appended N + 1 byte-identical records; this fixture drives that
+  // exact N + 1 call pattern against the same row and asserts the projection
+  // holds one record. A retried finalize (e.g. after crash recovery) is the
+  // same call shape. The turn-boundary git commit touches no message rows, so
+  // a commit timeout with background completion cannot introduce a duplicate
+  // either: the only JSONL append for the row is the finalize sync.
+  // Parameterized across both persisted tool id shapes: Anthropic-style
+  // `toolu_` ids and OpenAI Responses-native `call_` ids.
+  for (const idPrefix of ["toolu", "call"] as const) {
+    test(`the pre-fix N+1 sync pattern for a grouped tool-result row (${idPrefix}_ ids) projects one record`, async () => {
+      const conv = createConversation(`Tool Result Sync ${idPrefix}`);
+      const nToolResults = 3;
+      const batch = Array.from({ length: nToolResults }, (_, i) => ({
+        type: "tool_result",
+        tool_use_id: `${idPrefix}_${i + 1}`,
+        content: `result ${i + 1}`,
+      }));
+      const msg = await addMessage(conv.id, "user", JSON.stringify(batch), {
+        skipIndexing: true,
+      });
+
+      // One sync per arriving tool result, then the finalize sync.
+      for (let i = 0; i < nToolResults; i++) {
+        syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+      }
+      syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+      const lines = readJsonlLines(conv.id, conv.createdAt);
+      expect(lines).toHaveLength(1);
+      const record = JSON.parse(lines[0]);
+      expect(record.role).toBe("user");
+      expect(record.toolResults).toEqual(
+        batch.map((block) => ({ content: block.content })),
+      );
+    });
+  }
+
+  test("a row whose content changed since its last sync appends a new record", async () => {
+    const conv = createConversation("Changed Row");
+    const msg = await addMessage(conv.id, "user", "first draft", {
+      skipIndexing: true,
+    });
+
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+    updateMessageContent(msg.id, "final content");
+    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
+
+    const lines = readJsonlLines(conv.id, conv.createdAt);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).content).toBe("first draft");
+    expect(JSON.parse(lines[1]).content).toBe("final content");
+  });
+
+  test("distinct rows each project their own record", async () => {
+    const conv = createConversation("Distinct Rows");
+    const first = await addMessage(conv.id, "user", "question", {
+      skipIndexing: true,
+    });
+    const second = await addMessage(conv.id, "assistant", "answer", {
+      skipIndexing: true,
+    });
+
+    syncMessageToDisk(conv.id, first.id, conv.createdAt);
+    syncMessageToDisk(conv.id, second.id, conv.createdAt);
+
+    const lines = readJsonlLines(conv.id, conv.createdAt);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).content).toBe("question");
+    expect(JSON.parse(lines[1]).content).toBe("answer");
   });
 });
 

--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -183,14 +183,14 @@ describe("syncMessageToDisk idempotency", () => {
   });
 
   // The grouped tool-result row is written to the DB as each result arrives
-  // and projected to JSONL only at finalize. The agent loop used to sync the
-  // row once per arriving result AND once at finalize, so a turn with N tool
-  // results appended N + 1 byte-identical records; this fixture drives that
-  // exact N + 1 call pattern against the same row and asserts the projection
-  // holds one record. A retried finalize (e.g. after crash recovery) is the
-  // same call shape. The turn-boundary git commit touches no message rows, so
-  // a commit timeout with background completion cannot introduce a duplicate
-  // either: the only JSONL append for the row is the finalize sync.
+  // and projected to JSONL only at finalize. This fixture drives N + 1 sync
+  // calls against the same row (one per arriving result plus one at
+  // finalize) and asserts the projection holds exactly one record: the tail
+  // guard must absorb repeated syncs of a row no matter how many arrive. A
+  // retried finalize (e.g. after crash recovery) is the same call shape. The
+  // turn-boundary git commit touches no message rows, so a commit timeout
+  // with background completion cannot introduce a duplicate either: the only
+  // JSONL append for the row is the finalize sync.
   // Parameterized across both persisted tool id shapes: Anthropic-style
   // `toolu_` ids and OpenAI Responses-native `call_` ids.
   for (const idPrefix of ["toolu", "call"] as const) {

--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -150,10 +150,10 @@ describe("addMessage + syncMessageToDisk → disk view", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Sync idempotency: one DB row projects to one JSONL record
+// Append semantics: one call appends one record, unconditionally
 // ---------------------------------------------------------------------------
 
-describe("syncMessageToDisk idempotency", () => {
+describe("syncMessageToDisk append semantics", () => {
   beforeEach(() => {
     resetTables();
     resetConversationsDir();
@@ -167,60 +167,25 @@ describe("syncMessageToDisk idempotency", () => {
     return readFileSync(jsonlPath, "utf-8").trim().split("\n");
   }
 
-  test("re-syncing an unchanged row does not append a duplicate record", async () => {
-    const conv = createConversation("Idempotent Sync");
+  // Pins the caller contract: the projection appends per call and carries no
+  // row identity, so a row synced twice lands twice. Callers must therefore
+  // sync each row exactly once, at the seam where its content is final. This
+  // is what makes an on-arrival sync of a row that is rewritten in place (the
+  // grouped tool-result row) a duplication bug rather than a harmless retry.
+  test("syncing the same row twice appends two records", async () => {
+    const conv = createConversation("Repeated Sync");
     const msg = await addMessage(conv.id, "user", "Hello once", {
       skipIndexing: true,
     });
 
     syncMessageToDisk(conv.id, msg.id, conv.createdAt);
     syncMessageToDisk(conv.id, msg.id, conv.createdAt);
-    syncMessageToDisk(conv.id, msg.id, conv.createdAt);
 
     const lines = readJsonlLines(conv.id, conv.createdAt);
-    expect(lines).toHaveLength(1);
+    expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0]).content).toBe("Hello once");
+    expect(JSON.parse(lines[1]).content).toBe("Hello once");
   });
-
-  // The grouped tool-result row is written to the DB as each result arrives
-  // and projected to JSONL only at finalize. This fixture drives N + 1 sync
-  // calls against the same row (one per arriving result plus one at
-  // finalize) and asserts the projection holds exactly one record: the tail
-  // guard must absorb repeated syncs of a row no matter how many arrive. A
-  // retried finalize (e.g. after crash recovery) is the same call shape. The
-  // turn-boundary git commit touches no message rows, so a commit timeout
-  // with background completion cannot introduce a duplicate either: the only
-  // JSONL append for the row is the finalize sync.
-  // Parameterized across both persisted tool id shapes: Anthropic-style
-  // `toolu_` ids and OpenAI Responses-native `call_` ids.
-  for (const idPrefix of ["toolu", "call"] as const) {
-    test(`the pre-fix N+1 sync pattern for a grouped tool-result row (${idPrefix}_ ids) projects one record`, async () => {
-      const conv = createConversation(`Tool Result Sync ${idPrefix}`);
-      const nToolResults = 3;
-      const batch = Array.from({ length: nToolResults }, (_, i) => ({
-        type: "tool_result",
-        tool_use_id: `${idPrefix}_${i + 1}`,
-        content: `result ${i + 1}`,
-      }));
-      const msg = await addMessage(conv.id, "user", JSON.stringify(batch), {
-        skipIndexing: true,
-      });
-
-      // One sync per arriving tool result, then the finalize sync.
-      for (let i = 0; i < nToolResults; i++) {
-        syncMessageToDisk(conv.id, msg.id, conv.createdAt);
-      }
-      syncMessageToDisk(conv.id, msg.id, conv.createdAt);
-
-      const lines = readJsonlLines(conv.id, conv.createdAt);
-      expect(lines).toHaveLength(1);
-      const record = JSON.parse(lines[0]);
-      expect(record.role).toBe("user");
-      expect(record.toolResults).toEqual(
-        batch.map((block) => ({ content: block.content })),
-      );
-    });
-  }
 
   test("a row whose content changed since its last sync appends a new record", async () => {
     const conv = createConversation("Changed Row");

--- a/assistant/src/__tests__/conversation-tool-result-disk-projection.test.ts
+++ b/assistant/src/__tests__/conversation-tool-result-disk-projection.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The grouped tool-result row is rewritten in place as each parallel result
+ * lands, so it is durable in the DB well before the turn ends. The JSONL disk
+ * view is append-only and its records carry no row identity, so every sync of
+ * that row adds a line: projecting it anywhere but its final seam multiplies
+ * the row on disk (N results yield N + 1 copies, byte-identical because each
+ * concurrent writer snapshots the batch after the shared reservation resolves).
+ *
+ * This fixture drives a turn with three parallel tool results through the real
+ * handlers and asserts the row reaches `messages.jsonl` exactly once.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
+// One entry per `syncMessageToDisk` call, in order. The JSONL file appends one
+// record per call, so the call count for a row is the number of lines it
+// projects to.
+let diskSyncs: string[] = [];
+
+mock.module("../persistence/conversation-disk-view.js", () => ({
+  syncMessageToDisk: (_convId: string, messageId: string) => {
+    diskSyncs.push(messageId);
+  },
+  initConversationDir: () => {},
+  updateMetaFile: () => {},
+  removeConversationDir: () => {},
+  rebuildConversationDiskViewFromDbState: () => {},
+  getConversationDirName: () => "conv-1",
+  getConversationDirPath: () => "/tmp/conv-1",
+}));
+
+// Role each reserved row was opened with, keyed by row id. The grouped
+// tool-result row is the `user` reservation; the assistant row is the
+// `assistant` one. Content lands through the in-flight writer rather than
+// `updateMessageContent`, so the reservation role is what identifies the row.
+let reservedRowRoles: Map<string, string> = new Map();
+let reserveCounter = 0;
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => [],
+  getConversation: () => ({
+    id: "conv-1",
+    createdAt: 1_700_000_000_000,
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: (_convId: string, _role: string, _content: string) => ({
+    id: "msg-user",
+  }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  getMessageById: () => null,
+  getLastUserTimestampBefore: () => 0,
+  reserveMessage: mock(async (_convId: string, role: string) => {
+    const id = `msg-reserve-${++reserveCounter}`;
+    reservedRowRoles.set(id, role);
+    return { id };
+  }),
+  updateMessageContent: mock(() => {}),
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+const TOOL_RESULT_COUNT = 3;
+
+// A turn that runs three tools in parallel and completes normally.
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<AgentLoopRunResult> {
+      const { messages, onEvent } = options;
+      await onEvent({ type: "llm_call_started" });
+      const history = [...messages];
+
+      const assistantMessage: Message = {
+        role: "assistant",
+        content: Array.from({ length: TOOL_RESULT_COUNT }, (_, i) => ({
+          type: "tool_use" as const,
+          id: `toolu_${i + 1}`,
+          name: "bash",
+          input: { cmd: `echo ${i + 1}` },
+        })),
+      };
+      history.push(assistantMessage);
+      onEvent({
+        type: "usage",
+        inputTokens: 10,
+        outputTokens: 20,
+        model: "mock",
+        providerDurationMs: 50,
+      });
+      onEvent({ type: "message_complete", message: assistantMessage });
+
+      // Parallel results: the real loop emits these synchronously, so every
+      // handler reaches the shared row reservation before the first resolves.
+      for (let i = 0; i < TOOL_RESULT_COUNT; i++) {
+        onEvent({
+          type: "tool_result",
+          toolUseId: `toolu_${i + 1}`,
+          content: `result ${i + 1}`,
+          isError: false,
+        });
+      }
+
+      history.push({
+        role: "user",
+        content: Array.from({ length: TOOL_RESULT_COUNT }, (_, i) => ({
+          type: "tool_result" as const,
+          tool_use_id: `toolu_${i + 1}`,
+          content: `result ${i + 1}`,
+          is_error: false,
+        })),
+      });
+
+      return {
+        history,
+        exitReason: null,
+        newMessages: history.slice(messages.length),
+      };
+    }
+  },
+}));
+
+import { Conversation } from "../daemon/conversation.js";
+
+function makeConversation(): Conversation {
+  const provider = {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return new Conversation(
+    "conv-1",
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+}
+
+describe("grouped tool-result row disk projection", () => {
+  test("a turn with parallel tool results projects the grouped row once", async () => {
+    diskSyncs = [];
+    reservedRowRoles = new Map();
+    reserveCounter = 0;
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    await conversation.processMessage({
+      content: "Run tools",
+      attachments: [],
+    });
+
+    // Identify the grouped row by the role it was reserved with rather than
+    // by reservation order, so the assertion survives a change in which row
+    // is reserved first.
+    const groupedRowIds = Array.from(reservedRowRoles.entries())
+      .filter(([, role]) => role === "user")
+      .map(([id]) => id);
+
+    expect(groupedRowIds).toHaveLength(1);
+    const groupedRowId = groupedRowIds[0];
+
+    // The whole batch lands in one row, so one line on disk.
+    expect(diskSyncs.filter((id) => id === groupedRowId)).toHaveLength(1);
+
+    // Guard against the assertion passing because the row was never projected
+    // at all: the assistant row of the same turn must also reach disk once.
+    const assistantRowIds = Array.from(reservedRowRoles.entries())
+      .filter(([, role]) => role === "assistant")
+      .map(([id]) => id);
+    expect(assistantRowIds).toHaveLength(1);
+    expect(diskSyncs.filter((id) => id === assistantRowIds[0])).toHaveLength(1);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1929,7 +1929,8 @@ function ensureToolResultRowReserved(
  * `tool_result` blocks of one turn in a single message. `seq` is the position
  * stamped on the triggering `tool_result` event, captured by the caller before
  * any await so it reflects exactly the content now durable in the row.
- * Indexing and the buffer drain are deferred to `finalizePendingToolResultRow`.
+ * Indexing, the JSONL disk-view sync, and the buffer drain are deferred to
+ * `finalizePendingToolResultRow`, which projects the grouped row exactly once.
  */
 async function persistPendingToolResultRow(
   state: EventHandlerState,
@@ -1962,10 +1963,6 @@ async function persistPendingToolResultRow(
       );
   if (persisted) {
     recordConversationPersistedSeq(deps.ctx.conversationId, seq);
-  }
-  const conv = getConversation(deps.ctx.conversationId);
-  if (conv != null) {
-    syncMessageToDisk(deps.ctx.conversationId, rowId, conv.createdAt);
   }
 }
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1931,11 +1931,12 @@ function ensureToolResultRowReserved(
  * any await so it reflects exactly the content now durable in the row.
  * Indexing, the JSONL disk-view sync, and the buffer drain are deferred to
  * `finalizePendingToolResultRow`, which projects the grouped row exactly once.
- * A row this seam never reaches (daemon death before finalize) is folded into
- * the DB by the monitor's out-of-process in-flight recovery, which does not
- * write the disk view; that row stays absent from `messages.jsonl` until
- * `rebuild-conversation-disk-view` replays the conversation. The projection
- * is best-effort by contract, and the rebuild is its reconciliation path.
+ * A row that never reaches that seam (daemon death mid-turn) is folded into
+ * the DB by the monitor's out-of-process in-flight recovery, which opens a raw
+ * SQLite handle and so cannot write the disk view. That row is absent from
+ * `messages.jsonl`, and no automatic path adds it later: the rebuild helper
+ * runs only from workspace migrations 009/013 and the credential scrub. See
+ * LUM-3048 for the projection ownership work this sits under.
  */
 async function persistPendingToolResultRow(
   state: EventHandlerState,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1936,7 +1936,7 @@ function ensureToolResultRowReserved(
  * SQLite handle and so cannot write the disk view. That row is absent from
  * `messages.jsonl`, and no automatic path adds it later: the rebuild helper
  * runs only from workspace migrations 009/013 and the credential scrub. See
- * LUM-3048 for the projection ownership work this sits under.
+ * JARVIS-1465 for the projection ownership work this sits under.
  */
 async function persistPendingToolResultRow(
   state: EventHandlerState,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1931,6 +1931,11 @@ function ensureToolResultRowReserved(
  * any await so it reflects exactly the content now durable in the row.
  * Indexing, the JSONL disk-view sync, and the buffer drain are deferred to
  * `finalizePendingToolResultRow`, which projects the grouped row exactly once.
+ * A row this seam never reaches (daemon death before finalize) is folded into
+ * the DB by the monitor's out-of-process in-flight recovery, which does not
+ * write the disk view; that row stays absent from `messages.jsonl` until
+ * `rebuild-conversation-disk-view` replays the conversation. The projection
+ * is best-effort by contract, and the rebuild is its reconciliation path.
  */
 async function persistPendingToolResultRow(
   state: EventHandlerState,

--- a/assistant/src/persistence/conversation-disk-view.ts
+++ b/assistant/src/persistence/conversation-disk-view.ts
@@ -12,9 +12,13 @@
 
 import {
   appendFileSync,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
+  readSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
@@ -264,10 +268,43 @@ function writeAttachmentFile(
 // ---------------------------------------------------------------------------
 
 /**
+ * Whether the file at `filePath` ends with exactly `line` (trailing newline
+ * included). Reads only the trailing `line` bytes, so the check stays cheap
+ * on large JSONL files. Any I/O error (including a missing file) reports no
+ * match.
+ */
+function fileEndsWithLine(filePath: string, line: string): boolean {
+  try {
+    const expected = Buffer.from(line, "utf-8");
+    const { size } = statSync(filePath);
+    if (size < expected.length) {
+      return false;
+    }
+    const fd = openSync(filePath, "r");
+    try {
+      const tail = Buffer.alloc(expected.length);
+      readSync(fd, tail, 0, expected.length, size - expected.length);
+      return tail.equals(expected);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read a message and its attachments from DB, flatten content, and append
  * a JSONL line to `messages.jsonl` in the conversation's disk-view directory.
  * Attachment filenames are recorded from the conversation's attachments/
  * subdirectory, materializing legacy rows there only when needed.
+ *
+ * Idempotent per row state: when the file already ends with the exact record
+ * this call would write (a re-sync of an unchanged row, e.g. a retried
+ * finalize), the append is skipped so one DB row projects to one JSONL
+ * record. A row whose content changed since its last sync still appends a
+ * fresh record; `rebuildConversationDiskViewFromDbState` is the path that
+ * collapses those to the final state.
  *
  * Requires `createdAtMs` of the conversation to resolve the directory path.
  */
@@ -331,10 +368,12 @@ export function syncMessageToDisk(
       }
     }
 
-    appendFileSync(
-      join(dirPath, "messages.jsonl"),
-      JSON.stringify(record) + "\n",
-    );
+    const messagesPath = join(dirPath, "messages.jsonl");
+    const line = JSON.stringify(record) + "\n";
+    if (fileEndsWithLine(messagesPath, line)) {
+      return;
+    }
+    appendFileSync(messagesPath, line);
   } catch (err) {
     log.warn(
       { err, conversationId, messageId },

--- a/assistant/src/persistence/conversation-disk-view.ts
+++ b/assistant/src/persistence/conversation-disk-view.ts
@@ -12,13 +12,9 @@
 
 import {
   appendFileSync,
-  closeSync,
   existsSync,
   mkdirSync,
-  openSync,
-  readSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
@@ -268,43 +264,16 @@ function writeAttachmentFile(
 // ---------------------------------------------------------------------------
 
 /**
- * Whether the file at `filePath` ends with exactly `line` (trailing newline
- * included). Reads only the trailing `line` bytes, so the check stays cheap
- * on large JSONL files. Any I/O error (including a missing file) reports no
- * match.
- */
-function fileEndsWithLine(filePath: string, line: string): boolean {
-  try {
-    const expected = Buffer.from(line, "utf-8");
-    const { size } = statSync(filePath);
-    if (size < expected.length) {
-      return false;
-    }
-    const fd = openSync(filePath, "r");
-    try {
-      const tail = Buffer.alloc(expected.length);
-      readSync(fd, tail, 0, expected.length, size - expected.length);
-      return tail.equals(expected);
-    } finally {
-      closeSync(fd);
-    }
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Read a message and its attachments from DB, flatten content, and append
  * a JSONL line to `messages.jsonl` in the conversation's disk-view directory.
  * Attachment filenames are recorded from the conversation's attachments/
  * subdirectory, materializing legacy rows there only when needed.
  *
- * Idempotent per row state: when the file already ends with the exact record
- * this call would write (a re-sync of an unchanged row, e.g. a retried
- * finalize), the append is skipped so one DB row projects to one JSONL
- * record. A row whose content changed since its last sync still appends a
- * fresh record; `rebuildConversationDiskViewFromDbState` is the path that
- * collapses those to the final state.
+ * The append is unconditional, so each call adds a record. Callers are
+ * responsible for invoking this once per row, at the seam where that row's
+ * content is final. The record carries no row identity, so neither this
+ * function nor a reader can tell a re-sync of one row from two rows that
+ * happen to serialize alike.
  *
  * Requires `createdAtMs` of the conversation to resolve the directory path.
  */
@@ -368,12 +337,10 @@ export function syncMessageToDisk(
       }
     }
 
-    const messagesPath = join(dirPath, "messages.jsonl");
-    const line = JSON.stringify(record) + "\n";
-    if (fileEndsWithLine(messagesPath, line)) {
-      return;
-    }
-    appendFileSync(messagesPath, line);
+    appendFileSync(
+      join(dirPath, "messages.jsonl"),
+      JSON.stringify(record) + "\n",
+    );
   } catch (err) {
     log.warn(
       { err, conversationId, messageId },


### PR DESCRIPTION
## TL;DR

The grouped tool-result row was projected to `messages.jsonl` once per arriving tool result **and** once at finalize, so a turn with N parallel tools wrote `N + 1` byte-identical copies of the same row (486 duplicate records, 73.7% of file bytes, on the conversation that surfaced this). It is now projected only at finalize. The DB was verified clean; this is projection-only, and the DB write path is untouched.

**No token or inference cost was involved.** `tool_result` blocks flatten into the record's `toolResults` field, never `content`, and the only reader that feeds a model (memory graph extraction) skips records without `content`. The duplication cost disk and git history, nothing else. Calling this out because the bug was found during an unrelated investigation and is easy to misread as a spend fix.

This is a targeted stop-the-bleeding fix, not a redesign of the projection. The projection has deeper problems that this PR deliberately does not attempt (see **What this does not fix**).

## What changes

| | Before | After |
|---|---|---|
| Turn with N parallel tool results | `N + 1` identical records in `messages.jsonl` | 1 record |
| Workspace git commits | Each carried the duplicated rows | Carry one copy |
| `db repair` / migration 028 recovery | Reconstructed `N + 1` phantom messages per turn | Reconstructs 1 |
| `syncMessageToDisk` | Appends per call | Unchanged |

The only behavioural change is where the grouped row is projected from. `syncMessageToDisk` keeps its unconditional append: the record schema has no row identity, so a tail-bytes equality guard cannot distinguish a re-sync of one row from two distinct rows that serialize alike, and it would silently drop the second during a `rebuildConversationDiskViewFromDbState` replay. Callers own syncing each row once, at the seam where its content is final; that contract is now stated on the function and pinned by tests.

## Why this is worth more than file hygiene

`conversations/**` is force-included in the workspace `.gitignore` and exempted from the oversized-file guard (`workspace/git-service.ts`), so the duplication inflated every workspace commit. And `messages.jsonl` is not only browsable output: workspace migration 028 and the `db repair` CLI both **rebuild database rows from it, one row per line**. Duplicated lines became duplicated messages in any recovered database.

## Why this is safe

The removed call site wrote no data the DB did not already have. Tool results are still persisted to SQLite on arrival by the same function (that durability is what survives a refresh outliving the SSE replay window); only the JSONL append moved to the finalize seam that already existed a few lines away. Failures in the projection are logged and swallowed, as before, so it cannot break a turn.

Nothing consumes the mid-turn state that stops being written: no prompt or skill references `messages.jsonl` (the only documented assistant-facing path under `conversations/` is `attachments/`), memory extraction skips tool-result records, and the log-export scan reads only `ts`. Live clients render from the DB and SSE, not from this file.

## What this does not fix

Deliberately out of scope, all tracked in JARVIS-1465:

- **Crash-recovered rows are never projected.** If the daemon dies between a tool-result arrival and finalize, the monitor's out-of-process recovery folds the row into SQLite on a raw handle and cannot write the disk view. That row is now absent from `messages.jsonl` rather than present-and-duplicated. There is no automatic path that adds it later: the rebuild helper runs only from workspace migrations 009/013 (long since applied) and the credential scrub.
- **Mid-turn assistant rows are never projected.** `handleLlmCallStarted` reserves a fresh assistant row per LLM call and overwrites `lastAssistantMessageId`; only the final value is synced at the turn tail. In any tool-using turn, every assistant row but the last is missing from the file, including the ones carrying the `tool_use` blocks. This predates this PR and is the larger defect.
- **Records carry no row identity**, which is what forces the append contract above.

These are three symptoms of one cause: nothing owns the decision "this row is durable, project it" — there are 11 hand-placed `syncMessageToDisk` call sites, and the set is neither complete nor disjoint. JARVIS-1465 covers that, and the prior question it depends on: whether `messages.jsonl` should be a supported recovery source at all, given that reconstruction through it mints fresh `tool_use` ids and blanks every `tool_result.tool_use_id`, so recovered tool calls cannot be correlated even from a byte-perfect file.

## Coverage

New fixture drives a turn with three parallel tool results through the real handlers and asserts the grouped row reaches disk exactly once. Sensitivity-checked: restoring the on-arrival sync makes it report 4, reproducing `N + 1` end-to-end. It also asserts the turn's assistant row is projected once, so the count cannot pass by the row going unprojected entirely. The disk-view integration suite pins the append contract (same row twice yields two records) so a future tail-guard reintroduction fails loudly.

`bun test` green per-file on the disk-view integration suite (10), the new fixture (1), and the abort tool-result suite that shares the seam (2). Typecheck clean.


Fixes JARVIS-1195.
