### PR TITLE
fix(schedule): manifest-gate reconciler, close consent bypasses, deterministic notification copy

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24012,14 +24012,43 @@ paths:
                             description:
                               Registered tool names from `tools/<name>.{ts,js}` (filenames derived to tool names, e.g. `create-issue` →
                               `create_issue`).
+                          schedules:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: "Schedule name: the flat file's basename or the declaration directory's name."
+                                cadence:
+                                  type: string
+                                  description: Raw schedule `expression` string from the declaration's config.
+                                mode:
+                                  type: string
+                                  enum:
+                                    - execute
+                                    - script
+                                  description: "`execute` for a markdown prompt entrypoint, `script` for `index.sh`."
+                              required:
+                                - name
+                                - cadence
+                                - mode
+                              additionalProperties: false
+                            description:
+                              "Schedules declared under `schedules/`, in either loader form: a flat `<name>.md` with YAML frontmatter, or
+                              a `<name>/` directory with `config.json` plus one entrypoint. Display surface only;
+                              ambiguous or unsupported declarations are omitted."
                         required:
                           - skills
                           - hooks
                           - tools
+                          - schedules
                         additionalProperties: false
                         description: Surfaces the installed copy contributes, read from its on-disk tree.
                       - type: "null"
-                    description: Surfaces the installed copy contributes (skills, hooks, tools); null when the plugin is not installed.
+                    description:
+                      Surfaces the installed copy contributes (skills, hooks, tools, schedules); null when the plugin is not
+                      installed.
                 required:
                   - name
                   - installed

--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -33,6 +33,11 @@ import type {
   InstallPluginOptions,
   InstallPluginResult,
 } from "../../lib/install-from-github.js";
+import type {
+  PluginUpgradeResult,
+  UpgradePluginDeps,
+  UpgradePluginOptions,
+} from "../../lib/upgrade-plugin.js";
 
 // ---------------------------------------------------------------------------
 // Mock state
@@ -49,6 +54,19 @@ let stageFixture: ((stagingDir: string) => void) | null = null;
 
 let installPluginCalls: InstallPluginOptions[] = [];
 let platformInstallCalls: Array<{ name: string; force?: boolean }> = [];
+let upgradePluginCalls: UpgradePluginOptions[] = [];
+
+/**
+ * Queued daemon IPC responses. The default (empty queue) is a transport
+ * failure (`ok: false`, no `statusCode`), which routes upgrade to the local
+ * lib fallback where the consent gate lives.
+ */
+let ipcResults: Array<{
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+}> = [];
 
 let inspectResult: PluginInspection | null = null;
 
@@ -71,25 +89,29 @@ const realPlatform = await import("../../lib/install-from-platform.js");
 const realInspect = await import("../../lib/inspect-plugin.js");
 
 /**
- * Fake install: stage the fixture tree, run the real staged-install consent
- * gate (so a decline aborts exactly like production), and return a canned
- * success result.
+ * Stage the fixture tree and run the real staged-install consent gate, so a
+ * decline aborts exactly like production. Shared by the fake install and
+ * fake upgrade.
  */
