### PR TITLE
feat(web): per-tier default-profile overrides in Action Overrides

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4737,6 +4737,8 @@ paths:
                           type: string
                         defaultProfile:
                           type: string
+                        shippedDefaultProfile:
+                          type: string
                       required:
                         - id
                         - displayName

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33303,6 +33303,14 @@ components:
                 anyOf:
                   - $ref: "#/components/schemas/CallSiteOverrideDraft"
                   - type: "null"
+            defaultProfileOverrides:
+              type: object
+              propertyNames:
+                type: string
+              additionalProperties:
+                anyOf:
+                  - type: string
+                  - type: "null"
             profileSession:
               anyOf:
                 - type: object
@@ -34130,6 +34138,12 @@ components:
                         type: string
                     additionalProperties: false
                   - type: "null"
+            defaultProfileOverrides:
+              type: object
+              propertyNames:
+                type: string
+              additionalProperties:
+                type: string
             profileSession:
               type: object
               properties:

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1624,6 +1624,54 @@ describe("sparse services.stt patch provider seeding", () => {
   });
 });
 
+describe("config_patch tier-override clears", () => {
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+
+  beforeEach(() => {
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          mine: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+          },
+        },
+        defaultProfileOverrides: { balanced: "mine", "cost-optimized": "mine" },
+      },
+    };
+    seedRawConfig();
+  });
+
+  const savedTierOverrides = () =>
+    (loadRawConfig().llm as Record<string, unknown>).defaultProfileOverrides;
+
+  test("a null tier value deletes the key instead of persisting null", async () => {
+    // Tier values are strings, so the deep-merge null sentinel would assign
+    // null (deletion covers only object-valued keys); a persisted null
+    // fails LLMSchema and only loader recovery would clear it. The scrub
+    // makes the wire contract's "null clears" a real delete.
+    await configPatchRoute.handler({
+      body: { llm: { defaultProfileOverrides: { "cost-optimized": null } } },
+    });
+    expect(savedTierOverrides()).toEqual({ balanced: "mine" });
+  });
+
+  test("a remap write and an untouched tier survive a patch", async () => {
+    await configPatchRoute.handler({
+      body: {
+        llm: { defaultProfileOverrides: { balanced: "cost-optimized" } },
+      },
+    });
+    expect(savedTierOverrides()).toEqual({
+      balanced: "cost-optimized",
+      "cost-optimized": "mine",
+    });
+  });
+});
+
 describe("config invariant flag enrichment", () => {
   const configGetRoute = ROUTES.find((r) => r.operationId === "config_get")!;
   const configPatchRoute = ROUTES.find(

--- a/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { LLMCallSiteEnum } from "../../../config/schemas/llm.js";
+import { CALL_SITE_DEFAULTS } from "../../../config/call-site-defaults.js";
+import {
+  type LLMCallSite,
+  LLMCallSiteEnum,
+} from "../../../config/schemas/llm.js";
 import { ROUTES } from "../llm-call-sites-routes.js";
 
 const route = ROUTES.find((r) => r.operationId === "llm_call_sites_list")!;
@@ -59,6 +63,17 @@ describe("llm-call-sites-routes", () => {
         expect(typeof site.defaultProfile).toBe("string");
         expect(site.defaultProfile.length).toBeGreaterThan(0);
       }
+    }
+  });
+
+  test("shippedDefaultProfile is the code-owned tier, unaffected by pins", async () => {
+    const result = (await route.handler({})) as {
+      callSites: Array<{ id: string; shippedDefaultProfile?: string }>;
+    };
+    for (const site of result.callSites) {
+      expect(site.shippedDefaultProfile).toBe(
+        CALL_SITE_DEFAULTS[site.id as LLMCallSite]?.profile,
+      );
     }
   });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -800,7 +800,9 @@ const ConfigPatchRequestSchema = z
         callSites: z
           .record(z.string(), CallSiteOverrideDraftSchema.nullable())
           .optional(),
-        // `null` clears a tier's remap via the deep-merge delete semantics.
+        // `null` clears a tier's remap. Deep-merge deletion only covers
+        // object-valued keys, so `scrubClearedTierOverrides` turns the
+        // assigned null into a real delete before the write.
         defaultProfileOverrides: z
           .record(z.string(), z.string().nullable())
           .optional(),
@@ -1545,6 +1547,28 @@ function seedSttProviderForSparseBlock(raw: Record<string, unknown>): void {
   stt.provider = getConfig().services.stt.provider;
 }
 
+/**
+ * `llm.defaultProfileOverrides` values are strings, and the deep-merge null
+ * sentinel only DELETES object-valued keys: against a string it assigns
+ * `null`, which `saveRawConfig` persists unvalidated. A persisted null
+ * fails `LLMSchema`'s `z.string().min(1)` on the next load and would only
+ * be cleared by the loader's issue-path recovery, so drop cleared tiers
+ * here and the null clear becomes a real delete.
+ */
+function scrubClearedTierOverrides(raw: Record<string, unknown>): void {
+  const tiers = readPlainObject(
+    readPlainObject(raw.llm)?.defaultProfileOverrides,
+  );
+  if (!tiers) {
+    return;
+  }
+  for (const [tier, value] of Object.entries(tiers)) {
+    if (value === null) {
+      delete tiers[tier];
+    }
+  }
+}
+
 async function handlePatchConfig({ body }: RouteHandlerArgs) {
   if (
     !body ||
@@ -1564,6 +1588,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   backfillNewCallSiteEntries(raw, patch);
   deepMergeOverwrite(raw, patch);
   scrubRemovedServiceModes(raw);
+  scrubClearedTierOverrides(raw);
   seedSttProviderForSparseBlock(raw);
 
   await commitConfigWrite(raw, "patch");

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -691,6 +691,10 @@ const ConfigGetResponseSchema = z
             }).nullable(),
           )
           .optional(),
