### PR TITLE
fix(web): skip claim credits for self-hosted non-logged-in onboarding (LUM-3028)

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -150,12 +150,15 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
   POST_CHECKOUT_HATCH_PARAM: "post_checkout",
 }));
 
+let hasPlatformSession = true;
+
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     use: {
       user: () => ({ id: USER_ID, firstName: "Alice", lastName: "Example" }),
     },
   },
+  useHasPlatformSession: () => hasPlatformSession,
 }));
 
 mock.module("@/utils/routes", () => ({
@@ -179,8 +182,10 @@ mock.module("@/domains/onboarding/research-prompt", () => ({
   buildResearchPrompt: () => "research prompt",
 }));
 
+let adoptExistingAssistant = false;
+
 mock.module("@/domains/onboarding/adopt-existing-assistant", () => ({
-  shouldAdoptExistingAssistant: () => false,
+  shouldAdoptExistingAssistant: () => adoptExistingAssistant,
 }));
 
 mock.module("@/domains/onboarding/use-background-hatch", () => ({
@@ -421,6 +426,8 @@ function doneSnapshot(): ResearchOnboardingSnapshot {
 
 beforeEach(() => {
   localStorage.clear();
+  adoptExistingAssistant = false;
+  hasPlatformSession = true;
   researchStatus = "idle";
   installedPlugins = [];
   establishedResult = { established: false, assistantName: null };
@@ -1026,5 +1033,48 @@ describe("ResearchOnboardingRoute hatch retry", () => {
     // redo — and an idle turn has no restored installs to re-enqueue either.
     expect(applyPersonalityMock).not.toHaveBeenCalled();
     expect(reinstallPluginsMock).not.toHaveBeenCalled();
+  });
+});
+
+// The claim-credits step ("integration") promises managed free credits, which
+// only a platform account can hold — a self-hosted onboarding with no platform
+// login skips it (LUM-3028).
+describe("ResearchOnboardingRoute claim-credits skip", () => {
+  test("self-hosted without a platform session skips the claim-credits step", async () => {
+    adoptExistingAssistant = true;
+    hasPlatformSession = false;
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "personality" }));
+
+    render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("personality-continue"));
+
+    // Straight to the research reveal — the calendar steps are skipped for
+    // self-hosted too, so nothing renders between.
+    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+    expect(screen.queryByTestId("integration-step")).toBeNull();
+  });
+
+  test("self-hosted WITH a platform session keeps the claim-credits step", async () => {
+    adoptExistingAssistant = true;
+    hasPlatformSession = true;
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "personality" }));
+
+    render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("personality-continue"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("integration-step")).toBeTruthy(),
+    );
+  });
+
+  test("a snapshot resuming onto the skipped claim-credits step remaps to the research reveal", async () => {
+    adoptExistingAssistant = true;
+    hasPlatformSession = false;
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "integration" }));
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+    expect(screen.queryByTestId("integration-step")).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -1086,6 +1086,23 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
     );
   });
 
