### PR TITLE
fix(docs): add favicon

### DIFF
--- a/clients/docs/src/app/docs/icon.svg
+++ b/clients/docs/src/app/docs/icon.svg
@@ -1,0 +1,28 @@
+<svg width="177" height="177" viewBox="0 0 177 177" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_85_161)">
+<rect x="2" y="1" width="173" height="173" rx="24" fill="url(#paint0_radial_85_161)"/>
+<path d="M65.2927 45L87.5854 93.3893L109.79 45H132.171L87.4084 137.09L43 45H65.2927Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_di_85_161" x="0" y="0" width="177" height="177" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_85_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_85_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_85_161"/>
+</filter>
+<radialGradient id="paint0_radial_85_161" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(88.5 -123.344) rotate(90) scale(362.219 174.427)">
+<stop stop-color="#7A8B6F"/>
+<stop offset="1" stop-color="#23793D"/>
+</radialGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary
- Add the existing Vellum favicon to the docs app
- Serve it from the `/docs` ingress prefix via Next app metadata

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `GET /docs/icon.svg` returns 200