+        // Tier-to-profile remap of the shipped call-site defaults (see
+        // `defaultProfileOverrides` in `config/schemas/llm.ts`). Keys are
+        // default-profile tier keys; values are profile names.
+        defaultProfileOverrides: z.record(z.string(), z.string()).optional(),
         profileSession: z
           .object({
             defaultTtlSeconds: z.number().optional(),
@@ -795,6 +799,10 @@ const ConfigPatchRequestSchema = z
         advisorProfile: z.string().nullable().optional(),
         callSites: z
           .record(z.string(), CallSiteOverrideDraftSchema.nullable())
+          .optional(),
+        // `null` clears a tier's remap via the deep-merge delete semantics.
+        defaultProfileOverrides: z
+          .record(z.string(), z.string().nullable())
           .optional(),
         profileSession: z
           .object({

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { CALL_SITE_DEFAULTS } from "../../config/call-site-defaults.js";
 import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { loadConfig } from "../../config/loader.js";
@@ -21,7 +22,15 @@ const callSiteEntrySchema = z.object({
   displayName: z.string(),
   description: z.string(),
   domain: z.string(),
+  /** The effective winning profile key: includes per-call-site pins. */
   defaultProfile: z.string().optional(),
+  /**
+   * The code-owned `CALL_SITE_DEFAULTS` tier key, independent of pins and
+   * tier remaps. Clients group call sites by tier with this; grouping by
+   * `defaultProfile` would scatter pinned or remapped sites across their
+   * winners.
+   */
+  shippedDefaultProfile: z.string().optional(),
 });
 
 const callSiteCatalogResponseSchema = z.object({
@@ -36,6 +45,7 @@ async function handleGetCallSites() {
     callSites: CALL_SITE_CATALOG.map((entry) => ({
       ...entry,
       defaultProfile: resolveDefaultProfileKey(entry.id as LLMCallSite, llm),
+      shippedDefaultProfile: CALL_SITE_DEFAULTS[entry.id]?.profile,
     })),
   };
 }

--- a/clients/web/src/domains/settings/ai/ai-page.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.tsx
@@ -62,12 +62,16 @@ export function AiPage() {
     </div>
   );
 
-  const detailKey =
+  // Keyed by assistant so a panel that stays open across an assistant
+  // switch remounts instead of carrying one assistant's draft edits into
+  // another's save.
+  const detailKey = `${assistantId ?? "none"}:${
     lmPanel?.kind === "profile"
       ? `profile:${lmPanel.name}`
       : lmPanel?.kind === "provider"
         ? `provider:${lmPanel.name}`
-        : (lmPanel?.kind ?? "closed");
+        : (lmPanel?.kind ?? "closed")
+  }`;
   const isProviderPanel =
     lmPanel?.kind === "provider" || lmPanel?.kind === "add-provider";
   const detail =

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -73,10 +73,12 @@ let configPatchBodies: unknown[] = [];
 // persisted shape reassign this, because seeding the query cache alone is
 // not enough: `staleTime: 0` refetches and the mock's value wins.
 let servedConfig: unknown = CONFIG;
+// Same deal for the call-site catalog.
+let servedCatalog: unknown = CATALOG;
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...daemonSdk,
-  configLlmCallsitesGet: mock(async () => ({ data: CATALOG })),
+  configLlmCallsitesGet: mock(async () => ({ data: servedCatalog })),
   configGet: mock(async () => ({ data: servedConfig })),
   configPatch: async (options?: { body?: unknown }) => {
     configPatchBodies.push(options?.body);
@@ -86,6 +88,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 
 const { OverridesDetailPanel } =
   await import("@/domains/settings/ai/overrides-detail-panel");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -128,6 +132,7 @@ function pickOption(trigger: HTMLElement, optionLabel: string): void {
 beforeEach(() => {
   configPatchBodies = [];
   servedConfig = CONFIG;
+  servedCatalog = CATALOG;
 });
 
 afterEach(() => {
@@ -142,10 +147,7 @@ describe("OverridesDetailPanel - call-site enumeration", () => {
   test("renders catalog call sites but excludes mainAgent", async () => {
     render(
       <Wrapper>
-        <OverridesDetailPanel
-          assistantId="asst-1"
-          onClose={() => {}}
-        />
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
       </Wrapper>,
     );
     await waitFor(() => {
@@ -159,10 +161,7 @@ describe("OverridesDetailPanel - apply to all", () => {
   test("applies the chosen profile to every call site and saves", async () => {
     render(
       <Wrapper>
-        <OverridesDetailPanel
-          assistantId="asst-1"
-          onClose={() => {}}
-        />
+        <OverridesDetailPanel assistantId="asst-1" onClose={() => {}} />
       </Wrapper>,
     );
     await waitFor(() => {
@@ -337,9 +336,7 @@ describe("OverridesDetailPanel - tuning-only entries (LUM-2949)", () => {
       document.querySelectorAll<HTMLElement>(
         '[role="switch"], input[type="checkbox"]',
       ),
-    ).find((el) =>
-      (el.getAttribute("aria-label") ?? "").includes(displayName),
-    );
+    ).find((el) => (el.getAttribute("aria-label") ?? "").includes(displayName));
     if (!match) {
       throw new Error(`expected a toggle for ${displayName}`);
     }
@@ -391,5 +388,155 @@ describe("OverridesDetailPanel - tuning-only entries (LUM-2949)", () => {
       llm: { callSites: Record<string, unknown> };
     };
     expect(body.llm.callSites.heartbeatAgent).toBe(null);
+  });
+});
+
+describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
+  const TIER_CATALOG = {
+    domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+    callSites: [
+      {
+        id: "mainAgent",
+        displayName: "Main Agent",
+        description: "The primary chat agent.",
+        domain: "agentLoop",
+        defaultProfile: null,
+      },
+      {
+        id: "workflowLeaf",
+        displayName: "Workflow Leaf",
+        description: "Runs an ephemeral leaf agent.",
+        domain: "agentLoop",
+        defaultProfile: "balanced",
+      },
+      {
+        id: "heartbeatAgent",
+        displayName: "Heartbeat Agent",
+        description: "Runs background tasks on a schedule.",
+        domain: "agentLoop",
+        defaultProfile: "cost-optimized",
+      },
+    ],
+  };
+
+  const TIER_CONFIG = {
+    llm: {
+      ...CONFIG.llm,
+      profiles: {
+        ...CONFIG.llm.profiles,
+        balanced: {
+          label: "Balanced",
+          provider: "vellum",
+          model: "gpt-5.6-luna",
+        },
+        "cost-optimized": {
+          label: "Speed",
+          provider: "vellum",
+          model: "gpt-5.6-luna",
+        },
+      },
+    },
+  };
+
+  function renderTierPanel(config: unknown = TIER_CONFIG) {
+    servedCatalog = TIER_CATALOG;
+    servedConfig = config;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0 } },
+    });
+    client.setQueryData([{ _id: "configLlmCallsitesGet" }], TIER_CATALOG);
+    client.setQueryData([{ _id: "configGet" }], config);
+    return render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(OverridesDetailPanel, {
+          assistantId: "asst-1",
+          onClose: () => {},
+        }),
+      ),
+    );
+  }
+
+  function tierTrigger(label: string): HTMLElement {
+    const match = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    ).find((t) => t.textContent?.includes(label));
+    if (!match) {
+      throw new Error(`expected a dropdown trigger showing "${label}"`);
+    }
+    return match;
+  }
+
+  beforeEach(() => {
+    useAssistantIdentityStore.getState().setIdentity("asst-1", "0.11.1");
+  });
+
+  afterEach(() => {
+    useAssistantIdentityStore.getState().clearIdentity();
+  });
+
+  test("renders one Defaults row per shipped tier and hides apply-to-all", async () => {
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+    expect(renderedText()).toContain("Balanced");
+    expect(renderedText()).toContain("Speed");
+    expect(renderedText()).toContain("1 action");
+    expect(renderedText()).not.toContain("Use one profile for all actions");
+  });
+
+  test("remapping a tier saves only the changed key and shows provenance", async () => {
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+
+    pickOption(tierTrigger("Balanced (default)"), "My BYOK");
+    // The per-action caption reflects the pending remap.
+    expect(renderedText()).toContain("Balanced → My BYOK");
+
+    fireEvent.click(getButton("Save"));
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
+    expect(body.llm.defaultProfileOverrides).toEqual({ balanced: "my-byok" });
+    // No call-site row moved, so the map must not be sent.
+    expect("callSites" in body.llm).toBe(false);
+  });
+
+  test("clearing a persisted remap sends null for that tier", async () => {
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { "cost-optimized": "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+    // The persisted remap is visible on the tier row and in the caption.
+    expect(renderedText()).toContain("Speed → My BYOK");
+
+    pickOption(tierTrigger("My BYOK"), "Speed (default)");
+    fireEvent.click(getButton("Save"));
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
+    expect(body.llm.defaultProfileOverrides).toEqual({
+      "cost-optimized": null,
+    });
+  });
+
+  test("an unknown assistant version falls back to apply-to-all", async () => {
+    useAssistantIdentityStore.getState().clearIdentity();
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Use one profile for all actions");
+    });
+    expect(renderedText()).not.toContain("Defaults");
   });
 });

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -556,6 +556,37 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     });
   });
 
+  test("Reset clears per-action pins but keeps the tier remaps", async () => {
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { "cost-optimized": "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+
+    fireEvent.click(getButton("Reset to Defaults"));
+    // Confirm dialog: the destructive confirm carries the same label.
+    const confirm = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).filter((b) => b.textContent?.trim() === "Reset to Defaults")[1];
+    if (!confirm) {
+      throw new Error("expected the confirm dialog button");
+    }
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
+    // Per-action pins are nulled; the user's tier configuration is not an
+    // override to reset and must not be touched.
+    expect(body.llm.callSites).toBeTruthy();
+    expect("defaultProfileOverrides" in body.llm).toBe(false);
+  });
+
   test("an unknown assistant version falls back to a non-writing apply-to-all", async () => {
     useAssistantIdentityStore.getState().clearIdentity();
     renderTierPanel();

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -406,6 +406,7 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
         description: "The primary chat agent.",
         domain: "agentLoop",
         defaultProfile: null,
+        shippedDefaultProfile: null,
       },
       {
         id: "workflowLeaf",
@@ -413,6 +414,7 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
         description: "Runs an ephemeral leaf agent.",
         domain: "agentLoop",
         defaultProfile: "balanced",
+        shippedDefaultProfile: "balanced",
       },
       {
         id: "heartbeatAgent",
@@ -420,6 +422,17 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
         description: "Runs background tasks on a schedule.",
         domain: "agentLoop",
         defaultProfile: "cost-optimized",
+        shippedDefaultProfile: "cost-optimized",
+      },
+      {
+        // Pinned: `defaultProfile` is the winning pin, the shipped tier is
+        // cost-optimized. Must count toward Speed, not mint a My BYOK row.
+        id: "filingAgent",
+        displayName: "Filing Agent",
+        description: "Files memories after conversations.",
+        domain: "agentLoop",
+        defaultProfile: "my-byok",
+        shippedDefaultProfile: "cost-optimized",
       },
     ],
   };
@@ -440,6 +453,7 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
           model: "gpt-5.6-luna",
         },
       },
+      callSites: { filingAgent: { profile: "my-byok" } },
     },
   };
 
