### PR TITLE
fix(onboarding): surface provider-rejected API keys during local hatch

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27286,10 +27286,13 @@ paths:
                     type: string
                   name:
                     type: string
+                  error:
+                    description:
+                      Why the secret was not stored (e.g. provider-side API key validation failed). Present only when success is
+                      false.
+                    type: string
                 required:
                   - success
-                  - type
-                  - name
                 additionalProperties: false
   /v1/secrets/read:
     post:

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -756,8 +756,14 @@ export const ROUTES: RouteDefinition[] = [
     }),
     responseBody: z.object({
       success: z.boolean(),
-      type: z.string(),
-      name: z.string(),
+      type: z.string().optional(),
+      name: z.string().optional(),
+      error: z
+        .string()
+        .optional()
+        .describe(
+          "Why the secret was not stored (e.g. provider-side API key validation failed). Present only when success is false.",
+        ),
     }),
     handler: handleAddSecret,
   },

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -200,10 +200,12 @@ const operationalStatusReadMock = mock(async () => {
   };
 });
 
-const hatchLocalAssistantMock = mock(async () => ({
-  ok: true as const,
-  assistantId: "local-1",
-}));
+const hatchLocalAssistantMock = mock(
+  async (_species?: string, _remote?: string) => ({
+    ok: true as const,
+    assistantId: "local-1",
+  }),
+);
 
 const saveLockfileAssistantMock = mock(
   async (_entry: {
@@ -1025,6 +1027,51 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
       { timeout: 5000 },
     );
     expect(hatchLocalAssistantMock).toHaveBeenCalledTimes(1);
+  }, 15000);
+
+  test("switching hosting modes after a rejected key hatches fresh for the new mode instead of reusing the old assistant", async () => {
+    // First pass: a Local hatch whose key is rejected parks on the error
+    // screen with the hatch guard held.
+    isLocalClientValue = true;
+    searchParams = new URLSearchParams("hosting=local");
+    applyPendingProviderKeyMock.mockImplementation(async () => {
+      throw new MockProviderKeyRejectedError(
+        "anthropic",
+        "API key is invalid or expired.",
+      );
+    });
+
+    render(<HatchingScreen />);
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/rejected the API key you entered/),
+        ).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(hatchLocalAssistantMock).toHaveBeenCalledTimes(1);
+    expect(hatchLocalAssistantMock.mock.calls[0]?.[1]).toBeUndefined();
+
+    // The user backs out to the hosting screen and picks Docker instead. The
+    // held Local promise must not answer for the Docker choice.
+    cleanup();
+    navigateMock.mockClear();
+    applyPendingProviderKeyMock.mockImplementation(async () => {});
+    searchParams = new URLSearchParams("hosting=docker");
+
+    render(<HatchingScreen />);
+
+    await waitFor(
+      () =>
+        expect(navigateMock).toHaveBeenCalledWith(
+          expect.stringContaining("/onboarding/research"),
+          { replace: true },
+        ),
+      { timeout: 5000 },
+    );
+    expect(hatchLocalAssistantMock).toHaveBeenCalledTimes(2);
+    expect(hatchLocalAssistantMock.mock.calls[1]?.[1]).toBe("docker");
   }, 15000);
 
   test("a local hatch keeps its gateway session", async () => {

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -292,8 +292,22 @@ mock.module("@/domains/onboarding/prefs", () => ({
   writeSelectedVersion: () => {},
 }));
 
+// Stands in for the real error class (the screen's `instanceof` check runs
+// against this mocked module's export).
+class MockProviderKeyRejectedError extends Error {
+  constructor(
+    readonly provider: string,
+    readonly reason?: string,
+  ) {
+    super(reason ?? `${provider} rejected the API key`);
+  }
+}
+
+const applyPendingProviderKeyMock = mock(async () => {});
+
 mock.module("@/domains/onboarding/provider-key", () => ({
-  applyPendingProviderKey: async () => {},
+  applyPendingProviderKey: applyPendingProviderKeyMock,
+  ProviderKeyRejectedError: MockProviderKeyRejectedError,
 }));
 
 mock.module("@/domains/onboarding/plugin-attribution", () => ({
@@ -404,14 +418,19 @@ mock.module("@/utils/routes", () => ({
       research: "/onboarding/research",
       hosting: "/onboarding/hosting",
       privacy: "/onboarding/privacy",
+      apiKey: "/onboarding/api-key",
     },
   },
 }));
 
 mock.module("@vellumai/design-library/components/button", () => ({
-  Button: ({ children }: { children: ReactNode }) => (
-    <button>{children}</button>
-  ),
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
 }));
 
 mock.module("@vellumai/design-library/components/progress-bar", () => ({
@@ -435,6 +454,8 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     subscriptionRetrieveMock.mockClear();
     operationalStatusReadMock.mockClear();
     hatchLocalAssistantMock.mockClear();
+    applyPendingProviderKeyMock.mockClear();
+    applyPendingProviderKeyMock.mockImplementation(async () => {});
     saveLockfileAssistantMock.mockClear();
     clearGatewayTokenMock.mockClear();
     setSelfHostedConnectionMock.mockClear();
@@ -954,6 +975,57 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     expect(clearGatewayTokenMock).toHaveBeenCalled();
     expect(setSelfHostedConnectionMock).toHaveBeenCalledWith(null);
   });
+
+  test("a provider-rejected API key surfaces an Update API key path, and the corrected pass reuses the hatched assistant", async () => {
+    isLocalClientValue = true;
+    searchParams = new URLSearchParams("hosting=local");
+    applyPendingProviderKeyMock.mockImplementation(async () => {
+      throw new MockProviderKeyRejectedError(
+        "anthropic",
+        "API key is invalid or expired.",
+      );
+    });
+
+    render(<HatchingScreen />);
+
+    // The rejection surfaces as a correctable error, not a completed hatch.
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/rejected the API key you entered/),
+        ).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(screen.getByText("API key is invalid or expired.", { exact: false }))
+      .toBeTruthy();
+    expect(navigateMock).not.toHaveBeenCalled();
+    // A blind retry would re-apply nothing (the pending key was cleared), so
+    // the primary action is the path back to the API-key screen instead.
+    expect(screen.queryByText("Try again")).toBeNull();
+    screen.getByText("Update API key").click();
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/onboarding/api-key?hosting=local",
+      { replace: true },
+    );
+
+    // Returning with a corrected key remounts the screen. The held module
+    // guard must hand back the SAME hatched assistant: one hatch total.
+    cleanup();
+    navigateMock.mockClear();
+    applyPendingProviderKeyMock.mockImplementation(async () => {});
+
+    render(<HatchingScreen />);
+
+    await waitFor(
+      () =>
+        expect(navigateMock).toHaveBeenCalledWith(
+          expect.stringContaining("/onboarding/research"),
+          { replace: true },
+        ),
+      { timeout: 5000 },
+    );
+    expect(hatchLocalAssistantMock).toHaveBeenCalledTimes(1);
+  }, 15000);
 
   test("a local hatch keeps its gateway session", async () => {
     isLocalClientValue = true;

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -994,7 +994,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     await waitFor(
       () =>
         expect(
-          screen.getByText(/rejected the API key you entered/),
+          screen.getByText("Your API key didn't work"),
         ).toBeTruthy(),
       { timeout: 5000 },
     );
@@ -1046,7 +1046,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     await waitFor(
       () =>
         expect(
-          screen.getByText(/rejected the API key you entered/),
+          screen.getByText("Your API key didn't work"),
         ).toBeTruthy(),
       { timeout: 5000 },
     );

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -79,6 +79,12 @@ const COMPLETION_NAVIGATE_DELAY_MS = 800;
 let localHatchPromise: Promise<
   import("@/runtime/local-mode-host").LocalHatchResult
 > | null = null;
+// The hosting mode (`--remote` arg) the held localHatchPromise was created
+// with. A held promise only answers for the SAME mode: the guard can outlive
+// a trip through the hosting screen (the rejected-key hold below), where the
+// user may switch Local <-> Docker, and the abandoned mode's assistant must
+// not be adopted for the new choice.
+let localHatchRemote: string | undefined;
 let platformHatchPromise: Promise<
   import("@/assistant/api").HatchResult
 > | null = null;
@@ -86,6 +92,7 @@ let hatchTraitsCache: CharacterTraits | null = null;
 
 function releaseHatchGuards(): void {
   localHatchPromise = null;
+  localHatchRemote = undefined;
   platformHatchPromise = null;
   hatchTraitsCache = null;
 }
@@ -373,8 +380,14 @@ export function HatchingScreen() {
       // 4. Navigate to pre-chat flow
       if (useLocalHatch) {
         try {
+          const remote = hostingParam === "docker" ? "docker" : undefined;
+          // A promise held across the rejected-key hold answers only for the
+          // hosting mode it was created with; a switched mode hatches fresh.
+          if (localHatchPromise && localHatchRemote !== remote) {
+            releaseHatchGuards();
+          }
           if (!localHatchPromise) {
-            const remote = hostingParam === "docker" ? "docker" : undefined;
+            localHatchRemote = remote;
             localHatchPromise = hatchLocalAssistant(undefined, remote);
           }
           // Keep `localHatchPromise` set through the rest of the flow. The
@@ -450,8 +463,10 @@ export function HatchingScreen() {
                 // Surface a correctable error and hold here, KEEPING the
                 // module-level hatch guards: the user returns via the API-key
                 // screen and this screen re-adopts the same live assistant
-                // instead of hatching a duplicate. The pending selection was
-                // re-staged (key cleared) by applyPendingProviderKey.
+                // instead of hatching a duplicate. The pending selection
+                // (rejected key included) was re-staged by
+                // applyPendingProviderKey, so a reload here re-applies it and
+                // lands back on this screen rather than proceeding keyless.
                 if (!cancelled) {
                   const displayName =
                     onboardingProvider(err.provider)?.displayName ??

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -472,11 +472,8 @@ export function HatchingScreen() {
                     onboardingProvider(err.provider)?.displayName ??
                     err.provider;
                   setApiKeyRejected(true);
-                  setError(
-                    `${displayName} rejected the API key you entered. ${
-                      err.reason ?? "Please check the key and try again."
-                    }`,
-                  );
+                  const action = `Update your ${displayName} API key to continue.`;
+                  setError(err.reason ? `${err.reason} ${action}` : action);
                 }
                 return;
               }
@@ -775,7 +772,7 @@ export function HatchingScreen() {
                 : "text-3xl font-semibold tracking-tight"
             }
           >
-            Something went wrong
+            {apiKeyRejected ? "Your API key didn't work" : "Something went wrong"}
           </h1>
           <p
             className={`text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -23,7 +23,11 @@ import {
   readSelectedVersion,
   writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
-import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
+import {
+  applyPendingProviderKey,
+  ProviderKeyRejectedError,
+} from "@/domains/onboarding/provider-key";
+import { onboardingProvider } from "@/domains/onboarding/provider-catalog";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import {
   awaitPurchasedProvisioning,
@@ -183,6 +187,11 @@ export function HatchingScreen() {
   const [phase, setPhase] = useState<HatchPhase>("initializing");
   const [error, setError] = useState<string | null>(null);
   const [platformHostedDisabled, setPlatformHostedDisabled] = useState(false);
+  // The provider rejected the entered API key (daemon-side validation). The
+  // error screen swaps its retry for an "Update API key" path back to the
+  // key screen; the hatch guards stay held so the corrected pass reuses the
+  // already-hatched assistant instead of hatching a second one.
+  const [apiKeyRejected, setApiKeyRejected] = useState(false);
   const [attempt, setAttempt] = useState(0);
   const [displayProgress, setDisplayProgress] = useState<number>(0);
   const [animationEpoch, setAnimationEpoch] = useState(0);
@@ -231,6 +240,7 @@ export function HatchingScreen() {
     }
 
     setPlatformHostedDisabled(false);
+    setApiKeyRejected(false);
 
     let cancelled = false;
     let pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -435,6 +445,26 @@ export function HatchingScreen() {
             try {
               await applyPendingProviderKey(result.assistantId);
             } catch (err) {
+              if (err instanceof ProviderKeyRejectedError) {
+                // The assistant hatched fine; only the entered key is bad.
+                // Surface a correctable error and hold here, KEEPING the
+                // module-level hatch guards: the user returns via the API-key
+                // screen and this screen re-adopts the same live assistant
+                // instead of hatching a duplicate. The pending selection was
+                // re-staged (key cleared) by applyPendingProviderKey.
+                if (!cancelled) {
+                  const displayName =
+                    onboardingProvider(err.provider)?.displayName ??
+                    err.provider;
+                  setApiKeyRejected(true);
+                  setError(
+                    `${displayName} rejected the API key you entered. ${
+                      err.reason ?? "Please check the key and try again."
+                    }`,
+                  );
+                }
+                return;
+              }
               captureError(err, { context: "onboarding_apply_provider_key" });
             }
           }
@@ -765,26 +795,45 @@ export function HatchingScreen() {
           <div
             className={`flex w-full flex-col ${electron ? "gap-2.5 max-w-[280px]" : "gap-2 max-w-sm"}`}
           >
-            <Button
-              variant="primary"
-              size="regular"
-              fullWidth
-              className={electron ? undefined : "h-11 text-base"}
-              onClick={() => {
-                segmentStartRef.current = 0;
-                segmentStartTimeRef.current = Date.now();
-                phaseRef.current = "initializing";
-                displayProgressRef.current = 0;
-                setPhase("initializing");
-                setDisplayProgress(0);
-                setAnimationEpoch((n) => n + 1);
-                setError(null);
-                setPlatformHostedDisabled(false);
-                setAttempt((n) => n + 1);
-              }}
-            >
-              Try again
-            </Button>
+            {apiKeyRejected ? (
+              <Button
+                variant="primary"
+                size="regular"
+                fullWidth
+                className={electron ? undefined : "h-11 text-base"}
+                onClick={() =>
+                  void navigate(
+                    hostingParam
+                      ? `${routes.onboarding.apiKey}?hosting=${hostingParam}`
+                      : routes.onboarding.apiKey,
+                    { replace: true },
+                  )
+                }
+              >
+                Update API key
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                size="regular"
+                fullWidth
+                className={electron ? undefined : "h-11 text-base"}
+                onClick={() => {
+                  segmentStartRef.current = 0;
+                  segmentStartTimeRef.current = Date.now();
+                  phaseRef.current = "initializing";
+                  displayProgressRef.current = 0;
+                  setPhase("initializing");
+                  setDisplayProgress(0);
+                  setAnimationEpoch((n) => n + 1);
+                  setError(null);
+                  setPlatformHostedDisabled(false);
+                  setAttempt((n) => n + 1);
+                }}
+              >
+                Try again
+              </Button>
+            )}
             <Button
               variant="outlined"
               size="regular"

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -37,6 +37,7 @@ const {
   applyPendingProviderKey,
   consumePendingProviderKey,
   peekPendingProviderKey,
+  ProviderKeyRejectedError,
   setPendingProviderKey,
 } = await import("@/domains/onboarding/provider-key");
 
@@ -336,6 +337,66 @@ describe("pending provider key", () => {
       body: { llm: { activeProfile: "custom-balanced" } },
       throwOnError: false,
     });
+  });
+
+  test("a provider-rejected key throws, re-stages the selection with the key cleared, and writes nothing downstream", async () => {
+    // The daemon reports provider-side key validation failure as a 200 with
+    // success:false (the key is NOT stored).
+    secretsPostMock.mockImplementationOnce(async () => ({
+      data: { success: false, error: "API key is invalid or expired." },
+      response: { ok: true, status: 200 },
+    }));
+    setPendingProviderKey({ provider: "anthropic", key: "sk-ant-bad" });
+
+    const attempt = applyPendingProviderKey("local-8");
+
+    await expect(attempt).rejects.toBeInstanceOf(ProviderKeyRejectedError);
+    await attempt.catch((err: unknown) => {
+      expect(err).toEqual(
+        expect.objectContaining({
+          provider: "anthropic",
+          reason: "API key is invalid or expired.",
+        }),
+      );
+    });
+    // The selection survives for the API-key screen to prefill, minus the
+    // rejected key itself.
+    expect(peekPendingProviderKey()).toEqual({ provider: "anthropic", key: "" });
+    // Nothing downstream may reference the never-stored credential.
+    expect(inferenceProviderconnectionsPostMock).not.toHaveBeenCalled();
+    expect(configLlmDefaultproviderPutMock).not.toHaveBeenCalled();
+    expect(configLlmProfilesByNamePutMock).not.toHaveBeenCalled();
+    expect(configPatchMock).not.toHaveBeenCalled();
+  });
+
+  test("a success:false response without a reason still throws ProviderKeyRejectedError", async () => {
+    secretsPostMock.mockImplementationOnce(async () => ({
+      data: { success: false },
+      response: { ok: true, status: 200 },
+    }));
+    setPendingProviderKey({ provider: "openai", key: "sk-proj-bad" });
+
+    await expect(applyPendingProviderKey("local-9")).rejects.toBeInstanceOf(
+      ProviderKeyRejectedError,
+    );
+    expect(peekPendingProviderKey()).toEqual({ provider: "openai", key: "" });
+  });
+
+  test("a success:true response with a body proceeds normally", async () => {
+    secretsPostMock.mockImplementationOnce(async () => ({
+      data: { success: true, type: "api_key", name: "anthropic" },
+      response: { ok: true, status: 200 },
+    }));
+    setPendingProviderKey({ provider: "anthropic", key: "sk-ant-good" });
+
+    await applyPendingProviderKey("local-10");
+
+    expect(configLlmDefaultproviderPutMock).toHaveBeenCalledWith({
+      path: { assistant_id: "local-10" },
+      body: { provider: "anthropic" },
+      throwOnError: false,
+    });
+    expect(peekPendingProviderKey()).toBeNull();
   });
 
   test("a dev build on the gate's base version takes the new path", async () => {

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -339,7 +339,7 @@ describe("pending provider key", () => {
     });
   });
 
-  test("a provider-rejected key throws, re-stages the selection with the key cleared, and writes nothing downstream", async () => {
+  test("a provider-rejected key throws, re-stages the selection, and writes nothing downstream", async () => {
     // The daemon reports provider-side key validation failure as a 200 with
     // success:false (the key is NOT stored).
     secretsPostMock.mockImplementationOnce(async () => ({
@@ -359,9 +359,13 @@ describe("pending provider key", () => {
         }),
       );
     });
-    // The selection survives for the API-key screen to prefill, minus the
-    // rejected key itself.
-    expect(peekPendingProviderKey()).toEqual({ provider: "anthropic", key: "" });
+    // The full selection survives for the API-key screen to prefill. The
+    // rejected key is kept so a reload re-applies it and re-surfaces the
+    // rejection instead of proceeding with no provider key at all.
+    expect(peekPendingProviderKey()).toEqual({
+      provider: "anthropic",
+      key: "sk-ant-bad",
+    });
     // Nothing downstream may reference the never-stored credential.
     expect(inferenceProviderconnectionsPostMock).not.toHaveBeenCalled();
     expect(configLlmDefaultproviderPutMock).not.toHaveBeenCalled();
@@ -379,7 +383,10 @@ describe("pending provider key", () => {
     await expect(applyPendingProviderKey("local-9")).rejects.toBeInstanceOf(
       ProviderKeyRejectedError,
     );
-    expect(peekPendingProviderKey()).toEqual({ provider: "openai", key: "" });
+    expect(peekPendingProviderKey()).toEqual({
+      provider: "openai",
+      key: "sk-proj-bad",
+    });
   });
 
   test("a success:true response with a body proceeds normally", async () => {

--- a/clients/web/src/domains/onboarding/provider-key.ts
+++ b/clients/web/src/domains/onboarding/provider-key.ts
@@ -98,6 +98,24 @@ export function consumePendingProviderKey(): PendingProviderKey | null {
   return value;
 }
 
+/**
+ * The daemon validated the entered API key against the provider and the
+ * provider rejected it (e.g. a 401 on a typo'd key). A user-correctable input
+ * error, not a transport failure: callers surface it with a path back to the
+ * API-key screen instead of logging and moving on.
+ */
+export class ProviderKeyRejectedError extends Error {
+  readonly provider: OnboardingProviderId;
+  readonly reason?: string;
+
+  constructor(provider: OnboardingProviderId, reason?: string) {
+    super(reason ?? `${provider} rejected the API key`);
+    this.name = "ProviderKeyRejectedError";
+    this.provider = provider;
+    this.reason = reason;
+  }
+}
+
 // Daemon wrappers via the generated SDK. Duplicated minimally here because
 // cross-domain imports are ESLint-gated in clients/web.
 
@@ -115,12 +133,18 @@ async function writeApiKeySecret(
   provider: OnboardingProviderId,
   value: string,
 ): Promise<void> {
-  const { response } = await secretsPost({
+  const { data, response } = await secretsPost({
     path: { assistant_id: assistantId },
     body: { type: "api_key", name: provider, value },
     throwOnError: false,
   });
   ensureOk(response, "Failed to write provider secret");
+  // The daemon reports a provider-rejected key as a 200 with success:false.
+  // The key was NOT stored, so continuing would point the assistant's config
+  // at a credential that doesn't exist.
+  if (data && data.success === false) {
+    throw new ProviderKeyRejectedError(provider, data.error);
+  }
 }
 
 /**
@@ -307,7 +331,10 @@ async function applyLegacyOnboardingProfile(
 /**
  * Apply the model-provider selection collected during onboarding to the
  * freshly hatched local assistant. Consumes the pending key; no-op when nothing
- * was collected (e.g. Vellum Cloud, which skips the API-key step).
+ * was collected (e.g. Vellum Cloud, which skips the API-key step). Throws
+ * {@link ProviderKeyRejectedError} when the daemon's provider-side validation
+ * rejects the key, re-staging the selection (key cleared) so the API-key
+ * screen can prefill on the correction pass.
  *
  * API-key providers rely on the daemon's code-defined default profiles: store
  * the key, create the `<provider>-personal` connection the defaults dispatch
@@ -324,6 +351,23 @@ export async function applyPendingProviderKey(
   if (!pending) {
     return;
   }
+  try {
+    await applyProviderSelection(assistantId, pending);
+  } catch (err) {
+    if (err instanceof ProviderKeyRejectedError) {
+      // A rejected key is user-correctable: preserve the collected selection
+      // (with the bad key cleared) so the API-key screen prefills the
+      // provider/model when the user goes back to re-enter the key.
+      setPendingProviderKey({ ...pending, key: "" });
+    }
+    throw err;
+  }
+}
+
+async function applyProviderSelection(
+  assistantId: string,
+  pending: PendingProviderKey,
+): Promise<void> {
   const trimmed = pending.key.trim();
 
   if (!PROFILE_AUTHORING_PROVIDERS.has(pending.provider)) {

--- a/clients/web/src/domains/onboarding/provider-key.ts
+++ b/clients/web/src/domains/onboarding/provider-key.ts
@@ -333,8 +333,9 @@ async function applyLegacyOnboardingProfile(
  * freshly hatched local assistant. Consumes the pending key; no-op when nothing
  * was collected (e.g. Vellum Cloud, which skips the API-key step). Throws
  * {@link ProviderKeyRejectedError} when the daemon's provider-side validation
- * rejects the key, re-staging the selection (key cleared) so the API-key
- * screen can prefill on the correction pass.
+ * rejects the key, re-staging the full selection so the API-key screen can
+ * prefill on the correction pass (and a reload re-applies and re-surfaces
+ * the rejection).
  *
  * API-key providers rely on the daemon's code-defined default profiles: store
  * the key, create the `<provider>-personal` connection the defaults dispatch
@@ -355,10 +356,14 @@ export async function applyPendingProviderKey(
     await applyProviderSelection(assistantId, pending);
   } catch (err) {
     if (err instanceof ProviderKeyRejectedError) {
-      // A rejected key is user-correctable: preserve the collected selection
-      // (with the bad key cleared) so the API-key screen prefills the
-      // provider/model when the user goes back to re-enter the key.
-      setPendingProviderKey({ ...pending, key: "" });
+      // A rejected key is user-correctable: re-stage the collected selection,
+      // rejected key included, so the API-key screen prefills for correction.
+      // The key is deliberately KEPT: the hold on the error screen is
+      // in-memory, so a reload there re-runs the apply, and re-applying the
+      // bad key re-surfaces this rejection. A cleared key would instead
+      // no-op the apply and hand the user a provider-less assistant, which
+      // is the silent dead-chat state this error exists to prevent.
+      setPendingProviderKey(pending);
     }
     throw err;
   }


### PR DESCRIPTION
## TL;DR

Entering an invalid model-provider API key while hatching a local/Docker assistant no longer leaves the user stranded in a broken chat. The rejection is surfaced on the hatching screen with the provider's reason and an **Update API key** button back to the key screen, and the corrected pass reuses the already-hatched assistant.

Fixes [LUM-2977](https://linear.app/vellum/issue/LUM-2977).

## Root cause

The daemon already validates provider API keys at `POST /v1/secrets` (Anthropic/OpenAI/Gemini and others), but reports a rejected key as HTTP **200** with `{ success: false, error }`. The onboarding key write (`writeApiKeySecret`) only checked `response.ok`, so the rejection was silently swallowed. The flow then created the provider connection and set `llm.defaultProvider` pointing at a credential that was never stored, and every later LLM turn failed: the first chat turn never produced a message, so the user hit the auto-greet timeout overlay whose retry can only re-fail.

## What changed

- `secrets_add` route (`assistant/src/runtime/routes/secret-routes.ts`): the response schema now declares the `error` field the handler already returns (`type`/`name` become optional, matching the failure shape). Regenerated `openapi.yaml` + web client.
- `provider-key.ts` (web onboarding): detects `success: false` and throws a typed `ProviderKeyRejectedError`; the collected selection is re-staged in sessionStorage with the key cleared so the API-key screen prefills provider/model on the correction pass.
- `hatching-screen.tsx`: catches the rejection and shows an actionable error ("<Provider> rejected the API key you entered. <reason>") with an **Update API key** primary action. The module-level hatch guards are deliberately kept held, so returning through API key → privacy → hatching re-adopts the same live assistant. `vellum hatch` always creates a new assistant, so releasing the guards would hatch a duplicate.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Typo'd/invalid key during local onboarding | Onboarding completes normally; chat shows "taking longer than expected" forever; Try again does nothing | Hatching screen stops with "Anthropic rejected the API key you entered. API key is invalid or expired." and an Update API key button |
| Correcting the key | No in-product path (stuck) | API-key screen prefills the provider/model; continuing reuses the already-hatched assistant (no duplicate) |
| Valid key | Unchanged | Unchanged |
| Providers without daemon-side validators (fireworks, openrouter, vercel-ai-gateway, openai-compatible, ollama) | Key stored unvalidated | Unchanged (key stored unvalidated) |

## Why this is safe

- The daemon change is schema-only: the handler already returned `error`; the OpenAPI spec now admits it. `type`/`name` optionality matches the existing failure-shape reality.
- Web changes are confined to the onboarding domain; the settings provider forms and STT key writes are untouched.
- Rejection handling only triggers on the daemon's explicit `success: false` signal. Transport errors keep their existing swallow-and-continue behavior (`captureError`), so a flaky network still cannot block onboarding.
- Daemon-side validators already fail open on transient provider errors (429/5xx/network), so this cannot brick onboarding when the provider is merely down.

## Tests

- `provider-key.test.ts`: rejection throws `ProviderKeyRejectedError` with provider+reason, re-stages the selection with the key cleared, and writes nothing downstream; a reason-less `success:false` still throws; a `success:true` body proceeds.
- `hatching-screen.test.tsx`: a rejected key surfaces the Update API key UI (no Try again), navigation targets the API-key route with the hosting param, and the correction pass completes to research with `hatchLocalAssistant` called exactly once across both passes (duplicate-hatch regression guard).

## Deferred

- The settings AI provider forms (`provider-create-form.tsx`, `provider-editor-content.tsx`) have the same silent `success:false` swallow on their `type: "api_key"` branch and optimistically mark the credential present. Deferred to keep this PR one logical change; Follow-up filed: [LUM-3030](https://linear.app/vellum/issue/LUM-3030).
- Chat-side surfacing of provider auth failures mid-conversation (the "taking longer" overlay can still appear for keys that pass validation but fail later, e.g. revoked or out of credit) is a separate surface and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
