### PR TITLE
fix(compaction): pair-safe front truncation and orphan-output guards

### DIFF
--- a/assistant/src/__tests__/compactor-truncation-pairing.test.ts
+++ b/assistant/src/__tests__/compactor-truncation-pairing.test.ts
@@ -1,0 +1,368 @@
+/**
+ * The compaction summary call's front truncation must never split a
+ * tool_use/tool_result pair, and the outbound request must be repaired
+ * before the provider call.
+ *
+ * The token-budget drop loop advances one message at a time, so without a
+ * boundary check its cut can drop an assistant `tool_use` while keeping its
+ * user `tool_result` in the retained portion. Providers that validate
+ * pairing (OpenAI Responses: "No tool call found for function call output
+ * with call_id ...") reject such a request, and the retry ladder reproduces
+ * the same rejection every pass. The cut must advance to a pair-safe user
+ * boundary, and `buildCompactionRequest` runs the deterministic history
+ * repair so even a malformed input history reaches the provider valid.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getMessages: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  getAttachmentMetadataForMessage: () => [],
+  getAttachmentContent: () => null,
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+}));
+
+import { runAssistantDrivenCompaction } from "../context/compactor.js";
+import { estimatePromptTokens } from "../context/token-estimator.js";
+import type { ContentBlock, Message, Provider } from "../providers/types.js";
+
+const SUMMARY = "Earlier turns summarized in the assistant's own voice.";
+
+function turnTimestamp(turn: number): string {
+  const hour = String(10 + Math.floor(turn / 60)).padStart(2, "0");
+  const minute = String(turn % 60).padStart(2, "0");
+  return `2026-05-21 (Thursday) ${hour}:${minute}:00 -05:00 (America/Chicago)`;
+}
+
+function userTurn(turn: number, body: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `<turn_context>\ncurrent_time: ${turnTimestamp(
+          turn,
+        )}\n</turn_context>\n[U${turn}] ${body}`,
+      },
+    ],
+  };
+}
+
+function compactionResponse(tailTurn: number, preview: string): string {
+  return `<compaction_result>
+<summary>
+${SUMMARY}
+</summary>
+<key_state>
+- Nothing critical pending.
+</key_state>
+<tail_start timestamp="${turnTimestamp(tailTurn)}" preview="${preview}" />
+</compaction_result>`;
+}
+
+/**
+ * Fake provider enforcing the same pairing contract the OpenAI Responses
+ * serialization is subject to: a `tool_result` may only reference a
+ * `tool_use` emitted earlier in the same request (a `function_call_output`
+ * with no preceding matching `function_call` is a 400). Rejects with the
+ * provider's live error phrasing so a regression reproduces the real
+ * failure mode.
+ */
+function makeValidatingProvider(response: string): {
+  provider: Provider;
+  lastRequest: () => Message[] | null;
+} {
+  let captured: Message[] | null = null;
+  const provider: Provider = {
+    name: "mock-provider",
+    sendMessage: async (messages: Message[]) => {
+      const emittedToolUseIds = new Set<string>();
+      for (const msg of messages) {
+        for (const block of msg.content) {
+          if (msg.role === "assistant" && block.type === "tool_use") {
+            emittedToolUseIds.add(block.id);
+          }
+          if (block.type === "tool_result") {
+            // guard:allow-tool-result-only: the fake validates client-side pairing only
+            const toolUseId = (block as { tool_use_id: string }).tool_use_id;
+            if (!emittedToolUseIds.has(toolUseId)) {
+              throw new Error(
+                `No tool call found for function call output with call_id ${toolUseId}.`,
+              );
+            }
+          }
+        }
+      }
+      captured = messages;
+      return {
+        content: [{ type: "text", text: response }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return { provider, lastRequest: () => captured };
+}
+
+function estimate(messages: Message[]): number {
+  return estimatePromptTokens(messages, "system", {
+    providerName: "mock-provider",
+  });
+}
+
+/** Mirror of the compactor's pair-safe cut predicate for fixture guards. */
+function isCleanUserBoundary(message: Message | undefined): boolean {
+  return (
+    message != null &&
+    message.role === "user" &&
+    // guard:allow-tool-result-only: mirrors the compactor's boundary predicate
+    !message.content.some((block) => block.type === "tool_result")
+  );
+}
+
+/**
+ * Replay the token-budget drop loop without the pairing advance, to locate
+ * where the raw budget cut lands for a fixture.
+ */
+function naiveDropCount(messages: Message[], budgetTokens: number): number {
+  let dropCount = 0;
+  let estimated = estimate(messages);
+  while (estimated > budgetTokens && dropCount < messages.length - 1) {
+    dropCount++;
+    estimated = estimate(messages.slice(dropCount));
+  }
+  return dropCount;
+}
+
+function textOfMessage(message: Message | undefined): string {
+  return (message?.content ?? [])
+    .map((block) => ("text" in block ? (block.text as string) : ""))
+    .join("\n");
+}
+
+function requestText(messages: Message[]): string {
+  return messages.map(textOfMessage).join("\n");
+}
+
+describe("compaction summary call: pair-safe front truncation", () => {
+  // Rounds of [user text, assistant tool_use (heavy), user tool_result,
+  // assistant text]: the heavy tool_use messages dominate the estimate, so
+  // the raw budget loop settles right after dropping one of them, landing
+  // the cut on its orphaned tool_result (or the assistant text behind it),
+  // never on a clean user boundary.
+  function buildToolHeavyHistory(rounds: number, idPrefix: string): Message[] {
+    const messages: Message[] = [];
+    for (let i = 0; i < rounds; i++) {
+      messages.push(userTurn(i, "please inspect the next data batch"));
+      messages.push({
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: `${idPrefix}_${i}`,
+            name: "inspect_batch",
+            input: { payload: `batch ${i} `.repeat(600) },
+          },
+        ],
+      });
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: `${idPrefix}_${i}`,
+            content: `inspection ${i} complete. `.repeat(8),
+          },
+        ],
+      });
+      messages.push({
+        role: "assistant",
+        content: [
+          { type: "text", text: `[A${i}] batch ${i} looks consistent.` },
+        ],
+      });
+    }
+    return messages;
+  }
+
+  /** tool_result blocks in `messages` with no tool_use anywhere in `messages`. */
+  function orphanedResultIds(messages: Message[]): string[] {
+    const toolUseIds = new Set<string>();
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (msg.role === "assistant" && block.type === "tool_use") {
+          toolUseIds.add(block.id);
+        }
+      }
+    }
+    const orphans: string[] = [];
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type === "tool_result") {
+          // guard:allow-tool-result-only: counting client-side orphans
+          const toolUseId = (block as { tool_use_id: string }).tool_use_id;
+          if (!toolUseIds.has(toolUseId)) {
+            orphans.push(toolUseId);
+          }
+        }
+      }
+    }
+    return orphans;
+  }
+
+  // Pairing must be id-format-agnostic, so the fixture runs across both
+  // persisted tool id shapes: Anthropic-style `toolu_` ids and OpenAI
+  // Responses-native `call_` ids.
+  for (const idPrefix of ["toolu", "call"] as const) {
+    test(`advances the cut to a pair-safe boundary and succeeds against a pairing-validating provider (${idPrefix}_ ids)`, async () => {
+      const rounds = 30;
+      const messages = buildToolHeavyHistory(rounds, idPrefix);
+
+      const maxInputTokens = 20_000;
+      // Mirrors compactor.compactionPrefixBudget: window minus the
+      // instruction reserve (800) and the 15% output reserve.
+      const prefixBudget =
+        maxInputTokens - 800 - Math.floor(maxInputTokens * 0.15);
+      expect(estimate(messages)).toBeGreaterThan(prefixBudget);
+
+      // Fixture guard: without the pairing advance, the budget cut lands on
+      // an unsafe index and the retained tail carries a tool_result whose
+      // tool_use sits in the dropped prefix (the exact shape the provider
+      // rejects). If token-estimation changes ever make this land safely,
+      // the fixture must be re-tuned or this test proves nothing.
+      const rawCut = naiveDropCount(messages, prefixBudget);
+      expect(rawCut).toBeGreaterThan(0);
+      expect(isCleanUserBoundary(messages[rawCut])).toBe(false);
+      expect(orphanedResultIds(messages.slice(rawCut)).length).toBeGreaterThan(
+        0,
+      );
+
+      const { provider, lastRequest } = makeValidatingProvider(
+        compactionResponse(rounds - 2, "please inspect the next"),
+      );
+
+      const result = await runAssistantDrivenCompaction({
+        conversationId: "conv-test",
+        messages,
+        provider,
+        systemPrompt: "system",
+        compaction: { enabled: true, autoThreshold: 0.7 },
+        maxInputTokens,
+        force: true,
+        previousEstimatedInputTokens: 90_000,
+      });
+
+      // The pairing-validating provider accepted the request and the pass
+      // applied.
+      expect(result.compacted).toBe(true);
+
+      const sent = lastRequest();
+      expect(sent).not.toBeNull();
+      const sentMessages = sent ?? [];
+
+      // Every tool_result in the outbound request is preceded by its
+      // tool_use.
+      expect(orphanedResultIds(sentMessages)).toEqual([]);
+
+      // The cut itself was pair-safe: nothing needed the repair pass's
+      // orphan downgrade, and the retained pairs survive intact.
+      const sentText = requestText(sentMessages);
+      expect(sentText).not.toContain("[orphaned");
+
+      // The request still fits the window and announces the truncation.
+      expect(estimate(sentMessages)).toBeLessThan(maxInputTokens);
+      expect(sentText).toContain("summary covers only the visible portion");
+
+      // Recent valid content is retained verbatim: the last round's user
+      // turn, tool pair, and assistant reply all reach the provider.
+      const lastRound = rounds - 1;
+      expect(sentText).toContain(`[U${lastRound}] please inspect`);
+      expect(sentText).toContain(`[A${lastRound}] batch ${lastRound}`);
+      const sentToolUseIds = new Set<string>();
+      for (const msg of sentMessages) {
+        for (const block of msg.content) {
+          if (msg.role === "assistant" && block.type === "tool_use") {
+            sentToolUseIds.add(block.id);
+          }
+        }
+      }
+      expect(sentToolUseIds.has(`${idPrefix}_${lastRound}`)).toBe(true);
+    });
+  }
+
+  test("repairs a malformed below-budget history before the provider call", async () => {
+    // Orphan tool_result (its tool_use exists nowhere in the history) and a
+    // consecutive same-role user run, below the truncation budget so the
+    // request-build repair is the only transform in play.
+    const messages: Message[] = [
+      userTurn(0, "start the job"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_missing",
+            content: "stale result payload",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[A0] acknowledged." }],
+      },
+      userTurn(1, "carry on with the job"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[A1] done." }],
+      },
+    ];
+
+    const { provider, lastRequest } = makeValidatingProvider(
+      compactionResponse(1, "carry on with the job"),
+    );
+
+    const result = await runAssistantDrivenCompaction({
+      conversationId: "conv-test",
+      messages,
+      provider,
+      systemPrompt: "system",
+      compaction: { enabled: true, autoThreshold: 0.7 },
+      maxInputTokens: 200_000,
+      force: true,
+      previousEstimatedInputTokens: 90_000,
+    });
+
+    expect(result.compacted).toBe(true);
+
+    const sentMessages = lastRequest() ?? [];
+    // The orphan was downgraded to text: no tool_result blocks reach the
+    // provider, and the payload is preserved in the degraded form.
+    const hasToolResult = sentMessages.some((msg) =>
+      // guard:allow-tool-result-only: asserting the repair removed them
+      msg.content.some((block: ContentBlock) => block.type === "tool_result"),
+    );
+    expect(hasToolResult).toBe(false);
+    const sentText = requestText(sentMessages);
+    expect(sentText).toContain("stale result payload");
+    expect(sentText).toContain("orphaned tool_result");
+
+    // Same-role runs were merged: roles strictly alternate in the history
+    // portion of the request (everything before the trailing instruction).
+    const historyPortion = sentMessages.slice(0, -1);
+    for (let i = 1; i < historyPortion.length; i++) {
+      expect(historyPortion[i].role).not.toBe(historyPortion[i - 1].role);
+    }
+
+    // Valid user text survives the repair verbatim.
+    expect(sentText).toContain("[U0] start the job");
+    expect(sentText).toContain("[U1] carry on with the job");
+  });
+});

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { deepRepairHistory } from "../agent/history-repair/history-repair.js";
+import { isRepairableOrderingError } from "../agent/history-repair/history-repair.js";
 import { repairHistory } from "../agent/history-repair/history-repair.js";
 import type { Message } from "../providers/types.js";
 