@@ -484,9 +498,13 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     await waitFor(() => {
       expect(renderedText()).toContain("Defaults");
     });
-    expect(renderedText()).toContain("Balanced");
-    expect(renderedText()).toContain("Speed");
+    expect(renderedText()).toContain("Balanced (default)");
     expect(renderedText()).toContain("1 action");
+    // The pinned Filing Agent counts toward its shipped Speed tier...
+    expect(renderedText()).toContain("Speed (default)");
+    expect(renderedText()).toContain("2 actions");
+    // ...and its winning pin must not mint a tier row of its own.
+    expect(renderedText()).not.toContain("My BYOK (default)");
     expect(renderedText()).not.toContain("Use one profile for all actions");
   });
 
@@ -520,8 +538,12 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     await waitFor(() => {
       expect(renderedText()).toContain("Defaults");
     });
-    // The persisted remap is visible on the tier row and in the caption.
+    // The persisted remap is visible on the tier row and in the caption of
+    // unpinned Speed-tier sites.
     expect(renderedText()).toContain("Speed → My BYOK");
+    // The pinned Filing Agent keeps its winner caption without an arrow:
+    // its pin outranks the remap.
+    expect(renderedText()).toContain("Default: My BYOK");
 
     pickOption(tierTrigger("My BYOK"), "Speed (default)");
     fireEvent.click(getButton("Save"));