+  test("a probe settling absent moves an on-screen claim-credits step to the reveal", async () => {
+    adoptExistingAssistant = true;
+    hasPlatformSession = false;
+    platformSessionSettled = false;
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "integration" }));
+
+    const { rerender } = render(<ResearchOnboardingRoute />);
+    await waitFor(() =>
+      expect(screen.getByTestId("integration-step")).toBeTruthy(),
+    );
+
+    platformSessionSettled = true;
+    rerender(<ResearchOnboardingRoute />);
+
+    await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
+  });
+
   test("a snapshot resuming onto the skipped claim-credits step remaps to the research reveal", async () => {
     adoptExistingAssistant = true;
     hasPlatformSession = false;

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -151,6 +151,7 @@ mock.module("@/lib/navigation/navigation-resolver", () => ({
 }));
 
 let hasPlatformSession = true;
+let platformSessionSettled = true;
 
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
@@ -159,6 +160,7 @@ mock.module("@/stores/auth-store", () => ({
     },
   },
   useHasPlatformSession: () => hasPlatformSession,
+  useIsPlatformSessionSettled: () => platformSessionSettled,
 }));
 
 mock.module("@/utils/routes", () => ({
@@ -428,6 +430,7 @@ beforeEach(() => {
   localStorage.clear();
   adoptExistingAssistant = false;
   hasPlatformSession = true;
+  platformSessionSettled = true;
   researchStatus = "idle";
   installedPlugins = [];
   establishedResult = { established: false, assistantName: null };
@@ -1037,7 +1040,7 @@ describe("ResearchOnboardingRoute hatch retry", () => {
 });
 
 // The claim-credits step ("integration") promises managed free credits, which
-// only a platform account can hold — a self-hosted onboarding with no platform
+// only a platform account can hold: a self-hosted onboarding with no platform
 // login skips it (LUM-3028).
 describe("ResearchOnboardingRoute claim-credits skip", () => {
   test("self-hosted without a platform session skips the claim-credits step", async () => {
@@ -1048,7 +1051,7 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
     render(<ResearchOnboardingRoute />);
     fireEvent.click(await screen.findByTestId("personality-continue"));
 
-    // Straight to the research reveal — the calendar steps are skipped for
+    // Straight to the research reveal: the calendar steps are skipped for
     // self-hosted too, so nothing renders between.
     await waitFor(() => expect(screen.getByTestId("looking-step")).toBeTruthy());
     expect(screen.queryByTestId("integration-step")).toBeNull();
@@ -1062,6 +1065,22 @@ describe("ResearchOnboardingRoute claim-credits skip", () => {
     render(<ResearchOnboardingRoute />);
     fireEvent.click(await screen.findByTestId("personality-continue"));
 
+    await waitFor(() =>
+      expect(screen.getByTestId("integration-step")).toBeTruthy(),
+    );
+  });
+
+  test("an unsettled platform-session probe keeps the claim-credits step", async () => {
+    adoptExistingAssistant = true;
+    hasPlatformSession = false;
+    platformSessionSettled = false;
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "personality" }));
+
+    render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("personality-continue"));
+
+    // "No session yet" is not an answer: a signed-in user racing the probe
+    // must not lose the step to a decision that is never revisited.
     await waitFor(() =>
       expect(screen.getByTestId("integration-step")).toBeTruthy(),
     );

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -31,7 +31,7 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalClient } from "@/lib/local-mode";
 import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
-import { useAuthStore } from "@/stores/auth-store";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
@@ -301,6 +301,19 @@ export function ResearchOnboardingRoute() {
   // entirely and go straight to the research reveal. Vellum-cloud onboarding
   // keeps them: a managed hatch implies a platform session.
   const skipCheckinSteps = adoptExistingAssistant;
+  // The claim-credits step ("integration") promises managed free credits,
+  // which only a platform account can hold. A self-hosted onboarding with no
+  // platform login has no account to credit, so the promise would be empty —
+  // skip the step. A signed-in self-hosted user keeps it: their platform
+  // account is real, credits and all.
+  const hasPlatformSession = useHasPlatformSession();
+  const skipClaimCreditsStep = adoptExistingAssistant && !hasPlatformSession;
+  // Where "personality" advances to: the claim-credits step, or — when that's
+  // skipped — straight to the research reveal (skipping credits implies a
+  // self-hosted flow, which skips the calendar steps too).
+  const stepAfterPersonality: ResearchStep = skipClaimCreditsStep
+    ? "looking"
+    : "integration";
   const {
     start: startHatch,
     retry: retryHatch,
@@ -496,15 +509,15 @@ export function ResearchOnboardingRoute() {
         setResumeGuardPending(true);
       }
       // A snapshot written before the calendar steps were dropped from the
-      // local flow (or by a signed-in web session) may resume onto them —
-      // remap to the research reveal the skip lands on.
+      // local flow (or by a signed-in web session) may resume onto them, and
+      // one written while the claim-credits step still showed may resume onto
+      // it — remap to the research reveal the skips land on.
       const resumeStep = resolveResumeStep(snapshot);
-      setStep(
-        skipCheckinSteps &&
-          (resumeStep === "letschat" || resumeStep === "meeting")
-          ? "looking"
-          : resumeStep,
-      );
+      const resumeStepDropped =
+        (skipCheckinSteps &&
+          (resumeStep === "letschat" || resumeStep === "meeting")) ||
+        (skipClaimCreditsStep && resumeStep === "integration");
+      setStep(resumeStepDropped ? "looking" : resumeStep);
       setForwardStack([]);
     }
     setRestored(true);
@@ -514,6 +527,7 @@ export function ResearchOnboardingRoute() {
     hydrateResearch,
     awaitHatchReady,
     skipCheckinSteps,
+    skipClaimCreditsStep,
     syncDroppedClaimsScrubbed,
   ]);
 
@@ -1011,7 +1025,9 @@ export function ResearchOnboardingRoute() {
           {step === "different" && (
             <PitchStep
               onContinue={() =>
-                goForwardTo(personalityEnabled ? "personality" : "integration")
+                goForwardTo(
+                  personalityEnabled ? "personality" : stepAfterPersonality,
+                )
               }
               onBack={() => goBackTo("intro")}
               onForward={onForward}
@@ -1032,7 +1048,7 @@ export function ResearchOnboardingRoute() {
                   startPersonalityApply();
                   setPersonalityLocked(true);
                 }
-                goForwardTo("integration");
+                goForwardTo(stepAfterPersonality);
               }}
               onBack={() => goBackTo("different")}
               onForward={onForward}
@@ -1079,7 +1095,13 @@ export function ResearchOnboardingRoute() {
             <LookingYouUpStep
               onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
               onBack={() =>
-                goBackTo(skipCheckinSteps ? "integration" : "letschat")
+                goBackTo(
+                  skipClaimCreditsStep
+                    ? "personality"
+                    : skipCheckinSteps
+                      ? "integration"
+                      : "letschat",
+                )
               }
               onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
               onForward={onForward}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -31,7 +31,11 @@ import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { isLocalClient } from "@/lib/local-mode";
 import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
-import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import {
+  useAuthStore,
+  useHasPlatformSession,
+  useIsPlatformSessionSettled,
+} from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
@@ -303,13 +307,19 @@ export function ResearchOnboardingRoute() {
   const skipCheckinSteps = adoptExistingAssistant;
   // The claim-credits step ("integration") promises managed free credits,
   // which only a platform account can hold. A self-hosted onboarding with no
-  // platform login has no account to credit, so the promise would be empty —
-  // skip the step. A signed-in self-hosted user keeps it: their platform
-  // account is real, credits and all.
+  // platform login has no account to credit, so the promise would be empty:
+  // skip the step. A signed-in self-hosted user keeps it (their platform
+  // account is real, credits and all), and so does the probe's pre-settle
+  // window, where "no session yet" is not an answer. Skipping is a one-way
+  // transition with no later correction, so only a settled absent session may
+  // take it; every settle path resolves "unknown", including local gateway
+  // boot, which settles "absent" directly.
   const hasPlatformSession = useHasPlatformSession();
-  const skipClaimCreditsStep = adoptExistingAssistant && !hasPlatformSession;
-  // Where "personality" advances to: the claim-credits step, or — when that's
-  // skipped — straight to the research reveal (skipping credits implies a
+  const platformSessionSettled = useIsPlatformSessionSettled();
+  const skipClaimCreditsStep =
+    adoptExistingAssistant && platformSessionSettled && !hasPlatformSession;
+  // Where "personality" advances to: the claim-credits step, or, when that's
+  // skipped, straight to the research reveal (skipping credits implies a
   // self-hosted flow, which skips the calendar steps too).
   const stepAfterPersonality: ResearchStep = skipClaimCreditsStep
     ? "looking"
@@ -511,7 +521,7 @@ export function ResearchOnboardingRoute() {
       // A snapshot written before the calendar steps were dropped from the
       // local flow (or by a signed-in web session) may resume onto them, and
       // one written while the claim-credits step still showed may resume onto
-      // it — remap to the research reveal the skips land on.
+      // it: remap to the research reveal the skips land on.
       const resumeStep = resolveResumeStep(snapshot);
       const resumeStepDropped =
         (skipCheckinSteps &&

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -324,6 +324,15 @@ export function ResearchOnboardingRoute() {
   const stepAfterPersonality: ResearchStep = skipClaimCreditsStep
     ? "looking"
     : "integration";
+  // The skip verdict can land while the credits step is already on screen:
+  // the pre-settle window kept the step (or restored a snapshot onto it) and
+  // the probe then settled absent. Move along to the reveal so the empty
+  // promise can't be claimed.
+  useEffect(() => {
+    if (skipClaimCreditsStep && step === "integration") {
+      setStep("looking");
+    }
+  }, [skipClaimCreditsStep, step]);
   const {
     start: startHatch,
     retry: retryHatch,


### PR DESCRIPTION
## Summary
- Skip the "Here are some free credits" (claim-credits) onboarding step when the flow is self-hosted (adopting an existing local assistant) and a settled platform-session probe reports no session: those users have no platform account to credit, so the step's promise was empty. The probe's pre-settle window keeps the step, since skipping is a one-way transition.
- Personality now advances straight to the research reveal in that case; back-navigation from the reveal returns to personality, and a persisted snapshot resuming onto the dropped step remaps to the reveal (same pattern as the dropped calendar steps).
- A signed-in self-hosted user still sees the step, and managed (Vellum-cloud) onboarding is unchanged. Added route tests for skip, keep, pre-settle, and snapshot-remap cases.

## Original prompt
Fix https://linear.app/vellum/issue/LUM-3028/skip-claim-credits-for-self-hosted-non-logged-in-onboarding: the research-onboarding flow shows a "free credits" claim step to every user, but for a self-hosted onboarding with no platform login there is no account the credits could land on. Skip the step for that case, keeping it for logged-in and managed flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)