### PR TITLE
fix(schedules): sourced-row lifecycle guards in routes/tools, consent-listing sanitization, CLI cleanup

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -9,6 +9,7 @@ import { createGroup, deleteGroup } from "../persistence/group-crud.js";
 import {
   getSchedule,
   resolveScheduleConversationGroupId,
+  upsertDeclaredSchedule,
 } from "../schedule/schedule-store.js";
 import {
   __clearRegistryForTesting,
@@ -1885,6 +1886,83 @@ describe("schedule_delete tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Schedule not found");
+  });
+});
+
+// ── plugin-sourced schedules ────────────────────────────────────────
+
+describe("schedule tools on plugin-sourced schedules", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  function createSourcedSchedule() {
+    return upsertDeclaredSchedule("plugin:example/daily", {
+      name: "daily",
+      syntax: "cron",
+      expression: "0 9 * * *",
+      message: "Do the daily thing.",
+      mode: "execute",
+      enabled: true,
+      definitionHash: "hash-1",
+    });
+  }
+
+  test("schedule_update toggles enabled via the user_enabled override", async () => {
+    const job = await createSourcedSchedule();
+
+    const result = await executeScheduleUpdate(
+      { job_id: job.id, enabled: false },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Schedule updated successfully");
+    expect(result.content).toContain("Enabled: false");
+
+    const row = getRawDb()
+      .query("SELECT enabled, user_enabled FROM cron_jobs WHERE id = ?")
+      .get(job.id) as { enabled: number; user_enabled: number };
+    expect(row.enabled).toBe(0);
+    expect(row.user_enabled).toBe(0);
+  });
+
+  test("schedule_update refuses definition fields with a message naming the enabled toggle", async () => {
+    const job = await createSourcedSchedule();
+
+    const result = await executeScheduleUpdate(
+      { job_id: job.id, name: "renamed" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("managed by a plugin");
+    expect(result.content).toContain("only enabled can be changed");
+    expect(getSchedule(job.id)?.name).toBe("daily");
+  });
+
+  test("schedule_update refuses enabled mixed with definition fields", async () => {
+    const job = await createSourcedSchedule();
+
+    const result = await executeScheduleUpdate(
+      { job_id: job.id, enabled: false, message: "rewritten" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("managed by a plugin");
+    expect(getSchedule(job.id)?.enabled).toBe(true);
+  });
+
+  test("schedule_delete surfaces the store refusal as a normal tool error", async () => {
+    const job = await createSourcedSchedule();
+
+    const result = await executeScheduleDelete({ job_id: job.id }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("managed by a plugin");
+    expect(getSchedule(job.id)).not.toBeNull();
   });
 });
 

--- a/assistant/src/cli/commands/__tests__/cli-test-harness.ts
+++ b/assistant/src/cli/commands/__tests__/cli-test-harness.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared harness for CLI command tests: registers a command tree on a fresh
+ * Commander program, runs it against captured output sinks, and returns what
+ * the command emitted plus the resulting exit code.
+ *
+ * `process.stdout.write`, `console.log`, and `console.error` are captured for
+ * the duration of the run, so command output lands in the result regardless of
+ * which sink the command writes to; `process.exitCode` is reset afterwards.
+ * The caller passes its own (possibly mock-backed) registration function, so
+ * this helper imports nothing from `src/` beyond what any test file may
+ * import itself (see the test-machinery isolation rules in assistant/CLAUDE.md).
+ */
+
+import { Command } from "commander";
+
+export interface CliCommandRunResult {
+  stdout: string;
+  stderr: string;
+  /** stdout + stderr chunks in emission order, for cross-stream ordering. */
+  events: string[];
+  exitCode: number;
+}
+
+export async function runCliCommand(
+  register: (program: Command) => void,
+  args: string[],
+): Promise<CliCommandRunResult> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const events: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    const text = typeof chunk === "string" ? chunk : String(chunk);
+    stdoutChunks.push(text);
+    events.push(text);
+    return true;
+  }) as typeof process.stdout.write;
+  console.log = (...logArgs: unknown[]) => {
+    const text = logArgs.map(String).join(" ") + "\n";
+    stdoutChunks.push(text);
+    events.push(text);
+  };
+  console.error = (...logArgs: unknown[]) => {
+    const text = logArgs.map(String).join(" ") + "\n";
+    stderrChunks.push(text);
+    events.push(text);
+  };
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    register(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+    events,
+    exitCode,
+  };
+}

--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -24,8 +24,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { Command } from "commander";
-
 import type { ConfirmPromptOptions } from "../../lib/confirm-prompt.js";
 import type { PluginInspection } from "../../lib/inspect-plugin.js";
 import type {
@@ -33,6 +31,8 @@ import type {
   InstallPluginOptions,
   InstallPluginResult,
 } from "../../lib/install-from-github.js";
+import type { CliCommandRunResult } from "./cli-test-harness.js";
+import { runCliCommand } from "./cli-test-harness.js";
 
 // ---------------------------------------------------------------------------
 // Mock state
@@ -156,67 +156,22 @@ function writeScheduleFixture(dir: string): void {
   writeFileSync(join(dir, "schedules", "cleanup", "index.sh"), "#!/bin/sh\n");
 }
 
-async function runCommand(args: string[]): Promise<{
-  stdout: string;
-  stderr: string;
-  /** stdout + stderr lines in emission order, for cross-stream ordering. */
-  events: string[];
-  exitCode: number;
-}> {
-  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-  const originalConsoleLog = console.log;
-  const originalConsoleError = console.error;
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-  const events: string[] = [];
-
-  process.stdout.write = ((chunk: unknown) => {
-    const text = typeof chunk === "string" ? chunk : String(chunk);
-    stdoutChunks.push(text);
-    events.push(text);
-    return true;
-  }) as typeof process.stdout.write;
-  console.log = (...logArgs: unknown[]) => {
-    const text = logArgs.map(String).join(" ") + "\n";
-    stdoutChunks.push(text);
-    events.push(text);
+/** Stage a single flat schedule declaration with the given raw expression. */
+function stageFlatSchedule(
+  name: string,
+  expression: string,
+): (dir: string) => void {
+  return (dir) => {
+    mkdirSync(join(dir, "schedules"), { recursive: true });
+    writeFileSync(
+      join(dir, "schedules", `${name}.md`),
+      `---\nexpression: "${expression}"\n---\nBody.\n`,
+    );
   };
-  console.error = (...logArgs: unknown[]) => {
-    const text = logArgs.map(String).join(" ") + "\n";
-    stderrChunks.push(text);
-    events.push(text);
-  };
+}
 
-  process.exitCode = 0;
-
-  try {
-    const program = new Command();
-    program.exitOverride();
-    program.configureOutput({
-      writeErr: () => {},
-      writeOut: (str: string) => stdoutChunks.push(str),
-    });
-    registerPluginsCommand(program);
-    await program.parseAsync(["node", "assistant", ...args]);
-  } catch {
-    if (process.exitCode === 0) {
-      process.exitCode = 1;
-    }
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-    console.log = originalConsoleLog;
-    console.error = originalConsoleError;
-  }
-
-  const exitCode = process.exitCode ?? 0;
-  process.exitCode = 0;
-
-  return {
-    stdout: stdoutChunks.join(""),
-    stderr: stderrChunks.join(""),
-    events,
-    exitCode,
-  };
+function runCommand(args: string[]): Promise<CliCommandRunResult> {
+  return runCliCommand(registerPluginsCommand, args);
 }
 
 const savedDisablePlatform = process.env.VELLUM_DISABLE_PLATFORM;
@@ -349,6 +304,36 @@ describe("plugins install - declared-schedules consent", () => {
     expect(listingIdx).toBeGreaterThan(warningIdx);
 
     expect(r.stdout).toContain('Installed untrusted plugin "example-repo"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("strips terminal escape sequences from the listed declarations", async () => {
+    // The cadence carries a clear-screen CSI plus an OSC title write, aimed at
+    // rewriting the consent prompt. YAML's \u escapes decode to real bytes.
+    stageFixture = stageFlatSchedule(
+      "sneaky",
+      "0 9 * * *\\u001b[2J\\u001b]0;pwned\\u0007 SAFE",
+    );
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).toContain("sneaky");
+    expect(r.stdout).toContain("SAFE");
+    expect(r.stdout).not.toContain("\u001b");
+    expect(r.stdout).not.toContain("\u0007");
+    expect(r.stdout).not.toContain("pwned");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("caps listing cell width so a long expression cannot flood the prompt", async () => {
+    stageFixture = stageFlatSchedule("wall", `0 9 * * * ${"x".repeat(200)}`);
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).not.toContain("x".repeat(60));
+    expect(r.stdout).toContain("...");
     expect(r.exitCode).toBe(0);
   });
 

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import type { CliCommandRunResult } from "./cli-test-harness.js";
+import { runCliCommand } from "./cli-test-harness.js";
+
 let ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
 let mockIpcResult: {
   ok: boolean;
@@ -41,43 +44,8 @@ mock.module("../../../util/logger.js", () => ({
 
 const { registerSchedulesCommand } = await import("../schedules.js");
 
-async function runCommand(
-  args: string[],
-): Promise<{ stdout: string; exitCode: number }> {
-  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-  const stdoutChunks: string[] = [];
-
-  process.stdout.write = ((chunk: unknown) => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
-
-  process.exitCode = 0;
-
-  try {
-    const program = new Command();
-    program.exitOverride();
-    program.configureOutput({
-      writeErr: () => {},
-      writeOut: (str: string) => stdoutChunks.push(str),
-    });
-    registerSchedulesCommand(program);
-    await program.parseAsync(["node", "assistant", ...args]);
-  } catch {
-    if (process.exitCode === 0) {
-      process.exitCode = 1;
-    }
-  } finally {
-    process.stdout.write = originalStdoutWrite;
-  }
-
-  const exitCode = process.exitCode ?? 0;
-  process.exitCode = 0;
-
-  return {
-    exitCode,
-    stdout: stdoutChunks.join(""),
-  };
+function runCommand(args: string[]): Promise<CliCommandRunResult> {
+  return runCliCommand(registerSchedulesCommand, args);
 }
 
 beforeEach(() => {

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -998,6 +998,29 @@ async function confirmDeclaredSchedules(
   return true;
 }
 
+/**
+ * Maximum rendered width of a declared-schedule listing cell. Declaration
+ * strings come from the plugin being installed, so an overlong expression
+ * must not be able to push the consent prompt off-screen.
+ */
+const MAX_SCHEDULE_CELL_WIDTH = 60;
+
+/**
+ * Make a plugin-controlled declaration string safe to print next to the
+ * install consent prompt: drop well-formed CSI/OSC escape sequences whole,
+ * strip every remaining C0/C1 control character (which could rewrite or hide
+ * the surrounding untrusted-source warning), and cap the cell width.
+ */
+function sanitizeScheduleCell(value: string): string {
+  const stripped = value
+    .replace(/\u001b\[[0-9:;<=>?]*[ -\/]*[@-~]/g, "")
+    .replace(/\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)?/g, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
+  return stripped.length > MAX_SCHEDULE_CELL_WIDTH
+    ? `${stripped.slice(0, MAX_SCHEDULE_CELL_WIDTH - 3)}...`
+    : stripped;
+}
+
 /** Aligned `name  cadence  (mode)` rows for a declared-schedules listing. */
 function formatScheduleRows(
   schedules: readonly PluginScheduleSurface[],
@@ -1005,11 +1028,16 @@ function formatScheduleRows(
   if (schedules.length === 0) {
     return [];
   }
-  const nameW = Math.max(...schedules.map((s) => s.name.length));
-  const cadenceW = Math.max(...schedules.map((s) => s.cadence.length));
-  const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
-  return schedules.map(
-    (s) => `${pad(s.name, nameW)}  ${pad(s.cadence, cadenceW)}  (${s.mode})`,
+  const rows = schedules.map((s) => ({
+    name: sanitizeScheduleCell(s.name),
+    cadence: sanitizeScheduleCell(s.cadence),
+    mode: sanitizeScheduleCell(s.mode),
+  }));
+  const nameW = Math.max(...rows.map((r) => r.name.length));
+  const cadenceW = Math.max(...rows.map((r) => r.cadence.length));
+  return rows.map(
+    (r) =>
+      `${r.name.padEnd(nameW)}  ${r.cadence.padEnd(cadenceW)}  (${r.mode})`,
   );
 }
 

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -239,7 +239,7 @@ export function registerSchedulesCommand(program: Command): void {
             ["Retry backoff", formatDuration(schedule.retryBackoffMs)],
             ["Timeout", formatDuration(schedule.timeoutMs)],
             ["Source conversation", schedule.createdFromConversationId ?? "—"],
-            ["Plugin", describeSource(schedule.sourceKey) || "—"],
+            ["Plugin", describeSource(schedule.sourceKey) || "-"],
           ];
           const labelWidth = Math.max(...fields.map(([label]) => label.length));
           for (const [label, value] of fields) {

--- a/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
@@ -2,9 +2,14 @@
  * Tests for {@link detectPluginSurfaces}.
  *
  * Surface detection is a pure walk of an installed plugin's on-disk tree, so
- * the fixtures materialize the `hooks/`, `tools/`, and `skills/` directory
- * conventions in a real temp dir and assert the derived listing matches what
- * the runtime loader / skills catalog would discover.
+ * the fixtures materialize the `hooks/`, `tools/`, `skills/`, and `schedules/`
+ * directory conventions in a real temp dir and assert the derived listing
+ * matches what the runtime loader / skills catalog would discover.
+ *
+ * The schedules walk only mirrors the daemon parser's structural refusals;
+ * it stays permissive beyond structure. In particular, `expression` validity
+ * is not checked CLI-side, so a schedule whose expression the daemon rejects
+ * is still listed.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -157,9 +162,11 @@ describe("detectPluginSurfaces", () => {
     ]);
   });
 
-  test("skips schedule declarations the loader would refuse", () => {
+  test("skips structurally malformed schedule declarations (frontmatter, entrypoint, config, body)", () => {
     // GIVEN a flat file without frontmatter
     touch("schedules/no-frontmatter.md", "just a body\n");
+    // AND a flat file whose prompt body after the frontmatter is empty
+    touch("schedules/empty-body.md", '---\nexpression: "0 9 * * *"\n---\n  \n');
     // AND a directory with both entrypoints
     touch("schedules/two-entries/config.json", '{"expression": "0 9 * * *"}');
     touch("schedules/two-entries/index.md", "body\n");
@@ -167,6 +174,16 @@ describe("detectPluginSurfaces", () => {
     // AND a directory with an unsupported entrypoint
     touch("schedules/bad-entry/config.json", '{"expression": "0 9 * * *"}');
     touch("schedules/bad-entry/index.py", "print()\n");
+    // AND a directory whose index.md carries frontmatter (config belongs in
+    // config.json)
+    touch(
+      "schedules/md-frontmatter/config.json",
+      '{"expression": "0 9 * * *"}',
+    );
+    touch("schedules/md-frontmatter/index.md", flatSchedule("0 9 * * *"));
+    // AND a directory whose index.md prompt body is empty
+    touch("schedules/md-empty/config.json", '{"expression": "0 9 * * *"}');
+    touch("schedules/md-empty/index.md", "\n  \n");
     // AND a directory missing its config.json
     touch("schedules/no-config/index.md", "body\n");
     // AND a directory whose config declares no expression

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -237,7 +237,7 @@ export class PluginPostinstallError extends Error {
  * outcome rather than something to report as a failure.
  */
 export class PluginInstallDeclinedError extends Error {
-  constructor(readonly pluginName: string) {
+  constructor(pluginName: string) {
     super(`Install of "${pluginName}" was declined.`);
     this.name = "PluginInstallDeclinedError";
   }

--- a/assistant/src/cli/lib/plugin-surfaces.ts
+++ b/assistant/src/cli/lib/plugin-surfaces.ts
@@ -56,9 +56,12 @@ export interface PluginSurfaces {
    * a flat `<name>.md` with YAML frontmatter (mode `execute`), or a `<name>/`
    * directory with a `config.json` plus exactly one `index.md` (`execute`) or
    * `index.sh` (`script`) entrypoint. This is a display surface, not the arming
-   * path: ambiguous or unsupported declarations (a basename in both forms, a
-   * bad entrypoint set, an unreadable config, a missing `expression`) are
-   * skipped rather than reported as errors.
+   * path: structurally malformed declarations (a basename in both forms, a bad
+   * entrypoint set, an empty prompt body, frontmatter in a directory-form
+   * `index.md`, an unreadable config, a missing `expression`) are skipped
+   * rather than reported as errors. Detection stays permissive beyond
+   * structure: `expression` validity is not checked CLI-side, so a declaration
+   * whose expression the daemon rejects is still listed here.
    */
   readonly schedules: readonly PluginScheduleSurface[];
 }
@@ -139,7 +142,7 @@ function readConfigExpression(config: unknown): string | null {
 /**
  * Read the cadence of a flat `<name>.md` declaration: the `expression` field of
  * its YAML frontmatter. `null` when the file is unreadable, carries no
- * frontmatter, or declares no expression.
+ * frontmatter, has an empty prompt body, or declares no expression.
  */
 function readFlatScheduleCadence(filePath: string): string | null {
   let content: string;
@@ -150,6 +153,9 @@ function readFlatScheduleCadence(filePath: string): string | null {
   }
   const match = FRONTMATTER_REGEX.exec(content);
   if (!match) {
+    return null;
+  }
+  if (!content.slice(match[0].length).trim()) {
     return null;
   }
   let fields: unknown;
@@ -165,7 +171,8 @@ function readFlatScheduleCadence(filePath: string): string | null {
  * Read a `<name>/` directory declaration: `config.json` supplies the cadence
  * and the single `index.md`/`index.sh` entrypoint decides the mode. `null` for
  * anything the loader would refuse (zero or multiple `index.*` entries, an
- * unsupported entrypoint, an unreadable config, a missing expression).
+ * unsupported entrypoint, an `index.md` carrying frontmatter or an empty
+ * prompt body, an unreadable config, a missing expression).
  */
 function readDirectorySchedule(
   dirPath: string,
@@ -185,6 +192,19 @@ function readDirectorySchedule(
   const entrypoint = entrypoints[0]!;
   if (entrypoint !== "index.md" && entrypoint !== "index.sh") {
     return null;
+  }
+  if (entrypoint === "index.md") {
+    let body: string;
+    try {
+      body = readFileSync(join(dirPath, "index.md"), "utf8");
+    } catch {
+      return null;
+    }
+    // Directory-form config belongs in config.json, so the loader refuses an
+    // index.md with frontmatter; it also refuses an empty prompt body.
+    if (FRONTMATTER_REGEX.test(body) || !body.trim()) {
+      return null;
+    }
   }
   let config: unknown;
   try {

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -24,7 +24,15 @@ import { eq } from "drizzle-orm";
 import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
-import { conversations } from "../../../persistence/schema/index.js";
+import {
+  conversations,
+  scheduleJobs,
+} from "../../../persistence/schema/index.js";
+import {
+  createSchedule,
+  getSchedule,
+  upsertDeclaredSchedule,
+} from "../../../schedule/schedule-store.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "../inference-profile-session-routes.js";
 import type { RouteDefinition } from "../types.js";
@@ -82,7 +90,7 @@ function clearConversations(): void {
   getDb().delete(conversations).run();
 }
 
-function seedConversation(id: string): void {
+function seedConversation(id: string, scheduleJobId?: string): void {
   const now = Date.now();
   getDb()
     .insert(conversations)
@@ -93,6 +101,7 @@ function seedConversation(id: string): void {
       updatedAt: now,
       source: "test",
       conversationType: "standard",
+      scheduleJobId,
     })
     .run();
 }
@@ -365,5 +374,56 @@ describe("POST /v1/conversations/inference-profile-session/close (inference_prof
 
     expect(result.noop).toBe(true);
     expect(result.closed).toBeNull();
+  });
+});
+
+describe("DELETE /v1/conversations/:id (deleteConversation)", () => {
+  const deleteHandler = findHandler(
+    CONVERSATION_MANAGEMENT_ROUTES,
+    "deleteConversation",
+  );
+
+  beforeEach(() => {
+    clearConversations();
+    getDb().delete(scheduleJobs).run();
+  });
+
+  test("deleting the last conversation of a plugin-declared schedule keeps the schedule", async () => {
+    // GIVEN a plugin-sourced schedule with a single run conversation
+    const job = await upsertDeclaredSchedule("plugin:example/daily", {
+      name: "daily",
+      syntax: "cron",
+      expression: "0 9 * * *",
+      message: "Do the daily thing.",
+      mode: "execute",
+      enabled: true,
+      definitionHash: "hash-1",
+    });
+    const convId = crypto.randomUUID();
+    seedConversation(convId, job.id);
+
+    // WHEN the conversation is deleted
+    await deleteHandler({ pathParams: { id: convId } });
+
+    // THEN the conversation is gone but the schedule row survives: its
+    // lifecycle belongs to the reconciler, not conversation cleanup.
+    expect(getDb().select().from(conversations).all()).toHaveLength(0);
+    expect(getSchedule(job.id)).not.toBeNull();
+  });
+
+  test("deleting the last conversation of a user schedule still deletes the schedule", async () => {
+    const job = await createSchedule({
+      name: "imperative",
+      message: "Do the thing.",
+      syntax: "cron",
+      expression: "0 9 * * *",
+    });
+    const convId = crypto.randomUUID();
+    seedConversation(convId, job.id);
+
+    await deleteHandler({ pathParams: { id: convId } });
+
+    expect(getDb().select().from(conversations).all()).toHaveLength(0);
+    expect(getSchedule(job.id)).toBeNull();
   });
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -65,7 +65,7 @@ import {
 } from "../../persistence/conversation-key-store.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
-import { deleteSchedule } from "../../schedule/schedule-store.js";
+import { deleteSchedule, getSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
 import { safeParseRecord } from "../../util/json.js";
 import { getLogger } from "../../util/logger.js";
@@ -111,11 +111,17 @@ function resolveOrThrow(rawId: string): string {
 async function cancelScheduleIfLast(conversationId: string): Promise<void> {
   const conv = getConversation(conversationId);
   if (
-    conv?.scheduleJobId &&
-    countConversationsByScheduleJobId(conv.scheduleJobId) <= 1
+    !conv?.scheduleJobId ||
+    countConversationsByScheduleJobId(conv.scheduleJobId) > 1
   ) {
-    await deleteSchedule(conv.scheduleJobId);
+    return;
   }
+  // A plugin-declared schedule outlives its run conversations: its lifecycle
+  // belongs to the reconciler, and `deleteSchedule` refuses sourced rows.
+  if (getSchedule(conv.scheduleJobId)?.sourceKey != null) {
+    return;
+  }
+  await deleteSchedule(conv.scheduleJobId);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -93,7 +93,7 @@ export interface ParsedPluginSchedules {
   errors: DeclarationError[];
 }
 
-export function pluginScheduleSourceKey(
+function pluginScheduleSourceKey(
   pluginName: string,
   scheduleName: string,
 ): string {

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { deleteSchedule, getSchedule } from "../../schedule/schedule-store.js";
+import { UserError } from "../../util/errors.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -35,7 +36,18 @@ export async function executeScheduleDelete(
     return { content: `Error: Schedule not found: ${jobId}`, isError: true };
   }
 
-  const deleted = await deleteSchedule(jobId);
+  let deleted: boolean;
+  try {
+    deleted = await deleteSchedule(jobId);
+  } catch (err) {
+    // The store refuses to delete plugin-sourced rows with a UserError. That
+    // refusal is an expected outcome for the model to relay, not a daemon
+    // fault to classify as unexpected.
+    if (err instanceof UserError) {
+      return { content: `Error: ${err.message}`, isError: true };
+    }
+    throw err;
+  }
   if (!deleted) {
     return {
       content: `Error: Failed to delete schedule: ${jobId}`,

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -17,6 +17,7 @@ import {
   describeCronExpression,
   formatLocalDate,
   getSchedule,
+  setUserEnabled,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { resolveGroupReference } from "../conversation-groups/group_shared.js";
@@ -94,10 +95,11 @@ export async function executeScheduleUpdate(
     return { content: "Error: job_id is required", isError: true };
   }
 
+  const existing = getSchedule(jobId);
+
   // Prevent changing a one-shot to recurring or vice versa. (`fire_at` is
   // not an advertised update field, so it stays a raw-input read.)
   if (parsed.expression !== undefined || input.fire_at !== undefined) {
-    const existing = getSchedule(jobId);
     if (!existing) {
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
@@ -278,6 +280,22 @@ export async function executeScheduleUpdate(
     };
   }
 
+  // A plugin-sourced schedule accepts only the enabled toggle, recorded as
+  // the user_enabled override exactly like the HTTP toggle route. Every other
+  // field is owned by the plugin's schedule file, and the reconciler would
+  // overwrite a direct edit on its next pass.
+  const isPluginSourced = existing?.sourceKey != null;
+  if (
+    isPluginSourced &&
+    Object.keys(updates).some((field) => field !== "enabled")
+  ) {
+    return {
+      content:
+        "Error: This schedule is managed by a plugin, so only enabled can be changed here. To change anything else, edit the plugin's schedule file.",
+      isError: true,
+    };
+  }
+
   // Mirror the HTTP route: a schedule whose RESULTING mode is `workflow` must
   // carry a non-empty workflowName. Compute the post-update
   // state (the update's value if present, else the persisted one) so both
@@ -285,7 +303,6 @@ export async function executeScheduleUpdate(
   // schedule" are rejected — otherwise the scheduler hits the `!job.workflowName`
   // skip branch and a one-shot firing job wedges.
   if (updates.mode !== undefined || updates.workflowName !== undefined) {
-    const existing = getSchedule(jobId);
     if (existing) {
       const resultingMode =
         updates.mode !== undefined ? (updates.mode as string) : existing.mode;
@@ -325,31 +342,33 @@ export async function executeScheduleUpdate(
   }
 
   try {
-    const job = await updateSchedule(
-      jobId,
-      updates as {
-        name?: string;
-        description?: string;
-        cronExpression?: string;
-        timezone?: string | null;
-        message?: string;
-        script?: string | null;
-        enabled?: boolean;
-        syntax?: ScheduleSyntax;
-        expression?: string;
-        mode?: ScheduleMode;
-        routingIntent?: RoutingIntent;
-        routingHints?: Record<string, unknown>;
-        quiet?: boolean;
-        reuseConversation?: boolean;
-        maxRetries?: number;
-        retryBackoffMs?: number;
-        timeoutMs?: number | null;
-        workflowName?: string | null;
-        workflowArgs?: unknown;
-        inferenceProfile?: string | null;
-      },
-    );
+    const job = isPluginSourced
+      ? await setUserEnabled(jobId, updates.enabled as boolean)
+      : await updateSchedule(
+          jobId,
+          updates as {
+            name?: string;
+            description?: string;
+            cronExpression?: string;
+            timezone?: string | null;
+            message?: string;
+            script?: string | null;
+            enabled?: boolean;
+            syntax?: ScheduleSyntax;
+            expression?: string;
+            mode?: ScheduleMode;
+            routingIntent?: RoutingIntent;
+            routingHints?: Record<string, unknown>;
+            quiet?: boolean;
+            reuseConversation?: boolean;
+            maxRetries?: number;
+            retryBackoffMs?: number;
+            timeoutMs?: number | null;
+            workflowName?: string | null;
+            workflowArgs?: unknown;
+            inferenceProfile?: string | null;
+          },
+        );
 
     if (!job) {
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for plugin-schedules-v1.md: conversation cleanup skips plugin schedules, agent tools toggle sourced rows via user_enabled and surface refusals as expected errors, consent listing sanitized against terminal escapes, CLI walker catches two more invalid forms, dead code removed, shared CLI test harness extracted.