@@ -540,7 +562,7 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     await waitFor(() => {
       expect(renderedText()).toContain("Use one profile for all actions");
     });
-    expect(renderedText()).not.toContain("Defaults");
+    expect(renderedText()).not.toContain("Balanced (default)");
     // Non-writing until the version hydrates: on a tier-overrides daemon a
     // sweep would persist pins that outrank the tier remaps.
     const trigger = document.querySelector<HTMLElement>(
@@ -561,6 +583,6 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     await waitFor(() => {
       expect(renderedText()).toContain("Use one profile for all actions");
     });
-    expect(renderedText()).not.toContain("Defaults");
+    expect(renderedText()).not.toContain("Balanced (default)");
   });
 });

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -133,9 +133,14 @@ beforeEach(() => {
   configPatchBodies = [];
   servedConfig = CONFIG;
   servedCatalog = CATALOG;
+  // A hydrated pre-tier-overrides version: the legacy apply-to-all path is
+  // rendered AND writable (the Apply button stays disabled while the
+  // version is unknown).
+  useAssistantIdentityStore.getState().setIdentity("Asst", "0.10.0", "asst-1");
 });
 
 afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
   cleanup();
 });
 
@@ -469,11 +474,9 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
   }
 
   beforeEach(() => {
-    useAssistantIdentityStore.getState().setIdentity("asst-1", "0.11.1");
-  });
-
-  afterEach(() => {
-    useAssistantIdentityStore.getState().clearIdentity();
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Asst", "0.11.1", "asst-1");
   });
 
   test("renders one Defaults row per shipped tier and hides apply-to-all", async () => {
@@ -531,8 +534,29 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     });
   });
 
