### PR TITLE
fix(cli,notifications): honest upgrade help, human cadence, list-tool attribution, shared ANSI util, sanitized templates

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -1964,6 +1964,31 @@ describe("schedule tools on plugin-sourced schedules", () => {
     expect(result.content).toContain("managed by a plugin");
     expect(getSchedule(job.id)).not.toBeNull();
   });
+
+  test("schedule_list marks plugin-managed rows in list and detail modes", async () => {
+    const job = await createSourcedSchedule();
+
+    const list = await executeScheduleList({}, ctx);
+    expect(list.isError).toBe(false);
+    expect(list.content).toContain("(managed by plugin example)");
+
+    const detail = await executeScheduleList({ job_id: job.id }, ctx);
+    expect(detail.isError).toBe(false);
+    expect(detail.content).toContain("Managed by plugin: example");
+    expect(detail.content).toContain("only enabled can be changed");
+  });
+
+  test("schedule_list carries no plugin marker on imperative rows", async () => {
+    const created = await executeScheduleCreate(
+      { name: "imperative", expression: "0 9 * * *", message: "Do the thing." },
+      ctx,
+    );
+    expect(created.isError).toBe(false);
+
+    const list = await executeScheduleList({}, ctx);
+    expect(list.isError).toBe(false);
+    expect(list.content).not.toContain("managed by plugin");
+  });
 });
 
 // ── model-input schema validation (LUM-2853) ────────────────────────

--- a/assistant/src/acp/failure-error.ts
+++ b/assistant/src/acp/failure-error.ts
@@ -6,15 +6,13 @@
  * `{"error":{"message":"..."}}`. This picks the most specific signal available:
  * a structured stderr error, else the last stderr line, else the ack message.
  *
- * Pure and dependency-free.
+ * Pure; the only dependency is the shared escape-sequence strip.
  */
 
