### PR TITLE
fix(notifications,schedule): retain dedupe claim after partial dispatch, json-safe consent prompt, narrower ended suppression

### DIFF
--- a/assistant/src/__tests__/notification-schedule-notify-dedup.test.ts
+++ b/assistant/src/__tests__/notification-schedule-notify-dedup.test.ts
@@ -3,7 +3,7 @@
  * deduplicated against prior firings of the same schedule.
  *
  * The scheduler supplies a unique per-firing dedupeKey
- * (`schedule:notify:<id>:<timestamp>`) so `updateEventDedupeKey` is never
+ * (`schedule:notify:<id>:<timestamp>`) so `setEventDedupeKey` is never
  * called for schedule signals and `checkDedupe` never finds a matching
  * row when the LLM decision engine generates a stable key like
  * `schedule:notify:<id>`.

--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -13,8 +13,8 @@
  *     with the untrusted warning printed before the schedule listing
  *   - upgrade's local fallback runs the same consent gate with upgrade
  *     wording, while a daemon-routed upgrade never reaches it
- *   - under --json the consent listing goes to stderr, leaving stdout a pure
- *     JSON document
+ *   - under --json the consent listing, the prompt, and the cancellation line
+ *     all go to stderr, leaving stdout a pure JSON document
  *   - inspect renders the schedules surface block
  *
  * The installers are replaced by fakes that stage a fixture tree and run the
@@ -50,6 +50,8 @@ import { runCliCommand } from "./cli-test-harness.js";
 let confirmCalls: Array<{
   question: string;
   refuseNonInteractiveMessage: string;
+  /** Where the prompt line itself is written; undefined = readline's default. */
+  stdout: NodeJS.WritableStream | undefined;
 }> = [];
 let confirmResults: Array<"confirmed" | "denied" | "non-interactive"> = [];
 
