### PR TITLE
polish: rename View As labels, unbound Chats' scroll to the sidebar body

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -319,8 +319,8 @@ describe("AssistantSideMenu · All view", () => {
       await waitFor(() => {
         expect(document.body.textContent).toContain("View As");
       });
-      expect(document.body.textContent).toContain("List");
-      expect(document.body.textContent).toContain("Groups");
+      expect(document.body.textContent).toContain("All");
+      expect(document.body.textContent).toContain("Sources");
     } finally {
       cleanup();
     }
@@ -1081,28 +1081,50 @@ describe("AssistantSideMenu · equal section treatment", () => {
     ).toHaveLength(0);
   });
 
-  // Regression: Pinned used to cap at SIDEBAR_SECTION_MAX_HEIGHT and scroll
-  // within itself, with a drag handle on the rule below it to resize that
-  // cap. Both are gone: Pinned now grows to fit its own rows, unbounded,
-  // while a derived section like Chats still caps and scrolls.
-  test("Pinned's row list is unbounded; Chats still caps and scrolls", () => {
-    const container = parse(
-      renderMenu({
+  // Regression: Pinned and Chats used to cap at SIDEBAR_SECTION_MAX_HEIGHT
+  // and scroll within themselves - Pinned's even had a drag handle on the
+  // rule below it to resize that cap. Both are gone: Pinned grows to fit its
+  // own rows, unbounded, and Chats scrolls against the sidebar body instead,
+  // same as the flat list in List view. A derived channel section (Slack
+  // here) is the one kind of section that still caps and scrolls.
+  test("Pinned and Chats don't cap/scroll internally; a channel section still does", () => {
+    // A real DOM render, not `parse`: `scrollParent` only takes effect once
+    // the sidebar body's ref has mounted.
+    const { container } = render(
+      createElement(AssistantSideMenu, {
+        assistantId: "asst-1",
+        collapsed: false,
+        variant: "rail",
         conversations: LAYOUT_CONVERSATIONS,
         conversationGroups: LAYOUT_GROUPS,
+        onSelectConversation: () => {},
       }),
     );
+    try {
+      // Channel sections default closed (only Pinned/Chats default open),
+      // so Slack's row list isn't mounted until its chevron opens it.
+      const slackTrigger = container.querySelector<HTMLElement>(
+        '[aria-label="Slack"]',
+      );
+      act(() => {
+        slackTrigger?.click();
+      });
 
-    const sections = sectionElements(container);
-    const labels = sectionLabels(container);
-    const pinned = sections[labels.indexOf("Pinned")];
-    const chats = sections[labels.indexOf("Chats")];
-    if (!pinned || !chats) {
-      throw new Error("expected both Pinned and Chats sections");
+      const sections = sectionElements(container);
+      const labels = sectionLabels(container);
+      const pinned = sections[labels.indexOf("Pinned")];
+      const chats = sections[labels.indexOf("Chats")];
+      const slack = sections[labels.indexOf("Slack")];
+      if (!pinned || !chats || !slack) {
+        throw new Error("expected Pinned, Chats, and Slack sections");
+      }
+
+      expect(pinned.querySelector(".overflow-y-auto")).toBeNull();
+      expect(chats.querySelector(".overflow-y-auto")).toBeNull();
+      expect(slack.querySelector(".overflow-y-auto")).not.toBeNull();
+    } finally {
+      cleanup();
     }
-
-    expect(pinned.querySelector(".overflow-y-auto")).toBeNull();
-    expect(chats.querySelector(".overflow-y-auto")).not.toBeNull();
   });
 
   // The switch isn't statically rendered at all: it lives behind the

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -428,6 +428,7 @@ export function AssistantSideMenu({
       groupMenu={sectionMenu(section)}
       drag={sectionDragFor(section)}
       collapsedIndicator={collapsedActivityDot(section.all)}
+      scrollParent={bodyElement ?? undefined}
     />
   );
 

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -8,12 +8,14 @@
  *   `ConversationRowList`. Used by channel sections and custom groups.
  *
  * Nothing paginates: the rows just keep going. What differs is where they
- * scroll. A section caps at {@link SIDEBAR_SECTION_MAX_HEIGHT} and scrolls
- * within itself, since an uncapped busy section would push its neighbours off
- * screen, unless it opts out via `unbounded` (Pinned: expected to stay
- * short, and grows to fit its rows instead). The flat list instead scrolls
- * against the sidebar body it already fills (`scrollParent`), which keeps
- * the rail to a single scrollbar.
+ * scroll. A channel section or custom group caps at
+ * {@link SIDEBAR_SECTION_MAX_HEIGHT} and scrolls within itself, since an
+ * uncapped busy section would push its neighbours off screen. Pinned opts
+ * out via `unbounded` instead (expected to stay short, and grows to fit its
+ * rows). The flat list and Chats instead scroll against the sidebar body
+ * they already fill (`scrollParent`), which keeps the rail to a single
+ * scrollbar - the two render the same underlying conversations, just
+ * grouped differently, so they scroll the same way too.
  *
  * Either way a list past {@link CONVERSATION_LIST_VIRTUALIZE_THRESHOLD} rows
  * windows rather than mounting every one, because an assistant accumulates
@@ -64,16 +66,18 @@ export interface ConversationRowListProps {
   dragSiblings?: Conversation[];
   /**
    * Scroll against this ancestor rather than bounding the list. Only the flat
-   * list passes it: it already fills the sidebar body, so opening a scroller
-   * of its own would put a second scrollbar in the rail.
+   * list and Chats pass it: both already fill the sidebar body (directly, or
+   * nested in the persistent "Threads" header), so opening a scroller of
+   * their own would put a second scrollbar in the rail.
    */
   scrollParent?: HTMLElement;
   /**
    * Skips {@link SIDEBAR_SECTION_MAX_HEIGHT} entirely: the list grows to fit
    * every row instead of capping and scrolling within itself. Pinned is the
    * one section that wants this, the user's own curation, expected to stay
-   * short, and (unlike Chats or a channel section) not something that should
-   * ever need its own internal scrollbar.
+   * short - and (unlike a channel section, which still caps and scrolls
+   * internally) not something that should ever push its neighbours off
+   * screen.
    */
   unbounded?: boolean;
 }

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -20,7 +20,9 @@
  * the section drag wiring - is uniform, and comes in already resolved. The
  * row list is the other near-exception: every section caps and scrolls
  * within itself except Pinned, which grows to fit its own rows instead
- * (see `unbounded` on `ConversationRowList`).
+ * (see `unbounded` on `ConversationRowList`), and Chats, which scrolls
+ * against the sidebar body instead, same as the flat list in List view
+ * (see `scrollParent`).
  */
 
 import type { ReactNode } from "react";
@@ -42,14 +44,26 @@ export interface SidebarSectionItemProps {
   drag?: CollapsibleNavSectionDrag;
   /** Activity dot shown in the header only while the section is collapsed. */
   collapsedIndicator?: ReactNode;
+  /**
+   * Sidebar body element to scroll Chats against instead of capping it.
+   * Ignored by every other section type.
+   */
+  scrollParent?: HTMLElement;
 }
 
 /**
- * Row-list props for a section. Both branches carry the same keys so the
- * spread below stays a single object type rather than a union.
+ * Row-list props for a section. All three branches carry the same keys so
+ * the spread below stays a single object type rather than a union.
  */
-function rowListPropsFor(section: SidebarSection) {
-  if (section.type === "recents" || section.type === "channel") {
+function rowListPropsFor(section: SidebarSection, scrollParent?: HTMLElement) {
+  if (section.type === "recents") {
+    // Chats scrolls against the sidebar body instead of capping and
+    // scrolling within itself, same as the flat list in List view - the
+    // two render the same underlying conversations, just grouped
+    // differently, so they should feel identical to scroll through.
+    return { items: section.all, dragSection: undefined, scrollParent };
+  }
+  if (section.type === "channel") {
     return { items: section.all, dragSection: undefined };
   }
   return {
@@ -64,6 +78,7 @@ export function SidebarSectionItem({
   groupMenu,
   drag,
   collapsedIndicator,
+  scrollParent,
 }: SidebarSectionItemProps) {
   return (
     <ConversationNavSection
@@ -86,7 +101,7 @@ export function SidebarSectionItem({
       // to fit its own rows instead.
       collapsible={section.type !== "pinned"}
       unbounded={section.type === "pinned"}
-      {...rowListPropsFor(section)}
+      {...rowListPropsFor(section, scrollParent)}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/sidebar-view-mode-toggle.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-view-mode-toggle.tsx
@@ -8,8 +8,8 @@ import { SegmentControl } from "@vellumai/design-library/components/segment-cont
 import type { SidebarViewMode } from "@/domains/chat/utils/sidebar-view-mode";
 
 const VIEW_MODE_ITEMS: { value: SidebarViewMode; label: string }[] = [
-  { value: "all", label: "List" },
-  { value: "grouped", label: "Groups" },
+  { value: "all", label: "All" },
+  { value: "grouped", label: "Sources" },
 ];
 
 export interface SidebarViewModeToggleProps {


### PR DESCRIPTION
"Groups" -> "Sources" and "List" -> "All" in the View As toggle. Chats no longer caps and scrolls within itself in Grouped view; it now scrolls against the sidebar body instead, same as the flat list does in List view - channel sections and custom groups still cap/scroll internally.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
