### PR TITLE
Restore the favicon on docs pages

### DIFF
--- a/clients/docs/public/docs/favicon.svg
+++ b/clients/docs/public/docs/favicon.svg
@@ -1,0 +1,28 @@
+<svg width="177" height="177" viewBox="0 0 177 177" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_85_161)">
+<rect x="2" y="1" width="173" height="173" rx="24" fill="url(#paint0_radial_85_161)"/>
+<path d="M65.2927 45L87.5854 93.3893L109.79 45H132.171L87.4084 137.09L43 45H65.2927Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_di_85_161" x="0" y="0" width="177" height="177" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_85_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_85_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_85_161"/>
+</filter>
+<radialGradient id="paint0_radial_85_161" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(88.5 -123.344) rotate(90) scale(362.219 174.427)">
+<stop stop-color="#7A8B6F"/>
+<stop offset="1" stop-color="#23793D"/>
+</radialGradient>
+</defs>
+</svg>

--- a/clients/docs/src/app/layout.tsx
+++ b/clients/docs/src/app/layout.tsx
@@ -1,6 +1,17 @@
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 import "./globals.css";
+
+// Same asset as the marketing app's /favicon.svg, served under this app's
+// /docs prefix so the icon resolves even when the marketing backend is not
+// in front (e.g. direct pod access or a preview environment).
+export const metadata: Metadata = {
+  icons: {
+    icon: "/docs/favicon.svg",
+    apple: "/docs/favicon.svg",
+  },
+};
 
 /* Pre-hydration theme bootstrap. Mirrors the key precedence of the assistant
  * SPA's clients/web/public/theme-init.js (`device:theme` first, then the


### PR DESCRIPTION
## Summary
- The docs cutover to `clients/docs` lost the browser-tab favicon: the old platform-rendered docs pages inherited the marketing app's `<link rel="icon" href="/favicon.svg">`, the new app declared no icon, and `www.vellum.ai/favicon.ico` is a 404 so browsers had no fallback.
- Adds `public/docs/favicon.svg` (byte-identical to the marketing app's favicon and this repo's `clients/web/public/favicon.svg`) and declares it via an `icons` metadata export in the root layout, so every docs page emits icon + apple-touch-icon links under the app's own `/docs` prefix.

## Original prompt
After verifying the docs deploy pipeline cutover, the user noticed the browser tab on www.vellum.ai/docs no longer shows the Vellum favicon. They asked to restore it. The regression traces to the docs migration off the platform Next.js app: the new `clients/docs` app never declared an icon, and the root-domain `/favicon.ico` fallback does not exist.