### PR TITLE
feat(schedule): reconcile plugin-declared schedules into cron_jobs

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -49,6 +49,7 @@ import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { markCurrentProcessAsMainDaemon } from "../runtime/process-role.js";
 import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
+import { reconcilePluginSchedules } from "../schedule/plugin-schedule-reconciler.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -696,6 +697,16 @@ export async function runDaemon(): Promise<void> {
     await recoverStaleSchedules();
   } catch (err) {
     log.error({ err }, "Schedule recovery failed — continuing startup");
+  }
+
+  // Converge plugin-declared schedules into cron_jobs rows before the
+  // scheduler starts claiming. The reconciler contains its own failures and
+  // checks DB migration readiness itself; the catch is startup insurance in
+  // the same shape as schedule recovery above.
+  try {
+    await reconcilePluginSchedules();
+  } catch (err) {
+    log.error({ err }, "Plugin schedule reconcile failed, continuing startup");
   }
 
   // Reconcile workflow runs orphaned by a crash: any row still `running` was

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -66,6 +66,14 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description: "Scheduled notification triggered (one-shot or recurring)",
   },
   {
+    id: "schedule.definition_error",
+    description: "Plugin schedule declaration failed to parse or validate",
+  },
+  {
+    id: "schedule.definition_changed",
+    description: "Plugin upgrade changed an armed schedule's definition",
+  },
+  {
     id: "guardian.question",
     description: "Guardian approval question requiring response",
   },

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -293,6 +293,18 @@ export async function reconcilePluginSourcesNow(): Promise<void> {
     } catch (err) {
       log.error({ err }, "imperative plugin reconcile failed");
     }
