### PR TITLE
feat(cli): list declared schedules at plugin install and in plugins inspect

### DIFF
--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Tests for the `assistant plugins` CLI command's declared-schedules consent
+ * and surfacing.
+ *
+ * Validates:
+ *   - install lists a staged plugin's declared schedules (name, cadence, mode)
+ *     and prompts for consent before the install finalizes
+ *   - declining cancels the install cleanly (exit 0, nothing installed)
+ *   - a non-interactive refusal exits 1
+ *   - --force skips the prompt but still lists the schedules
+ *   - a plugin without schedules installs with zero consent UX
+ *   - the direct-GitHub and bundled-catalog install branches are gated too,
+ *     with the untrusted warning printed before the schedule listing
+ *   - inspect renders the schedules surface block
+ *
+ * The installers are replaced by fakes that stage a fixture tree and run the
+ * real `confirmStagedOrAbort` gate, so the command's consent callback is
+ * exercised against a real on-disk staged tree via the real
+ * `detectPluginSurfaces` walk.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import type { ConfirmPromptOptions } from "../../lib/confirm-prompt.js";
+import type { PluginInspection } from "../../lib/inspect-plugin.js";
+import type {
+  InstallPluginDeps,
+  InstallPluginOptions,
+  InstallPluginResult,
+} from "../../lib/install-from-github.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let confirmCalls: Array<{
+  question: string;
+  refuseNonInteractiveMessage: string;
+}> = [];
+let confirmResults: Array<"confirmed" | "denied" | "non-interactive"> = [];
+
+/** Written into each fake install's staging dir before the consent gate runs. */
+let stageFixture: ((stagingDir: string) => void) | null = null;
+
+let installPluginCalls: InstallPluginOptions[] = [];
+let platformInstallCalls: Array<{ name: string; force?: boolean }> = [];
+
+let inspectResult: PluginInspection | null = null;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../lib/confirm-prompt.js", () => ({
+  confirmPrompt: async (opts: ConfirmPromptOptions) => {
+    confirmCalls.push({
+      question: opts.question,
+      refuseNonInteractiveMessage: opts.refuseNonInteractiveMessage,
+    });
+    return confirmResults.shift() ?? "confirmed";
+  },
+}));
+
+const realGithub = await import("../../lib/install-from-github.js");
+const realPlatform = await import("../../lib/install-from-platform.js");
+const realInspect = await import("../../lib/inspect-plugin.js");
+
+/**
+ * Fake install: stage the fixture tree, run the real staged-install consent
+ * gate (so a decline aborts exactly like production), and return a canned
+ * success result.
+ */
+async function runFakeInstall(
+  name: string,
+  deps: Pick<InstallPluginDeps, "confirmStaged"> | undefined,
+): Promise<InstallPluginResult> {
+  const stagingDir = mkdtempSync(join(tmpdir(), "plugins-cmd-staging-"));
+  try {
+    stageFixture?.(stagingDir);
+    await realGithub.confirmStagedOrAbort(
+      name,
+      stagingDir,
+      deps?.confirmStaged,
+    );
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+  return {
+    name,
+    target: `/plugins/${name}`,
+    fileCount: 3,
+    ref: "main",
+    commit: "a".repeat(40),
+    committedAt: null,
+  };
+}
+
+mock.module("../../lib/install-from-github.js", () => ({
+  ...realGithub,
+  installPlugin: async (
+    opts: InstallPluginOptions,
+    deps: InstallPluginDeps,
+  ) => {
+    installPluginCalls.push(opts);
+    return runFakeInstall(opts.name, deps);
+  },
+}));
+
+mock.module("../../lib/install-from-platform.js", () => ({
+  ...realPlatform,
+  installPluginViaPlatform: async (
+    opts: { name: string; force?: boolean },
+    deps: Pick<InstallPluginDeps, "confirmStaged">,
+  ) => {
+    platformInstallCalls.push(opts);
+    return runFakeInstall(opts.name, deps);
+  },
+}));
+
+mock.module("../../lib/inspect-plugin.js", () => ({
+  ...realInspect,
+  inspectPlugin: async () => {
+    if (!inspectResult) {
+      throw new Error("inspectResult fixture not set");
+    }
+    return inspectResult;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerPluginsCommand } = await import("../plugins.js");
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Write a two-schedule fixture (one flat execute, one directory script). */
+function writeScheduleFixture(dir: string): void {
+  mkdirSync(join(dir, "schedules", "cleanup"), { recursive: true });
+  writeFileSync(
+    join(dir, "schedules", "daily-report.md"),
+    '---\nexpression: "0 9 * * *"\n---\nSend the daily report.\n',
+  );
+  writeFileSync(
+    join(dir, "schedules", "cleanup", "config.json"),
+    '{"expression": "0 0 * * 0"}',
+  );
+  writeFileSync(join(dir, "schedules", "cleanup", "index.sh"), "#!/bin/sh\n");
+}
+
+async function runCommand(args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+  /** stdout + stderr lines in emission order, for cross-stream ordering. */
+  events: string[];
+  exitCode: number;
+}> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const events: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    const text = typeof chunk === "string" ? chunk : String(chunk);
+    stdoutChunks.push(text);
+    events.push(text);
+    return true;
+  }) as typeof process.stdout.write;
+  console.log = (...logArgs: unknown[]) => {
+    const text = logArgs.map(String).join(" ") + "\n";
+    stdoutChunks.push(text);
+    events.push(text);
+  };
+  console.error = (...logArgs: unknown[]) => {
+    const text = logArgs.map(String).join(" ") + "\n";
+    stderrChunks.push(text);
+    events.push(text);
+  };
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerPluginsCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+    events,
+    exitCode,
+  };
+}
+
+const savedDisablePlatform = process.env.VELLUM_DISABLE_PLATFORM;
+const savedIsPlatform = process.env.IS_PLATFORM;
+
+beforeEach(() => {
+  confirmCalls = [];
+  confirmResults = [];
+  stageFixture = null;
+  installPluginCalls = [];
+  platformInstallCalls = [];
+  inspectResult = null;
+  // Platform features on by default, so a plain name install takes the
+  // platform-tarball branch.
+  delete process.env.VELLUM_DISABLE_PLATFORM;
+  delete process.env.IS_PLATFORM;
+});
+
+afterEach(() => {
+  if (savedDisablePlatform === undefined) {
+    delete process.env.VELLUM_DISABLE_PLATFORM;
+  } else {
+    process.env.VELLUM_DISABLE_PLATFORM = savedDisablePlatform;
+  }
+  if (savedIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = savedIsPlatform;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("plugins install - declared-schedules consent", () => {
+  test("lists declared schedules and prompts before finalizing", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stdout).toContain("daily-report");
+    expect(r.stdout).toContain("0 9 * * *");
+    expect(r.stdout).toContain("(execute)");
+    expect(r.stdout).toContain("cleanup");
+    expect(r.stdout).toContain("0 0 * * 0");
+    expect(r.stdout).toContain("(script)");
+
+    expect(confirmCalls.length).toBe(1);
+    expect(confirmCalls[0]!.question).toContain(
+      'Install "example" and allow these schedules?',
+    );
+
+    // The listing precedes the install result, since consent gates finalize.
+    expect(r.stdout.indexOf("declares 2 schedules")).toBeLessThan(
+      r.stdout.indexOf('Installed plugin "example"'),
+    );
+    expect(r.exitCode).toBe(0);
+    expect(platformInstallCalls.length).toBe(1);
+  });
+
+  test("declining cancels the install cleanly", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["denied"];
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).toContain("Install cancelled.");
+    expect(r.stdout).not.toContain("Installed plugin");
+    expect(r.stderr).not.toContain("Plugin install failed");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a non-interactive refusal exits 1", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["non-interactive"];
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).not.toContain("Installed plugin");
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("--force skips the prompt but still lists the schedules", async () => {
+    stageFixture = writeScheduleFixture;
+
+    const r = await runCommand(["plugins", "install", "example", "--force"]);
+
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stdout).toContain('Installed plugin "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a plugin without schedules installs with zero consent UX", async () => {
+    stageFixture = null;
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stdout).not.toContain("declares");
+    expect(r.stdout).not.toContain("schedule");
+    expect(r.stdout).toContain('Installed plugin "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a direct GitHub install is gated too, after the untrusted warning", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand([
+      "plugins",
+      "install",
+      "https://github.com/example-owner/example-repo",
+    ]);
+
+    expect(installPluginCalls.length).toBe(1);
+    expect(installPluginCalls[0]!.directSource).toBeDefined();
+    expect(confirmCalls.length).toBe(1);
+    expect(r.stderr).toContain("unreviewed GitHub source");
+
+    // The untrusted warning prints before the schedule listing.
+    const warningIdx = r.events.findIndex((e) =>
+      e.includes("unreviewed GitHub source"),
+    );
+    const listingIdx = r.events.findIndex((e) => e.includes("declares"));
+    expect(warningIdx).toBeGreaterThanOrEqual(0);
+    expect(listingIdx).toBeGreaterThan(warningIdx);
+
+    expect(r.stdout).toContain('Installed untrusted plugin "example-repo"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a bundled-catalog install (platform disabled) is gated too", async () => {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand(["plugins", "install", "caveman"]);
+
+    expect(platformInstallCalls.length).toBe(0);
+    expect(installPluginCalls.length).toBe(1);
+    expect(installPluginCalls[0]!.trustedSource).toBeDefined();
+    expect(confirmCalls.length).toBe(1);
+    expect(r.stdout).toContain('Plugin "caveman" declares 2 schedules:');
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe("plugins inspect - schedules surface", () => {
+  test("renders declared schedules with cadence and mode", async () => {
+    inspectResult = {
+      name: "example",
+      installed: true,
+      status: "not-in-marketplace",
+      local: {
+        target: "/plugins/example",
+        commit: null,
+        committedAt: null,
+        version: null,
+        description: null,
+        installedAt: null,
+        source: null,
+        localChanges: null,
+        issues: [],
+      },
+      remote: null,
+      remoteError: null,
+      surfaces: {
+        skills: [],
+        hooks: [],
+        tools: ["do_thing"],
+        schedules: [
+          { name: "daily-report", cadence: "0 9 * * *", mode: "execute" },
+          { name: "cleanup", cadence: "0 0 * * 0", mode: "script" },
+        ],
+      },
+    };
+
+    const r = await runCommand(["plugins", "inspect", "example"]);
+
+    expect(r.stdout).toContain("schedules");
+    expect(r.stdout).toContain("daily-report  0 9 * * *  (execute)");
+    expect(r.stdout).toContain("cleanup       0 0 * * 0  (script)");
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -48,7 +48,11 @@ Examples:
       description:
         "Install a plugin by name from the Vellum platform (content is served as a verified tarball from the plugin's pinned commit), or directly from a GitHub URL (untrusted)",
       options: [
-        { flags: "--force", description: "Overwrite an existing install" },
+        {
+          flags: "--force",
+          description:
+            "Overwrite an existing install and skip the declared-schedules confirmation prompt",
+        },
         {
           flags: "--ref <ref>",
           description: `For a marketplace install, the manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). For a GitHub URL, the git ref (branch/tag/SHA) to clone — states a slash-containing branch (e.g. feature/x) explicitly and skips the remote ref lookup a bare /tree/ URL otherwise does`,
@@ -70,6 +74,11 @@ Examples:
         },
       ],
       helpText: `
+A plugin that declares schedules (a schedules/ directory) has them listed
+during the install, and the install asks for confirmation before finalizing:
+schedules run automatically in the background once the plugin is installed.
+Pass --force to skip the prompt (required for non-interactive installs).
+
 A GitHub URL (anything containing a slash) installs directly from that repo,
 bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
 been reviewed and its hooks/tools run with full assistant access — so the
@@ -121,7 +130,7 @@ Examples:
       name: "inspect",
       args: "<name>",
       description:
-        "Show a plugin's local install metadata, the marketplace pin, whether an update is available, and the surfaces (skills, hooks, tools) it contributes",
+        "Show a plugin's local install metadata, the marketplace pin, whether an update is available, and the surfaces (skills, hooks, tools, schedules) it contributes",
       options: [
         {
           flags: "--json",

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -20,6 +20,7 @@ import type {
   PluginRemoteInfo,
 } from "../lib/inspect-plugin.js";
 import type {
+  ConfirmStagedInstall,
   InstallPluginOptions,
   PluginFetchSource,
 } from "../lib/install-from-github.js";
@@ -37,6 +38,7 @@ import {
 } from "../lib/plugin-constants.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
 import type { PluginPinHistoryEntry } from "../lib/plugin-pin-history.js";
+import type { PluginScheduleSurface } from "../lib/plugin-surfaces.js";
 import { runPublish } from "../lib/publish-plugin.js";
 import { registerCommand } from "../lib/register-command.js";
 import {
@@ -99,6 +101,11 @@ const libs = {
       "../lib/search-plugins.js",
     ) as typeof import("../lib/search-plugins.js");
   },
+  get surfaces() {
+    return loadModule(
+      "../lib/plugin-surfaces.js",
+    ) as typeof import("../lib/plugin-surfaces.js");
+  },
   get uninstall() {
     return loadModule(
       "../lib/uninstall-plugin.js",
@@ -157,6 +164,13 @@ export function registerPluginsCommand(program: Command): void {
             const usesMarketplaceGit =
               !direct && Boolean(opts.pin || opts.ref || opts.allowUnreviewed);
 
+            // Consent gate the installers run between staging and finalize:
+            // a plugin that declares schedules gets them listed and, unless
+            // --force, must be confirmed before anything lands on disk that
+            // the daemon's schedule reconciler could arm.
+            const confirmStaged: ConfirmStagedInstall = (staged) =>
+              confirmDeclaredSchedules(staged, Boolean(opts.force));
+
             let result;
             let untrusted = false;
             if (!direct && !usesMarketplaceGit) {
@@ -167,7 +181,7 @@ export function registerPluginsCommand(program: Command): void {
               if (libs.catalogLocal.arePlatformFeaturesEnabled()) {
                 result = await libs.installPlatform.installPluginViaPlatform(
                   { name: nameOrUrl, force: opts.force },
-                  { fetch: globalThis.fetch.bind(globalThis) },
+                  { fetch: globalThis.fetch.bind(globalThis), confirmStaged },
                 );
               } else {
                 const source =
@@ -190,7 +204,7 @@ export function registerPluginsCommand(program: Command): void {
                       ref: source.ref,
                     },
                   },
-                  { fetch: globalThis.fetch.bind(globalThis) },
+                  { fetch: globalThis.fetch.bind(globalThis), confirmStaged },
                 );
               }
             } else {
@@ -210,6 +224,7 @@ export function registerPluginsCommand(program: Command): void {
               }
               result = await libs.installGitHub.installPlugin(installOpts, {
                 fetch: globalThis.fetch.bind(globalThis),
+                confirmStaged,
               });
             }
             log.info(
@@ -231,6 +246,11 @@ export function registerPluginsCommand(program: Command): void {
               `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
             );
           } catch (err) {
+            if (err instanceof libs.installGitHub.PluginInstallDeclinedError) {
+              // The consent gate already printed the outcome and set the exit
+              // code; the install was aborted with nothing left on disk.
+              return;
+            }
             if (err instanceof libs.installGitHub.PluginAlreadyInstalledError) {
               console.error(`${err.message}\nPass --force to overwrite.`);
               process.exitCode = 1;
@@ -936,6 +956,64 @@ function printUntrustedPluginWarning(
 }
 
 /**
+ * List a staged plugin's declared schedules and ask for consent. Schedules run
+ * automatically once armed, so an install may not add any silently: the user
+ * either confirms the listing or passes --force. Returns whether the install
+ * may proceed; a refusal's user-facing outcome (message + exit code) is fully
+ * handled here, so the caller aborts without further output.
+ */
+async function confirmDeclaredSchedules(
+  staged: { name: string; stagingDir: string },
+  force: boolean,
+): Promise<boolean> {
+  const { schedules } = libs.surfaces.detectPluginSurfaces(staged.stagingDir);
+  if (schedules.length === 0) {
+    return true;
+  }
+  console.log(
+    `Plugin "${staged.name}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
+  );
+  for (const row of formatScheduleRows(schedules)) {
+    console.log(`  ${row}`);
+  }
+  console.log(
+    "Schedules run automatically in the background once the plugin is installed.",
+  );
+  if (force) {
+    return true;
+  }
+  const result = await confirmPrompt({
+    question: `Install "${staged.name}" and allow these schedules? [y/N] `,
+    isTTY: Boolean(process.stdin.isTTY),
+    refuseNonInteractiveMessage: `Refusing to install "${staged.name}" non-interactively: it declares schedules. Pass --force to confirm.`,
+  });
+  if (result === "non-interactive") {
+    process.exitCode = 1;
+    return false;
+  }
+  if (result === "denied") {
+    console.log("Install cancelled.");
+    return false;
+  }
+  return true;
+}
+
+/** Aligned `name  cadence  (mode)` rows for a declared-schedules listing. */
+function formatScheduleRows(
+  schedules: readonly PluginScheduleSurface[],
+): string[] {
+  if (schedules.length === 0) {
+    return [];
+  }
+  const nameW = Math.max(...schedules.map((s) => s.name.length));
+  const cadenceW = Math.max(...schedules.map((s) => s.cadence.length));
+  const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
+  return schedules.map(
+    (s) => `${pad(s.name, nameW)}  ${pad(s.cadence, cadenceW)}  (${s.mode})`,
+  );
+}
+
+/**
  * Render a plugin's marketplace-pin history as a table: the pinned commit (short
  * SHA), when it was promoted, and a marker for the pin currently active. An
  * empty history reports that none was found.
@@ -1124,6 +1202,7 @@ function formatInspection(inspection: PluginInspection): string[] {
     surfaceBlock("skills", surfaces.skills);
     surfaceBlock("hooks", surfaces.hooks);
     surfaceBlock("tools", surfaces.tools);
+    surfaceBlock("schedules", formatScheduleRows(surfaces.schedules));
   }
 
   for (const issue of local?.issues ?? []) {

--- a/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
@@ -405,6 +405,7 @@ describe("inspectPlugin", () => {
       skills: ["first-skill", "second-skill"],
       hooks: ["init", "post-model-call"],
       tools: [],
+      schedules: [],
     });
   });
 

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -28,6 +28,7 @@ import {
   installPlugin,
   InvalidPluginNameError,
   PluginAlreadyInstalledError,
+  PluginInstallDeclinedError,
   PluginNotFoundError,
   PluginPostinstallError,
   PluginSourceUnavailableError,
@@ -359,6 +360,81 @@ describe("installPlugin — install lifecycle", () => {
     expect(readFileSync(join(target, "package.json"), "utf-8")).toBe(
       '{"name":"caveman-existing"}',
     );
+  });
+});
+
+describe("installPlugin - staged-install consent", () => {
+  let ws: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "vellum-plugins-consent-"));
+    pluginsDir = join(ws, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const CLONE_TREE = {
+    "package.json": '{"name":"caveman"}',
+    "schedules/daily.md": "---\nexpression: 0 9 * * *\n---\nDo it.\n",
+  };
+
+  test("confirmStaged sees the staged tree before anything is finalized", async () => {
+    const fetch = makeContentsFetch({ tree: {}, manifest: CAVEMAN_MANIFEST });
+    const runGit = fakeGitRunner({ tree: CLONE_TREE, commit: CAVEMAN_SHA });
+    const observed: Array<{ name: string; stagingDir: string }> = [];
+
+    const result = await installPlugin(
+      { name: "caveman", ref: "main" },
+      {
+        fetch,
+        runGit,
+        workspacePluginsDir: pluginsDir,
+        confirmStaged: async (staged) => {
+          observed.push(staged);
+          // The staged tree is fully materialized, but nothing has been
+          // swapped into the served plugins dir yet.
+          expect(
+            existsSync(join(staged.stagingDir, "schedules/daily.md")),
+          ).toBe(true);
+          expect(existsSync(join(pluginsDir, "caveman"))).toBe(false);
+          return true;
+        },
+      },
+    );
+
+    expect(observed.length).toBe(1);
+    expect(observed[0]!.name).toBe("caveman");
+    expect(result.target).toBe(join(pluginsDir, "caveman"));
+    expect(existsSync(join(result.target, "schedules/daily.md"))).toBe(true);
+  });
+
+  test("declining aborts cleanly: no target, staging removed", async () => {
+    const fetch = makeContentsFetch({ tree: {}, manifest: CAVEMAN_MANIFEST });
+    const runGit = fakeGitRunner({ tree: CLONE_TREE, commit: CAVEMAN_SHA });
+    const stagingDirs: string[] = [];
+
+    await expect(
+      installPlugin(
+        { name: "caveman", ref: "main" },
+        {
+          fetch,
+          runGit,
+          workspacePluginsDir: pluginsDir,
+          confirmStaged: async (staged) => {
+            stagingDirs.push(staged.stagingDir);
+            return false;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginInstallDeclinedError);
+
+    expect(existsSync(join(pluginsDir, "caveman"))).toBe(false);
+    expect(stagingDirs.length).toBe(1);
+    expect(existsSync(stagingDirs[0]!)).toBe(false);
   });
 });
 

--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -15,7 +15,10 @@ import { gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { FetchLike } from "../fetch-like.js";
-import { readInstallMeta } from "../install-from-github.js";
+import {
+  PluginInstallDeclinedError,
+  readInstallMeta,
+} from "../install-from-github.js";
 import {
   extractPluginTarball,
   installPluginFromPlatform,
@@ -303,6 +306,46 @@ describe("installPluginFromPlatform — integrity", () => {
     ).rejects.toBeInstanceOf(PluginIntegrityError);
 
     expect(existsSync(join(pluginsDir, "reading-pal"))).toBe(false);
+  });
+});
+
+// ─── Staged-install consent ──────────────────────────────────────────────────
+
+describe("installPluginFromPlatform - staged-install consent", () => {
+  test("confirmStaged runs over the staged tree; declining leaves nothing behind", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [
+        { name: "plugin.json", content: '{"name":"reading-pal"}' },
+        {
+          name: "schedules/daily.md",
+          content: "---\nexpression: 0 9 * * *\n---\nDo it.\n",
+        },
+      ],
+    });
+    const stagingDirs: string[] = [];
+
+    await expect(
+      installPluginFromPlatform(
+        { name: "reading-pal" },
+        {
+          fetch: fetchFn,
+          platformBaseUrl: PLATFORM,
+          workspacePluginsDir: pluginsDir,
+          confirmStaged: async (staged) => {
+            stagingDirs.push(staged.stagingDir);
+            expect(
+              existsSync(join(staged.stagingDir, "schedules", "daily.md")),
+            ).toBe(true);
+            expect(existsSync(join(pluginsDir, "reading-pal"))).toBe(false);
+            return false;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginInstallDeclinedError);
+
+    expect(existsSync(join(pluginsDir, "reading-pal"))).toBe(false);
+    expect(stagingDirs.length).toBe(1);
+    expect(existsSync(stagingDirs[0]!)).toBe(false);
   });
 });
 

--- a/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
@@ -24,11 +24,16 @@ afterEach(() => {
   rmSync(pluginDir, { recursive: true, force: true });
 });
 
-/** Create `<pluginDir>/<rel>` with empty contents, making parents as needed. */
-function touch(rel: string): void {
+/** Create `<pluginDir>/<rel>` with the given contents, making parents as needed. */
+function touch(rel: string, content = ""): void {
   const path = join(pluginDir, rel);
   mkdirSync(join(path, ".."), { recursive: true });
-  writeFileSync(path, "");
+  writeFileSync(path, content);
+}
+
+/** A flat schedule declaration body with frontmatter carrying `expression`. */
+function flatSchedule(expression: string): string {
+  return `---\nexpression: "${expression}"\n---\nDo the thing.\n`;
 }
 
 describe("detectPluginSurfaces", () => {
@@ -106,6 +111,70 @@ describe("detectPluginSurfaces", () => {
     const surfaces = detectPluginSurfaces(pluginDir);
 
     // THEN every surface type is empty
-    expect(surfaces).toEqual({ skills: [], hooks: [], tools: [] });
+    expect(surfaces).toEqual({
+      skills: [],
+      hooks: [],
+      tools: [],
+      schedules: [],
+    });
+  });
+
+  test("lists declared schedules in both forms with cadence and mode", () => {
+    // GIVEN a flat markdown declaration and both directory-form entrypoints
+    touch("schedules/daily-report.md", flatSchedule("0 9 * * *"));
+    touch(
+      "schedules/cleanup/config.json",
+      '{"expression": "0 0 * * 0", "timezone": "UTC"}',
+    );
+    touch("schedules/cleanup/index.sh", "#!/bin/sh\necho hi\n");
+    touch("schedules/digest/config.json", '{"expression": "0 8 * * 1"}');
+    touch("schedules/digest/index.md", "Summarize the week.\n");
+
+    // WHEN its surfaces are detected
+    const surfaces = detectPluginSurfaces(pluginDir);
+
+    // THEN each declaration reports its raw expression and entrypoint mode
+    expect(surfaces.schedules).toEqual([
+      { name: "cleanup", cadence: "0 0 * * 0", mode: "script" },
+      { name: "daily-report", cadence: "0 9 * * *", mode: "execute" },
+      { name: "digest", cadence: "0 8 * * 1", mode: "execute" },
+    ]);
+  });
+
+  test("skips a schedule basename declared in both forms", () => {
+    // GIVEN the same basename as a flat file and a directory (ambiguous)
+    touch("schedules/dupe.md", flatSchedule("0 9 * * *"));
+    touch("schedules/dupe/config.json", '{"expression": "0 9 * * *"}');
+    touch("schedules/dupe/index.md", "body\n");
+    touch("schedules/keeper.md", flatSchedule("30 7 * * *"));
+
+    // WHEN its surfaces are detected
+    const surfaces = detectPluginSurfaces(pluginDir);
+
+    // THEN neither ambiguous form is listed, and the sibling still is
+    expect(surfaces.schedules).toEqual([
+      { name: "keeper", cadence: "30 7 * * *", mode: "execute" },
+    ]);
+  });
+
+  test("skips schedule declarations the loader would refuse", () => {
+    // GIVEN a flat file without frontmatter
+    touch("schedules/no-frontmatter.md", "just a body\n");
+    // AND a directory with both entrypoints
+    touch("schedules/two-entries/config.json", '{"expression": "0 9 * * *"}');
+    touch("schedules/two-entries/index.md", "body\n");
+    touch("schedules/two-entries/index.sh", "#!/bin/sh\n");
+    // AND a directory with an unsupported entrypoint
+    touch("schedules/bad-entry/config.json", '{"expression": "0 9 * * *"}');
+    touch("schedules/bad-entry/index.py", "print()\n");
+    // AND a directory missing its config.json
+    touch("schedules/no-config/index.md", "body\n");
+    // AND a directory whose config declares no expression
+    touch("schedules/no-expression/config.json", '{"timezone": "UTC"}');
+    touch("schedules/no-expression/index.md", "body\n");
+
+    // WHEN its surfaces are detected
+    // THEN none of them are listed
+    expect(detectPluginSurfaces(pluginDir).schedules).toEqual([]);
   });
 });

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -154,6 +154,20 @@ export interface InstallPluginOptions {
   readonly trustedSource?: PluginFetchSource;
 }
 
+/**
+ * Consent gate invoked after the plugin tree is fully staged and before it is
+ * finalized (dependencies installed, provenance recorded, swapped live). The
+ * caller inspects the staged tree to see what the plugin declares (e.g.
+ * schedules) and asks the user. Returning `false` aborts the install: the
+ * staging directory is removed, nothing is swapped, and
+ * {@link PluginInstallDeclinedError} is thrown.
+ */
+export type ConfirmStagedInstall = (staged: {
+  readonly name: string;
+  /** Absolute path of the fully materialized staging directory. */
+  readonly stagingDir: string;
+}) => Promise<boolean>;
+
 /** Dependencies injected by the caller. */
 export interface InstallPluginDeps {
   /** HTTP client. Production callers pass `globalThis.fetch.bind(globalThis)`. */
@@ -168,6 +182,8 @@ export interface InstallPluginDeps {
   readonly runInstallDeps?: DependencyInstaller;
   /** Forwarded to {@link finalizeStagedInstall}; see {@link FinalizeStagedInstallParams.beforeSwap}. */
   readonly beforeSwap?: () => Promise<void>;
+  /** Consent gate between staging and finalize; see {@link ConfirmStagedInstall}. */
+  readonly confirmStaged?: ConfirmStagedInstall;
 }
 
 /** Successful install result. */
@@ -211,6 +227,19 @@ export class PluginPostinstallError extends Error {
   ) {
     super(`Postinstall adapter for "${pluginName}" failed: ${detail}`);
     this.name = "PluginPostinstallError";
+  }
+}
+
+/**
+ * The caller's {@link ConfirmStagedInstall} gate declined the staged install.
+ * Nothing was installed and the staging directory was removed. The caller that
+ * supplied the gate owns the user-facing messaging, so this error signals the
+ * outcome rather than something to report as a failure.
+ */
+export class PluginInstallDeclinedError extends Error {
+  constructor(readonly pluginName: string) {
+    super(`Install of "${pluginName}" was declined.`);
+    this.name = "PluginInstallDeclinedError";
   }
 }
 
@@ -503,6 +532,8 @@ export async function installPlugin(
     throw new PluginNotFoundError(name, ref, sourceLabel(effectiveSource));
   }
 
+  await confirmStagedOrAbort(name, stagingDir, deps.confirmStaged);
+
   await finalizeStagedInstall(stagingDir, {
     name,
     source: effectiveSource,
@@ -515,6 +546,36 @@ export async function installPlugin(
   });
 
   return { name, target, fileCount, ref, commit, committedAt };
+}
+
+/**
+ * Run the caller's {@link ConfirmStagedInstall} gate over the staged tree. A
+ * decline (or a gate that throws) removes the staging directory so no partial
+ * install is left behind; a decline then surfaces as
+ * {@link PluginInstallDeclinedError}. A no-op when no gate was supplied.
+ *
+ * Shared by {@link installPlugin} and the platform-endpoint install so both
+ * abort a declined install the same way.
+ */
+export async function confirmStagedOrAbort(
+  name: string,
+  stagingDir: string,
+  confirmStaged: ConfirmStagedInstall | undefined,
+): Promise<void> {
+  if (!confirmStaged) {
+    return;
+  }
+  let confirmed = false;
+  try {
+    confirmed = await confirmStaged({ name, stagingDir });
+  } finally {
+    if (!confirmed) {
+      rmSync(stagingDir, { recursive: true, force: true });
+    }
+  }
+  if (!confirmed) {
+    throw new PluginInstallDeclinedError(name);
+  }
 }
 
 /** Inputs for {@link finalizeStagedInstall}. */

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -33,6 +33,8 @@ import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
 import type { FetchLike } from "./fetch-like.js";
 import {
+  type ConfirmStagedInstall,
+  confirmStagedOrAbort,
   finalizeStagedInstall,
   type InstallPluginResult,
   PluginAlreadyInstalledError,
@@ -123,6 +125,8 @@ export interface InstallFromPlatformDeps {
   readonly maxAttempts?: number;
   /** Sleep between retries. Injected so tests don't wait real time. */
   readonly sleep?: (ms: number) => Promise<void>;
+  /** Consent gate between staging and finalize; see {@link ConfirmStagedInstall}. */
+  readonly confirmStaged?: ConfirmStagedInstall;
 }
 
 /** Total attempts (initial + retries) for a transient upstream status. */
@@ -194,6 +198,8 @@ export async function installPluginFromPlatform(
     throw new PluginNotFoundError(name, meta.ref ?? "", meta.repo ?? name);
   }
 
+  await confirmStagedOrAbort(name, stagingDir, deps.confirmStaged);
+
   // Record provenance for future update/version UX. The endpoint re-roots the
   // tarball to the plugin root, so the recorded ref is the pinned commit and
   // the ETag documents exactly which bytes were verified.
@@ -223,7 +229,7 @@ export async function installPluginFromPlatform(
  */
 export async function installPluginViaPlatform(
   opts: { name: string; force?: boolean; conversationId?: string },
-  deps: { fetch: FetchLike },
+  deps: { fetch: FetchLike; confirmStaged?: ConfirmStagedInstall },
 ): Promise<InstallPluginResult> {
   const platformBaseUrl = getPlatformBaseUrl();
   const apiKey = await resolveAssistantApiKey();
@@ -237,7 +243,12 @@ export async function installPluginViaPlatform(
       ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
       assistantVersion: APP_VERSION,
     },
-    { fetch: deps.fetch, platformBaseUrl, ...(apiKey ? { apiKey } : {}) },
+    {
+      fetch: deps.fetch,
+      platformBaseUrl,
+      ...(apiKey ? { apiKey } : {}),
+      ...(deps.confirmStaged ? { confirmStaged: deps.confirmStaged } : {}),
+    },
   );
 }
 

--- a/assistant/src/cli/lib/plugin-surfaces.ts
+++ b/assistant/src/cli/lib/plugin-surfaces.ts
@@ -10,16 +10,31 @@
  *                                (see the external plugin loader's tool walk).
  * - `skills/<id>/SKILL.md`     → a skill owned by the plugin (see the skills
  *                                catalog's `discoverPluginResidentSkills`).
+ * - `schedules/<name>.md` or
+ *   `schedules/<name>/`        → a declared schedule (see the daemon's plugin
+ *                                schedule declaration parser).
  *
  * This module re-derives those same sets so `plugins inspect` can report exactly
  * what a plugin contributes. Detection is intentionally a self-contained walk of
- * the install tree — `cli/lib` does not reach into the daemon-internal loader or
- * skills catalog — but it mirrors their conventions so inspect agrees with what
- * the runtime actually loads.
+ * the install tree (`cli/lib` does not reach into the daemon-internal loader,
+ * skills catalog, or schedule parser), but it mirrors their conventions so
+ * inspect agrees with what the runtime actually loads.
  */
 
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+/** A schedule the plugin declares under `schedules/`. */
+export interface PluginScheduleSurface {
+  /** Schedule name: the flat file's basename or the declaration directory's name. */
+  readonly name: string;
+  /** Raw schedule `expression` string from the declaration's config. */
+  readonly cadence: string;
+  /** `execute` for a markdown prompt entrypoint, `script` for `index.sh`. */
+  readonly mode: "execute" | "script";
+}
 
 /** The surfaces an installed plugin contributes, each sorted and de-duplicated. */
 export interface PluginSurfaces {
@@ -36,6 +51,16 @@ export interface PluginSurfaces {
    * importing and executing untrusted plugin code, which inspection avoids.
    */
   readonly tools: readonly string[];
+  /**
+   * Schedules declared under `schedules/`, in either of the loader's two forms:
+   * a flat `<name>.md` with YAML frontmatter (mode `execute`), or a `<name>/`
+   * directory with a `config.json` plus exactly one `index.md` (`execute`) or
+   * `index.sh` (`script`) entrypoint. This is a display surface, not the arming
+   * path: ambiguous or unsupported declarations (a basename in both forms, a
+   * bad entrypoint set, an unreadable config, a missing `expression`) are
+   * skipped rather than reported as errors.
+   */
+  readonly schedules: readonly PluginScheduleSurface[];
 }
 
 /**
@@ -97,6 +122,134 @@ function listSkillIds(skillsDir: string): string[] {
   return ids.sort();
 }
 
+/** Matches a `---` delimited YAML frontmatter block at the start of a file. */
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+/** Read the raw `expression` string from a parsed schedule config, or `null`. */
+function readConfigExpression(config: unknown): string | null {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return null;
+  }
+  const expression = (config as Record<string, unknown>).expression;
+  return typeof expression === "string" && expression.trim() !== ""
+    ? expression
+    : null;
+}
+
+/**
+ * Read the cadence of a flat `<name>.md` declaration: the `expression` field of
+ * its YAML frontmatter. `null` when the file is unreadable, carries no
+ * frontmatter, or declares no expression.
+ */
+function readFlatScheduleCadence(filePath: string): string | null {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  const match = FRONTMATTER_REGEX.exec(content);
+  if (!match) {
+    return null;
+  }
+  let fields: unknown;
+  try {
+    fields = parseYaml(match[1]!);
+  } catch {
+    return null;
+  }
+  return readConfigExpression(fields);
+}
+
+/**
+ * Read a `<name>/` directory declaration: `config.json` supplies the cadence
+ * and the single `index.md`/`index.sh` entrypoint decides the mode. `null` for
+ * anything the loader would refuse (zero or multiple `index.*` entries, an
+ * unsupported entrypoint, an unreadable config, a missing expression).
+ */
+function readDirectorySchedule(
+  dirPath: string,
+): { cadence: string; mode: PluginScheduleSurface["mode"] } | null {
+  let children;
+  try {
+    children = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const entrypoints = children
+    .filter((c) => c.isFile() && c.name.startsWith("index."))
+    .map((c) => c.name);
+  if (entrypoints.length !== 1) {
+    return null;
+  }
+  const entrypoint = entrypoints[0]!;
+  if (entrypoint !== "index.md" && entrypoint !== "index.sh") {
+    return null;
+  }
+  let config: unknown;
+  try {
+    config = JSON.parse(readFileSync(join(dirPath, "config.json"), "utf8"));
+  } catch {
+    return null;
+  }
+  const cadence = readConfigExpression(config);
+  if (cadence === null) {
+    return null;
+  }
+  return { cadence, mode: entrypoint === "index.md" ? "execute" : "script" };
+}
+
+/**
+ * List the schedules a plugin declares under `schedules/`, mirroring the
+ * declaration parser's two forms. A basename declared in both forms is
+ * ambiguous (the loader refuses it), so neither form is listed. Returns
+ * schedules sorted by name; a missing directory yields `[]`.
+ */
+function listSchedules(schedulesDir: string): PluginScheduleSurface[] {
+  let entries;
+  try {
+    entries = readdirSync(schedulesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const flatNames = new Map<string, string>();
+  const dirNames = new Set<string>();
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      dirNames.add(entry.name);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      flatNames.set(entry.name.slice(0, -".md".length), entry.name);
+    }
+  }
+  for (const name of [...flatNames.keys()]) {
+    if (dirNames.has(name)) {
+      flatNames.delete(name);
+      dirNames.delete(name);
+    }
+  }
+
+  const schedules: PluginScheduleSurface[] = [];
+  for (const [name, fileName] of flatNames) {
+    const cadence = readFlatScheduleCadence(join(schedulesDir, fileName));
+    if (cadence !== null) {
+      schedules.push({ name, cadence, mode: "execute" });
+    }
+  }
+  for (const name of dirNames) {
+    const parsed = readDirectorySchedule(join(schedulesDir, name));
+    if (parsed) {
+      schedules.push({ name, ...parsed });
+    }
+  }
+  return schedules.sort((a, b) =>
+    a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  );
+}
+
 /**
  * Detect the {@link PluginSurfaces} an installed plugin contributes by walking
  * its install tree at `pluginDir`. Surface types with no contributions come
@@ -110,5 +263,6 @@ export function detectPluginSurfaces(pluginDir: string): PluginSurfaces {
     skills: listSkillIds(join(pluginDir, "skills")),
     hooks: listModuleBasenames(join(pluginDir, "hooks")),
     tools: [...new Set(toolNames)].sort(),
+    schedules: listSchedules(join(pluginDir, "schedules")),
   };
 }

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -1883,7 +1883,7 @@ function inspection(
     remoteError: overrides.remoteError ?? null,
     surfaces:
       overrides.surfaces === undefined
-        ? { skills: [], hooks: ["post-model-call"], tools: [] }
+        ? { skills: [], hooks: ["post-model-call"], tools: [], schedules: [] }
         : overrides.surfaces,
   };
 }


### PR DESCRIPTION
## Summary
- detectPluginSurfaces now walks schedules/ and reports name, cadence, mode
- plugin install lists declared schedules and requires confirmation before finalizing (--force bypasses); all three install branches covered
- plugins inspect shows declared schedules

Part of plan: plugin-schedules-v1.md (PR 4 of 5)