### PR TITLE
feat(cli): nginx edge proxies /webhooks/* and denylists sensitive routes in both modes

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -70,10 +70,21 @@ describe("buildIngressNginxConfig", () => {
     expect(conf).toContain("location / {");
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
     expect(conf).toContain('proxy_set_header X-Vellum-Edge-Forwarded "1";');
-    expect(conf).not.toContain("return 404;");
-    expect(conf).not.toContain("return 403;");
-    expect(conf).not.toContain("location =");
-    expect(conf).not.toContain("location ~");
+  });
+
+  test("blocks local-only bootstrap helpers before the catch-all proxy", () => {
+    const catchAll = conf.indexOf("location / {");
+    expect(catchAll).toBeGreaterThan(-1);
+    const deniedLocations = [
+      "location = /auth/token { return 404; }",
+      "location = /v1/pair { return 404; }",
+      "location = /v1/guardian/init { return 404; }",
+      "location = /v1/remote-web/pairing-verification { return 404; }",
+    ];
+    for (const location of deniedLocations) {
+      expect(conf).toContain(location);
+      expect(conf.indexOf(location)).toBeLessThan(catchAll);
+    }
   });
 
   test("declares static MIME types needed by the SPA", () => {
@@ -131,6 +142,26 @@ describe("buildIngressNginxConfig", () => {
     expect(remoteConf).toContain(
       'proxy_set_header X-Vellum-Edge-Forwarded "1";',
     );
+  });
+
+  test("proxies webhook callbacks to the gateway in remote web mode", () => {
+    const webhooksStart = remoteConf.indexOf("location ^~ /webhooks/ {");
+    expect(webhooksStart).toBeGreaterThan(-1);
+    const webhooksBlock = remoteConf.slice(
+      webhooksStart,
+      remoteConf.indexOf("}", webhooksStart),
+    );
+    expect(webhooksBlock).toContain("proxy_pass http://127.0.0.1:7830;");
+    expect(webhooksBlock).toContain("proxy_set_header Upgrade $http_upgrade;");
+  });
+
+  test("proxies /healthz in both modes", () => {
+    expect(remoteConf).toContain("location = /healthz {");
+    // The plain-proxy mode has no /healthz denylist entry, so the catch-all
+    // proxy serves it.
+    expect(conf).not.toContain("/healthz { return 404; }");
+    expect(conf).toContain("location / {");
+    expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
   });
 
   test("blocks local-only bootstrap helpers before generic API proxying", () => {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -117,6 +117,31 @@ function gatewayProxyBlock(gatewayPort: number): string {
       proxy_set_header Connection $connection_upgrade;`;
 }
 
+/**
+ * Sensitive local-only routes the edge must never expose to the internet,
+ * regardless of whether the SPA is being served.
+ */
+function denylistLocations(): string {
+  return `    location = /auth/token { return 404; }
+    location = /auth/token/ { return 404; }
+    location = /v1/pair { return 404; }
+    location = /v1/pair/ { return 404; }
+    location = /v1/pair/web-init { return 404; }
+    location = /v1/pair/web-init/ { return 404; }
+    location = /v1/devices { return 404; }
+    location = /v1/devices/ { return 404; }
+    location = /v1/devices/revoke { return 404; }
+    location = /v1/devices/revoke/ { return 404; }
+    location = /v1/guardian/init { return 404; }
+    location = /v1/guardian/init/ { return 404; }
+    location = /v1/guardian/reset-bootstrap { return 404; }
+    location = /v1/guardian/reset-bootstrap/ { return 404; }
+    location = /v1/remote-web/pairing-verification { return 404; }
+    location = /v1/remote-web/pairing-verification/ { return 404; }
+    location ^~ /assistant/__local/ { return 404; }
+    location ^~ /assistant/__gateway/ { return 404; }`;
+}
+
 export interface RemoteWebIngressOptions {
   webDistDir: string;
   indexHtmlPath?: string;
@@ -169,7 +194,9 @@ export function buildIngressNginxConfig(opts: {
         indexHtmlPath: remoteWebIngress.indexHtmlPath,
         config: remoteWebIngressConfig(remoteWebIngress.config),
       })
-    : `    location / {
+    : `${denylistLocations()}
+
+    location / {
 ${proxyBlock}
     }`;
 
@@ -236,30 +263,17 @@ function buildRemoteWebIngressLocations(opts: {
     opts.indexHtmlPath ?? join(opts.webDistDir, "index.html");
   const configJson = JSON.stringify(opts.config);
 
-  return `    location = /auth/token { return 404; }
-    location = /auth/token/ { return 404; }
-    location = /v1/pair { return 404; }
-    location = /v1/pair/ { return 404; }
-    location = /v1/pair/web-init { return 404; }
-    location = /v1/pair/web-init/ { return 404; }
-    location = /v1/devices { return 404; }
-    location = /v1/devices/ { return 404; }
-    location = /v1/devices/revoke { return 404; }
-    location = /v1/devices/revoke/ { return 404; }
-    location = /v1/guardian/init { return 404; }
-    location = /v1/guardian/init/ { return 404; }
-    location = /v1/guardian/reset-bootstrap { return 404; }
-    location = /v1/guardian/reset-bootstrap/ { return 404; }
-    location = /v1/remote-web/pairing-verification { return 404; }
-    location = /v1/remote-web/pairing-verification/ { return 404; }
-    location ^~ /assistant/__local/ { return 404; }
-    location ^~ /assistant/__gateway/ { return 404; }
+  return `${denylistLocations()}
 
     location = /healthz {
 ${proxyBlock}
     }
 
     location ^~ /v1/ {
+${proxyBlock}
+    }
+
+    location ^~ /webhooks/ {
 ${proxyBlock}
     }
 


### PR DESCRIPTION
## Summary
- Extract the sensitive-route denylist into a shared denylistLocations() used by both edge config modes
- Proxy /webhooks/* to the gateway in remote-web mode (WS upgrade headers included for Twilio media streams)
- No-SPA (webhooks-only) config now carries the same denylist ahead of its catch-all proxy

Part of plan: tunnel-edge-unify.md (PR 1 of 7)