### PR TITLE
fix(subagent): make the tool-stats footer honest and index the spawn-mode backfill

### DIFF
--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -394,7 +394,7 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     await asInternals(manager).runSubagent(subagentId, "Do something");
 
     expect(capturedNotifications[0].message).toContain(
-      "[stats: 2 tool calls, 2 succeeded, files written: 1]",
+      "[stats: 2 tool calls, 2 succeeded, files written via file_write/file_edit: 1]",
     );
 
     asInternals(manager).stopSweep();
@@ -440,9 +440,8 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
     counters.filesWritten.add("/queued-turn.md");
 
     expect(manager.currentToolStats(subagentId)).toEqual({
-      calls: 5,
-      succeeded: 4,
-      filesWritten: 1,
+      kind: "counted",
+      stats: { calls: 5, succeeded: 4, filesWritten: 1 },
     });
 
     asInternals(manager).stopSweep();
@@ -478,9 +477,8 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     expect(managed.conversation).toBeNull();
     expect(manager.currentToolStats(subagentId)).toEqual({
-      calls: 5,
-      succeeded: 4,
-      filesWritten: 0,
+      kind: "counted",
+      stats: { calls: 5, succeeded: 4, filesWritten: 0 },
     });
 
     asInternals(manager).stopSweep();
@@ -493,7 +491,20 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
 
     // Still running: its counters are mid-flight, and a zero read off them now
     // would read as "this subagent used no tools".
-    expect(manager.currentToolStats(subagentId)).toBeUndefined();
+    expect(manager.currentToolStats(subagentId)).toEqual({
+      kind: "unmeasured",
+    });
+  });
+
+  test("an id the manager never held reports its counters unrecoverable", () => {
+    const manager = new SubagentManager();
+
+    // The counters exist nowhere but memory, so a caller holding a
+    // record-derived state for this id can never get them, and reporting zero
+    // calls would read as "this subagent did nothing".
+    expect(manager.currentToolStats("sub-not-in-manager")).toEqual({
+      kind: "unrecoverable",
+    });
   });
 
   test("failed subagent does not notify if already aborted", async () => {

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -160,7 +160,7 @@ describe("buildSubagentTerminalMessage", () => {
 
     expect(msg).toContain("Renamed the helper across the module.");
     expect(msg).toContain(
-      "[stats: 7 tool calls, 6 succeeded, files written: 2]",
+      "[stats: 7 tool calls, 6 succeeded, files written via file_write/file_edit: 2]",
     );
   });
 
@@ -178,7 +178,7 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).toContain('subagent_read with subagent_id "sa-11"');
     // Singular reading for a single call, so the footer never says "1 tool calls".
     expect(msg).toContain(
-      "[stats: 1 tool call, 1 succeeded, files written: 0]",
+      "[stats: 1 tool call, 1 succeeded, files written via file_write/file_edit: 0]",
     );
   });
 