+async function stageAndConfirm(
+  name: string,
+  confirmStaged: InstallPluginDeps["confirmStaged"],
+): Promise<void> {
+  const stagingDir = mkdtempSync(join(tmpdir(), "plugins-cmd-staging-"));
+  try {
+    stageFixture?.(stagingDir);
+    await realGithub.confirmStagedOrAbort(name, stagingDir, confirmStaged);
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+/** Fake install: run the consent gate, then return a canned success result. */
 async function runFakeInstall(
   name: string,
   deps: Pick<InstallPluginDeps, "confirmStaged"> | undefined,
 ): Promise<InstallPluginResult> {
-  const stagingDir = mkdtempSync(join(tmpdir(), "plugins-cmd-staging-"));
-  try {
-    stageFixture?.(stagingDir);
-    await realGithub.confirmStagedOrAbort(
-      name,
-      stagingDir,
-      deps?.confirmStaged,
-    );
-  } finally {
-    rmSync(stagingDir, { recursive: true, force: true });
-  }
+  await stageAndConfirm(name, deps?.confirmStaged);
   return {
     name,
     target: `/plugins/${name}`,
@@ -131,6 +153,46 @@ mock.module("../../lib/inspect-plugin.js", () => ({
     return inspectResult;
   },
 }));
+
+const realUpgrade = await import("../../lib/upgrade-plugin.js");
+const realCliClient = await import("../../../ipc/cli-client.js");
+
+/** Fake upgrade: run the consent gate, then return a canned upgraded result. */
+mock.module("../../lib/upgrade-plugin.js", () => ({
+  ...realUpgrade,
+  upgradePlugin: async (
+    opts: UpgradePluginOptions,
+    deps: UpgradePluginDeps,
+  ): Promise<PluginUpgradeResult> => {
+    upgradePluginCalls.push(opts);
+    await stageAndConfirm(opts.name, deps.confirmStaged);
+    return upgradedResult(opts.name);
+  },
+}));
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  ...realCliClient,
+  cliIpcCall: async () =>
+    ipcResults.shift() ?? { ok: false, error: "daemon unreachable" },
+}));
+
+function upgradedResult(name: string): PluginUpgradeResult {
+  return {
+    name,
+    outcome: "upgraded",
+    fromCommit: "a".repeat(40),
+    fromTimestamp: null,
+    toCommit: "b".repeat(40),
+    toTimestamp: null,
+    target: `/plugins/${name}`,
+    fileCount: 3,
+    dryRun: false,
+    strategy: "overwrite",
+    conflicts: [],
+    binaryConflicts: [],
+    provenanceWasUnknown: false,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Import module under test (after mocks)
@@ -228,6 +290,8 @@ beforeEach(() => {
   stageFixture = null;
   installPluginCalls = [];
   platformInstallCalls = [];
+  upgradePluginCalls = [];
+  ipcResults = [];
   inspectResult = null;
   // Platform features on by default, so a plain name install takes the
   // platform-tarball branch.
@@ -364,6 +428,83 @@ describe("plugins install - declared-schedules consent", () => {
     expect(installPluginCalls[0]!.trustedSource).toBeDefined();
     expect(confirmCalls.length).toBe(1);
     expect(r.stdout).toContain('Plugin "caveman" declares 2 schedules:');
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe("plugins upgrade - declared-schedules consent (local fallback)", () => {
+  test("lists declared schedules and prompts before finalizing", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["confirmed"];
+
+    const r = await runCommand(["plugins", "upgrade", "example"]);
+
+    expect(upgradePluginCalls.length).toBe(1);
+    expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stdout).toContain("daily-report");
+    expect(r.stdout).toContain("cleanup");
+    expect(confirmCalls.length).toBe(1);
+    expect(confirmCalls[0]!.question).toContain(
+      'Upgrade "example" and allow these schedules?',
+    );
+    expect(r.stdout).toContain('Upgraded "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("declining cancels the upgrade cleanly", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["denied"];
+
+    const r = await runCommand(["plugins", "upgrade", "example"]);
+
+    expect(r.stdout).toContain("Upgrade cancelled.");
+    expect(r.stdout).not.toContain('Upgraded "example"');
+    expect(r.stderr).not.toContain("Plugin upgrade failed");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a non-interactive refusal exits 1", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["non-interactive"];
+
+    const r = await runCommand(["plugins", "upgrade", "example"]);
+
+    expect(r.stdout).not.toContain('Upgraded "example"');
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("--force skips the prompt but still lists the schedules", async () => {
+    stageFixture = writeScheduleFixture;
+
+    const r = await runCommand(["plugins", "upgrade", "example", "--force"]);
+
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stdout).toContain('Upgraded "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("an upgrade without declared schedules has zero consent UX", async () => {
+    stageFixture = null;
+
+    const r = await runCommand(["plugins", "upgrade", "example"]);
+
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stdout).toContain('Upgraded "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("a daemon-routed upgrade never reaches the local gate", async () => {
+    // The daemon route is unattended by design; the reconciler's
+    // schedule.declared notification is its consent surface.
+    stageFixture = writeScheduleFixture;
+    ipcResults = [{ ok: true, result: upgradedResult("example") }];
+
+    const r = await runCommand(["plugins", "upgrade", "example"]);
+
+    expect(upgradePluginCalls.length).toBe(0);
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stdout).toContain('Upgraded "example"');
     expect(r.exitCode).toBe(0);
   });
 });

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -254,6 +254,11 @@ $ assistant plugins publish --json`,
           flags: "--json",
           description: "Emit machine-readable JSON instead of a summary",
         },
+        {
+          flags: "--force",
+          description:
+            "Skip the confirmation prompt when the upgraded revision declares schedules",
+        },
       ],
       helpText: `
 A marketplace plugin upgrades to the curated pin. A plugin installed directly

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -169,7 +169,7 @@ export function registerPluginsCommand(program: Command): void {
             // --force, must be confirmed before anything lands on disk that
             // the daemon's schedule reconciler could arm.
             const confirmStaged: ConfirmStagedInstall = (staged) =>
-              confirmDeclaredSchedules(staged, Boolean(opts.force));
+              confirmDeclaredSchedules(staged, Boolean(opts.force), "install");
 
             let result;
             let untrusted = false;
@@ -685,7 +685,12 @@ export function registerPluginsCommand(program: Command): void {
       subcommand(plugins, "upgrade").action(
         async (
           name: string,
-          opts: { dryRun?: boolean; strategy?: string; json?: boolean },
+          opts: {
+            dryRun?: boolean;
+            strategy?: string;
+            json?: boolean;
+            force?: boolean;
+          },
         ) => {
           const strategy = opts.strategy;
           if (
@@ -702,6 +707,9 @@ export function registerPluginsCommand(program: Command): void {
             // Prefer the daemon: when the upgrade re-materializes files it runs
             // the plugin's `shutdown` + `init` hooks in the main process —
             // symmetric to how install/uninstall run their lifecycle there.
+            // The daemon route is unattended (no staging prompt); a schedule
+            // the upgraded revision adds is surfaced by the reconciler's
+            // `schedule.declared` notification instead.
             // Fall back to a local upgrade only when the daemon is unreachable
             // (a transport error carries no `statusCode`); an operator can still
             // upgrade while it's stopped, and the new code is picked up on the
@@ -722,13 +730,22 @@ export function registerPluginsCommand(program: Command): void {
                 { name, error: daemon.error },
                 "upgrade could not reach the daemon; upgrading locally",
               );
+              // The local path stages in this process, so it gets the same
+              // consent gate as install: declared schedules are listed and
+              // confirmed (or --force) before the staged tree goes live.
+              const confirmStaged: ConfirmStagedInstall = (staged) =>
+                confirmDeclaredSchedules(
+                  staged,
+                  Boolean(opts.force),
+                  "upgrade",
+                );
               result = await libs.upgrade.upgradePlugin(
                 {
                   name,
                   dryRun: opts.dryRun,
                   strategy: strategy as PluginUpgradeStrategy | undefined,
                 },
-                { fetch: globalThis.fetch.bind(globalThis) },
+                { fetch: globalThis.fetch.bind(globalThis), confirmStaged },
               );
             } else {
               console.error(daemon.error ?? "Plugin upgrade failed.");
@@ -757,6 +774,11 @@ export function registerPluginsCommand(program: Command): void {
               console.log(line);
             }
           } catch (err) {
+            if (err instanceof libs.installGitHub.PluginInstallDeclinedError) {
+              // The consent gate already printed the outcome and set the exit
+              // code; the upgrade was aborted with the live install untouched.
+              return;
+            }
             if (
               err instanceof libs.uninstall.PluginNotInstalledError ||
               err instanceof libs.upgrade.PluginNotUpgradableError ||
@@ -957,14 +979,16 @@ function printUntrustedPluginWarning(
 
 /**
  * List a staged plugin's declared schedules and ask for consent. Schedules run
- * automatically once armed, so an install may not add any silently: the user
- * either confirms the listing or passes --force. Returns whether the install
- * may proceed; a refusal's user-facing outcome (message + exit code) is fully
- * handled here, so the caller aborts without further output.
+ * automatically once armed, so neither an install nor an upgrade may add any
+ * silently: the user either confirms the listing or passes --force. Returns
+ * whether the operation may proceed; a refusal's user-facing outcome (message
+ * + exit code) is fully handled here, so the caller aborts without further
+ * output. `action` selects the install vs upgrade wording.
  */
 async function confirmDeclaredSchedules(
   staged: { name: string; stagingDir: string },
   force: boolean,
+  action: "install" | "upgrade",
 ): Promise<boolean> {
   const { schedules } = libs.surfaces.detectPluginSurfaces(staged.stagingDir);
   if (schedules.length === 0) {
@@ -982,17 +1006,18 @@ async function confirmDeclaredSchedules(
   if (force) {
     return true;
   }
+  const verb = action === "install" ? "Install" : "Upgrade";
   const result = await confirmPrompt({
-    question: `Install "${staged.name}" and allow these schedules? [y/N] `,
+    question: `${verb} "${staged.name}" and allow these schedules? [y/N] `,
     isTTY: Boolean(process.stdin.isTTY),
-    refuseNonInteractiveMessage: `Refusing to install "${staged.name}" non-interactively: it declares schedules. Pass --force to confirm.`,
+    refuseNonInteractiveMessage: `Refusing to ${action} "${staged.name}" non-interactively: it declares schedules. Pass --force to confirm.`,
   });
   if (result === "non-interactive") {
     process.exitCode = 1;
     return false;
   }
   if (result === "denied") {
-    console.log("Install cancelled.");
+    console.log(`${verb} cancelled.`);
     return false;
   }
   return true;

--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { FetchLike } from "../fetch-like.js";
 import {
   type GitRunner,
+  PluginInstallDeclinedError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
 } from "../install-from-github.js";
@@ -1031,5 +1032,126 @@ describe("upgradePlugin --strategy", () => {
       "added upstream\n",
     );
     expect(installedFile("level-up", "conflict.txt")).toBe("ours\n");
+  });
+});
+
+describe("upgradePlugin confirmStaged consent gate", () => {
+  test("overwrite: declining aborts and preserves the existing install", async () => {
+    // GIVEN an installed copy pinned to SHA_A with a newer marketplace pin
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = fakeGitRunner(SHA_B);
+    const seen: Array<{ name: string; staged: boolean }> = [];
+
+    // WHEN the consent gate declines the staged upgrade
+    await expect(
+      upgradePlugin(
+        { name: "level-up" },
+        {
+          fetch,
+          runGit,
+          workspacePluginsDir: pluginsDir,
+          confirmStaged: async ({ name, stagingDir }) => {
+            seen.push({
+              name,
+              staged: existsSync(join(stagingDir, "package.json")),
+            });
+            return false;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginInstallDeclinedError);
+
+    // THEN the gate saw the fully staged tree exactly once
+    expect(seen).toEqual([{ name: "level-up", staged: true }]);
+    // AND the live install still carries the old pin
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_A);
+  });
+
+  test("overwrite: an accepting gate lets the upgrade proceed", async () => {
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = fakeGitRunner(SHA_B);
+
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      {
+        fetch,
+        runGit,
+        workspacePluginsDir: pluginsDir,
+        confirmStaged: async () => true,
+      },
+    );
+
+    expect(result.outcome).toBe("upgraded");
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_B);
+  });
+
+  test("merge: the gate sees the merged tree; declining keeps the local install", async () => {
+    const PKG = '{"name":"level-up"}\n';
+    const base: Tree = { "package.json": PKG, "note.txt": "base\n" };
+    const ours: Tree = {
+      "package.json": PKG,
+      "note.txt": "base\n",
+      "local.txt": "mine\n",
+    };
+    const theirs: Tree = { "package.json": PKG, "note.txt": "upstream\n" };
+    installMergeCopy("level-up", ours, SHA_A, base);
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = treeGitRunner({ [SHA_A]: base, [SHA_B]: theirs });
+    let sawMerged = false;
+
+    await expect(
+      upgradePlugin(
+        { name: "level-up", strategy: "ours" },
+        {
+          fetch,
+          runGit,
+          workspacePluginsDir: pluginsDir,
+          confirmStaged: async ({ stagingDir }) => {
+            // The staged tree is the merged result: the upstream edit plus
+            // the surviving local addition.
+            sawMerged =
+              readFileSync(join(stagingDir, "note.txt"), "utf-8") ===
+                "upstream\n" && existsSync(join(stagingDir, "local.txt"));
+            return false;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginInstallDeclinedError);
+
+    expect(sawMerged).toBe(true);
+    // The live install is untouched by the declined merge.
+    expect(installedFile("level-up", "note.txt")).toBe("base\n");
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_A);
+  });
+
+  test("dry runs and no-ops never invoke the gate", async () => {
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const gate = async () => {
+      throw new Error("confirmStaged must not run without staging");
+    };
+
+    const dry = await upgradePlugin(
+      { name: "level-up", dryRun: true },
+      {
+        fetch: makeFetch({ manifest: manifestWith("level-up", SHA_B) }),
+        runGit: unusedGitRunner,
+        workspacePluginsDir: pluginsDir,
+        confirmStaged: gate,
+      },
+    );
+    expect(dry.outcome).toBe("would-upgrade");
+
+    const noop = await upgradePlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch({ manifest: manifestWith("level-up", SHA_A) }),
+        runGit: unusedGitRunner,
+        workspacePluginsDir: pluginsDir,
+        confirmStaged: gate,
+      },
+    );
+    expect(noop.outcome).toBe("already-up-to-date");
   });
 });

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -54,6 +54,8 @@ import {
   type PluginLocalInfo,
 } from "./inspect-plugin.js";
 import {
+  type ConfirmStagedInstall,
+  confirmStagedOrAbort,
   finalizeStagedInstall,
   type GitRunner,
   installPlugin,
@@ -138,6 +140,14 @@ export interface UpgradePluginDeps {
    * for dry runs or no-op upgrades (they never reach the swap).
    */
   readonly beforeSwap?: () => Promise<void>;
+  /**
+   * Consent gate between staging and finalize, identical to the install
+   * path's ({@link ConfirmStagedInstall}): the caller inspects the staged
+   * upgraded tree (e.g. its declared schedules) and may abort before
+   * anything replaces the live install. Applies to overwrite and merge
+   * upgrades alike; dry runs and no-ops never stage, so it is not invoked.
+   */
+  readonly confirmStaged?: ConfirmStagedInstall;
 }
 
 /** Result of an upgrade attempt. */
@@ -401,6 +411,7 @@ export async function upgradePlugin(
       runPostinstall: deps.runPostinstall,
       runInstallDeps: deps.runInstallDeps,
       beforeSwap: deps.beforeSwap,
+      confirmStaged: deps.confirmStaged,
     },
   );
 
@@ -591,6 +602,7 @@ async function directUpgrade(
       runPostinstall: deps.runPostinstall,
       runInstallDeps: deps.runInstallDeps,
       beforeSwap: deps.beforeSwap,
+      confirmStaged: deps.confirmStaged,
     },
   );
 
@@ -746,6 +758,12 @@ async function mergeUpgrade(
       strategy,
       conflictLabels,
     });
+
+    // Same staging-to-finalize consent boundary as `installPlugin`: the
+    // caller sees the fully merged tree before it replaces the live install.
+    // A decline removes the staging dir and throws; the outer catch's rmSync
+    // is then a no-op.
+    await confirmStagedOrAbort(name, stagingDir, deps.confirmStaged);
 
     const toCommit = theirs.commit ?? ctx.toCommit;
     const toTimestamp = theirs.committedAt ?? ctx.toTimestamp;

--- a/assistant/src/notifications/__tests__/copy-composer.test.ts
+++ b/assistant/src/notifications/__tests__/copy-composer.test.ts
@@ -255,6 +255,86 @@ describe("composeFallbackCopy honors requestedMessage / requestedTitle", () => {
   });
 });
 
+// ── Plugin schedule templates ─────────────────────────────────────────
+
+describe("composeFallbackCopy plugin schedule templates", () => {
+  test("schedule.declared renders plugin, schedule name, and cadence", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.declared",
+      contextPayload: {
+        pluginName: "news",
+        scheduleName: "digest",
+        sourceKey: "plugin:news/digest",
+        cadence: "0 9 * * *",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("New plugin schedule: digest");
+    expect(copy.vellum?.body).toContain('Plugin "news"');
+    expect(copy.vellum?.body).toContain('"digest"');
+    expect(copy.vellum?.body).toContain("0 9 * * *");
+  });
+
+  test("schedule.declared omits the cadence suffix when absent", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.declared",
+      contextPayload: { pluginName: "news", scheduleName: "digest" },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.body).not.toContain("(");
+    expect(copy.vellum?.body).toContain('"digest"');
+  });
+
+  test("schedule.definition_changed renders plugin and schedule name", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.definition_changed",
+      contextPayload: {
+        pluginName: "news",
+        scheduleName: "digest",
+        sourceKey: "plugin:news/digest",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Plugin schedule changed: digest");
+    expect(copy.vellum?.body).toBe(
+      'Plugin "news" changed the definition of its schedule "digest".',
+    );
+  });
+
+  test("schedule.definition_error renders plugin, schedule name, and reason", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.definition_error",
+      contextPayload: {
+        pluginName: "news",
+        scheduleName: "digest",
+        sourceKey: "plugin:news/digest",
+        reason: "invalid cron expression",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("Plugin schedule error: digest");
+    expect(copy.vellum?.body).toContain('Plugin "news"');
+    expect(copy.vellum?.body).toContain("invalid cron expression");
+    // A non-empty body means the broadcaster's empty-body skip never
+    // suppresses a definition error when the notification LLM is down.
+    expect(copy.vellum?.body?.length).toBeGreaterThan(0);
+  });
+
+  test("schedule.definition_error still renders with an empty payload", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.definition_error",
+      contextPayload: {},
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.body?.length).toBeGreaterThan(0);
+  });
+});
+
 // ── deriveTitle ───────────────────────────────────────────────────────
 
 describe("deriveTitle", () => {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -115,6 +115,38 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     body: str(payload.message, "A reminder has fired"),
   }),
 
+  "schedule.declared": (payload) => {
+    const scheduleName = str(payload.scheduleName, "a schedule");
+    const pluginName = str(payload.pluginName, "A plugin");
+    const cadence =
+      typeof payload.cadence === "string" && payload.cadence.length > 0
+        ? ` (${payload.cadence})`
+        : "";
+    return {
+      title: `New plugin schedule: ${scheduleName}`,
+      body: `Plugin "${pluginName}" armed the schedule "${scheduleName}"${cadence}. It will run automatically; you can disable it from your schedules.`,
+    };
+  },
+
+  "schedule.definition_changed": (payload) => {
+    const scheduleName = str(payload.scheduleName, "a schedule");
+    const pluginName = str(payload.pluginName, "A plugin");
+    return {
+      title: `Plugin schedule changed: ${scheduleName}`,
+      body: `Plugin "${pluginName}" changed the definition of its schedule "${scheduleName}".`,
+    };
+  },
+
+  "schedule.definition_error": (payload) => {
+    const scheduleName = str(payload.scheduleName, "a schedule");
+    const pluginName = str(payload.pluginName, "A plugin");
+    const reason = str(payload.reason, "the declaration is invalid");
+    return {
+      title: `Plugin schedule error: ${scheduleName}`,
+      body: `Plugin "${pluginName}" has a schedule "${scheduleName}" that could not be loaded: ${reason}`,
+    };
+  },
+
   "guardian.question": (payload) => {
     const question = str(
       payload.questionText,

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -70,6 +70,10 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description: "Plugin schedule declaration failed to parse or validate",
   },
   {
+    id: "schedule.declared",
+    description: "Plugin-declared schedule armed for the first time",
+  },
+  {
     id: "schedule.definition_changed",
     description: "Plugin upgrade changed an armed schedule's definition",
   },

--- a/assistant/src/plugins/collect-source-versions.ts
+++ b/assistant/src/plugins/collect-source-versions.ts
@@ -12,13 +12,11 @@
  * causes a spurious reload.
  */
 
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import {
-  getWorkspaceHooksDir,
-  getWorkspacePluginsDir,
-} from "../util/platform.js";
+import { getWorkspaceHooksDir } from "../util/platform.js";
+import { listInstalledPluginDirs } from "./installed-plugin-dirs.js";
 import { snapshotPluginSource } from "./source-fingerprint.js";
 import type { PluginSourceVersion } from "./source-versions.js";
 
@@ -33,28 +31,7 @@ import type { PluginSourceVersion } from "./source-versions.js";
 export function collectSourceVersions(): Record<string, PluginSourceVersion> {
   const out: Record<string, PluginSourceVersion> = {};
 
-  const pluginsDir = getWorkspacePluginsDir();
-  let entries: string[] = [];
-  try {
-    entries = readdirSync(pluginsDir);
-  } catch {
-    // No plugins directory yet — nothing to watch there.
-  }
-  for (const entry of entries) {
-    if (entry.startsWith(".")) {
-      continue;
-    }
-    const dir = join(pluginsDir, entry);
-    try {
-      if (!statSync(dir).isDirectory()) {
-        continue;
-      }
-    } catch {
-      continue;
-    }
-    if (!existsSync(join(dir, "package.json"))) {
-      continue;
-    }
+  for (const { dir } of listInstalledPluginDirs()) {
     const snapshot = snapshotPluginSource(dir);
     out[dir] = {
       fingerprint: snapshot.fingerprint,

--- a/assistant/src/plugins/installed-plugin-dirs.ts
+++ b/assistant/src/plugins/installed-plugin-dirs.ts
@@ -1,0 +1,57 @@
+/**
+ * Enumerate installed plugin directories under the workspace plugins dir.
+ *
+ * An installed plugin is a non-hidden directory carrying a `package.json`.
+ * This walk is shared by the plugin source-version collector
+ * (`./collect-source-versions.ts`) and the schedule reconciler
+ * (`../schedule/plugin-schedule-reconciler.ts`) so both agree on what counts
+ * as an installed plugin. Disabled-state and manifest validation are caller
+ * concerns: the source collector fingerprints disabled plugins too, while the
+ * reconciler skips them and additionally gates on `parsePluginManifest`.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspacePluginsDir } from "../util/platform.js";
+
+export interface InstalledPluginDir {
+  /** Directory basename: the plugin's install identity. */
+  readonly name: string;
+  /** Absolute path to the plugin directory. */
+  readonly dir: string;
+}
+
+/**
+ * List every installed plugin directory, sorted by the underlying readdir
+ * order. A missing plugins directory yields `[]`.
+ */
+export function listInstalledPluginDirs(): InstalledPluginDir[] {
+  const pluginsDir = getWorkspacePluginsDir();
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch {
+    // No plugins directory yet, so nothing installed.
+    return [];
+  }
+  const out: InstalledPluginDir[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      continue;
+    }
+    const dir = join(pluginsDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(dir, "package.json"))) {
+      continue;
+    }
+    out.push({ name: entry, dir });
+  }
+  return out;
+}

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -1883,7 +1883,14 @@ function inspection(
     remoteError: overrides.remoteError ?? null,
     surfaces:
       overrides.surfaces === undefined
-        ? { skills: [], hooks: ["post-model-call"], tools: [], schedules: [] }
+        ? {
+            skills: [],
+            hooks: ["post-model-call"],
+            tools: [],
+            schedules: [
+              { name: "digest", cadence: "0 9 * * *", mode: "execute" },
+            ],
+          }
         : overrides.surfaces,
   };
 }
@@ -1911,6 +1918,26 @@ describe("GET /v1/plugins/:name/inspect", () => {
     expect(result).toEqual(view);
     // AND the name is forwarded to the lib (ref is never caller-supplied)
     expect(inspectSpy.mock.calls[0]?.[0]).toEqual({ name: "level-up" });
+  });
+
+  test("the inspect wire schema carries the schedules surface", async () => {
+    // GIVEN an inspection whose surfaces declare a schedule
+    inspectSpy.mockImplementation(async () => inspection());
+    const result = await invokeInspect({ pathParams: { name: "level-up" } });
+
+    // WHEN the handler result is parsed through the route's response schema
+    // (zod strips undeclared keys, so an omission would drop the field)
+    const route = PLUGINS_ROUTES.find(
+      (r) => r.operationId === "plugins_inspect",
+    )!;
+    const parsed = (
+      route.responseBody as { parse: (v: unknown) => PluginInspection }
+    ).parse(result);
+
+    // THEN the declared schedules survive the wire contract
+    expect(parsed.surfaces?.schedules).toEqual([
+      { name: "digest", cadence: "0 9 * * *", mode: "execute" },
+    ]);
   });
 
   test("a captured marketplace error is returned as 200 with remote-unavailable, not thrown", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -525,6 +525,29 @@ const pluginSurfacesSchema = z
       .describe(
         "Registered tool names from `tools/<name>.{ts,js}` (filenames derived to tool names, e.g. `create-issue` \u2192 `create_issue`).",
       ),
+    schedules: z
+      .array(
+        z.object({
+          name: z
+            .string()
+            .describe(
+              "Schedule name: the flat file's basename or the declaration directory's name.",
+            ),
+          cadence: z
+            .string()
+            .describe(
+              "Raw schedule `expression` string from the declaration's config.",
+            ),
+          mode: z
+            .enum(["execute", "script"])
+            .describe(
+              "`execute` for a markdown prompt entrypoint, `script` for `index.sh`.",
+            ),
+        }),
+      )
+      .describe(
+        "Schedules declared under `schedules/`, in either loader form: a flat `<name>.md` with YAML frontmatter, or a `<name>/` directory with `config.json` plus one entrypoint. Display surface only; ambiguous or unsupported declarations are omitted.",
+      ),
   })
   .describe(
     "Surfaces the installed copy contributes, read from its on-disk tree.",
@@ -568,7 +591,7 @@ const pluginInspectResponseSchema = z.object({
   surfaces: pluginSurfacesSchema
     .nullable()
     .describe(
-      "Surfaces the installed copy contributes (skills, hooks, tools); null when the plugin is not installed.",
+      "Surfaces the installed copy contributes (skills, hooks, tools, schedules); null when the plugin is not installed.",
     ),
 });
 
@@ -1206,6 +1229,11 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
   // that introduced it through the plugin's reviewed pin history; an unreviewed
   // SHA is refused. Operators who need an unreviewed revision use the local
   // CLI's `assistant plugins install --pin <sha> --allow-unreviewed`.
+  //
+  // No `confirmStaged` consent gate: the daemon route is unattended by design
+  // (there is no interactive surface to prompt on). Declared schedules the
+  // install arms are surfaced to the user by the schedule reconciler's
+  // `schedule.declared` notification.
   try {
     // Validate the name up front — before any catalog/pin/network work — so a
     // malformed name (`../escape`) is a deterministic 400 rather than a 404/503
@@ -1429,6 +1457,10 @@ async function handleUpgradePlugin({
   let deactivated = false;
   try {
     const name = sanitizePluginName(rawName);
+    // No `confirmStaged` consent gate here: the daemon route is unattended by
+    // design (there is no interactive surface to prompt on). A schedule the
+    // upgraded revision adds is surfaced to the user by the schedule
+    // reconciler's `schedule.declared` notification when it arms.
     const result = await upgradePlugin(
       { name, dryRun, strategy },
       {

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -34,7 +34,10 @@ mock.module("../../notifications/emit-signal.js", () => ({
 import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
-import { reconcilePluginSchedules } from "../plugin-schedule-reconciler.js";
+import {
+  reconcilePluginSchedules,
+  resetDefinitionErrorEmitGuardForTests,
+} from "../plugin-schedule-reconciler.js";
 import {
   claimDueSchedules,
   createSchedule,
@@ -97,6 +100,7 @@ describe("reconcilePluginSchedules", () => {
     getDb().run("DELETE FROM cron_jobs");
     rmSync(pluginsDir, { recursive: true, force: true });
     emittedSignals.length = 0;
+    resetDefinitionErrorEmitGuardForTests();
   });
 
   test("converges both declaration forms into rows the engine claims", async () => {
@@ -124,6 +128,24 @@ describe("reconcilePluginSchedules", () => {
     expect(sync.script).toContain("index.sh");
     expect(sync.message).toBe("");
 
+    // Every newly created armed row announces itself, deduped by hash.
+    const declared = emittedSignals.filter(
+      (s) => s.sourceEventName === "schedule.declared",
+    );
+    expect(declared).toHaveLength(2);
+    const digestDeclared = declared.find(
+      (s) => s.sourceContextId === DIGEST_KEY,
+    )!;
+    expect(digestDeclared.dedupeKey).toBe(
+      `schedule-declared:${DIGEST_KEY}:${digest.definitionHash}`,
+    );
+    expect(digestDeclared.contextPayload).toEqual({
+      pluginName: "news",
+      scheduleName: "digest",
+      sourceKey: DIGEST_KEY,
+      cadence: "* * * * *",
+    });
+
     // The untouched engine picks the row up: an every-minute cron is always
     // due within a two-minute claim horizon.
     const claimed = await claimDueSchedules(Date.now() + 120_000);
@@ -135,6 +157,7 @@ describe("reconcilePluginSchedules", () => {
     await reconcilePluginSchedules();
     const row = listDeclaredSchedules()[0]!;
     const before = rawJob(row.id);
+    emittedSignals.length = 0;
 
     await reconcilePluginSchedules();
 
@@ -146,6 +169,7 @@ describe("reconcilePluginSchedules", () => {
     writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
     await reconcilePluginSchedules();
     const created = listDeclaredSchedules()[0]!;
+    emittedSignals.length = 0;
 
     writePlugin("news", { "digest.md": digestMd("Summarize the WEEK.") });
     await reconcilePluginSchedules();
@@ -186,6 +210,7 @@ describe("reconcilePluginSchedules", () => {
       .get(created.id) as { n: number };
     expect(runs.n).toBe(1);
 
+    emittedSignals.length = 0;
     writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
     await reconcilePluginSchedules();
 
@@ -194,6 +219,10 @@ describe("reconcilePluginSchedules", () => {
     expect(relinked[0]!.id).toBe(created.id);
     expect(relinked[0]!.enabled).toBe(true);
     expect(relinked[0]!.nextRunAt).toBeGreaterThan(0);
+    // Re-linking an existing row is not a first arming: no arrival signal.
+    expect(
+      emittedSignals.filter((s) => s.sourceEventName === "schedule.declared"),
+    ).toHaveLength(0);
   });
 
   test("user_enabled survives upgrades and disarm/re-arm cycles", async () => {
@@ -202,6 +231,7 @@ describe("reconcilePluginSchedules", () => {
     const created = listDeclaredSchedules()[0]!;
 
     await setUserEnabled(created.id, false);
+    emittedSignals.length = 0;
 
     // Upgrade: definition columns update, the user override keeps the row
     // disabled, and no definition_changed emits for an unarmed row.
@@ -272,6 +302,7 @@ describe("reconcilePluginSchedules", () => {
     await reconcilePluginSchedules();
     const created = listDeclaredSchedules()[0]!;
     const before = rawJob(created.id);
+    emittedSignals.length = 0;
 
     // Break the declaration: no frontmatter means no config.
     writePlugin("news", { "digest.md": "Just a body, no config." });
@@ -296,6 +327,7 @@ describe("reconcilePluginSchedules", () => {
     writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
     await reconcilePluginSchedules();
     const created = listDeclaredSchedules()[0]!;
+    emittedSignals.length = 0;
 
     // Recurrence exhaustion latch: the claim path disables the row, zeroes
     // nextRunAt, and stamps lastRunAt in one write.
@@ -337,5 +369,108 @@ describe("reconcilePluginSchedules", () => {
     const rows = listDeclaredSchedules();
     expect(rows).toHaveLength(1);
     expect(rows[0]!.sourceKey).toBe(DIGEST_KEY);
+  });
+
+  test("a manifest-rejected plugin contributes nothing and its schedules disarm", async () => {
+    const dir = writePlugin("news", {
+      "digest.md": digestMd("Summarize the day."),
+    });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    expect(created.enabled).toBe(true);
+    emittedSignals.length = 0;
+
+    // A package.json the loader's schema rejects (empty name): the runtime
+    // refuses to bring such a plugin up, so its schedules must disarm too.
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "" }));
+    await reconcilePluginSchedules();
+
+    const disarmed = listDeclaredSchedules()[0]!;
+    expect(disarmed.id).toBe(created.id);
+    expect(disarmed.enabled).toBe(false);
+    expect(emittedSignals).toHaveLength(0);
+
+    // Restoring a valid manifest re-arms the row on the next pass.
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "news", version: "1.0.0" }),
+    );
+    await reconcilePluginSchedules();
+    expect(listDeclaredSchedules()[0]!.enabled).toBe(true);
+  });
+
+  test("a plugin with an unparseable package.json creates no rows", async () => {
+    const dir = writePlugin("news", {
+      "digest.md": digestMd("Summarize the day."),
+    });
+    writeFileSync(join(dir, "package.json"), "{not json");
+
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()).toHaveLength(0);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("an upgrade that adds a schedule arms it and emits schedule.declared", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    emittedSignals.length = 0;
+
+    // The upgraded revision ships an additional declaration alongside the
+    // unchanged digest.
+    writePlugin("news", {
+      "sync/config.json": JSON.stringify({ expression: "0 */2 * * *" }),
+      "sync/index.sh": "#!/bin/sh\necho synced\n",
+    });
+    await reconcilePluginSchedules();
+
+    const sync = listDeclaredSchedules().find(
+      (r) => r.sourceKey === "plugin:news/sync",
+    )!;
+    expect(sync.enabled).toBe(true);
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("schedule.declared");
+    expect(signal.dedupeKey).toBe(
+      `schedule-declared:plugin:news/sync:${sync.definitionHash}`,
+    );
+    const payload = signal.contextPayload as Record<string, unknown>;
+    expect(payload.pluginName).toBe("news");
+    expect(payload.scheduleName).toBe("sync");
+    expect(payload.cadence).toBe("0 */2 * * *");
+  });
+
+  test("a declaration shipped disabled creates its row silently", async () => {
+    writePlugin("news", {
+      "digest.md": [
+        "---",
+        'expression: "* * * * *"',
+        "enabled: false",
+        "---",
+        "",
+        "Summarize the day.",
+        "",
+      ].join("\n"),
+    });
+
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()[0]!.enabled).toBe(false);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("a persistently broken declaration emits its error once, not per pass", async () => {
+    writePlugin("news", { "digest.md": "Just a body, no config." });
+
+    await reconcilePluginSchedules();
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "schedule.definition_error",
+    );
+
+    await reconcilePluginSchedules();
+    await reconcilePluginSchedules();
+
+    expect(emittedSignals).toHaveLength(1);
   });
 });

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -18,15 +18,13 @@
  * plugin source reconcile.
  */
 
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
-
 import { getDbMigrationReadiness } from "../daemon/daemon-readiness.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { AttentionHints } from "../notifications/signal.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
+import { parsePluginManifest } from "../plugins/external-plugin-loader.js";
+import { listInstalledPluginDirs } from "../plugins/installed-plugin-dirs.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspacePluginsDir } from "../util/platform.js";
 import {
   type DeclarationError,
   parsePluginScheduleDeclarations,
@@ -82,7 +80,7 @@ async function runReconcilePass(): Promise<void> {
     return;
   }
 
-  const { desired, errors } = collectDesiredDeclarations();
+  const { desired, errors } = await collectDesiredDeclarations();
 
   const existingByKey = new Map<string, ScheduleJob>();
   for (const row of listDeclaredSchedules()) {
@@ -98,8 +96,9 @@ async function runReconcilePass(): Promise<void> {
       row !== undefined &&
       row.enabled &&
       row.definitionHash !== definition.definitionHash;
+    let applied: ScheduleJob;
     try {
-      await upsertDeclaredSchedule(sourceKey, definition);
+      applied = await upsertDeclaredSchedule(sourceKey, definition);
     } catch (err) {
       log.error(
         { err, sourceKey },
@@ -109,6 +108,15 @@ async function runReconcilePass(): Promise<void> {
     }
     if (changesArmedRow) {
       emitDefinitionChanged(pluginName, declaration);
+    }
+    // A brand-new armed row must never appear silently: a daemon-route
+    // install/upgrade has no interactive consent prompt, and even a CLI
+    // upgrade only confirms what it staged. The arrival notification is the
+    // consent surface for those paths; a CLI install that already prompted
+    // gets one redundant, hash-deduped notification. A re-linked row (its
+    // `source_key` already existed, e.g. reinstall or re-enable) is not new.
+    if (row === undefined && applied.enabled) {
+      emitScheduleDeclared(pluginName, declaration);
     }
   }
 
@@ -143,47 +151,34 @@ async function runReconcilePass(): Promise<void> {
 }
 
 /**
- * Enumerate installed plugins with the same gates as the plugin source walk
- * (`plugins/collect-source-versions.ts`): a directory under the workspace
- * plugins dir carrying a `package.json`, identity = the directory basename
- * (mirroring `parsePluginManifest`). Disabled plugins are skipped entirely,
- * so their declarations fall out of the desired set and disarm.
+ * Enumerate installed plugins ({@link listInstalledPluginDirs}, the same walk
+ * as the plugin source collector) and gather their schedule declarations.
+ * Identity = the directory basename, mirroring `parsePluginManifest`.
+ *
+ * Disabled plugins are skipped entirely, so their declarations fall out of
+ * the desired set and disarm. A plugin whose manifest fails
+ * `parsePluginManifest` (unreadable or schema-invalid `package.json`) is
+ * treated the same way: the runtime loader refuses to bring such a plugin up,
+ * so its schedules must not stay armed either. The parse failure is logged
+ * with attribution by `parsePluginManifest` itself.
  */
-function collectDesiredDeclarations(): {
+async function collectDesiredDeclarations(): Promise<{
   desired: Map<string, DesiredEntry>;
   errors: DeclarationError[];
-} {
+}> {
   const desired = new Map<string, DesiredEntry>();
   const errors: DeclarationError[] = [];
 
-  const pluginsDir = getWorkspacePluginsDir();
-  let entries: string[] = [];
-  try {
-    entries = readdirSync(pluginsDir);
-  } catch {
-    // No plugins directory yet, so nothing declared.
-  }
-  for (const entry of entries) {
-    if (entry.startsWith(".")) {
+  for (const { name, dir } of listInstalledPluginDirs()) {
+    if (isPluginDisabled(name)) {
       continue;
     }
-    const dir = join(pluginsDir, entry);
-    try {
-      if (!statSync(dir).isDirectory()) {
-        continue;
-      }
-    } catch {
+    if ((await parsePluginManifest(dir)) === undefined) {
       continue;
     }
-    if (!existsSync(join(dir, "package.json"))) {
-      continue;
-    }
-    if (isPluginDisabled(entry)) {
-      continue;
-    }
-    const parsed = parsePluginScheduleDeclarations(dir, entry);
+    const parsed = parsePluginScheduleDeclarations(dir, name);
     for (const declaration of parsed.declarations) {
-      desired.set(declaration.sourceKey, { pluginName: entry, declaration });
+      desired.set(declaration.sourceKey, { pluginName: name, declaration });
     }
     errors.push(...parsed.errors);
   }
@@ -247,11 +242,28 @@ function emitDefinitionSignal(
 }
 
 /**
+ * UTC day of the last definition-error emit per `sourceKey`. A persistently
+ * broken declaration re-surfaces on every pass (60s sweep); the downstream
+ * daily dedupe key would drop the repeats, but this guard skips the emit call
+ * entirely so steady-state passes do no notification work.
+ */
+const definitionErrorEmittedDay = new Map<string, string>();
+
+/** Test-only: forget which definition errors were already emitted today. */
+export function resetDefinitionErrorEmitGuardForTests(): void {
+  definitionErrorEmittedDay.clear();
+}
+
+/**
  * Surface a malformed declaration. Deduped per schedule per UTC day so a
  * broken file doesn't spam on every pass.
  */
 function emitDefinitionError(error: DeclarationError): void {
   const day = new Date().toISOString().slice(0, 10);
+  if (definitionErrorEmittedDay.get(error.sourceKey) === day) {
+    return;
+  }
+  definitionErrorEmittedDay.set(error.sourceKey, day);
   emitDefinitionSignal(
     "schedule.definition_error",
     error.sourceKey,
@@ -282,6 +294,29 @@ function emitDefinitionChanged(
       pluginName,
       scheduleName: declaration.name,
       sourceKey: declaration.sourceKey,
+    },
+  );
+}
+
+/**
+ * Surface a declared schedule arming for the first time (its row was created
+ * by this pass). Deduped by definition hash, so the CLI-install case (which
+ * already prompted for consent) collapses to a single notification and
+ * concurrent triggers emit once.
+ */
+function emitScheduleDeclared(
+  pluginName: string,
+  declaration: ScheduleDeclaration,
+): void {
+  emitDefinitionSignal(
+    "schedule.declared",
+    declaration.sourceKey,
+    `schedule-declared:${declaration.sourceKey}:${declaration.definitionHash}`,
+    {
+      pluginName,
+      scheduleName: declaration.name,
+      sourceKey: declaration.sourceKey,
+      cadence: declaration.config.expression,
     },
   );
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for plugin-schedules-v1.md: reconciler now honors loader manifest validation (shared plugin-dir enumeration helper), newly armed schedules always notify, CLI upgrade gets the same consent gate as install, definition-error/arrival notifications have deterministic fallback copy, per-sweep emit churn guarded, plugins inspect wire schema includes schedules.