### PR TITLE
feat(schedule): source_key/definition_hash/user_enabled columns + declared-schedule store APIs

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -58,7 +58,10 @@ describe("schedule_syntax column migration", () => {
         capabilities_json TEXT,
         description TEXT NOT NULL DEFAULT '',
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        source_key TEXT,
+        definition_hash TEXT,
+        user_enabled INTEGER
       )
     `);
 

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -22,6 +22,7 @@ import {
   LEGACY_DEFER_CREATED_BY,
   OWNER_DEFER_CREATED_BY,
 } from "../schedule/defer-provenance.js";
+import type { DeclaredScheduleDefinition } from "../schedule/schedule-store.js";
 import {
   cancelSchedule,
   claimDueSchedules,
@@ -32,10 +33,14 @@ import {
   createScheduleRun,
   deleteSchedule,
   describeCronExpression,
+  disarmDeclaredSchedule,
   failOneShot,
   getSchedule,
+  listDeclaredSchedules,
   listSchedules,
+  setUserEnabled,
   updateSchedule,
+  upsertDeclaredSchedule,
 } from "../schedule/schedule-store.js";
 import { UserError } from "../util/errors.js";
 
@@ -1504,5 +1509,284 @@ describe("owner-defer provenance", () => {
     expect(updated!.message).toBe("something else");
     expect(updated!.wakeConversationId).toBe("conv-elsewhere");
     expect(hasOwnerDeferProvenance(updated!.createdBy)).toBe(false);
+  });
+});
+
+// ── Plugin-declared schedules ───────────────────────────────────────
+
+describe("declared schedules", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM cron_runs");
+    getDb().run("DELETE FROM cron_jobs");
+  });
+
+  const SOURCE_KEY = "plugin:example/daily";
+
+  function makeDefinition(
+    overrides: Partial<DeclaredScheduleDefinition> = {},
+  ): DeclaredScheduleDefinition {
+    return {
+      name: "Daily digest",
+      description: "Summarize the day",
+      syntax: "cron",
+      expression: "0 9 * * *",
+      message: "produce the digest",
+      mode: "execute",
+      enabled: true,
+      definitionHash: "hash-1",
+      ...overrides,
+    };
+  }
+
+  function rawJob(id: string): Record<string, unknown> {
+    return getRawDb()
+      .query("SELECT * FROM cron_jobs WHERE id = ?")
+      .get(id) as Record<string, unknown>;
+  }
+
+  test("upsert inserts a sourced row with declared enabled state", async () => {
+    const job = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+
+    expect(job.sourceKey).toBe(SOURCE_KEY);
+    expect(job.definitionHash).toBe("hash-1");
+    expect(job.userEnabled).toBeNull();
+    expect(job.enabled).toBe(true);
+    expect(job.expression).toBe("0 9 * * *");
+    expect(job.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("listDeclaredSchedules returns only sourced rows", async () => {
+    await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const imperative = await createSchedule({
+      name: "Mine",
+      cronExpression: "0 8 * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+
+    const declared = listDeclaredSchedules();
+    expect(declared).toHaveLength(1);
+    expect(declared[0].sourceKey).toBe(SOURCE_KEY);
+    expect(imperative.sourceKey).toBeNull();
+    expect(imperative.definitionHash).toBeNull();
+    expect(imperative.userEnabled).toBeNull();
+  });
+
+  test("upsert with an unchanged hash is a no-op", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const before = rawJob(created.id);
+
+    const again = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+
+    expect(again.id).toBe(created.id);
+    expect(rawJob(created.id)).toEqual(before);
+  });
+
+  test("upsert with a changed hash updates definition columns without moving nextRunAt", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+
+    const updated = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({
+        message: "produce a longer digest",
+        definitionHash: "hash-2",
+      }),
+    );
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.message).toBe("produce a longer digest");
+    expect(updated.definitionHash).toBe("hash-2");
+    expect(updated.nextRunAt).toBe(created.nextRunAt);
+  });
+
+  test("upsert recomputes nextRunAt when the expression changes", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+
+    const updated = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ expression: "0 15 * * *", definitionHash: "hash-2" }),
+    );
+
+    expect(updated.expression).toBe("0 15 * * *");
+    expect(updated.nextRunAt).not.toBe(created.nextRunAt);
+    expect(updated.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("upsert leaves engine-latched rows untouched", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    // Recurrence exhaustion latch: the claim path disables the row, zeroes
+    // nextRunAt, and stamps lastRunAt in one write.
+    getRawDb().run(
+      "UPDATE cron_jobs SET enabled = 0, next_run_at = 0, last_run_at = ? WHERE id = ?",
+      [Date.now(), created.id],
+    );
+    const latched = rawJob(created.id);
+
+    await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ definitionHash: "hash-2" }),
+    );
+
+    expect(rawJob(created.id)).toEqual(latched);
+  });
+
+  test("a declaration shipped disabled inserts disarmed and is not treated as latched", async () => {
+    const created = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ enabled: false }),
+    );
+    expect(created.enabled).toBe(false);
+    expect(created.nextRunAt).toBe(0);
+    expect(created.lastRunAt).toBeNull();
+
+    const armed = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ enabled: true, definitionHash: "hash-2" }),
+    );
+    expect(armed.enabled).toBe(true);
+    expect(armed.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("disarm keeps the row and its runs; a later pass re-arms it", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const runId = await createScheduleRun(created.id, "conv-123");
+    await completeScheduleRun(runId, { status: "ok" });
+
+    await disarmDeclaredSchedule(created.id);
+
+    const disarmed = getSchedule(created.id);
+    expect(disarmed!.enabled).toBe(false);
+    const runs = getRawDb()
+      .query("SELECT COUNT(*) AS n FROM cron_runs WHERE job_id = ?")
+      .get(created.id) as { n: number };
+    expect(runs.n).toBe(1);
+
+    // Same declaration back in the desired set (e.g. plugin re-enabled):
+    // effective enabled is recomputed even though the hash matches.
+    const rearmed = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    expect(rearmed.enabled).toBe(true);
+    expect(rearmed.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("disarm refuses imperative rows", async () => {
+    const imperative = await createSchedule({
+      name: "Mine",
+      cronExpression: "0 8 * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+
+    await expect(disarmDeclaredSchedule(imperative.id)).rejects.toThrow(
+      /plugin-sourced/,
+    );
+    expect(getSchedule(imperative.id)!.enabled).toBe(true);
+  });
+
+  test("user override wins over the declared value in both directions", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+
+    const off = await setUserEnabled(created.id, false);
+    expect(off!.userEnabled).toBe(false);
+    expect(off!.enabled).toBe(false);
+
+    // A reconcile pass with the declaration still enabled must not undo the
+    // user's override.
+    const afterPass = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition(),
+    );
+    expect(afterPass.enabled).toBe(false);
+    expect(afterPass.userEnabled).toBe(false);
+
+    const on = await setUserEnabled(created.id, true);
+    expect(on!.userEnabled).toBe(true);
+    expect(on!.enabled).toBe(true);
+    expect(on!.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("clearing the override falls back to the declared value on the next pass", async () => {
+    const created = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ enabled: false }),
+    );
+    await setUserEnabled(created.id, true);
+    expect(getSchedule(created.id)!.enabled).toBe(true);
+
+    const cleared = await setUserEnabled(created.id, null);
+    expect(cleared!.userEnabled).toBeNull();
+
+    const afterPass = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({ enabled: false }),
+    );
+    expect(afterPass.enabled).toBe(false);
+  });
+
+  test("setUserEnabled on an imperative row behaves like the existing toggle", async () => {
+    const imperative = await createSchedule({
+      name: "Mine",
+      cronExpression: "0 8 * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+
+    const off = await setUserEnabled(imperative.id, false);
+    expect(off!.enabled).toBe(false);
+    expect(off!.userEnabled).toBeNull();
+    expect(off!.nextRunAt).toBe(0);
+
+    const on = await setUserEnabled(imperative.id, true);
+    expect(on!.enabled).toBe(true);
+    expect(on!.userEnabled).toBeNull();
+    expect(on!.nextRunAt).toBeGreaterThan(Date.now());
+
+    await expect(setUserEnabled(imperative.id, null)).rejects.toThrow(
+      UserError,
+    );
+  });
+
+  test("updateSchedule refuses sourced rows", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const before = rawJob(created.id);
+
+    await expect(
+      updateSchedule(created.id, { name: "renamed" }),
+    ).rejects.toThrow(UserError);
+    await expect(
+      updateSchedule(created.id, { name: "renamed" }),
+    ).rejects.toThrow(/managed by a plugin/);
+    expect(rawJob(created.id)).toEqual(before);
+  });
+
+  test("deleteSchedule refuses sourced rows and keeps runs", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const runId = await createScheduleRun(created.id, "conv-123");
+    await completeScheduleRun(runId, { status: "ok" });
+
+    await expect(deleteSchedule(created.id)).rejects.toThrow(UserError);
+    await expect(deleteSchedule(created.id)).rejects.toThrow(
+      /managed by a plugin/,
+    );
+
+    expect(getSchedule(created.id)).not.toBeNull();
+    const runs = getRawDb()
+      .query("SELECT COUNT(*) AS n FROM cron_runs WHERE job_id = ?")
+      .get(created.id) as { n: number };
+    expect(runs.n).toBe(1);
+  });
+
+  test("update and delete on imperative rows are unchanged", async () => {
+    const imperative = await createSchedule({
+      name: "Mine",
+      cronExpression: "0 8 * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+
+    const renamed = await updateSchedule(imperative.id, { name: "Renamed" });
+    expect(renamed!.name).toBe("Renamed");
+
+    expect(await deleteSchedule(imperative.id)).toBe(true);
+    expect(getSchedule(imperative.id)).toBeNull();
   });
 });

--- a/assistant/src/persistence/migrations/361-add-schedule-source-key.test.ts
+++ b/assistant/src/persistence/migrations/361-add-schedule-source-key.test.ts
@@ -1,0 +1,120 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAddScheduleSourceKey } from "./361-add-schedule-source-key.js";
+
+const NEW_COLUMNS = ["source_key", "definition_hash", "user_enabled"];
+
+/** Pre-361 shape: the cron_jobs table exactly as core tables created it. */
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      cron_expression TEXT NOT NULL,
+      schedule_syntax TEXT NOT NULL DEFAULT 'cron',
+      timezone TEXT,
+      message TEXT NOT NULL,
+      next_run_at INTEGER NOT NULL,
+      last_run_at INTEGER,
+      last_status TEXT,
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      created_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(cron_jobs)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+function insertJob(
+  sqlite: Database,
+  id: string,
+  sourceKey: string | null,
+): void {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO cron_jobs (id, name, cron_expression, message, next_run_at, created_by, created_at, updated_at, source_key)
+       VALUES (?, 'Job', '0 9 * * *', 'hello', 1000, 'agent', 1000, 1000, ?)`,
+    )
+    .run(id, sourceKey);
+}
+
+describe("migration 361: cron_jobs declaration provenance", () => {
+  test("adds the nullable columns to an existing database", () => {
+    const { sqlite, db } = createTestDb();
+    const before = columnInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(before).not.toContain(name);
+    }
+
+    migrateAddScheduleSourceKey(db);
+
+    const after = columnInfo(sqlite);
+    for (const name of NEW_COLUMNS) {
+      const column = after.find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("rows written before the columns existed read back null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO cron_jobs (id, name, cron_expression, message, next_run_at, created_by, created_at, updated_at)
+      VALUES ('job-old', 'Old', '0 9 * * *', 'hello', 1000, 'agent', 1000, 1000)
+    `);
+
+    migrateAddScheduleSourceKey(db);
+
+    const row = sqlite
+      .query(
+        "SELECT source_key, definition_hash, user_enabled FROM cron_jobs WHERE id = 'job-old'",
+      )
+      .get() as Record<string, unknown>;
+    expect(row.source_key).toBeNull();
+    expect(row.definition_hash).toBeNull();
+    expect(row.user_enabled).toBeNull();
+  });
+
+  test("rejects a second row with the same source_key", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddScheduleSourceKey(db);
+
+    insertJob(sqlite, "job-a", "plugin:example/daily");
+
+    expect(() => insertJob(sqlite, "job-b", "plugin:example/daily")).toThrow();
+  });
+
+  test("leaves imperative schedules unconstrained", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddScheduleSourceKey(db);
+
+    insertJob(sqlite, "job-a", null);
+    expect(() => insertJob(sqlite, "job-b", null)).not.toThrow();
+  });
+
+  test("is idempotent: re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAddScheduleSourceKey(db);
+    expect(() => migrateAddScheduleSourceKey(db)).not.toThrow();
+
+    const names = columnInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(names.filter((n) => n === name)).toHaveLength(1);
+    }
+  });
+});

--- a/assistant/src/persistence/migrations/361-add-schedule-source-key.ts
+++ b/assistant/src/persistence/migrations/361-add-schedule-source-key.ts
@@ -1,0 +1,43 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMNS: ReadonlyArray<{ name: string; definition: string }> = [
+  { name: "source_key", definition: "source_key TEXT" },
+  { name: "definition_hash", definition: "definition_hash TEXT" },
+  { name: "user_enabled", definition: "user_enabled INTEGER" },
+];
+
+/**
+ * Add plugin-declaration provenance columns to `cron_jobs`.
+ *
+ * `source_key` links a schedule row to the plugin declaration it was
+ * reconciled from (`plugin:<pluginName>/<scheduleName>`). Rows with a NULL
+ * `source_key` are imperative schedules and keep their existing behavior.
+ * `definition_hash` is the reconciler's change detector over the declaration
+ * files. `user_enabled` is the user's enable/disable override for a sourced
+ * row; NULL means the declaration's own enabled value applies.
+ *
+ * The unique index is partial (`WHERE source_key IS NOT NULL`) so the many
+ * NULL rows stay unconstrained while a given declaration resolves to exactly
+ * one row. The reconciler's upsert depends on that uniqueness.
+ *
+ * Nullable with no backfill: nothing recorded declaration provenance before
+ * these columns existed, so pre-existing rows correctly stay NULL.
+ *
+ * Idempotent: each column add is guarded with `tableHasColumn` and the index
+ * with `IF NOT EXISTS`, so a crash partway through does not break the next
+ * boot.
+ */
+export function migrateAddScheduleSourceKey(database: DrizzleDb): void {
+  for (const column of COLUMNS) {
+    if (!tableHasColumn(database, "cron_jobs", column.name)) {
+      database.run(`ALTER TABLE cron_jobs ADD COLUMN ${column.definition}`);
+    }
+  }
+
+  database.run(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_cron_jobs_source_key
+    ON cron_jobs(source_key)
+    WHERE source_key IS NOT NULL
+  `);
+}

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -40,6 +40,9 @@ export const cronJobs = sqliteTable("cron_jobs", {
   workflowName: text("workflow_name"), // saved workflow to trigger (nullable, only used when mode = 'workflow')
   workflowArgsJson: text("workflow_args_json"), // JSON-encoded args passed to the workflow run (nullable)
   capabilitiesJson: text("capabilities_json"), // JSON-encoded capability manifest for the run (nullable; null = hardcoded read-only manifest)
+  sourceKey: text("source_key"), // plugin declaration key ('plugin:<pluginName>/<scheduleName>'); null = imperative schedule
+  definitionHash: text("definition_hash"), // reconciler change detector over the declaration files (nullable, only used when source_key is set)
+  userEnabled: integer("user_enabled", { mode: "boolean" }), // user override for a sourced row's enabled state; null = declaration's value applies
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -468,6 +468,7 @@ import { migrateMoveMemorySegmentsToMemoryDb } from "./migrations/357-move-memor
 import { migrateMoveMemoryEmbeddingsToMemoryDb } from "./migrations/358-move-memory-embeddings-to-memory-db.js";
 import { migrateMoveMemorySummariesToMemoryDb } from "./migrations/359-move-memory-summaries-to-memory-db.js";
 import { migrateAddDocumentWorkspacePath } from "./migrations/360-add-document-workspace-path.js";
+import { migrateAddScheduleSourceKey } from "./migrations/361-add-schedule-source-key.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1543,4 +1544,5 @@ export const migrationSteps: MigrationStep[] = [
     ],
   },
   migrateAddDocumentWorkspacePath,
+  migrateAddScheduleSourceKey,
 ];

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,5 +1,16 @@
 import { Cron } from "croner";
-import { and, asc, desc, eq, inArray, isNull, lt, lte, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  sql,
+} from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
@@ -89,6 +100,24 @@ export interface ScheduleJob {
   groupId: string | null;
   createdFromConversationId: string | null;
   createdBy: string;
+  /**
+   * Plugin declaration this row was reconciled from
+   * (`plugin:<pluginName>/<scheduleName>`); null = imperative schedule.
+   * Sourced rows are read-only through {@link updateSchedule} and
+   * {@link deleteSchedule}: the declaration file is the source of truth for
+   * definition columns, and the reconciler is their only writer.
+   */
+  sourceKey: string | null;
+  /**
+   * Reconciler change detector over the plugin's declaration files; null on
+   * imperative rows.
+   */
+  definitionHash: string | null;
+  /**
+   * User enable/disable override for a sourced row; null = the declaration's
+   * own enabled value applies. Always null on imperative rows.
+   */
+  userEnabled: boolean | null;
   mode: ScheduleMode;
   routingIntent: RoutingIntent;
   routingHints: Record<string, unknown>;
@@ -156,6 +185,8 @@ interface InsertScheduleParams {
   inferenceProfile?: string | null;
   groupId?: string | null;
   createdFromConversationId?: string | null;
+  sourceKey?: string | null;
+  definitionHash?: string | null;
 }
 
 /**
@@ -172,10 +203,35 @@ export type OrdinaryScheduleCreator =
   | "user"
   | typeof LEGACY_DEFER_CREATED_BY;
 
-/** Parameters for ordinary schedule creation. */
-export type CreateScheduleParams = Omit<InsertScheduleParams, "createdBy"> & {
+/**
+ * Parameters for ordinary schedule creation. `sourceKey` and `definitionHash`
+ * are excluded for the same structural reason `createdBy` is constrained:
+ * plugin-declaration provenance is minted only by
+ * {@link upsertDeclaredSchedule}, so an ordinary create cannot produce a row
+ * the reconciler believes it owns.
+ */
+export type CreateScheduleParams = Omit<
+  InsertScheduleParams,
+  "createdBy" | "sourceKey" | "definitionHash"
+> & {
   createdBy?: OrdinaryScheduleCreator;
 };
+
+/**
+ * Timezone stored for a recurring schedule. A wall-clock expression with no
+ * zone otherwise evaluates in the host clock (UTC on managed containers), so
+ * it defaults to the user's configured/detected zone; expressions that carry
+ * their own zone keep the caller's value verbatim.
+ */
+function resolveStoredTimezone(
+  syntax: ScheduleSyntax,
+  expression: string | null,
+  timezone: string | null | undefined,
+): string | null {
+  return expressionCarriesOwnTimezone(syntax, expression)
+    ? (timezone ?? null)
+    : resolveScheduleTimezone(timezone);
+}
 
 async function insertSchedule(
   params: InsertScheduleParams,
@@ -206,14 +262,10 @@ async function insertSchedule(
   const id = uuid();
   const now = Date.now();
   const enabled = params.enabled ?? true;
-  // A recurring wall-clock schedule with no zone otherwise evaluates in the host
-  // clock (UTC on managed containers). Default it to the user's configured/detected
-  // zone so it fires at the intended local hour. One-shot schedules (absolute epoch)
-  // and expressions that carry their own zone keep the caller's value verbatim.
-  const timezone =
-    isOneShot || expressionCarriesOwnTimezone(syntax, expression)
-      ? (params.timezone ?? null)
-      : resolveScheduleTimezone(params.timezone);
+  // One-shot schedules (absolute epoch) keep the caller's value verbatim.
+  const timezone = isOneShot
+    ? (params.timezone ?? null)
+    : resolveStoredTimezone(syntax, expression, params.timezone);
   const mode = params.mode ?? "execute";
   const routingIntent = params.routingIntent ?? "all_channels";
   const routingHints = params.routingHints ?? {};
@@ -268,6 +320,9 @@ async function insertSchedule(
     groupId,
     createdFromConversationId,
     createdBy: params.createdBy ?? "agent",
+    sourceKey: params.sourceKey ?? null,
+    definitionHash: params.definitionHash ?? null,
+    userEnabled: null as boolean | null,
     mode,
     routingIntent,
     routingHintsJson: JSON.stringify(routingHints),
@@ -478,6 +533,16 @@ export async function updateSchedule(
     return null;
   }
 
+  // Plugin-sourced rows are read-only here: the plugin's schedule file is the
+  // source of truth for every definition column, and the reconciler would
+  // overwrite any edit on its next pass. Enable/disable goes through
+  // `setUserEnabled`; every other change is an edit to the declaration file.
+  if (existing.sourceKey != null) {
+    throw new UserError(
+      "This schedule is managed by a plugin. Edit the plugin's schedule file instead.",
+    );
+  }
+
   // Owner-defer provenance certifies that the assistant's owner chose both the
   // conversation this wake resumes and the text it carries. Rewriting either
   // would leave the marker standing over content it does not describe, so on
@@ -644,6 +709,20 @@ export async function updateSchedule(
 
 export async function deleteSchedule(id: string): Promise<boolean> {
   const db = getDb();
+  // Plugin-sourced rows keep their identity and run history: deleting one
+  // would just have the reconciler recreate it from the declaration on its
+  // next pass. Disable is the supported action; removal means removing the
+  // plugin's schedule file.
+  const target = db
+    .select({ sourceKey: scheduleJobs.sourceKey })
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  if (target?.sourceKey != null) {
+    throw new UserError(
+      "This schedule is managed by a plugin and cannot be deleted. Disable it instead, or remove the plugin's schedule file.",
+    );
+  }
   // Capture rawChanges() inside the awaited closure: reading it after the
   // await would race other async DB work on the shared connection.
   const deleted = await withSqliteRetry(
@@ -657,6 +736,277 @@ export async function deleteSchedule(id: string): Promise<boolean> {
     notifySchedulesChanged();
   }
   return deleted;
+}
+
+// ── Plugin-declared schedules ───────────────────────────────────────
+//
+// Rows with a non-null `source_key` mirror a declaration in a plugin's
+// `schedules/` directory. The reconciler owns their definition columns (via
+// the functions below, the only writers of `source_key`, `definition_hash`,
+// and the definition side of `enabled`), the engine owns the runtime columns,
+// and the user owns `user_enabled`. Rows with a null `source_key` are
+// imperative schedules and none of this section touches them.
+
+/**
+ * Definition of a plugin-declared schedule, as parsed from the plugin's
+ * declaration files. `enabled` is the declaration's own value; the stored
+ * row's `enabled` is the effective value, `user_enabled ?? enabled`.
+ */
+export interface DeclaredScheduleDefinition {
+  name: string;
+  description?: string;
+  syntax: ScheduleSyntax;
+  expression: string;
+  timezone?: string | null;
+  message: string;
+  script?: string | null;
+  mode: ScheduleMode;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  quiet?: boolean;
+  inferenceProfile?: string | null;
+  timeoutMs?: number | null;
+  enabled: boolean;
+  definitionHash: string;
+}
+
+/** All plugin-sourced schedule rows, including disarmed ones. */
+export function listDeclaredSchedules(): ScheduleJob[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(scheduleJobs)
+    .where(isNotNull(scheduleJobs.sourceKey))
+    .orderBy(asc(scheduleJobs.nextRunAt))
+    .all();
+  return rows.map(parseJobRow);
+}
+
+/**
+ * True when the engine has latched the row: a fired or cancelled one-shot, or
+ * a recurrence the claim path exhausted. The exhaust path stamps `lastRunAt`
+ * as it writes `nextRunAt = 0` and disables the row, so `nextRunAt = 0` with
+ * a null `lastRunAt` is a declared schedule inserted disabled, not an engine
+ * latch, and stays re-armable.
+ */
+function isEngineLatched(row: {
+  status: string;
+  nextRunAt: number;
+  lastRunAt: number | null;
+}): boolean {
+  return (
+    row.status === "fired" ||
+    row.status === "cancelled" ||
+    (row.nextRunAt === 0 && row.lastRunAt != null)
+  );
+}
+
+/**
+ * Insert or update the row for a plugin declaration, keyed by `sourceKey`.
+ *
+ * Effective `enabled` (`user_enabled ?? definition.enabled`) is recomputed on
+ * every call, so a row disarmed while its plugin was disabled re-arms once
+ * the declaration is back in the desired set. `nextRunAt` is recomputed only
+ * when the timing changed or the row transitions to enabled; a matching hash
+ * with matching effective `enabled` is a no-op. Rows the engine has latched
+ * are returned untouched.
+ */
+export async function upsertDeclaredSchedule(
+  sourceKey: string,
+  definition: DeclaredScheduleDefinition,
+): Promise<ScheduleJob> {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.sourceKey, sourceKey))
+    .get();
+
+  if (!existing) {
+    return insertSchedule({ ...definition, createdBy: "agent", sourceKey });
+  }
+
+  if (isEngineLatched(existing)) {
+    return parseJobRow(existing);
+  }
+
+  // Same timezone defaulting as insert, so change detection compares the
+  // value that would actually be stored.
+  const timezone = resolveStoredTimezone(
+    definition.syntax,
+    definition.expression,
+    definition.timezone,
+  );
+
+  const definitionChanged =
+    existing.definitionHash !== definition.definitionHash;
+  const effectiveEnabled = existing.userEnabled ?? definition.enabled;
+  if (!definitionChanged && effectiveEnabled === existing.enabled) {
+    return parseJobRow(existing);
+  }
+
+  const spec = {
+    syntax: definition.syntax,
+    expression: definition.expression,
+    timezone,
+  };
+  if (definitionChanged && !isValidScheduleExpression(spec)) {
+    throw new Error(
+      `Invalid ${definition.syntax} expression: "${definition.expression}"`,
+    );
+  }
+
+  const timingChanged =
+    definition.expression !== existing.cronExpression ||
+    definition.syntax !== existing.scheduleSyntax ||
+    timezone !== existing.timezone;
+
+  const set: Record<string, unknown> = {
+    enabled: effectiveEnabled,
+    updatedAt: Date.now(),
+  };
+  if (definitionChanged) {
+    set.name = definition.name;
+    set.description = normalizeDescription(
+      definition.description,
+      definition.name,
+    );
+    set.cronExpression = definition.expression;
+    set.scheduleSyntax = definition.syntax;
+    set.timezone = timezone;
+    set.message = definition.message;
+    set.script = definition.script ?? null;
+    set.mode = definition.mode;
+    set.maxRetries = definition.maxRetries ?? 3;
+    set.retryBackoffMs = definition.retryBackoffMs ?? 60000;
+    set.quiet = definition.quiet ?? false;
+    set.inferenceProfile = definition.inferenceProfile ?? null;
+    set.timeoutMs = definition.timeoutMs ?? null;
+    set.definitionHash = definition.definitionHash;
+  }
+  // While disabled, `nextRunAt` is left alone so a stale value never reads as
+  // the engine's exhaust latch (`nextRunAt = 0` with `lastRunAt` set).
+  if (
+    effectiveEnabled &&
+    (timingChanged || !existing.enabled || existing.nextRunAt === 0)
+  ) {
+    set.nextRunAt = computeNextRunAtEngine(spec);
+  }
+
+  await withSqliteRetry(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set(set)
+        .where(eq(scheduleJobs.id, existing.id))
+        .run(),
+    { op: "upsertDeclaredSchedule", context: { scheduleId: existing.id } },
+  );
+  notifySchedulesChanged();
+
+  const updated = getSchedule(existing.id);
+  if (!updated) {
+    throw new Error(`Declared schedule ${existing.id} vanished during upsert`);
+  }
+  return updated;
+}
+
+/**
+ * Pause a sourced row whose declaration is gone or whose plugin is disabled.
+ * The row and its runs are kept so a reinstall re-links by `source_key` and
+ * `user_enabled` survives. `nextRunAt` is left alone: a disabled row never
+ * fires, and `nextRunAt = 0` is reserved for the engine's exhaust latch.
+ */
+export async function disarmDeclaredSchedule(id: string): Promise<void> {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  if (!existing) {
+    return;
+  }
+  if (existing.sourceKey == null) {
+    throw new Error(
+      "disarmDeclaredSchedule applies only to plugin-sourced schedules",
+    );
+  }
+  if (!existing.enabled) {
+    return;
+  }
+  await withSqliteRetry(
+    () =>
+      db
+        .update(scheduleJobs)
+        .set({ enabled: false, updatedAt: Date.now() })
+        .where(eq(scheduleJobs.id, id))
+        .run(),
+    { op: "disarmDeclaredSchedule", context: { scheduleId: id } },
+  );
+  notifySchedulesChanged();
+}
+
+/**
+ * The user's side of the enabled toggle.
+ *
+ * On an imperative row this is exactly the existing toggle
+ * (`updateSchedule(id, { enabled })`) and `user_enabled` stays null. On a
+ * plugin-sourced row it records the override in `user_enabled` and applies a
+ * boolean to the effective `enabled` on the spot; null clears the override,
+ * and the next reconcile pass restores the declaration's own value, which the
+ * store does not persist separately. Engine-latched rows record the override
+ * without being re-armed.
+ */
+export async function setUserEnabled(
+  id: string,
+  value: boolean | null,
+): Promise<ScheduleJob | null> {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  if (!existing) {
+    return null;
+  }
+  if (existing.sourceKey == null) {
+    if (value == null) {
+      throw new UserError(
+        "Only plugin-managed schedules support clearing the enabled override",
+      );
+    }
+    return updateSchedule(id, { enabled: value });
+  }
+
+  const set: Record<string, unknown> = {
+    userEnabled: value,
+    updatedAt: Date.now(),
+  };
+  if (
+    value != null &&
+    value !== existing.enabled &&
+    !isEngineLatched(existing)
+  ) {
+    set.enabled = value;
+    // Re-arming needs a fresh occurrence: the stored one went stale while the
+    // row was disabled. Disabling keeps `nextRunAt`; see the disarm note.
+    if (value && existing.cronExpression != null) {
+      set.nextRunAt = computeNextRunAtEngine({
+        syntax: existing.scheduleSyntax as ScheduleSyntax,
+        expression: existing.cronExpression,
+        timezone: existing.timezone,
+      });
+    }
+  }
+
+  await withSqliteRetry(
+    () => db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run(),
+    { op: "setUserEnabled", context: { scheduleId: id } },
+  );
+  notifySchedulesChanged();
+  return getSchedule(id);
 }
 
 /**
@@ -1537,6 +1887,9 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     groupId: row.groupId ?? null,
     createdFromConversationId: row.createdFromConversationId ?? null,
     createdBy: row.createdBy,
+    sourceKey: row.sourceKey ?? null,
+    definitionHash: row.definitionHash ?? null,
+    userEnabled: row.userEnabled ?? null,
     mode: (row.mode ?? "execute") as ScheduleMode,
     routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,
     routingHints: safeParseJson(row.routingHintsJson),


### PR DESCRIPTION
## Summary
- Adds nullable source_key, definition_hash, user_enabled columns to cron_jobs (migration 361) with a partial unique index on source_key
- Adds reconciler-owned store APIs: listDeclaredSchedules, upsertDeclaredSchedule, disarmDeclaredSchedule, setUserEnabled
- Store-layer read-only guard: update/delete refuse plugin-sourced rows

Part of plan: plugin-schedules-v1.md (PR 1 of 5)