### PR TITLE
feat(schedules): surface plugin-sourced schedules read-only in routes, CLI, and web

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25359,6 +25359,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -25391,6 +25405,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Schedule objects
@@ -25571,6 +25587,20 @@ paths:
                         anyOf:
                           - type: string
                           - type: "null"
+                      sourceKey:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                        description:
+                          Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                          schedules
+                      userEnabled:
+                        anyOf:
+                          - type: boolean
+                          - type: "null"
+                        description:
+                          User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                          applies. Always null for user-created schedules.
                       isOneShot:
                         type: boolean
                     required:
@@ -25603,6 +25633,8 @@ paths:
                       - reuseConversation
                       - wakeConversationId
                       - workflowName
+                      - sourceKey
+                      - userEnabled
                       - isOneShot
                     additionalProperties: false
                     description: The created schedule
@@ -25737,6 +25769,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -25769,6 +25815,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -25900,6 +25948,20 @@ paths:
                         anyOf:
                           - type: string
                           - type: "null"
+                      sourceKey:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                        description:
+                          Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                          schedules
+                      userEnabled:
+                        anyOf:
+                          - type: boolean
+                          - type: "null"
+                        description:
+                          User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                          applies. Always null for user-created schedules.
                       isOneShot:
                         type: boolean
                     required:
@@ -25932,6 +25994,8 @@ paths:
                       - reuseConversation
                       - wakeConversationId
                       - workflowName
+                      - sourceKey
+                      - userEnabled
                       - isOneShot
                     additionalProperties: false
                     description: Schedule object
@@ -26122,6 +26186,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -26154,6 +26232,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -26288,6 +26368,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -26320,6 +26414,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -26454,6 +26550,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -26486,6 +26596,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -26621,7 +26733,7 @@ paths:
     post:
       operationId: schedules_by_id_toggle_post
       summary: Toggle schedule
-      description: Enable or disable a schedule.
+      description: Enable or disable a schedule. On a plugin-managed schedule this records the user's override (userEnabled).
       tags:
         - schedules
       parameters:
@@ -26757,6 +26869,20 @@ paths:
                           anyOf:
                             - type: string
                             - type: "null"
+                        sourceKey:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description:
+                            Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created
+                            schedules
+                        userEnabled:
+                          anyOf:
+                            - type: boolean
+                            - type: "null"
+                          description:
+                            User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value
+                            applies. Always null for user-created schedules.
                         isOneShot:
                           type: boolean
                       required:
@@ -26789,6 +26915,8 @@ paths:
                         - reuseConversation
                         - wakeConversationId
                         - workflowName
+                        - sourceKey
+                        - userEnabled
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -62,7 +62,9 @@ import {
   completeScheduleRun,
   createSchedule,
   createScheduleRun,
+  type DeclaredScheduleDefinition,
   listSchedules,
+  upsertDeclaredSchedule,
 } from "../schedule/schedule-store.js";
 
 await initializeDb();
@@ -1364,6 +1366,133 @@ describe("PATCH /schedules/:id — description", () => {
         body: { expression: "not a schedule" },
       }),
     ).rejects.toThrow(BadRequestError);
