### PR TITLE
fix(schedule): shebang-aware invocation, arming-transition notifications, manifest-gate hygiene

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1715,24 +1715,6 @@ describe("declared schedules", () => {
     expect(on!.nextRunAt).toBeGreaterThan(Date.now());
   });
 
-  test("clearing the override falls back to the declared value on the next pass", async () => {
-    const created = await upsertDeclaredSchedule(
-      SOURCE_KEY,
-      makeDefinition({ enabled: false }),
-    );
-    await setUserEnabled(created.id, true);
-    expect(getSchedule(created.id)!.enabled).toBe(true);
-
-    const cleared = await setUserEnabled(created.id, null);
-    expect(cleared!.userEnabled).toBeNull();
-
-    const afterPass = await upsertDeclaredSchedule(
-      SOURCE_KEY,
-      makeDefinition({ enabled: false }),
-    );
-    expect(afterPass.enabled).toBe(false);
-  });
-
   test("setUserEnabled on an imperative row behaves like the existing toggle", async () => {
     const imperative = await createSchedule({
       name: "Mine",
@@ -1750,10 +1732,6 @@ describe("declared schedules", () => {
     expect(on!.enabled).toBe(true);
     expect(on!.userEnabled).toBeNull();
     expect(on!.nextRunAt).toBeGreaterThan(Date.now());
-
-    await expect(setUserEnabled(imperative.id, null)).rejects.toThrow(
-      UserError,
-    );
   });
 
   test("upsert rewrites a moved script path without touching timing", async () => {
@@ -1817,6 +1795,20 @@ describe("declared schedules", () => {
 
     expect(result!.enabled).toBe(true);
     expect(result!.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  test("enabling a schedule of a disabled plugin records the override without re-arming", async () => {
+    const created = await upsertDeclaredSchedule(SOURCE_KEY, makeDefinition());
+    await setUserEnabled(created.id, false);
+    // The declaration file is still on disk; the `.disabled` sentinel alone
+    // must keep the enable probe from re-arming the row before the next
+    // reconcile pass.
+    writeFileSync(join(examplePluginDir(), ".disabled"), "");
+
+    const result = await setUserEnabled(created.id, true);
+
+    expect(result!.userEnabled).toBe(true);
+    expect(result!.enabled).toBe(false);
   });
 
   test("updateSchedule refuses sourced rows", async () => {

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -461,9 +461,14 @@ export async function loadExternalPlugin(
  * Exported so the mtime cache can discover plugin identity without going
  * through the full `buildExternalPlugin` path. The identity mirrors
  * {@link buildPluginFromDir}: the directory name, not `package.json` `name`.
+ *
+ * `quiet` suppresses the failure logs, for callers that poll on a timer and
+ * surface the failure through their own channel (e.g. the schedule
+ * reconciler's per-day deduped notification).
  */
 export async function parsePluginManifest(
   pluginDir: string,
+  opts: { quiet?: boolean } = {},
 ): Promise<
   Pick<PluginManifest, "name" | "version" | "credentialKeyPatterns"> | undefined
 > {
@@ -473,18 +478,22 @@ export async function parsePluginManifest(
     rawPkg = JSON.parse(await readFile(pkgPath, "utf8"));
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    log.error(
-      { err, pluginDir },
-      `package.json at ${pluginDir} could not be read or parsed: ${reason}`,
-    );
+    if (!opts.quiet) {
+      log.error(
+        { err, pluginDir },
+        `package.json at ${pluginDir} could not be read or parsed: ${reason}`,
+      );
+    }
     return undefined;
   }
   const parsed = PluginPackageJsonSchema.safeParse(rawPkg);
   if (!parsed.success) {
-    log.error(
-      { err: parsed.error, pluginDir },
-      `package.json at ${pluginDir} failed schema validation: ${parsed.error.message}`,
-    );
+    if (!opts.quiet) {
+      log.error(
+        { err: parsed.error, pluginDir },
+        `package.json at ${pluginDir} failed schema validation: ${parsed.error.message}`,
+      );
+    }
     return undefined;
   }
   const pkg: PluginPackageJson = parsed.data;

--- a/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
@@ -148,10 +148,10 @@ describe("parsePluginScheduleDeclarations", () => {
     expect(decl.scriptInvocation).toBeNull();
   });
 
-  test("parses a directory declaration with index.sh as an sh path invocation", () => {
+  test("parses a directory declaration with index.sh, honoring a direct shebang", () => {
     const pluginDir = makePlugin({
       "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
-      "backup/index.sh": "#!/bin/sh\necho backup\n",
+      "backup/index.sh": "#!/bin/bash\necho backup\n",
     });
     const { declarations, errors } = parsePluginScheduleDeclarations(
       pluginDir,
@@ -164,9 +164,41 @@ describe("parsePluginScheduleDeclarations", () => {
     // Explicit interpreter: platform installs do not restore exec bits, so a
     // bare path invocation would fail with exit 126.
     expect(decl.scriptInvocation).toBe(
-      `sh '${join(pluginDir, "schedules", "backup", "index.sh")}'`,
+      `'/bin/bash' '${join(pluginDir, "schedules", "backup", "index.sh")}'`,
     );
     expect(decl.scriptInvocation).not.toContain("echo backup");
+  });
+
+  test("honors an env-form shebang: interpreter plus one argument", () => {
+    const pluginDir = makePlugin({
+      "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+      "backup/index.sh": "#!/usr/bin/env bash\necho backup\n",
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    expect(declarations[0]!.scriptInvocation).toBe(
+      `'/usr/bin/env' 'bash' '${join(pluginDir, "schedules", "backup", "index.sh")}'`,
+    );
+  });
+
+  test("a shebang-less index.sh is parsed by sh, still via an explicit interpreter", () => {
+    const pluginDir = makePlugin({
+      "backup/config.json": JSON.stringify({ expression: "0 3 * * *" }),
+      "backup/index.sh": "echo backup\n",
+    });
+    const { declarations, errors } = parsePluginScheduleDeclarations(
+      pluginDir,
+      "p",
+    );
+    expect(errors).toEqual([]);
+    // The exec-bit rationale holds for every form: the invocation never
+    // executes the script path directly.
+    expect(declarations[0]!.scriptInvocation).toBe(
+      `sh '${join(pluginDir, "schedules", "backup", "index.sh")}'`,
+    );
   });
 
   describe("fail-closed cases", () => {
@@ -328,7 +360,7 @@ describe("parsePluginScheduleDeclarations", () => {
     test("single-fire RRULE (COUNT=1) errors; larger counts stay valid", () => {
       const single = makePlugin({
         "once.md":
-          '---\nexpression: "DTSTART:20260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=1"\nexpression_syntax: rrule\n---\nHi.',
+          '---\nexpression: "DTSTART:21260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=1"\nexpression_syntax: rrule\n---\nHi.',
       });
       const parsed = parsePluginScheduleDeclarations(single, "p");
       expect(parsed.declarations).toEqual([]);
@@ -336,9 +368,22 @@ describe("parsePluginScheduleDeclarations", () => {
 
       const thrice = makePlugin({
         "thrice.md":
-          '---\nexpression: "DTSTART:20260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=3"\nexpression_syntax: rrule\n---\nHi.',
+          '---\nexpression: "DTSTART:21260101T090000Z\\nRRULE:FREQ=DAILY;COUNT=3"\nexpression_syntax: rrule\n---\nHi.',
       });
       expect(parsePluginScheduleDeclarations(thrice, "p").errors).toEqual([]);
+    });
+
+    test("an RRULE whose UNTIL is already past errors", () => {
+      const pluginDir = makePlugin({
+        "expired.md":
+          '---\nexpression: "DTSTART:20200101T090000Z\\nRRULE:FREQ=DAILY;UNTIL=20200201T000000Z"\nexpression_syntax: rrule\n---\nHi.',
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations).toEqual([]);
+      expect(errors[0]!.reason).toContain("no upcoming occurrences");
     });
 
     test("empty prompt body errors", () => {

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -18,6 +18,9 @@ mock.module("../../background-wake/publisher.js", () => ({
 
 const emittedSignals: Array<Record<string, unknown>> = [];
 
+/** When set, merged into the next emit results (e.g. a failure reason). */
+let emitResultOverride: Record<string, unknown> | null = null;
+
 mock.module("../../notifications/emit-signal.js", () => ({
   emitNotificationSignal: async (params: Record<string, unknown>) => {
     emittedSignals.push(params);
@@ -27,6 +30,7 @@ mock.module("../../notifications/emit-signal.js", () => ({
       dispatched: true,
       reason: "test",
       deliveryResults: [],
+      ...(emitResultOverride ?? {}),
     };
   },
 }));
@@ -100,6 +104,7 @@ describe("reconcilePluginSchedules", () => {
     getDb().run("DELETE FROM cron_jobs");
     rmSync(pluginsDir, { recursive: true, force: true });
     emittedSignals.length = 0;
+    emitResultOverride = null;
     resetDefinitionErrorEmitGuardForTests();
   });
 
@@ -254,6 +259,35 @@ describe("reconcilePluginSchedules", () => {
     expect(row.userEnabled).toBe(false);
   });
 
+  test("an upgrade that flips a disarmed declaration to enabled arms it and notifies", async () => {
+    writePlugin("news", {
+      "digest.md": [
+        "---",
+        'expression: "* * * * *"',
+        "enabled: false",
+        "---",
+        "",
+        "Summarize the day.",
+        "",
+      ].join("\n"),
+    });
+    await reconcilePluginSchedules();
+    expect(listDeclaredSchedules()[0]!.enabled).toBe(false);
+    expect(emittedSignals).toHaveLength(0);
+
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+
+    const armed = listDeclaredSchedules()[0]!;
+    expect(armed.enabled).toBe(true);
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("schedule.declared");
+    expect(signal.dedupeKey).toBe(
+      `schedule-declared:${DIGEST_KEY}:${armed.definitionHash}`,
+    );
+  });
+
   test("a user override enables a declaration shipped disabled", async () => {
     writePlugin("news", {
       "digest.md": [
@@ -371,7 +405,7 @@ describe("reconcilePluginSchedules", () => {
     expect(rows[0]!.sourceKey).toBe(DIGEST_KEY);
   });
 
-  test("a manifest-rejected plugin contributes nothing and its schedules disarm", async () => {
+  test("a manifest-rejected plugin disarms its schedules and surfaces the failure", async () => {
     const dir = writePlugin("news", {
       "digest.md": digestMd("Summarize the day."),
     });
@@ -388,7 +422,18 @@ describe("reconcilePluginSchedules", () => {
     const disarmed = listDeclaredSchedules()[0]!;
     expect(disarmed.id).toBe(created.id);
     expect(disarmed.enabled).toBe(false);
-    expect(emittedSignals).toHaveLength(0);
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("schedule.definition_error");
+    const payload = signal.contextPayload as Record<string, unknown>;
+    expect(payload.pluginName).toBe("news");
+    expect(payload.scheduleName).toBe("digest");
+    expect(payload.sourceKey).toBe(DIGEST_KEY);
+    expect(payload.reason).toContain("package.json");
+
+    // The failure surfaces once per day, not per pass.
+    await reconcilePluginSchedules();
+    expect(emittedSignals).toHaveLength(1);
 
     // Restoring a valid manifest re-arms the row on the next pass.
     writeFileSync(
@@ -399,10 +444,24 @@ describe("reconcilePluginSchedules", () => {
     expect(listDeclaredSchedules()[0]!.enabled).toBe(true);
   });
 
-  test("a plugin with an unparseable package.json creates no rows", async () => {
+  test("a plugin with an unparseable package.json creates no rows and surfaces the failure", async () => {
     const dir = writePlugin("news", {
       "digest.md": digestMd("Summarize the day."),
     });
+    writeFileSync(join(dir, "package.json"), "{not json");
+
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()).toHaveLength(0);
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "schedule.definition_error",
+    );
+  });
+
+  test("a broken manifest on a plugin without schedules stays silent", async () => {
+    const dir = join(pluginsDir, "quiet");
+    mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "package.json"), "{not json");
 
     await reconcilePluginSchedules();
@@ -467,6 +526,38 @@ describe("reconcilePluginSchedules", () => {
     expect(emittedSignals[0]!.sourceEventName).toBe(
       "schedule.definition_error",
     );
+
+    await reconcilePluginSchedules();
+    await reconcilePluginSchedules();
+
+    expect(emittedSignals).toHaveLength(1);
+  });
+
+  test("a pipeline-failed error emit does not latch the day guard; the next pass retries", async () => {
+    writePlugin("news", { "digest.md": "Just a body, no config." });
+    emitResultOverride = {
+      dispatched: false,
+      reason: "Signal pipeline failed: transient outage",
+    };
+
+    await reconcilePluginSchedules();
+    expect(emittedSignals).toHaveLength(1);
+
+    emitResultOverride = null;
+    await reconcilePluginSchedules();
+    expect(emittedSignals).toHaveLength(2);
+
+    // The completed retry latched the guard, so further passes stay quiet.
+    await reconcilePluginSchedules();
+    expect(emittedSignals).toHaveLength(2);
+  });
+
+  test("a suppressed error emit still latches the day guard", async () => {
+    writePlugin("news", { "digest.md": "Just a body, no config." });
+    emitResultOverride = {
+      dispatched: false,
+      reason: "Signal blocked by deterministic checks: quiet hours",
+    };
 
     await reconcilePluginSchedules();
     await reconcilePluginSchedules();

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -6,7 +6,8 @@
  *   markdown body (the prompt message). Mode is `execute`.
  * - Directory: `<name>/` containing `config.json` (the schedule config) plus
  *   exactly one entrypoint, `index.md` (mode `execute`, body is the prompt)
- *   or `index.sh` (mode `script`, invoked via `sh` by absolute path).
+ *   or `index.sh` (mode `script`, invoked by absolute path via its shebang
+ *   interpreter, or `sh` when it has none).
  *
  * Ambiguity fails closed, never resolves by precedence: a basename declared
  * in both forms, a directory with zero or multiple entrypoints, or an
@@ -22,17 +23,20 @@
  */
 
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { z } from "zod";
 
+import { isPluginDisabled } from "../plugins/disabled-state.js";
 import { walkPluginTree } from "../plugins/plugin-tree-walk.js";
 import {
   FRONTMATTER_REGEX,
   parseFrontmatterFields,
 } from "../skills/frontmatter.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
 import {
+  computeNextRunAt,
   isSingleFireRRule,
   isValidScheduleExpression,
   validateRruleSetLines,
@@ -66,8 +70,9 @@ export interface ScheduleDeclaration {
   /** Prompt body for `execute` mode; null for `script` mode. */
   message: string | null;
   /**
-   * Shell invocation of the declaration's `index.sh`, as `sh '<absolute
-   * path>'` rather than the file's content. The explicit interpreter keeps
+   * Shell invocation of the declaration's `index.sh`: its shebang
+   * interpreter (or `sh` when it has none) followed by the quoted absolute
+   * path, rather than the file's content. The explicit interpreter keeps
    * the entrypoint runnable when an install path drops its exec bit. Null
    * for `execute` mode.
    */
@@ -98,6 +103,31 @@ function pluginScheduleSourceKey(
   scheduleName: string,
 ): string {
   return `plugin:${pluginName}/${scheduleName}`;
+}
+
+/**
+ * True when the declaration behind `sourceKey`
+ * (`plugin:<pluginName>/<scheduleName>`) is present on disk in either
+ * declaration form, a flat `<name>.md` or a `<name>/` directory, and the
+ * plugin is not disabled. The `.disabled` sentinel counts as absent: a
+ * disabled plugin's schedules must not be re-armable from a stale row even
+ * though its files are still on disk. A cheap existence probe only; parsing
+ * and validity are the reconciler's business.
+ */
+export function declarationExistsOnDisk(sourceKey: string): boolean {
+  const match = /^plugin:([^/]+)\/(.+)$/.exec(sourceKey);
+  if (!match) {
+    return false;
+  }
+  const [, pluginName, scheduleName] = match;
+  if (isPluginDisabled(pluginName!)) {
+    return false;
+  }
+  const schedulesDir = join(getWorkspacePluginsDir(), pluginName!, "schedules");
+  return (
+    existsSync(join(schedulesDir, `${scheduleName!}.md`)) ||
+    existsSync(join(schedulesDir, scheduleName!))
+  );
 }
 
 const scheduleConfigSchema = z
@@ -168,6 +198,24 @@ function parseScheduleConfig(
       }`,
     };
   }
+  if (resolved.syntax === "rrule") {
+    // A syntactically valid recurrence can still be exhausted (UNTIL in the
+    // past, COUNT consumed). Such a schedule has no firing left, so it fails
+    // closed here as a declaration error rather than surviving to throw on
+    // every reconcile upsert.
+    try {
+      computeNextRunAt({
+        syntax: resolved.syntax,
+        expression: resolved.expression,
+        timezone: fields.timezone ?? null,
+      });
+    } catch {
+      return {
+        error:
+          "expression has no upcoming occurrences: the recurrence has already ended",
+      };
+    }
+  }
 
   return {
     config: {
@@ -221,6 +269,30 @@ function collectDeclarationFiles(
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Shell invocation for a declaration's `index.sh`. The script always runs
+ * through an explicit interpreter rather than being executed directly, which
+ * keeps the entrypoint runnable when an install path drops its exec bit. A
+ * `#!` first line names that interpreter plus at most one argument (the
+ * kernel's own shebang contract, covering both `#!/bin/bash` and
+ * `#!/usr/bin/env bash`); a script without one is parsed by `sh`.
+ */
+function buildScriptInvocation(scriptPath: string, content: string): string {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? "";
+  if (firstLine.startsWith("#!")) {
+    const rest = firstLine.slice(2).trim();
+    const spaceIdx = rest.search(/\s/);
+    const interpreter = spaceIdx === -1 ? rest : rest.slice(0, spaceIdx);
+    const argument = spaceIdx === -1 ? "" : rest.slice(spaceIdx).trim();
+    if (interpreter) {
+      return [interpreter, ...(argument ? [argument] : []), scriptPath]
+        .map(shellQuote)
+        .join(" ");
+    }
+  }
+  return `sh ${shellQuote(scriptPath)}`;
 }
 
 const SUPPORTED_ENTRYPOINTS = ["index.md", "index.sh"];
@@ -330,7 +402,11 @@ function parseDirectoryDeclaration(
     }
     mode = "execute";
   } else {
-    scriptInvocation = `sh ${shellQuote(join(dirPath, "index.sh"))}`;
+    const scriptPath = join(dirPath, "index.sh");
+    scriptInvocation = buildScriptInvocation(
+      scriptPath,
+      readFileSync(scriptPath, "utf8"),
+    );
     mode = "script";
   }
 

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -18,6 +18,9 @@
  * plugin source reconcile.
  */
 
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import { getDbMigrationReadiness } from "../daemon/daemon-readiness.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { AttentionHints } from "../notifications/signal.js";
@@ -80,7 +83,8 @@ async function runReconcilePass(): Promise<void> {
     return;
   }
 
-  const { desired, errors } = await collectDesiredDeclarations();
+  const { desired, errors, manifestFailures } =
+    await collectDesiredDeclarations();
 
   const existingByKey = new Map<string, ScheduleJob>();
   for (const row of listDeclaredSchedules()) {
@@ -92,10 +96,14 @@ async function runReconcilePass(): Promise<void> {
   for (const [sourceKey, { pluginName, declaration }] of desired) {
     const row = existingByKey.get(sourceKey);
     const definition = toDefinition(declaration);
-    const changesArmedRow =
-      row !== undefined &&
-      row.enabled &&
-      row.definitionHash !== definition.definitionHash;
+    const definitionChanged =
+      row !== undefined && row.definitionHash !== definition.definitionHash;
+    const changesArmedRow = definitionChanged && row.enabled;
+    // A definition change can also arm a row that was disarmed (e.g. an
+    // upgrade flipping the declared `enabled` from false to true). That
+    // transition gets the arrival notification below; a plain re-enable or
+    // reinstall re-link (hash unchanged) stays quiet.
+    const armsDisarmedRow = definitionChanged && !row.enabled;
     let applied: ScheduleJob;
     try {
       applied = await upsertDeclaredSchedule(sourceKey, definition);
@@ -109,13 +117,14 @@ async function runReconcilePass(): Promise<void> {
     if (changesArmedRow) {
       emitDefinitionChanged(pluginName, declaration);
     }
-    // A brand-new armed row must never appear silently: a daemon-route
+    // A row arming without consent must never be silent: a daemon-route
     // install/upgrade has no interactive consent prompt, and even a CLI
     // upgrade only confirms what it staged. The arrival notification is the
     // consent surface for those paths; a CLI install that already prompted
     // gets one redundant, hash-deduped notification. A re-linked row (its
-    // `source_key` already existed, e.g. reinstall or re-enable) is not new.
-    if (row === undefined && applied.enabled) {
+    // `source_key` already existed, e.g. reinstall or re-enable) is not new
+    // unless its definition change is what armed it.
+    if ((row === undefined || armsDisarmedRow) && applied.enabled) {
       emitScheduleDeclared(pluginName, declaration);
     }
   }
@@ -145,7 +154,10 @@ async function runReconcilePass(): Promise<void> {
     }
   }
 
-  for (const error of errors) {
+  // Manifest failures ride the same emit path as declaration errors but are
+  // kept out of `erroredKeys` above: an errored key preserves its last-good
+  // row, while a manifest failure must let the disarm loop pause the rows.
+  for (const error of [...errors, ...manifestFailures]) {
     emitDefinitionError(error);
   }
 }
@@ -155,35 +167,58 @@ async function runReconcilePass(): Promise<void> {
  * as the plugin source collector) and gather their schedule declarations.
  * Identity = the directory basename, mirroring `parsePluginManifest`.
  *
- * Disabled plugins are skipped entirely, so their declarations fall out of
- * the desired set and disarm. A plugin whose manifest fails
- * `parsePluginManifest` (unreadable or schema-invalid `package.json`) is
- * treated the same way: the runtime loader refuses to bring such a plugin up,
- * so its schedules must not stay armed either. The parse failure is logged
- * with attribution by `parsePluginManifest` itself.
+ * Disabled plugins and plugins without a `schedules/` directory are skipped
+ * entirely; in particular, only schedule-declaring plugins pay the manifest
+ * parse each pass. A schedule-declaring plugin whose manifest fails
+ * `parsePluginManifest` (unreadable or schema-invalid `package.json`) also
+ * contributes nothing to the desired set: the runtime loader refuses to
+ * bring such a plugin up, so its schedules must not stay armed either. Each
+ * of its declared schedules comes back in `manifestFailures` so the pause is
+ * surfaced with the same visibility as a bad declaration.
  */
 async function collectDesiredDeclarations(): Promise<{
   desired: Map<string, DesiredEntry>;
   errors: DeclarationError[];
+  manifestFailures: DeclarationError[];
 }> {
   const desired = new Map<string, DesiredEntry>();
   const errors: DeclarationError[] = [];
+  const manifestFailures: DeclarationError[] = [];
 
   for (const { name, dir } of listInstalledPluginDirs()) {
     if (isPluginDisabled(name)) {
       continue;
     }
-    if ((await parsePluginManifest(dir)) === undefined) {
+    if (!existsSync(join(dir, "schedules"))) {
       continue;
     }
     const parsed = parsePluginScheduleDeclarations(dir, name);
+    if ((await parsePluginManifest(dir, { quiet: true })) === undefined) {
+      const reason =
+        "the plugin's package.json could not be read or validated, so its schedules are paused";
+      for (const declared of [
+        ...parsed.declarations.map((d) => ({
+          scheduleName: d.name,
+          sourceKey: d.sourceKey,
+        })),
+        ...parsed.errors,
+      ]) {
+        manifestFailures.push({
+          pluginName: name,
+          scheduleName: declared.scheduleName,
+          sourceKey: declared.sourceKey,
+          reason,
+        });
+      }
+      continue;
+    }
     for (const declaration of parsed.declarations) {
       desired.set(declaration.sourceKey, { pluginName: name, declaration });
     }
     errors.push(...parsed.errors);
   }
 
-  return { desired, errors };
+  return { desired, errors, manifestFailures };
 }
 
 function toDefinition(
@@ -220,32 +255,45 @@ const DEFINITION_NOTIFICATION_HINTS: AttentionHints = {
   visibleInSourceNow: false,
 };
 
-function emitDefinitionSignal(
+/**
+ * Emit one definition-lifecycle signal. Resolves `true` when the pipeline
+ * reached a verdict (dispatched, deduplicated, or suppressed) and `false`
+ * when it failed outright, so a caller latching a dedupe guard can retry a
+ * transient failure on a later pass.
+ */
+async function emitDefinitionSignal(
   sourceEventName: string,
   sourceKey: string,
   dedupeKey: string,
   contextPayload: Record<string, unknown>,
-): void {
-  emitNotificationSignal({
-    sourceChannel: "scheduler",
-    sourceContextId: sourceKey,
-    sourceEventName,
-    dedupeKey,
-    contextPayload,
-    attentionHints: DEFINITION_NOTIFICATION_HINTS,
-  }).catch((err) => {
+): Promise<boolean> {
+  try {
+    const result = await emitNotificationSignal({
+      sourceChannel: "scheduler",
+      sourceContextId: sourceKey,
+      sourceEventName,
+      dedupeKey,
+      contextPayload,
+      attentionHints: DEFINITION_NOTIFICATION_HINTS,
+    });
+    // emitNotificationSignal resolves (never rejects) with `dispatched:
+    // false` and a "Signal pipeline failed" reason on a pipeline error;
+    // every other outcome, including dedupe and suppression, is a verdict.
+    return !result.reason.startsWith("Signal pipeline failed");
+  } catch (err) {
     log.warn(
       { err, sourceKey, sourceEventName },
       "Failed to emit schedule definition notification",
     );
-  });
+    return false;
+  }
 }
 
 /**
- * UTC day of the last definition-error emit per `sourceKey`. A persistently
- * broken declaration re-surfaces on every pass (60s sweep); the downstream
- * daily dedupe key would drop the repeats, but this guard skips the emit call
- * entirely so steady-state passes do no notification work.
+ * UTC day of the last completed definition-error emit per `sourceKey`. A
+ * persistently broken declaration re-surfaces on every pass (60s sweep); the
+ * downstream daily dedupe key would drop the repeats, but this guard skips
+ * the emit call entirely so steady-state passes do no notification work.
  */
 const definitionErrorEmittedDay = new Map<string, string>();
 
@@ -255,16 +303,18 @@ export function resetDefinitionErrorEmitGuardForTests(): void {
 }
 
 /**
- * Surface a malformed declaration. Deduped per schedule per UTC day so a
- * broken file doesn't spam on every pass.
+ * Surface a malformed declaration (or a manifest failure pausing one).
+ * Deduped per schedule per UTC day so a broken file doesn't spam on every
+ * pass. The day guard latches only after the emit resolves with a pipeline
+ * verdict; a transient pipeline failure is retried on the next pass instead
+ * of being silenced for the rest of the day.
  */
 function emitDefinitionError(error: DeclarationError): void {
   const day = new Date().toISOString().slice(0, 10);
   if (definitionErrorEmittedDay.get(error.sourceKey) === day) {
     return;
   }
-  definitionErrorEmittedDay.set(error.sourceKey, day);
-  emitDefinitionSignal(
+  void emitDefinitionSignal(
     "schedule.definition_error",
     error.sourceKey,
     `schedule-definition-error:${error.sourceKey}:${day}`,
@@ -274,7 +324,11 @@ function emitDefinitionError(error: DeclarationError): void {
       sourceKey: error.sourceKey,
       reason: error.reason,
     },
-  );
+  ).then((completed) => {
+    if (completed) {
+      definitionErrorEmittedDay.set(error.sourceKey, day);
+    }
+  });
 }
 
 /**
@@ -286,7 +340,7 @@ function emitDefinitionChanged(
   pluginName: string,
   declaration: ScheduleDeclaration,
 ): void {
-  emitDefinitionSignal(
+  void emitDefinitionSignal(
     "schedule.definition_changed",
     declaration.sourceKey,
     `schedule-definition-changed:${declaration.sourceKey}:${declaration.definitionHash}`,
@@ -299,16 +353,16 @@ function emitDefinitionChanged(
 }
 
 /**
- * Surface a declared schedule arming for the first time (its row was created
- * by this pass). Deduped by definition hash, so the CLI-install case (which
- * already prompted for consent) collapses to a single notification and
- * concurrent triggers emit once.
+ * Surface a declared schedule arming (its row was created by this pass, or a
+ * definition change armed a disarmed row). Deduped by definition hash, so
+ * the CLI-install case (which already prompted for consent) collapses to a
+ * single notification and concurrent triggers emit once.
  */
 function emitScheduleDeclared(
   pluginName: string,
   declaration: ScheduleDeclaration,
 ): void {
-  emitDefinitionSignal(
+  void emitDefinitionSignal(
     "schedule.declared",
     declaration.sourceKey,
     `schedule-declared:${declaration.sourceKey}:${declaration.definitionHash}`,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,6 +1,3 @@
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-
 import { Cron } from "croner";
 import {
   and,
@@ -24,7 +21,6 @@ import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspacePluginsDir } from "../util/platform.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
 import {
   hasOwnerDeferProvenance,
@@ -32,6 +28,7 @@ import {
   LEGACY_DEFER_CREATED_BY,
   OWNER_DEFER_CREATED_BY,
 } from "./defer-provenance.js";
+import { declarationExistsOnDisk } from "./plugin-schedule-declarations.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -967,37 +964,17 @@ export async function disarmDeclaredSchedule(id: string): Promise<void> {
 }
 
 /**
- * True when the plugin declaration behind `sourceKey` is still present on
- * disk, in either declaration form: a flat `<name>.md` or a `<name>/`
- * directory under the plugin's schedules/ dir. A cheap existence probe only;
- * parsing and validity are the reconciler's business.
- */
-function declaredScheduleSourceExists(sourceKey: string): boolean {
-  const match = /^plugin:([^/]+)\/(.+)$/.exec(sourceKey);
-  if (!match) {
-    return false;
-  }
-  const schedulesDir = join(getWorkspacePluginsDir(), match[1]!, "schedules");
-  return (
-    existsSync(join(schedulesDir, `${match[2]!}.md`)) ||
-    existsSync(join(schedulesDir, match[2]!))
-  );
-}
-
-/**
  * The user's side of the enabled toggle.
  *
  * On an imperative row this is exactly the existing toggle
  * (`updateSchedule(id, { enabled })`) and `user_enabled` stays null. On a
- * plugin-sourced row it records the override in `user_enabled` and applies a
- * boolean to the effective `enabled` on the spot; null clears the override,
- * and the next reconcile pass restores the declaration's own value, which the
- * store does not persist separately. Engine-latched rows record the override
- * without being re-armed.
+ * plugin-sourced row it records the override in `user_enabled` and applies
+ * it to the effective `enabled` on the spot. Engine-latched rows record the
+ * override without being re-armed.
  */
 export async function setUserEnabled(
   id: string,
-  value: boolean | null,
+  value: boolean,
 ): Promise<ScheduleJob | null> {
   const db = getDb();
   const existing = db
@@ -1009,11 +986,6 @@ export async function setUserEnabled(
     return null;
   }
   if (existing.sourceKey == null) {
-    if (value == null) {
-      throw new UserError(
-        "Only plugin-managed schedules support clearing the enabled override",
-      );
-    }
     return updateSchedule(id, { enabled: value });
   }
 
@@ -1021,18 +993,14 @@ export async function setUserEnabled(
     userEnabled: value,
     updatedAt: Date.now(),
   };
-  if (
-    value != null &&
-    value !== existing.enabled &&
-    !isEngineLatched(existing)
-  ) {
+  if (value !== existing.enabled && !isEngineLatched(existing)) {
     // Enabling a row whose declaration has left the disk (plugin
-    // uninstalled, schedule file removed) would let it fire an orphaned run
-    // before the next reconcile pass disarms it again. The reconciler is the
-    // authority on the declaration set; this existence probe only closes
-    // that fire-before-next-sweep window. The override itself is still
-    // recorded, so it applies if the declaration returns.
-    if (value && !declaredScheduleSourceExists(existing.sourceKey)) {
+    // uninstalled or disabled, schedule file removed) would let it fire an
+    // orphaned run before the next reconcile pass disarms it again. The
+    // reconciler is the authority on the declaration set; this existence
+    // probe only closes that fire-before-next-sweep window. The override
+    // itself is still recorded, so it applies if the declaration returns.
+    if (value && !declarationExistsOnDisk(existing.sourceKey)) {
       logger.info(
         { scheduleId: id, sourceKey: existing.sourceKey },
         "Enable override recorded without re-arming: declaration missing on disk",


### PR DESCRIPTION
## Summary
Round-2 review fixes for plugin-schedules-v1.md: shebang-honoring script invocation, disarmed-to-armed upgrade transitions now notify, manifest gate scoped and deduped with user-facing surfacing, expired RRULEs fail as declaration errors, emit guard latches after resolve, on-disk probe moved to the declarations module and aware of disabled plugins, setUserEnabled narrowed to boolean.