### PR TITLE
feat(web): keep a failed send on screen as an unsent message

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -269,6 +269,8 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const {
     sendMessage,
+    retryFailedSend,
+    discardFailedSend,
     handleStopGenerating,
     queuedMessages,
     handleCancelQueuedMessage,
@@ -550,6 +552,8 @@ export function ActiveChatView() {
     onRetryLatestTurn: supportsRetryTurn
       ? handleRetryLatestTurnRequested
       : undefined,
+    onRetryFailedSend: retryFailedSend,
+    onDiscardFailedSend: discardFailedSend,
     handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
 
     // History pagination

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -187,7 +187,10 @@ export interface ChatMainPanelProps {
   onSummarizeUpToHere?: (messageId: string) => void;
   /** Opens the "Retry" confirm dialog for the latest assistant turn. */
   onRetryLatestTurn?: () => void;
-  onRetryFailedSend?: (clientMessageId: string) => void;
+  onRetryFailedSend?: (
+    clientMessageId: string,
+    options?: { bypassSecretCheck?: boolean },
+  ) => void;
   onDiscardFailedSend?: (clientMessageId: string) => void;
   handleInspectMessage?: (messageId: string) => void;
 

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -187,6 +187,8 @@ export interface ChatMainPanelProps {
   onSummarizeUpToHere?: (messageId: string) => void;
   /** Opens the "Retry" confirm dialog for the latest assistant turn. */
   onRetryLatestTurn?: () => void;
+  onRetryFailedSend?: (clientMessageId: string) => void;
+  onDiscardFailedSend?: (clientMessageId: string) => void;
   handleInspectMessage?: (messageId: string) => void;
 
   // History pagination (from useConversationLoader in ActiveChatView)
@@ -277,6 +279,8 @@ export function ChatMainPanel({
   handleForkConversation,
   onSummarizeUpToHere,
   onRetryLatestTurn,
+  onRetryFailedSend,
+  onDiscardFailedSend,
   handleInspectMessage,
   historyPagination,
   diskPressure,
@@ -1121,6 +1125,8 @@ export function ChatMainPanel({
     // Hidden while a turn is in flight: retrying mid-generation would 409,
     // and the affordance targets the settled latest response.
     onRetryLatestTurn: isAssistantBusy ? undefined : onRetryLatestTurn,
+    onRetryFailedSend,
+    onDiscardFailedSend,
     onInspectMessage: handleInspectMessage,
     renderAvatar,
     onPullRefresh: handlePullRefresh,

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -203,11 +203,30 @@ export function useSendMessage({
   const addOptimisticSend = useChatSessionStore.use.addOptimisticSend();
   const setOptimisticSends = useChatSessionStore.use.setOptimisticSends();
 
-  /** Flag a still-present optimistic row as unsent. */
+  /**
+   * Mark a still-present optimistic row unsent, carrying what a retry needs to
+   * reproduce the original send. Queue bookkeeping is dropped at the same time:
+   * the message never reached the server queue, so leaving it tracked would
+   * bind the next queued ack to a row that is not waiting for one.
+   */
   const markSendFailed = useCallback(
-    (rowId: string) => {
+    (rowId: string, detail: NonNullable<DisplayMessage["sendFailed"]> = {}) => {
+      const queueIds = useChatSessionStore.getState().pendingQueuedMessageIds;
+      const queueIdx = queueIds.indexOf(rowId);
+      if (queueIdx !== -1) {
+        queueIds.splice(queueIdx, 1);
+      }
       setOptimisticSends((prev) =>
-        prev.map((m) => (m.id === rowId ? { ...m, sendFailed: true } : m)),
+        prev.map((m) =>
+          m.id === rowId
+            ? {
+                ...m,
+                sendFailed: detail,
+                queueStatus: undefined,
+                queuePosition: undefined,
+              }
+            : m,
+        ),
       );
     },
     [setOptimisticSends],
@@ -812,7 +831,12 @@ export function useSendMessage({
             },
           );
           if (!postResult.ok) {
-            revertQueuedMessage(userMessage.id);
+            markSendFailed(userMessage.id, {
+              ...(postResult.error.code
+                ? { code: postResult.error.code }
+                : {}),
+              ...(opts.scripted ? { scripted: true } : {}),
+            });
             const detail = resolvePostError(
               postResult.error.code,
               postResult.error.detail,
@@ -882,7 +906,10 @@ export function useSendMessage({
           }
         } catch (err) {
           captureError(err, { context: "send_message_queue" });
-          revertQueuedMessage(userMessage.id);
+          markSendFailed(
+            userMessage.id,
+            opts.scripted ? { scripted: true } : {},
+          );
           setError({ message: "Failed to queue message. Please try again." });
         }
         return;
@@ -937,7 +964,10 @@ export function useSendMessage({
           // attachments, and its `clientMessageId`, so retrying resends this
           // same message instead of composing a new one. Hidden sends render
           // no row, so they have nothing to mark.
-          markSendFailed(userMessage.id);
+          markSendFailed(userMessage.id, {
+            ...(result.error.code ? { code: result.error.code } : {}),
+            ...(opts.scripted ? { scripted: true } : {}),
+          });
           useConversationStore
             .getState()
             .removeProcessingConversationId(activeConversationId);
@@ -1003,7 +1033,7 @@ export function useSendMessage({
         // saw it is unknown. Mark the row unsent and keep it: retry reuses its
         // `clientMessageId`, which is what lets the daemon recognize a send it
         // already received instead of running the turn twice.
-        markSendFailed(userMessage.id);
+        markSendFailed(userMessage.id, opts.scripted ? { scripted: true } : {});
         setError({ message: "Something went wrong. Please try again." });
         // Multi-key processing-key cleanup: when a send is retargeted
         // (e.g. draft → new conversation), both the original active key
@@ -1051,7 +1081,7 @@ export function useSendMessage({
    * send it already received but never answered for.
    */
   const retryFailedSend = useCallback(
-    async (clientMessageId: string) => {
+    async (clientMessageId: string, options: { bypassSecretCheck?: boolean } = {}) => {
       const row = useChatSessionStore
         .getState()
         .optimisticSends.find((m) => m.id === clientMessageId);
@@ -1060,6 +1090,10 @@ export function useSendMessage({
       }
       await sendMessage(row.textSegments?.[0] ?? "", row.attachments ?? [], {
         retryOfClientMessageId: clientMessageId,
+        // Carry the original turn's provenance so a retried auto-send is still
+        // excluded from activation metrics.
+        ...(row.sendFailed.scripted ? { scripted: true } : {}),
+        ...(options.bypassSecretCheck ? { bypassSecretCheck: true } : {}),
       });
     },
     [sendMessage],

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -132,6 +132,13 @@ export interface SendChatMessageOptions {
    */
   hidden?: boolean;
   /**
+   * Resend an unsent row under its original identity rather than minting a new
+   * one. The daemon deduplicates on (conversation, clientMessageId), so a send
+   * whose response was lost is recognized instead of running the turn twice.
+   * Set only by {@link UseSendMessageResult.retryFailedSend}.
+   */
+  retryOfClientMessageId?: string;
+  /**
    * Single-use override for the daemon's `secret_blocked` ingress guard.
    * Set ONLY by the composer secret guard's "Send anyway" handler, after
    * the user explicitly confirmed sending content the client-side scan
@@ -195,6 +202,16 @@ export function useSendMessage({
   const doctorGate = usePlatformGate({ platformHostedOnly: true });
   const addOptimisticSend = useChatSessionStore.use.addOptimisticSend();
   const setOptimisticSends = useChatSessionStore.use.setOptimisticSends();
+
+  /** Flag a still-present optimistic row as unsent. */
+  const markSendFailed = useCallback(
+    (rowId: string) => {
+      setOptimisticSends((prev) =>
+        prev.map((m) => (m.id === rowId ? { ...m, sendFailed: true } : m)),
+      );
+    },
+    [setOptimisticSends],
+  );
   const setError = useChatSessionStore.use.setError();
   const setNotice = useChatSessionStore.use.setNotice();
 
@@ -734,7 +751,10 @@ export function useSendMessage({
       }
 
       const willQueue = isSending(useTurnStore.getState().phase);
-      const clientMessageId = crypto.randomUUID();
+      // A retry carries the identity of the row it is resending, so the daemon
+      // can recognize a message it already received. Everything downstream
+      // treats this send normally.
+      const clientMessageId = opts.retryOfClientMessageId ?? crypto.randomUUID();
       const userMessage: DisplayMessage = {
         id: clientMessageId,
         clientMessageId,
@@ -751,7 +771,17 @@ export function useSendMessage({
           : {}),
       };
       if (!isHidden) {
-        addOptimisticSend(userMessage);
+        if (opts.retryOfClientMessageId) {
+          // The row is already on screen. Clear the unsent mark in place so the
+          // retry does not stack a second copy beside it.
+          setOptimisticSends((prev) =>
+            prev.map((m) =>
+              m.id === clientMessageId ? { ...userMessage } : m,
+            ),
+          );
+        } else {
+          addOptimisticSend(userMessage);
+        }
       }
       void getSoundManager().play("message_sent");
 
@@ -902,28 +932,22 @@ export function useSendMessage({
         );
 
         if (result.status === "failed") {
-          // Roll back every piece of optimistic state we just set up: the
-          // optimistic send, the processing flag on the conversation, the
-          // prepended draft conversation in the sidebar, and the cleared
-          // composer input. Then surface the error.
-          setOptimisticSends((prev) =>
-            prev.filter((m) => m.id !== userMessage.id),
-          );
+          // Mark the row unsent and leave it where the user put it, rather
+          // than rolling it back into the composer. It keeps its text, its
+          // attachments, and its `clientMessageId`, so retrying resends this
+          // same message instead of composing a new one. Hidden sends render
+          // no row, so they have nothing to mark.
+          markSendFailed(userMessage.id);
           useConversationStore
             .getState()
             .removeProcessingConversationId(activeConversationId);
           if (isDraft) {
             removeConversation(queryClient, assistantId, activeConversationId);
-            setError({
-              message: result.error.message,
-              ...(result.error.code ? { code: result.error.code } : {}),
-              displayAs: "modal",
-              restoreContent: content,
-            });
-          } else {
-            useComposerStore.getState().setInput(content);
-            setError(result.error);
           }
+          setError({
+            message: result.error.message,
+            ...(result.error.code ? { code: result.error.code } : {}),
+          });
           return;
         }
 
@@ -975,6 +999,11 @@ export function useSendMessage({
         void refreshConversations();
       } catch (err) {
         captureError(err, { context: "send_chat_message" });
+        // A throw means the request never got an answer, so whether the daemon
+        // saw it is unknown. Mark the row unsent and keep it: retry reuses its
+        // `clientMessageId`, which is what lets the daemon recognize a send it
+        // already received instead of running the turn twice.
+        markSendFailed(userMessage.id);
         setError({ message: "Something went wrong. Please try again." });
         // Multi-key processing-key cleanup: when a send is retargeted
         // (e.g. draft → new conversation), both the original active key
@@ -1013,6 +1042,40 @@ export function useSendMessage({
   );
 
   // -------------------------------------------------------------------------
+  // retryFailedSend / discardFailedSend: actions on an unsent row
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resend an unsent row as itself: same text, same attachments, same
+   * `clientMessageId`. Reusing the identity is what lets the daemon dedup a
+   * send it already received but never answered for.
+   */
+  const retryFailedSend = useCallback(
+    async (clientMessageId: string) => {
+      const row = useChatSessionStore
+        .getState()
+        .optimisticSends.find((m) => m.id === clientMessageId);
+      if (!row?.sendFailed) {
+        return;
+      }
+      await sendMessage(row.textSegments?.[0] ?? "", row.attachments ?? [], {
+        retryOfClientMessageId: clientMessageId,
+      });
+    },
+    [sendMessage],
+  );
+
+  /** Drop an unsent row the user no longer wants. */
+  const discardFailedSend = useCallback(
+    (clientMessageId: string) => {
+      setOptimisticSends((prev) =>
+        prev.filter((m) => !(m.id === clientMessageId && m.sendFailed)),
+      );
+    },
+    [setOptimisticSends],
+  );
+
+  // -------------------------------------------------------------------------
   // handleStopGenerating — cancel the active generation
   // -------------------------------------------------------------------------
   const handleStopGenerating = useCallback(async () => {
@@ -1042,6 +1105,8 @@ export function useSendMessage({
 
   return {
     sendMessage,
+    retryFailedSend,
+    discardFailedSend,
     handleStopGenerating,
     queuedMessages,
     handleCancelQueuedMessage,

--- a/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * A send that does not reach the server leaves its row in the transcript,
+ * marked unsent, holding the text and attachments the user submitted. Retry
+ * resends that same row under its original `clientMessageId`, which is what
+ * lets the daemon deduplicate a message it already received but never answered
+ * for; discard drops it.
+ *
+ * Driven end-to-end against a spied daemon client, mirroring the sibling
+ * plugins test so the module registry stays clean.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import type { ReactNode } from "react";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { useSendMessage } from "@/domains/chat/hooks/use-send-message";
+import { useComposerStore } from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useTurnStore, INITIAL_TURN_STATE } from "@/domains/chat/turn-store";
+
+const DRAFT_ID = "draft-1";
+const SENT_TEXT = "resume: oil change, tire change, appraisal";
+
+const sentNonces: string[] = [];
+const originalPost = daemonClient.post;
+
+const queryClient = new QueryClient();
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function baseProps() {
+  return {
+    assistantId: "assistant-1",
+    activeConversationId: DRAFT_ID,
+    diskPressureChatBlockReason: null,
+    uiContextRef: { current: null },
+    pendingOnboardingContextRef: { current: null },
+    onboardingDraftConversationIdRef: { current: null },
+    startReconciliationLoop: () => {},
+    cancelReconciliation: () => {},
+    refreshConversations: async () => {},
+  };
+}
+
+function renderSend() {
+  useAssistantIdentityStore.getState().setIdentity("Assistant", "0.10.12");
+  return renderHook(() => useSendMessage(baseProps()), { wrapper: Wrapper });
+}
+
+const unsentRows = () =>
+  useChatSessionStore.getState().optimisticSends.filter((m) => m.sendFailed);
+
+beforeEach(() => {
+  sentNonces.length = 0;
+  queryClient.clear();
+  useConversationStore.getState().reset();
+  useTurnStore.setState(INITIAL_TURN_STATE);
+  useChatSessionStore.getState().setOptimisticSends([]);
+  useChatSessionStore.getState().setError(null);
+  useComposerStore.getState().setInput("");
+  useResolvedAssistantsStore.getState().setActiveAssistantId("assistant-1");
+  useConversationStore.getState().setActiveConversationId(DRAFT_ID);
+
+  daemonClient.post = mock(
+    async (options: { body?: Record<string, unknown> }) => {
+      const nonce = options.body?.clientMessageId;
+      if (typeof nonce === "string") {
+        sentNonces.push(nonce);
+      }
+      throw new Error("Load failed");
+    },
+  ) as typeof daemonClient.post;
+});
+
+afterEach(() => {
+  daemonClient.post = originalPost;
+  cleanup();
+});
+
+describe("useSendMessage: a send that never reaches the server", () => {
+  test("keeps the message on screen, marked unsent, with its text", async () => {
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage(SENT_TEXT);
+    });
+
+    const rows = unsentRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.textSegments).toEqual([SENT_TEXT]);
+    // The composer is left alone; the message lives in the transcript.
+    expect(useComposerStore.getState().input).toBe("");
+  });
+
+  test("retry resends the same row under its original identity", async () => {
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage(SENT_TEXT);
+    });
+    const rowId = unsentRows()[0]!.id;
+
+    await act(async () => {
+      await result.current.retryFailedSend(rowId);
+    });
+
+    expect(sentNonces).toHaveLength(2);
+    expect(sentNonces[0]).toBe(sentNonces[1]!);
+    // Still one row, not a second copy stacked beside the first.
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
+  });
+
+  test("discard drops the row", async () => {
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage(SENT_TEXT);
+    });
+    const rowId = unsentRows()[0]!.id;
+
+    act(() => {
+      result.current.discardFailedSend(rowId);
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+  });
+
+  test("a hidden machine send leaves nothing behind to retry", async () => {
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage("<system marker>", [], { hidden: true });
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
@@ -28,6 +28,7 @@ const DRAFT_ID = "draft-1";
 const SENT_TEXT = "resume: oil change, tire change, appraisal";
 
 const sentNonces: string[] = [];
+const sentBodies: Record<string, unknown>[] = [];
 const originalPost = daemonClient.post;
 
 const queryClient = new QueryClient();
@@ -63,6 +64,7 @@ const unsentRows = () =>
 
 beforeEach(() => {
   sentNonces.length = 0;
+  sentBodies.length = 0;
   queryClient.clear();
   useConversationStore.getState().reset();
   useTurnStore.setState(INITIAL_TURN_STATE);
@@ -74,6 +76,7 @@ beforeEach(() => {
 
   daemonClient.post = mock(
     async (options: { body?: Record<string, unknown> }) => {
+      sentBodies.push(options.body ?? {});
       const nonce = options.body?.clientMessageId;
       if (typeof nonce === "string") {
         sentNonces.push(nonce);
@@ -134,6 +137,43 @@ describe("useSendMessage: a send that never reaches the server", () => {
     });
 
     expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+  });
+
+  test("a send that fails while another turn is active is also kept", async () => {
+    // The queue branch used to revert the row outright, so an ordinary message
+    // sent while the assistant was busy still vanished on failure.
+    useTurnStore.setState({ ...INITIAL_TURN_STATE, phase: "sending" });
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage(SENT_TEXT);
+    });
+
+    const rows = unsentRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.textSegments).toEqual([SENT_TEXT]);
+    // Queue bookkeeping is dropped: the message never reached the server queue.
+    expect(rows[0]!.queueStatus).toBeUndefined();
+    expect(
+      useChatSessionStore.getState().pendingQueuedMessageIds,
+    ).not.toContain(rows[0]!.id);
+  });
+
+  test("retry carries the original send's scripted provenance", async () => {
+    const { result } = renderSend();
+
+    await act(async () => {
+      await result.current.sendMessage(SENT_TEXT, [], { scripted: true });
+    });
+    const row = unsentRows()[0]!;
+    expect(row.sendFailed?.scripted).toBe(true);
+
+    await act(async () => {
+      await result.current.retryFailedSend(row.id);
+    });
+
+    expect(sentBodies).toHaveLength(2);
+    expect(sentBodies[1]!.scripted).toBe(true);
   });
 
   test("a hidden machine send leaves nothing behind to retry", async () => {

--- a/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message.unsent.test.tsx
@@ -142,7 +142,7 @@ describe("useSendMessage: a send that never reaches the server", () => {
   test("a send that fails while another turn is active is also kept", async () => {
     // The queue branch used to revert the row outright, so an ordinary message
     // sent while the assistant was busy still vanished on failure.
-    useTurnStore.setState({ ...INITIAL_TURN_STATE, phase: "sending" });
+    useTurnStore.setState({ ...INITIAL_TURN_STATE, phase: "streaming" });
     const { result } = renderSend();
 
     await act(async () => {

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -46,7 +46,10 @@ export interface TranscriptRowProps {
   onSummarizeUpToHere?: (messageId: string) => void;
   onRetryLatestTurn?: () => void;
   /** Resend an unsent row under its original identity. */
-  onRetryFailedSend?: (clientMessageId: string) => void;
+  onRetryFailedSend?: (
+    clientMessageId: string,
+    options?: { bypassSecretCheck?: boolean },
+  ) => void;
   /** Drop an unsent row. */
   onDiscardFailedSend?: (clientMessageId: string) => void;
   onInspectMessage?: (messageId: string) => void;
@@ -228,6 +231,12 @@ export const TranscriptRow = memo(function TranscriptRow({
             <UnsentMessageActions
               onRetry={() => onRetryFailedSend?.(failedId)}
               onDiscard={() => onDiscardFailedSend?.(failedId)}
+              blockedForSecret={
+                item.message.sendFailed.code === "secret_blocked"
+              }
+              onSendAnyway={() =>
+                onRetryFailedSend?.(failedId, { bypassSecretCheck: true })
+              }
             />
           </div>
         );

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -16,6 +16,7 @@ import { PendingContactRequestRow } from "@/domains/chat/transcript/pending-cont
 import { PendingSecretRow } from "@/domains/chat/transcript/pending-secret-row";
 import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
+import { UnsentMessageActions } from "@/domains/chat/transcript/unsent-message-actions";
 import { isInteractiveClickTarget } from "@/domains/chat/transcript/transcript-message-body-shared";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -44,6 +45,10 @@ export interface TranscriptRowProps {
   onForkConversation?: (messageId: string) => void;
   onSummarizeUpToHere?: (messageId: string) => void;
   onRetryLatestTurn?: () => void;
+  /** Resend an unsent row under its original identity. */
+  onRetryFailedSend?: (clientMessageId: string) => void;
+  /** Drop an unsent row. */
+  onDiscardFailedSend?: (clientMessageId: string) => void;
   onInspectMessage?: (messageId: string) => void;
   /** Render-prop for `kind: "onboardingChoice"` items. Onboarding depends on
    *  props from the parent (sendMessage, didOnboarding, etc.) and has a
@@ -164,6 +169,8 @@ export const TranscriptRow = memo(function TranscriptRow({
   onForkConversation,
   onSummarizeUpToHere,
   onRetryLatestTurn,
+  onRetryFailedSend,
+  onDiscardFailedSend,
   onInspectMessage,
   renderOnboardingChoice,
   onOpenRuleEditor,
@@ -188,6 +195,41 @@ export const TranscriptRow = memo(function TranscriptRow({
       if (item.message.isSystemCard) {
         return (
           <SystemCardRow message={item.message} assistantId={assistantId} />
+        );
+      }
+      if (item.message.sendFailed) {
+        const failedId = item.message.clientMessageId ?? item.message.id;
+        return (
+          <div className="opacity-60">
+            <TranscriptMessageBody
+              message={item.message}
+              conversationId={conversationId}
+              assistantDisplayName={assistantDisplayName}
+              onSurfaceAction={onSurfaceAction}
+              onForkConversation={onForkConversation}
+              onSummarizeUpToHere={onSummarizeUpToHere}
+              onRetryLatestTurn={onRetryLatestTurn}
+              onInspectMessage={onInspectMessage}
+              onOpenRuleEditor={onOpenRuleEditor}
+              unknownNudgeToolCallIds={unknownNudgeToolCallIds}
+              onDismissUnknownNudge={onDismissUnknownNudge}
+              onConfirmationSubmit={onConfirmationSubmit}
+              onAllowAndCreateRule={onAllowAndCreateRule}
+              onOpenApp={onOpenApp}
+              onOpenDocument={onOpenDocument}
+              assistantId={assistantId}
+              onSubagentClick={onSubagentClick}
+              onStopSubagent={onStopSubagent}
+              onWorkflowClick={onWorkflowClick}
+              onStopWorkflow={onStopWorkflow}
+              isStreaming={isStreaming}
+              isLatestMessage={isLatestMessage}
+            />
+            <UnsentMessageActions
+              onRetry={() => onRetryFailedSend?.(failedId)}
+              onDiscard={() => onDiscardFailedSend?.(failedId)}
+            />
+          </div>
         );
       }
       return (

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -47,6 +47,10 @@ export interface TranscriptProps {
   onSummarizeUpToHere?: (messageId: string) => void;
   /** Callback for "Retry" from the latest assistant message's hover actions. */
   onRetryLatestTurn?: () => void;
+  /** Resend an unsent row under its original identity. */
+  onRetryFailedSend?: (clientMessageId: string) => void;
+  /** Drop an unsent row. */
+  onDiscardFailedSend?: (clientMessageId: string) => void;
   /** Callback for "Inspect" from a message's hover actions. */
   onInspectMessage?: (messageId: string) => void;
 
@@ -268,6 +272,8 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       onForkConversation: rest.onForkConversation,
       onSummarizeUpToHere: rest.onSummarizeUpToHere,
       onRetryLatestTurn: rest.onRetryLatestTurn,
+      onRetryFailedSend: rest.onRetryFailedSend,
+      onDiscardFailedSend: rest.onDiscardFailedSend,
       onInspectMessage: rest.onInspectMessage,
       renderOnboardingChoice: rest.renderOnboardingChoice,
       assistantDisplayName: rest.assistantDisplayName,

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -48,7 +48,10 @@ export interface TranscriptProps {
   /** Callback for "Retry" from the latest assistant message's hover actions. */
   onRetryLatestTurn?: () => void;
   /** Resend an unsent row under its original identity. */
-  onRetryFailedSend?: (clientMessageId: string) => void;
+  onRetryFailedSend?: (
+    clientMessageId: string,
+    options?: { bypassSecretCheck?: boolean },
+  ) => void;
   /** Drop an unsent row. */
   onDiscardFailedSend?: (clientMessageId: string) => void;
   /** Callback for "Inspect" from a message's hover actions. */

--- a/clients/web/src/domains/chat/transcript/unsent-message-actions.tsx
+++ b/clients/web/src/domains/chat/transcript/unsent-message-actions.tsx
@@ -15,12 +15,38 @@ import { AlertCircle } from "lucide-react";
 export interface UnsentMessageActionsProps {
   onRetry: () => void;
   onDiscard: () => void;
+  /**
+   * The daemon blocked this message for a suspected credential. A plain retry
+   * resends the same content and is rejected identically, so the row offers
+   * the same explicit override the composer's blocked notice does.
+   */
+  blockedForSecret?: boolean;
+  onSendAnyway?: () => void;
 }
 
 export function UnsentMessageActions({
   onRetry,
   onDiscard,
+  blockedForSecret,
+  onSendAnyway,
 }: UnsentMessageActionsProps) {
+  if (blockedForSecret && onSendAnyway) {
+    return (
+      <div
+        data-testid="unsent-message-actions"
+        className="mt-1 flex items-center justify-end gap-2 text-body-small-default text-[var(--content-secondary)]"
+      >
+        <AlertCircle aria-hidden className="size-3.5" />
+        <span>Not sent</span>
+        <Button variant="ghost" size="compact" onClick={onSendAnyway}>
+          Send anyway
+        </Button>
+        <Button variant="ghost" size="compact" onClick={onDiscard}>
+          Discard
+        </Button>
+      </div>
+    );
+  }
   return (
     <div
       data-testid="unsent-message-actions"

--- a/clients/web/src/domains/chat/transcript/unsent-message-actions.tsx
+++ b/clients/web/src/domains/chat/transcript/unsent-message-actions.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { AlertCircle } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Actions under a message whose send did not reach the server
+// ---------------------------------------------------------------------------
+//
+// A failed send keeps its row in the transcript instead of being rolled back
+// into the composer, so the text and any attachments stay where the user put
+// them. This strip is what tells them it did not go and gives them a way to
+// act on it. Retry resends the same row under its original identity, which is
+// what lets the daemon deduplicate a send it received but never answered for;
+// discard drops it.
+
+export interface UnsentMessageActionsProps {
+  onRetry: () => void;
+  onDiscard: () => void;
+}
+
+export function UnsentMessageActions({
+  onRetry,
+  onDiscard,
+}: UnsentMessageActionsProps) {
+  return (
+    <div
+      data-testid="unsent-message-actions"
+      className="mt-1 flex items-center justify-end gap-2 text-body-small-default text-[var(--content-secondary)]"
+    >
+      <AlertCircle aria-hidden className="size-3.5" />
+      <span>Not sent</span>
+      <Button variant="ghost" size="compact" onClick={onRetry}>
+        Retry
+      </Button>
+      <Button variant="ghost" size="compact" onClick={onDiscard}>
+        Discard
+      </Button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -82,6 +82,15 @@ export interface DisplayMessage {
    */
   isOptimistic?: boolean;
   /**
+   * True on a user message whose send did not reach the server. The row stays
+   * in the transcript so the text and its attachments are still in front of
+   * the user, rendered as unsent with retry and discard actions. Retry resends
+   * this same row under its original `clientMessageId`, so a send that did
+   * reach the daemon and lost only its response is deduplicated rather than
+   * run a second time.
+   */
+  sendFailed?: boolean;
+  /**
    * Server message ids folded into this canonical display row. Reconcile treats
    * these as aliases so a live SSE row can merge into its collapsed history row.
    */

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -82,14 +82,22 @@ export interface DisplayMessage {
    */
   isOptimistic?: boolean;
   /**
-   * True on a user message whose send did not reach the server. The row stays
-   * in the transcript so the text and its attachments are still in front of
-   * the user, rendered as unsent with retry and discard actions. Retry resends
-   * this same row under its original `clientMessageId`, so a send that did
-   * reach the daemon and lost only its response is deduplicated rather than
-   * run a second time.
+   * Set on a user message whose send did not go through. The row stays in the
+   * transcript so the text and its attachments are still in front of the user,
+   * rendered as unsent with retry and discard actions. Retry resends this same
+   * row under its original `clientMessageId`, so a send that did reach the
+   * daemon and lost only its response is deduplicated rather than run a second
+   * time, and carries the fields here so the retried turn is identical to the
+   * one that failed.
    */
-  sendFailed?: boolean;
+  sendFailed?: {
+    /** Error code from the daemon, when it answered. Drives recovery actions
+     *  a plain retry cannot resolve, e.g. `secret_blocked`. */
+    code?: string;
+    /** The original send's `scripted` flag, so a retried auto-send is still
+     *  excluded from activation metrics. */
+    scripted?: boolean;
+  };
   /**
    * Server message ids folded into this canonical display row. Reconcile treats
    * these as aliases so a live SSE row can merge into its collapsed history row.


### PR DESCRIPTION
When a send does not reach the server, the message it produced is torn down: the row is removed and the text is either pushed back into the composer or lost outright. A customer watched a five-task message disappear this way and had no way to get it back.

The message now stays where they put it, marked unsent, still holding its text and attachments. Two actions sit under it:

- **Retry** resends that same message under its original `clientMessageId`. The daemon deduplicates on (conversation, clientMessageId), so a send it received but never answered for is recognized rather than run a second time along with its tool calls.
- **Discard** drops it.

Nothing round-trips through the composer, so text typed since the failure is untouched and a message can no longer end up in neither the transcript nor the input.

A server error still surfaces its own message, so a billing or blocked-content rejection reads as itself rather than as the generic string. Hidden machine sends render no row and so produce nothing to retry.

The existing prune already handles the ambiguous case: an unsent row whose message did land gets a server twin on the next snapshot and is cleaned up automatically.

Note this is session state, not persisted. Leaving the conversation and returning drops an unsent message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)