### PR TITLE
polish: mobile menu touch fixes, equal-width action pills, lighter se…

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -14,6 +14,7 @@ import {
   SIDEBAR_CHIP_SIZE,
   SIDEBAR_ROW_PADDING_X,
   SIDEBAR_SECTION_INDENT,
+  SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
 } from "@/components/sidebar-nav-geometry";
 import { useLongPressSheet } from "@/hooks/use-long-press-sheet";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -230,8 +231,7 @@ function CollapsibleNavSectionSection({
           className={cn(
             "flex h-[30px] min-w-0 flex-1 items-center max-md:h-auto",
             "rounded-[6px] py-[6px] max-md:py-3",
-            "text-left text-body-medium-lighter max-md:text-body-large-lighter",
-            "text-[var(--content-tertiary)]",
+            SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
           )}
           style={{
             paddingLeft: SIDEBAR_ROW_PADDING_X,
@@ -256,8 +256,7 @@ function CollapsibleNavSectionSection({
             // row below reads as too large at the full py-3 (matches the
             // desktop py-[6px] top/bottom, kept as-is above).
             "rounded-[6px] py-[6px] max-md:pt-3 max-md:pb-1.5",
-            "text-left text-body-medium-lighter max-md:text-body-large-lighter",
-            "text-[var(--content-tertiary)]",
+            SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
           )}
           style={{
             paddingLeft: SIDEBAR_ROW_PADDING_X,

--- a/clients/web/src/components/sidebar-nav-geometry.ts
+++ b/clients/web/src/components/sidebar-nav-geometry.ts
@@ -49,3 +49,17 @@ export const SIDEBAR_SECTION_MAX_HEIGHT = 300;
  */
 export const SIDEBAR_SECTION_RESIZE_MIN_HEIGHT = 64;
 export const SIDEBAR_SECTION_RESIZE_MAX_HEIGHT = 600;
+
+/**
+ * Text treatment for a section title (Pinned, Pinned Apps, a custom
+ * group, the persistent Threads header, View As). `font-[350]!` sits below
+ * the `lighter` type-scale tier's own 400 weight, a step past the scale's
+ * lightest named weight rather than a new tier of its own (DM Sans is a
+ * variable font down to 300). The trailing `!` forces it over the
+ * `text-body-*-lighter` utility's own font-weight: cross-package Tailwind
+ * generation order doesn't reliably favor a plain (unmarked) override here.
+ * Shared so every title reads at the same weight without drifting per call
+ * site.
+ */
+export const SIDEBAR_SECTION_TITLE_TEXT_CLASSES =
+  "text-left font-[350]! text-body-medium-lighter max-md:text-body-large-lighter text-[var(--content-tertiary)]";

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -195,7 +195,10 @@ export function ChatLayoutHeader({
 
       <div
         inert={controlsHidden || centerHidden || undefined}
-        className={`flex min-w-0 flex-1 items-center justify-center transition-opacity duration-300${controlsHidden || centerHidden ? " pointer-events-none opacity-0" : ""}`}
+        // Left-aligned on mobile, pulled in 12px past the header's own
+        // `gap-4` (16px) to sit closer to the menu button, 4px total.
+        // Desktop keeps the title centered in the remaining space.
+        className={`flex min-w-0 flex-1 items-center max-md:-ml-3 max-md:justify-start justify-center transition-opacity duration-300${controlsHidden || centerHidden ? " pointer-events-none opacity-0" : ""}`}
       >
         {topBarCenter}
       </div>

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -15,6 +15,7 @@ import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
 import {
   SIDEBAR_CHIP_GAP,
   SIDEBAR_ROW_PADDING_X,
+  SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
 } from "@/components/sidebar-nav-geometry";
 import {
   CollapsedGroupIcon,
@@ -55,7 +56,7 @@ import {
 } from "@/domains/chat/utils/sidebar-section-icon";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { Conversation } from "@/types/conversation-types";
-import { Button, SideMenu } from "@vellumai/design-library";
+import { Button, cn, SideMenu } from "@vellumai/design-library";
 
 export interface AssistantSideMenuProps extends UseSidebarStateParams {
   assistantName?: string | null;
@@ -409,11 +410,8 @@ export function AssistantSideMenu({
 
   // List/Groups switch, in the persistent "Threads" header's menu.
   const viewAsFooter = (
-    <div className="mt-2 px-2 pb-1">
-      <div
-        className="mb-1.5 text-label-small-default text-[var(--content-tertiary)]"
-        style={{ fontSize: 12 }}
-      >
+    <div className="px-2 pb-1">
+      <div className={cn("mt-3 mb-2", SIDEBAR_SECTION_TITLE_TEXT_CLASSES)}>
         View As
       </div>
       <SidebarViewModeToggle
@@ -502,7 +500,10 @@ export function AssistantSideMenu({
               // both contexts. Mobile (always the overlay) shaves more,
               // halving the 16px gap to Lucky Dip below instead of the
               // 12px this leaves elsewhere.
-              className="flex h-[30px] max-md:h-auto items-center rounded-[6px] py-[6px] max-md:pt-3 max-md:pb-1.5 text-left text-body-medium-lighter max-md:text-body-large-lighter text-[var(--content-tertiary)] -mb-1 max-md:-mb-[10px]"
+              className={cn(
+                "flex h-[30px] max-md:h-auto items-center rounded-[6px] py-[6px] max-md:pt-3 max-md:pb-1.5 -mb-1 max-md:-mb-[10px]",
+                SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
+              )}
               style={{
                 paddingLeft: SIDEBAR_ROW_PADDING_X,
                 paddingRight: SIDEBAR_ROW_PADDING_X,
@@ -807,14 +808,31 @@ export function AssistantSideMenu({
                 {tipCard}
               </div>
             ) : null}
-            <div className="flex items-center justify-center gap-4">
+            {/* Grid, not flex: a plain `flex-1` on both children doesn't
+               actually split them evenly here, since the Preferences pill
+               (wrapped in its own div, see `footerAction` below) and the New
+               Chat button (a flex item directly) don't carry the same
+               content-based automatic minimum size, so equal flex-grow still
+               resolves to unequal widths. `minmax(0,1fr)` tracks are immune
+               to that: each column is forced to the same size regardless of
+               its content or DOM depth. */}
+            <div
+              className={cn(
+                "grid items-center gap-4",
+                footerAction
+                  ? "grid-cols-[minmax(0,1fr)_minmax(0,1fr)]"
+                  : "grid-cols-1",
+              )}
+            >
               {footerAction ? (
-                <div className="pointer-events-auto flex-1">{footerAction}</div>
+                <div className="pointer-events-auto min-w-0">
+                  {footerAction}
+                </div>
               ) : null}
               {onStartNewConversation ? (
                 <Button
                   variant="primary"
-                  className="pointer-events-auto h-10 flex-1 rounded-full px-4 shadow-[var(--shadow-lg)]"
+                  className="pointer-events-auto h-10 w-full rounded-full px-4 shadow-[var(--shadow-lg)]"
                   leftIcon={<SquarePen />}
                   onClick={() => {
                     onStartNewConversation();

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -490,7 +490,7 @@ export function renderConversationMenuItemsAsPanelItems({
   const moveToGroupBlock = showMoveToGroup ? (
     <>
       <PanelMenuDivider />
-      <div className="flex items-center gap-2 px-2 pt-1 pb-1 text-body-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
+      <div className="flex items-center gap-2 px-2 pt-2 pb-1 text-body-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
         <FolderInput size={14} aria-hidden />
         Move to group
       </div>
@@ -671,11 +671,25 @@ export function ConversationActionsSheet({
       {trigger ? (
         <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
       ) : null}
-      <BottomSheet.Content aria-describedby={undefined}>
+      {/* This sheet's item list is open-ended (bulk actions, "Move to
+          group" targets, …), so it grows with its content rather than
+          taking the shared default's 50dvh ceiling. `!` forces this over
+          that default: cross-package Tailwind generation order doesn't
+          reliably favor a plain (unmarked) override here. Once content
+          would come within 120px of the top of the screen, the sheet stops
+          growing and its body scrolls instead. */}
+      <BottomSheet.Content
+        aria-describedby={undefined}
+        className="max-h-[calc(100dvh-120px)]!"
+      >
         <BottomSheet.Header className="sr-only">
           <BottomSheet.Title>Conversation actions</BottomSheet.Title>
         </BottomSheet.Header>
-        <BottomSheet.Body className="pt-0">
+        {/* Scrollbar hidden, not just at rest: this sheet has no fixed
+            track-width budget to spare, so a hover-revealed thumb would
+            shift the row content instead. Scroll itself (wheel/trackpad/
+            touch) is unaffected. */}
+        <BottomSheet.Body className="pt-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {renderConversationMenuItemsAsPanelItems({
             ...itemProps,
             onClose: () => onOpenChange(false),

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -17,6 +17,7 @@ import { ContextMenu, PanelItem } from "@vellumai/design-library";
 import { cn } from "@vellumai/design-library/utils/cn";
 
 import { SwipeActionReveal } from "@/components/swipe-action-reveal";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
   ConversationActionsMenu,
   ConversationActionsSheet,
@@ -257,6 +258,15 @@ export function ConversationRow({
   );
 
   const isTouch = isPointerCoarse();
+  // The ellipsis-hiding decision below also honors a narrow *viewport*, not
+  // just a coarse *pointer*: `isTouch` alone misses a desktop browser
+  // window narrowed to the mobile width with a mouse/trackpad, which still
+  // gets the mobile row layout (`max-md:` styling) but isn't touch. This
+  // doesn't affect which affordance actually opens the menu below (that
+  // still keys off real touch capability, via `isTouch`): a narrow desktop
+  // window still falls through to the right-click `ContextMenu.Root`
+  // branch, just without a visible ellipsis prompting it.
+  const isMobileViewport = useIsMobile();
 
   const panelItem = (
     <SwipeActionReveal
@@ -268,14 +278,25 @@ export function ConversationRow({
         marqueeOnHover={marquee}
         active={conversationId === ctx.activeConversationId}
         onSelect={() => select(conversationId)}
-        hideTrailingActionOnTouch={withContextMenu}
         badge={
           hasThreadStatus(status) ? (
             <ThreadStatusIndicator {...status} />
           ) : undefined
         }
         badgeBare
-        trailingAction={<ConversationActionsMenu {...menuProps} />}
+        // On touch, or a mobile-width viewport, the row already opens this
+        // exact menu another way (long-press → bottom sheet on touch,
+        // right-click on a narrow desktop window), so the trailing button
+        // isn't just hidden, it's absent: no leftover hover/active-state
+        // opacity rule can force it visible (as `hideTrailingActionOnTouch`
+        // alone didn't, for an active row), and the dot lands at the row's
+        // true right edge instead of sitting next to an invisible-but-
+        // space-reserving button.
+        trailingAction={
+          (isTouch || isMobileViewport) && withContextMenu ? undefined : (
+            <ConversationActionsMenu {...menuProps} />
+          )
+        }
         {...dragProps}
         className={cn(
           // `!` forces this over PanelItem's own max-md:py-3: cross-package

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -13,14 +13,12 @@ import { PanelItem } from "./panel-item";
 
 function renderRow(
   trailingAction = createElement("button", {}, "⋯"),
-  hideTrailingActionOnTouch = false,
 ): string {
   return renderToStaticMarkup(
     createElement(PanelItem, {
       label: "Row",
       onSelect: () => {},
       trailingAction,
-      hideTrailingActionOnTouch,
     }),
   );
 }
@@ -42,22 +40,11 @@ describe("PanelItem trailing action", () => {
     expect(html).toContain("has-[[aria-expanded=true]]:opacity-100");
   });
 
-  test("stays visible on touch devices by default (no hover to reveal it)", () => {
+  test("stays visible on touch devices (no hover to reveal it)", () => {
+    // Callers that already have their own touch affordance (long-press,
+    // swipe) simply don't pass `trailingAction` on touch, rather than
+    // asking PanelItem to hide one it was given, see conversation-row.tsx.
     expect(renderRow()).toContain("pointer-coarse:opacity-100");
-  });
-
-  test("is hidden on touch when hideTrailingActionOnTouch is set (caller has long-press + swipe)", () => {
-    const html = renderRow(undefined, true);
-    expect(html).not.toContain("pointer-coarse:opacity-100");
-  });
-
-  test("disables pointer events on touch when hideTrailingActionOnTouch is set (taps pass through to the row)", () => {
-    const html = renderRow(undefined, true);
-    expect(html).toContain("pointer-coarse:pointer-events-none");
-  });
-
-  test("keeps pointer events on touch by default (trailing action is visible and tappable)", () => {
-    expect(renderRow()).not.toContain("pointer-coarse:pointer-events-none");
   });
 
   test("stays visible on the active row", () => {
@@ -67,13 +54,17 @@ describe("PanelItem trailing action", () => {
 });
 
 describe("PanelItem badge", () => {
-  function renderWithBadge(badgeBare?: boolean): string {
+  function renderWithBadge(
+    badgeBare?: boolean,
+    trailingAction?: ReturnType<typeof createElement>,
+  ): string {
     return renderToStaticMarkup(
       createElement(PanelItem, {
         label: "Row",
         onSelect: () => {},
         badge: createElement("span", null, "3"),
         badgeBare,
+        trailingAction,
       }),
     );
   }
@@ -90,6 +81,16 @@ describe("PanelItem badge", () => {
     expect(html).not.toContain("rounded-[4px]");
     // Still renders the badge content itself.
     expect(html).toContain(">3<");
+  });
+
+  test("a bare badge alone gets an 8px inset from the row's edge", () => {
+    const html = renderWithBadge(true);
+    expect(html).toContain("mr-2");
+  });
+
+  test("a bare badge next to a trailing action skips the extra inset (gap-2 already separates them)", () => {
+    const html = renderWithBadge(true, createElement("button", {}, "⋯"));
+    expect(html).not.toContain("mr-2");
   });
 });
 

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -96,19 +96,13 @@ interface PanelItemProps {
    * (`aria-expanded="true"` on the trigger), and always when `active`.
    *
    * On touch (coarse-pointer) devices the trailing action stays visible by
-   * default so users can reach it without hover. Set
-   * `hideTrailingActionOnTouch` when the caller provides its own touch
-   * affordance (long-press → bottom sheet, swipe-to-reveal, etc.) so the
-   * ellipsis doesn't duplicate the gesture.
+   * default, since there's no hover to reveal it. If the row already has
+   * its own touch affordance (long-press → bottom sheet, swipe-to-reveal,
+   * etc.), pass `undefined` here on touch rather than rendering a redundant
+   * ellipsis: an always-visible-but-inert trailing element still reserves
+   * layout space next to `badge`, which reads as broken.
    */
   trailingAction?: ReactNode;
-  /**
-   * Suppress the touch-visible trailing action. Default `false` — the
-   * trailing action is shown on coarse-pointer devices. Set to `true` when
-   * the row has its own long-press or swipe-to-reveal gesture that makes
-   * the trailing ellipsis redundant on touch.
-   */
-  hideTrailingActionOnTouch?: boolean;
   /** Selected state. Sets `aria-current="page"` automatically. */
   active?: boolean;
   /**
@@ -216,6 +210,15 @@ const BADGE_BASE_CLASSES = [
 /** {@link PanelItemProps.badgeBare}: layout only, no pill chrome at any state. */
 const BADGE_BARE_CLASSES = "inline-flex items-center justify-center shrink-0";
 
+/**
+ * 8px inset from the row's true right edge, for a bare badge with no
+ * `trailingAction` beside it (e.g. conversation-row's mobile status dot,
+ * once its ellipsis is gone). Only applied then: with a trailing action
+ * present, `RIGHT_CLUSTER_CLASSES`'s own `gap-2` already separates the two,
+ * and this would stack on top of it.
+ */
+const BADGE_BARE_ALONE_CLASSES = "mr-2";
+
 const TRAILING_ACTION_CLASSES = [
   "flex items-center shrink-0",
   "opacity-0 transition-opacity",
@@ -245,7 +248,6 @@ function PanelItem({
   badge,
   badgeBare = false,
   trailingAction,
-  hideTrailingActionOnTouch = false,
   active = false,
   activeVariant = "default",
   disabled = false,
@@ -289,24 +291,19 @@ function PanelItem({
 
   const badgeNode =
     badge != null ? (
-      <span className={badgeBare ? BADGE_BARE_CLASSES : BADGE_BASE_CLASSES}>
+      <span
+        className={cn(
+          badgeBare ? BADGE_BARE_CLASSES : BADGE_BASE_CLASSES,
+          badgeBare && !trailingAction && BADGE_BARE_ALONE_CLASSES,
+        )}
+      >
         {badge}
       </span>
     ) : null;
 
   const trailingNode = trailingAction ? (
     <span
-      className={cn(
-        TRAILING_ACTION_CLASSES,
-        !hideTrailingActionOnTouch && "pointer-coarse:opacity-100",
-        // When the caller opts out of touch-visible trailing actions, also
-        // disable pointer events on coarse pointers so taps pass through to
-        // the row's own long-press / swipe handlers. Re-enable for the
-        // states where the action is still visible (active row, open menu,
-        // keyboard focus) so those interaction paths stay reachable.
-        hideTrailingActionOnTouch &&
-          "pointer-coarse:pointer-events-none pointer-coarse:has-[[aria-expanded=true]]:pointer-events-auto pointer-coarse:group-focus-within:pointer-events-auto pointer-coarse:group-aria-[current=page]:pointer-events-auto",
-      )}
+      className={cn(TRAILING_ACTION_CLASSES, "pointer-coarse:opacity-100")}
       onClick={(event: MouseEvent<HTMLSpanElement>) => {
         event.stopPropagation();
         event.preventDefault();


### PR DESCRIPTION
…ction titles

Touch/mobile: drops the conversation row's trailing ellipsis on touch and narrow-viewport devices (long-press/right-click already open the same menu) and insets the lone unread dot 8px from the row edge; mobile chat title sits 4px off the menu button. The mobile actions drawer now grows with its content up to 120px from the top of the screen before scrolling, with its scrollbar hidden. Preferences/New Chat footer pills split evenly via grid tracks instead of an unreliable flex-1 split. Section titles (Pinned, Pinned Apps, custom groups, Threads, View As) render at a lighter weight.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