@@ -83,6 +85,7 @@ mock.module("../../lib/confirm-prompt.js", () => ({
     confirmCalls.push({
       question: opts.question,
       refuseNonInteractiveMessage: opts.refuseNonInteractiveMessage,
+      stdout: opts.stdout,
     });
     return confirmResults.shift() ?? "confirmed";
   },
@@ -492,6 +495,24 @@ describe("plugins upgrade - declared-schedules consent (local fallback)", () => 
       name: "example",
       outcome: "upgraded",
     });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("--json keeps the prompt and the cancellation off stdout", async () => {
+    stageFixture = writeScheduleFixture;
+    confirmResults = ["denied"];
+
+    const r = await runCommand(["plugins", "upgrade", "example", "--json"]);
+
+    // readline writes the question to whatever stream it is handed, so under
+    // --json that has to be stderr.
+    expect(confirmCalls).toHaveLength(1);
+    expect(confirmCalls[0]!.stdout).toBe(process.stderr);
+    expect(confirmCalls[0]!.question).toContain('Upgrade "example"');
+
+    expect(r.stderr).toContain('Plugin "example" declares 2 schedules:');
+    expect(r.stderr).toContain("Upgrade cancelled.");
+    expect(r.stdout).toBe("");
     expect(r.exitCode).toBe(0);
   });
 

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -1049,8 +1049,9 @@ async function confirmDeclaredSchedules(
   if (!listing) {
     return true;
   }
-  // The listing is human output. Under --json it goes to stderr so it cannot
-  // corrupt the JSON document the caller parses off stdout.
+  // Everything this gate prints is human output: the listing, the prompt
+  // itself, and the cancellation line. Under --json all of it goes to stderr
+  // so it cannot corrupt the JSON document the caller parses off stdout.
   const write = (line: string): void => {
     if (opts.json) {
       console.error(line);
@@ -1073,13 +1074,14 @@ async function confirmDeclaredSchedules(
     question: `${verb} "${staged.name}" and allow these schedules? [y/N] `,
     isTTY: Boolean(process.stdin.isTTY),
     refuseNonInteractiveMessage: `Refusing to ${action} "${staged.name}" non-interactively: it declares schedules. Pass --force to confirm.`,
+    stdout: opts.json ? process.stderr : undefined,
   });
   if (result === "non-interactive") {
     process.exitCode = 1;
     return false;
   }
   if (result === "denied") {
-    console.log(`${verb} cancelled.`);
+    write(`${verb} cancelled.`);
     return false;
   }
   return true;

--- a/assistant/src/notifications/__tests__/emit-signal-pipeline-failure.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-pipeline-failure.test.ts
@@ -1,12 +1,15 @@
 /**
  * Regression tests for what a failed emit leaves behind in the events store.
  *
- * `createEvent` claims the producer's dedupe key as its first pipeline step,
- * so a failure after that point used to leave the key claimed by an emit that
- * never reached a verdict: every retry short-circuited as "deduplicated at
- * event store level" and nothing was ever delivered. The failure path releases
- * the claim instead, while a completed emit keeps it so real duplicates still
- * collapse.
+ * `createEvent` claims the producer's dedupe key as its first pipeline step.
+ * A failure after that point releases the claim, so the retry is not
+ * short-circuited as "deduplicated at event store level" by an emit that
+ * never reached a verdict. A completed emit keeps its claim so real
+ * duplicates still collapse.
+ *
+ * A failure that already reached a channel keeps its claim too: the retry
+ * would broadcast under a fresh decision id, and delivery dedupe is keyed to
+ * the decision, so every channel that already went out would go out twice.
  *
  * The events store, its DB, and the deterministic checks are the real ones;
  * only the decision engine, the dispatch step, and the adapter graph around
@@ -75,6 +78,7 @@ import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { notificationEvents } from "../../persistence/schema/index.js";
 import type { EmitSignalParams } from "../emit-signal.js";
+import type { NotificationDeliveryResult } from "../types.js";
 
 await initializeDb();
 
@@ -95,6 +99,25 @@ function emit() {
     },
   };
   return emitNotificationSignal(params);
+}
+
+/**
+ * Stub one dispatch as a broadcast that settles the given channels and then
+ * throws on a later channel's prep. What already happened leaves the
+ * broadcast through the results sink; the return value dies with the throw.
+ */
+function throwAfterChannels(...settled: NotificationDeliveryResult[]): void {
+  dispatchDecisionMock.mockImplementationOnce(
+    (
+      _signal: unknown,
+      _decision: unknown,
+      _broadcaster: unknown,
+      options: { resultsSink?: NotificationDeliveryResult[] },
+    ) => {
+      options.resultsSink?.push(...settled);
+      throw new Error("conversation pairing failed for a later channel");
+    },
+  );
 }
 
 beforeEach(() => {
@@ -128,6 +151,45 @@ describe("emitNotificationSignal dedupe claim on failure", () => {
     expect(rows.find((r) => r.id === retried.signalId)?.dedupeKey).toBe(
       DEDUPE_KEY,
     );
+  });
+
+  // "sent" is a completed channel delivery; "pending" is the platform push
+  // that passed its outcome deadline and is still in flight. Both are
+  // side effects a retry would repeat.
+  for (const status of ["sent", "pending"] as const) {
+    test(`a failure after a ${status} channel keeps its dedupe key`, async () => {
+      throwAfterChannels({
+        channel: "vellum",
+        destination: "vellum",
+        status,
+      });
+
+      const partial = await emit();
+      expect(partial.pipelineFailed).toBe(true);
+
+      const retried = await emit();
+      expect(retried.deduplicated).toBe(true);
+      expect(retried.dispatched).toBe(false);
+      expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
+
+      const rows = getDb().select().from(notificationEvents).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.dedupeKey).toBe(DEDUPE_KEY);
+    });
+  }
+
+  test("a failure after only skipped and failed channels releases its key", async () => {
+    throwAfterChannels(
+      { channel: "slack", destination: "slack", status: "skipped" },
+      { channel: "telegram", destination: "telegram", status: "failed" },
+    );
+
+    const failed = await emit();
+    expect(failed.pipelineFailed).toBe(true);
+
+    const retried = await emit();
+    expect(retried.deduplicated).toBe(false);
+    expect(retried.dispatched).toBe(true);
   });
 
   test("a completed emit keeps its dedupe key, so a repeat is deduplicated", async () => {

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -229,6 +229,13 @@ export interface BroadcastDecisionOptions {
   onConversationCreated?: OnConversationCreatedFn;
   /** Deadline override for tests; defaults to PLATFORM_OUTCOME_DEADLINE_MS. */
   platformOutcomeDeadlineMs?: number;
+  /**
+   * Array each channel's result is appended to as it settles, and the same
+   * array `broadcastDecision` returns. Pass one when a broadcast that throws
+   * partway still has to be told apart from one that touched no channel: the
+   * return value is lost to the throw, the sink is not.
+   */
+  resultsSink?: NotificationDeliveryResult[];
 }
 
 // Cap on how long the deferred vellum send waits for the platform dispatch
@@ -348,7 +355,7 @@ export class NotificationBroadcaster {
       signal.contextPayload
         ? parseAccessRequestPayload(signal.contextPayload)
         : undefined;
-    const results: NotificationDeliveryResult[] = [];
+    const results: NotificationDeliveryResult[] = options?.resultsSink ?? [];
 
     // Vellum pairing carried forward for the platform channel's deep link.
     // A single-pass carry is safe because orderedChannels sorts vellum first.

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -236,6 +236,18 @@ export interface EmitSignalResult {
 }
 
 /**
+ * True when at least one channel adapter has already been handed the signal.
+ * `sent` is a completed delivery; `pending` is the platform push that passed
+ * its outcome deadline and is still in flight. Both mean a retry would
+ * re-deliver.
+ */
+function hasChannelSideEffect(
+  results: readonly NotificationDeliveryResult[],
+): boolean {
+  return results.some((r) => r.status === "sent" || r.status === "pending");
+}
+
+/**
  * Emit a notification signal through the full pipeline:
  * createEvent -> (source-active pre-gate) -> evaluateSignal ->
  * runDeterministicChecks -> dispatchDecision.
@@ -255,6 +267,11 @@ export async function emitNotificationSignal<TEventName extends string>(
   // The event row claims `params.dedupeKey` when it lands, and the failure
   // path below releases that claim.
   let eventPersisted = false;
+
+  // Every channel result the broadcast produces, appended as each channel
+  // settles. A throw discards the dispatch return value, so this is how the
+  // failure path learns which channels already ran.
+  const channelResults: NotificationDeliveryResult[] = [];
 
   const signal: NotificationSignal<TEventName> = {
     signalId,
@@ -487,9 +504,10 @@ export async function emitNotificationSignal<TEventName extends string>(
       signal,
       decision,
       broadcaster,
-      params.onConversationCreated
-        ? { onConversationCreated: params.onConversationCreated }
-        : undefined,
+      {
+        onConversationCreated: params.onConversationCreated,
+        resultsSink: channelResults,
+      },
     );
 
     // Step 5: Mirror background-origin signals into the home activity feed.
@@ -538,7 +556,13 @@ export async function emitNotificationSignal<TEventName extends string>(
     // pipeline threw. Leaving the claim in place makes every retry
     // short-circuit as a duplicate of an emit that never reached a verdict,
     // so release it. The row itself stays as the audit trail of the attempt.
-    if (eventPersisted) {
+    //
+    // A partially dispatched broadcast is the exception. Its retry gets a
+    // fresh decision id, and delivery dedupe is keyed to the decision, so
+    // the channels that already went out would go out again. Keeping the
+    // claim costs the channels that did not get the signal; releasing it
+    // double-sends to the ones that did.
+    if (eventPersisted && !hasChannelSideEffect(channelResults)) {
       try {
         setEventDedupeKey(signalId, null);
       } catch (releaseErr) {

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -611,6 +611,51 @@ describe("reconcilePluginSchedules", () => {
     );
   });
 
+  test("an ended recurrence on a row this pass disarmed still surfaces", async () => {
+    const dir = writePlugin("news", {
+      "digest.md": digestMd("Summarize the day."),
+    });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+
+    // Disabling the plugin disarms the row without the engine latching it:
+    // `enabled` goes false, the run clock is untouched.
+    writeFileSync(join(dir, ".disabled"), "");
+    await reconcilePluginSchedules();
+    const disarmed = listDeclaredSchedules()[0]!;
+    expect(disarmed.enabled).toBe(false);
+    expect(disarmed.lastRunAt).toBeNull();
+    expect(disarmed.userEnabled).toBeNull();
+    emittedSignals.length = 0;
+
+    // The recurrence runs out while the plugin is off. Re-enabling brings back
+    // a schedule that can never fire, so the user has to hear about it.
+    writePlugin("news", { "digest.md": endedDigestMd() });
+    rmSync(join(dir, ".disabled"));
+    await reconcilePluginSchedules();
+
+    expect(listDeclaredSchedules()[0]!.id).toBe(created.id);
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceEventName).toBe(
+      "schedule.definition_error",
+    );
+  });
+
+  test("a user-disabled row keeps an ended recurrence quiet", async () => {
+    writePlugin("news", { "digest.md": digestMd("Summarize the day.") });
+    await reconcilePluginSchedules();
+    const created = listDeclaredSchedules()[0]!;
+    await setUserEnabled(created.id, false);
+    emittedSignals.length = 0;
+
+    // The user turned the schedule off, so its recurrence running out costs
+    // no firing they expected.
+    writePlugin("news", { "digest.md": endedDigestMd() });
+    await reconcilePluginSchedules();
+
+    expect(emittedSignals).toHaveLength(0);
+  });
+
   test("a freshly installed declaration that is already expired errors", async () => {
     writePlugin("news", { "digest.md": endedDigestMd() });
 

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -167,20 +167,25 @@ async function runReconcilePass(): Promise<void> {
 
 /**
  * True when an `ended` recurrence is the expected end of a bounded schedule
- * rather than something to tell the user about. Its row has already stopped,
- * either latched by the engine on the last occurrence or disabled by the
- * user, so no firing was lost. An ended declaration whose row is still armed
- * does lose firings, and one with no row at all arrives dead; both surface.
+ * rather than something to tell the user about. Two rows qualify: one the
+ * engine latched on its last occurrence (`next_run_at` zeroed with a run
+ * behind it), and one the user turned off. Neither lost a firing.
+ *
+ * A row this reconciler disarmed does not qualify. `enabled = false` there
+ * means the plugin is disabled or its declaration was briefly absent, and
+ * once the plugin comes back the ended recurrence is a dead schedule the
+ * user has to hear about. An ended declaration whose row is still armed
+ * loses firings, and one with no row at all arrives dead; both surface.
  */
 function isCompletedRecurrence(
   error: DeclarationError,
   row: ScheduleJob | undefined,
 ): boolean {
-  return (
-    error.kind === "ended" &&
-    row !== undefined &&
-    (!row.enabled || row.nextRunAt === 0)
-  );
+  if (error.kind !== "ended" || row === undefined) {
+    return false;
+  }
+  const engineLatched = row.nextRunAt === 0 && row.lastRunAt != null;
+  return engineLatched || row.userEnabled === false;
 }
 
 /**


### PR DESCRIPTION
## Summary
Round-4 review fixes for plugin-schedules-v1.md: a partially dispatched signal keeps its dedupe claim so retries cannot re-send delivered channels; the --json consent prompt and cancellation message route to stderr; ended-recurrence errors are suppressed only for engine-latched or user-disabled rows, so reconciler-disarmed schedules surface on re-enable.