@@ -197,6 +197,28 @@ describe("buildSubagentTerminalMessage", () => {
       "[stats: no tools were used by this subagent; treat any claims of executed work as unverified]",
     );
     expect(msg).not.toContain("tool calls,");
+  });
+
+  test("the file count names the two tools it comes from", () => {
+    // A builder runs on the parent's whole tool surface and can write with a
+    // bash heredoc, a document tool, or an MCP tool, none of which the counter
+    // sees. A bare "files written: 0" next to a builder reporting the files it
+    // created would read as fabricated work, so the footer says which
+    // instrument it measured.
+    const msg = buildSubagentTerminalMessage({
+      label: "shell-builder",
+      subagentId: "sa-14",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Created scripts/export.py with a heredoc.",
+      stats: { calls: 14, succeeded: 14, filesWritten: 0 },
+    });
+
+    expect(msg).toContain(
+      "[stats: 14 tool calls, 14 succeeded, files written via file_write/file_edit: 0]",
+    );
+    expect(msg).not.toContain("succeeded, files written: 0");
   });
 
   test("omits the stats footer when no stats were harvested", () => {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -127,13 +127,16 @@ const findTool = (name: string) =>
 /**
  * Inject a fake subagent into the singleton manager so tool executors
  * can find it. Uses the same private-internals trick as the notify tests.
+ *
+ * `rehydrated` is a manager-entry property rather than a state field, so it is
+ * passed alongside the state overrides and applied to the entry.
  */
 function injectSubagent(
   manager: SubagentManager,
   subagentId: string,
   parentConversationId: string,
   status: SubagentState["status"] = "running",
-  overrides: Partial<SubagentState> = {},
+  overrides: Partial<SubagentState> & { rehydrated?: boolean } = {},
 ): SubagentState {
   const internals = manager as unknown as {
     subagents: Map<
@@ -142,11 +145,13 @@ function injectSubagent(
         conversation: unknown;
         state: SubagentState;
         parentSendToClient: () => void;
+        rehydrated?: boolean;
       }
     >;
     parentToChildren: Map<string, Set<string>>;
     labelIndex: Map<string, string>;
   };
+  const { rehydrated, ...stateOverrides } = overrides;
   const state: SubagentState = {
     config: {
       id: subagentId,
@@ -159,7 +164,7 @@ function injectSubagent(
     isFork: false,
     createdAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
-    ...overrides,
+    ...stateOverrides,
   };
   const fakeConversation = {
     abort: () => {},
@@ -208,9 +213,10 @@ function injectSubagent(
   // A rehydrated entry is metadata rebuilt from the durable row, so it never
   // has a live conversation behind it.
   internals.subagents.set(subagentId, {
-    conversation: state.rehydrated ? null : fakeConversation,
+    conversation: rehydrated ? null : fakeConversation,
     state,
     parentSendToClient: () => {},
+    ...(rehydrated ? { rehydrated: true } : {}),
   });
   if (!internals.parentToChildren.has(parentConversationId)) {
     internals.parentToChildren.set(parentConversationId, new Set());
@@ -1887,7 +1893,7 @@ describe("Subagent read stats footer", () => {
       );
       expect(result.isError).toBe(false);
       expect(result.content).toBe(
-        "Refactored the parser.\n\n[stats: 5 tool calls, 4 succeeded, files written: 2]",
+        "Refactored the parser.\n\n[stats: 5 tool calls, 4 succeeded, files written via file_write/file_edit: 2]",
       );
     } finally {
       mockGetMessages = () => null;
@@ -1931,7 +1937,7 @@ describe("Subagent read stats footer", () => {
       );
       expect(result.content).toContain("no text output");
       expect(result.content).toContain(
-        "[stats: 3 tool calls, 3 succeeded, files written: 1]",
+        "[stats: 3 tool calls, 3 succeeded, files written via file_write/file_edit: 1]",
       );
     } finally {
       mockGetMessages = () => null;
@@ -1979,7 +1985,7 @@ describe("Subagent read stats footer", () => {
         makeContext(ownerConversation),
       );
       expect(result.content).toBe(
-        "Applied the follow-up guidance.\n\n[stats: 5 tool calls, 4 succeeded, files written: 1]",
+        "Applied the follow-up guidance.\n\n[stats: 5 tool calls, 4 succeeded, files written via file_write/file_edit: 1]",
       );
     } finally {
       mockGetMessages = () => null;
@@ -2062,7 +2068,7 @@ describe("Subagent read while a queued follow-up turn is still in flight", () =>
       );
       expect(result.content).toBe(
         "Initial run output.\n\nApplied the follow-up guidance.\n\n" +
-          "[stats: 5 tool calls, 5 succeeded, files written: 1]",
+          "[stats: 5 tool calls, 5 succeeded, files written via file_write/file_edit: 1]",
       );
       expect(result.content).not.toContain("still processing");
     } finally {
@@ -2130,7 +2136,7 @@ describe("Subagent read while a queued follow-up turn is still in flight", () =>
       expect(result.content).toBe(
         "Initial run output.\n\n" +
           `${SUBAGENT_READ_STILL_PROCESSING}\n\n` +
-          "[stats: 2 tool calls, 2 succeeded, files written: 1]",
+          "[stats: 2 tool calls, 2 succeeded, files written via file_write/file_edit: 1]",
       );
     } finally {
       drain.processing = false;
@@ -2154,7 +2160,7 @@ describe("Subagent read while a queued follow-up turn is still in flight", () =>
       );
       expect(Date.now() - startedAt).toBeLessThan(500);
       expect(result.content).toBe(
-        "Ran to completion.\n\n[stats: 1 tool call, 1 succeeded, files written: 0]",
+        "Ran to completion.\n\n[stats: 1 tool call, 1 succeeded, files written via file_write/file_edit: 0]",
       );
     } finally {
       mockGetMessages = () => null;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -347,6 +347,10 @@ export function createToolExecutor(
     stats.succeeded++;
     // Both file tools name their target `path`. A Set dedupes repeated edits
     // of the same file, so the count reads as "files touched", not "writes".
+    // These two are the only writes with a path to attribute: a builder can
+    // also write through the shell, a document tool, or an MCP tool, and those
+    // are invisible here, which is why the footer names the two tools it
+    // counts (see `formatSubagentToolStats`).
     if (toolName === "file_write" || toolName === "file_edit") {
       const target = toolInput.path;
       if (typeof target === "string" && target.length > 0) {

--- a/assistant/src/persistence/migrations/360-add-conversation-subagent-kind.test.ts
+++ b/assistant/src/persistence/migrations/360-add-conversation-subagent-kind.test.ts
@@ -146,6 +146,34 @@ describe("migration 360: conversations subagent role / spawn mode", () => {
     });
   });
 
+  test("indexes subagents.conversation_id so the backfill is not quadratic", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAddConversationSubagentKind(db);
+
+    const indexes = (
+      sqlite.query("PRAGMA index_list(subagents)").all() as Array<{
+        name: string;
+      }>
+    ).map((i) => i.name);
+    expect(indexes).toContain("idx_subagents_conversation_id");
+
+    // Both backfill statements look `subagents` up once per `conversations`
+    // row. Without the index that lookup is a full scan of `subagents`, which
+    // makes a step that blocks daemon startup quadratic.
+    const plan = (
+      sqlite
+        .query(
+          "EXPLAIN QUERY PLAN SELECT 1 FROM subagents s WHERE s.conversation_id = 'c1'",
+        )
+        .all() as Array<{ detail: string }>
+    )
+      .map((row) => row.detail)
+      .join(" ");
+    expect(plan).toContain("idx_subagents_conversation_id");
+    expect(plan).not.toContain("SCAN");
+  });
+
   test("is idempotent: re-run is a no-op", () => {
     const { sqlite, db } = createTestDb();
 

--- a/assistant/src/persistence/migrations/360-add-conversation-subagent-kind.ts
+++ b/assistant/src/persistence/migrations/360-add-conversation-subagent-kind.ts
@@ -8,9 +8,10 @@ const SPAWN_MODE_COLUMN = "subagent_spawn_mode";
  * Add `subagent_role` and `subagent_spawn_mode` columns to `conversations`.
  *
  * Both are nullable, free-form strings describing the subagent that owns the
- * conversation: the role it was spawned with (`general`, `researcher`,
- * `coder`, `planner`, `investigator`, `advisor`) and how it was spawned
- * (`regular`, `fork`, `advisor_consult`, `voice_continuation`). NULL for
+ * conversation: the role it was spawned with and how it was spawned. The
+ * accepted values, and what each one means, are documented once on
+ * `SubagentRole` / `SubagentSpawnMode` in `subagent/types.ts`; the columns
+ * take whatever the row carried, including role names retired since. NULL for
  * every conversation that is not a subagent.
  *
  * Together they make delegated LLM spend separable. Every subagent variety
@@ -36,11 +37,24 @@ const SPAWN_MODE_COLUMN = "subagent_spawn_mode";
  * pre-migration), so those rows backfill as `fork`, a small, bounded
  * inaccuracy confined to the backfill window.
  *
+ * The backfill needs `subagents(conversation_id)` indexed, which migration 311
+ * did not create: both statements look the `subagents` table up once per
+ * `conversations` row, so unindexed they are a full scan of `subagents` per
+ * row and the whole step is quadratic. Migrations run during startup and block
+ * readiness, so on a long-lived assistant that is a multi-minute stall at
+ * boot. The index is created here rather than appended as a later migration
+ * because it has to exist BEFORE these statements run; it also serves the
+ * by-conversation lookup in `subagent-store.ts`, which scanned until now.
+ *
  * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
  * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
- * the next boot, and the backfill only fills NULL rows for the same reason.
+ * the next boot, `IF NOT EXISTS` on the index, and the backfill only fills
+ * NULL rows for the same reason.
  */
 export function migrateAddConversationSubagentKind(database: DrizzleDb): void {
+  database.run(
+    `CREATE INDEX IF NOT EXISTS idx_subagents_conversation_id ON subagents(conversation_id)`,
+  );
   if (!tableHasColumn(database, "conversations", ROLE_COLUMN)) {
     database.run(`ALTER TABLE conversations ADD COLUMN ${ROLE_COLUMN} TEXT`);
   }

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -62,12 +62,9 @@ export const conversations = sqliteTable(
     subagentRole: text("subagent_role"),
     /**
      * How the subagent that owns this conversation was spawned: context
-     * inheritance and lifecycle, orthogonal to {@link subagentRole}:
-     * `regular` (fire-and-forget `subagent_spawn`, fresh objective-only
-     * context), `fork` (`subagent_spawn` with `fork: true`, inherits the
-     * parent transcript), `advisor_consult` (synchronous read-only advisor
-     * consult the parent turn blocks on), `voice_continuation` (silent
-     * read-only live-voice continuation of an interrupted turn). NULL for
+     * inheritance and lifecycle, orthogonal to {@link subagentRole}. One of
+     * `regular`, `fork`, `advisor_consult`, `voice_continuation`, each
+     * described once on `SubagentSpawnMode` in `subagent/types.ts`. NULL for
      * every conversation that is not a subagent.
      */
     subagentSpawnMode: text("subagent_spawn_mode"),

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -54,6 +54,7 @@ import {
   type SubagentSpawnMode,
   type SubagentState,
   type SubagentStatus,
+  type SubagentToolStatsReading,
   type SubagentToolStatsSummary,
   TERMINAL_STATUSES,
 } from "./types.js";
@@ -104,13 +105,13 @@ const QUEUED_TURN_POLL_MS = 25;
  * profile overrides) are absent, so this shape answers lifecycle questions
  * only.
  *
- * The result is marked `rehydrated`, which is what tells a reader that its
- * missing tool-call counters are unrecoverable rather than merely unrecorded:
- * a rehydrated entry lives in the manager alongside live ones.
+ * Tool-call counters are in-memory only and the row carries none, so a state
+ * built here never has {@link SubagentState.stats}. What that absence means is
+ * the manager's answer to give, not this shape's: see
+ * {@link SubagentManager.currentToolStats}.
  */
 export function subagentStateFromRecord(rec: SubagentRecord): SubagentState {
   return {
-    rehydrated: true,
     config: {
       id: rec.id,
       parentConversationId: rec.parentConversationId,
@@ -355,6 +356,14 @@ interface ManagedSubagent {
   parentSendToClient: (msg: AssistantEvent) => void;
   /** Epoch ms after which this terminal entry can be removed by the TTL sweep. */
   retainedUntil?: number;
+  /**
+   * True for an entry the startup rehydration rebuilt from a durable row
+   * rather than a run this process executed. Such an entry sits in the manager
+   * exactly like a live one but can never have tool-call counters, so
+   * {@link SubagentManager.currentToolStats} reads this to tell "never
+   * measured here" apart from "not measured yet".
+   */
+  rehydrated?: boolean;
   /**
    * Sticky monotonic flag: set to true when sendMessage enqueues a follow-up
    * message while a run is in progress, and never cleared. Needed because the
@@ -1327,7 +1336,8 @@ export class SubagentManager {
   }
 
   /**
-   * The subagent's tool-call counters, brought up to date first.
+   * The subagent's tool-call counters, brought up to date first, or why there
+   * are none (see {@link SubagentToolStatsReading}).
    *
    * `runSubagent` harvests when its awaited agent loop returns, but that is not
    * the end of the child's work: guidance queued during the run drains
@@ -1336,14 +1346,24 @@ export class SubagentManager {
    * still retained (see {@link refreshToolStats}), and the release freezes the
    * settled numbers. Readers that need the queued turn's calls included wait
    * for it first, via {@link settleQueuedTurns}.
+   *
+   * An id the manager does not hold is `unrecoverable` rather than unknown:
+   * counters exist nowhere else, so no caller can ever obtain them, and the
+   * only state a caller can be holding for such an id came from the durable
+   * row.
    */
-  currentToolStats(subagentId: string): SubagentToolStatsSummary | undefined {
+  currentToolStats(subagentId: string): SubagentToolStatsReading {
     const managed = this.subagents.get(subagentId);
     if (!managed) {
-      return undefined;
+      return { kind: "unrecoverable" };
     }
     this.refreshToolStats(managed);
-    return managed.state.stats;
+    if (managed.state.stats) {
+      return { kind: "counted", stats: managed.state.stats };
+    }
+    return managed.rehydrated
+      ? { kind: "unrecoverable" }
+      : { kind: "unmeasured" };
   }
 
   /**
@@ -1661,6 +1681,7 @@ export class SubagentManager {
         state,
         parentSendToClient: () => {},
         retainedUntil: now + TERMINAL_RETENTION_MS,
+        rehydrated: true,
       };
       this.subagents.set(rec.id, managed);
 

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -204,20 +204,10 @@ export interface SubagentState {
    * What the subagent actually ran, harvested from the child conversation when
    * the run ends and re-read while that conversation is still retained (a
    * follow-up turn queued during the run drains after the run returns). In
-   * memory only: see {@link rehydrated}.
+   * memory only, so a state rebuilt from the durable row never has it: the
+   * manager answers that case with {@link SubagentToolStatsReading}.
    */
   stats?: SubagentToolStatsSummary;
-  /**
-   * True when this state was rebuilt from the subagent's durable row rather
-   * than from a run this process executed: the startup rehydration, or the
-   * tools' fallback for a subagent the manager's window no longer holds.
-   *
-   * The row carries no tool-call counters, so {@link stats} can never be
-   * filled in for one of these. Readers key the "unavailable" stats footer on
-   * this flag: a rehydrated entry sits in the manager exactly like a live one,
-   * so manager membership alone cannot tell the two apart.
-   */
-  rehydrated?: boolean;
 }
 
 /**
@@ -228,14 +218,48 @@ export interface SubagentState {
 export interface SubagentToolStatsSummary {
   calls: number;
   succeeded: number;
+  /**
+   * Distinct paths the child passed to `file_write` / `file_edit`. Those two
+   * tools are the only writes the executor can attribute to a path, so a
+   * builder that writes through the shell, a document tool, or an MCP tool
+   * adds nothing here. {@link formatSubagentToolStats} names the two tools for
+   * that reason.
+   */
   filesWritten: number;
 }
+
+/**
+ * What the manager can say about a subagent's tool-call counters, which live in
+ * memory only.
+ *
+ * - `counted`: the run was harvested, so the numbers are real.
+ * - `unmeasured`: a live run that never reached its harvest. Nothing was
+ *   measured and nothing was lost, so a reader claims neither.
+ * - `unrecoverable`: the state was rebuilt from the durable row (the startup
+ *   rehydration, or a subagent the manager's window no longer holds). The row
+ *   carries no counters, so they can never be produced for this subagent, and
+ *   reporting zero calls would read as "this subagent did nothing".
+ *
+ * A rehydrated entry sits in the manager exactly like a live one, so manager
+ * membership alone cannot separate the last two; the manager tracks which of
+ * its entries it rebuilt and answers with this instead.
+ */
+export type SubagentToolStatsReading =
+  | { kind: "counted"; stats: SubagentToolStatsSummary }
+  | { kind: "unmeasured" }
+  | { kind: "unrecoverable" };
 
 /**
  * The machine half of a subagent's result, appended to the parent's completion
  * notification and to `subagent_read`. The child's prose is its own account of
  * what it did; this line is the measured one, so a report of executed work by a
  * subagent that called nothing is visible instead of taken on trust.
+ *
+ * The file count names the two tools it comes from. A builder runs on the
+ * parent's whole tool surface and can write through the shell, a document tool,
+ * or an MCP tool, none of which the counter sees; an unqualified "files
+ * written: 0" would read as fabricated work for a subagent that really did
+ * write, which is the exact misreading this line exists to prevent.
  */
 export function formatSubagentToolStats(
   stats: SubagentToolStatsSummary,
@@ -244,7 +268,7 @@ export function formatSubagentToolStats(
     return "[stats: no tools were used by this subagent; treat any claims of executed work as unverified]";
   }
   const plural = stats.calls === 1 ? "" : "s";
-  return `[stats: ${stats.calls} tool call${plural}, ${stats.succeeded} succeeded, files written: ${stats.filesWritten}]`;
+  return `[stats: ${stats.calls} tool call${plural}, ${stats.succeeded} succeeded, files written via file_write/file_edit: ${stats.filesWritten}]`;
 }
 
 /** Stats footer for a subagent whose in-memory counters no longer exist. */
@@ -391,8 +415,17 @@ export function subagentOutputContractText(
  * - `fork`: `subagent_spawn` with `fork: true`, inherits the parent transcript.
  * - `advisor_consult`: synchronous, read-only advisor consult on the advisor
  *   profile; the parent turn blocks on it and returns its guidance inline.
- * - `voice_continuation`: silent, read-only live-voice background
- *   continuation of an interrupted turn.
+ * - `voice_continuation`: live-voice background continuation of an interrupted
+ *   turn, spawned as a fork with no role and therefore WRITE-CAPABLE: it runs
+ *   as {@link DEFAULT_SUBAGENT_ROLE} on the parent's full tool surface, with
+ *   side effects governed by the standard non-interactive permission path
+ *   under the trust the foreground voice turn ran under. "Silent" is about
+ *   sound, not blast radius: the run says nothing itself, and a later session
+ *   turn speaks its answer.
+ *
+ * This block is the single description of the modes. The persistence and
+ * telemetry layers that carry the same values point here rather than restate
+ * them, so a correction lands once.
  *
  * Mirrored on the wire as `llm_usage.subagent_spawn_mode`, which is an OPEN
  * string set on the platform side: adding a value here needs no coordinated

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -419,9 +419,9 @@ export function subagentOutputContractText(
  *   turn, spawned as a fork with no role and therefore WRITE-CAPABLE: it runs
  *   as {@link DEFAULT_SUBAGENT_ROLE} on the parent's full tool surface, with
  *   side effects governed by the standard non-interactive permission path
- *   under the trust the foreground voice turn ran under. "Silent" is about
- *   sound, not blast radius: the run says nothing itself, and a later session
- *   turn speaks its answer.
+ *   under the trust the foreground voice turn ran under. It is silent only in
+ *   the sense that the run makes no sound of its own, a later session turn
+ *   speaking its answer; that is a statement about sound, not blast radius.
  *
  * This block is the single description of the modes. The persistence and
  * telemetry layers that carry the same values point here rather than restate

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -5,7 +5,6 @@ import {
   formatSubagentToolStats,
   SUBAGENT_READ_STILL_PROCESSING,
   SUBAGENT_STATS_UNAVAILABLE,
-  type SubagentState,
 } from "../../subagent/types.js";
 import { bundledToolInputMisuseMessage } from "../shared/input-misuse.js";
 import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
@@ -25,30 +24,23 @@ import {
  * guidance is still being processed, which makes both the transcript above and
  * these counts an interim reading, so the footer says so.
  *
- * The counters live in memory only, so a subagent rebuilt from its durable row
- * says they are unavailable rather than reporting zero calls, which would read
- * as "this subagent did nothing". That covers both a row the manager never
- * held (its window dropped it) and one the startup rehydration loaded back in:
- * the rehydrated entry is in the manager like any other, so `state.rehydrated`
- * is what separates it from a run this process actually executed. A live entry
- * with no stats never reached the end of a run, so it has nothing measured to
- * report and claims nothing.
+ * The manager owns the whole answer, including why there are no counters: they
+ * live in memory only, so a subagent rebuilt from its durable row says they are
+ * unavailable rather than reporting zero calls, which would read as "this
+ * subagent did nothing", while a live run that never reached its harvest has
+ * nothing measured to report and claims nothing.
  */
-function statsFooter(
-  subagentId: string,
-  state: SubagentState,
-  settled: boolean,
-): string {
+function statsFooter(subagentId: string, settled: boolean): string {
   const note = settled ? "" : `\n\n${SUBAGENT_READ_STILL_PROCESSING}`;
-  const stats =
-    getSubagentManager().currentToolStats(subagentId) ?? state.stats;
-  if (stats) {
-    return `${note}\n\n${formatSubagentToolStats(stats)}`;
+  const reading = getSubagentManager().currentToolStats(subagentId);
+  switch (reading.kind) {
+    case "counted":
+      return `${note}\n\n${formatSubagentToolStats(reading.stats)}`;
+    case "unrecoverable":
+      return `${note}\n\n${SUBAGENT_STATS_UNAVAILABLE}`;
+    default:
+      return note;
   }
-  if (state.rehydrated) {
-    return `${note}\n\n${SUBAGENT_STATS_UNAVAILABLE}`;
-  }
-  return note;
 }
 
 // `last_n` is deliberately UNDECLARED (loose passthrough): the executor's
@@ -161,7 +153,7 @@ export async function executeSubagentRead(
     }
   }
 
-  const footer = statsFooter(subagentId, state, settled);
+  const footer = statsFooter(subagentId, settled);
 
   if (messageTexts.length === 0) {
     return {


### PR DESCRIPTION
## Summary

- **Honest file count.** `recordToolResult` can only attribute a path to `file_write` / `file_edit`, but a `builder` runs on the parent's whole tool surface and the `artifact` contract asks it to list the files it created. A builder writing via a bash heredoc, a document tool, or an MCP tool produced `[stats: 14 tool calls, 14 succeeded, files written: 0]`, which reads as fabricated work. The footer now names its instrument: `files written via file_write/file_edit: 0`. Zero-call wording is unchanged.
- **Dead fallback removed.** `currentToolStats(id) ?? state.stats` had an unreachable right-hand side (both sides are the same object when the manager holds the entry, and both are undefined when it does not). `currentToolStats` now returns a discriminated `SubagentToolStatsReading` (`counted` / `unmeasured` / `unrecoverable`), so `SubagentState.rehydrated` is deleted: the flag moved onto the manager's own `ManagedSubagent` entry, which is the only thing that needed it.
- **voice_continuation is write-capable.** The live-voice continuation forks with no role, so it resolves to the default `builder` on the parent's full tool surface; the type docs called it read-only. `SubagentSpawnMode` now carries the single full description ("silent" is about sound, not blast radius), and the `conversations` schema column and migration 360 point at it instead of restating it.
- **Migration 360 backfill indexed.** Migration 311 indexes only `parent_conversation_id` and `status`, so 360's two `UPDATE conversations` statements scanned the whole `subagents` table once per conversations row, during startup, before DB readiness. 360 now creates `idx_subagents_conversation_id` before the backfill (it has to exist first, so it cannot be a later migration). The index also serves `getSubagentRecordByConversationId`, which scanned until now.

## Notes

- 360 is edited in place: the repo's append-only rule is about never deleting or reordering migration files and steps, and 360 has not left this feature branch, so no database outside it has checkpointed the step. A dev DB that already ran 360 keeps the pre-index shape (it also already paid the slow backfill).
- Copies of the spawn-mode prose outside this PR's scope remain in `persistence/conversation-bootstrap.ts`, `persistence/llm-usage-store.ts`, and `telemetry/types.ts`. They only enumerate the values, so none of them is wrong, but they could be pointed at `SubagentSpawnMode` too.

## Test plan

Per-file, all green: `subagent-tools`, `subagent-tool-gate-mode`, `subagent-terminal-message`, `subagent-role-registry`, `subagent-manager-notify`, `subagent-persistence`, `subagent-fork-spawn`, `subagent-fork-notifications`, `subagent-disposal`, `subagent-spawn-and-await`, `subagent-notify-parent`, `conversation-tool-setup-attribution`, `360-add-conversation-subagent-kind`. New coverage: the footer names its instrument for a shell-writing builder, the manager reports `unrecoverable` for an id it never held, and migration 360 creates the index and the correlated lookup uses it (`EXPLAIN QUERY PLAN`).

Fixes gaps found during self-review of plan subagent-type-consolidation.md
