### PR TITLE
fix(schedule): harden declaration parsing and sourced-row store guards

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../heartbeat/heartbeat-service.js", () => ({
@@ -66,6 +68,7 @@ import {
   listSchedules,
   upsertDeclaredSchedule,
 } from "../schedule/schedule-store.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 
 await initializeDb();
 
@@ -1372,11 +1375,18 @@ describe("PATCH /schedules/:id — description", () => {
 // ── Plugin-sourced schedules ──────────────────────────────────────────────
 
 describe("plugin-sourced schedules over routes", () => {
+  const SOURCE_KEY = "plugin:example-plugin/daily-digest";
+
+  // The store's enable path probes the declaration's on-disk presence before
+  // re-arming, so the suite keeps a flat-file declaration in place.
   beforeEach(() => {
     clearTables();
+    const pluginDir = join(getWorkspacePluginsDir(), "example-plugin");
+    rmSync(pluginDir, { recursive: true, force: true });
+    const schedulesDir = join(pluginDir, "schedules");
+    mkdirSync(schedulesDir, { recursive: true });
+    writeFileSync(join(schedulesDir, "daily-digest.md"), "declaration");
   });
-
-  const SOURCE_KEY = "plugin:example-plugin/daily-digest";
 
   function seedSourcedSchedule(
     overrides: Partial<DeclaredScheduleDefinition> = {},
@@ -1492,6 +1502,17 @@ describe("plugin-sourced schedules over routes", () => {
     await expect(remove()).rejects.toThrow(BadRequestError);
     await expect(remove()).rejects.toThrow(
       "This schedule is managed by a plugin and cannot be deleted. Disable it instead, or remove the plugin's schedule file.",
+    );
+  });
+
+  test("cancel on a sourced row surfaces the store refusal as a 400", async () => {
+    const sourced = await seedSourcedSchedule();
+    const route = findRoute("schedules/:id/cancel", "POST");
+    const cancel = () => route.handler({ pathParams: { id: sourced.id } });
+
+    await expect(cancel()).rejects.toThrow(BadRequestError);
+    await expect(cancel()).rejects.toThrow(
+      "This schedule is managed by a plugin and cannot be cancelled. Disable it instead via the enabled toggle.",
     );
   });
 });

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { mock } from "bun:test";
 
@@ -43,6 +45,7 @@ import {
   upsertDeclaredSchedule,
 } from "../schedule/schedule-store.js";
 import { UserError } from "../util/errors.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 
 await initializeDb();
 
@@ -1515,12 +1518,20 @@ describe("owner-defer provenance", () => {
 // ── Plugin-declared schedules ───────────────────────────────────────
 
 describe("declared schedules", () => {
+  const SOURCE_KEY = "plugin:example/daily";
+  const examplePluginDir = () => join(getWorkspacePluginsDir(), "example");
+
+  // setUserEnabled's enable path probes the declaration's on-disk presence,
+  // so the suite keeps a flat-file declaration in place for SOURCE_KEY;
+  // ghost-row tests remove it.
   beforeEach(() => {
     getDb().run("DELETE FROM cron_runs");
     getDb().run("DELETE FROM cron_jobs");
+    rmSync(examplePluginDir(), { recursive: true, force: true });
+    const schedulesDir = join(examplePluginDir(), "schedules");
+    mkdirSync(schedulesDir, { recursive: true });
+    writeFileSync(join(schedulesDir, "daily.md"), "declaration");
   });
-
-  const SOURCE_KEY = "plugin:example/daily";
 
   function makeDefinition(
     overrides: Partial<DeclaredScheduleDefinition> = {},
@@ -1743,6 +1754,69 @@ describe("declared schedules", () => {
     await expect(setUserEnabled(imperative.id, null)).rejects.toThrow(
       UserError,
     );
+  });
+
+  test("upsert rewrites a moved script path without touching timing", async () => {
+    const created = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({
+        mode: "script",
+        message: "",
+        script: "sh '/workspace-a/plugins/example/schedules/daily/index.sh'",
+      }),
+    );
+
+    // Same definition hash: relocation moves the absolute entrypoint path
+    // while the schedules/-relative content is unchanged.
+    const updated = await upsertDeclaredSchedule(
+      SOURCE_KEY,
+      makeDefinition({
+        mode: "script",
+        message: "",
+        script: "sh '/workspace-b/plugins/example/schedules/daily/index.sh'",
+      }),
+    );
+
+    expect(updated.script).toBe(
+      "sh '/workspace-b/plugins/example/schedules/daily/index.sh'",
+    );
+    expect(updated.definitionHash).toBe("hash-1");
+    expect(updated.nextRunAt).toBe(created.nextRunAt);
+  });
+
+  test("cancelSchedule refuses sourced rows", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    const before = rawJob(created.id);
+
+    await expect(cancelSchedule(created.id)).rejects.toThrow(UserError);
+    await expect(cancelSchedule(created.id)).rejects.toThrow(
+      /managed by a plugin/,
+    );
+    expect(rawJob(created.id)).toEqual(before);
+  });
+
+  test("enabling a row whose declaration is gone records the override without re-arming", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    await setUserEnabled(created.id, false);
+    rmSync(examplePluginDir(), { recursive: true, force: true });
+
+    const result = await setUserEnabled(created.id, true);
+
+    expect(result!.userEnabled).toBe(true);
+    expect(result!.enabled).toBe(false);
+  });
+
+  test("a directory-form declaration also satisfies the enable probe", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    await setUserEnabled(created.id, false);
+    const schedulesDir = join(examplePluginDir(), "schedules");
+    rmSync(join(schedulesDir, "daily.md"));
+    mkdirSync(join(schedulesDir, "daily"), { recursive: true });
+
+    const result = await setUserEnabled(created.id, true);
+
+    expect(result!.enabled).toBe(true);
+    expect(result!.nextRunAt).toBeGreaterThan(Date.now());
   });
 
   test("updateSchedule refuses sourced rows", async () => {

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -522,7 +522,18 @@ async function handleCancelSchedule(
   headers?: Record<string, string>,
 ) {
   await assertWakeMutationAllowed(getSchedule(id), undefined, headers);
-  const cancelled = await cancelSchedule(id);
+  let cancelled: boolean;
+  try {
+    cancelled = await cancelSchedule(id);
+  } catch (err) {
+    // Store-layer refusals (plugin-sourced rows, for which cancellation is a
+    // permanent latch) are caller mistakes with an actionable message, not
+    // daemon faults.
+    if (err instanceof UserError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
   if (!cancelled) {
     throw new NotFoundError("Schedule not found or not cancellable");
   }

--- a/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
@@ -148,7 +148,7 @@ describe("parsePluginScheduleDeclarations", () => {
     expect(decl.scriptInvocation).toBeNull();
   });
 
-  test("parses a directory declaration with index.sh as a path invocation", () => {
+  test("parses a directory declaration with index.sh as an sh path invocation", () => {
     const pluginDir = makePlugin({
       "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
       "backup/index.sh": "#!/bin/sh\necho backup\n",
@@ -161,8 +161,10 @@ describe("parsePluginScheduleDeclarations", () => {
     const decl = declarations[0]!;
     expect(decl.mode).toBe("script");
     expect(decl.message).toBeNull();
+    // Explicit interpreter: platform installs do not restore exec bits, so a
+    // bare path invocation would fail with exit 126.
     expect(decl.scriptInvocation).toBe(
-      `'${join(pluginDir, "schedules", "backup", "index.sh")}'`,
+      `sh '${join(pluginDir, "schedules", "backup", "index.sh")}'`,
     );
     expect(decl.scriptInvocation).not.toContain("echo backup");
   });
@@ -300,6 +302,43 @@ describe("parsePluginScheduleDeclarations", () => {
       });
       const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
       expect(errors[0]!.reason).toContain("invalid config");
+    });
+
+    test("timeout_ms below the script minimum errors", () => {
+      const pluginDir = makePlugin({
+        "fast.md": '---\nexpression: "0 9 * * *"\ntimeout_ms: 500\n---\nHi.',
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations).toEqual([]);
+      expect(errors[0]!.reason).toContain("timeout_ms must be between");
+    });
+
+    test("timeout_ms above the script maximum errors", () => {
+      const pluginDir = makePlugin({
+        "slow.md":
+          '---\nexpression: "0 9 * * *"\ntimeout_ms: 1800001\n---\nHi.',
+      });
+      const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
+      expect(errors[0]!.reason).toContain("timeout_ms must be between");
+    });
+
+    test("single-fire RRULE (COUNT=1) errors; larger counts stay valid", () => {
+      const single = makePlugin({
+        "once.md":
+          '---\nexpression: "DTSTART:20260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=1"\nexpression_syntax: rrule\n---\nHi.',
+      });
+      const parsed = parsePluginScheduleDeclarations(single, "p");
+      expect(parsed.declarations).toEqual([]);
+      expect(parsed.errors[0]!.reason).toContain("must be recurring");
+
+      const thrice = makePlugin({
+        "thrice.md":
+          '---\nexpression: "DTSTART:20260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=3"\nexpression_syntax: rrule\n---\nHi.',
+      });
+      expect(parsePluginScheduleDeclarations(thrice, "p").errors).toEqual([]);
     });
 
     test("empty prompt body errors", () => {

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -6,7 +6,7 @@
  *   markdown body (the prompt message). Mode is `execute`.
  * - Directory: `<name>/` containing `config.json` (the schedule config) plus
  *   exactly one entrypoint, `index.md` (mode `execute`, body is the prompt)
- *   or `index.sh` (mode `script`, invoked by absolute path).
+ *   or `index.sh` (mode `script`, invoked via `sh` by absolute path).
  *
  * Ambiguity fails closed, never resolves by precedence: a basename declared
  * in both forms, a directory with zero or multiple entrypoints, or an
@@ -14,8 +14,8 @@
  * schedule does not load. Errors are per-schedule; one bad declaration never
  * blocks siblings.
  *
- * Declared schedules are recurring only: `expression` is required and there
- * is no one-shot form.
+ * Declared schedules are recurring only: `expression` is required, a
+ * single-fire RRULE (COUNT=1) is rejected, and there is no one-shot form.
  *
  * Pure filesystem + parsing. This module must not import from persistence or
  * schedule-store; the reconciler owns all database interaction.
@@ -33,11 +33,13 @@ import {
   parseFrontmatterFields,
 } from "../skills/frontmatter.js";
 import {
+  isSingleFireRRule,
   isValidScheduleExpression,
   validateRruleSetLines,
 } from "./recurrence-engine.js";
 import type { ScheduleSyntax } from "./recurrence-types.js";
 import { normalizeScheduleSyntax } from "./recurrence-types.js";
+import { validateScriptTimeoutMs } from "./run-script.js";
 
 export type PluginScheduleMode = "execute" | "script";
 
@@ -64,8 +66,10 @@ export interface ScheduleDeclaration {
   /** Prompt body for `execute` mode; null for `script` mode. */
   message: string | null;
   /**
-   * Shell invocation of the declaration's `index.sh` by absolute path (not
-   * the file's content); null for `execute` mode.
+   * Shell invocation of the declaration's `index.sh`, as `sh '<absolute
+   * path>'` rather than the file's content. The explicit interpreter keeps
+   * the entrypoint runnable when an install path drops its exec bit. Null
+   * for `execute` mode.
    */
   scriptInvocation: string | null;
   config: PluginScheduleConfig;
@@ -123,6 +127,13 @@ function parseScheduleConfig(
   }
   const fields = result.data;
 
+  if (fields.timeout_ms !== undefined) {
+    const timeoutError = validateScriptTimeoutMs(fields.timeout_ms);
+    if (timeoutError) {
+      return { error: timeoutError };
+    }
+  }
+
   const resolved = normalizeScheduleSyntax({
     syntax: fields.expression_syntax,
     expression: fields.expression,
@@ -136,6 +147,12 @@ function parseScheduleConfig(
     const setError = validateRruleSetLines(resolved.expression);
     if (setError) {
       return { error: setError };
+    }
+    if (isSingleFireRRule(resolved.expression)) {
+      return {
+        error:
+          "expression fires exactly once (COUNT=1): declared schedules must be recurring",
+      };
     }
   }
   if (
@@ -313,7 +330,7 @@ function parseDirectoryDeclaration(
     }
     mode = "execute";
   } else {
-    scriptInvocation = shellQuote(join(dirPath, "index.sh"));
+    scriptInvocation = `sh ${shellQuote(join(dirPath, "index.sh"))}`;
     mode = "script";
   }
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import { Cron } from "croner";
 import {
   and,
@@ -21,6 +24,7 @@ import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   hasOwnerDeferProvenance,
@@ -707,18 +711,23 @@ export async function updateSchedule(
   return getSchedule(id);
 }
 
+/** `source_key` of the row, or null when the row is absent or imperative. */
+function getRowSourceKey(id: string): string | null {
+  const row = getDb()
+    .select({ sourceKey: scheduleJobs.sourceKey })
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  return row?.sourceKey ?? null;
+}
+
 export async function deleteSchedule(id: string): Promise<boolean> {
   const db = getDb();
   // Plugin-sourced rows keep their identity and run history: deleting one
   // would just have the reconciler recreate it from the declaration on its
   // next pass. Disable is the supported action; removal means removing the
   // plugin's schedule file.
-  const target = db
-    .select({ sourceKey: scheduleJobs.sourceKey })
-    .from(scheduleJobs)
-    .where(eq(scheduleJobs.id, id))
-    .get();
-  if (target?.sourceKey != null) {
+  if (getRowSourceKey(id) != null) {
     throw new UserError(
       "This schedule is managed by a plugin and cannot be deleted. Disable it instead, or remove the plugin's schedule file.",
     );
@@ -760,7 +769,7 @@ export interface DeclaredScheduleDefinition {
   timezone?: string | null;
   message: string;
   script?: string | null;
-  mode: ScheduleMode;
+  mode: Extract<ScheduleMode, "execute" | "script">;
   maxRetries?: number;
   retryBackoffMs?: number;
   quiet?: boolean;
@@ -808,8 +817,11 @@ function isEngineLatched(row: {
  * every call, so a row disarmed while its plugin was disabled re-arms once
  * the declaration is back in the desired set. `nextRunAt` is recomputed only
  * when the timing changed or the row transitions to enabled; a matching hash
- * with matching effective `enabled` is a no-op. Rows the engine has latched
- * are returned untouched.
+ * with matching script path and effective `enabled` is a no-op. A script
+ * path that moved on a matching hash (the invocation embeds the absolute
+ * entrypoint path, which moves with the workspace while the hash covers only
+ * schedules/-relative paths and contents) is rewritten without touching
+ * timing. Rows the engine has latched are returned untouched.
  */
 export async function upsertDeclaredSchedule(
   sourceKey: string,
@@ -840,8 +852,13 @@ export async function upsertDeclaredSchedule(
 
   const definitionChanged =
     existing.definitionHash !== definition.definitionHash;
+  const scriptChanged = (definition.script ?? null) !== existing.script;
   const effectiveEnabled = existing.userEnabled ?? definition.enabled;
-  if (!definitionChanged && effectiveEnabled === existing.enabled) {
+  if (
+    !definitionChanged &&
+    !scriptChanged &&
+    effectiveEnabled === existing.enabled
+  ) {
     return parseJobRow(existing);
   }
 
@@ -883,6 +900,8 @@ export async function upsertDeclaredSchedule(
     set.inferenceProfile = definition.inferenceProfile ?? null;
     set.timeoutMs = definition.timeoutMs ?? null;
     set.definitionHash = definition.definitionHash;
+  } else if (scriptChanged) {
+    set.script = definition.script ?? null;
   }
   // While disabled, `nextRunAt` is left alone so a stale value never reads as
   // the engine's exhaust latch (`nextRunAt = 0` with `lastRunAt` set).
@@ -948,6 +967,24 @@ export async function disarmDeclaredSchedule(id: string): Promise<void> {
 }
 
 /**
+ * True when the plugin declaration behind `sourceKey` is still present on
+ * disk, in either declaration form: a flat `<name>.md` or a `<name>/`
+ * directory under the plugin's schedules/ dir. A cheap existence probe only;
+ * parsing and validity are the reconciler's business.
+ */
+function declaredScheduleSourceExists(sourceKey: string): boolean {
+  const match = /^plugin:([^/]+)\/(.+)$/.exec(sourceKey);
+  if (!match) {
+    return false;
+  }
+  const schedulesDir = join(getWorkspacePluginsDir(), match[1]!, "schedules");
+  return (
+    existsSync(join(schedulesDir, `${match[2]!}.md`)) ||
+    existsSync(join(schedulesDir, match[2]!))
+  );
+}
+
+/**
  * The user's side of the enabled toggle.
  *
  * On an imperative row this is exactly the existing toggle
@@ -989,15 +1026,29 @@ export async function setUserEnabled(
     value !== existing.enabled &&
     !isEngineLatched(existing)
   ) {
-    set.enabled = value;
-    // Re-arming needs a fresh occurrence: the stored one went stale while the
-    // row was disabled. Disabling keeps `nextRunAt`; see the disarm note.
-    if (value && existing.cronExpression != null) {
-      set.nextRunAt = computeNextRunAtEngine({
-        syntax: existing.scheduleSyntax as ScheduleSyntax,
-        expression: existing.cronExpression,
-        timezone: existing.timezone,
-      });
+    // Enabling a row whose declaration has left the disk (plugin
+    // uninstalled, schedule file removed) would let it fire an orphaned run
+    // before the next reconcile pass disarms it again. The reconciler is the
+    // authority on the declaration set; this existence probe only closes
+    // that fire-before-next-sweep window. The override itself is still
+    // recorded, so it applies if the declaration returns.
+    if (value && !declaredScheduleSourceExists(existing.sourceKey)) {
+      logger.info(
+        { scheduleId: id, sourceKey: existing.sourceKey },
+        "Enable override recorded without re-arming: declaration missing on disk",
+      );
+    } else {
+      set.enabled = value;
+      // Re-arming needs a fresh occurrence: the stored one went stale while
+      // the row was disabled. Disabling keeps `nextRunAt`; see the disarm
+      // note.
+      if (value && existing.cronExpression != null) {
+        set.nextRunAt = computeNextRunAtEngine({
+          syntax: existing.scheduleSyntax as ScheduleSyntax,
+          expression: existing.cronExpression,
+          timezone: existing.timezone,
+        });
+      }
     }
   }
 
@@ -1280,6 +1331,15 @@ export async function failOneShotPermanently(id: string): Promise<void> {
  */
 export async function cancelSchedule(id: string): Promise<boolean> {
   const db = getDb();
+  // Cancelled is a permanent latch on a sourced row: the reconciler, the
+  // enabled toggle, and delete all skip it, so cancelling would brick the
+  // plugin's schedule even across reinstalls. Disable is the supported
+  // action, as with update and delete.
+  if (getRowSourceKey(id) != null) {
+    throw new UserError(
+      "This schedule is managed by a plugin and cannot be cancelled. Disable it instead via the enabled toggle.",
+    );
+  }
   const now = Date.now();
   const cancelled = await withSqliteRetry(
     () => {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for plugin-schedules-v1.md: timeout clamping, single-fire RRULE rejection, exec-bit-free script invocation, narrowed declared mode type, script-path staleness, cancel refusal on sourced rows, ghost-row re-arm guard.