-  test("an unknown assistant version falls back to apply-to-all", async () => {
+  test("an unknown assistant version falls back to a non-writing apply-to-all", async () => {
     useAssistantIdentityStore.getState().clearIdentity();
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Use one profile for all actions");
+    });
+    expect(renderedText()).not.toContain("Defaults");
+    // Non-writing until the version hydrates: on a tier-overrides daemon a
+    // sweep would persist pins that outrank the tier remaps.
+    const trigger = document.querySelector<HTMLElement>(
+      'button[role="combobox"]',
+    );
+    if (!trigger) {
+      throw new Error("expected the apply-all dropdown trigger");
+    }
+    pickOption(trigger, "My BYOK");
+    expect(getButton("Apply to all").disabled).toBe(true);
+  });
+
+  test("a version fetched for a different assistant keeps the gate off", async () => {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Other", "0.11.1", "asst-other");
     renderTierPanel();
     await waitFor(() => {
       expect(renderedText()).toContain("Use one profile for all actions");

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -105,10 +105,15 @@ export function OverridesDetailPanel({
 
   const supportsTierOverrides = useSupportsDefaultProfileOverrides(assistantId);
   // The legacy apply-to-all sweep stays non-writing until the version is
-  // hydrated: on a tier-overrides daemon it would persist per-call-site
-  // pins, which outrank `defaultProfileOverrides` and lock the Defaults
-  // rows out of those actions.
-  const identityVersionKnown = useAssistantIdentityStore.use.version() != null;
+  // hydrated FOR THIS ASSISTANT: on a tier-overrides daemon it would
+  // persist per-call-site pins, which outrank `defaultProfileOverrides`
+  // and lock the Defaults rows out of those actions. The assistant scope
+  // matters on assistant switch, where a remounted panel can render once
+  // against the previous assistant's not-yet-cleared identity.
+  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
+  const identityVersionKnown =
+    useAssistantIdentityStore.use.version() != null &&
+    identityAssistantId === assistantId;
 
   const [search, setSearch] = useState("");
   const [applyAllProfile, setApplyAllProfile] = useState("");
@@ -187,12 +192,18 @@ export function OverridesDetailPanel({
   );
 
   // One Defaults row per tier that call sites actually ship on, ordered by
-  // the profile picker's own ordering so the rows match it.
+  // the profile picker's own ordering so the rows match it. Grouped by the
+  // code-owned shipped tier: `defaultProfile` is the effective winner, so
+  // grouping by it would scatter pinned or remapped sites across their
+  // winning profiles instead of their tiers.
   const tierGroups = useMemo(() => {
     const counts = new Map<string, number>();
     for (const cs of gatedCallSites) {
-      if (cs.defaultProfile) {
-        counts.set(cs.defaultProfile, (counts.get(cs.defaultProfile) ?? 0) + 1);
+      if (cs.shippedDefaultProfile) {
+        counts.set(
+          cs.shippedDefaultProfile,
+          (counts.get(cs.shippedDefaultProfile) ?? 0) + 1,
+        );
       }
     }
     const pickerIndex = new Map(orderedProfiles.map((p, i) => [p.name, i]));
@@ -734,16 +745,27 @@ export function OverridesDetailPanel({
                         }
                         return d.profile ?? "";
                       })();
-                      // A remapped tier shows its provenance: the shipped
-                      // tier plus what it currently resolves to.
-                      const tierRemap =
-                        supportsTierOverrides && cs.defaultProfile
-                          ? effectiveTierRemap(cs.defaultProfile)
-                          : null;
-                      const defaultProfileLabel = cs.defaultProfile
-                        ? profileLabelFor(cs.defaultProfile) +
-                          (tierRemap ? ` → ${profileLabelFor(tierRemap)}` : "")
-                        : null;
+                      // Caption provenance for an unpinned site on a
+                      // tier-overrides daemon builds from the shipped tier
+                      // plus its remap; `defaultProfile` (the effective
+                      // winner) already IS the remapped profile there, so
+                      // deriving from it would lose the tier. A pinned
+                      // site keeps the winner caption: the pin outranks
+                      // the remap, so an arrow would claim an effect the
+                      // resolver doesn't apply.
+                      const pinned = isDraftActive(drafts[cs.id] ?? null);
+                      const shippedTier = cs.shippedDefaultProfile;
+                      let defaultProfileLabel: string | null = null;
+                      if (supportsTierOverrides && shippedTier && !pinned) {
+                        const tierRemap = effectiveTierRemap(shippedTier);
+                        defaultProfileLabel =
+                          profileLabelFor(shippedTier) +
+                          (tierRemap ? ` → ${profileLabelFor(tierRemap)}` : "");
+                      } else if (cs.defaultProfile) {
+                        defaultProfileLabel = profileLabelFor(
+                          cs.defaultProfile,
+                        );
+                      }
 
                       return (
                         <CallSiteOverrideRow

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -260,19 +260,17 @@ export function OverridesDetailPanel({
     return q === "" || "advisor".includes(q) || "second opinion".includes(q);
   }, [search]);
 
-  const hasPersistedTierOverride =
-    supportsTierOverrides &&
-    Object.values(persistedTierOverrides).some((v) => v != null);
-
+  // Per-action pins only: Reset deliberately leaves the tier remaps alone
+  // (they are the user's intended defaults, cleared per-row instead), so
+  // tier state neither shows the button nor enters the reset patch.
   const hasAnyPersistedOverride = useMemo(
     () =>
-      hasPersistedTierOverride ||
       Object.entries(persistedOverrides).some(
         ([id, s]) =>
           gatedCallSiteIdSet.has(id) &&
           (s?.profile != null || s?.provider != null || s?.model != null),
       ),
-    [hasPersistedTierOverride, persistedOverrides, gatedCallSiteIdSet],
+    [persistedOverrides, gatedCallSiteIdSet],
   );
 
   const callSiteDraftsDirty = useMemo(() => {
@@ -500,22 +498,9 @@ export function OverridesDetailPanel({
       for (const id of Object.keys(drafts)) {
         resetPatch[id] = null;
       }
-      const tierResetPatch: Record<string, null> = {};
-      if (supportsTierOverrides) {
-        for (const tier of Object.keys(persistedTierOverrides)) {
-          tierResetPatch[tier] = null;
-        }
-      }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: {
-          llm: {
-            callSites: resetPatch,
-            ...(Object.keys(tierResetPatch).length > 0
-              ? { defaultProfileOverrides: tierResetPatch }
-              : {}),
-          },
-        },
+        body: { llm: { callSites: resetPatch } },
       });
       onClose();
       toast.success("Overrides reset.");
@@ -525,14 +510,7 @@ export function OverridesDetailPanel({
     } finally {
       setSaving(false);
     }
-  }, [
-    drafts,
-    supportsTierOverrides,
-    persistedTierOverrides,
-    onClose,
-    configMutation,
-    assistantId,
-  ]);
+  }, [drafts, onClose, configMutation, assistantId]);
 
   // ---------------------------------------------------------------------------
   // Render
@@ -796,7 +774,11 @@ export function OverridesDetailPanel({
       <ConfirmDialog
         open={showResetConfirmation}
         title="Reset to Defaults"
-        message="Every task override will be reset and will follow your active profile. This cannot be undone."
+        message={
+          supportsTierOverrides
+            ? "Every action override will be reset and will follow its tier default above. Your tier choices are kept. This cannot be undone."
+            : "Every task override will be reset and will follow your active profile. This cannot be undone."
+        }
         confirmLabel="Reset to Defaults"
         destructive
         onConfirm={() => {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -31,6 +31,7 @@ import type {
 } from "@/generated/daemon/types.gen";
 import { useSupportsDefaultProfileOverrides } from "@/lib/backwards-compat/use-supports-default-profile-overrides";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { DetailShell } from "@/components/detail-shell";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
@@ -102,7 +103,12 @@ export function OverridesDetailPanel({
     },
   });
 
-  const supportsTierOverrides = useSupportsDefaultProfileOverrides();
+  const supportsTierOverrides = useSupportsDefaultProfileOverrides(assistantId);
+  // The legacy apply-to-all sweep stays non-writing until the version is
+  // hydrated: on a tier-overrides daemon it would persist per-call-site
+  // pins, which outrank `defaultProfileOverrides` and lock the Defaults
+  // rows out of those actions.
+  const identityVersionKnown = useAssistantIdentityStore.use.version() != null;
 
   const [search, setSearch] = useState("");
   const [applyAllProfile, setApplyAllProfile] = useState("");
@@ -645,7 +651,9 @@ export function OverridesDetailPanel({
               variant="outlined"
               size="compact"
               onClick={handleApplyAll}
-              disabled={!applyAllProfile || !isSeeded || saving}
+              disabled={
+                !applyAllProfile || !isSeeded || saving || !identityVersionKnown
+              }
             >
               Apply to all
             </Button>

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -29,6 +29,7 @@ import type {
   CallSiteOverrideDraft,
   ConfigLlmCallsitesGetResponse,
 } from "@/generated/daemon/types.gen";
+import { useSupportsDefaultProfileOverrides } from "@/lib/backwards-compat/use-supports-default-profile-overrides";
 import { captureError } from "@/lib/sentry/capture-error";
 import { DetailShell } from "@/components/detail-shell";
 import { Button } from "@vellumai/design-library/components/button";
@@ -52,8 +53,9 @@ export interface OverridesDetailPanelProps {
 
 /**
  * Sidepanel host for the Action Overrides editor (the Overrides section's
- * Manage action): search, apply-to-all, and per-call-site rows grouped by
- * domain in the scrollable body, with Save / Reset pinned in the
+ * Manage action): search, per-tier default rows (apply-to-all on daemons
+ * predating `llm.defaultProfileOverrides`), and per-call-site rows grouped
+ * by domain in the scrollable body, with Save / Reset pinned in the
  * DetailShell footer so a long catalog never hides the actions. Hosts
  * remount the panel per open so draft state resets.
  */
@@ -80,6 +82,10 @@ export function OverridesDetailPanel({
     () => daemonConfig?.llm?.callSites ?? {},
     [daemonConfig?.llm?.callSites],
   );
+  const persistedTierOverrides = useMemo(
+    () => daemonConfig?.llm?.defaultProfileOverrides ?? {},
+    [daemonConfig?.llm?.defaultProfileOverrides],
+  );
   const orderedProfiles = useMemo(
     () => buildOrderedProfiles(profiles, profileOrder),
     [profiles, profileOrder],
@@ -96,8 +102,13 @@ export function OverridesDetailPanel({
     },
   });
 
+  const supportsTierOverrides = useSupportsDefaultProfileOverrides();
+
   const [search, setSearch] = useState("");
   const [applyAllProfile, setApplyAllProfile] = useState("");
+  // Tier remap edits this session: value is a profile name, `null` clears a
+  // persisted remap, absent means untouched (falls through to persisted).
+  const [tierEdits, setTierEdits] = useState<Record<string, string | null>>({});
   const [draftEdits, setDraftEdits] = useState<
     Record<string, CallSiteOverrideDraft | null>
   >({});
@@ -163,6 +174,50 @@ export function OverridesDetailPanel({
     [catalogCallSiteIds],
   );
 
+  const profileLabelFor = useCallback(
+    (name: string) =>
+      orderedProfiles.find((p) => p.name === name)?.label ?? name,
+    [orderedProfiles],
+  );
+
+  // One Defaults row per tier that call sites actually ship on, ordered by
+  // the profile picker's own ordering so the rows match it.
+  const tierGroups = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const cs of gatedCallSites) {
+      if (cs.defaultProfile) {
+        counts.set(cs.defaultProfile, (counts.get(cs.defaultProfile) ?? 0) + 1);
+      }
+    }
+    const pickerIndex = new Map(orderedProfiles.map((p, i) => [p.name, i]));
+    return [...counts.entries()]
+      .map(([tier, count]) => ({ tier, count }))
+      .sort(
+        (a, b) =>
+          (pickerIndex.get(a.tier) ?? Number.MAX_SAFE_INTEGER) -
+          (pickerIndex.get(b.tier) ?? Number.MAX_SAFE_INTEGER),
+      );
+  }, [gatedCallSites, orderedProfiles]);
+
+  // The remap a tier resolves to right now: this session's edit when the
+  // row was touched, else the persisted value; `null` means unremapped.
+  const effectiveTierRemap = useCallback(
+    (tier: string): string | null =>
+      tier in tierEdits
+        ? (tierEdits[tier] ?? null)
+        : (persistedTierOverrides[tier] ?? null),
+    [tierEdits, persistedTierOverrides],
+  );
+
+  const tierOverridesDirty = useMemo(
+    () =>
+      Object.entries(tierEdits).some(
+        ([tier, value]) =>
+          (value ?? null) !== (persistedTierOverrides[tier] ?? null),
+      ),
+    [tierEdits, persistedTierOverrides],
+  );
+
   // The advisor is a top-level `llm.advisorProfile` selection, not a call-site
   // override. It rides this panel's draft/Save cycle but never enters the
   // `llm.callSites` patch, the apply-to-all sweep, or the Overrides count.
@@ -172,10 +227,12 @@ export function OverridesDetailPanel({
 
   const advisorOptions = useMemo(
     () =>
-      visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map((p) => ({
-        value: p.name,
-        label: profilePickerLabel(p),
-      })),
+      visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map(
+        (p) => ({
+          value: p.name,
+          label: profilePickerLabel(p),
+        }),
+      ),
     [orderedProfiles, persistedAdvisor],
   );
 
@@ -186,14 +243,19 @@ export function OverridesDetailPanel({
     return q === "" || "advisor".includes(q) || "second opinion".includes(q);
   }, [search]);
 
+  const hasPersistedTierOverride =
+    supportsTierOverrides &&
+    Object.values(persistedTierOverrides).some((v) => v != null);
+
   const hasAnyPersistedOverride = useMemo(
     () =>
+      hasPersistedTierOverride ||
       Object.entries(persistedOverrides).some(
         ([id, s]) =>
           gatedCallSiteIdSet.has(id) &&
           (s?.profile != null || s?.provider != null || s?.model != null),
       ),
-    [persistedOverrides, gatedCallSiteIdSet],
+    [hasPersistedTierOverride, persistedOverrides, gatedCallSiteIdSet],
   );
 
   const callSiteDraftsDirty = useMemo(() => {
@@ -208,7 +270,8 @@ export function OverridesDetailPanel({
     return false;
   }, [isSeeded, drafts, persistedOverrides]);
 
-  const hasUnsavedDrafts = advisorDirty || callSiteDraftsDirty;
+  const hasUnsavedDrafts =
+    advisorDirty || callSiteDraftsDirty || tierOverridesDirty;
 
   const hasValidationError = useMemo(
     () =>
@@ -363,6 +426,14 @@ export function OverridesDetailPanel({
           patch[id] = null;
         }
       }
+      // Only the tier keys that actually moved: a profile name sets the
+      // remap, `null` clears it via the deep-merge delete semantics.
+      const tierPatch: Record<string, string | null> = {};
+      for (const [tier, value] of Object.entries(tierEdits)) {
+        if ((value ?? null) !== (persistedTierOverrides[tier] ?? null)) {
+          tierPatch[tier] = value ?? null;
+        }
+      }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: {
@@ -374,6 +445,11 @@ export function OverridesDetailPanel({
             ...(callSiteDraftsDirty ? { callSites: patch } : {}),
             // Likewise: a no-op key would still rewrite the config file.
             ...(advisorDirty ? { advisorProfile } : {}),
+            // Gated: an older daemon's schema rejects the unknown key and
+            // with it the whole patch.
+            ...(supportsTierOverrides && tierOverridesDirty
+              ? { defaultProfileOverrides: tierPatch }
+              : {}),
           },
         },
       });
@@ -391,6 +467,10 @@ export function OverridesDetailPanel({
     callSiteDraftsDirty,
     advisorDirty,
     advisorProfile,
+    tierEdits,
+    persistedTierOverrides,
+    tierOverridesDirty,
+    supportsTierOverrides,
     onClose,
     configMutation,
     assistantId,
@@ -403,9 +483,22 @@ export function OverridesDetailPanel({
       for (const id of Object.keys(drafts)) {
         resetPatch[id] = null;
       }
+      const tierResetPatch: Record<string, null> = {};
+      if (supportsTierOverrides) {
+        for (const tier of Object.keys(persistedTierOverrides)) {
+          tierResetPatch[tier] = null;
+        }
+      }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: { llm: { callSites: resetPatch } },
+        body: {
+          llm: {
+            callSites: resetPatch,
+            ...(Object.keys(tierResetPatch).length > 0
+              ? { defaultProfileOverrides: tierResetPatch }
+              : {}),
+          },
+        },
       });
       onClose();
       toast.success("Overrides reset.");
@@ -415,7 +508,14 @@ export function OverridesDetailPanel({
     } finally {
       setSaving(false);
     }
-  }, [drafts, onClose, configMutation, assistantId]);
+  }, [
+    drafts,
+    supportsTierOverrides,
+    persistedTierOverrides,
+    onClose,
+    configMutation,
+    assistantId,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Render
@@ -471,8 +571,63 @@ export function OverridesDetailPanel({
           />
         </div>
 
-        {/* Apply one profile to every action */}
-        {applyAllOptions.length > 0 && (
+        {/* Per-tier defaults: every action whose shipped default is a tier
+            follows that tier's profile unless overridden per-action below. */}
+        {supportsTierOverrides && !search.trim() && tierGroups.length > 0 && (
+          <div className="mb-4">
+            {/* typography: off-scale. Matches the domain section label below */}
+            <p className="mb-2 text-body-small-default font-semibold uppercase tracking-wider text-[var(--content-tertiary)]">
+              Defaults
+            </p>
+            <div className="space-y-1">
+              {tierGroups.map(({ tier, count }) => {
+                const tierLabel = profileLabelFor(tier);
+                const remap = effectiveTierRemap(tier);
+                const options = [
+                  { value: "", label: `${tierLabel} (default)` },
+                  ...visibleProfilesForPicker(orderedProfiles, [remap])
+                    .filter((p) => p.name !== tier)
+                    .map((p) => ({
+                      value: p.name,
+                      label: profilePickerLabel(p),
+                    })),
+                ];
+                return (
+                  <div
+                    key={tier}
+                    className="flex items-center gap-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-body-medium-default text-[var(--content-default)]">
+                        {tierLabel}
+                      </p>
+                      <p className="text-body-small-default text-[var(--content-tertiary)]">
+                        {count === 1 ? "1 action" : `${count} actions`}
+                      </p>
+                    </div>
+                    <Dropdown
+                      value={remap ?? ""}
+                      onChange={(value) =>
+                        setTierEdits((prev) => ({
+                          ...prev,
+                          [tier]: value === "" ? null : value,
+                        }))
+                      }
+                      options={options}
+                      className="w-44"
+                      menuMinWidth={280}
+                      menuAlign="end"
+                      disabled={saving}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Apply one profile to every action (pre-tier-override daemons) */}
+        {!supportsTierOverrides && applyAllOptions.length > 0 && (
           <div className="mb-4 flex items-center gap-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-base)] p-3">
             <p className="min-w-0 flex-1 text-body-medium-default text-[var(--content-default)]">
               Use one profile for all actions
@@ -571,10 +726,15 @@ export function OverridesDetailPanel({
                         }
                         return d.profile ?? "";
                       })();
+                      // A remapped tier shows its provenance: the shipped
+                      // tier plus what it currently resolves to.
+                      const tierRemap =
+                        supportsTierOverrides && cs.defaultProfile
+                          ? effectiveTierRemap(cs.defaultProfile)
+                          : null;
                       const defaultProfileLabel = cs.defaultProfile
-                        ? (orderedProfiles.find(
-                            (op) => op.name === cs.defaultProfile,
-                          )?.label ?? cs.defaultProfile)
+                        ? profileLabelFor(cs.defaultProfile) +
+                          (tierRemap ? ` → ${profileLabelFor(tierRemap)}` : "")
                         : null;
 
                       return (
@@ -602,7 +762,6 @@ export function OverridesDetailPanel({
           </div>
         )}
       </div>
-
 
       <ConfirmDialog
         open={showResetConfirmation}

--- a/clients/web/src/lib/backwards-compat/use-supports-default-profile-overrides.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-default-profile-overrides.ts
@@ -1,0 +1,36 @@
+/**
+ * Backwards-compat gate: per-tier default-profile overrides.
+ *
+ * Old behavior (< MIN_VERSION): the daemon's `LLMSchema` has no
+ * `defaultProfileOverrides` field, so a `PATCH /v1/config` carrying it
+ * fails validation and the whole save is rejected. The Action Overrides
+ * panel renders its apply-one-profile-to-all-actions affordance and never
+ * sends the field.
+ *
+ * New behavior (>= MIN_VERSION): the daemon resolves
+ * `llm.defaultProfileOverrides` (tier key to profile name) in its
+ * call-site resolution chain. The panel replaces apply-to-all with the
+ * per-tier Defaults rows and includes the map in its config patch.
+ *
+ * Reading needs no gate: an older daemon simply omits the field from
+ * `GET /v1/config` and the panel treats every tier as unremapped.
+ *
+ * MIN_VERSION names the next scheduled cut from main. A hotfix release
+ * branches from the latest release tag instead, so a hotfix that claims
+ * this version number would NOT carry the feature; if that happens (or if
+ * the daemon-side PR misses the cut), retarget this gate to the next
+ * scheduled cut's number.
+ */
+import { useAssistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.11.1";
+
+/**
+ * Returns `true` when the active assistant resolves per-tier default
+ * profile overrides. Subscribes to the identity store so consumers
+ * re-render when the assistant version crosses `MIN_VERSION`;
+ * conservative `false` while the version is unknown.
+ */
+export function useSupportsDefaultProfileOverrides(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/backwards-compat/use-supports-default-profile-overrides.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-default-profile-overrides.ts
@@ -21,16 +21,19 @@
  * the daemon-side PR misses the cut), retarget this gate to the next
  * scheduled cut's number.
  */
-import { useAssistantSupports } from "./utils";
+import { useAssistantScopedSupports } from "./utils";
 
 export const MIN_VERSION = "0.11.1";
 
 /**
- * Returns `true` when the active assistant resolves per-tier default
- * profile overrides. Subscribes to the identity store so consumers
- * re-render when the assistant version crosses `MIN_VERSION`;
- * conservative `false` while the version is unknown.
+ * Returns `true` when the assistant owning the gated surface resolves
+ * per-tier default profile overrides. Scoped to `assistantId` so a panel
+ * that stays mounted across an assistant switch never reads another
+ * assistant's version; conservative `false` while the version is unknown
+ * or was fetched for a different assistant.
  */
-export function useSupportsDefaultProfileOverrides(): boolean {
-  return useAssistantSupports(MIN_VERSION);
+export function useSupportsDefaultProfileOverrides(
+  assistantId: string,
+): boolean {
+  return useAssistantScopedSupports(MIN_VERSION, assistantId);
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #39907 (daemon schema + resolver for `llm.defaultProfileOverrides`) - merged 2026-08-04. The 0.11.1 gate here assumes the same release cut carries both; if the 0.11.1 cut somehow ships without #39907, bump `MIN_VERSION` in `use-supports-default-profile-overrides.ts` first.

## Summary
- The Action Overrides sheet shows a **Defaults** group (gated on assistant >= 0.11.1): one row per tier that call sites ship on, with the action count and a profile picker whose empty state reads "<Tier> (default)". Picking a profile writes `llm.defaultProfileOverrides` through the existing `PATCH /v1/config` pipe with the panel's dirty-tracking discipline (changed keys only, `null` to clear); Reset also clears the map, and per-action captions show provenance (`Default: Speed -> My BYOK`).
- Older daemons (or unknown version) keep the previous "Use one profile for all actions" affordance and never receive the new key, whose absence from their `LLMSchema` would reject the whole patch. Gate lives in `lib/backwards-compat/use-supports-default-profile-overrides.ts`.
- The daemon's config GET/PATCH wire schemas (`conversation-query-routes.ts`) now describe `defaultProfileOverrides`, so the generated web SDK types the field (openapi.yaml regenerated; the daemon already accepted it via passthrough).

## Original prompt
PR 2 of 2 for per-tier default-profile overrides: #39907 added the daemon-side `llm.defaultProfileOverrides` tier->profile remap consulted by the call-site resolver. This PR adds the web UI in the Action Overrides sheet, replacing the single apply-to-all override with per-tier rows (all balanced-default actions -> profile A, all quality-default actions -> profile B, etc.), version-gated on the daemon release carrying #39907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H68iCJ2sedJyhFMYTnBQkh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
