### PR TITLE
[LUM-3020] Deduplicate transcriptItems against clientMessages in feedback captures

### DIFF
--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -23,7 +23,7 @@ mock.module("@/stores/auth-store", () => ({
   },
 }));
 
-const { ShareFeedbackModal, stripBulkBase64 } =
+const { ShareFeedbackModal, stripBulkBase64, dedupeAgainstClientMessages } =
   await import("@/components/share-feedback-modal");
 
 afterEach(() => {
@@ -193,14 +193,19 @@ describe("diagnostics capture base64 stripping", () => {
     expect(logsText).not.toContain(bigBase64);
     expect(logsText).toContain("[stripped data URI image/png,");
     expect(logsText).toContain("[stripped base64,");
-    // The diagnostic signal survives IN BOTH SURFACES: transcript items
-    // embed the same message objects clientMessages lists, and a shared
-    // reference is not a cycle. Each capture surface must carry the full
-    // message, so the text and both stripped markers appear twice.
+    // The message ships once, via clientMessages (text appears twice there:
+    // textSegments + contentBlocks). The transcript item that embeds the
+    // same object by reference carries a pointer, not a second copy, and a
+    // shared reference is never misread as a cycle.
     expect(logsText).not.toContain("[cyclic]");
-    expect(logsText.split("look at this photo").length - 1).toBe(4);
-    expect(logsText.split("[stripped data URI image/png,").length - 1).toBe(2);
-    expect(logsText.split("[stripped base64,").length - 1).toBe(2);
+    expect(logsText.split("look at this photo").length - 1).toBe(2);
+    expect(logsText.split("[stripped data URI image/png,").length - 1).toBe(1);
+    expect(logsText.split("[stripped base64,").length - 1).toBe(1);
+    expect(logsText).toContain(
+      "[deduplicated: see clientMessages msg-1]",
+    );
+    // The item-layer structure survives alongside the pointer.
+    expect(logsText).toContain('"kind": "message"');
     expect(logsText).toContain('"photo.png"');
   });
 
@@ -226,6 +231,38 @@ describe("diagnostics capture base64 stripping", () => {
 
     expect(logsText).toContain(prose);
     expect(logsText).not.toContain("[stripped");
+  });
+});
+
+describe("dedupeAgainstClientMessages", () => {
+  test("replaces identity-shared messages, keeps structurally-equal copies", () => {
+    const shared = { id: "msg-1", text: "hello" };
+    const copy = { id: "msg-1", text: "hello" };
+    const items = [
+      { kind: "message", key: "a", message: shared },
+      { kind: "message", key: "b", message: copy },
+      { kind: "thinking", key: "c", active: true },
+    ];
+    const result = dedupeAgainstClientMessages(items, [shared]) as Array<
+      Record<string, unknown>
+    >;
+
+    // Identity match becomes a pointer; the item wrapper survives.
+    expect(result[0]).toEqual({
+      kind: "message",
+      key: "a",
+      message: "[deduplicated: see clientMessages msg-1]",
+    });
+    // A structurally-equal but distinct object is NOT deduplicated: any
+    // divergence between the surfaces must be captured in full.
+    expect(result[1].message).toEqual(copy);
+    // Non-message items pass through untouched.
+    expect(result[2]).toEqual({ kind: "thinking", key: "c", active: true });
+  });
+
+  test("passes items through when clientMessages is unavailable", () => {
+    const items = [{ kind: "message", message: { id: "m" } }];
+    expect(dedupeAgainstClientMessages(items, null)).toBe(items);
   });
 });
 

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -184,6 +184,54 @@ const DATA_URI_RE = /^data:([^;,]+);base64,/i;
 const PURE_BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
 /**
+ * Marker (or transformed leaf) to emit in place of `value`, or `null` to
+ * leave primitives as-is and descend into objects/arrays.
+ */
+type CaptureVisitor = (value: unknown) => { replacement: unknown } | null;
+
+/**
+ * Depth-first structural map over a diagnostics snapshot.
+ *
+ * The `path` set holds only the current recursion ancestry, so a true cycle
+ * is replaced with `"[cyclic]"` while shared (sibling) references are
+ * traversed in full. The capture leans on shared references by construction:
+ * transcript items embed the same message objects `clientMessages` lists.
+ * JSON.stringify duplicates shared references the same way.
+ *
+ * Every capture pass (base64 stripping, message deduplication) is a visitor
+ * over this one walker, so traversal and cycle handling have a single home.
+ */
+function deepMapCapture(
+  value: unknown,
+  visit: CaptureVisitor,
+  path = new WeakSet<object>(),
+): unknown {
+  const hit = visit(value);
+  if (hit) {
+    return hit.replacement;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (path.has(value)) {
+    return "[cyclic]";
+  }
+  path.add(value);
+  let out: unknown;
+  if (Array.isArray(value)) {
+    out = value.map((v) => deepMapCapture(v, visit, path));
+  } else {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      obj[k] = deepMapCapture(v, visit, path);
+    }
+    out = obj;
+  }
+  path.delete(value);
+  return out;
+}
+
+/**
  * Replace bulk binary payloads in a diagnostics snapshot with size markers.
  *
  * Message state carries image bytes in two shapes: `data:` URIs (derived
@@ -196,41 +244,22 @@ const PURE_BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
  * tokens) are below the length floor. The marker keeps the mime type and
  * length, which is the diagnostically useful part.
  */
