### PR TITLE
fix(notifications,schedule): honest sent result on status-write failure, silence never-enabled ended declarations

### DIFF
--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -61,9 +61,14 @@ mock.module("../conversation-pairing.js", () => ({
   },
 }));
 
+// Status writes are inert by default; tests that need a failing store swap
+// the implementation in.
+let updateDeliveryStatusImpl: (status: string) => void = () => {};
+
 mock.module("../deliveries-store.js", () => ({
   createDelivery: () => {},
-  updateDeliveryStatus: () => {},
+  updateDeliveryStatus: (_deliveryId: string, status: string) =>
+    updateDeliveryStatusImpl(status),
   findDeliveryByDecisionAndChannel: () => undefined,
 }));
 
@@ -162,6 +167,7 @@ beforeEach(() => {
   knownConversations = new Set();
   pairingByChannel = {};
   pairingErrorByChannel = {};
+  updateDeliveryStatusImpl = () => {};
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -232,6 +238,36 @@ describe("NotificationBroadcaster last-resort copy resolution", () => {
     expect(sends[0]?.payload.copy.body).toBe("Time to drink water");
     expect(results.length).toBe(1);
     expect(results[0]?.status).toBe("sent");
+  });
+});
+
+describe("NotificationBroadcaster delivery status recording", () => {
+  test("a successful send is recorded as sent even when its status write throws", async () => {
+    // The results array is what `emitNotificationSignal` reads to decide
+    // whether a retry would re-deliver. Reporting a real send as failed
+    // releases the signal's dedupe claim, so the retry sends this message a
+    // second time. The lost status write only costs the delivery row.
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Time to drink water" },
+    };
+    updateDeliveryStatusImpl = (status: string) => {
+      if (status === "sent") {
+        throw new Error("deliveries store is locked");
+      }
+    };
+
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal(),
+      makeDecision({ renderedCopy: {} }),
+    );
+
+    expect(sends.length).toBe(1);
+    expect(results.length).toBe(1);
+    expect(results[0]?.status).toBe("sent");
+    expect(results[0]?.errorMessage).toBeUndefined();
   });
 });
 

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -801,7 +801,9 @@ export class NotificationBroadcaster {
   /**
    * Dispatch a prepared payload through its channel adapter and record the
    * outcome (delivery row status + results entry). Returns the adapter's
-   * result, or null when the send threw.
+   * result, or null when the send threw. The recorded result tracks what the
+   * adapter actually did, so a status write that fails after a successful
+   * send is logged and swallowed rather than downgrading the result.
    */
   private async sendAndRecord(
     dispatch: PendingChannelDispatch,
@@ -829,14 +831,25 @@ export class NotificationBroadcaster {
         const resolvedMessageId =
           adapterResult.messageId ?? pairing.messageId ?? undefined;
         if (hasPersistedDecision) {
-          updateDeliveryStatus(
-            deliveryId,
-            "sent",
-            undefined,
-            adapterResult.messageId
-              ? { messageId: adapterResult.messageId }
-              : undefined,
-          );
+          try {
+            updateDeliveryStatus(
+              deliveryId,
+              "sent",
+              undefined,
+              adapterResult.messageId
+                ? { messageId: adapterResult.messageId }
+                : undefined,
+            );
+          } catch (statusErr) {
+            // The message is already out; a lost status write must not turn
+            // this into a `failed` result. Callers read the results to decide
+            // whether a retry would re-deliver, so reporting a real send as
+            // failed releases the signal's dedupe claim and double-sends.
+            log.warn(
+              { err: statusErr, channel, signalId: signal.signalId },
+              "Failed to record a sent delivery; the send itself succeeded",
+            );
+          }
         }
         results.push(
           buildDeliveryResult(dispatch, "sent", {

--- a/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
+++ b/assistant/src/schedule/__tests__/plugin-schedule-reconciler.test.ts
@@ -113,6 +113,24 @@ function endedDigestMd(): string {
   ].join("\n");
 }
 
+/**
+ * The same five daily occurrences, shipped switched off and starting at the
+ * given DTSTART. A declaration with `enabled: false` inserts its row unarmed:
+ * the clock is zeroed, no run sits behind it, and no user choice is recorded.
+ */
+function disabledDigestMd(dtstart: string): string {
+  return [
+    "---",
+    `expression: "DTSTART:${dtstart}\\nRRULE:FREQ=DAILY;COUNT=5"`,
+    "expression_syntax: rrule",
+    "enabled: false",
+    "---",
+    "",
+    "Summarize the day.",
+    "",
+  ].join("\n");
+}
+
 const DIGEST_KEY = "plugin:news/digest";
 
 describe("reconcilePluginSchedules", () => {
@@ -651,6 +669,27 @@ describe("reconcilePluginSchedules", () => {
     // The user turned the schedule off, so its recurrence running out costs
     // no firing they expected.
     writePlugin("news", { "digest.md": endedDigestMd() });
+    await reconcilePluginSchedules();
+
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("a declaration that shipped disabled keeps an ended recurrence quiet", async () => {
+    writePlugin("news", { "digest.md": disabledDigestMd("20990101T090000Z") });
+    await reconcilePluginSchedules();
+
+    const created = listDeclaredSchedules()[0]!;
+    expect(created.enabled).toBe(false);
+    expect(created.nextRunAt).toBe(0);
+    expect(created.lastRunAt).toBeNull();
+    expect(created.userEnabled).toBeNull();
+    emittedSignals.length = 0;
+
+    // The row was never armed, so the recurrence running out costs no firing
+    // the user was going to get. Telling them every day about a schedule they
+    // never turned on is noise.
+    writePlugin("news", { "digest.md": disabledDigestMd("20200101T090000Z") });
+    await reconcilePluginSchedules();
     await reconcilePluginSchedules();
 
     expect(emittedSignals).toHaveLength(0);

--- a/assistant/src/schedule/plugin-schedule-reconciler.ts
+++ b/assistant/src/schedule/plugin-schedule-reconciler.ts
@@ -167,15 +167,19 @@ async function runReconcilePass(): Promise<void> {
 
 /**
  * True when an `ended` recurrence is the expected end of a bounded schedule
- * rather than something to tell the user about. Two rows qualify: one the
- * engine latched on its last occurrence (`next_run_at` zeroed with a run
- * behind it), and one the user turned off. Neither lost a firing.
+ * rather than something to tell the user about. Three rows qualify: one the
+ * engine latched on its last occurrence, which zeroes `next_run_at` with a
+ * run behind it; one the user turned off; and one that shipped disabled and
+ * was never armed, which has `next_run_at` zeroed with no run behind it and
+ * no user choice recorded. None of them lost a firing the user expected.
  *
- * A row this reconciler disarmed does not qualify. `enabled = false` there
- * means the plugin is disabled or its declaration was briefly absent, and
- * once the plugin comes back the ended recurrence is a dead schedule the
- * user has to hear about. An ended declaration whose row is still armed
- * loses firings, and one with no row at all arrives dead; both surface.
+ * A row this reconciler disarmed does not qualify, and cannot be mistaken
+ * for the never-armed one because it keeps the stale non-zero `next_run_at`
+ * it was armed with. `enabled = false` there means the plugin is disabled or
+ * its declaration was briefly absent, and once the plugin comes back the
+ * ended recurrence is a dead schedule the user has to hear about. An ended
+ * declaration whose row is still armed loses firings, and one with no row at
+ * all arrives dead; both surface.
  */
 function isCompletedRecurrence(
   error: DeclarationError,
@@ -185,7 +189,12 @@ function isCompletedRecurrence(
     return false;
   }
   const engineLatched = row.nextRunAt === 0 && row.lastRunAt != null;
-  return engineLatched || row.userEnabled === false;
+  const insertedDisabled =
+    !row.enabled &&
+    row.nextRunAt === 0 &&
+    row.lastRunAt == null &&
+    row.userEnabled == null;
+  return engineLatched || row.userEnabled === false || insertedDisabled;
 }
 
 /**


### PR DESCRIPTION
## Summary
Final review fixes for plugin-schedules-v1.md: a successful adapter send whose local status write fails still records as sent so the dedupe claim survives, and a declaration shipped disabled that was never armed stays silent when its bounded recurrence ends.