+    // Converge plugin-declared schedules against the plugin set this apply
+    // just settled, so install/uninstall/upgrade arm and disarm rows in the
+    // same poke. Imported lazily to keep the notification pipeline out of
+    // this module's static graph (sidecar workers import it for hook reads).
+    // Self-contained: never throws and checks DB readiness itself.
+    try {
+      const { reconcilePluginSchedules } =
+        await import("../schedule/plugin-schedule-reconciler.js");
+      await reconcilePluginSchedules();
+    } catch (err) {
+      log.error({ err }, "plugin schedule reconcile failed");
+    }
   })().finally(() => {
     reconcileInFlight = null;
   });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -34,6 +34,10 @@ import {
 import { getLiveVoiceSessionManager } from "../live-voice/live-voice-manager.js";
 import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import {
+  startPluginScheduleReconcileSweep,
+  stopPluginScheduleReconcileSweep,
+} from "../schedule/plugin-schedule-reconciler.js";
+import {
   activeSttStreamSessions,
   SttStreamSession,
 } from "../stt/stt-stream-session.js";
@@ -511,12 +515,20 @@ export class RuntimeHttpServer {
 
     startTelegramWebhookHealthSweep();
     log.info("Telegram webhook health sweep started");
+
+    // Backstop for plugin enable/disable, which flips the `.disabled`
+    // sentinel without poking the plugin source reconcile. The readiness
+    // guard lives inside reconcilePluginSchedules, which no-ops while
+    // migrations are unready.
+    startPluginScheduleReconcileSweep();
+    log.info("Plugin schedule reconcile sweep started");
   }
 
   async stop(): Promise<void> {
     stopGuardianExpirySweep();
     stopInferenceProfileSessionReaper();
     stopTelegramWebhookHealthSweep();
+    stopPluginScheduleReconcileSweep();
     if (this.retrySweepTimer) {
       clearInterval(this.retrySweepTimer);
       this.retrySweepTimer = null;

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for `reconcilePluginSchedules()`.
+ *
+ * Fixture plugin directories are written under the (per-test-process)
+ * workspace plugins dir and converged against the real schedule store; the
+ * only stubs are the notification emitter (recorded for assertions) and the
+ * background-wake publisher (kept out for hermeticity, mirroring
+ * schedule-store.test.ts).
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../background-wake/publisher.js", () => ({
+  refreshBackgroundWakeIntent: () => {},
+}));
+
+const emittedSignals: Array<Record<string, unknown>> = [];
+
+mock.module("../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emittedSignals.push(params);
+    return {
+      signalId: "test-signal",
+      deduplicated: false,
+      dispatched: true,
+      reason: "test",
+      deliveryResults: [],
+    };
+  },
+}));
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { reconcilePluginSchedules } from "../plugin-schedule-reconciler.js";
+import {
+  claimDueSchedules,
+  createSchedule,
+  createScheduleRun,
+  listDeclaredSchedules,
+  setUserEnabled,
+} from "../schedule-store.js";
+
+await initializeDb();
+
+const pluginsDir = getWorkspacePluginsDir();
+
+function getRawDb(): import("bun:sqlite").Database {
+  return (getDb() as unknown as { $client: import("bun:sqlite").Database })
+    .$client;
+}
+
+function rawJob(id: string): Record<string, unknown> {
+  return getRawDb()
+    .query("SELECT * FROM cron_jobs WHERE id = ?")
+    .get(id) as Record<string, unknown>;
+}
+
+/**
+ * Write a plugin fixture: a `package.json` plus the given files under
+ * `schedules/` (paths relative to the schedules dir).
+ */
+function writePlugin(name: string, files: Record<string, string>): string {
+  const dir = join(pluginsDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, "schedules", rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return dir;
+}
+
+function digestMd(body: string): string {
+  return [
+    "---",
+    'expression: "* * * * *"',
+    "description: Daily digest",
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+const DIGEST_KEY = "plugin:news/digest";
+
+describe("reconcilePluginSchedules", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM cron_runs");
+    getDb().run("DELETE FROM cron_jobs");
+    rmSync(pluginsDir, { recursive: true, force: true });
+    emittedSignals.length = 0;
+  });
+
+  test("converges both declaration forms into rows the engine claims", async () => {
+    writePlugin("news", {
+      "digest.md": digestMd("Summarize the day."),
+      "sync/config.json": JSON.stringify({ expression: "0 */2 * * *" }),
+      "sync/index.sh": "#!/bin/sh\necho synced\n",
+    });
+
+    await reconcilePluginSchedules();
+
+    const rows = listDeclaredSchedules();
+    expect(rows).toHaveLength(2);
+
+    const digest = rows.find((r) => r.sourceKey === DIGEST_KEY)!;
+    expect(digest.mode).toBe("execute");
+    expect(digest.message).toBe("Summarize the day.");
+    expect(digest.description).toBe("Daily digest");
+    expect(digest.enabled).toBe(true);
+    expect(digest.userEnabled).toBeNull();
+    expect(digest.definitionHash).toMatch(/^[0-9a-f]{64}$/);
+
+    const sync = rows.find((r) => r.sourceKey === "plugin:news/sync")!;
+    expect(sync.mode).toBe("script");
+    expect(sync.script).toContain("index.sh");
+    expect(sync.message).toBe("");
+
+    // The untouched engine picks the row up: an every-minute cron is always
+    // due within a two-minute claim horizon.
+    const claimed = await claimDueSchedules(Date.now() + 120_000);
+    expect(claimed.map((j) => j.id)).toContain(digest.id);
+  });
+
+  test("a repeat pass with unchanged declarations is a no-op", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const row = listDeclaredSchedules()[0]!;
+    const before = rawJob(row.id);
+
+    await reconcilePluginSchedules();
+
+    expect(rawJob(row.id)).toEqual(before);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("an upgrade updates by hash and emits definition_changed for the armed row", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    writePlugin("news", { "digest.md": digestMd("Summarize the WEEK.") });
+    await reconcilePluginSchedules();
+
+    const updated = listDeclaredSchedules()[0]!;
+    expect(updated.id).toBe(created.id);
+    expect(updated.message).toBe("Summarize the WEEK.");
+    expect(updated.definitionHash).not.toBe(created.definitionHash);
+
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("schedule.definition_changed");
+    expect(signal.dedupeKey).toBe(
+      `schedule-definition-changed:${DIGEST_KEY}:${updated.definitionHash}`,
+    );
+    expect(signal.contextPayload).toEqual({
+      pluginName: "news",
+      scheduleName: "digest",
+      sourceKey: DIGEST_KEY,
+    });
+  });
+
+  test("uninstall disarms without deleting rows or runs; reinstall re-links and re-arms", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    await createScheduleRun(created.id, "conv-1");
+
+    rmSync(join(pluginsDir, "news"), { recursive: true, force: true });
+    await reconcilePluginSchedules();
+
+    const disarmed = listDeclaredSchedules()[0]!;
+    expect(disarmed.id).toBe(created.id);
+    expect(disarmed.enabled).toBe(false);
+    expect(disarmed.sourceKey).toBe(DIGEST_KEY);
+    const runs = getRawDb()
+      .query("SELECT COUNT(*) AS n FROM cron_runs WHERE job_id = ?")
+      .get(created.id) as { n: number };
+    expect(runs.n).toBe(1);
+
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+
+    const relinked = listDeclaredSchedules();
+    expect(relinked).toHaveLength(1);
+    expect(relinked[0]!.id).toBe(created.id);
+    expect(relinked[0]!.enabled).toBe(true);
+    expect(relinked[0]!.nextRunAt).toBeGreaterThan(0);
+  });
+
+  test("user_enabled survives upgrades and disarm/re-arm cycles", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    await setUserEnabled(created.id, false);
+
+    // Upgrade: definition columns update, the user override keeps the row
+    // disabled, and no definition_changed emits for an unarmed row.
+    writePlugin("news", { "digest.md": digestMd("Summarize the WEEK.") });
+    await reconcilePluginSchedules();
+    let row = listDeclaredSchedules()[0]!;
+    expect(row.message).toBe("Summarize the WEEK.");
+    expect(row.enabled).toBe(false);
+    expect(row.userEnabled).toBe(false);
+    expect(emittedSignals).toHaveLength(0);
+
+    // Disarm (uninstall) then re-arm (reinstall): the override still wins.
+    rmSync(join(pluginsDir, "news"), { recursive: true, force: true });
+    await reconcilePluginSchedules();
+    writePlugin("news", { "digest.md": digestMd("Summarize the WEEK.") });
+    await reconcilePluginSchedules();
+    row = listDeclaredSchedules()[0]!;
+    expect(row.id).toBe(created.id);
+    expect(row.enabled).toBe(false);
+    expect(row.userEnabled).toBe(false);
+  });
+
+  test("a user override enables a declaration shipped disabled", async () => {
+    writePlugin("news", {
+      "digest.md": [
+        "---",
+        'expression: "* * * * *"',
+        "enabled: false",
+        "---",
+        "",
+        "Summarize the day.",
+        "",
+      ].join("\n"),
+    });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    expect(created.enabled).toBe(false);
+
+    await setUserEnabled(created.id, true);
+    await reconcilePluginSchedules();
+
+    const row = listDeclaredSchedules()[0]!;
+    expect(row.enabled).toBe(true);
+    expect(row.userEnabled).toBe(true);
+  });
+
+  test("disabling a plugin pauses its schedules; re-enabling restores them", async () => {
+    const dir = writePlugin("news", {
+      "digest.md": digestMd("Summarize the day."),
+    });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    writeFileSync(join(dir, ".disabled"), "");
+    await reconcilePluginSchedules();
+    expect(listDeclaredSchedules()[0]!.enabled).toBe(false);
+
+    rmSync(join(dir, ".disabled"));
+    await reconcilePluginSchedules();
+    const restored = listDeclaredSchedules()[0]!;
+    expect(restored.id).toBe(created.id);
+    expect(restored.enabled).toBe(true);
+    expect(restored.userEnabled).toBeNull();
+  });
+
+  test("a parse error keeps the last-good row running and emits a deduped notification", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    const before = rawJob(created.id);
+
+    // Break the declaration: no frontmatter means no config.
+    writePlugin("news", { "digest.md": "Just a body, no config." });
+    await reconcilePluginSchedules();
+
+    expect(rawJob(created.id)).toEqual(before);
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("schedule.definition_error");
+    const day = new Date().toISOString().slice(0, 10);
+    expect(signal.dedupeKey).toBe(
+      `schedule-definition-error:${DIGEST_KEY}:${day}`,
+    );
+    const payload = signal.contextPayload as Record<string, unknown>;
+    expect(payload.pluginName).toBe("news");
+    expect(payload.scheduleName).toBe("digest");
+    expect(payload.sourceKey).toBe(DIGEST_KEY);
+    expect(typeof payload.reason).toBe("string");
+  });
+
+  test("engine-latched rows are left untouched by definition changes", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    // Recurrence exhaustion latch: the claim path disables the row, zeroes
+    // nextRunAt, and stamps lastRunAt in one write.
+    getRawDb().run(
+      "UPDATE cron_jobs SET enabled = 0, next_run_at = 0, last_run_at = ? WHERE id = ?",
+      [Date.now(), created.id],
+    );
+    const latched = rawJob(created.id);
+
+    writePlugin("news", { "digest.md": digestMd("Summarize the WEEK.") });
+    await reconcilePluginSchedules();
+
+    expect(rawJob(created.id)).toEqual(latched);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("imperative rows are byte-identical across passes", async () => {
+    const imperative = await createSchedule({
+      name: "Mine",
+      cronExpression: "0 8 * * *",
+      message: "hello",
+      syntax: "cron",
+    });
+    const before = rawJob(imperative.id);
+
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    rmSync(join(pluginsDir, "news"), { recursive: true, force: true });
+    await reconcilePluginSchedules();
+
+    expect(rawJob(imperative.id)).toEqual(before);
+  });
+
+  test("concurrent reconciles serialize into one row per declaration", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+
+    await Promise.all([reconcilePluginSchedules(), reconcilePluginSchedules()]);
+
+    const rows = listDeclaredSchedules();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.sourceKey).toBe(DIGEST_KEY);
+  });
+});

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -1,0 +1,330 @@
+/**
+ * Level-based reconciler converging plugin `schedules/` declarations into
+ * `cron_jobs` rows.
+ *
+ * Each pass enumerates the installed, enabled plugins, parses their
+ * declarations (see `./plugin-schedule-declarations.ts`), and diffs the
+ * desired set against the sourced rows in the store: new declarations are
+ * inserted, changed ones (by `definition_hash`) updated, and rows whose
+ * declaration is gone are disarmed in place. The reconciler owns only the
+ * definition columns; the engine owns the runtime columns and the user owns
+ * `user_enabled` (both enforced in `./schedule-store.ts`). Rows with a null
+ * `source_key` are imperative schedules and are never touched.
+ *
+ * Triggers: daemon startup (`daemon/lifecycle.ts`), plugin-set convergence
+ * (`plugins/mtime-cache.ts` after an imperative source reconcile), and a
+ * periodic backstop sweep (`runtime/http-server.ts`) that covers plugin
+ * enable/disable, which flips the `.disabled` sentinel without poking the
+ * plugin source reconcile.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getDbMigrationReadiness } from "../daemon/daemon-readiness.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { AttentionHints } from "../notifications/signal.js";
+import { isPluginDisabled } from "../plugins/disabled-state.js";
+import { getLogger } from "../util/logger.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
+import {
+  type DeclarationError,
+  parsePluginScheduleDeclarations,
+  type ScheduleDeclaration,
+} from "./plugin-schedule-declarations.js";
+import {
+  type DeclaredScheduleDefinition,
+  disarmDeclaredSchedule,
+  listDeclaredSchedules,
+  type ScheduleJob,
+  upsertDeclaredSchedule,
+} from "./schedule-store.js";
+
+const log = getLogger("plugin-schedule-reconciler");
+
+/** In-flight pass; concurrent triggers await it rather than racing. */
+let reconcileInFlight: Promise<void> | null = null;
+
+/**
+ * Converge plugin-declared schedules against the current on-disk plugin set.
+ *
+ * Single-flight: concurrent triggers serialize through the in-flight latch,
+ * so two passes never interleave their list/diff/write sequences. Never
+ * throws: a failed pass is logged and the next trigger retries from disk.
+ * No-ops while DB migrations are unready.
+ */
+export async function reconcilePluginSchedules(): Promise<void> {
+  while (reconcileInFlight !== null) {
+    await reconcileInFlight;
+  }
+  reconcileInFlight = (async () => {
+    try {
+      await runReconcilePass();
+    } catch (err) {
+      log.error({ err }, "Plugin schedule reconcile failed");
+    }
+  })().finally(() => {
+    reconcileInFlight = null;
+  });
+  await reconcileInFlight;
+}
+
+interface DesiredEntry {
+  pluginName: string;
+  declaration: ScheduleDeclaration;
+}
+
+async function runReconcilePass(): Promise<void> {
+  // The pass is pure DB reads/writes over cron_jobs; refuse to touch a
+  // partially-migrated schema (see assistant/CLAUDE.md, DB migration
+  // readiness gating). A skipped pass is retried by the periodic sweep.
+  if (!getDbMigrationReadiness().ready) {
+    return;
+  }
+
+  const { desired, errors } = collectDesiredDeclarations();
+
+  const existingByKey = new Map<string, ScheduleJob>();
+  for (const row of listDeclaredSchedules()) {
+    if (row.sourceKey !== null) {
+      existingByKey.set(row.sourceKey, row);
+    }
+  }
+
+  for (const [sourceKey, { pluginName, declaration }] of desired) {
+    const row = existingByKey.get(sourceKey);
+    const definition = toDefinition(declaration);
+    const changesArmedRow =
+      row !== undefined &&
+      row.enabled &&
+      row.definitionHash !== definition.definitionHash;
+    try {
+      await upsertDeclaredSchedule(sourceKey, definition);
+    } catch (err) {
+      log.error(
+        { err, sourceKey },
+        "Failed to apply declared schedule, skipping",
+      );
+      continue;
+    }
+    if (changesArmedRow) {
+      emitDefinitionChanged(pluginName, declaration);
+    }
+  }
+
+  // A key with a declaration error keeps its last-good row untouched: fail
+  // closed means the broken declaration does not load, not that a previously
+  // healthy schedule is torn down by its own typo.
+  const erroredKeys = new Set(errors.map((e) => e.sourceKey));
+
+  // Disarm rows whose declaration is absent from the desired set (plugin
+  // uninstalled or disabled, or the schedule file removed). Teardown
+  // deliberately does not ride plugin shutdown hooks: uninstalling a disabled
+  // plugin skips them entirely (`cli/lib/uninstall-plugin.ts`), so
+  // directory-absence diffing here is the only reliable reap. The row and its
+  // runs are kept so a reinstall re-links by `source_key`.
+  for (const [sourceKey, row] of existingByKey) {
+    if (desired.has(sourceKey) || erroredKeys.has(sourceKey)) {
+      continue;
+    }
+    try {
+      await disarmDeclaredSchedule(row.id);
+    } catch (err) {
+      log.error(
+        { err, sourceKey, scheduleId: row.id },
+        "Failed to disarm declared schedule, skipping",
+      );
+    }
+  }
+
+  for (const error of errors) {
+    emitDefinitionError(error);
+  }
+}
+
+/**
+ * Enumerate installed plugins with the same gates as the plugin source walk
+ * (`plugins/collect-source-versions.ts`): a directory under the workspace
+ * plugins dir carrying a `package.json`, identity = the directory basename
+ * (mirroring `parsePluginManifest`). Disabled plugins are skipped entirely,
+ * so their declarations fall out of the desired set and disarm.
+ */
+function collectDesiredDeclarations(): {
+  desired: Map<string, DesiredEntry>;
+  errors: DeclarationError[];
+} {
+  const desired = new Map<string, DesiredEntry>();
+  const errors: DeclarationError[] = [];
+
+  const pluginsDir = getWorkspacePluginsDir();
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch {
+    // No plugins directory yet, so nothing declared.
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      continue;
+    }
+    const dir = join(pluginsDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(dir, "package.json"))) {
+      continue;
+    }
+    if (isPluginDisabled(entry)) {
+      continue;
+    }
+    const parsed = parsePluginScheduleDeclarations(dir, entry);
+    for (const declaration of parsed.declarations) {
+      desired.set(declaration.sourceKey, { pluginName: entry, declaration });
+    }
+    errors.push(...parsed.errors);
+  }
+
+  return { desired, errors };
+}
+
+function toDefinition(
+  declaration: ScheduleDeclaration,
+): DeclaredScheduleDefinition {
+  const { config } = declaration;
+  return {
+    name: declaration.name,
+    description: config.description ?? undefined,
+    syntax: config.syntax,
+    expression: config.expression,
+    timezone: config.timezone,
+    // Script-mode runs ignore the message column (the engine executes
+    // `script`); it is non-null in the schema, so store an empty string.
+    message: declaration.message ?? "",
+    script: declaration.scriptInvocation,
+    mode: declaration.mode,
+    maxRetries: config.maxRetries ?? undefined,
+    retryBackoffMs: config.retryBackoffMs ?? undefined,
+    quiet: config.quiet ?? undefined,
+    inferenceProfile: config.inferenceProfile,
+    timeoutMs: config.timeoutMs,
+    enabled: config.enabled,
+    definitionHash: declaration.definitionHash,
+  };
+}
+
+// Same shape as the background-job failure notification: passive home-feed
+// surfacing, no action required.
+const DEFINITION_NOTIFICATION_HINTS: AttentionHints = {
+  requiresAction: false,
+  urgency: "medium",
+  isAsyncBackground: true,
+  visibleInSourceNow: false,
+};
+
+function emitDefinitionSignal(
+  sourceEventName: string,
+  sourceKey: string,
+  dedupeKey: string,
+  contextPayload: Record<string, unknown>,
+): void {
+  emitNotificationSignal({
+    sourceChannel: "scheduler",
+    sourceContextId: sourceKey,
+    sourceEventName,
+    dedupeKey,
+    contextPayload,
+    attentionHints: DEFINITION_NOTIFICATION_HINTS,
+  }).catch((err) => {
+    log.warn(
+      { err, sourceKey, sourceEventName },
+      "Failed to emit schedule definition notification",
+    );
+  });
+}
+
+/**
+ * Surface a malformed declaration. Deduped per schedule per UTC day so a
+ * broken file doesn't spam on every pass.
+ */
+function emitDefinitionError(error: DeclarationError): void {
+  const day = new Date().toISOString().slice(0, 10);
+  emitDefinitionSignal(
+    "schedule.definition_error",
+    error.sourceKey,
+    `schedule-definition-error:${error.sourceKey}:${day}`,
+    {
+      pluginName: error.pluginName,
+      scheduleName: error.scheduleName,
+      sourceKey: error.sourceKey,
+      reason: error.reason,
+    },
+  );
+}
+
+/**
+ * Surface a plugin upgrade rewriting an armed schedule's definition, so the
+ * user learns the thing firing on their behalf changed. Deduped by the new
+ * hash so concurrent triggers emit once per change.
+ */
+function emitDefinitionChanged(
+  pluginName: string,
+  declaration: ScheduleDeclaration,
+): void {
+  emitDefinitionSignal(
+    "schedule.definition_changed",
+    declaration.sourceKey,
+    `schedule-definition-changed:${declaration.sourceKey}:${declaration.definitionHash}`,
+    {
+      pluginName,
+      scheduleName: declaration.name,
+      sourceKey: declaration.sourceKey,
+    },
+  );
+}
+
+// ── Periodic backstop sweep ─────────────────────────────────────────────
+
+/**
+ * Backstop interval. Enable/disable flows write the `.disabled` sentinel
+ * without poking the plugin source reconcile, so this bounds how long a
+ * toggle can go unreflected in the rows.
+ */
+const SWEEP_INTERVAL_MS = 60_000;
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Guard against a slow pass stacking further passes behind the latch. */
+let sweepInProgress = false;
+
+/**
+ * Start the periodic reconcile sweep. Idempotent: repeat calls reuse the
+ * timer. The DB-readiness guard lives inside {@link reconcilePluginSchedules},
+ * which no-ops while migrations are unready.
+ */
+export function startPluginScheduleReconcileSweep(): void {
+  if (sweepTimer) {
+    return;
+  }
+  sweepTimer = setInterval(() => {
+    if (sweepInProgress) {
+      return;
+    }
+    sweepInProgress = true;
+    void reconcilePluginSchedules().finally(() => {
+      sweepInProgress = false;
+    });
+  }, SWEEP_INTERVAL_MS);
+}
+
+/** Stop the periodic reconcile sweep. Used in tests and shutdown. */
+export function stopPluginScheduleReconcileSweep(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+  sweepInProgress = false;
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,6 +17,7 @@ wired surface.
 - [Public API surface](#public-api-surface--vellumaiplugin-api)
 - [Hooks](#hooks)
 - [Tools](#tools)
+- [Schedules](#schedules)
 - [Marketplace — whitelisting external plugins](#marketplace--whitelisting-external-plugins)
 - [Conventions](#conventions)
 
@@ -36,12 +37,13 @@ wired surface.
 
 The external plugin loader extends the assistant by wiring these contribution surfaces.
 
-| Surface             | Directory                | Discovery                                                       |
-| ------------------- | ------------------------ | --------------------------------------------------------------- |
-| Lifecycle hooks     | `hooks/<name>.ts`        | filename → `plugin.hooks[<name>]`                               |
-| Model-visible tools | `tools/<name>.ts`        | each file's default export → `plugin.tools[]`                   |
-| Skills              | `skills/<id>/SKILL.md`   | picked up on disk by the skill catalog loader                   |
-| Skill-scoped tools  | `skills/<id>/TOOLS.json` | registered only while the skill is active (see [Tools](#tools)) |
+| Surface             | Directory                             | Discovery                                                             |
+| ------------------- | ------------------------------------- | --------------------------------------------------------------------- |
+| Lifecycle hooks     | `hooks/<name>.ts`                     | filename → `plugin.hooks[<name>]`                                     |
+| Model-visible tools | `tools/<name>.ts`                     | each file's default export → `plugin.tools[]`                         |
+| Skills              | `skills/<id>/SKILL.md`                | picked up on disk by the skill catalog loader                         |
+| Skill-scoped tools  | `skills/<id>/TOOLS.json`              | registered only while the skill is active (see [Tools](#tools))       |
+| Schedules           | `schedules/<name>.md` or `<name>/`    | reconciled into schedule rows on install/upgrade (see [Schedules](#schedules)) |
 
 ---
 
@@ -64,6 +66,9 @@ my-plugin/
 ├── tools/
 │   ├── my_tool.ts             # Default export = tool definition
 │   └── ...
+├── schedules/
+│   ├── digest.md              # Flat form: frontmatter config + prompt body
+│   └── nightly-sync/          # Directory form: config.json + index.md or index.sh
 └── src/                       # Internal modules (NOT walked by the loader)
     └── state.ts               # Shared state, helpers
 ```
@@ -568,6 +573,54 @@ defaults when an author omits a field:
 `export default {}` is therefore a valid (if useless) tool — broken
 individual tools never block plugin load; misconfigurations surface at
 call time.
+
+---
+
+## Schedules
+
+A plugin declares recurring scheduled tasks as files under `schedules/`.
+A reconciler converges each declaration into an ordinary schedule row, so
+declared schedules run through the same engine, run history, and UI as
+user-created ones. Two forms are supported:
+
+**Flat file** `schedules/<name>.md`: YAML frontmatter carries the config,
+the markdown body is the prompt the assistant executes.
+
+```md
+---
+expression: "0 9 * * *"
+description: Daily digest
+timezone: America/New_York
+---
+
+Summarize the day's activity and post it to the home feed.
+```
+
+**Directory** `schedules/<name>/`: a `config.json` with the same fields,
+plus exactly one entrypoint. `index.md` (prompt body, no frontmatter) runs
+as an assistant task; `index.sh` runs as a shell script with no LLM.
+
+Config fields: `expression` (required; cron or RRULE, auto-detected or
+pinned via `expression_syntax`), `timezone`, `description`, `max_retries`,
+`retry_backoff_ms`, `quiet`, `inference_profile`, `timeout_ms`, `enabled`
+(defaults to true). Declared schedules are recurring only; there is no
+one-shot form.
+
+Fail-closed rules. Ambiguity never resolves by precedence: a name declared
+as both `<name>.md` and `<name>/`, a directory with zero or multiple
+entrypoints, or an unsupported entrypoint (anything but `index.md` /
+`index.sh`) is an error and that schedule does not load. Errors are
+per-schedule: one bad declaration never blocks siblings, and a declaration
+that breaks in an upgrade keeps its last-good schedule running while the
+error is surfaced as a notification.
+
+Lifecycle. The declaration file is the source of truth: edits and upgrades
+update the schedule row in place, uninstalling or disabling the plugin
+pauses its schedules (runs and history are kept), and reinstalling re-links
+them. Users can enable/disable a declared schedule from the schedules UI;
+that override survives plugin upgrades. Rows are managed by the reconciler,
+so declared schedules cannot be edited or deleted imperatively: change the
+file instead.
 
 ---
 


### PR DESCRIPTION
## Summary
- Level-based reconciler converging plugin schedules/ declarations into cron_jobs rows (create/update-by-hash/disarm; engine latches and user_enabled respected)
- Triggers: daemon startup, plugin-set convergence in reconcilePluginSourcesNow, periodic backstop sweep
- Declaration errors surface as deduped notifications; plugins/README.md documents the new surface

Part of plan: plugin-schedules-v1.md (PR 3 of 5)