### PR TITLE
fix(assistant): make surface completion writes deterministic and consistent on failure

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -318,6 +318,8 @@ const deleteMessageByIdMock = mock(() => ({
   deletedSummaryIds: [],
 }));
 const reserveMessageMock = mock(async () => ({ id: "msg-reserve" }));
+/** Persisted rows the loop reads back. Empty unless a test seeds one. */
+let mockStoredMessages: unknown[] = [];
 const updateMessageContentMock = mock(() => {});
 const finalizeMessageContentMock = mock(() => {});
 const addMessageMock = mock(() => ({ id: "mock-msg-id" }));
@@ -328,7 +330,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
   updateConversationUsage: () => {},
   updateMessageMetadata: updateMessageMetadataMock,
   setConversationHistoryStrippedAt: setConversationHistoryStrippedAtMock,
-  getMessages: () => [],
+  getMessages: () => mockStoredMessages,
   getConversation: () => mockConversationRow,
   provenanceFromTrustContext: () => ({
     source: "user",
@@ -931,7 +933,9 @@ beforeEach(() => {
   getSlackCompactionWatermarkForPrefixMock.mockClear();
   deleteMessageByIdMock.mockClear();
   reserveMessageMock.mockClear();
+  mockStoredMessages = [];
   updateMessageContentMock.mockClear();
+  updateMessageContentMock.mockImplementation(() => {});
   finalizeMessageContentMock.mockClear();
   rmSync(inflightDir(), { recursive: true, force: true });
   addMessageMock.mockClear();
@@ -1969,6 +1973,37 @@ describe("session-agent-loop", () => {
       expect(ctx.pendingSurfaceActions.has("page-1")).toBe(true);
       expect(ctx.pendingSurfaceActions.has("stale-table-1")).toBe(false);
       expect(ctx.pendingSurfaceActions.has("stale-form-1")).toBe(false);
+    });
+
+    test("withholds the dismissal event when its persisted write fails", async () => {
+      const events: AssistantEvent[] = [];
+
+      const ctx = makeCtx();
+      ctx.pendingSurfaceActions.set("stale-table-2", { surfaceType: "table" });
+      mockStoredMessages = [
+        {
+          id: "msg-with-stale-surface",
+          conversationId: "conv-1",
+          role: "assistant",
+          content: [{ type: "ui_surface", surfaceId: "stale-table-2" }],
+          createdAt: 0,
+          metadata: null,
+        },
+      ];
+      updateMessageContentMock.mockImplementationOnce(() => {
+        throw new Error("database is locked");
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg), {
+        isUserMessage: true,
+      });
+
+      // Announcing a dismissal the DB still holds as pending leaves the client
+      // showing a card the next history reseed reverts.
+      expect(
+        events.filter((e) => e.type === "ui_surface_complete"),
+      ).toHaveLength(0);
+      expect(ctx.pendingSurfaceActions.has("stale-table-2")).toBe(false);
     });
 
     test("does not auto-complete surfaces when request is a surface action", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { UISurfaceCompleteEvent } from "../api/events/ui-surface-complete.js";
 import type { AssistantEvent } from "../api/index.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import {
+  createMockLoggerModule,
+  makeMockLogger,
+} from "./helpers/mock-logger.js";
 
 /** Interleaved record of persist writes and broadcasts, for ordering asserts. */
 let callOrder: string[] = [];
@@ -19,18 +23,20 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 
 let loggedWarnings: Array<{ fields: Record<string, unknown>; msg: string }> =
   [];
-mock.module("../util/logger.js", () => ({
-  getLogger: () => ({
-    debug: () => {},
-    info: () => {},
-    warn: (fields: Record<string, unknown>, msg: string) =>
-      loggedWarnings.push({ fields, msg }),
-    error: () => {},
-    fatal: () => {},
-    trace: () => {},
-    child: () => ({}),
+mock.module("../util/logger.js", () =>
+  createMockLoggerModule({
+    getLogger: () => ({
+      debug: () => {},
+      info: () => {},
+      warn: (fields: Record<string, unknown>, msg: string) =>
+        loggedWarnings.push({ fields, msg }),
+      error: () => {},
+      fatal: () => {},
+      trace: () => {},
+      child: makeMockLogger,
+    }),
   }),
-}));
+);
 
 // Stand-in for the persisted message store: `getMessages` reads it and
 // `updateMessageContent` writes back through JSON, so a read after a write
@@ -94,12 +100,14 @@ function resetSurfaceState(): void {
 // Import must come AFTER mock.module so the surface module picks up the
 // mocked event hub and persistence functions.
 const {
+  completeSurfaceAndNotify,
   createSurfaceMutex,
   handleSurfaceAction,
   markSurfaceCompleted,
   surfaceProxyResolver,
 } = await import("../daemon/conversation-surfaces.js");
 
+import type { SurfaceStateEntry } from "../daemon/conversation-surface-state.js";
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType } from "../daemon/message-protocol.js";
 
@@ -234,10 +242,8 @@ describe("history-restored surface completion", () => {
   test("one-shot choice surface with no in-memory state is completed and persisted", async () => {
     const surfaceId = "surface-choice-history-1";
     seedSurfaceRow(surfaceId, "choice");
+    // Neither live map holds anything, so the type can only come from history.
     const ctx = makeContext();
-
-    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
-    expect(ctx.surfaceState.has(surfaceId)).toBe(false);
 
     // The history-restored branch signals acceptance by returning nothing; the
     // HTTP route maps that to `{ ok: true }`.
@@ -272,11 +278,8 @@ describe("history-restored surface completion", () => {
       confirmLabel: "Delete forever",
       cancelLabel: "Keep it",
     });
+    // Neither live map holds anything, so the labels come from history.
     const ctx = makeContext();
-
-    // Neither live map has anything: the labels can only come from history.
-    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
-    expect(ctx.surfaceState.has(surfaceId)).toBe(false);
 
     await handleSurfaceAction(ctx, surfaceId, "confirm", {});
 
@@ -373,7 +376,7 @@ describe("history-restored surface completion", () => {
     expect(completions[0].summary).toBe("Answered");
   });
 
-  test("the pending branch still completes a one-shot surface exactly as before", async () => {
+  test("the pending branch completes a one-shot surface too", async () => {
     const surfaceId = "surface-choice-pending-1";
     seedSurfaceRow(surfaceId, "choice");
     const ctx = makeContext();
@@ -443,7 +446,7 @@ describe("history-restored surface completion", () => {
 describe("history-restored surface completion: requester provenance", () => {
   beforeEach(resetSurfaceState);
 
-  test("an untrusted requester cannot complete a guardian-provenance surface", async () => {
+  test("the type-driven rule does not read a guardian-provenance surface for an untrusted requester", async () => {
     const surfaceId = "surface-choice-guardian-1";
     seedSurfaceRow(
       surfaceId,
@@ -457,7 +460,9 @@ describe("history-restored surface completion: requester provenance", () => {
     await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
 
     // The live path hides this row from this actor, so the persisted fallback
-    // must not hand back its type or its labels.
+    // must not hand back its type or its labels. The filter covers that read
+    // only: an explicit `_completeSurface` request skips it, and the write
+    // scan is unfiltered.
     expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
     expect(contentWrites).toHaveLength(0);
     expect(completionBroadcasts(surfaceId)).toHaveLength(0);
@@ -484,15 +489,17 @@ describe("history-restored surface completion: requester provenance", () => {
 describe("history-restored surface completion: scan cost", () => {
   beforeEach(resetSurfaceState);
 
-  test("a one-shot action with no live state costs one full scan", async () => {
+  test("a one-shot action with no live state costs two full scans", async () => {
     const surfaceId = "surface-scan-1";
     seedSurfaceRow(surfaceId, "choice");
     const ctx = makeContext();
 
     await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
 
-    // One read that resolves the type and the labels, reused by the write.
-    expect(getMessagesCalls).toBe(1);
+    // One read to resolve the type and the labels, then the write's own scan.
+    // The write scans unfiltered while the read is provenance-filtered, so
+    // each resolves its own row rather than sharing one.
+    expect(getMessagesCalls).toBe(2);
     expect(readPersistedSurface(surfaceId)?.completed).toBe(true);
   });
 
@@ -707,6 +714,75 @@ describe("markSurfaceCompleted in-memory patching", () => {
     expect(newer.completionSummary).toBe("Done");
     expect(older.completed).toBeUndefined();
   });
+
+  test("leaves in-memory messages pending when the persisted write throws", () => {
+    const surfaceId = "surface-rollback-1";
+    seedSurfaceRow(surfaceId, "choice");
+    const block = { type: "ui_surface", surfaceId } as Record<string, unknown>;
+    persistError = new Error("database is locked");
+
+    expect(
+      markSurfaceCompleted(
+        { conversationId: CONVERSATION_ID, messages: [{ content: [block] }] },
+        surfaceId,
+        "Done",
+      ),
+    ).toBe(false);
+
+    // A patched in-memory block over a pending DB row is the same divergence
+    // the completion write exists to close.
+    expect(block.completed).toBeUndefined();
+    expect(block.completionSummary).toBeUndefined();
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+  });
+
+  test("patches in-memory messages when there is no persisted block to write", () => {
+    const surfaceId = "surface-memory-only-1";
+    const block = { type: "ui_surface", surfaceId } as Record<string, unknown>;
+
+    expect(
+      markSurfaceCompleted(
+        { conversationId: CONVERSATION_ID, messages: [{ content: [block] }] },
+        surfaceId,
+        "Done",
+      ),
+    ).toBe(true);
+
+    expect(block.completed).toBe(true);
+    expect(block.completionSummary).toBe("Done");
+  });
+});
+
+describe("completion summary sourcing", () => {
+  beforeEach(resetSurfaceState);
+
+  test("keeps live surface data when the persisted block carries none", async () => {
+    const surfaceId = "surface-live-data-1";
+    storedRows = [
+      {
+        id: "msg-typed-dataless",
+        conversationId: CONVERSATION_ID,
+        role: "assistant",
+        content: [
+          { type: "ui_surface", surfaceId, surfaceType: "confirmation" },
+        ],
+        createdAt: 0,
+        metadata: null,
+      },
+    ];
+    const ctx = makeContext();
+    // `liveSurfaceType` and `liveSurfaceData` are independent inputs, so live
+    // labels must survive a persisted read that only resolves the type.
+    ctx.surfaceState.set(surfaceId, {
+      data: { message: "Delete it?", confirmLabel: "Delete forever" },
+    } as unknown as SurfaceStateEntry);
+
+    await handleSurfaceAction(ctx, surfaceId, "confirm", {});
+
+    expect(completionBroadcasts(surfaceId)[0].summary).toBe(
+      'User chose: "Delete forever"',
+    );
+  });
 });
 
 describe("surface completion when the persisted write does not land", () => {
@@ -753,5 +829,20 @@ describe("surface completion when the persisted write does not land", () => {
     expect(readPersistedSurface(surfaceId)).toBeUndefined();
     expect(contentWrites).toHaveLength(0);
     expect(completionBroadcasts(surfaceId)).toHaveLength(1);
+  });
+
+  test("a guardian card withdrawal is announced even when its write throws", () => {
+    const surfaceId = "surface-withdrawn-1";
+    seedSurfaceRow(surfaceId, "confirmation");
+    persistError = new Error("database is locked");
+
+    completeSurfaceAndNotify(CONVERSATION_ID, surfaceId, "Approved");
+
+    // The request is already resolved, so withholding the announcement would
+    // strand a live, clickable approval card for a decided request.
+    expect(readPersistedSurface(surfaceId)?.completed).toBeUndefined();
+    const completions = completionBroadcasts(surfaceId);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].summary).toBe("Approved");
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-persisted-info.test.ts
@@ -143,18 +143,14 @@ describe("findPersistedSurfaceInfo", () => {
     ).toBeUndefined();
   });
 
-  test("returns the type for a block behind the compaction boundary", () => {
-    // The surface sits in the oldest row, with three newer rows after it. A
-    // conversation compacted to `contextCompactedMessageCount: 3` hides this
-    // row from `findPersistedSurfaceState`, whose scan is bounded by
-    // `rn > liveHistoryStartRow`. This helper consults no boundary at all.
+  test("reaches the oldest row when the newer ones carry no surface", () => {
     seedRows([
       {
-        id: "msg-compacted",
+        id: "msg-oldest",
         content: [
           {
             type: "ui_surface",
-            surfaceId: "surface-compacted-1",
+            surfaceId: "surface-oldest-1",
             surfaceType: "choice",
             data: {},
           },
@@ -166,7 +162,7 @@ describe("findPersistedSurfaceInfo", () => {
     ]);
 
     expect(
-      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-compacted-1", GUARDIAN)
+      findPersistedSurfaceInfo(CONVERSATION_ID, "surface-oldest-1", GUARDIAN)
         ?.surfaceType,
     ).toBe("choice");
   });

--- a/assistant/src/__tests__/surface-completion-compaction-boundary.test.ts
+++ b/assistant/src/__tests__/surface-completion-compaction-boundary.test.ts
@@ -9,6 +9,8 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { conversations, messages } from "../persistence/schema/index.js";
 import { findPersistedSurfaceState } from "../runtime/routes/surface-conversation-resolver.js";
+import { getDbPath } from "../util/platform.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
 
 await initializeDb();
 
@@ -25,6 +27,9 @@ const GUARDIAN = { requesterCanAccessMemory: true };
  */
 function seedCompactedConversation(): void {
   const db = getDb();
+  // Without the test preload these deletes would clear the user's live
+  // workspace database.
+  assertNotLiveDb(getDbPath());
   db.delete(messages).run();
   db.delete(conversations).run();
   db.insert(conversations)

--- a/assistant/src/__tests__/surface-completion-compaction-boundary.test.ts
+++ b/assistant/src/__tests__/surface-completion-compaction-boundary.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  findPersistedSurfaceInfo,
+  markSurfaceCompleted,
+} from "../daemon/conversation-surfaces.js";
+import { getMessages } from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { conversations, messages } from "../persistence/schema/index.js";
+import { findPersistedSurfaceState } from "../runtime/routes/surface-conversation-resolver.js";
+
+await initializeDb();
+
+const CONVERSATION_ID = "conv-compaction-boundary-1";
+const SURFACE_ID = "surface-behind-boundary-1";
+/** The surface sits in row 1, so this boundary drops it from live history. */
+const COMPACTED_MESSAGE_COUNT = 3;
+
+const GUARDIAN = { requesterCanAccessMemory: true };
+
+/**
+ * Four real message rows, the oldest carrying a `choice` surface between two
+ * text siblings, plus a conversation compacted past that row.
+ */
+function seedCompactedConversation(): void {
+  const db = getDb();
+  db.delete(messages).run();
+  db.delete(conversations).run();
+  db.insert(conversations)
+    .values({
+      id: CONVERSATION_ID,
+      title: null,
+      createdAt: 1,
+      updatedAt: 1,
+      contextCompactedMessageCount: COMPACTED_MESSAGE_COUNT,
+    })
+    .run();
+
+  const rows = [
+    [
+      { type: "text", text: "Which one?" },
+      {
+        type: "ui_surface",
+        surfaceId: SURFACE_ID,
+        surfaceType: "choice",
+        data: { options: [{ id: "inbox", title: "Clean up my inbox" }] },
+      },
+      { type: "text", text: "Take your time." },
+    ],
+    [{ type: "text", text: "still waiting" }],
+    [{ type: "text", text: "still waiting" }],
+    [{ type: "text", text: "still waiting" }],
+  ];
+  rows.forEach((content, i) => {
+    db.insert(messages)
+      .values({
+        id: `msg-${i + 1}`,
+        conversationId: CONVERSATION_ID,
+        role: "assistant",
+        content: JSON.stringify(content),
+        createdAt: i + 1,
+        metadata: null,
+      })
+      .run();
+  });
+}
+
+/** The surface block as a history reseed would read it back. */
+function readPersistedBlocks(): Array<Record<string, unknown>> {
+  const row = getMessages(CONVERSATION_ID).find((r) => r.id === "msg-1")!;
+  return row.content as unknown as Array<Record<string, unknown>>;
+}
+
+describe("a surface behind the context-compaction boundary", () => {
+  beforeEach(seedCompactedConversation);
+
+  test("is invisible to the compaction-bounded read", () => {
+    expect(
+      findPersistedSurfaceState(CONVERSATION_ID, SURFACE_ID, {
+        liveHistoryStartRow: COMPACTED_MESSAGE_COUNT,
+        ...GUARDIAN,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("is found by the same read once the boundary is lifted", () => {
+    expect(
+      findPersistedSurfaceState(CONVERSATION_ID, SURFACE_ID, {
+        liveHistoryStartRow: 0,
+        ...GUARDIAN,
+      })?.surfaceType,
+    ).toBe("choice");
+  });
+
+  test("still yields its type to the completion path's read", () => {
+    expect(
+      findPersistedSurfaceInfo(CONVERSATION_ID, SURFACE_ID, GUARDIAN)
+        ?.surfaceType,
+    ).toBe("choice");
+  });
+
+  test("is completed by the write, leaving its sibling blocks intact", () => {
+    expect(
+      markSurfaceCompleted(
+        { conversationId: CONVERSATION_ID },
+        SURFACE_ID,
+        'User chose: "Clean up my inbox"',
+      ),
+    ).toBe(true);
+
+    const blocks = readPersistedBlocks();
+    const surface = blocks.find((b) => b.type === "ui_surface");
+    expect(surface?.completed).toBe(true);
+    expect(surface?.completionSummary).toBe('User chose: "Clean up my inbox"');
+    expect(surface?.surfaceType).toBe("choice");
+    expect(blocks.map((b) => b.type)).toEqual(["text", "ui_surface", "text"]);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -737,13 +737,16 @@ export async function runAgentLoopImpl(
         if (entry.surfaceType === "dynamic_page") {
           continue;
         }
-        onEvent({
-          type: "ui_surface_complete",
-          conversationId: ctx.conversationId,
-          surfaceId,
-          summary: "Dismissed",
-        });
-        markSurfaceCompleted(ctx, surfaceId, "Dismissed");
+        // Persist before announcing: a client told the card was dismissed
+        // while the write failed would watch the next reseed revert it.
+        if (markSurfaceCompleted(ctx, surfaceId, "Dismissed")) {
+          onEvent({
+            type: "ui_surface_complete",
+            conversationId: ctx.conversationId,
+            surfaceId,
+            summary: "Dismissed",
+          });
+        }
         ctx.pendingSurfaceActions.delete(surfaceId);
       }
     }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -179,32 +179,11 @@ const pendingSurfacePersists = new Map<
 
 /** A located `ui_surface` block plus everything needed to write it back. */
 type PersistedSurfaceHit = {
-  /** Message row the block lives in, for `updateMessageContent`. */
   rowId: string;
-  /** The row's full content block array, mutated in place then re-serialized. */
   blocks: unknown[];
-  /** The matching `ui_surface` block, a live reference into `blocks`. */
   block: Record<string, unknown>;
-  /** Index of `block` within `blocks`. */
   blockIndex: number;
 };
-
-/**
- * Provenance scoping for a persisted-surface scan.
- *
- * A read hands the block's content back to the requester, so it passes that
- * requester's memory capability and the scan applies
- * {@link isRowVisibleToUntrustedActor} per row. That is the identical
- * predicate `loadFromDb` applies when building `messages`, which
- * `restoreSurfaceStateFromHistory` turns into `surfaceState`, so the
- * persisted fallback can never surface a row the live path deliberately hid
- * from this actor.
- *
- * A write passes `"write"` and scans unfiltered on purpose: it addresses a
- * block by an id the caller already holds and returns nothing about it, so
- * there is no content for the filter to protect.
- */
-type PersistedSurfaceScope = { requesterCanAccessMemory: boolean } | "write";
 
 /**
  * Locate the persisted `ui_surface` content block for `surfaceId`.
@@ -218,6 +197,15 @@ type PersistedSurfaceScope = { requesterCanAccessMemory: boolean } | "write";
  * `ui_surface` reader and deliberately does not: it runs its own SQL scan,
  * bounded by the compaction boundary, for the read-only content route.
  *
+ * `filterByProvenance` applies {@link isRowVisibleToUntrustedActor} per row,
+ * the identical predicate `loadFromDb` applies when building `messages`. It
+ * covers the persisted type/data read ({@link findPersistedSurfaceInfo})
+ * only. Writes scan unfiltered, so a completion write can mutate a row the
+ * requester cannot see and push requester-controlled summary text into it.
+ * The live-state path (`ctx.surfaceState` / `ctx.pendingSurfaceActions`) is
+ * unfiltered too: it is scoped to the trust the conversation was loaded
+ * under, not the requester's.
+ *
  * The scan is deliberately unbounded by compaction (see
  * {@link findPersistedSurfaceInfo}), and it throws rather than swallowing DB
  * errors so each caller keeps its own logging.
@@ -225,10 +213,9 @@ type PersistedSurfaceScope = { requesterCanAccessMemory: boolean } | "write";
 function findPersistedSurfaceBlock(
   conversationId: string,
   surfaceId: string,
-  scope: PersistedSurfaceScope,
+  opts: { filterByProvenance: boolean },
 ): PersistedSurfaceHit | undefined {
-  const filterByProvenance =
-    scope !== "write" && !scope.requesterCanAccessMemory;
+  const { filterByProvenance } = opts;
   const rows = getMessages(conversationId);
   for (let r = rows.length - 1; r >= 0; r--) {
     if (filterByProvenance && !isRowVisibleToUntrustedActor(rows[r].metadata)) {
@@ -265,7 +252,9 @@ function persistSurfaceData(
   data: SurfaceData,
 ): void {
   try {
-    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, "write");
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, {
+      filterByProvenance: false,
+    });
     if (!hit) {
       return;
     }
@@ -304,19 +293,15 @@ export function scheduleSurfaceDataPersist(
  * Force-flush any pending debounced persist for `surfaceId`. Called on
  * surface completion so the final state is durable before the surface
  * record transitions to `completed`.
- *
- * Returns whether a write actually landed, so a caller holding a block
- * located before the flush knows to discard it and re-locate.
  */
-export function flushSurfaceDataPersist(surfaceId: string): boolean {
+export function flushSurfaceDataPersist(surfaceId: string): void {
   const pending = pendingSurfacePersists.get(surfaceId);
   if (!pending) {
-    return false;
+    return;
   }
   clearTimeout(pending.timer);
   pendingSurfacePersists.delete(surfaceId);
   persistSurfaceData(pending.conversationId, surfaceId, pending.data);
-  return true;
 }
 
 /**
@@ -372,55 +357,54 @@ export function flushPendingSurfaceDataPersists(conversationId?: string): void {
 }
 
 /**
- * How the persisted half of {@link markSurfaceCompleted} went.
- *
- * `"not_found"` and `"failed"` both wrote nothing, and the difference decides
- * whether a caller may still broadcast `ui_surface_complete`: `"not_found"`
- * leaves no persisted block that could revert to pending on the next history
- * reseed, while `"failed"` leaves one that will.
- */
-export type SurfaceCompletionPersistResult =
-  | "persisted"
-  | "not_found"
-  | "failed";
-
-/**
- * Whether a completion may be announced to clients given how its persist went.
- * Every completion broadcast site asks this, so the rule cannot drift between
- * them.
- */
-function canBroadcastCompletion(
-  result: SurfaceCompletionPersistResult,
-): boolean {
-  return result !== "failed";
-}
-
-/**
  * Mark a `ui_surface` content block as completed in the database so that
- * history reconstruction preserves the completion state.  Also updates
+ * history reconstruction preserves the completion state. Also updates
  * in-memory messages when available.
  *
- * `prelocated` lets a caller that already scanned for the block (the
- * completion path's persisted read) reuse that hit instead of paying a second
- * full-history scan.
- *
  * Never throws: a persistence hiccup must not fail the surface action that
- * triggered it. The outcome comes back in the return value instead, so a
- * caller about to announce the completion can withhold it.
+ * triggered it. Returns whether the completion is safe to announce to
+ * clients, so a caller about to broadcast `ui_surface_complete` can withhold
+ * it. A write that threw is not safe: it leaves a persisted block that reverts
+ * to pending on the next history reseed. Finding no block to write IS safe: a
+ * standalone surface owns none, so nothing can revert.
+ *
+ * One window escapes that rule. A surface still in `ctx.currentTurnSurfaces`
+ * has no persisted block yet; its block is appended when the turn's message
+ * lands, without `completed`. A click inside that window reports safe here and
+ * still reverts on the next reseed.
  */
 export function markSurfaceCompleted(
   ctx: { conversationId: string; messages?: Array<{ content: unknown }> },
   surfaceId: string,
   summary: string,
-  prelocated?: PersistedSurfaceHit,
-): SurfaceCompletionPersistResult {
+): boolean {
   // Force-flush any pending debounced data persist so the completion
   // patch lands on top of the latest data instead of racing with it.
-  const flushed = flushSurfaceDataPersist(surfaceId);
+  flushSurfaceDataPersist(surfaceId);
+
+  try {
+    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId, {
+      filterByProvenance: false,
+    });
+    if (hit) {
+      hit.block.completed = true;
+      hit.block.completionSummary = summary;
+      updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
+    }
+  } catch (err) {
+    // Error, not warn: a silent failure here presents as the user's answer being discarded.
+    log.error(
+      { err, conversationId: ctx.conversationId, surfaceId },
+      "Failed to persist surface completion to DB",
+    );
+    // In-memory messages stay untouched so this process's history cannot
+    // claim an answered card the database still holds as pending.
+    return false;
+  }
 
   // Update in-memory messages when available so subsequent reads within
   // this session see the change without waiting for DB. Newest match only,
-  // matching the persisted patch below: marking every copy of a duplicated
+  // matching the persisted patch above: marking every copy of a duplicated
   // surfaceId would make memory and history disagree, and a reseed would
   // revert the extras.
   if (ctx.messages) {
@@ -440,28 +424,7 @@ export function markSurfaceCompleted(
     }
   }
 
-  // Persist to DB. A flush above re-read and rewrote the row, so any block
-  // located before it is stale and has to be re-located.
-  try {
-    const hit =
-      prelocated && !flushed
-        ? prelocated
-        : findPersistedSurfaceBlock(ctx.conversationId, surfaceId, "write");
-    if (!hit) {
-      return "not_found";
-    }
-    hit.block.completed = true;
-    hit.block.completionSummary = summary;
-    updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
-    return "persisted";
-  } catch (err) {
-    // Error, not warn: a silent failure here presents as the user's answer being discarded.
-    log.error(
-      { err, conversationId: ctx.conversationId, surfaceId },
-      "Failed to persist surface completion to DB",
-    );
-    return "failed";
-  }
+  return true;
 }
 
 /** What a persisted `ui_surface` block can still tell us once it is cold. */
@@ -470,11 +433,6 @@ type PersistedSurfaceInfo = {
   surfaceType: string | undefined;
   /** The block's `data`, absent when it carries no plain-object data. */
   data: Record<string, unknown> | undefined;
-  /**
-   * The block this was read from, so a completion write can patch it without
-   * scanning the conversation a second time.
-   */
-  hit: PersistedSurfaceHit;
 };
 
 /**
@@ -510,7 +468,9 @@ export function findPersistedSurfaceInfo(
   opts: { requesterCanAccessMemory: boolean },
 ): PersistedSurfaceInfo | undefined {
   try {
-    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, opts);
+    const hit = findPersistedSurfaceBlock(conversationId, surfaceId, {
+      filterByProvenance: !opts.requesterCanAccessMemory,
+    });
     if (!hit) {
       return undefined;
     }
@@ -521,7 +481,6 @@ export function findPersistedSurfaceInfo(
           ? hit.block.surfaceType
           : undefined,
       data: isPlainObject(data) ? data : undefined,
-      hit,
     };
   } catch (err) {
     log.warn(
@@ -542,20 +501,18 @@ export function findPersistedSurfaceInfo(
  * request was resolved on another surface (or by the expiry sweep). Persists
  * the completion (reload-safe) first, then broadcasts `ui_surface_complete` so
  * every connected client of this guardian converges.
+ *
+ * The broadcast is deliberately NOT gated on the persist, unlike the
+ * user-action completion paths: the underlying request is already resolved, so
+ * withholding the announcement on a transient write failure strands a live,
+ * clickable approval card for a decision that has already been made.
  */
 export function completeSurfaceAndNotify(
   conversationId: string,
   surfaceId: string,
   summary: string,
 ): void {
-  const persisted = markSurfaceCompleted(
-    { conversationId },
-    surfaceId,
-    summary,
-  );
-  if (!canBroadcastCompletion(persisted)) {
-    return;
-  }
+  markSurfaceCompleted({ conversationId }, surfaceId, summary);
   broadcastMessage({
     type: "ui_surface_complete",
     conversationId,
@@ -595,11 +552,9 @@ export function removeSurfaceBlock(
   }
 
   try {
-    const hit = findPersistedSurfaceBlock(
-      ctx.conversationId,
-      surfaceId,
-      "write",
-    );
+    const hit = findPersistedSurfaceBlock(ctx.conversationId, surfaceId, {
+      filterByProvenance: false,
+    });
     if (hit) {
       hit.blocks.splice(hit.blockIndex, 1);
       updateMessageContent(hit.rowId, JSON.stringify(hit.blocks));
@@ -1944,7 +1899,7 @@ const ONE_SHOT_SURFACE_TYPES = [
  *
  * `liveSurfaceType` / `liveSurfaceData` come from in-memory state. When the
  * type is missing the persisted block supplies both, read at most once per
- * action, only once the decision actually needs it, and reused for the write.
+ * action and only once the decision actually needs it.
  */
 function maybeCompleteSurfaceAfterAction(
   ctx: SurfaceConversationContext,
@@ -1962,7 +1917,6 @@ function maybeCompleteSurfaceAfterAction(
 
   let surfaceType = opts.liveSurfaceType;
   let surfaceData = opts.liveSurfaceData;
-  let hit: PersistedSurfaceHit | undefined;
   // Only the type-driven one-shot rule needs history: an explicit request
   // carries its own summary and decides on its own. Type and labels come from
   // the same read so the decision and the summary can never disagree.
@@ -1971,8 +1925,7 @@ function maybeCompleteSurfaceAfterAction(
       requesterCanAccessMemory: opts.requesterCanAccessMemory,
     });
     surfaceType = persisted?.surfaceType;
-    surfaceData = persisted?.data;
-    hit = persisted?.hit;
+    surfaceData = persisted?.data ?? surfaceData;
   }
 
   const isOneShot =
@@ -1984,8 +1937,7 @@ function maybeCompleteSurfaceAfterAction(
   const summary =
     requestedSummary ??
     buildCompletionSummary(surfaceType, actionId, actionData, surfaceData);
-  const persisted = markSurfaceCompleted(ctx, surfaceId, summary, hit);
-  if (!canBroadcastCompletion(persisted)) {
+  if (!markSurfaceCompleted(ctx, surfaceId, summary)) {
     return;
   }
   broadcastMessage({
@@ -3659,8 +3611,7 @@ export async function surfaceProxyResolver(
       );
       // A `ui_show` surface owns a persisted block, so the completion has to
       // land before the client is told the card is answered.
-      const persisted = markSurfaceCompleted(ctx, surfaceId, summary);
-      if (canBroadcastCompletion(persisted)) {
+      if (markSurfaceCompleted(ctx, surfaceId, summary)) {
         ctx.sendToClient({
           type: "ui_surface_complete",
           conversationId: ctx.conversationId,


### PR DESCRIPTION
## Summary
- Drop the prelocated-hit optimization so the completion write always targets the same row regardless of debounce timing
- Roll back the in-memory completion patch when the persisted write fails, so memory and the database cannot disagree
- Keep live surface data when falling back to persisted state, and keep the guardian withdrawal broadcast on a transient write failure
- Persist before announcing on the stale-surface dismiss sweep
- Add a real-database test covering a surface behind the context-compaction boundary

Part of plan: choice-surface-completion-persist.md (self-review remediation, round 2)