### PR TITLE
fix(web): stop the onboarding screen reload loop before an assistant exists

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1475,9 +1475,13 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   const flush = (): Promise<void> =>
     new Promise((resolve) => setTimeout(resolve, 0));
 
+  const PLATFORM_AUTH_REDIRECT_KEY = "vellum:platform:auth-redirect-attempts";
+  const PLATFORM_AUTH_MAX_REDIRECTS = 3;
+
   beforeEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
+    sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
     mockAuthState.sessionStatus = "authenticated";
     mockAuthState.refreshSession = mock(async () => true);
     hardNavigateMock.mockClear();
@@ -1486,7 +1490,19 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   afterEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
+    sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
   });
+
+  /** Drive one full rejection→recovery round trip against a dead session. */
+  const rejectOnce = async (): Promise<void> => {
+    mockAuthState.sessionStatus = "authenticated";
+    mockAuthState.refreshSession = mock(async () => {
+      mockAuthState.sessionStatus = "unauthenticated";
+      return false;
+    });
+    platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
+    await flush();
+  };
 
   test("401 while authenticated re-verifies; a dead session redirects to login", async () => {
     const refreshSession = mock(async () => {
@@ -1581,5 +1597,52 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     resolveRefresh(true);
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops redirecting to login once the budget is spent (#39820)", async () => {
+    // The redirect is a full page load, so the in-memory latch cannot count
+    // round trips — a destination that bounces back and rejects again gets a
+    // fresh latch every time. Without the sessionStorage budget this is an
+    // unbounded loop.
+    for (let i = 0; i < PLATFORM_AUTH_MAX_REDIRECTS; i++) {
+      await rejectOnce();
+    }
+    expect(hardNavigateMock).toHaveBeenCalledTimes(PLATFORM_AUTH_MAX_REDIRECTS);
+
+    await rejectOnce();
+    expect(hardNavigateMock).toHaveBeenCalledTimes(PLATFORM_AUTH_MAX_REDIRECTS);
+  });
+
+  test("a successful platform response restores the redirect budget", async () => {
+    sessionStorage.setItem(
+      PLATFORM_AUTH_REDIRECT_KEY,
+      String(PLATFORM_AUTH_MAX_REDIRECTS),
+    );
+
+    await rejectOnce();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+
+    // The platform answering is the only evidence the session works again.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBeNull();
+
+    await rejectOnce();
+    expect(hardNavigateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a self-hosted gateway 2xx does not restore the platform budget", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    sessionStorage.setItem(
+      PLATFORM_AUTH_REDIRECT_KEY,
+      String(PLATFORM_AUTH_MAX_REDIRECTS),
+    );
+
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, `${INGRESS}/v1/assistants/123/messages`),
+    );
+
+    expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBe(
+      String(PLATFORM_AUTH_MAX_REDIRECTS),
+    );
   });
 });

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -58,12 +58,15 @@ mock.module("@/lib/local-mode", () => ({
 // store's heavy dependency graph. `subscribe` is a no-op the (unrelated)
 // organization-store binds but never calls in these tests.
 type MockSessionStatus = "initializing" | "authenticated" | "unauthenticated";
+type MockPlatformSession = "unknown" | "present" | "absent";
 
 const mockAuthState: {
   sessionStatus: MockSessionStatus;
+  platformSession: MockPlatformSession;
   refreshSession: () => Promise<boolean>;
 } = {
   sessionStatus: "authenticated",
+  platformSession: "present",
   refreshSession: async () => true,
 };
 
@@ -1483,6 +1486,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     setSelfHostedConnection(null);
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
     mockAuthState.sessionStatus = "authenticated";
+    mockAuthState.platformSession = "present";
     mockAuthState.refreshSession = mock(async () => true);
     hardNavigateMock.mockClear();
   });
@@ -1599,11 +1603,9 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(1);
   });
 
