### PR TITLE
fix(schedule,notifications): structured emit verdicts with retryable dedupe, ended-recurrence handling, json-safe consent output

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -5,7 +5,7 @@ const enforceRoutingIntentMock = mock();
 const updateDecisionMock = mock();
 const runDeterministicChecksMock = mock();
 const createEventMock = mock();
-const updateEventDedupeKeyMock = mock();
+const setEventDedupeKeyMock = mock();
 const dispatchDecisionMock = mock();
 const isPlatformClientConfiguredMock = mock();
 
@@ -77,8 +77,7 @@ mock.module("../notifications/deterministic-checks.js", () => ({
 
 mock.module("../notifications/events-store.js", () => ({
   createEvent: (...args: unknown[]) => createEventMock(...args),
-  updateEventDedupeKey: (...args: unknown[]) =>
-    updateEventDedupeKeyMock(...args),
+  setEventDedupeKey: (...args: unknown[]) => setEventDedupeKeyMock(...args),
 }));
 
 mock.module("../notifications/runtime-dispatch.js", () => ({
@@ -104,7 +103,7 @@ beforeEach(() => {
   updateDecisionMock.mockReset();
   runDeterministicChecksMock.mockReset();
   createEventMock.mockReset();
-  updateEventDedupeKeyMock.mockReset();
+  setEventDedupeKeyMock.mockReset();
   dispatchDecisionMock.mockReset();
   isPlatformClientConfiguredMock.mockReset();
 

--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -13,6 +13,8 @@
  *     with the untrusted warning printed before the schedule listing
  *   - upgrade's local fallback runs the same consent gate with upgrade
  *     wording, while a daemon-routed upgrade never reaches it
+ *   - under --json the consent listing goes to stderr, leaving stdout a pure
+ *     JSON document
  *   - inspect renders the schedules surface block
  *
  * The installers are replaced by fakes that stage a fixture tree and run the
@@ -468,6 +470,28 @@ describe("plugins upgrade - declared-schedules consent (local fallback)", () => 
     expect(confirmCalls.length).toBe(0);
     expect(r.stdout).toContain('Plugin "example" declares 2 schedules:');
     expect(r.stdout).toContain('Upgraded "example"');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("--json --force leaves stdout as pure JSON and lists on stderr", async () => {
+    stageFixture = writeScheduleFixture;
+
+    const r = await runCommand([
+      "plugins",
+      "upgrade",
+      "example",
+      "--json",
+      "--force",
+    ]);
+
+    expect(confirmCalls.length).toBe(0);
+    expect(r.stderr).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stderr).toContain("daily-report");
+    expect(r.stdout).not.toContain("declares");
+    expect(JSON.parse(r.stdout)).toMatchObject({
+      name: "example",
+      outcome: "upgraded",
+    });
     expect(r.exitCode).toBe(0);
   });
 

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -173,7 +173,10 @@ export function registerPluginsCommand(program: Command): void {
             // --force, must be confirmed before anything lands on disk that
             // the daemon's schedule reconciler could arm.
             const confirmStaged: ConfirmStagedInstall = (staged) =>
-              confirmDeclaredSchedules(staged, Boolean(opts.force), "install");
+              confirmDeclaredSchedules(staged, "install", {
+                force: Boolean(opts.force),
+                json: false,
+              });
 
             let result;
             let untrusted = false;
@@ -737,19 +740,24 @@ export function registerPluginsCommand(program: Command): void {
               result = daemon.result;
               upgradedViaDaemon = true;
             } else if (daemon.statusCode === undefined) {
-              log.debug(
-                { name, error: daemon.error },
-                "upgrade could not reach the daemon; upgrading locally",
-              );
+              // The CLI logger writes debug to stdout, which would corrupt
+              // --json output, so under --json the same note goes to stderr.
+              // The CLI logger drops structured fields either way.
+              const fallbackNote =
+                "upgrade could not reach the daemon; upgrading locally";
+              if (opts.json) {
+                console.error(fallbackNote);
+              } else {
+                log.debug({ name, error: daemon.error }, fallbackNote);
+              }
               // The local path stages in this process, so it gets the same
               // consent gate as install: declared schedules are listed and
               // confirmed (or --force) before the staged tree goes live.
               const confirmStaged: ConfirmStagedInstall = (staged) =>
-                confirmDeclaredSchedules(
-                  staged,
-                  Boolean(opts.force),
-                  "upgrade",
-                );
+                confirmDeclaredSchedules(staged, "upgrade", {
+                  force: Boolean(opts.force),
+                  json: Boolean(opts.json),
+                });
               result = await libs.upgrade.upgradePlugin(
                 {
                   name,
@@ -997,6 +1005,31 @@ function printUntrustedPluginWarning(
 }
 
 /**
+ * The declared-schedules block for a plugin tree: a heading plus one aligned
+ * row per schedule, or null when the plugin declares none. Callers own the
+ * output stream and any per-row annotation.
+ */
+async function buildDeclaredScheduleListing(
+  pluginName: string,
+  pluginDir: string,
+): Promise<{
+  heading: string;
+  rows: string[];
+  schedules: readonly PluginScheduleSurface[];
+} | null> {
+  const { schedules } = libs.surfaces.detectPluginSurfaces(pluginDir);
+  if (schedules.length === 0) {
+    return null;
+  }
+  const describeCron = await loadCronDescriber();
+  return {
+    heading: `Plugin "${pluginName}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
+    rows: formatScheduleRows(schedules, describeCron),
+    schedules,
+  };
+}
+
+/**
  * List a staged plugin's declared schedules and ask for consent. Schedules run
  * automatically once armed, so neither an install nor an upgrade may add any
  * silently: the user either confirms the listing or passes --force. Returns
@@ -1006,24 +1039,33 @@ function printUntrustedPluginWarning(
  */
 async function confirmDeclaredSchedules(
   staged: { name: string; stagingDir: string },
-  force: boolean,
   action: "install" | "upgrade",
+  opts: { force: boolean; json: boolean },
 ): Promise<boolean> {
-  const { schedules } = libs.surfaces.detectPluginSurfaces(staged.stagingDir);
-  if (schedules.length === 0) {
+  const listing = await buildDeclaredScheduleListing(
+    staged.name,
+    staged.stagingDir,
+  );
+  if (!listing) {
     return true;
   }
-  const describeCron = await loadCronDescriber();
-  console.log(
-    `Plugin "${staged.name}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
-  );
-  for (const row of formatScheduleRows(schedules, describeCron)) {
-    console.log(`  ${row}`);
+  // The listing is human output. Under --json it goes to stderr so it cannot
+  // corrupt the JSON document the caller parses off stdout.
+  const write = (line: string): void => {
+    if (opts.json) {
+      console.error(line);
+    } else {
+      console.log(line);
+    }
+  };
+  write(listing.heading);
+  for (const row of listing.rows) {
+    write(`  ${row}`);
   }
-  console.log(
+  write(
     "Schedules run automatically in the background once the plugin is installed.",
   );
-  if (force) {
+  if (opts.force) {
     return true;
   }
   const verb = action === "install" ? "Install" : "Upgrade";
@@ -1145,16 +1187,13 @@ async function printDeclaredSchedulesAfterUpgrade(
   target: string,
   previousNames: ReadonlySet<string>,
 ): Promise<void> {
-  const { schedules } = libs.surfaces.detectPluginSurfaces(target);
-  if (schedules.length === 0) {
+  const listing = await buildDeclaredScheduleListing(name, target);
+  if (!listing) {
     return;
   }
-  const describeCron = await loadCronDescriber();
+  const { heading, rows, schedules } = listing;
   console.log("");
-  console.log(
-    `Plugin "${name}" declares ${schedules.length} schedule${schedules.length === 1 ? "" : "s"}:`,
-  );
-  const rows = formatScheduleRows(schedules, describeCron);
+  console.log(heading);
   schedules.forEach((schedule, index) => {
     const marker = previousNames.has(schedule.name) ? "" : "  [new]";
     console.log(`  ${rows[index]}${marker}`);

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
-import { pluginNameFromScheduleSourceKey } from "../../util/schedule-source-key.js";
+import { describeScheduleSource } from "../../util/schedule-source-key.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { formatCostUsd } from "../lib/cli-output.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
@@ -118,7 +118,7 @@ export function registerSchedulesCommand(program: Command): void {
             name: schedule.name,
             enabled: schedule.enabled ? "enabled" : "disabled",
             mode: schedule.mode,
-            source: describeSource(schedule.sourceKey),
+            source: describeScheduleSource(schedule.sourceKey) ?? "",
             schedule: describeSchedule(schedule),
             nextRun: formatTimestamp(schedule.nextRunAt),
             lastStatus: schedule.lastStatus ?? "—",
@@ -240,7 +240,7 @@ export function registerSchedulesCommand(program: Command): void {
             ["Retry backoff", formatDuration(schedule.retryBackoffMs)],
             ["Timeout", formatDuration(schedule.timeoutMs)],
             ["Source conversation", schedule.createdFromConversationId ?? "—"],
-            ["Plugin", describeSource(schedule.sourceKey) || "-"],
+            ["Plugin", describeScheduleSource(schedule.sourceKey) ?? "-"],
           ];
           const labelWidth = Math.max(...fields.map(([label]) => label.length));
           for (const [label, value] of fields) {
@@ -785,17 +785,6 @@ async function toggleScheduleEnabled(
   }
 
   log.info(`${enabled ? "Enabled" : "Disabled"} schedule: ${scheduleId}`);
-}
-
-/**
- * Plugin attribution for the list's SOURCE column: the owning plugin's name,
- * the raw key when it does not parse, blank for imperative schedules.
- */
-function describeSource(sourceKey: string | null | undefined): string {
-  if (!sourceKey) {
-    return "";
-  }
-  return pluginNameFromScheduleSourceKey(sourceKey) ?? sourceKey;
 }
 
 function describeSchedule(schedule: ScheduleRecord): string {

--- a/assistant/src/notifications/__tests__/emit-signal-pipeline-failure.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-pipeline-failure.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for what a failed emit leaves behind in the events store.
+ *
+ * `createEvent` claims the producer's dedupe key as its first pipeline step,
+ * so a failure after that point used to leave the key claimed by an emit that
+ * never reached a verdict: every retry short-circuited as "deduplicated at
+ * event store level" and nothing was ever delivered. The failure path releases
+ * the claim instead, while a completed emit keeps it so real duplicates still
+ * collapse.
+ *
+ * The events store, its DB, and the deterministic checks are the real ones;
+ * only the decision engine, the dispatch step, and the adapter graph around
+ * them are stubbed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const dispatchDecisionMock = mock();
+
+mock.module("../../channels/config.js", () => ({
+  getDeliverableChannels: () => ["vellum"],
+}));
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  guardianForChannel: () => undefined,
+}));
+
+mock.module("../../platform/client.js", () => ({
+  VellumPlatformClient: class {
+    static async create(): Promise<null> {
+      return null;
+    }
+  },
+  isPlatformClientConfigured: async () => false,
+}));
+
+mock.module("../broadcaster.js", () => ({
+  NotificationBroadcaster: class {
+    constructor(_adapters: unknown[]) {}
+    setOnConversationCreated(_fn: unknown) {}
+  },
+}));
+
+const DEDUPE_KEY = "schedule-definition-error:plugin:news/digest:2026-01-01";
+
+mock.module("../decision-engine.js", () => ({
+  evaluateSignal: async () => ({
+    shouldNotify: true,
+    selectedChannels: ["vellum"],
+    reasoningSummary: "deliver",
+    renderedCopy: {
+      vellum: { title: "Plugin schedule error", body: "digest failed to load" },
+    },
+    dedupeKey: DEDUPE_KEY,
+    confidence: 0.9,
+    fallbackUsed: false,
+  }),
+  enforceRoutingIntent: (decision: unknown) => decision,
+}));
+
+mock.module("../decisions-store.js", () => ({
+  updateDecision: () => {},
+}));
+
+mock.module("../home-feed-side-effect.js", () => ({
+  writeHomeFeedItemForSignal: async () => {},
+}));
+
+mock.module("../runtime-dispatch.js", () => ({
+  dispatchDecision: (...args: unknown[]) => dispatchDecisionMock(...args),
+}));
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { notificationEvents } from "../../persistence/schema/index.js";
+import type { EmitSignalParams } from "../emit-signal.js";
+
+await initializeDb();
+
+const { emitNotificationSignal } = await import("../emit-signal.js");
+
+function emit() {
+  const params: EmitSignalParams<string> = {
+    sourceEventName: "schedule.definition_error",
+    sourceChannel: "scheduler",
+    sourceContextId: "plugin:news/digest",
+    dedupeKey: DEDUPE_KEY,
+    contextPayload: { pluginName: "news", scheduleName: "digest" },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+  };
+  return emitNotificationSignal(params);
+}
+
+beforeEach(() => {
+  getDb().delete(notificationEvents).run();
+  dispatchDecisionMock.mockReset();
+  dispatchDecisionMock.mockResolvedValue({
+    dispatched: true,
+    reason: "Dispatched to 1/1 channels",
+    deliveryResults: [],
+  });
+});
+
+describe("emitNotificationSignal dedupe claim on failure", () => {
+  test("a retry after a mid-pipeline failure dispatches", async () => {
+    dispatchDecisionMock.mockRejectedValueOnce(new Error("transient outage"));
+
+    const failed = await emit();
+    expect(failed.pipelineFailed).toBe(true);
+    expect(failed.dispatched).toBe(false);
+
+    const retried = await emit();
+    expect(retried.pipelineFailed).toBe(false);
+    expect(retried.deduplicated).toBe(false);
+    expect(retried.dispatched).toBe(true);
+
+    // The failed attempt keeps its row for the audit trail; only its claim on
+    // the dedupe key is released.
+    const rows = getDb().select().from(notificationEvents).all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === failed.signalId)?.dedupeKey).toBeNull();
+    expect(rows.find((r) => r.id === retried.signalId)?.dedupeKey).toBe(
+      DEDUPE_KEY,
+    );
+  });
+
+  test("a completed emit keeps its dedupe key, so a repeat is deduplicated", async () => {
+    const first = await emit();
+    expect(first.dispatched).toBe(true);
+
+    const second = await emit();
+    expect(second.deduplicated).toBe(true);
+    expect(second.dispatched).toBe(false);
+    expect(second.pipelineFailed).toBe(false);
+    expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -50,13 +50,32 @@ function str(value: unknown, fallback: string): string {
 
 /**
  * Read an untrusted payload string for interpolation into copy: sanitized
- * like an identity field, falling back when the value is absent, not a
- * string, or sanitizes down to nothing.
+ * like an identity field, undefined when the value is absent, not a string,
+ * or sanitizes down to nothing.
  */
+function optionalSanitizedPayloadField(value: unknown): string | undefined {
+  return typeof value === "string"
+    ? nonEmpty(sanitizeIdentityField(value))
+    : undefined;
+}
+
+/** {@link optionalSanitizedPayloadField} with a fallback for the empty case. */
 function sanitizedPayloadField(value: unknown, fallback: string): string {
-  const sanitized =
-    typeof value === "string" ? sanitizeIdentityField(value).trim() : "";
-  return sanitized.length > 0 ? sanitized : fallback;
+  return optionalSanitizedPayloadField(value) ?? fallback;
+}
+
+/**
+ * Plugin and schedule names from a `schedule.*` payload, with the fallbacks
+ * every schedule template shares.
+ */
+function schedulePayloadNames(payload: Record<string, unknown>): {
+  scheduleName: string;
+  pluginName: string;
+} {
+  return {
+    scheduleName: sanitizedPayloadField(payload.scheduleName, "a schedule"),
+    pluginName: sanitizedPayloadField(payload.pluginName, "A plugin"),
+  };
 }
 
 /**
@@ -131,15 +150,8 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
   // plugin-authored declaration files, so they are sanitized like any other
   // untrusted actor-controlled string before interpolation.
   "schedule.declared": (payload) => {
-    const scheduleName = sanitizedPayloadField(
-      payload.scheduleName,
-      "a schedule",
-    );
-    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
-    const cadence =
-      typeof payload.cadence === "string"
-        ? nonEmpty(sanitizeIdentityField(payload.cadence))
-        : undefined;
+    const { scheduleName, pluginName } = schedulePayloadNames(payload);
+    const cadence = optionalSanitizedPayloadField(payload.cadence);
     const cadenceSuffix = cadence ? ` (${cadence})` : "";
     return {
       title: `New plugin schedule: ${scheduleName}`,
@@ -148,11 +160,7 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
   },
 
   "schedule.definition_changed": (payload) => {
-    const scheduleName = sanitizedPayloadField(
-      payload.scheduleName,
-      "a schedule",
-    );
-    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
+    const { scheduleName, pluginName } = schedulePayloadNames(payload);
     return {
       title: `Plugin schedule changed: ${scheduleName}`,
       body: `Plugin "${pluginName}" changed the definition of its schedule "${scheduleName}".`,
@@ -160,11 +168,7 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
   },
 
   "schedule.definition_error": (payload) => {
-    const scheduleName = sanitizedPayloadField(
-      payload.scheduleName,
-      "a schedule",
-    );
-    const pluginName = sanitizedPayloadField(payload.pluginName, "A plugin");
+    const { scheduleName, pluginName } = schedulePayloadNames(payload);
     const reason = sanitizeMessagePreview(
       str(payload.reason, "the declaration is invalid"),
     );

--- a/assistant/src/notifications/deferred-emit.ts
+++ b/assistant/src/notifications/deferred-emit.ts
@@ -82,6 +82,7 @@ export function bufferIfDeferred(
       dispatched: false,
       reason: "Notification dropped: background job did not complete",
       deliveryResults: [],
+      pipelineFailed: false,
     };
   }
   entry.items.push(params);
@@ -91,6 +92,7 @@ export function bufferIfDeferred(
     dispatched: false,
     reason: "Notification deferred until background job completes",
     deliveryResults: [],
+    pipelineFailed: false,
   };
 }
 

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -36,7 +36,7 @@ import {
   type DeterministicCheckContext,
   runDeterministicChecks,
 } from "./deterministic-checks.js";
-import { createEvent, updateEventDedupeKey } from "./events-store.js";
+import { createEvent, setEventDedupeKey } from "./events-store.js";
 import { writeHomeFeedItemForSignal } from "./home-feed-side-effect.js";
 import { dispatchDecision } from "./runtime-dispatch.js";
 import type {
@@ -226,6 +226,13 @@ export interface EmitSignalResult {
   dispatched: boolean;
   reason: string;
   deliveryResults: NotificationDeliveryResult[];
+  /**
+   * True when the pipeline threw before reaching a verdict. Dispatch, dedupe,
+   * suppression, and a blocked deterministic check are all verdicts. Callers
+   * that latch their own guard on a completed emit branch on this flag;
+   * `reason` is a human-facing log string and never a control signal.
+   */
+  pipelineFailed: boolean;
 }
 
 /**
@@ -244,6 +251,10 @@ export async function emitNotificationSignal<TEventName extends string>(
   params: EmitSignalParams<TEventName>,
 ): Promise<EmitSignalResult> {
   const signalId = uuid();
+
+  // The event row claims `params.dedupeKey` when it lands, and the failure
+  // path below releases that claim.
+  let eventPersisted = false;
 
   const signal: NotificationSignal<TEventName> = {
     signalId,
@@ -285,8 +296,10 @@ export async function emitNotificationSignal<TEventName extends string>(
         dispatched: false,
         reason: "Signal deduplicated at event store level",
         deliveryResults: [],
+        pipelineFailed: false,
       };
     }
+    eventPersisted = true;
 
     // Step 1.5: Source-active pre-gate. visibleInSourceNow is a hard invariant
     // the decision engine cannot override, and it depends only on the signal —
@@ -307,6 +320,7 @@ export async function emitNotificationSignal<TEventName extends string>(
         dispatched: false,
         reason: `Signal suppressed: ${sourceActiveCheck.reason}`,
         deliveryResults: [],
+        pipelineFailed: false,
       };
     }
 
@@ -427,7 +441,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     // only the producer's dedupeKey, which may be null).
     if (decision.dedupeKey && !params.dedupeKey) {
       try {
-        updateEventDedupeKey(signalId, decision.dedupeKey);
+        setEventDedupeKey(signalId, decision.dedupeKey);
       } catch (err) {
         log.warn(
           { err, signalId },
@@ -458,6 +472,7 @@ export async function emitNotificationSignal<TEventName extends string>(
           dispatched: false,
           reason: `Signal blocked by deterministic checks: ${checkResult.reason}`,
           deliveryResults: [],
+          pipelineFailed: false,
         };
       }
     }
@@ -511,6 +526,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       dispatched: dispatchResult.dispatched,
       reason: dispatchResult.reason,
       deliveryResults: dispatchResult.deliveryResults,
+      pipelineFailed: false,
     };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -518,6 +534,20 @@ export async function emitNotificationSignal<TEventName extends string>(
       { err: errMsg, signalId, sourceEventName: params.sourceEventName },
       "Signal pipeline failed",
     );
+    // The persisted event claimed this signal's dedupe key before the
+    // pipeline threw. Leaving the claim in place makes every retry
+    // short-circuit as a duplicate of an emit that never reached a verdict,
+    // so release it. The row itself stays as the audit trail of the attempt.
+    if (eventPersisted) {
+      try {
+        setEventDedupeKey(signalId, null);
+      } catch (releaseErr) {
+        log.warn(
+          { err: releaseErr, signalId },
+          "Failed to release the dedupe key of a failed signal",
+        );
+      }
+    }
     if (params.throwOnError) {
       throw err instanceof Error ? err : new Error(errMsg);
     }
@@ -527,6 +557,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       dispatched: false,
       reason: `Signal pipeline failed: ${errMsg}`,
       deliveryResults: [],
+      pipelineFailed: true,
     };
   }
 }

--- a/assistant/src/notifications/events-store.ts
+++ b/assistant/src/notifications/events-store.ts
@@ -91,8 +91,16 @@ export function createEvent(
   return row;
 }
 
-/** Update the dedupeKey on an existing event (e.g. when the decision engine generates one). */
-export function updateEventDedupeKey(eventId: string, dedupeKey: string): void {
+/**
+ * Write an existing event's dedupe key. A string claims that key, which is
+ * how a decision-engine-generated key lands on the row. `null` releases the
+ * claim so a later event may take it while this row stays for the audit
+ * trail.
+ */
+export function setEventDedupeKey(
+  eventId: string,
+  dedupeKey: string | null,
+): void {
   const db = getDb();
   db.update(notificationEvents)
     .set({ dedupeKey, updatedAt: Date.now() })

--- a/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-declarations.test.ts
@@ -316,6 +316,7 @@ describe("parsePluginScheduleDeclarations", () => {
       });
       const { errors } = parsePluginScheduleDeclarations(pluginDir, "p");
       expect(errors[0]!.reason).toContain("invalid cron expression");
+      expect(errors[0]!.kind).toBe("invalid");
     });
 
     test("RRULE without DTSTART errors", () => {
@@ -384,6 +385,22 @@ describe("parsePluginScheduleDeclarations", () => {
       );
       expect(declarations).toEqual([]);
       expect(errors[0]!.reason).toContain("no upcoming occurrences");
+      // A well-formed recurrence with nothing left to fire, not a mistake:
+      // the reconciler stays quiet about it once the row has stopped.
+      expect(errors[0]!.kind).toBe("ended");
+    });
+
+    test("a COUNT-bounded RRULE with every occurrence consumed reports 'ended'", () => {
+      const pluginDir = makePlugin({
+        "consumed.md":
+          '---\nexpression: "DTSTART:20200101T090000Z\\nRRULE:FREQ=DAILY;COUNT=5"\nexpression_syntax: rrule\n---\nHi.',
+      });
+      const { declarations, errors } = parsePluginScheduleDeclarations(
+        pluginDir,
+        "p",
+      );
+      expect(declarations).toEqual([]);
+      expect(errors[0]!.kind).toBe("ended");
     });
 
     test("empty prompt body errors", () => {

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -30,6 +30,7 @@ mock.module("../../notifications/emit-signal.js", () => ({
       dispatched: true,
       reason: "test",
       deliveryResults: [],
+      pipelineFailed: false,
       ...(emitResultOverride ?? {}),
     };
   },
@@ -92,6 +93,22 @@ function digestMd(body: string): string {
     "---",
     "",
     body,
+    "",
+  ].join("\n");
+}
+
+/**
+ * A digest declaration whose recurrence has nothing left to fire: five daily
+ * occurrences, all of them in 2020. Well-formed, just finished.
+ */
+function endedDigestMd(): string {
+  return [
+    "---",
+    'expression: "DTSTART:20200101T090000Z\\nRRULE:FREQ=DAILY;COUNT=5"',
+    "expression_syntax: rrule",
+    "---",
+    "",
+    "Summarize the day.",
     "",
   ].join("\n");
 }
@@ -537,6 +554,7 @@ describe("reconcilePluginSchedules", () => {
     writePlugin("news", { "digest.md": "Just a body, no config." });
     emitResultOverride = {
       dispatched: false,
+      pipelineFailed: true,
       reason: "Signal pipeline failed: transient outage",
     };
 
@@ -552,10 +570,69 @@ describe("reconcilePluginSchedules", () => {
     expect(emittedSignals).toHaveLength(2);
   });
 
+  test("a completed bounded recurrence stays silent across passes", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    // The engine latches an exhausted recurrence in one write: disabled,
+    // next run zeroed, last run stamped.
+    getRawDb().run(
+      "UPDATE cron_jobs SET enabled = 0, next_run_at = 0, last_run_at = ? WHERE id = ?",
+      [Date.now(), created.id],
+    );
+    const latched = rawJob(created.id);
+    emittedSignals.length = 0;
+
+    // The declaration is unchanged in spirit: its last occurrence simply
+    // passed, so the parser now reports it as ended.
+    writePlugin("news", { "digest.md": endedDigestMd() });
+    await reconcilePluginSchedules();
+    await reconcilePluginSchedules();
+
+    expect(rawJob(created.id)).toEqual(latched);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("an ended recurrence on a still-armed row surfaces the error", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    expect(listDeclaredSchedules()[0]!.enabled).toBe(true);
+    emittedSignals.length = 0;
+
+    // The armed row expects more firings; an upgrade that ends the
+    // recurrence stops them, which the user has to hear about.
+    writePlugin("news", { "digest.md": endedDigestMd() });
+    await reconcilePluginSchedules();
+
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "schedule.definition_error",
+    );
+  });
+
+  test("a freshly installed declaration that is already expired errors", async () => {
+    writePlugin("news", { "digest.md": endedDigestMd() });
+
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()).toHaveLength(0);
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "schedule.definition_error",
+    );
+    const payload = emittedSignals[0]!.contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(payload.reason).toContain("no upcoming occurrences");
+  });
+
   test("a suppressed error emit still latches the day guard", async () => {
     writePlugin("news", { "digest.md": "Just a body, no config." });
     emitResultOverride = {
       dispatched: false,
+      pipelineFailed: false,
       reason: "Signal blocked by deterministic checks: quiet hours",
     };
 

--- a/assistant/src/schedule/plugin-schedule-declarations.ts
+++ b/assistant/src/schedule/plugin-schedule-declarations.ts
@@ -86,11 +86,29 @@ export interface ScheduleDeclaration {
   definitionHash: string;
 }
 
+/**
+ * Why a declaration did not load.
+ *
+ * `invalid` is a broken declaration and needs a fix in the plugin. `ended` is
+ * a well-formed recurrence with nothing left to fire, its COUNT consumed or
+ * its UNTIL past. A bounded schedule that ran to completion reaches that
+ * state on its own, so the reconciler surfaces it only when the row it
+ * belongs to is still armed, or when there is no row at all.
+ */
+export type DeclarationErrorKind = "invalid" | "ended";
+
 export interface DeclarationError {
   pluginName: string;
   scheduleName: string;
   sourceKey: string;
   reason: string;
+  kind: DeclarationErrorKind;
+}
+
+/** A declaration that did not load, before it is keyed to a plugin. */
+interface DeclarationFailure {
+  error: string;
+  kind?: DeclarationErrorKind;
 }
 
 export interface ParsedPluginSchedules {
@@ -147,7 +165,7 @@ const scheduleConfigSchema = z
 
 function parseScheduleConfig(
   raw: unknown,
-): { config: PluginScheduleConfig } | { error: string } {
+): { config: PluginScheduleConfig } | DeclarationFailure {
   const result = scheduleConfigSchema.safeParse(raw);
   if (!result.success) {
     const detail = result.error.issues
@@ -201,8 +219,10 @@ function parseScheduleConfig(
   if (resolved.syntax === "rrule") {
     // A syntactically valid recurrence can still be exhausted (UNTIL in the
     // past, COUNT consumed). Such a schedule has no firing left, so it fails
-    // closed here as a declaration error rather than surviving to throw on
-    // every reconcile upsert.
+    // closed here rather than surviving to throw on every reconcile upsert.
+    // The `ended` kind separates it from a broken declaration, since a
+    // bounded recurrence that simply ran its course is not something the
+    // plugin author has to fix.
     try {
       computeNextRunAt({
         syntax: resolved.syntax,
@@ -213,6 +233,7 @@ function parseScheduleConfig(
       return {
         error:
           "expression has no upcoming occurrences: the recurrence has already ended",
+        kind: "ended",
       };
     }
   }
@@ -308,7 +329,7 @@ interface ParsedDeclarationBody {
 function parseFlatDeclaration(
   schedulesDir: string,
   fileName: string,
-): ParsedDeclarationBody | { error: string } {
+): ParsedDeclarationBody | DeclarationFailure {
   const content = readFileSync(join(schedulesDir, fileName), "utf8");
   const parsed = parseFrontmatterFields(content);
   if (!parsed) {
@@ -341,7 +362,7 @@ function parseFlatDeclaration(
 function parseDirectoryDeclaration(
   schedulesDir: string,
   dirName: string,
-): ParsedDeclarationBody | { error: string } {
+): ParsedDeclarationBody | DeclarationFailure {
   const dirPath = join(schedulesDir, dirName);
   const children = readdirSync(dirPath, { withFileTypes: true });
 
@@ -439,12 +460,17 @@ export function parsePluginScheduleDeclarations(
 
   const declarations: ScheduleDeclaration[] = [];
   const errors: DeclarationError[] = [];
-  const fail = (scheduleName: string, reason: string): void => {
+  const fail = (
+    scheduleName: string,
+    reason: string,
+    kind: DeclarationErrorKind = "invalid",
+  ): void => {
     errors.push({
       pluginName,
       scheduleName,
       sourceKey: pluginScheduleSourceKey(pluginName, scheduleName),
       reason,
+      kind,
     });
   };
 
@@ -479,9 +505,9 @@ export function parsePluginScheduleDeclarations(
 
   const parseOne = (
     name: string,
-    parse: () => ParsedDeclarationBody | { error: string },
+    parse: () => ParsedDeclarationBody | DeclarationFailure,
   ): void => {
-    let result: ParsedDeclarationBody | { error: string };
+    let result: ParsedDeclarationBody | DeclarationFailure;
     try {
       result = parse();
     } catch (err) {
@@ -490,7 +516,7 @@ export function parsePluginScheduleDeclarations(
       };
     }
     if ("error" in result) {
-      fail(name, result.error);
+      fail(name, result.error, result.kind);
       return;
     }
     declarations.push({

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -158,8 +158,29 @@ async function runReconcilePass(): Promise<void> {
   // kept out of `erroredKeys` above: an errored key preserves its last-good
   // row, while a manifest failure must let the disarm loop pause the rows.
   for (const error of [...errors, ...manifestFailures]) {
+    if (isCompletedRecurrence(error, existingByKey.get(error.sourceKey))) {
+      continue;
+    }
     emitDefinitionError(error);
   }
+}
+
+/**
+ * True when an `ended` recurrence is the expected end of a bounded schedule
+ * rather than something to tell the user about. Its row has already stopped,
+ * either latched by the engine on the last occurrence or disabled by the
+ * user, so no firing was lost. An ended declaration whose row is still armed
+ * does lose firings, and one with no row at all arrives dead; both surface.
+ */
+function isCompletedRecurrence(
+  error: DeclarationError,
+  row: ScheduleJob | undefined,
+): boolean {
+  return (
+    error.kind === "ended" &&
+    row !== undefined &&
+    (!row.enabled || row.nextRunAt === 0)
+  );
 }
 
 /**
@@ -208,6 +229,7 @@ async function collectDesiredDeclarations(): Promise<{
           scheduleName: declared.scheduleName,
           sourceKey: declared.sourceKey,
           reason,
+          kind: "invalid",
         });
       }
       continue;
@@ -276,10 +298,10 @@ async function emitDefinitionSignal(
       contextPayload,
       attentionHints: DEFINITION_NOTIFICATION_HINTS,
     });
-    // emitNotificationSignal resolves (never rejects) with `dispatched:
-    // false` and a "Signal pipeline failed" reason on a pipeline error;
-    // every other outcome, including dedupe and suppression, is a verdict.
-    return !result.reason.startsWith("Signal pipeline failed");
+    // emitNotificationSignal resolves (never rejects) and flags a pipeline
+    // error as `pipelineFailed`; every other outcome, including dedupe and
+    // suppression, is a verdict.
+    return !result.pipelineFailed;
   } catch (err) {
     log.warn(
       { err, sourceKey, sourceEventName },

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -8,7 +8,7 @@ import {
   getScheduleRuns,
   listSchedules,
 } from "../../schedule/schedule-store.js";
-import { pluginNameFromScheduleSourceKey } from "../../util/schedule-source-key.js";
+import { describeScheduleSource } from "../../util/schedule-source-key.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -36,18 +36,6 @@ function isOneShot(job: { expression: string | null }): boolean {
 
 function describeAuthoredPurpose(job: { description: string }): string {
   return job.description || "(none)";
-}
-
-/**
- * Owning plugin for a plugin-declared schedule, or null for imperative rows.
- * Falls back to the raw source key when it does not parse, so provenance is
- * never silently dropped.
- */
-function managingPlugin(job: { sourceKey: string | null }): string | null {
-  if (!job.sourceKey) {
-    return null;
-  }
-  return pluginNameFromScheduleSourceKey(job.sourceKey) ?? job.sourceKey;
 }
 
 /**
@@ -90,7 +78,7 @@ export async function executeScheduleList(
       `  Description: ${describeAuthoredPurpose(job)}`,
     ];
 
-    const detailPlugin = managingPlugin(job);
+    const detailPlugin = describeScheduleSource(job.sourceKey);
     if (detailPlugin) {
       lines.push(
         `  Managed by plugin: ${detailPlugin} (definition read-only; only enabled can be changed)`,
@@ -162,7 +150,7 @@ export async function executeScheduleList(
   for (const job of jobs) {
     const status = job.enabled ? "enabled" : "disabled";
     const oneShot = isOneShot(job);
-    const plugin = managingPlugin(job);
+    const plugin = describeScheduleSource(job.sourceKey);
     const managed = plugin ? ` (managed by plugin ${plugin})` : "";
 
     if (oneShot) {

--- a/assistant/src/util/schedule-source-key.ts
+++ b/assistant/src/util/schedule-source-key.ts
@@ -9,14 +9,15 @@
 const PLUGIN_SOURCE_KEY_RE = /^plugin:([^/]+)\//;
 
 /**
- * The owning plugin's name from a schedule row's `source_key`, or `null` when
- * the row is imperative (no key) or the key does not match the format.
+ * Display attribution for a schedule row: the owning plugin's name, the raw
+ * key when it does not match the format so provenance is never silently
+ * dropped, or null when the row is imperative.
  */
-export function pluginNameFromScheduleSourceKey(
+export function describeScheduleSource(
   sourceKey: string | null | undefined,
 ): string | null {
   if (!sourceKey) {
     return null;
   }
-  return PLUGIN_SOURCE_KEY_RE.exec(sourceKey)?.[1] ?? null;
+  return PLUGIN_SOURCE_KEY_RE.exec(sourceKey)?.[1] ?? sourceKey;
 }


### PR DESCRIPTION
## Summary
Round-3 review fixes for plugin-schedules-v1.md: EmitSignalResult gains a structured pipeline-failure discriminant and failed emits no longer orphan their dedupe row; legitimately completed bounded recurrences stay silent instead of erroring daily; local-fallback upgrade consent output is json-safe; small dedup consolidations in plugins CLI, copy-composer, and schedule-source-key.