+  });
+});
+
+// ── Plugin-sourced schedules ──────────────────────────────────────────────
+
+describe("plugin-sourced schedules over routes", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  const SOURCE_KEY = "plugin:example-plugin/daily-digest";
+
+  function seedSourcedSchedule(
+    overrides: Partial<DeclaredScheduleDefinition> = {},
+  ) {
+    return upsertDeclaredSchedule(SOURCE_KEY, {
+      name: "Daily digest",
+      description: "Summarize the day",
+      syntax: "cron",
+      expression: "0 9 * * *",
+      message: "produce the digest",
+      mode: "execute",
+      enabled: true,
+      definitionHash: "hash-1",
+      ...overrides,
+    });
+  }
+
+  type SerializedEntry = {
+    id: string;
+    enabled: boolean;
+    sourceKey: string | null;
+    userEnabled: boolean | null;
+  };
+
+  test("list serializes sourceKey and userEnabled for sourced and imperative rows", async () => {
+    const sourced = await seedSourcedSchedule();
+    const imperative = await createSchedule({
+      name: "Imperative schedule",
+      cronExpression: "* * * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = (await route.handler({})) as {
+      schedules: SerializedEntry[];
+    };
+    const byId = new Map(result.schedules.map((s) => [s.id, s]));
+
+    expect(byId.get(sourced.id)).toMatchObject({
+      sourceKey: SOURCE_KEY,
+      userEnabled: null,
+    });
+    expect(byId.get(imperative.id)).toMatchObject({
+      sourceKey: null,
+      userEnabled: null,
+    });
+  });
+
+  test("toggle on a sourced row records and round-trips the user override", async () => {
+    const sourced = await seedSourcedSchedule();
+    const route = findRoute("schedules/:id/toggle", "POST");
+
+    const disabled = (await route.handler({
+      pathParams: { id: sourced.id },
+      body: { enabled: false },
+    })) as { schedules: SerializedEntry[] };
+    expect(disabled.schedules.find((s) => s.id === sourced.id)).toMatchObject({
+      enabled: false,
+      userEnabled: false,
+    });
+
+    const enabled = (await route.handler({
+      pathParams: { id: sourced.id },
+      body: { enabled: true },
+    })) as { schedules: SerializedEntry[] };
+    expect(enabled.schedules.find((s) => s.id === sourced.id)).toMatchObject({
+      enabled: true,
+      userEnabled: true,
+    });
+  });
+
+  test("toggle on an imperative row keeps userEnabled null", async () => {
+    const imperative = await createSchedule({
+      name: "Imperative toggle",
+      cronExpression: "* * * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules/:id/toggle", "POST");
+    const result = (await route.handler({
+      pathParams: { id: imperative.id },
+      body: { enabled: false },
+    })) as { schedules: SerializedEntry[] };
+
+    expect(result.schedules.find((s) => s.id === imperative.id)).toMatchObject({
+      enabled: false,
+      userEnabled: null,
+    });
+  });
+
+  test("PATCH on a sourced row surfaces the store refusal as a 400", async () => {
+    const sourced = await seedSourcedSchedule();
+    const route = findRoute("schedules/:id", "PATCH");
+    const patch = () =>
+      route.handler({
+        pathParams: { id: sourced.id },
+        body: { name: "Renamed" },
+      });
+
+    await expect(patch()).rejects.toThrow(BadRequestError);
+    await expect(patch()).rejects.toThrow(
+      "This schedule is managed by a plugin. Edit the plugin's schedule file instead.",
+    );
+  });
+
+  test("DELETE on a sourced row surfaces the store refusal as a 400", async () => {
+    const sourced = await seedSourcedSchedule();
+    const route = findRoute("schedules/:id", "DELETE");
+    const remove = () => route.handler({ pathParams: { id: sourced.id } });
+
+    await expect(remove()).rejects.toThrow(BadRequestError);
+    await expect(remove()).rejects.toThrow(
+      "This schedule is managed by a plugin and cannot be deleted. Disable it instead, or remove the plugin's schedule file.",
+    );
   });
 });
 

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -231,6 +231,137 @@ describe("schedules list", () => {
     expect(logLines.join("\n")).not.toContain("Authored heartbeat check");
   });
 
+  test("renders a SOURCE column with the owning plugin's name", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        schedules: [
+          {
+            id: "schedule-plugin",
+            name: "Inbox poll",
+            enabled: true,
+            syntax: "cron",
+            expression: "*/15 * * * *",
+            cronExpression: "*/15 * * * *",
+            timezone: null,
+            message: "poll the inbox",
+            script: null,
+            nextRunAt: 1_778_800_000_000,
+            lastRunAt: null,
+            lastStatus: "ok",
+            retryCount: 0,
+            maxRetries: 3,
+            retryBackoffMs: 60_000,
+            description: "Polls the inbox",
+            cadenceDescription: "Every 15 minutes",
+            mode: "execute",
+            status: "active",
+            routingIntent: "all_channels",
+            reuseConversation: false,
+            wakeConversationId: null,
+            sourceKey: "plugin:gmail/poll-inbox",
+            userEnabled: null,
+            isOneShot: false,
+          },
+          {
+            id: "schedule-imperative",
+            name: "Heartbeat",
+            enabled: true,
+            syntax: "cron",
+            expression: "*/30 * * * *",
+            cronExpression: "*/30 * * * *",
+            timezone: null,
+            message: "run heartbeat",
+            script: null,
+            nextRunAt: 1_778_800_100_000,
+            lastRunAt: null,
+            lastStatus: "ok",
+            retryCount: 0,
+            maxRetries: 3,
+            retryBackoffMs: 60_000,
+            description: "Checks the heartbeat",
+            cadenceDescription: "Every 30 minutes",
+            mode: "execute",
+            status: "active",
+            routingIntent: "all_channels",
+            reuseConversation: false,
+            wakeConversationId: null,
+            sourceKey: null,
+            userEnabled: null,
+            isOneShot: false,
+          },
+        ],
+      },
+    };
+
+    const { exitCode } = await runCommand(["schedules", "list"]);
+
+    expect(exitCode).toBe(0);
+    expect(logLines.join("\n")).toContain("SOURCE");
+    const pluginLine = logLines.find((line) =>
+      line.includes("schedule-plugin"),
+    );
+    const imperativeLine = logLines.find((line) =>
+      line.includes("schedule-imperative"),
+    );
+    expect(pluginLine).toContain("gmail");
+    expect(imperativeLine).not.toContain("gmail");
+  });
+
+  test("--json passes sourceKey and userEnabled through untouched", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        schedules: [
+          {
+            id: "schedule-plugin",
+            name: "Inbox poll",
+            enabled: false,
+            syntax: "cron",
+            expression: "*/15 * * * *",
+            cronExpression: "*/15 * * * *",
+            timezone: null,
+            message: "poll the inbox",
+            script: null,
+            nextRunAt: 1_778_800_000_000,
+            lastRunAt: null,
+            lastStatus: "ok",
+            retryCount: 0,
+            maxRetries: 3,
+            retryBackoffMs: 60_000,
+            description: "Polls the inbox",
+            cadenceDescription: "Every 15 minutes",
+            mode: "execute",
+            status: "active",
+            routingIntent: "all_channels",
+            reuseConversation: false,
+            wakeConversationId: null,
+            sourceKey: "plugin:gmail/poll-inbox",
+            userEnabled: false,
+            isOneShot: false,
+          },
+        ],
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "schedules",
+      "list",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      schedules: [
+        expect.objectContaining({
+          id: "schedule-plugin",
+          sourceKey: "plugin:gmail/poll-inbox",
+          userEnabled: false,
+        }),
+      ],
+    });
+  });
+
   test("sets exit code on IPC failure", async () => {
     mockIpcResult = { ok: false, error: "daemon unavailable" };
 

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -36,6 +36,8 @@ interface ScheduleRecord {
   routingIntent: string;
   reuseConversation: boolean;
   wakeConversationId: string | null;
+  sourceKey: string | null;
+  userEnabled: boolean | null;
   isOneShot: boolean;
 }
 
@@ -115,6 +117,7 @@ export function registerSchedulesCommand(program: Command): void {
             name: schedule.name,
             enabled: schedule.enabled ? "enabled" : "disabled",
             mode: schedule.mode,
+            source: describeSource(schedule.sourceKey),
             schedule: describeSchedule(schedule),
             nextRun: formatTimestamp(schedule.nextRunAt),
             lastStatus: schedule.lastStatus ?? "—",
@@ -125,6 +128,7 @@ export function registerSchedulesCommand(program: Command): void {
             "NAME",
             "ENABLED",
             "MODE",
+            "SOURCE",
             "SCHEDULE",
             "NEXT RUN",
             "LAST STATUS",
@@ -137,6 +141,7 @@ export function registerSchedulesCommand(program: Command): void {
             headers[4].length,
             headers[5].length,
             headers[6].length,
+            headers[7].length,
           ];
 
           for (const row of rows) {
@@ -144,9 +149,10 @@ export function registerSchedulesCommand(program: Command): void {
             widths[1] = Math.max(widths[1], row.name.length);
             widths[2] = Math.max(widths[2], row.enabled.length);
             widths[3] = Math.max(widths[3], row.mode.length);
-            widths[4] = Math.max(widths[4], row.schedule.length);
-            widths[5] = Math.max(widths[5], row.nextRun.length);
-            widths[6] = Math.max(widths[6], row.lastStatus.length);
+            widths[4] = Math.max(widths[4], row.source.length);
+            widths[5] = Math.max(widths[5], row.schedule.length);
+            widths[6] = Math.max(widths[6], row.nextRun.length);
+            widths[7] = Math.max(widths[7], row.lastStatus.length);
           }
 
           const pad = (value: string, width: number) => value.padEnd(width);
@@ -163,6 +169,7 @@ export function registerSchedulesCommand(program: Command): void {
                 row.name,
                 row.enabled,
                 row.mode,
+                row.source,
                 row.schedule,
                 row.nextRun,
                 row.lastStatus,
@@ -232,6 +239,7 @@ export function registerSchedulesCommand(program: Command): void {
             ["Retry backoff", formatDuration(schedule.retryBackoffMs)],
             ["Timeout", formatDuration(schedule.timeoutMs)],
             ["Source conversation", schedule.createdFromConversationId ?? "—"],
+            ["Plugin", describeSource(schedule.sourceKey) || "—"],
           ];
           const labelWidth = Math.max(...fields.map(([label]) => label.length));
           for (const [label, value] of fields) {
@@ -776,6 +784,19 @@ async function toggleScheduleEnabled(
   }
 
   log.info(`${enabled ? "Enabled" : "Disabled"} schedule: ${scheduleId}`);
+}
+
+/**
+ * Plugin attribution for the list's SOURCE column: the owning plugin's name,
+ * the raw key when it does not parse, blank for imperative schedules. Parses
+ * the wire value locally; the key format is defined by
+ * `pluginScheduleSourceKey` in schedule/plugin-schedule-declarations.ts.
+ */
+function describeSource(sourceKey: string | null | undefined): string {
+  if (!sourceKey) {
+    return "";
+  }
+  return /^plugin:([^/]+)\//.exec(sourceKey)?.[1] ?? sourceKey;
 }
 
 function describeSchedule(schedule: ScheduleRecord): string {

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -39,6 +39,7 @@ import {
   listSchedules,
   resolveScheduleConversationGroupId,
   type ScheduleJob,
+  setUserEnabled,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
@@ -135,6 +136,18 @@ const scheduleSchema = z.object({
   reuseConversation: z.boolean(),
   wakeConversationId: z.string().nullable(),
   workflowName: z.string().nullable(),
+  sourceKey: z
+    .string()
+    .nullable()
+    .describe(
+      "Plugin declaration this schedule mirrors (plugin:<pluginName>/<scheduleName>); null for user-created schedules",
+    ),
+  userEnabled: z
+    .boolean()
+    .nullable()
+    .describe(
+      "User enable/disable override on a plugin-sourced schedule; null when the declaration's own enabled value applies. Always null for user-created schedules.",
+    ),
   isOneShot: z.boolean(),
 });
 
@@ -271,6 +284,8 @@ function serializeSchedule(
     reuseConversation: j.reuseConversation,
     wakeConversationId: j.wakeConversationId,
     workflowName: j.workflowName,
+    sourceKey: j.sourceKey,
+    userEnabled: j.userEnabled,
     isOneShot: isOneShotForDisplay(j),
   };
 }
@@ -468,7 +483,9 @@ async function handleToggleSchedule(
   // enabled, with no further caller involvement.
   await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
 
-  const updated = await updateSchedule(id, { enabled });
+  // One endpoint serves both kinds of row: imperative schedules take the
+  // plain enabled write, plugin-sourced ones record the user_enabled override.
+  const updated = await setUserEnabled(id, enabled);
   if (!updated) {
     throw new NotFoundError("Schedule not found");
   }
@@ -481,7 +498,18 @@ async function handleDeleteSchedule(
   headers?: Record<string, string>,
 ) {
   await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
-  const removed = await deleteSchedule(id);
+  let removed: boolean;
+  try {
+    removed = await deleteSchedule(id);
+  } catch (err) {
+    // Store-layer refusals (e.g. plugin-sourced rows, which only the plugin's
+    // schedule file can remove) are caller mistakes with an actionable
+    // message, not daemon faults.
+    if (err instanceof UserError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
   if (!removed) {
     throw new NotFoundError("Schedule not found");
   }
@@ -919,7 +947,8 @@ export const ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Toggle schedule",
-    description: "Enable or disable a schedule.",
+    description:
+      "Enable or disable a schedule. On a plugin-managed schedule this records the user's override (userEnabled).",
     tags: ["schedules"],
     requestBody: z.object({
       enabled: z.boolean().describe("New enabled state"),

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for ScheduleDetailPanel's plugin-sourced treatment: sourced schedules
+ * hide the Delete affordance and show plugin attribution in its place;
+ * user-created schedules keep the Delete button.
+ *
+ * The generated daemon SDK is mocked so the runs query resolves without a
+ * daemon.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+
+import { makeSchedule } from "./schedule-test-fixtures";
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  schedulesByIdRunsGet: async () => ({
+    data: { runs: [], nextCursor: null },
+    error: undefined,
+    response: { ok: true, status: 200 },
+  }),
+}));
+
+const { ScheduleDetailPanel } = await import("./schedule-detail-panel");
+
+afterEach(cleanup);
+
+function renderPanel(schedule: ReturnType<typeof makeSchedule>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ScheduleDetailPanel
+          schedule={schedule}
+          assistantId="assistant-1"
+          usage={{ status: "error" }}
+          onClose={() => {}}
+          onDeleted={() => {}}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ScheduleDetailPanel plugin-sourced treatment", () => {
+  test("user-created schedules keep the Delete button", async () => {
+    const { getByText, queryByText } = renderPanel(makeSchedule());
+
+    await waitFor(() => {
+      expect(getByText("Delete")).toBeTruthy();
+    });
+    expect(queryByText(/Managed by plugin/)).toBeNull();
+  });
+
+  test("plugin-sourced schedules hide Delete and show plugin attribution", async () => {
+    const { getByText, queryByText } = renderPanel(
+      makeSchedule({ sourceKey: "plugin:gmail/poll-inbox" }),
+    );
+
+    await waitFor(() => {
+      expect(getByText("Managed by plugin gmail")).toBeTruthy();
+    });
+    expect(queryByText("Delete")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -13,6 +13,7 @@ import {
 import { useState } from "react";
 import { useNavigate } from "react-router";
 
+import { pluginNameFromSourceKey } from "@/domains/schedules/plugin-source";
 import {
   deleteSchedule,
   fetchScheduleRuns,
@@ -370,6 +371,7 @@ export function ScheduleDetailPanel({
   const [isRunning, setIsRunning] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const pluginName = pluginNameFromSourceKey(schedule.sourceKey);
 
   const handleRunNow = async () => {
     setIsRunning(true);
@@ -478,7 +480,13 @@ export function ScheduleDetailPanel({
 
       {/* Footer actions */}
       <div className="flex shrink-0 items-center justify-between gap-2 border-t border-[var(--border-base)] p-[var(--app-spacing-lg)]">
-        {!confirmingDelete ? (
+        {pluginName ? (
+          // Plugin-sourced schedules cannot be deleted here; the plugin's
+          // schedule file is the source of truth, so only attribution shows.
+          <span className="text-body-small-default text-[var(--content-tertiary)]">
+            Managed by plugin {pluginName}
+          </span>
+        ) : !confirmingDelete ? (
           <Button
             variant="dangerOutline"
             leftIcon={<Trash2 className="h-3.5 w-3.5" />}

--- a/clients/web/src/domains/schedules/components/schedule-row.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for ScheduleRow's plugin-sourced treatment: rows whose schedule
+ * carries a `sourceKey` render a plugin-name badge while keeping the enabled
+ * toggle; user-created rows render no badge.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ScheduleRow } from "./schedule-row";
+import { makeSchedule } from "./schedule-test-fixtures";
+
+afterEach(cleanup);
+
+describe("ScheduleRow plugin attribution", () => {
+  test("renders a plugin-name badge when the schedule is plugin-sourced", () => {
+    const { getByText } = render(
+      <ScheduleRow
+        schedule={makeSchedule({ sourceKey: "plugin:gmail/poll-inbox" })}
+        usage={{ status: "error" }}
+        onClick={() => {}}
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(getByText("gmail")).toBeTruthy();
+  });
+
+  test("renders no badge for a user-created schedule", () => {
+    const { queryByText } = render(
+      <ScheduleRow
+        schedule={makeSchedule()}
+        usage={{ status: "error" }}
+        onClick={() => {}}
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(queryByText("gmail")).toBeNull();
+  });
+
+  test("keeps the enabled toggle on a plugin-sourced row", () => {
+    const onToggle = mock(() => {});
+    const { getByLabelText } = render(
+      <ScheduleRow
+        schedule={makeSchedule({
+          sourceKey: "plugin:gmail/poll-inbox",
+          enabled: true,
+        })}
+        usage={{ status: "error" }}
+        onClick={() => {}}
+        onToggle={onToggle}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("Toggle Daily digest"));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+});

--- a/clients/web/src/domains/schedules/components/schedule-row.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.tsx
@@ -1,13 +1,15 @@
-import { Fragment } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import { ChevronRight } from "lucide-react";
 
+import { pluginNameFromSourceKey } from "@/domains/schedules/plugin-source";
 import {
   formatScheduleCost,
   formatScheduleRunCount,
   formatTimestamp,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
+import { Tag } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
@@ -48,6 +50,7 @@ function inlineUsage(usage: ScheduleRowUsage) {
  */
 export function ScheduleRowShell({
   name,
+  badge,
   metaParts,
   usage,
   enabled,
@@ -57,6 +60,8 @@ export function ScheduleRowShell({
   toggleAriaLabel,
 }: {
   name: string;
+  /** Optional chip rendered after the name (e.g. plugin attribution). */
+  badge?: ReactNode;
   metaParts: string[];
   usage: ScheduleRowUsage;
   enabled: boolean;
@@ -87,8 +92,11 @@ export function ScheduleRowShell({
         className="flex min-w-0 flex-1 cursor-pointer items-center gap-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="truncate text-body-medium-default text-[var(--content-default)]">
-            {name}
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-body-medium-default text-[var(--content-default)]">
+              {name}
+            </span>
+            {badge}
           </span>
           {metaParts.length > 0 ? (
             <span className="flex min-w-0 items-center gap-2 text-label-small-default text-[var(--content-tertiary)]">
@@ -131,10 +139,12 @@ export function ScheduleRow({
   const metaParts = [cadence, runAt ? formatTimestamp(runAt) : ""].filter(
     Boolean,
   );
+  const pluginName = pluginNameFromSourceKey(schedule.sourceKey);
 
   return (
     <ScheduleRowShell
       name={schedule.name}
+      badge={pluginName ? <Tag tone="info">{pluginName}</Tag> : undefined}
       metaParts={metaParts}
       usage={usage}
       enabled={schedule.enabled}

--- a/clients/web/src/domains/schedules/components/schedule-test-fixtures.ts
+++ b/clients/web/src/domains/schedules/components/schedule-test-fixtures.ts
@@ -1,0 +1,46 @@
+import type { SchedulesGetResponse } from "@/generated/daemon/types.gen";
+
+/**
+ * The wire schedule shape; assignable to the settings domain's `Schedule`
+ * view-model, which the schedule components consume.
+ */
+type Schedule = SchedulesGetResponse["schedules"][number];
+
+/** Fully-populated recurring execute schedule for component tests. */
+export function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: "schedule-1",
+    name: "Daily digest",
+    enabled: true,
+    syntax: "cron",
+    expression: "0 9 * * *",
+    cronExpression: "0 9 * * *",
+    timezone: null,
+    message: "produce the digest",
+    script: null,
+    nextRunAt: 1_778_800_000_000,
+    lastRunAt: null,
+    lastStatus: null,
+    retryCount: 0,
+    maxRetries: 3,
+    retryBackoffMs: 60_000,
+    timeoutMs: null,
+    inferenceProfile: null,
+    groupId: null,
+    createdFromConversationId: null,
+    createdFromConversationExists: false,
+    createdFromConversationArchivedAt: null,
+    description: "Summarize the day",
+    cadenceDescription: "Every day at 9:00 AM",
+    mode: "execute",
+    status: "active",
+    routingIntent: "all_channels",
+    reuseConversation: false,
+    wakeConversationId: null,
+    workflowName: null,
+    sourceKey: null,
+    userEnabled: null,
+    isOneShot: false,
+    ...overrides,
+  };
+}

--- a/clients/web/src/domains/schedules/plugin-source.ts
+++ b/clients/web/src/domains/schedules/plugin-source.ts
@@ -1,0 +1,17 @@
+/**
+ * Plugin-sourced schedules carry a `sourceKey` of the form
+ * `plugin:<pluginName>/<scheduleName>`. Their definition is edited via the
+ * plugin's schedule files; the only user mutation the UI offers is the
+ * enabled toggle (persisted server-side as `userEnabled`).
+ */
+
+/**
+ * Plugin name embedded in a schedule's source key; null for user-created
+ * schedules, unrecognized keys, and daemons that predate the field.
+ */
+export function pluginNameFromSourceKey(
+  sourceKey: string | null | undefined,
+): string | null {
+  const match = /^plugin:([^/]+)\//.exec(sourceKey ?? "");
+  return match?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary
- Routes expose sourceKey/userEnabled; enabled toggle writes user_enabled for sourced rows; PATCH/DELETE refusals surface as 4xx
- CLI schedules list gains a SOURCE column
- Web: plugin badge, toggle kept, delete hidden for plugin-managed schedules

Part of plan: plugin-schedules-v1.md (PR 5 of 5)