-  test("stops redirecting to login once the budget is spent (#39820)", async () => {
+  test("stops redirecting to login once the budget is spent", async () => {
     // The redirect is a full page load, so the in-memory latch cannot count
-    // round trips — a destination that bounces back and rejects again gets a
-    // fresh latch every time. Without the sessionStorage budget this is an
-    // unbounded loop.
+    // round trips and a bouncing destination would drive them without bound.
     for (let i = 0; i < PLATFORM_AUTH_MAX_REDIRECTS; i++) {
       await rejectOnce();
     }
@@ -1613,7 +1615,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(hardNavigateMock).toHaveBeenCalledTimes(PLATFORM_AUTH_MAX_REDIRECTS);
   });
 
-  test("a successful platform response restores the redirect budget", async () => {
+  test("a platform 2xx on a confirmed session restores the redirect budget", async () => {
     sessionStorage.setItem(
       PLATFORM_AUTH_REDIRECT_KEY,
       String(PLATFORM_AUTH_MAX_REDIRECTS),
@@ -1622,7 +1624,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     await rejectOnce();
     expect(hardNavigateMock).not.toHaveBeenCalled();
 
-    // The platform answering is the only evidence the session works again.
+    mockAuthState.platformSession = "present";
     platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
     expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBeNull();
 
@@ -1630,8 +1632,28 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(hardNavigateMock).toHaveBeenCalledTimes(1);
   });
 
+  test("a 2xx without a platform session does not restore the budget", async () => {
+    // The platform serves some routes to anonymous visitors, and the login
+    // screen loads one: `AccountLayout` syncs client feature flags. Treating
+    // that as proof of a live session would refill the budget on every bounce.
+    mockAuthState.platformSession = "absent";
+    sessionStorage.setItem(
+      PLATFORM_AUTH_REDIRECT_KEY,
+      String(PLATFORM_AUTH_MAX_REDIRECTS),
+    );
+
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, "https://platform.test/v1/feature-flags/"),
+    );
+
+    expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBe(
+      String(PLATFORM_AUTH_MAX_REDIRECTS),
+    );
+  });
+
   test("a self-hosted gateway 2xx does not restore the platform budget", async () => {
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    mockAuthState.platformSession = "present";
     sessionStorage.setItem(
       PLATFORM_AUTH_REDIRECT_KEY,
       String(PLATFORM_AUTH_MAX_REDIRECTS),

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -53,6 +53,7 @@ import { getActiveOrganizationIdForRequests } from "@/stores/organization-store"
 import { hardNavigate } from "@/lib/auth/hard-navigate";
 import { useAuthStore } from "@/stores/auth-store";
 import {
+  hasLivePlatformSession,
   isAuthenticated,
   isSettledSessionRejection,
 } from "@/stores/session-status";
@@ -517,25 +518,11 @@ export function localGatewayAuthRecoveryInterceptor(
 let platformAuthRecoveryFired = false;
 
 /**
- * Cross-page-load budget for the redirect below.
- *
- * The in-memory latch above only de-duplicates rejections within one page
- * lifecycle, and the redirect is a full page load — so a destination that comes
- * back and rejects again gets a fresh latch every time, and nothing counts the
- * round trips. That is a loop with no floor, and #39820 rode it: the login page
- * bounced straight back to the caller's `returnTo`, which rejected again, twice
- * a second, indefinitely.
- *
- * The specific cause of that loop is fixed in `refreshSession` (a local session
- * no longer ends on a platform rejection), so this is the structural backstop
- * rather than the fix: whatever the reason a redirect fails to resolve the
- * rejection, the app stops re-driving it after a few attempts and the normal
- * error path surfaces the state instead.
- *
- * Mirrors the gateway budget above, including why elapsed time never restores
- * it: only a platform request actually succeeding proves the session works, so
- * only that clears it. Living in sessionStorage means a quit-and-reopen grants
- * a fresh budget.
+ * Caps the login redirects below. The redirect is a full page load, so the
+ * in-memory latch cannot count round trips and a destination that bounces back
+ * and rejects again would drive them without bound. Only a confirmed platform
+ * session restores the budget; sessionStorage means a relaunch grants a fresh
+ * one.
  */
 const PLATFORM_AUTH_REDIRECT_KEY = "vellum:platform:auth-redirect-attempts";
 const PLATFORM_AUTH_MAX_REDIRECTS = 3;
@@ -546,9 +533,8 @@ export function resetPlatformAuthRecoveryFlag(): void {
 }
 
 /**
- * Spend one redirect from the budget. Returns false when it is exhausted (or
- * when sessionStorage is unavailable, so an environment that cannot count fails
- * closed rather than looping).
+ * Spend one redirect. False when the budget is exhausted, or when
+ * sessionStorage is unavailable so an uncountable environment fails closed.
  */
 function claimPlatformAuthRedirect(): boolean {
   try {
@@ -566,6 +552,11 @@ function claimPlatformAuthRedirect(): boolean {
   }
 }
 
+/**
+ * Restore the budget. Gated on a confirmed platform session by the caller: the
+ * platform serves some routes (client feature flags) to anonymous visitors, so
+ * a 2xx alone does not mean the session works.
+ */
 function clearPlatformAuthRedirectBudget(): void {
   try {
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
@@ -613,8 +604,8 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
  * {@link localGatewayAuthRecoveryInterceptor}.
  *
- * A platform request that succeeds restores the redirect budget: it is the only
- * evidence the session is working again.
+ * A platform request that succeeds against a confirmed session restores the
+ * redirect budget.
  */
 export function platformAuthRecoveryInterceptor(response: Response): Response {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -622,9 +613,12 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
     !!ingressUrl && response.url.startsWith(ingressUrl);
 
   if (response.ok) {
-    // Scoped to platform responses — a working self-hosted gateway says nothing
-    // about the platform session the budget is counting redirects for.
-    if (!fromSelfHostedGateway) {
+    // A working self-hosted gateway says nothing about the platform session,
+    // and neither does a route the platform serves anonymously.
+    if (
+      !fromSelfHostedGateway &&
+      hasLivePlatformSession(useAuthStore.getState().platformSession)
+    ) {
       clearPlatformAuthRedirectBudget();
     }
     return response;

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -516,9 +516,62 @@ export function localGatewayAuthRecoveryInterceptor(
 // permission-403 that left the session live is still caught later.
 let platformAuthRecoveryFired = false;
 
+/**
+ * Cross-page-load budget for the redirect below.
+ *
+ * The in-memory latch above only de-duplicates rejections within one page
+ * lifecycle, and the redirect is a full page load — so a destination that comes
+ * back and rejects again gets a fresh latch every time, and nothing counts the
+ * round trips. That is a loop with no floor, and #39820 rode it: the login page
+ * bounced straight back to the caller's `returnTo`, which rejected again, twice
+ * a second, indefinitely.
+ *
+ * The specific cause of that loop is fixed in `refreshSession` (a local session
+ * no longer ends on a platform rejection), so this is the structural backstop
+ * rather than the fix: whatever the reason a redirect fails to resolve the
+ * rejection, the app stops re-driving it after a few attempts and the normal
+ * error path surfaces the state instead.
+ *
+ * Mirrors the gateway budget above, including why elapsed time never restores
+ * it: only a platform request actually succeeding proves the session works, so
+ * only that clears it. Living in sessionStorage means a quit-and-reopen grants
+ * a fresh budget.
+ */
+const PLATFORM_AUTH_REDIRECT_KEY = "vellum:platform:auth-redirect-attempts";
+const PLATFORM_AUTH_MAX_REDIRECTS = 3;
+
 /** @internal Exposed for test teardown only. */
 export function resetPlatformAuthRecoveryFlag(): void {
   platformAuthRecoveryFired = false;
+}
+
+/**
+ * Spend one redirect from the budget. Returns false when it is exhausted (or
+ * when sessionStorage is unavailable, so an environment that cannot count fails
+ * closed rather than looping).
+ */
+function claimPlatformAuthRedirect(): boolean {
+  try {
+    const stored = Number(
+      sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY) ?? "0",
+    );
+    const attempts = Number.isFinite(stored) ? stored : 0;
+    if (attempts >= PLATFORM_AUTH_MAX_REDIRECTS) {
+      return false;
+    }
+    sessionStorage.setItem(PLATFORM_AUTH_REDIRECT_KEY, String(attempts + 1));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearPlatformAuthRedirectBudget(): void {
+  try {
+    sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
+  } catch {
+    // sessionStorage unavailable; the claim above already fails closed.
+  }
 }
 
 async function recoverFromPlatformSessionRejection(): Promise<void> {
@@ -530,7 +583,10 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // and keeps `sessionStatus` authenticated, so the redirect below is
     // skipped there.
     await useAuthStore.getState().refreshSession();
-    if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
+    if (
+      !isAuthenticated(useAuthStore.getState().sessionStatus) &&
+      claimPlatformAuthRedirect()
+    ) {
       hardNavigate(
         `${routes.account.login}?returnTo=${encodeURIComponent(
           window.location.pathname + window.location.search,
@@ -556,8 +612,24 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * and prevents a redirect loop), and the response did not come from the
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
  * {@link localGatewayAuthRecoveryInterceptor}.
+ *
+ * A platform request that succeeds restores the redirect budget: it is the only
+ * evidence the session is working again.
  */
 export function platformAuthRecoveryInterceptor(response: Response): Response {
+  const ingressUrl = getSelfHostedIngressUrl();
+  const fromSelfHostedGateway =
+    !!ingressUrl && response.url.startsWith(ingressUrl);
+
+  if (response.ok) {
+    // Scoped to platform responses — a working self-hosted gateway says nothing
+    // about the platform session the budget is counting redirects for.
+    if (!fromSelfHostedGateway) {
+      clearPlatformAuthRedirectBudget();
+    }
+    return response;
+  }
+
   if (
     !isSettledSessionRejection({ ok: response.ok, status: response.status })
   ) {
@@ -569,8 +641,7 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
     return response;
   }
-  const ingressUrl = getSelfHostedIngressUrl();
-  if (ingressUrl && response.url.startsWith(ingressUrl)) {
+  if (fromSelfHostedGateway) {
     return response;
   }
 

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -48,8 +48,7 @@ mock.module("@/lib/consent/diagnostics-consent", () => ({
 
 type MockUser = { id: string; kind: "platform" | "local" };
 const PLATFORM_USER: MockUser = { id: "u1", kind: "platform" };
-// What local mode signs in before anything is hatched: a synthetic identity
-// with no platform account behind it.
+// The synthetic identity local mode signs in, with no platform account behind it.
 const LOCAL_USER: MockUser = { id: "gateway-local", kind: "local" };
 let currentUser: MockUser | null = PLATFORM_USER;
 mock.module("@/stores/auth-store", () => ({
@@ -141,11 +140,9 @@ describe("refreshDiagnosticsConsent", () => {
     expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
   });
 
-  test("no-ops for a local-mode user with no platform account (#39820)", async () => {
-    // A truthy id is not a platform account. Fetching consent for the synthetic
-    // local user asks the platform about someone it has never heard of, and the
-    // 401/403 it answers with is a settled rejection that arms the platform auth
-    // recovery — the redirect half of the onboarding reload loop.
+  test("no-ops for a local-mode user with no platform account", async () => {
+    // A truthy id is not a platform account, and the 401/403 the platform
+    // answers with is a settled rejection that arms the auth recovery.
     currentUser = LOCAL_USER;
     await refreshDiagnosticsConsent();
     expect(fetchConsent).not.toHaveBeenCalled();

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -46,7 +46,12 @@ mock.module("@/lib/consent/diagnostics-consent", () => ({
   failCloseDiagnosticsGateUntilFirstSync: mock(() => {}),
 }));
 
-let currentUser: { id: string } | null = { id: "u1" };
+type MockUser = { id: string; kind: "platform" | "local" };
+const PLATFORM_USER: MockUser = { id: "u1", kind: "platform" };
+// What local mode signs in before anything is hatched: a synthetic identity
+// with no platform account behind it.
+const LOCAL_USER: MockUser = { id: "gateway-local", kind: "local" };
+let currentUser: MockUser | null = PLATFORM_USER;
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: { getState: () => ({ user: currentUser }) },
 }));
@@ -115,7 +120,7 @@ beforeEach(() => {
   setServerAnalyticsEffective.mockClear();
   setPendingAnalyticsOptIn.mockClear();
   setServerDiagnosticsEffective.mockClear();
-  currentUser = { id: "u1" };
+  currentUser = PLATFORM_USER;
   consentResult = Promise.resolve(consentRecord());
   clock += FLOOR_CLEAR_MS;
   setSystemTime(new Date(clock));
@@ -131,6 +136,17 @@ const flush = (): Promise<void> => Promise.resolve();
 describe("refreshDiagnosticsConsent", () => {
   test("no-ops when unauthenticated", async () => {
     currentUser = null;
+    await refreshDiagnosticsConsent();
+    expect(fetchConsent).not.toHaveBeenCalled();
+    expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
+  });
+
+  test("no-ops for a local-mode user with no platform account (#39820)", async () => {
+    // A truthy id is not a platform account. Fetching consent for the synthetic
+    // local user asks the platform about someone it has never heard of, and the
+    // 401/403 it answers with is a settled rejection that arms the platform auth
+    // recovery — the redirect half of the onboarding reload loop.
+    currentUser = LOCAL_USER;
     await refreshDiagnosticsConsent();
     expect(fetchConsent).not.toHaveBeenCalled();
     expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -32,13 +32,8 @@ export async function refreshDiagnosticsConsent(): Promise<void> {
   // Capture the authenticated user BEFORE the await so we can detect a
   // logout/account-switch that races the in-flight fetch.
   //
-  // Gated on `kind`, not merely on a truthy id: local mode signs in a synthetic
-  // `"local"` user (`id: "gateway-local"`) that has no platform account behind
-  // it, so an id check alone sent this fetch out for users the platform has
-  // never heard of. `/v1/user/consent/` then answers 401/403 — a settled
-  // rejection, which arms `platformAuthRecoveryInterceptor` — to ask a question
-  // that has no server-side answer to begin with. There is no consent record to
-  // read without a platform account (#39820).
+  // Gated on `kind`, not a truthy id: local mode signs in a synthetic `"local"`
+  // user that has no platform account, and so no consent record to read.
   const userBefore = useAuthStore.getState().user;
   const userIdBefore = userBefore?.id;
   if (!userIdBefore || userBefore?.kind !== "platform") {

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -24,15 +24,24 @@ const BACKSTOP_INTERVAL_MS = 30 * 60_000;
 let lastRefreshAt = 0;
 
 /**
- * When a user is authenticated, fetch the server consent and route it through
- * the diagnostics chokepoint. No-op when unauthenticated; a thrown fetch leaves
+ * When a platform account is signed in, fetch the server consent and route it
+ * through the diagnostics chokepoint. No-op otherwise; a thrown fetch leaves
  * state unchanged.
  */
 export async function refreshDiagnosticsConsent(): Promise<void> {
   // Capture the authenticated user BEFORE the await so we can detect a
   // logout/account-switch that races the in-flight fetch.
-  const userIdBefore = useAuthStore.getState().user?.id;
-  if (!userIdBefore) {
+  //
+  // Gated on `kind`, not merely on a truthy id: local mode signs in a synthetic
+  // `"local"` user (`id: "gateway-local"`) that has no platform account behind
+  // it, so an id check alone sent this fetch out for users the platform has
+  // never heard of. `/v1/user/consent/` then answers 401/403 — a settled
+  // rejection, which arms `platformAuthRecoveryInterceptor` — to ask a question
+  // that has no server-side answer to begin with. There is no consent record to
+  // read without a platform account (#39820).
+  const userBefore = useAuthStore.getState().user;
+  const userIdBefore = userBefore?.id;
+  if (!userIdBefore || userBefore?.kind !== "platform") {
     return;
   }
   try {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -534,17 +534,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent"); // stale platform state cleared
   });
 
-  test("refreshSession keeps a pre-hatch local session alive on a settled 401 (#39820)", async () => {
-    // Brand-new desktop user: local mode, nothing hatched yet, so there is no
-    // local gateway URL and `isGatewayAuthEnabled()` is false. They have no
-    // platform account either, so the probe legitimately settles 401. Ending
-    // the local session here is what drove the onboarding reload loop — the
-    // recovery interceptor sent them to `/account/login?returnTo=…`, which
-    // bounced straight back once boot re-established the local session.
+  test("refreshSession keeps a pre-hatch local session alive on a settled 401", async () => {
+    // Brand-new desktop user: nothing hatched, so no local gateway URL, and no
+    // platform account for the probe to find.
     mockIsLocalClient = true;
-    mockIsGatewayAuth = false; // nothing hatched → no local gateway URL
+    mockIsGatewayAuth = false;
     mockGatewayToken = null;
-    mockPlatformAssistants = []; // and no managed assistant to answer for
+    mockPlatformAssistants = [];
     sessionUser = null;
     useAuthStore.setState({
       sessionStatus: "authenticated",
@@ -560,9 +556,7 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("refreshSession still ends a local session whose assistants are platform-hosted", async () => {
     // A managed assistant is unreachable without a platform session, so the
-    // demotion above deliberately does not cover this case — routing to login
-    // is the honest outcome rather than stranding the user beside an assistant
-    // that can no longer answer.
+    // demotion above excludes this case and login is the right destination.
     mockIsLocalClient = true;
     mockIsGatewayAuth = false;
     mockGatewayToken = null;
@@ -580,7 +574,7 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("refreshSession still ends the session for a platform-mode client on a settled 401", async () => {
     // The web SPA has no local session to fall back on, so a settled rejection
-    // must still log out — the guard above is local-mode only.
+    // still logs out.
     mockIsLocalClient = false;
     mockIsGatewayAuth = false;
     mockGatewayToken = null;

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -534,6 +534,69 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent"); // stale platform state cleared
   });
 
+  test("refreshSession keeps a pre-hatch local session alive on a settled 401 (#39820)", async () => {
+    // Brand-new desktop user: local mode, nothing hatched yet, so there is no
+    // local gateway URL and `isGatewayAuthEnabled()` is false. They have no
+    // platform account either, so the probe legitimately settles 401. Ending
+    // the local session here is what drove the onboarding reload loop — the
+    // recovery interceptor sent them to `/account/login?returnTo=…`, which
+    // bounced straight back once boot re-established the local session.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = false; // nothing hatched → no local gateway URL
+    mockGatewayToken = null;
+    mockPlatformAssistants = []; // and no managed assistant to answer for
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "unknown",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local");
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("refreshSession still ends a local session whose assistants are platform-hosted", async () => {
+    // A managed assistant is unreachable without a platform session, so the
+    // demotion above deliberately does not cover this case — routing to login
+    // is the honest outcome rather than stranding the user beside an assistant
+    // that can no longer answer.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = false;
+    mockGatewayToken = null;
+    mockPlatformAssistants = [{ assistantId: "managed-1", cloud: "vellum" }];
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  test("refreshSession still ends the session for a platform-mode client on a settled 401", async () => {
+    // The web SPA has no local session to fall back on, so a settled rejection
+    // must still log out — the guard above is local-mode only.
+    mockIsLocalClient = false;
+    mockIsGatewayAuth = false;
+    mockGatewayToken = null;
+    mockPlatformAssistants = [];
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+
   test("refreshSession leaves an unauthenticated session untouched in the gateway window", async () => {
     // Mid cold-start hatch: gateway enabled, token not minted, session not yet
     // established. A settled 401 must not promote to authenticated — the gateway

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -1034,20 +1034,46 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       return isAuthenticated(get().sessionStatus);
     }
     // A settled "no platform session" (401) ends the platform session, not the
-    // local gateway session. When the gateway is the auth source, demote an
-    // authenticated session to the local user and mark the platform session
-    // absent — dropping the now-stale platform user and offline snapshot so
-    // platform-gated surfaces stop treating it as signed in — while keeping
-    // `sessionStatus` "authenticated"; a 401 must not log a local-only user out.
-    // (The successful probe above still adopts the platform user, so provider
-    // sign-in keeps working.) An unauthenticated session — e.g. mid cold-start
-    // hatch — is left for the gateway to settle once its token mints.
+    // local one. Demote an authenticated session to the local user and mark the
+    // platform session absent — dropping the now-stale platform user and
+    // offline snapshot so platform-gated surfaces stop treating it as signed in
+    // — while keeping `sessionStatus` "authenticated"; a 401 must not log a
+    // local-only user out. (The successful probe above still adopts the platform
+    // user, so provider sign-in keeps working.) An unauthenticated session —
+    // e.g. mid cold-start hatch — is left for the gateway to settle once its
+    // token mints.
     //
     // Holding `sessionStatus` "authenticated" is load-bearing: in-app consumers
     // read `useIsAuthenticated()` directly to scope the QueryClient cache and
     // gate signed-in UI, so ending the session would drop them into the
     // anonymous cache scope and hide that UI.
-    if (isGatewayAuthEnabled()) {
+    //
+    // The predicate asks whether this client's session can stand on its own
+    // without the platform, and mirrors how `initSession` above branches: a
+    // local gateway is one way, and having no platform assistant to answer for
+    // is the other.
+    //
+    // Gateway auth alone was too narrow, because it additionally requires a
+    // local gateway URL — which does not exist until an assistant has been
+    // hatched. That left every brand-new desktop user out of the protection
+    // they need most: their platform account does not exist yet, so the first
+    // platform request legitimately answers 401/403, this branch was skipped,
+    // `sessionEnded()` logged them out of the local session they did have, and
+    // `platformAuthRecoveryInterceptor` sent them to
+    // `/account/login?returnTo=/assistant/welcome` — which bounces straight
+    // back once boot re-establishes the local session, looping the onboarding
+    // screen roughly twice a second and never leaving the Log In button on
+    // screen long enough to click (#39820).
+    //
+    // A local client whose assistants are platform-hosted is deliberately NOT
+    // covered: a managed assistant is unreachable without a platform session,
+    // so ending it and routing to login is the honest outcome there — demoting
+    // instead would strand the user in the app next to an assistant that can
+    // no longer answer. Remote-gateway mode returns at the top of this action.
+    const localSessionStandsAlone =
+      isLocalClient() &&
+      (isGatewayAuthEnabled() || getPlatformAssistants().length === 0);
+    if (localSessionStandsAlone) {
       const wasAuthenticated = isAuthenticated(get().sessionStatus);
       if (wasAuthenticated) {
         clearUserSnapshot();

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -1035,41 +1035,25 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
     // A settled "no platform session" (401) ends the platform session, not the
     // local one. Demote an authenticated session to the local user and mark the
-    // platform session absent — dropping the now-stale platform user and
-    // offline snapshot so platform-gated surfaces stop treating it as signed in
-    // — while keeping `sessionStatus` "authenticated"; a 401 must not log a
-    // local-only user out. (The successful probe above still adopts the platform
-    // user, so provider sign-in keeps working.) An unauthenticated session —
-    // e.g. mid cold-start hatch — is left for the gateway to settle once its
-    // token mints.
+    // platform session absent, dropping the stale platform user and offline
+    // snapshot so platform-gated surfaces stop treating it as signed in, while
+    // keeping `sessionStatus` "authenticated": a 401 must not log a local-only
+    // user out. (The successful probe above still adopts the platform user, so
+    // provider sign-in keeps working.) An unauthenticated session, e.g. mid
+    // cold-start hatch, is left for the gateway to settle once its token mints.
     //
     // Holding `sessionStatus` "authenticated" is load-bearing: in-app consumers
     // read `useIsAuthenticated()` directly to scope the QueryClient cache and
     // gate signed-in UI, so ending the session would drop them into the
     // anonymous cache scope and hide that UI.
     //
-    // The predicate asks whether this client's session can stand on its own
-    // without the platform, and mirrors how `initSession` above branches: a
-    // local gateway is one way, and having no platform assistant to answer for
-    // is the other.
-    //
-    // Gateway auth alone was too narrow, because it additionally requires a
-    // local gateway URL — which does not exist until an assistant has been
-    // hatched. That left every brand-new desktop user out of the protection
-    // they need most: their platform account does not exist yet, so the first
-    // platform request legitimately answers 401/403, this branch was skipped,
-    // `sessionEnded()` logged them out of the local session they did have, and
-    // `platformAuthRecoveryInterceptor` sent them to
-    // `/account/login?returnTo=/assistant/welcome` — which bounces straight
-    // back once boot re-establishes the local session, looping the onboarding
-    // screen roughly twice a second and never leaving the Log In button on
-    // screen long enough to click (#39820).
-    //
-    // A local client whose assistants are platform-hosted is deliberately NOT
-    // covered: a managed assistant is unreachable without a platform session,
-    // so ending it and routing to login is the honest outcome there — demoting
-    // instead would strand the user in the app next to an assistant that can
-    // no longer answer. Remote-gateway mode returns at the top of this action.
+    // The predicate asks whether the local session can stand on its own,
+    // mirroring how `initSession` branches: a local gateway answers for itself,
+    // and so does a client with no platform assistant to reach. A local client
+    // whose assistants are platform-hosted is excluded, since a managed
+    // assistant is unreachable without a platform session and routing to login
+    // beats stranding the user beside one that cannot answer. Remote-gateway
+    // mode returns at the top of this action.
     const localSessionStandsAlone =
       isLocalClient() &&
       (isGatewayAuthEnabled() || getPlatformAssistants().length === 0);


### PR DESCRIPTION
Fixes #39820.

A brand-new desktop user cannot get through onboarding. The welcome screen tears down and rebuilds itself roughly twice a second, so the Log In button — which fades in over `0.5s` delay + `0.5s` duration — never stays on screen long enough to click. The reporter described it as "app GUI blinks repeatedly, no login button."

This is not machine-specific. It was reported on macOS Sequoia 15.7.5 and reproduced independently on macOS Tahoe 26.6, and in both cases hatching an assistant from the CLI and restarting makes it go away — which is what localizes it to the pre-hatch state. The Metal/GPU init error in the first reporter's log is a real but separate problem on that machine, not this.

## The loop

```
/assistant/welcome
  -> a platform request answers 401/403 (there is no platform account yet)
  -> platformAuthRecoveryInterceptor -> refreshSession()
  -> refreshSession sees isGatewayAuthEnabled() === false, because gateway auth
     needs a local gateway URL and nothing has been hatched, so it skips the
     "a 401 must not log a local-only user out" demotion and calls sessionEnded()
  -> the interceptor hard-navigates to /account/login?returnTo=/assistant/welcome
  -> boot re-establishes the local session, so useReturnToShortCircuit bounces
     straight back to /assistant/welcome
  -> repeat
```

Nothing breaks the cycle. `platformAuthRecoveryFired` resets in its own `finally` and dies with the document, and the redirect is a full page load, so no state survives to count the round trips.

## Changes

**1. `stores/auth-store.ts` — the regression.** `refreshSession()` now keys the demotion on whether the local session can stand on its own (a local gateway, or no platform assistant to answer for), mirroring how `initSession` already branches. `isGatewayAuthEnabled()` was too narrow because it additionally requires a local gateway URL, which does not exist until something has been hatched.

A local client whose assistants are *platform-hosted* is deliberately still logged out: a managed assistant is unreachable without a platform session, so routing to login is the honest outcome there — demoting instead would strand the user in the app beside an assistant that can no longer answer. There is a test pinning that boundary.

**2. `lib/consent/consent-refresh.ts` — the trigger.** `refreshDiagnosticsConsent()` now requires `user.kind === "platform"`. Local mode signs in a synthetic `"local"` user with a truthy id (`"gateway-local"`), so the previous id-only check sent `/v1/user/consent/` out for users the platform has never heard of — and the 401/403 it answers with is a settled rejection, which is what arms the recovery each cycle. There is no consent record to read without a platform account.

**3. `lib/api-interceptors.ts` — the backstop.** The login redirect now spends from a `sessionStorage` budget (3 per browser session), cleared by any successful platform response. This mirrors the budget the gateway-401 reload path already carries, including why elapsed time never restores it: only a platform request actually succeeding proves the session works. This is structural insurance, not the fix — change 1 is what closes this particular loop.

## Prompt / plan

Investigated from the two screen recordings and logs attached to #39820, then traced through the code. Evidence that identified the loop:

- Frame analysis of the reporter's recording: a full teardown/rebuild every ~533 ms (32 ±2 frames at 60 fps across all 28 cycles), cream `#F4F4F1` (`--surface-base`) alternating with pure `#FFFFFF` — the latter being a route that renders nothing, since `body` carries no background rule and `AccountLayout` renders no chrome of its own.
- Independent corroboration from the reporter's main-process log, from a different day and session: `[mac-helper] enabled/disabled Fn push-to-talk` pairs every ~580 ms. That signal is driven by `useNativePushToTalkRegistration`, mounted in `GlobalPushToTalkBridge` under `RootLayout`, so each pair is one teardown and rebuild of the `/assistant` layout.
- Measuring the `h1` in the recording (23 px ink height, 256 px wide ⇒ ~30 px sans) matches `WelcomeScreen`'s `text-3xl font-semibold` as it shipped in 0.11.1, confirming both the screen and the build.
- `Error checking assistant status: TypeError: Failed to fetch` in the same log is the local daemon not running, which is expected pre-hatch. It is a symptom, not the driver: a thrown fetch takes the `isInconclusiveProbe` branch and never logs anyone out.

## Test plan

- `bun run test:ci` — 837/837 test files pass (per-file subprocesses, which is what this package requires for `mock.module` isolation).
- `bunx tsc --noEmit` clean.
- `bun run lint` clean — 0 errors; the 16 warnings are pre-existing and in files this PR does not touch.
- Six new tests: pre-hatch local session survives a settled 401; a local session with platform-hosted assistants still ends; a platform-mode client still ends; consent refresh no-ops for the synthetic local user; the redirect budget stops after N attempts; a platform 2xx restores it while a self-hosted gateway 2xx does not.

Not verified by running the packaged desktop app end to end. The one thing I could not confirm from the attached logs is exactly which platform request returns the settled 401/403 each cycle — the reporter trimmed the renderer console output. `/v1/user/consent/` is the best-supported candidate and is what change 2 addresses, but change 1 closes the loop regardless of which request arms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLkDmbWdVUrbn3fEh1WWcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLkDmbWdVUrbn3fEh1WWcz)_