### PR TITLE
feat(schedule): parse plugin schedule declarations (schedules/ surface)

### DIFF
--- a/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
@@ -1,0 +1,395 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { parsePluginScheduleDeclarations } from "../plugin-schedule-declarations.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Create a plugin dir whose schedules/ contains the given relative files. */
+function makePlugin(files: Record<string, string>): string {
+  const pluginDir = mkdtempSync(join(tmpdir(), "plugin-sched-test-"));
+  tempDirs.push(pluginDir);
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(pluginDir, "schedules", rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return pluginDir;
+}
+
+const FLAT_MD = [
+  "---",
+  'expression: "0 9 * * *"',
+  "description: Daily digest",
+  "timezone: America/New_York",
+  "max_retries: 2",
+  "retry_backoff_ms: 5000",
+  "quiet: true",
+  "inference_profile: fast",
+  "timeout_ms: 30000",
+  "---",
+  "",
+  "Summarize the day.",
+  "",
+].join("\n");
+
+describe("parsePluginScheduleDeclarations", () => {
+  test("returns empty results when schedules/ is absent", () => {
+    const pluginDir = mkdtempSync(join(tmpdir(), "plugin-sched-test-"));
+    tempDirs.push(pluginDir);
+    expect(parsePluginScheduleDeclarations(pluginDir, "p")).toEqual({
+      declarations: [],
+      errors: [],
+    });
+  });
+
+  test("parses a flat .md declaration with full config", () => {
+    const pluginDir = makePlugin({ "digest.md": FLAT_MD });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "news",
+    );
+    expect(errors).toEqual([]);
+    expect(declarations).toHaveLength(1);
+    const decl = declarations[0]!;
+    expect(decl.sourceKey).toBe("plugin:news/digest");
+    expect(decl.name).toBe("digest");
+    expect(decl.mode).toBe("execute");
+    expect(decl.message).toBe("Summarize the day.");
+    expect(decl.scriptInvocation).toBeNull();
+    expect(decl.config).toEqual({
+      expression: "0 9 * * *",
+      syntax: "cron",
+      timezone: "America/New_York",
+      description: "Daily digest",
+      maxRetries: 2,
+      retryBackoffMs: 5000,
+      quiet: true,
+      inferenceProfile: "fast",
+      timeoutMs: 30000,
+      enabled: true,
+    });
+    expect(decl.definitionHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("applies defaults: optional fields null, enabled true, syntax auto-detected", () => {
+    const pluginDir = makePlugin({
+      "simple.md": '---\nexpression: "*/5 * * * *"\n---\nPing.',
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    expect(declarations[0]!.config).toEqual({
+      expression: "*/5 * * * *",
+      syntax: "cron",
+      timezone: null,
+      description: null,
+      maxRetries: null,
+      retryBackoffMs: null,
+      quiet: null,
+      inferenceProfile: null,
+      timeoutMs: null,
+      enabled: true,
+    });
+  });
+
+  test("honors declared enabled: false", () => {
+    const pluginDir = makePlugin({
+      "paused.md": '---\nexpression: "0 9 * * *"\nenabled: false\n---\nHi.',
+    });
+    const { declarations } = parsePluginScheduleDeclarations(pluginDir, "p");
+    expect(declarations[0]!.config.enabled).toBe(false);
+  });
+
+  test("parses an RRULE declaration with explicit syntax", () => {
+    const expression =
+      "DTSTART;TZID=America/New_York:20260101T090000\nRRULE:FREQ=WEEKLY;BYDAY=MO";
+    const pluginDir = makePlugin({
+      "weekly.md": `---\nexpression: "${expression.replace("\n", "\\n")}"\nexpression_syntax: rrule\n---\nWeekly.`,
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    expect(declarations[0]!.config.syntax).toBe("rrule");
+  });
+
+  test("parses a directory declaration with index.md", () => {
+    const pluginDir = makePlugin({
+      "report/config.json": JSON.stringify({ expression: "0 8 * * 1" }),
+      "report/index.md": "Write the weekly report.\n",
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    const decl = declarations[0]!;
+    expect(decl.sourceKey).toBe("plugin:p/report");
+    expect(decl.mode).toBe("execute");
+    expect(decl.message).toBe("Write the weekly report.");
+    expect(decl.scriptInvocation).toBeNull();
+  });
+
+  test("parses a directory declaration with index.sh as a path invocation", () => {
+    const pluginDir = makePlugin({
+      "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+      "backup/index.sh": "#!/bin/sh\necho backup\n",
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    const decl = declarations[0]!;
+    expect(decl.mode).toBe("script");
+    expect(decl.message).toBeNull();
+    expect(decl.scriptInvocation).toBe(
+      `'${join(pluginDir, "schedules", "backup", "index.sh")}'`,
+    );
+    expect(decl.scriptInvocation).not.toContain("echo backup");
+  });
+
+  describe("fail-closed cases", () => {
+    test("basename collision between .md and directory loads neither", () => {
+      const pluginDir = makePlugin({
+        "dup.md": '---\nexpression: "0 9 * * *"\n---\nFlat.',
+        "dup/config.json": JSON.stringify({ expression: "0 9 * * *" }),
+        "dup/index.md": "Dir.",
+        "ok.md": '---\nexpression: "0 9 * * *"\n---\nFine.',
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations.map((d) => d.name)).toEqual(["ok"]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        pluginName: "p",
+        scheduleName: "dup",
+        sourceKey: "plugin:p/dup",
+      });
+      expect(errors[0]!.reason).toContain("both");
+    });
+
+    test("directory with no entrypoint errors", () => {
+      const pluginDir = makePlugin({
+        "empty/config.json": JSON.stringify({ expression: "0 9 * * *" }),
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations).toEqual([]);
+      expect(errors[0]!.reason).toContain("no entrypoint");
+    });
+
+    test("directory with both index.md and index.sh errors", () => {
+      const pluginDir = makePlugin({
+        "twin/config.json": JSON.stringify({ expression: "0 9 * * *" }),
+        "twin/index.md": "Prompt.",
+        "twin/index.sh": "echo hi",
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations).toEqual([]);
+      expect(errors[0]!.reason).toContain("multiple entrypoints");
+    });
+
+    test("unsupported entrypoint (index.ts) errors", () => {
+      const pluginDir = makePlugin({
+        "ts/config.json": JSON.stringify({ expression: "0 9 * * *" }),
+        "ts/index.ts": "export {};",
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain('unsupported entrypoint "index.ts"');
+    });
+
+    test("stray non-md file in schedules/ errors", () => {
+      const pluginDir = makePlugin({ "notes.txt": "hi" });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("unsupported entry");
+    });
+
+    test("directory missing config.json errors", () => {
+      const pluginDir = makePlugin({ "bare/index.md": "Prompt." });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("missing config.json");
+    });
+
+    test("invalid JSON in config.json errors", () => {
+      const pluginDir = makePlugin({
+        "bad/config.json": "{ nope",
+        "bad/index.md": "Prompt.",
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("not valid JSON");
+    });
+
+    test("directory index.md with frontmatter errors", () => {
+      const pluginDir = makePlugin({
+        "fm/config.json": JSON.stringify({ expression: "0 9 * * *" }),
+        "fm/index.md": '---\nexpression: "0 9 * * *"\n---\nPrompt.',
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("must not contain frontmatter");
+    });
+
+    test("flat .md without frontmatter errors", () => {
+      const pluginDir = makePlugin({ "plain.md": "Just a prompt." });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("missing frontmatter");
+    });
+
+    test("malformed YAML frontmatter errors", () => {
+      const pluginDir = makePlugin({
+        "broken.md": "---\nexpression: [unclosed\n---\nPrompt.",
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("invalid YAML frontmatter");
+    });
+
+    test("missing expression errors", () => {
+      const pluginDir = makePlugin({
+        "noexpr.md": "---\ndescription: nope\n---\nPrompt.",
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("expression");
+    });
+
+    test("invalid cron expression errors", () => {
+      const pluginDir = makePlugin({
+        "badcron.md": '---\nexpression: "99 99 * * *"\n---\nPrompt.',
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("invalid cron expression");
+    });
+
+    test("RRULE without DTSTART errors", () => {
+      const pluginDir = makePlugin({
+        "badrrule.md":
+          "---\nexpression: RRULE:FREQ=DAILY\nexpression_syntax: rrule\n---\nPrompt.",
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("DTSTART");
+    });
+
+    test("unknown config key errors", () => {
+      const pluginDir = makePlugin({
+        "typo.md":
+          '---\nexpression: "0 9 * * *"\nexpresion_syntax: cron\n---\nHi.',
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("invalid config");
+    });
+
+    test("empty prompt body errors", () => {
+      const pluginDir = makePlugin({
+        "hollow.md": '---\nexpression: "0 9 * * *"\n---\n   \n',
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("prompt body is empty");
+    });
+
+    test("one bad declaration never blocks siblings", () => {
+      const pluginDir = makePlugin({
+        "bad.md": "---\nexpression: nonsense\n---\nPrompt.",
+        "good.md": '---\nexpression: "0 9 * * *"\n---\nPrompt.',
+        "also-good/config.json": JSON.stringify({ expression: "0 10 * * *" }),
+        "also-good/index.md": "Prompt.",
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations.map((d) => d.name)).toEqual(["also-good", "good"]);
+      expect(errors.map((e) => e.scheduleName)).toEqual(["bad"]);
+    });
+  });
+
+  describe("definitionHash", () => {
+    test("is stable across parses of identical content", () => {
+      const files = {
+        "digest.md": FLAT_MD,
+        "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+        "backup/index.sh": "echo backup\n",
+      };
+      const a = parsePluginScheduleDeclarations(makePlugin(files), "p");
+      const b = parsePluginScheduleDeclarations(makePlugin(files), "p");
+      for (const decl of a.declarations) {
+        const twin = b.declarations.find((d) => d.name === decl.name);
+        expect(twin?.definitionHash).toBe(decl.definitionHash);
+      }
+    });
+
+    test("changes when the flat file body is edited", () => {
+      const pluginDir = makePlugin({ "digest.md": FLAT_MD });
+      const before = parsePluginScheduleDeclarations(pluginDir, "p")
+        .declarations[0]!.definitionHash;
+      writeFileSync(
+        join(pluginDir, "schedules", "digest.md"),
+        FLAT_MD.replace("Summarize the day.", "Summarize the week."),
+      );
+      const after = parsePluginScheduleDeclarations(pluginDir, "p")
+        .declarations[0]!.definitionHash;
+      expect(after).not.toBe(before);
+    });
+
+    test("changes when a helper file inside a directory declaration is edited or renamed", () => {
+      const pluginDir = makePlugin({
+        "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+        "backup/index.sh": "sh lib/helper.sh\n",
+        "backup/lib/helper.sh": "echo v1\n",
+      });
+      const parse = () =>
+        parsePluginScheduleDeclarations(pluginDir, "p").declarations[0]!
+          .definitionHash;
+      const original = parse();
+
+      const helperPath = join(
+        pluginDir,
+        "schedules",
+        "backup",
+        "lib",
+        "helper.sh",
+      );
+      writeFileSync(helperPath, "echo v2\n");
+      const afterEdit = parse();
+      expect(afterEdit).not.toBe(original);
+
+      renameSync(
+        helperPath,
+        join(pluginDir, "schedules", "backup", "lib", "helper2.sh"),
+      );
+      expect(parse()).not.toBe(afterEdit);
+    });
+
+    test("differs between two schedules with different names but same content", () => {
+      const body = '---\nexpression: "0 9 * * *"\n---\nSame.';
+      const pluginDir = makePlugin({ "a.md": body, "b.md": body });
+      const { declarations } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(declarations[0]!.definitionHash).not.toBe(
+        declarations[1]!.definitionHash,
+      );
+    });
+  });
+});

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -1,0 +1,430 @@
+/**
+ * Parser for plugin-declared schedules under `<pluginDir>/schedules/`.
+ *
+ * Two declaration forms are supported:
+ * - Flat file: `<name>.md` with YAML frontmatter (the schedule config) and a
+ *   markdown body (the prompt message). Mode is `execute`.
+ * - Directory: `<name>/` containing `config.json` (the schedule config) plus
+ *   exactly one entrypoint, `index.md` (mode `execute`, body is the prompt)
+ *   or `index.sh` (mode `script`, invoked by absolute path).
+ *
+ * Ambiguity fails closed, never resolves by precedence: a basename declared
+ * in both forms, a directory with zero or multiple entrypoints, or an
+ * unsupported entrypoint each yield a {@link DeclarationError} and the
+ * schedule does not load. Errors are per-schedule; one bad declaration never
+ * blocks siblings.
+ *
+ * Declared schedules are recurring only: `expression` is required and there
+ * is no one-shot form.
+ *
+ * Pure filesystem + parsing. This module must not import from persistence or
+ * schedule-store; the reconciler owns all database interaction.
+ */
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { walkPluginTree } from "../plugins/plugin-tree-walk.js";
+import {
+  FRONTMATTER_REGEX,
+  parseFrontmatterFields,
+} from "../skills/frontmatter.js";
+import {
+  isValidScheduleExpression,
+  validateRruleSetLines,
+} from "./recurrence-engine.js";
+import type { ScheduleSyntax } from "./recurrence-types.js";
+import { normalizeScheduleSyntax } from "./recurrence-types.js";
+
+export type PluginScheduleMode = "execute" | "script";
+
+/** Normalized schedule config parsed from frontmatter or config.json. */
+export interface PluginScheduleConfig {
+  expression: string;
+  syntax: ScheduleSyntax;
+  timezone: string | null;
+  description: string | null;
+  maxRetries: number | null;
+  retryBackoffMs: number | null;
+  quiet: boolean | null;
+  inferenceProfile: string | null;
+  timeoutMs: number | null;
+  /** Declared enabled state; defaults to true when omitted. */
+  enabled: boolean;
+}
+
+export interface ScheduleDeclaration {
+  /** `plugin:<pluginName>/<scheduleName>`; the reconciler's identity key. */
+  sourceKey: string;
+  name: string;
+  mode: PluginScheduleMode;
+  /** Prompt body for `execute` mode; null for `script` mode. */
+  message: string | null;
+  /**
+   * Shell invocation of the declaration's `index.sh` by absolute path (not
+   * the file's content); null for `execute` mode.
+   */
+  scriptInvocation: string | null;
+  config: PluginScheduleConfig;
+  /**
+   * Stable sha256 over the declaration's file contents and their paths
+   * relative to `schedules/`. Any edit, addition, removal, or rename of a
+   * declaration file changes the hash.
+   */
+  definitionHash: string;
+}
+
+export interface DeclarationError {
+  pluginName: string;
+  scheduleName: string;
+  sourceKey: string;
+  reason: string;
+}
+
+export interface ParsedPluginSchedules {
+  declarations: ScheduleDeclaration[];
+  errors: DeclarationError[];
+}
+
+export function pluginScheduleSourceKey(
+  pluginName: string,
+  scheduleName: string,
+): string {
+  return `plugin:${pluginName}/${scheduleName}`;
+}
+
+const scheduleConfigSchema = z
+  .object({
+    expression: z.string().min(1),
+    expression_syntax: z.enum(["cron", "rrule"]).optional(),
+    timezone: z.string().min(1).optional(),
+    description: z.string().optional(),
+    max_retries: z.number().int().min(0).optional(),
+    retry_backoff_ms: z.number().int().min(0).optional(),
+    quiet: z.boolean().optional(),
+    inference_profile: z.string().min(1).optional(),
+    timeout_ms: z.number().int().positive().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+function parseScheduleConfig(
+  raw: unknown,
+): { config: PluginScheduleConfig } | { error: string } {
+  const result = scheduleConfigSchema.safeParse(raw);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join(".") || "config"}: ${i.message}`)
+      .join("; ");
+    return { error: `invalid config: ${detail}` };
+  }
+  const fields = result.data;
+
+  const resolved = normalizeScheduleSyntax({
+    syntax: fields.expression_syntax,
+    expression: fields.expression,
+  });
+  if (!resolved) {
+    return {
+      error: `could not determine syntax for expression "${fields.expression}"; set expression_syntax to "cron" or "rrule"`,
+    };
+  }
+  if (resolved.syntax === "rrule") {
+    const setError = validateRruleSetLines(resolved.expression);
+    if (setError) {
+      return { error: setError };
+    }
+  }
+  if (
+    !isValidScheduleExpression({
+      syntax: resolved.syntax,
+      expression: resolved.expression,
+      timezone: fields.timezone ?? null,
+    })
+  ) {
+    return {
+      error: `invalid ${resolved.syntax} expression "${fields.expression}"${
+        fields.timezone ? ` (timezone "${fields.timezone}")` : ""
+      }`,
+    };
+  }
+
+  return {
+    config: {
+      expression: resolved.expression,
+      syntax: resolved.syntax,
+      timezone: fields.timezone ?? null,
+      description: fields.description ?? null,
+      maxRetries: fields.max_retries ?? null,
+      retryBackoffMs: fields.retry_backoff_ms ?? null,
+      quiet: fields.quiet ?? null,
+      inferenceProfile: fields.inference_profile ?? null,
+      timeoutMs: fields.timeout_ms ?? null,
+      enabled: fields.enabled ?? true,
+    },
+  };
+}
+
+interface DeclarationFile {
+  relPath: string;
+  content: Buffer;
+}
+
+function hashDeclarationFiles(files: DeclarationFile[]): string {
+  const sorted = [...files].sort((a, b) =>
+    a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
+  );
+  const hash = createHash("sha256");
+  for (const file of sorted) {
+    hash.update(file.relPath);
+    hash.update("\0");
+    hash.update(file.content);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Collect every regular file under `dir` (recursively, dot entries and
+ * symlinks skipped) with paths relative to the schedules/ root.
+ */
+function collectDeclarationFiles(
+  dir: string,
+  relPrefix: string,
+): DeclarationFile[] {
+  const files: DeclarationFile[] = [];
+  walkPluginTree(dir, { excludeDotEntries: true }, (rel, abs) => {
+    files.push({ relPath: `${relPrefix}${rel}`, content: readFileSync(abs) });
+  });
+  return files;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+const SUPPORTED_ENTRYPOINTS = ["index.md", "index.sh"];
+
+interface ParsedDeclarationBody {
+  mode: PluginScheduleMode;
+  message: string | null;
+  scriptInvocation: string | null;
+  config: PluginScheduleConfig;
+  files: DeclarationFile[];
+}
+
+function parseFlatDeclaration(
+  schedulesDir: string,
+  fileName: string,
+): ParsedDeclarationBody | { error: string } {
+  const content = readFileSync(join(schedulesDir, fileName), "utf8");
+  const parsed = parseFrontmatterFields(content);
+  if (!parsed) {
+    // parseFrontmatterFields returns null for both a missing block and
+    // malformed YAML; the regex distinguishes the two.
+    return FRONTMATTER_REGEX.test(content)
+      ? { error: "invalid YAML frontmatter" }
+      : {
+          error:
+            "missing frontmatter: schedule config (expression, ...) is required",
+        };
+  }
+  const configResult = parseScheduleConfig(parsed.fields);
+  if ("error" in configResult) {
+    return configResult;
+  }
+  const message = parsed.body.trim();
+  if (!message) {
+    return { error: "prompt body is empty" };
+  }
+  return {
+    mode: "execute",
+    message,
+    scriptInvocation: null,
+    config: configResult.config,
+    files: [{ relPath: fileName, content: Buffer.from(content) }],
+  };
+}
+
+function parseDirectoryDeclaration(
+  schedulesDir: string,
+  dirName: string,
+): ParsedDeclarationBody | { error: string } {
+  const dirPath = join(schedulesDir, dirName);
+  const children = readdirSync(dirPath, { withFileTypes: true });
+
+  const entrypoints = children
+    .filter((c) => c.isFile() && c.name.startsWith("index."))
+    .map((c) => c.name)
+    .sort();
+  if (entrypoints.length === 0) {
+    return {
+      error: "no entrypoint: expected exactly one of index.md or index.sh",
+    };
+  }
+  if (entrypoints.length > 1) {
+    return {
+      error: `multiple entrypoints (${entrypoints.join(", ")}): expected exactly one of index.md or index.sh`,
+    };
+  }
+  const entrypoint = entrypoints[0]!;
+  if (!SUPPORTED_ENTRYPOINTS.includes(entrypoint)) {
+    return {
+      error: `unsupported entrypoint "${entrypoint}": expected index.md or index.sh`,
+    };
+  }
+
+  let rawConfigText: string;
+  try {
+    rawConfigText = readFileSync(join(dirPath, "config.json"), "utf8");
+  } catch {
+    return { error: "missing config.json" };
+  }
+  let rawConfig: unknown;
+  try {
+    rawConfig = JSON.parse(rawConfigText);
+  } catch (err) {
+    return {
+      error: `config.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const configResult = parseScheduleConfig(rawConfig);
+  if ("error" in configResult) {
+    return configResult;
+  }
+
+  let message: string | null = null;
+  let scriptInvocation: string | null = null;
+  let mode: PluginScheduleMode;
+  if (entrypoint === "index.md") {
+    const content = readFileSync(join(dirPath, "index.md"), "utf8");
+    if (FRONTMATTER_REGEX.test(content)) {
+      return {
+        error:
+          "index.md must not contain frontmatter: directory-form config belongs in config.json",
+      };
+    }
+    message = content.trim();
+    if (!message) {
+      return { error: "prompt body is empty" };
+    }
+    mode = "execute";
+  } else {
+    scriptInvocation = shellQuote(join(dirPath, "index.sh"));
+    mode = "script";
+  }
+
+  return {
+    mode,
+    message,
+    scriptInvocation,
+    config: configResult.config,
+    files: collectDeclarationFiles(dirPath, `${dirName}/`),
+  };
+}
+
+/**
+ * Parse every schedule declaration under `<pluginDir>/schedules/`. A missing
+ * or unreadable schedules/ directory yields no declarations and no errors.
+ * Every malformed or ambiguous declaration yields a per-schedule
+ * {@link DeclarationError} without affecting siblings.
+ */
+export function parsePluginScheduleDeclarations(
+  pluginDir: string,
+  pluginName: string,
+): ParsedPluginSchedules {
+  const schedulesDir = join(pluginDir, "schedules");
+  let entries;
+  try {
+    entries = readdirSync(schedulesDir, { withFileTypes: true });
+  } catch {
+    return { declarations: [], errors: [] };
+  }
+
+  const declarations: ScheduleDeclaration[] = [];
+  const errors: DeclarationError[] = [];
+  const fail = (scheduleName: string, reason: string): void => {
+    errors.push({
+      pluginName,
+      scheduleName,
+      sourceKey: pluginScheduleSourceKey(pluginName, scheduleName),
+      reason,
+    });
+  };
+
+  const flatNames = new Map<string, string>();
+  const dirNames = new Set<string>();
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      dirNames.add(entry.name);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      flatNames.set(entry.name.slice(0, -".md".length), entry.name);
+    } else {
+      fail(
+        entry.name,
+        `unsupported entry "${entry.name}": expected <name>.md or a <name>/ directory`,
+      );
+    }
+  }
+
+  for (const name of flatNames.keys()) {
+    if (dirNames.has(name)) {
+      fail(
+        name,
+        `declared as both ${name}.md and ${name}/ directory: remove one form`,
+      );
+      flatNames.delete(name);
+      dirNames.delete(name);
+    }
+  }
+
+  const parseOne = (
+    name: string,
+    parse: () => ParsedDeclarationBody | { error: string },
+  ): void => {
+    let result: ParsedDeclarationBody | { error: string };
+    try {
+      result = parse();
+    } catch (err) {
+      result = {
+        error: `failed to read declaration: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if ("error" in result) {
+      fail(name, result.error);
+      return;
+    }
+    declarations.push({
+      sourceKey: pluginScheduleSourceKey(pluginName, name),
+      name,
+      mode: result.mode,
+      message: result.message,
+      scriptInvocation: result.scriptInvocation,
+      config: result.config,
+      definitionHash: hashDeclarationFiles(result.files),
+    });
+  };
+
+  for (const [name, fileName] of flatNames) {
+    parseOne(name, () => parseFlatDeclaration(schedulesDir, fileName));
+  }
+  for (const name of dirNames) {
+    parseOne(name, () => parseDirectoryDeclaration(schedulesDir, name));
+  }
+
+  declarations.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  errors.sort((a, b) =>
+    a.scheduleName < b.scheduleName
+      ? -1
+      : a.scheduleName > b.scheduleName
+        ? 1
+        : 0,
+  );
+  return { declarations, errors };
+}


### PR DESCRIPTION
## Summary
- New pure parser for plugin schedules/ declarations: flat <name>.md (frontmatter + prompt body) and <name>/ directories (config.json + index.md|index.sh)
- Fail-closed on basename collisions, multiple/zero/unsupported entrypoints; per-schedule error isolation
- Deterministic definition hashing for reconciler change detection

Part of plan: plugin-schedules-v1.md (PR 2 of 5)