-export function stripBulkBase64(value: unknown, path = new WeakSet()): unknown {
-  if (typeof value === "string") {
-    const dataUri = DATA_URI_RE.exec(value);
+export function stripBulkBase64(value: unknown): unknown {
+  return deepMapCapture(value, (v) => {
+    if (typeof v !== "string") {
+      return null;
+    }
+    const dataUri = DATA_URI_RE.exec(v);
     if (dataUri) {
-      return `[stripped data URI ${dataUri[1]}, ${value.length} chars]`;
+      return {
+        replacement: `[stripped data URI ${dataUri[1]}, ${v.length} chars]`,
+      };
     }
-    if (value.length >= BULK_BASE64_MIN_CHARS && PURE_BASE64_RE.test(value)) {
-      return `[stripped base64, ${value.length} chars]`;
+    if (v.length >= BULK_BASE64_MIN_CHARS && PURE_BASE64_RE.test(v)) {
+      return { replacement: `[stripped base64, ${v.length} chars]` };
     }
-    return value;
-  }
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  // `path` holds only the current recursion ancestry, so a true cycle is
-  // replaced while shared (sibling) references are traversed in full. The
-  // capture leans on shared references by construction: transcript items
-  // embed the same message objects `clientMessages` lists, and both copies
-  // must survive. JSON.stringify duplicates shared references the same way.
-  if (path.has(value)) {
-    return "[cyclic]";
-  }
-  path.add(value);
-  let out: unknown;
-  if (Array.isArray(value)) {
-    out = value.map((v) => stripBulkBase64(v, path));
-  } else {
-    const obj: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
-      obj[k] = stripBulkBase64(v, path);
-    }
-    out = obj;
-  }
-  path.delete(value);
-  return out;
+    return null;
+  });
 }
 
 /**
@@ -257,32 +286,15 @@ export function dedupeAgainstClientMessages(
     }
   });
 
-  const replace = (value: unknown, path: WeakSet<object>): unknown => {
-    if (value === null || typeof value !== "object") {
-      return value;
+  return deepMapCapture(transcriptItems, (v) => {
+    if (v === null || typeof v !== "object") {
+      return null;
     }
-    const ref = refs.get(value);
-    if (ref !== undefined) {
-      return `[deduplicated: see clientMessages ${ref}]`;
-    }
-    if (path.has(value)) {
-      return "[cyclic]";
-    }
-    path.add(value);
-    let out: unknown;
-    if (Array.isArray(value)) {
-      out = value.map((v) => replace(v, path));
-    } else {
-      const obj: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(value)) {
-        obj[k] = replace(v, path);
-      }
-      out = obj;
-    }
-    path.delete(value);
-    return out;
-  };
-  return replace(transcriptItems, new WeakSet());
+    const ref = refs.get(v);
+    return ref !== undefined
+      ? { replacement: `[deduplicated: see clientMessages ${ref}]` }
+      : null;
+  });
 }
 
 function buildTarEntry(filename: string, data: Uint8Array): Uint8Array {

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -233,6 +233,58 @@ export function stripBulkBase64(value: unknown, path = new WeakSet()): unknown {
   return out;
 }
 
+/**
+ * Replace transcript-item message objects that are identical (by reference)
+ * to a `clientMessages` entry with a pointer marker, so the capture carries
+ * each message once. Matching is object identity, which is exactly how the
+ * duplication arises: transcript items embed the same `DisplayMessage`
+ * instances `clientMessages` lists. A structurally-equal copy is not
+ * identity-matched and is captured in full, so any divergence between the
+ * two surfaces survives; only true duplicates collapse.
+ */
+export function dedupeAgainstClientMessages(
+  transcriptItems: unknown,
+  clientMessages: unknown,
+): unknown {
+  if (!Array.isArray(clientMessages)) {
+    return transcriptItems;
+  }
+  const refs = new Map<object, string>();
+  clientMessages.forEach((m, i) => {
+    if (m && typeof m === "object") {
+      const id = (m as { id?: unknown }).id;
+      refs.set(m, typeof id === "string" ? id : `index ${i}`);
+    }
+  });
+
+  const replace = (value: unknown, path: WeakSet<object>): unknown => {
+    if (value === null || typeof value !== "object") {
+      return value;
+    }
+    const ref = refs.get(value);
+    if (ref !== undefined) {
+      return `[deduplicated: see clientMessages ${ref}]`;
+    }
+    if (path.has(value)) {
+      return "[cyclic]";
+    }
+    path.add(value);
+    let out: unknown;
+    if (Array.isArray(value)) {
+      out = value.map((v) => replace(v, path));
+    } else {
+      const obj: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        obj[k] = replace(v, path);
+      }
+      out = obj;
+    }
+    path.delete(value);
+    return out;
+  };
+  return replace(transcriptItems, new WeakSet());
+}
+
 function buildTarEntry(filename: string, data: Uint8Array): Uint8Array {
   const blockSize = 512;
   const dataBlocks = Math.ceil(data.length / blockSize);
@@ -444,9 +496,17 @@ async function buildClientLogsFile(
             ._vellumDebug?.chat
         : null;
     if (debugApi) {
+      const clientMessages = debugApi.getClientMessages?.() ?? null;
+      const transcriptItems = debugApi.getTranscriptItems?.() ?? null;
       const triagePayload = {
-        clientMessages: debugApi.getClientMessages?.() ?? null,
-        transcriptItems: debugApi.getTranscriptItems?.() ?? null,
+        clientMessages,
+        // Transcript items embed the same message objects `clientMessages`
+        // lists; carry the item-layer structure (kinds, keys, ordering) with
+        // pointers instead of a second full copy of every message.
+        transcriptItems: dedupeAgainstClientMessages(
+          transcriptItems,
+          clientMessages,
+        ),
         // Ephemeral interaction prompts (secret / confirmation /
         // contact-request / question) render as transcript trailer rows
         // outside any message's `contentBlocks`, so they're invisible in


### PR DESCRIPTION
## TL;DR

Completes the secondary scope of LUM-3020 that #39908 left open: the feedback triage capture serialized every message **twice** — once in `clientMessages` and again inside `transcriptItems`, which embed the same `DisplayMessage` objects by reference. Transcript items now carry a pointer marker (`[deduplicated: see clientMessages <id>]`) where the embedded object is reference-identical to a `clientMessages` entry; the item-layer structure (kinds, keys, ordering) survives intact.

With #39908's payload dedup and binary elision already in, this removes the last duplication: the capture now carries each message exactly once, text-only.

Part of LUM-3020

## Why it's safe

- **Identity-based matching is automatically conservative.** Only objects that *are* the same instance collapse — which is precisely how the duplication arises. A structurally-equal-but-distinct object is captured in full, so any real divergence between the two surfaces (the thing the transcript capture exists to reveal) survives.
- Capture-boundary only: the DevTools `_vellumDebug` API is untouched and stays full-fidelity.
- When `clientMessages` is unavailable, items pass through unchanged.

## Before / after (capture content for one message)

| Surface | Before | After |
|---|---|---|
| `clientMessages` | full message | full message (unchanged) |
| `transcriptItems[].message` (same object) | full second copy | pointer marker |
| `transcriptItems` structure (kinds/keys/order) | present | present (unchanged) |
| A transcript item embedding a *different* object | full copy | full copy (unchanged) |

## Verification

- Capture test asserts exact occurrence counts: message text ×2 (both within `clientMessages`: `textSegments` + `contentBlocks`), each stripped-binary marker ×1, the dedup pointer present, `"kind": "message"` structure retained, no `[cyclic]`.
- Unit tests pin identity-match vs structural-equality behavior and the `clientMessages`-unavailable passthrough.
- Sensitivity-checked: bypassing the dedupe fails the capture test.
- Full web suite: 835 files, 0 failures. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->