-// CSI escape sequences (colour codes, cursor moves) that adapters interleave
-// with their log lines: ESC `[`, parameter/intermediate bytes, then final byte.
-const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+import { stripAnsiSequences } from "../util/ansi.js";
 
 export function deriveFailureError(ackMessage: string, stderr: string): string {
-  const clean = stderr.replace(ANSI_ESCAPE, "").trim();
+  const clean = stripAnsiSequences(stderr).trim();
 
   // Most precise: a structured adapter error — prefer it over the ack.
   const jsonMessage = lastJsonErrorMessage(clean);

--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -281,7 +281,8 @@ describe("plugins install - declared-schedules consent", () => {
 
     expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
     expect(r.stdout).toContain("daily-report");
-    expect(r.stdout).toContain("0 9 * * *");
+    // The cadence is humanized, with the raw expression as ground truth.
+    expect(r.stdout).toContain("Every day at 9:00 AM (0 9 * * *)");
     expect(r.stdout).toContain("(execute)");
     expect(r.stdout).toContain("cleanup");
     expect(r.stdout).toContain("0 0 * * 0");
@@ -493,11 +494,92 @@ describe("plugins upgrade - declared-schedules consent (local fallback)", () => 
     expect(r.stdout).toContain('Upgraded "example"');
     expect(r.exitCode).toBe(0);
   });
+
+  test("a daemon-routed upgrade prints the declared schedules, marking new ones", async () => {
+    // Pre-upgrade install: one declared schedule under the workspace plugins
+    // dir. Post-upgrade tree (the daemon result's target): the same schedule
+    // plus a newly declared one.
+    const workspaceDir = mkdtempSync(join(tmpdir(), "plugins-cmd-ws-"));
+    const upgradedDir = mkdtempSync(join(tmpdir(), "plugins-cmd-upgraded-"));
+    const savedWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+    try {
+      const installedDir = join(workspaceDir, "plugins", "example");
+      stageFlatSchedule("daily-report", "0 9 * * *")(installedDir);
+      stageFlatSchedule("daily-report", "0 9 * * *")(upgradedDir);
+      stageFlatSchedule("weekly-new", "0 8 * * 1")(upgradedDir);
+      ipcResults = [
+        {
+          ok: true,
+          result: { ...upgradedResult("example"), target: upgradedDir },
+        },
+      ];
+
+      const r = await runCommand(["plugins", "upgrade", "example"]);
+
+      expect(confirmCalls.length).toBe(0);
+      expect(r.stdout).toContain('Upgraded "example"');
+      expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
+      const dailyLine = r.stdout
+        .split("\n")
+        .find((line) => line.includes("daily-report"));
+      const weeklyLine = r.stdout
+        .split("\n")
+        .find((line) => line.includes("weekly-new"));
+      expect(dailyLine).toBeDefined();
+      expect(dailyLine).not.toContain("[new]");
+      expect(weeklyLine).toContain("[new]");
+      expect(r.stdout).toContain("New schedules run automatically");
+      expect(r.exitCode).toBe(0);
+    } finally {
+      if (savedWorkspaceDir === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = savedWorkspaceDir;
+      }
+      rmSync(workspaceDir, { recursive: true, force: true });
+      rmSync(upgradedDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a daemon-routed dry run prints no schedule listing", async () => {
+    const upgradedDir = mkdtempSync(join(tmpdir(), "plugins-cmd-dry-"));
+    try {
+      stageFlatSchedule("daily-report", "0 9 * * *")(upgradedDir);
+      ipcResults = [
+        {
+          ok: true,
+          result: {
+            ...upgradedResult("example"),
+            outcome: "would-upgrade",
+            dryRun: true,
+            target: upgradedDir,
+          },
+        },
+      ];
+
+      const r = await runCommand([
+        "plugins",
+        "upgrade",
+        "example",
+        "--dry-run",
+      ]);
+
+      expect(r.stdout).toContain("would upgrade");
+      expect(r.stdout).not.toContain("declares");
+      expect(r.exitCode).toBe(0);
+    } finally {
+      rmSync(upgradedDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("plugins inspect - schedules surface", () => {
-  test("renders declared schedules with cadence and mode", async () => {
-    inspectResult = {
+  /** Minimal installed-plugin inspection carrying the given surfaces block. */
+  function inspectionWithSurfaces(
+    surfaces: PluginInspection["surfaces"],
+  ): PluginInspection {
+    return {
       name: "example",
       installed: true,
       status: "not-in-marketplace",
@@ -514,22 +596,53 @@ describe("plugins inspect - schedules surface", () => {
       },
       remote: null,
       remoteError: null,
-      surfaces: {
-        skills: [],
-        hooks: [],
-        tools: ["do_thing"],
-        schedules: [
-          { name: "daily-report", cadence: "0 9 * * *", mode: "execute" },
-          { name: "cleanup", cadence: "0 0 * * 0", mode: "script" },
-        ],
-      },
+      surfaces,
     };
+  }
+
+  test("renders declared schedules with cadence and mode", async () => {
+    inspectResult = inspectionWithSurfaces({
+      skills: [],
+      hooks: [],
+      tools: ["do_thing"],
+      schedules: [
+        { name: "daily-report", cadence: "0 9 * * *", mode: "execute" },
+        { name: "cleanup", cadence: "0 0 * * 0", mode: "script" },
+      ],
+    });
 
     const r = await runCommand(["plugins", "inspect", "example"]);
 
     expect(r.stdout).toContain("schedules");
-    expect(r.stdout).toContain("daily-report  0 9 * * *  (execute)");
-    expect(r.stdout).toContain("cleanup       0 0 * * 0  (script)");
+    // Cadences render humanized with the raw expression as ground truth.
+    expect(r.stdout).toContain(
+      "daily-report  Every day at 9:00 AM (0 9 * * *)",
+    );
+    expect(r.stdout).toContain("(execute)");
+    expect(r.stdout).toContain(
+      "cleanup       Every Sun at 12:00 AM (0 0 * * 0)",
+    );
+    expect(r.stdout).toContain("(script)");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("renders an RRULE cadence as the raw expression", async () => {
+    inspectResult = inspectionWithSurfaces({
+      skills: [],
+      hooks: [],
+      tools: [],
+      schedules: [
+        {
+          name: "weekly",
+          cadence: "RRULE:FREQ=WEEKLY;BYDAY=MO",
+          mode: "execute",
+        },
+      ],
+    });
+
+    const r = await runCommand(["plugins", "inspect", "example"]);
+
+    expect(r.stdout).toContain("weekly  RRULE:FREQ=WEEKLY;BYDAY=MO  (execute)");
     expect(r.exitCode).toBe(0);
   });
 });

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -257,7 +257,7 @@ $ assistant plugins publish --json`,
         {
           flags: "--force",
           description:
-            "Skip the confirmation prompt when the upgraded revision declares schedules",
+            "Skip the declared-schedules confirmation prompt of a local upgrade (the assistant-applied path never prompts)",
         },
       ],
       helpText: `
@@ -266,6 +266,15 @@ from a GitHub URL (untrusted) upgrades against its recorded source: it re-fetche
 whatever its recorded ref resolves to now — a pinned commit SHA is immutable (a
 no-op), while a branch/tag/HEAD advances as upstream does — and re-materializes
 it verbatim, with no curated adapter overlay.
+
+With the assistant running, the upgrade is applied by it immediately, with no
+confirmation prompt: a schedule the new revision declares is armed by the
+assistant and surfaced as a notification, and the upgrade output lists the
+revision's declared schedules with any new ones marked. Only when the
+assistant is unreachable does the upgrade run locally instead; that path
+stages the new revision first, and a revision that declares schedules lists
+them and asks for confirmation before going live (--force skips that prompt,
+as for install).
 
 Examples:
   $ assistant plugins upgrade example

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -7,10 +7,14 @@
  */
 
 import { createRequire } from "node:module";
+import { join } from "node:path";
 
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { stripAnsiAndControlChars } from "../../util/ansi.js";
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { truncate } from "../../util/truncate.js";
 import { yellow } from "../lib/cli-colors.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
@@ -427,7 +431,10 @@ export function registerPluginsCommand(program: Command): void {
               "plugin inspect",
             );
 
-            for (const line of formatInspection(inspection)) {
+            const describeCron = inspection.surfaces?.schedules.length
+              ? await loadCronDescriber()
+              : null;
+            for (const line of formatInspection(inspection, describeCron)) {
               console.log(line);
             }
           } catch (err) {
@@ -709,12 +716,14 @@ export function registerPluginsCommand(program: Command): void {
             // symmetric to how install/uninstall run their lifecycle there.
             // The daemon route is unattended (no staging prompt); a schedule
             // the upgraded revision adds is surfaced by the reconciler's
-            // `schedule.declared` notification instead.
+            // `schedule.declared` notification, and mirrored at the terminal
+            // by the declared-schedules listing printed after the upgrade.
             // Fall back to a local upgrade only when the daemon is unreachable
             // (a transport error carries no `statusCode`); an operator can still
             // upgrade while it's stopped, and the new code is picked up on the
             // daemon's next start. A daemon-side decision (not installed, not
             // upgradable, …) is surfaced rather than silently retried locally.
+            const preUpgradeScheduleNames = listInstalledScheduleNames(name);
             const daemon = await cliIpcCall<PluginUpgradeResult>(
               "plugins_upgrade",
               {
@@ -723,8 +732,10 @@ export function registerPluginsCommand(program: Command): void {
               },
             );
             let result: PluginUpgradeResult;
+            let upgradedViaDaemon = false;
             if (daemon.ok && daemon.result) {
               result = daemon.result;
+              upgradedViaDaemon = true;
             } else if (daemon.statusCode === undefined) {
               log.debug(
                 { name, error: daemon.error },
@@ -772,6 +783,14 @@ export function registerPluginsCommand(program: Command): void {
 
             for (const line of formatUpgrade(result)) {
               console.log(line);
+            }
+
+            if (upgradedViaDaemon && result.outcome === "upgraded") {
+              await printDeclaredSchedulesAfterUpgrade(
+                result.name,
+                result.target,
+                preUpgradeScheduleNames,
+              );
             }
           } catch (err) {
             if (err instanceof libs.installGitHub.PluginInstallDeclinedError) {
@@ -994,10 +1013,11 @@ async function confirmDeclaredSchedules(
   if (schedules.length === 0) {
     return true;
   }
+  const describeCron = await loadCronDescriber();
   console.log(
     `Plugin "${staged.name}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
   );
-  for (const row of formatScheduleRows(schedules)) {
+  for (const row of formatScheduleRows(schedules, describeCron)) {
     console.log(`  ${row}`);
   }
   console.log(
@@ -1032,31 +1052,61 @@ const MAX_SCHEDULE_CELL_WIDTH = 60;
 
 /**
  * Make a plugin-controlled declaration string safe to print next to the
- * install consent prompt: drop well-formed CSI/OSC escape sequences whole,
- * strip every remaining C0/C1 control character (which could rewrite or hide
- * the surrounding untrusted-source warning), and cap the cell width.
+ * install consent prompt: drop escape sequences and control characters
+ * (which could rewrite or hide the surrounding untrusted-source warning)
+ * and cap the cell width.
  */
 function sanitizeScheduleCell(value: string): string {
-  const stripped = value
-    .replace(/\u001b\[[0-9:;<=>?]*[ -\/]*[@-~]/g, "")
-    .replace(/\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)?/g, "")
-    .replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
-  return stripped.length > MAX_SCHEDULE_CELL_WIDTH
-    ? `${stripped.slice(0, MAX_SCHEDULE_CELL_WIDTH - 3)}...`
-    : stripped;
+  return truncate(stripAnsiAndControlChars(value), MAX_SCHEDULE_CELL_WIDTH);
+}
+
+/** Humanizes a cron expression for display; returns the input when unrecognized. */
+type CronDescriber = (expression: string) => string;
+
+/**
+ * Load the schedule store's cron humanizer for cadence display. Loaded
+ * lazily inside actions because it lives in the daemon's module graph
+ * (see the `cli/no-daemon-internals` hoisting rule); when it cannot be
+ * loaded, listings fall back to raw expressions.
+ */
+async function loadCronDescriber(): Promise<CronDescriber | null> {
+  try {
+    const { describeCronExpression } =
+      await import("../../schedule/schedule-store.js");
+    return describeCronExpression;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cadence cell for a declared-schedules listing: the humanized cron cadence
+ * with the raw expression kept as ground truth ("Every day at 9:00 AM
+ * (0 9 * * *)"). RRULEs and anything the describer does not recognize stay
+ * as the raw expression alone.
+ */
+function formatCadenceCell(
+  cadence: string,
+  describeCron: CronDescriber | null,
+): string {
+  const described = describeCron?.(cadence);
+  return described && described !== cadence
+    ? `${described} (${cadence})`
+    : cadence;
 }
 
 /** Aligned `name  cadence  (mode)` rows for a declared-schedules listing. */
 function formatScheduleRows(
   schedules: readonly PluginScheduleSurface[],
+  describeCron: CronDescriber | null,
 ): string[] {
   if (schedules.length === 0) {
     return [];
   }
   const rows = schedules.map((s) => ({
     name: sanitizeScheduleCell(s.name),
-    cadence: sanitizeScheduleCell(s.cadence),
-    mode: sanitizeScheduleCell(s.mode),
+    cadence: sanitizeScheduleCell(formatCadenceCell(s.cadence, describeCron)),
+    mode: s.mode,
   }));
   const nameW = Math.max(...rows.map((r) => r.name.length));
   const cadenceW = Math.max(...rows.map((r) => r.cadence.length));
@@ -1064,6 +1114,56 @@ function formatScheduleRows(
     (r) =>
       `${r.name.padEnd(nameW)}  ${r.cadence.padEnd(cadenceW)}  (${r.mode})`,
   );
+}
+
+/**
+ * Names of the schedules the installed copy of a plugin currently declares.
+ * Empty when the plugin (or its schedules/ dir) is absent, or when the
+ * install path cannot be probed at all (for example an unsanitized name);
+ * the upgrade itself surfaces such errors, this snapshot never does.
+ */
+function listInstalledScheduleNames(name: string): ReadonlySet<string> {
+  try {
+    const surfaces = libs.surfaces.detectPluginSurfaces(
+      join(getWorkspacePluginsDir(), name),
+    );
+    return new Set(surfaces.schedules.map((s) => s.name));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * After a daemon-applied upgrade, list the revision's declared schedules with
+ * a `[new]` marker on the ones the previous revision did not declare. The
+ * daemon path has no staging prompt, so this display is how the operator sees
+ * at the terminal what the reconciler's notification says. Display only:
+ * arming decisions stay with the reconciler.
+ */
+async function printDeclaredSchedulesAfterUpgrade(
+  name: string,
+  target: string,
+  previousNames: ReadonlySet<string>,
+): Promise<void> {
+  const { schedules } = libs.surfaces.detectPluginSurfaces(target);
+  if (schedules.length === 0) {
+    return;
+  }
+  const describeCron = await loadCronDescriber();
+  console.log("");
+  console.log(
+    `Plugin "${name}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
+  );
+  const rows = formatScheduleRows(schedules, describeCron);
+  schedules.forEach((schedule, index) => {
+    const marker = previousNames.has(schedule.name) ? "" : "  [new]";
+    console.log(`  ${rows[index]}${marker}`);
+  });
+  if (schedules.some((schedule) => !previousNames.has(schedule.name))) {
+    console.log(
+      "New schedules run automatically in the background. Run 'assistant schedules list' to review them, or 'assistant schedules disable <id>' to turn one off.",
+    );
+  }
 }
 
 /**
@@ -1190,7 +1290,10 @@ function remoteLocation(remote: PluginRemoteInfo): string {
  * that each carry `timestamp` (the human version), `hash` (the precise id), and
  * `location`, with a `drift` line under the installed copy.
  */
-function formatInspection(inspection: PluginInspection): string[] {
+function formatInspection(
+  inspection: PluginInspection,
+  describeCron: CronDescriber | null,
+): string[] {
   const { name, status, local, remote, remoteError, surfaces } = inspection;
   const lines: string[] = [name, "─".repeat(44)];
   const topRow = (label: string, value: string) =>
@@ -1255,7 +1358,10 @@ function formatInspection(inspection: PluginInspection): string[] {
     surfaceBlock("skills", surfaces.skills);
     surfaceBlock("hooks", surfaces.hooks);
     surfaceBlock("tools", surfaces.tools);
-    surfaceBlock("schedules", formatScheduleRows(surfaces.schedules));
+    surfaceBlock(
+      "schedules",
+      formatScheduleRows(surfaces.schedules, describeCron),
+    );
   }
 
   for (const issue of local?.issues ?? []) {

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { pluginNameFromScheduleSourceKey } from "../../util/schedule-source-key.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { formatCostUsd } from "../lib/cli-output.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
@@ -788,15 +789,13 @@ async function toggleScheduleEnabled(
 
 /**
  * Plugin attribution for the list's SOURCE column: the owning plugin's name,
- * the raw key when it does not parse, blank for imperative schedules. Parses
- * the wire value locally; the key format is defined by
- * `pluginScheduleSourceKey` in schedule/plugin-schedule-declarations.ts.
+ * the raw key when it does not parse, blank for imperative schedules.
  */
 function describeSource(sourceKey: string | null | undefined): string {
   if (!sourceKey) {
     return "";
   }
-  return /^plugin:([^/]+)\//.exec(sourceKey)?.[1] ?? sourceKey;
+  return pluginNameFromScheduleSourceKey(sourceKey) ?? sourceKey;
 }
 
 function describeSchedule(schedule: ScheduleRecord): string {

--- a/assistant/src/notifications/__tests__/copy-composer.test.ts
+++ b/assistant/src/notifications/__tests__/copy-composer.test.ts
@@ -333,6 +333,59 @@ describe("composeFallbackCopy plugin schedule templates", () => {
 
     expect(copy.vellum?.body?.length).toBeGreaterThan(0);
   });
+
+  test("schedule.declared sanitizes plugin-controlled fields", () => {
+    // Plugin-authored declaration strings carrying a clear-screen CSI, an OSC
+    // title write, a BEL, and a newline must not reach the rendered copy.
+    const signal = makeSignal({
+      sourceEventName: "schedule.declared",
+      contextPayload: {
+        pluginName: "news\u001b[2Jext",
+        scheduleName: "digest\u0007",
+        cadence: "0 9 * * *\u001b]0;pwned\u0007",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.title).toBe("New plugin schedule: digest");
+    expect(copy.vellum?.body).toContain('Plugin "newsext"');
+    expect(copy.vellum?.body).toContain("0 9 * * *");
+    expect(copy.vellum?.body).not.toContain("\u001b");
+    expect(copy.vellum?.body).not.toContain("\u0007");
+    expect(copy.vellum?.body).not.toContain("pwned");
+  });
+
+  test("schedule.declared omits a cadence that sanitizes to nothing", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.declared",
+      contextPayload: {
+        pluginName: "news",
+        scheduleName: "digest",
+        cadence: "\u001b[2J\u0007",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.body).not.toContain("(");
+    expect(copy.vellum?.body).not.toContain("\u001b");
+  });
+
+  test("schedule.definition_error sanitizes and flattens the reason", () => {
+    const signal = makeSignal({
+      sourceEventName: "schedule.definition_error",
+      contextPayload: {
+        pluginName: "news\u001b[31m",
+        scheduleName: "digest",
+        reason: "bad\nexpression\u001b[0m",
+      },
+    });
+    const copy = composeFallbackCopy(signal, CHANNELS);
+
+    expect(copy.vellum?.body).toContain('Plugin "news"');
+    expect(copy.vellum?.body).toContain("bad expression");
+    expect(copy.vellum?.body).not.toContain("\u001b");
+    expect(copy.vellum?.body).not.toContain("\n");
+  });
 });
 
 // ── deriveTitle ───────────────────────────────────────────────────────

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -30,6 +30,7 @@ import {
   NOTIFICATION_TITLE_MAX_LENGTH,
   readPayloadString,
   sanitizeIdentityField,
+  sanitizeMessagePreview,
 } from "./notification-utils.js";
 import type {
   NotificationSignal,
@@ -45,6 +46,17 @@ function str(value: unknown, fallback: string): string {
     return value;
   }
   return fallback;
+}
+
+/**
+ * Read an untrusted payload string for interpolation into copy: sanitized
+ * like an identity field, falling back when the value is absent, not a
+ * string, or sanitizes down to nothing.
+ */
+function sanitizedPayloadField(value: unknown, fallback: string): string {
+  const sanitized =
+    typeof value === "string" ? sanitizeIdentityField(value).trim() : "";
+  return sanitized.length > 0 ? sanitized : fallback;
 }
 
 /**
@@ -115,22 +127,32 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     body: str(payload.message, "A reminder has fired"),
   }),
 
+  // The schedule.* fields below (names, cadence, error reason) originate in
+  // plugin-authored declaration files, so they are sanitized like any other
+  // untrusted actor-controlled string before interpolation.
   "schedule.declared": (payload) => {
-    const scheduleName = str(payload.scheduleName, "a schedule");
-    const pluginName = str(payload.pluginName, "A plugin");
+    const scheduleName = sanitizedPayloadField(
+      payload.scheduleName,
+      "a schedule",
+    );
+    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
     const cadence =
-      typeof payload.cadence === "string" && payload.cadence.length > 0
-        ? ` (${payload.cadence})`
-        : "";
+      typeof payload.cadence === "string"
+        ? nonEmpty(sanitizeIdentityField(payload.cadence))
+        : undefined;
+    const cadenceSuffix = cadence ? ` (${cadence})` : "";
     return {
       title: `New plugin schedule: ${scheduleName}`,
-      body: `Plugin "${pluginName}" armed the schedule "${scheduleName}"${cadence}. It will run automatically; you can disable it from your schedules.`,
+      body: `Plugin "${pluginName}" armed the schedule "${scheduleName}"${cadenceSuffix}. It will run automatically; you can disable it from your schedules.`,
     };
   },
 
   "schedule.definition_changed": (payload) => {
-    const scheduleName = str(payload.scheduleName, "a schedule");
-    const pluginName = str(payload.pluginName, "A plugin");
+    const scheduleName = sanitizedPayloadField(
+      payload.scheduleName,
+      "a schedule",
+    );
+    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
     return {
       title: `Plugin schedule changed: ${scheduleName}`,
       body: `Plugin "${pluginName}" changed the definition of its schedule "${scheduleName}".`,
@@ -138,9 +160,14 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
   },
 
   "schedule.definition_error": (payload) => {
-    const scheduleName = str(payload.scheduleName, "a schedule");
-    const pluginName = str(payload.pluginName, "A plugin");
-    const reason = str(payload.reason, "the declaration is invalid");
+    const scheduleName = sanitizedPayloadField(
+      payload.scheduleName,
+      "a schedule",
+    );
+    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
+    const reason = sanitizeMessagePreview(
+      str(payload.reason, "the declaration is invalid"),
+    );
     return {
       title: `Plugin schedule error: ${scheduleName}`,
       body: `Plugin "${pluginName}" has a schedule "${scheduleName}" that could not be loaded: ${reason}`,

--- a/assistant/src/notifications/notification-utils.ts
+++ b/assistant/src/notifications/notification-utils.ts
@@ -6,6 +6,7 @@
  * circular dependencies.
  */
 
+import { stripAnsiAndControlChars } from "../util/ansi.js";
 import { isPlainObject } from "../util/object.js";
 
 // ── String helpers ──────────────────────────────────────────────────────────
@@ -61,12 +62,12 @@ export function truncate(text: string, maxLength: number): string {
 
 // ── Sanitization ────────────────────────────────────────────────────────────
 
-/** Strip control characters and newlines, then truncate to `maxLength`. */
+/**
+ * Strip escape sequences, flatten control characters and newlines to spaces,
+ * then truncate to `maxLength`.
+ */
 function sanitize(value: string, maxLength: number): string {
-  return truncate(
-    value.replace(/[\x00-\x1f\x7f-\x9f\r\n]+/g, " ").trim(),
-    maxLength,
-  );
+  return truncate(stripAnsiAndControlChars(value, " ").trim(), maxLength);
 }
 
 /**

--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -24,6 +24,7 @@
 import { spawn } from "node:child_process";
 
 import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
+import { stripAnsiSequences } from "../util/ansi.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("inline-command-runner");
@@ -44,12 +45,6 @@ const MAX_OUTPUT_CHARS = 20_000;
  * be stripped before the character-level clamp.
  */
 const MAX_STDOUT_BUFFER_BYTES = MAX_OUTPUT_CHARS * 4;
-
-/**
- * ANSI escape sequence pattern (covers SGR, cursor movement, erase, etc.).
- * Matches: ESC[ ... final_byte  and  ESC] ... ST  (OSC sequences).
- */
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
 
 /**
  * Heuristic for binary output: if more than 10% of the characters are
@@ -198,7 +193,7 @@ export async function runInlineCommand(
       // Strip ANSI sequences first — these are terminal artifacts, not
       // binary data. Stripping before the binary check prevents legitimate
       // color-coded tool output from being rejected.
-      let cleaned = raw.replace(ANSI_RE, "");
+      let cleaned = stripAnsiSequences(raw);
 
       // Reject binary-ish output (after ANSI stripping)
       if (isBinaryish(cleaned)) {

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -8,6 +8,7 @@ import {
   getScheduleRuns,
   listSchedules,
 } from "../../schedule/schedule-store.js";
+import { pluginNameFromScheduleSourceKey } from "../../util/schedule-source-key.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -35,6 +36,18 @@ function isOneShot(job: { expression: string | null }): boolean {
 
 function describeAuthoredPurpose(job: { description: string }): string {
   return job.description || "(none)";
+}
+
+/**
+ * Owning plugin for a plugin-declared schedule, or null for imperative rows.
+ * Falls back to the raw source key when it does not parse, so provenance is
+ * never silently dropped.
+ */
+function managingPlugin(job: { sourceKey: string | null }): string | null {
+  if (!job.sourceKey) {
+    return null;
+  }
+  return pluginNameFromScheduleSourceKey(job.sourceKey) ?? job.sourceKey;
 }
 
 /**
@@ -76,6 +89,13 @@ export async function executeScheduleList(
       `  Status: ${job.status}`,
       `  Description: ${describeAuthoredPurpose(job)}`,
     ];
+
+    const detailPlugin = managingPlugin(job);
+    if (detailPlugin) {
+      lines.push(
+        `  Managed by plugin: ${detailPlugin} (definition read-only; only enabled can be changed)`,
+      );
+    }
 
     if (oneShot) {
       lines.push(`  Fire at: ${formatLocalDate(job.nextRunAt)}`);
@@ -142,18 +162,20 @@ export async function executeScheduleList(
   for (const job of jobs) {
     const status = job.enabled ? "enabled" : "disabled";
     const oneShot = isOneShot(job);
+    const plugin = managingPlugin(job);
+    const managed = plugin ? ` (managed by plugin ${plugin})` : "";
 
     if (oneShot) {
       const fireTime = formatLocalDate(job.nextRunAt);
       lines.push(
-        `  - [${status}] ${job.name} (id: ${job.id}) (one-shot, ${job.mode}) [${job.status}]`,
+        `  - [${status}] ${job.name} (id: ${job.id}) (one-shot, ${job.mode}) [${job.status}]${managed}`,
         `    Description: ${describeAuthoredPurpose(job)}`,
         `    fire at: ${fireTime}`,
       );
     } else {
       const next = job.enabled ? formatLocalDate(job.nextRunAt) : "n/a";
       lines.push(
-        `  - [${status}] ${job.name} (id: ${job.id}) (${job.mode})`,
+        `  - [${status}] ${job.name} (id: ${job.id}) (${job.mode})${managed}`,
         `    Description: ${describeAuthoredPurpose(job)}`,
         `    Schedule: [${job.syntax}] ${describeSchedule(job)}`,
         `    Next: ${next}`,

--- a/assistant/src/util/ansi.ts
+++ b/assistant/src/util/ansi.ts
@@ -1,0 +1,44 @@
+/**
+ * Stripping of terminal escape sequences and control characters from
+ * untrusted strings before they reach a terminal or notification copy.
+ *
+ * One pattern serves every call site so coverage cannot drift between
+ * hand-rolled copies. CSI sequences carry the full parameter and
+ * intermediate byte ranges; OSC sequences match through their BEL/ST
+ * terminator, with the terminator optional so an unterminated sequence
+ * cannot smuggle its body past the strip.
+ */
+
+/**
+ * Well-formed ANSI escape sequences: CSI (`ESC [ params intermediates final`,
+ * covering colors, cursor moves, erase) and OSC (`ESC ] payload BEL|ST`,
+ * covering window-title writes and hyperlinks).
+ */
+const ANSI_SEQUENCE_RE =
+  /\u001b\[[0-?]*[ -/]*[@-~]|\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)?/g;
+
+/**
+ * Runs of C0/C1 control characters, including DEL and any bare ESC left by a
+ * malformed sequence. `\r` and `\n` are C0, so this also flattens newlines.
+ */
+const CONTROL_CHAR_RUN_RE = /[\u0000-\u001f\u007f-\u009f]+/g;
+
+/**
+ * Remove ANSI CSI/OSC escape sequences, leaving other control characters
+ * (newlines, tabs) intact. For multi-line text whose line structure matters.
+ */
+export function stripAnsiSequences(value: string): string {
+  return value.replace(ANSI_SEQUENCE_RE, "");
+}
+
+/**
+ * Remove ANSI CSI/OSC escape sequences, then replace every remaining run of
+ * C0/C1 control characters with `replacement` (removed by default). For
+ * single-line rendering where no control character may survive.
+ */
+export function stripAnsiAndControlChars(
+  value: string,
+  replacement = "",
+): string {
+  return stripAnsiSequences(value).replace(CONTROL_CHAR_RUN_RE, replacement);
+}

--- a/assistant/src/util/schedule-source-key.ts
+++ b/assistant/src/util/schedule-source-key.ts
@@ -1,0 +1,22 @@
+/**
+ * Plugin-declared schedules record their provenance in the `source_key`
+ * column as `plugin:<pluginName>/<scheduleName>`. The format is minted by
+ * `pluginScheduleSourceKey` in schedule/plugin-schedule-declarations.ts;
+ * this leaf parser lets display surfaces (CLI tables, tool output) derive
+ * the owning plugin without importing the daemon's schedule modules.
+ */
+
+const PLUGIN_SOURCE_KEY_RE = /^plugin:([^/]+)\//;
+
+/**
+ * The owning plugin's name from a schedule row's `source_key`, or `null` when
+ * the row is imperative (no key) or the key does not match the format.
+ */
+export function pluginNameFromScheduleSourceKey(
+  sourceKey: string | null | undefined,
+): string | null {
+  if (!sourceKey) {
+    return null;
+  }
+  return PLUGIN_SOURCE_KEY_RE.exec(sourceKey)?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary
Round-2 review fixes for plugin-schedules-v1.md: upgrade help text matches the daemon-path model and prints declared schedules post-upgrade, consent listing humanizes cron cadence, schedule_list marks plugin-managed rows, one shared ANSI-strip util replaces three copies, notification templates sanitize plugin-controlled strings.