### PR TITLE
feat(web): randomize avatar appearance from the onboarding dice button

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-avatar-pool-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-avatar-pool-store.ts
@@ -53,6 +53,8 @@ interface OnboardingAvatarPoolState {
   selectedIndex: number;
   /** Populate the pool once (no-op if already done). */
   ensureGenerated: (components: CharacterComponents) => void;
+  /** Replace one character's traits (e.g. the picker's shuffle-dice reroll). */
+  setCharacterTraits: (index: number, traits: CharacterTraits) => void;
   setSelectedIndex: (index: number) => void;
   selectNext: () => void;
   selectPrev: () => void;
@@ -68,6 +70,10 @@ const useOnboardingAvatarPoolStoreBase = create<OnboardingAvatarPoolState>(
       }
       set({ characters: HARDCODED_POOL, selectedIndex: 0 });
     },
+    setCharacterTraits: (index, traits) =>
+      set((s) => ({
+        characters: s.characters.map((c, i) => (i === index ? traits : c)),
+      })),
     setSelectedIndex: (index) => set({ selectedIndex: index }),
     selectNext: () =>
       set((s) => ({

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -24,6 +24,7 @@ import {
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { randomCharacterTraits } from "@/utils/avatar-random";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import type { CharacterTraits } from "@/types/avatar";
 import { Button } from "@vellumai/design-library/components/button";
@@ -69,6 +70,8 @@ export function GiveMeAFaceScreen({
   const ensureGenerated = useOnboardingAvatarPoolStore.use.ensureGenerated();
   const selectedIndex = useOnboardingAvatarPoolStore.use.selectedIndex();
   const setSelectedIndex = useOnboardingAvatarPoolStore.use.setSelectedIndex();
+  const setCharacterTraits =
+    useOnboardingAvatarPoolStore.use.setCharacterTraits();
 
   useEffect(() => {
     if (components) {
@@ -164,10 +167,11 @@ export function GiveMeAFaceScreen({
     }
   }
 
-  // Roll a random name from the pool (different from the current one). Counts as
-  // a deliberate pick, so — like editing — it sticks across avatar cycling
-  // instead of being re-prefilled from the centered avatar.
-  function randomizeName() {
+  // Reroll both the name and the centered avatar's traits, each guaranteed to
+  // differ from the current one. The name counts as a deliberate pick, so —
+  // like editing — it sticks across avatar cycling instead of being
+  // re-prefilled from the centered avatar.
+  function randomizeCharacter() {
     nameCustomized.current = true;
     setName((current) => {
       const options = ASSISTANT_NAMES.filter(
@@ -176,6 +180,17 @@ export function GiveMeAFaceScreen({
       const pool = options.length > 0 ? options : ASSISTANT_NAMES;
       return pool[Math.floor(Math.random() * pool.length)]!;
     });
+    if (components && arrangement && centeredTraits) {
+      let traits = randomCharacterTraits(components);
+      while (
+        traits.bodyShape === centeredTraits.bodyShape &&
+        traits.eyeStyle === centeredTraits.eyeStyle &&
+        traits.color === centeredTraits.color
+      ) {
+        traits = randomCharacterTraits(components);
+      }
+      setCharacterTraits(arrangement.centerChar, traits);
+    }
   }
 
   const arrowClass =
@@ -282,9 +297,9 @@ export function GiveMeAFaceScreen({
                 </button>
                 <button
                   type="button"
-                  onClick={randomizeName}
-                  aria-label="Shuffle name"
-                  title="Shuffle name"
+                  onClick={randomizeCharacter}
+                  aria-label="Shuffle name and appearance"
+                  title="Shuffle name and appearance"
                   className="cursor-pointer text-[var(--content-tertiary)] transition-[transform,color] duration-300 hover:rotate-180 hover:text-[var(--content-default)]"
                 >
                   <Dices className="h-5 w-5" />

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -168,8 +168,8 @@ export function GiveMeAFaceScreen({
   }
 
   // Reroll both the name and the centered avatar's traits, each guaranteed to
-  // differ from the current one. The name counts as a deliberate pick, so —
-  // like editing — it sticks across avatar cycling instead of being
+  // differ from the current one. The name counts as a deliberate pick, so
+  // (like editing) it sticks across avatar cycling instead of being
   // re-prefilled from the centered avatar.
   function randomizeCharacter() {
     nameCustomized.current = true;


### PR DESCRIPTION
## Summary
- The dice button on the onboarding "Give me a face and a name" step now rerolls the centered avatar's eyes, body shape, and color (via the existing `randomCharacterTraits` helper) in addition to shuffling the name; the reroll is guaranteed to differ from the current trait combo.
- Added a `setCharacterTraits(index, traits)` action to the onboarding avatar pool store so the picker can replace the centered character's traits in place.
- Updated the button's aria-label/title from "Shuffle name" to "Shuffle name and appearance".

## Original prompt
On the onboarding "Give me a face and a name" step, the dice icon next to the assistant name only randomizes the name. The user asked for it to also randomize the avatar character's eyes, body shape, and color.