@@ -1108,5 +1109,43 @@ describe("deepRepairHistory", () => {
     expect(stats.assistantToolResultsMigrated).toBe(0);
     expect(stats.missingToolResultsInserted).toBe(0);
     expect(stats.orphanToolResultsDowngraded).toBe(0);
+  });
+});
+
+describe("isRepairableOrderingError", () => {
+  test("matches Anthropic tool ordering rejections", () => {
+    expect(
+      isRepairableOrderingError(
+        "Requests which include `tool_use` blocks must have a corresponding `tool_result` block in the next message.",
+      ),
+    ).toBe(true);
+    expect(
+      isRepairableOrderingError(
+        "messages.5: tool_result block references tool_use_id toolu_abc which was not found",
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the OpenAI Responses orphan function_call_output rejection", () => {
+    expect(
+      isRepairableOrderingError(
+        "No tool call found for function call output with call_id call_abc123.",
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the OpenAI Chat Completions orphan tool_call_id rejection", () => {
+    expect(
+      isRepairableOrderingError(
+        "Invalid parameter: 'tool_call_id' of 'call_abc123' not found in 'tool_calls' of previous message.",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match unrelated provider errors", () => {
+    expect(isRepairableOrderingError("Rate limit exceeded")).toBe(false);
+    expect(
+      isRepairableOrderingError("Request too large for model context window"),
+    ).toBe(false);
   });
 });

--- a/assistant/src/agent/history-repair/history-repair.ts
+++ b/assistant/src/agent/history-repair/history-repair.ts
@@ -399,6 +399,14 @@ export const ORDERING_ERROR_PATTERNS: readonly RegExp[] = [
   /tool_use_id.*without.*tool_result/i,
   /tool_result.*tool_use_id.*not found/i,
   /messages.*invalid.*order/i,
+  // OpenAI Responses API: a function_call_output whose call_id has no
+  // matching function_call earlier in the request ("No tool call found for
+  // function call output with call_id ...").
+  /no tool call found for function call output/i,
+  // OpenAI Chat Completions API: a tool message whose tool_call_id is not in
+  // a preceding assistant message's tool_calls ("Invalid parameter:
+  // 'tool_call_id' of '...' not found in 'tool_calls' of previous message").
+  /tool_call_id.*not found/i,
 ];
 
 /**

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -18,6 +18,7 @@
  * On any parse or resolution failure we abort the compaction and return
  * `compacted: false` — never silently lose messages.
  */
+import { repairHistory } from "../agent/history-repair/history-repair.js";
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import type { CompactionConfig } from "../config/schemas/compaction.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
@@ -1056,9 +1057,14 @@ function extractTextFromResponse(content: ContentBlock[]): string {
 
 // Build the outbound message list for a compaction provider call: apply the
 // same pre-send sanitization bundle as the agent loop's model calls
-// (`preModelCallSanitize` — old tool-result media stripped, AX trees
-// collapsed, historical web-search results converted to text), then append
-// the summarization instruction at the tail.
+// (`preModelCallSanitize`: old tool-result media stripped, AX trees
+// collapsed, historical web-search results converted to text), run the
+// deterministic history repair over the sanitized projection, then append
+// the summarization instruction at the tail. The repair pass downgrades any
+// orphaned `tool_result` (its `tool_use` outside the request, e.g. cut off
+// by front truncation) to plain text and merges consecutive same-role runs,
+// so the request always satisfies the provider's pairing validation. A
+// well-formed history passes through repair structurally unchanged.
 //
 // Matching the loop's projection matters for two reasons. First, the summary
 // call's prefix stays byte-aligned with the agent's warm prompt cache — an
@@ -1076,7 +1082,10 @@ function buildCompactionRequest(
   history: Message[],
   instruction: Message,
 ): Message[] {
-  return [...preModelCallSanitize(history), instruction];
+  return [
+    ...repairHistory(preModelCallSanitize(history)).messages,
+    instruction,
+  ];
 }
 
 // Token headroom a compaction summary call reserves on top of its history: room
@@ -1128,6 +1137,34 @@ function truncateHistoryToBudget(args: {
   }
   if (dropCount === 0) {
     return messages;
+  }
+  // Advance the cut to a pair-safe boundary. The budget loop stops wherever
+  // the estimate first fits, which can land between an assistant `tool_use`
+  // and its user `tool_result` and leave an orphaned `tool_result` opening
+  // the retained portion (rejected by providers that validate pairing).
+  // Walk forward to the next clean user boundary, never dropping the final
+  // message (mirroring the budget loop's own bound). When no boundary exists
+  // the requested cut stands; the request-build repair pass downgrades any
+  // orphaned results so the outbound call remains valid.
+  const requestedDropCount = dropCount;
+  if (!isForwardCutBoundary(messages, dropCount)) {
+    for (let i = dropCount + 1; i < messages.length; i++) {
+      if (isForwardCutBoundary(messages, i)) {
+        dropCount = i;
+        break;
+      }
+    }
+  }
+  if (dropCount !== requestedDropCount) {
+    log.info(
+      {
+        requestedDropCount,
+        pairSafeDropCount: dropCount,
+        budgetTokens,
+        totalMessages: messages.length,
+      },
+      "Advanced compaction summary-call front truncation to a pair-safe boundary",
+    );
   }
   log.info(
     { dropCount, budgetTokens, totalMessages: messages.length },

--- a/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
+++ b/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Serialization guard for orphaned tool results on the OpenAI providers.
+ *
+ * Both transports validate pairing server-side: the Responses API rejects a
+ * `function_call_output` whose `call_id` was not emitted as a `function_call`
+ * earlier in the request, and the Chat Completions API rejects a tool-role
+ * message whose `tool_call_id` is not in a preceding assistant message's
+ * `tool_calls`. A `tool_result` with no backward match in the request (e.g.
+ * its `tool_use` truncated away) is therefore degraded into plain user text
+ * with an `[orphaned tool result]` prefix, preserving the information while
+ * keeping the request valid. Paired results serialize unchanged.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Message } from "../../types.js";
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+import { OpenAIResponsesProvider } from "../responses-provider.js";
+
+// ---------------------------------------------------------------------------
+// Responses transport harness
+// ---------------------------------------------------------------------------
+
+type ResponsesStreamEvent = { type: string; [key: string]: unknown };
+
+const RESPONSES_OK_EVENTS: ResponsesStreamEvent[] = [
+  { type: "response.output_text.delta", delta: "ok" },
+  {
+    type: "response.completed",
+    response: {
+      model: "gpt-5.2",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  },
+];
+
+function makeEventStream(
+  events: ResponsesStreamEvent[],
+): AsyncIterable<ResponsesStreamEvent> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+/** Swap `responses.create` for a canned stream that records request params. */
+function stubResponsesCreate(provider: OpenAIResponsesProvider): {
+  input: () => unknown[];
+} {
+  let captured: unknown;
+  const inner = provider as unknown as {
+    client: {
+      responses: {
+        create: (
+          params: unknown,
+        ) => Promise<AsyncIterable<ResponsesStreamEvent>>;
+      };
+    };
+  };
+  inner.client.responses.create = async (params) => {
+    captured = params;
+    return makeEventStream(RESPONSES_OK_EVENTS);
+  };
+  return {
+    input: () => (captured as { input: unknown[] }).input,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chat Completions transport harness
+// ---------------------------------------------------------------------------
+
+type ChatChunk = {
+  choices: Array<{
+    delta: { content?: string | null };
+    finish_reason?: string | null;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+const CHAT_OK_CHUNKS: ChatChunk[] = [
+  {
+    choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 10, completion_tokens: 2 },
+  },
+];
+
+function makeChunkStream(chunks: ChatChunk[]): AsyncIterable<ChatChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  };
+}
+
+type ChatMessageParam = {
+  role: string;
+  content: string | Array<Record<string, unknown>>;
+  tool_call_id?: string;
+};
+
+/** Swap chat `create` for a canned stream that records request params. */
+function stubChatCreate(provider: OpenAIChatCompletionsProvider): {
+  messages: () => ChatMessageParam[];
+} {
+  let captured: unknown;
+  const inner = provider as unknown as {
+    client: {
+      chat: {
+        completions: {
+          create: (params: unknown) => Promise<AsyncIterable<ChatChunk>>;
+        };
+      };
+    };
+  };
+  inner.client.chat.completions.create = async (params) => {
+    captured = params;
+    return makeChunkStream(CHAT_OK_CHUNKS);
+  };
+  return {
+    messages: () => (captured as { messages: ChatMessageParam[] }).messages,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Persisted tool id shapes: `call_` is the Responses-native pass-through
+ * (conversations that always ran on this transport), `toolu_` is an
+ * Anthropic-shaped history routed to an OpenAI call site (cross-provider
+ * routing, e.g. a compaction call over imported history). The guard must be
+ * id-format-agnostic, so every case runs across both.
+ */
+const ID_SHAPES = [
+  { label: "call_ ids", pairedId: "call_paired", orphanId: "call_orphan" },
+  { label: "toolu_ ids", pairedId: "toolu_paired", orphanId: "toolu_orphan" },
+] as const;
+
+/** History whose tool_result is paired with a preceding tool_use. */
+function pairedHistory(id: string): Message[] {
+  return [
+    { role: "user", content: [{ type: "text", text: "Read the file" }] },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id,
+          name: "file_read",
+          input: { path: "/tmp/a" },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: id,
+          content: "file contents",
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * History whose leading tool_result has no matching tool_use anywhere in
+ * the request (the shape a pairing-blind front truncation produces).
+ */
+function orphanHistory(id: string): Message[] {
+  return [
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: id,
+          content: "stranded output",
+        },
+        { type: "text", text: "continue from here" },
+      ],
+    },
+    { role: "assistant", content: [{ type: "text", text: "continuing" }] },
+    { role: "user", content: [{ type: "text", text: "thanks" }] },
+  ];
+}
+
+/**
+ * A tool_result that arrives BEFORE its tool_use in the request order. The
+ * API contract only accepts backward matches, so this is orphaned too.
+ */
+function forwardReferenceHistory(): Message[] {
+  return [
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_later",
+          content: "premature output",
+        },
+        { type: "text", text: "odd ordering" },
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "call_later",
+          name: "file_read",
+          input: { path: "/tmp/b" },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_later",
+          content: "real output",
+        },
+      ],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Responses transport
+// ---------------------------------------------------------------------------
+
+describe("OpenAIResponsesProvider orphan tool_result guard", () => {
+  for (const shape of ID_SHAPES) {
+    test(`emits function_call_output for a paired tool_result (${shape.label})`, async () => {
+      const provider = new OpenAIResponsesProvider("sk-test", "gpt-5.2");
+      const stub = stubResponsesCreate(provider);
+
+      await provider.sendMessage(pairedHistory(shape.pairedId));
+
+      const input = stub.input() as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(3);
+      expect(input[1]).toEqual({
+        type: "function_call",
+        call_id: shape.pairedId,
+        name: "file_read",
+        arguments: '{"path":"/tmp/a"}',
+      });
+      expect(input[2]).toEqual({
+        type: "function_call_output",
+        call_id: shape.pairedId,
+        output: "file contents",
+      });
+    });
+
+    test(`degrades an orphaned tool_result to user text instead of function_call_output (${shape.label})`, async () => {
+      const provider = new OpenAIResponsesProvider("sk-test", "gpt-5.2");
+      const stub = stubResponsesCreate(provider);
+
+      await provider.sendMessage(orphanHistory(shape.orphanId));
+
+      const input = stub.input() as Array<Record<string, unknown>>;
+      // No function_call_output items at all: the only tool_result was
+      // orphaned.
+      expect(input.some((item) => item.type === "function_call_output")).toBe(
+        false,
+      );
+
+      // The orphan's content is preserved as prefixed text inside the user
+      // message, alongside the message's own text.
+      const firstUser = input[0] as {
+        type: string;
+        role: string;
+        content: Array<{ type: string; text?: string }>;
+      };
+      expect(firstUser.type).toBe("message");
+      expect(firstUser.role).toBe("user");
+      const texts = firstUser.content.map((part) => part.text ?? "");
+      expect(texts).toContain("continue from here");
+      expect(texts).toContain("[orphaned tool result] stranded output");
+    });
+  }
+
+  test("treats a forward-referencing tool_result as orphaned, keeps the backward match", async () => {
+    const provider = new OpenAIResponsesProvider("sk-test", "gpt-5.2");
+    const stub = stubResponsesCreate(provider);
+
+    await provider.sendMessage(forwardReferenceHistory());
+
+    const input = stub.input() as Array<Record<string, unknown>>;
+    const outputs = input.filter(
+      (item) => item.type === "function_call_output",
+    );
+    // Only the tool_result AFTER the function_call serializes as an output.
+    expect(outputs).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_later",
+        output: "real output",
+      },
+    ]);
+    // The premature result is degraded into the first user message.
+    const firstUser = input[0] as {
+      content: Array<{ type: string; text?: string }>;
+    };
+    const texts = firstUser.content.map((part) => part.text ?? "");
+    expect(texts).toContain("[orphaned tool result] premature output");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat Completions transport
+// ---------------------------------------------------------------------------
+
+describe("OpenAIChatCompletionsProvider orphan tool_result guard", () => {
+  function makeProvider(): OpenAIChatCompletionsProvider {
+    return new OpenAIChatCompletionsProvider("sk-test", "test-model", {
+      providerName: "openai",
+      providerLabel: "OpenAI",
+    });
+  }
+
+  for (const shape of ID_SHAPES) {
+    test(`emits a tool message for a paired tool_result (${shape.label})`, async () => {
+      const provider = makeProvider();
+      const stub = stubChatCreate(provider);
+
+      await provider.sendMessage(pairedHistory(shape.pairedId));
+
+      const sent = stub.messages();
+      const toolMessages = sent.filter((message) => message.role === "tool");
+      expect(toolMessages).toEqual([
+        {
+          role: "tool",
+          tool_call_id: shape.pairedId,
+          content: "file contents",
+        },
+      ]);
+    });
+
+    test(`degrades an orphaned tool_result to user text instead of a tool message (${shape.label})`, async () => {
+      const provider = makeProvider();
+      const stub = stubChatCreate(provider);
+
+      await provider.sendMessage(orphanHistory(shape.orphanId));
+
+      const sent = stub.messages();
+      expect(sent.some((message) => message.role === "tool")).toBe(false);
+
+      const firstUser = sent.find((message) => message.role === "user");
+      expect(firstUser).toBeDefined();
+      const content = firstUser!.content;
+      const texts = Array.isArray(content)
+        ? content.map((part) => (part.text as string) ?? "")
+        : [content];
+      expect(texts).toContain("continue from here");
+      expect(texts).toContain("[orphaned tool result] stranded output");
+    });
+  }
+
+  test("treats a forward-referencing tool_result as orphaned, keeps the backward match", async () => {
+    const provider = makeProvider();
+    const stub = stubChatCreate(provider);
+
+    await provider.sendMessage(forwardReferenceHistory());
+
+    const sent = stub.messages();
+    const toolMessages = sent.filter((message) => message.role === "tool");
+    expect(toolMessages).toEqual([
+      {
+        role: "tool",
+        tool_call_id: "call_later",
+        content: "real output",
+      },
+    ]);
+  });
+});

--- a/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
+++ b/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
@@ -384,3 +384,95 @@ describe("OpenAIChatCompletionsProvider orphan tool_result guard", () => {
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-transport agreement
+// ---------------------------------------------------------------------------
+
+describe("orphan degradation agrees across both OpenAI transports", () => {
+  /** Every degraded orphan text a request carried, in request order. */
+  async function responsesOrphanTexts(history: Message[]): Promise<string[]> {
+    const provider = new OpenAIResponsesProvider("sk-test", "gpt-5.2");
+    const stub = stubResponsesCreate(provider);
+    await provider.sendMessage(history);
+    const input = stub.input() as Array<Record<string, unknown>>;
+    return input
+      .flatMap((item) =>
+        Array.isArray(item.content) ? (item.content as unknown[]) : [],
+      )
+      .map((part) => (part as { text?: string }).text ?? "")
+      .filter((text) => text.startsWith("[orphaned"));
+  }
+
+  async function chatOrphanTexts(history: Message[]): Promise<string[]> {
+    const provider = new OpenAIChatCompletionsProvider(
+      "sk-test",
+      "test-model",
+      {
+        providerName: "openai",
+        providerLabel: "OpenAI",
+      },
+    );
+    const stub = stubChatCreate(provider);
+    await provider.sendMessage(history);
+    return (
+      stub
+        .messages()
+        // A user message carrying a single text part serializes as a plain
+        // string on this transport rather than a one-element array.
+        .flatMap((message) =>
+          Array.isArray(message.content)
+            ? (message.content as unknown[]).map(
+                (part) => (part as { text?: string }).text ?? "",
+              )
+            : [String(message.content ?? "")],
+        )
+        .filter((text) => text.startsWith("[orphaned"))
+    );
+  }
+
+  // The detection rule and the degraded wording live in one shared helper
+  // (`serializeToolResult`), so the two transports cannot drift into
+  // different markers for the same input. Byte equality is the assertion:
+  // re-inlining the rule in one converter and editing it there fails here,
+  // which is the regression this pins.
+  test("both transports degrade the same orphan to byte-identical text", async () => {
+    const history = orphanHistory("call_orphan");
+
+    const [fromResponses, fromChat] = await Promise.all([
+      responsesOrphanTexts(history),
+      chatOrphanTexts(history),
+    ]);
+
+    expect(fromResponses).toEqual(["[orphaned tool result] stranded output"]);
+    expect(fromChat).toEqual(fromResponses);
+  });
+
+  test("both transports carry an executor failure into the same degraded text", async () => {
+    // `is_error` prefixing is part of the shared payload rule, so it must
+    // survive degradation identically on both transports.
+    const history: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_orphan",
+            content: "boom",
+            is_error: true,
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "continuing" }] },
+      { role: "user", content: [{ type: "text", text: "thanks" }] },
+    ];
+
+    const [fromResponses, fromChat] = await Promise.all([
+      responsesOrphanTexts(history),
+      chatOrphanTexts(history),
+    ]);
+
+    expect(fromResponses).toEqual(["[orphaned tool result] [ERROR] boom"]);
+    expect(fromChat).toEqual(fromResponses);
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -956,9 +956,19 @@ export class OpenAIChatCompletionsProvider implements Provider {
       });
     }
 
+    // Tool-call ids emitted in assistant messages earlier in this request.
+    // The API rejects a tool-role message whose `tool_call_id` has no
+    // preceding assistant `tool_calls` entry, so tool results are only
+    // serialized as tool messages when their call was emitted first
+    // (backward matches only).
+    const emittedToolCallIds = new Set<string>();
     for (const msg of messages) {
       if (msg.role === "assistant") {
-        result.push(this.toOpenAIAssistantMessage(msg));
+        const assistantMessage = this.toOpenAIAssistantMessage(msg);
+        for (const toolCall of assistantMessage.tool_calls ?? []) {
+          emittedToolCallIds.add(toolCall.id);
+        }
+        result.push(assistantMessage);
       } else {
         // User messages may contain tool_result blocks mixed with text/image
         const toolResults = msg.content.filter(
@@ -975,7 +985,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
         // Emit tool results as separate tool-role messages
         // OpenAI's API only supports string content in tool messages, so media
         // from contentBlocks is collected and injected as a user message below.
+        // A tool_result whose id has no preceding assistant tool call in this
+        // request is orphaned; its content is degraded into the user message
+        // instead of being sent as a rejectable tool message.
         const toolResultMedia: ContentBlock[] = [];
+        const orphanedResultBlocks: ContentBlock[] = [];
         for (const tr of toolResults) {
           let textContent = tr.content;
           if (tr.contentBlocks && tr.contentBlocks.length > 0) {
@@ -1003,18 +1017,31 @@ export class OpenAIChatCompletionsProvider implements Provider {
               }
             }
           }
+          const content = tr.is_error ? `[ERROR] ${textContent}` : textContent;
+          if (!emittedToolCallIds.has(tr.tool_use_id)) {
+            orphanedResultBlocks.push({
+              type: "text",
+              text: `[orphaned tool result] ${content}`,
+            });
+            continue;
+          }
           result.push({
             role: "tool",
             tool_call_id: tr.tool_use_id,
-            content: tr.is_error ? `[ERROR] ${textContent}` : textContent,
+            content,
           });
         }
 
-        // Emit remaining content + any tool result media as a user message.
-        // Media from tool results (e.g. browser_screenshot, audio a tool read)
-        // must go in a user message because OpenAI-compatible APIs don't
-        // support media parts in tool messages.
-        const userContent = [...otherBlocks, ...toolResultMedia];
+        // Emit remaining content, degraded orphaned results, and any tool
+        // result media as a user message. Media from tool results (e.g.
+        // browser_screenshot, audio a tool read) must go in a user message
+        // because OpenAI-compatible APIs don't support media parts in tool
+        // messages.
+        const userContent = [
+          ...otherBlocks,
+          ...orphanedResultBlocks,
+          ...toolResultMedia,
+        ];
         if (userContent.length > 0) {
           result.push(this.toOpenAIUserMessage(userContent, audioInputEnabled));
         }

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -46,6 +46,7 @@ import {
   OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES,
   openAIInputAudioFormat,
 } from "./input-audio.js";
+import { serializeToolResult } from "./orphaned-tool-result.js";
 
 /**
  * Detect OpenAI-compatible context-overflow signals on an `OpenAI.APIError`.
@@ -991,44 +992,32 @@ export class OpenAIChatCompletionsProvider implements Provider {
         const toolResultMedia: ContentBlock[] = [];
         const orphanedResultBlocks: ContentBlock[] = [];
         for (const tr of toolResults) {
-          let textContent = tr.content;
-          if (tr.contentBlocks && tr.contentBlocks.length > 0) {
-            const extraText = tr.contentBlocks
-              .filter(
-                (cb): cb is Extract<ContentBlock, { type: "text" }> =>
-                  cb.type === "text",
+          // Media this transport can carry: images always, plus inline audio
+          // when the model accepts it. The text payload and the orphan
+          // decision are the shared cross-transport rule.
+          for (const cb of tr.contentBlocks ?? []) {
+            if (cb.type === "image") {
+              toolResultMedia.push(cb);
+            } else if (
+              audioInputEnabled &&
+              cb.type === "file" &&
+              isOpenAICompatInlineAudio(
+                cb.source.media_type,
+                mediaSourceByteLength(cb.source),
               )
-              .map((cb) => cb.text);
-            if (extraText.length > 0) {
-              textContent = textContent + "\n" + extraText.join("\n");
-            }
-            for (const cb of tr.contentBlocks) {
-              if (cb.type === "image") {
-                toolResultMedia.push(cb);
-              } else if (
-                audioInputEnabled &&
-                cb.type === "file" &&
-                isOpenAICompatInlineAudio(
-                  cb.source.media_type,
-                  mediaSourceByteLength(cb.source),
-                )
-              ) {
-                toolResultMedia.push(cb);
-              }
+            ) {
+              toolResultMedia.push(cb);
             }
           }
-          const content = tr.is_error ? `[ERROR] ${textContent}` : textContent;
-          if (!emittedToolCallIds.has(tr.tool_use_id)) {
-            orphanedResultBlocks.push({
-              type: "text",
-              text: `[orphaned tool result] ${content}`,
-            });
+          const serialized = serializeToolResult(tr, emittedToolCallIds);
+          if (serialized.kind === "orphaned") {
+            orphanedResultBlocks.push(serialized.block);
             continue;
           }
           result.push({
             role: "tool",
             tool_call_id: tr.tool_use_id,
-            content,
+            content: serialized.payload,
           });
         }
 

--- a/assistant/src/providers/openai/orphaned-tool-result.ts
+++ b/assistant/src/providers/openai/orphaned-tool-result.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared wire-serialization rule for OpenAI tool results.
+ *
+ * Both OpenAI transports reject a tool result whose call was never emitted
+ * earlier in the same request: chat-completions rejects a `tool`-role message
+ * whose `tool_call_id` has no preceding assistant `tool_calls` entry, and the
+ * Responses API rejects a `function_call_output` whose `call_id` has no
+ * preceding `function_call`. Both therefore serialize a result as its native
+ * paired item only on a backward match, and degrade an unmatched one into
+ * plain text carried by the accompanying user message.
+ *
+ * The text payload and the orphan decision are identical across the two
+ * transports, so they live here; only the paired wire shape (and which media
+ * kinds each transport accepts alongside it) differs, and that stays at the
+ * call sites.
+ *
+ * Distinct from `agent/history-repair`'s `[orphaned <type> for <id>]:` marker,
+ * which operates one layer up on persisted history: it repairs the stored
+ * conversation shape (naming the id, and covering `web_search_tool_result`
+ * too) before any transport is chosen. This marker means "the call never
+ * reached this request's wire payload", so the id it would name is absent by
+ * construction. Keeping the two readable apart tells an operator which layer
+ * degraded the block.
+ */
+
+import type { ContentBlock, ToolResultContent } from "../types.js";
+
+/** Text prefix marking a tool result whose call is absent from the request. */
+const ORPHANED_MARKER = "[orphaned tool result]";
+
+/** Text prefix marking a tool result the executor reported as failed. */
+const ERROR_MARKER = "[ERROR]";
+
+/**
+ * How a tool result should be serialized for an OpenAI transport:
+ *
+ * - `paired`: its call was emitted earlier in this request, so the transport
+ *   emits its native tool-output item carrying `payload`.
+ * - `orphaned`: no matching call, so `block` is folded into the user message
+ *   instead of being sent as a rejectable tool-output item.
+ */
+export type ToolResultSerialization =
+  | { kind: "paired"; payload: string }
+  | { kind: "orphaned"; block: ContentBlock };
+
+/**
+ * Flatten a tool result's text (its own `content` plus any text in
+ * `contentBlocks`), mark executor failures, and decide whether the request
+ * can carry it as a paired tool-output item.
+ *
+ * `emittedCallIds` holds the ids already emitted as calls earlier in the same
+ * request, so membership is a backward match by construction. Media in
+ * `contentBlocks` is not consulted: each transport accepts a different set and
+ * collects it separately.
+ */
+export function serializeToolResult(
+  toolResult: ToolResultContent,
+  emittedCallIds: ReadonlySet<string>,
+): ToolResultSerialization {
+  let text = toolResult.content;
+  const extraText = (toolResult.contentBlocks ?? [])
+    .filter(
+      (cb): cb is Extract<ContentBlock, { type: "text" }> => cb.type === "text",
+    )
+    .map((cb) => cb.text);
+  if (extraText.length > 0) {
+    text = text + "\n" + extraText.join("\n");
+  }
+
+  const payload = toolResult.is_error ? `${ERROR_MARKER} ${text}` : text;
+
+  if (!emittedCallIds.has(toolResult.tool_use_id)) {
+    return {
+      kind: "orphaned",
+      block: { type: "text", text: `${ORPHANED_MARKER} ${payload}` },
+    };
+  }
+  return { kind: "paired", payload };
+}

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -26,6 +26,7 @@ import {
   normalizeOpenAIAPIError,
 } from "./api-error-normalization.js";
 import { detectOpenAICompatibleContextOverflow } from "./chat-completions-provider.js";
+import { serializeToolResult } from "./orphaned-tool-result.js";
 
 const log = getLogger("openai-responses");
 
@@ -974,35 +975,22 @@ export class OpenAIResponsesProvider implements Provider {
     const toolResultImages: ContentBlock[] = [];
     const orphanedResultBlocks: ContentBlock[] = [];
     for (const tr of toolResults) {
-      let textContent = tr.content;
-      if (tr.contentBlocks && tr.contentBlocks.length > 0) {
-        const extraText = tr.contentBlocks
-          .filter(
-            (cb): cb is Extract<ContentBlock, { type: "text" }> =>
-              cb.type === "text",
-          )
-          .map((cb) => cb.text);
-        if (extraText.length > 0) {
-          textContent = textContent + "\n" + extraText.join("\n");
-        }
-        for (const cb of tr.contentBlocks) {
-          if (cb.type === "image") {
-            toolResultImages.push(cb);
-          }
+      // This transport carries images only; the text payload and the orphan
+      // decision are the shared cross-transport rule.
+      for (const cb of tr.contentBlocks ?? []) {
+        if (cb.type === "image") {
+          toolResultImages.push(cb);
         }
       }
-      const output = tr.is_error ? `[ERROR] ${textContent}` : textContent;
-      if (!emittedCallIds.has(tr.tool_use_id)) {
-        orphanedResultBlocks.push({
-          type: "text",
-          text: `[orphaned tool result] ${output}`,
-        });
+      const serialized = serializeToolResult(tr, emittedCallIds);
+      if (serialized.kind === "orphaned") {
+        orphanedResultBlocks.push(serialized.block);
         continue;
       }
       result.push({
         type: "function_call_output",
         call_id: tr.tool_use_id,
-        output,
+        output: serialized.payload,
       });
     }
 

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -758,11 +758,16 @@ export class OpenAIResponsesProvider implements Provider {
     messages = resolveMediaReferences(messages);
     const result: unknown[] = [];
 
+    // `call_id`s emitted as `function_call` items earlier in this request.
+    // The API rejects a `function_call_output` whose `call_id` has no
+    // preceding `function_call`, so tool results are only serialized as
+    // outputs when their call was emitted first (backward matches only).
+    const emittedCallIds = new Set<string>();
     for (const msg of messages) {
       if (msg.role === "assistant") {
-        this.appendAssistantItems(result, msg);
+        this.appendAssistantItems(result, msg, emittedCallIds);
       } else {
-        this.appendUserItems(result, msg);
+        this.appendUserItems(result, msg, emittedCallIds);
       }
     }
 
@@ -887,8 +892,16 @@ export class OpenAIResponsesProvider implements Provider {
     }
   }
 
-  /** Convert an assistant message's content blocks to Responses input items. */
-  private appendAssistantItems(result: unknown[], msg: Message): void {
+  /**
+   * Convert an assistant message's content blocks to Responses input items.
+   * Every `function_call` emitted is recorded in `emittedCallIds` so the
+   * user-item conversion can pair `tool_result` blocks against it.
+   */
+  private appendAssistantItems(
+    result: unknown[],
+    msg: Message,
+    emittedCallIds: Set<string>,
+  ): void {
     const textParts: string[] = [];
 
     for (const block of msg.content) {
@@ -912,6 +925,7 @@ export class OpenAIResponsesProvider implements Provider {
             name: block.name,
             arguments: JSON.stringify(block.input),
           });
+          emittedCallIds.add(block.id);
           break;
         case "server_tool_use":
           textParts.push(`[Web search: ${block.name}]`);
@@ -932,8 +946,18 @@ export class OpenAIResponsesProvider implements Provider {
     }
   }
 
-  /** Convert a user message's content blocks to Responses input items. */
-  private appendUserItems(result: unknown[], msg: Message): void {
+  /**
+   * Convert a user message's content blocks to Responses input items.
+   * A `tool_result` whose `tool_use_id` was not emitted as a `function_call`
+   * earlier in this request (`emittedCallIds`) is orphaned; the API rejects
+   * an unmatched `function_call_output`, so its content is degraded into the
+   * plain user message instead of dropped.
+   */
+  private appendUserItems(
+    result: unknown[],
+    msg: Message,
+    emittedCallIds: Set<string>,
+  ): void {
     // Separate tool results from other blocks
     const toolResults = msg.content.filter(
       (b): b is Extract<ContentBlock, { type: "tool_result" }> =>
@@ -948,6 +972,7 @@ export class OpenAIResponsesProvider implements Provider {
 
     // Emit tool results as function_call_output items
     const toolResultImages: ContentBlock[] = [];
+    const orphanedResultBlocks: ContentBlock[] = [];
     for (const tr of toolResults) {
       let textContent = tr.content;
       if (tr.contentBlocks && tr.contentBlocks.length > 0) {
@@ -966,15 +991,28 @@ export class OpenAIResponsesProvider implements Provider {
           }
         }
       }
+      const output = tr.is_error ? `[ERROR] ${textContent}` : textContent;
+      if (!emittedCallIds.has(tr.tool_use_id)) {
+        orphanedResultBlocks.push({
+          type: "text",
+          text: `[orphaned tool result] ${output}`,
+        });
+        continue;
+      }
       result.push({
         type: "function_call_output",
         call_id: tr.tool_use_id,
-        output: tr.is_error ? `[ERROR] ${textContent}` : textContent,
+        output,
       });
     }
 
-    // Emit remaining content + any tool result images as a user message
-    const userContent = [...otherBlocks, ...toolResultImages];
+    // Emit remaining content, degraded orphaned results, and any tool result
+    // images as a user message
+    const userContent = [
+      ...otherBlocks,
+      ...orphanedResultBlocks,
+      ...toolResultImages,
+    ];
     if (userContent.length > 0) {
       result.push(this.toResponsesUserMessage(userContent));
     }


### PR DESCRIPTION
## TL;DR

Compaction summary calls failed with OpenAI 400 `No tool call found for function call output with call_id ...` whenever front truncation split an atomic tool_use/tool_result pair, and the retry ladder reproduced the identical orphan every pass (11 events across 5+ conversations in one day on a live instance; every 400 directly followed a `truncating from front` log line). Split out of #39909 (part 2 of 2).

## What changes

1. `truncateHistoryToBudget` advances the settled cut forward to the next pair-safe boundary (reusing `isForwardCutBoundary`; dropping more never violates the budget), logging `requestedDropCount`/`pairSafeDropCount`.
2. `buildCompactionRequest` runs the deterministic `repairHistory` after sanitization, so residual orphans are downgraded to inert text before the provider call. A well-formed history passes through structurally unchanged.
3. Both OpenAI converters track backward-emitted call ids and degrade an unmatched `tool_result` to `[orphaned tool result]`-prefixed plain text instead of an invalid `function_call_output` / `role:"tool"` item. Persisted ids are natively `call_...` on Responses-transport conversations (pure pass-through; no id minting).
4. OpenAI orphan-rejection phrasings join `ORDERING_ERROR_PATTERNS`, so the agent loop's deep-repair recovery now fires on that transport (it previously matched only Anthropic phrasings).

Intended repair semantics: at the truncation seam the pair drops together (prevention); a residual orphaned output is preserved as recoverable prefixed text, never silently dropped and never sent invalid. DB rows are never mutated; all repair is per-request.

## Coverage

Truncation-pairing suite 3/3 (reproduces the pre-fix orphaning cut, asserts pair-safe cut + content retention, and proves compaction succeeds against a provider-shaped validator that rejects unmatched outputs), orphan-guard suite 10/10 (both transports, both id shapes, order-awareness), history-repair 40/40, existing compactor suites green per-file; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Release decision

**Why this is needed now.** This fixes a live, repeated user-facing compaction failure: OpenAI returned HTTP 400 when front truncation split an atomic tool-call/tool-result pair. The PR body records 11 such events across 5+ conversations in one day. Without this change, compaction retries reproduce the same invalid outbound history.

**Why this is safe to cherry-pick.** The change is confined to request-local compaction truncation, history repair, and OpenAI outbound conversion guards. It does not change database rows, schema, persisted conversation data, public API shape, retrieval/scoring behavior, or model selection. At reviewed HEAD `817b0235`, the targeted suites are green (pairing 3/3, orphan guards 10/10, history repair 40/40), typecheck is clean, and all exact-head GitHub checks are successful or expected-skipped.

**Bounded residual.** The independent exact-head audit found no blocker in the final diff. A non-adjacent tool-pair behavior in the pre-existing Anthropic repair path is outside this PR and is not introduced by the change.
