### PR TITLE
fix(media): resolve the automatic media-analysis model via the catalog vision intent

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -72,7 +72,7 @@ Parameters:
 - `output_schema` (required) - JSON Schema for structured output.
 - `mode` - Analysis mode: `'keyframes'` (default) or `'direct_video'`.
 - `context` - Additional context to include in the prompt.
-- `model` - Gemini model to use (default: `gemini-2.5-flash`).
+- `model` - Gemini model to use (defaults to the Gemini provider's recommended vision model).
 - `concurrency` - Maximum concurrent API requests (default: 10, keyframes mode only).
 - `max_retries` - Retry attempts per segment on failure (default: 3).
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -130,7 +130,7 @@
           },
           "model": {
             "type": "string",
-            "description": "Gemini model to use. Default: 'gemini-2.5-flash'"
+            "description": "Gemini model to use. Defaults to the Gemini provider's recommended vision model."
           },
           "concurrency": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/media-analysis-default-model.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/media-analysis-default-model.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock @google/genai module: must be before importing the services
+// ---------------------------------------------------------------------------
+
+let capturedModels: string[] = [];
+
+mock.module("@google/genai", () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    constructor(_opts: Record<string, unknown>) {}
+    models = {
+      generateContent: async (params: { model: string }) => {
+        capturedModels.push(params.model);
+        return {
+          text: '{"frames":[]}',
+          usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+          modelVersion: params.model,
+        };
+      },
+    };
+    files = {
+      upload: async (_params: Record<string, unknown>) => ({
+        name: "files/test-upload",
+        uri: "https://example.com/files/test-upload",
+        mimeType: "video/mp4",
+      }),
+      get: async (_params: Record<string, unknown>) => ({ state: "ACTIVE" }),
+      delete: async (_params: Record<string, unknown>) => ({}),
+    };
+  },
+  ApiError: class MockApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Import after mocking
+import { resolveModelIntent } from "../../../../providers/model-intents.js";
+import { mapSegments } from "../services/gemini-map.js";
+import { analyzeVideoDirectly } from "../services/gemini-video.js";
+import { resolveMediaAnalysisModel } from "../services/media-analysis-model.js";
+import type { Segment } from "../services/preprocess.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EXPECTED_DEFAULT = resolveModelIntent("gemini", "vision-optimized");
+
+const OUTPUT_SCHEMA = { type: "object", properties: {} };
+
+async function createPipelineDir(): Promise<{
+  pipelineDir: string;
+  segments: Segment[];
+}> {
+  const pipelineDir = await mkdtemp(join(tmpdir(), "media-model-test-"));
+  const framePath = join(pipelineDir, "frame-000.jpg");
+  await writeFile(framePath, Buffer.from("fake-jpeg-bytes"));
+  const segments: Segment[] = [
+    {
+      id: "seg-000",
+      startSeconds: 0,
+      endSeconds: 10,
+      framePaths: [framePath],
+      frameTimestamps: [0],
+    },
+  ];
+  return { pipelineDir, segments };
+}
+
+function mapOptions(model?: string) {
+  return {
+    apiKey: "test-key",
+    systemPrompt: "Describe the frames.",
+    outputSchema: OUTPUT_SCHEMA,
+    model,
+  };
+}
+
+beforeEach(() => {
+  capturedModels = [];
+});
+
+// ---------------------------------------------------------------------------
+// Automatic no-override path (the background media-processing job passes no
+// model, so the services' default is what runs in production)
+// ---------------------------------------------------------------------------
+
+describe("media analysis default model (no-override path)", () => {
+  test("resolveMediaAnalysisModel defaults to the vision-optimized catalog intent", () => {
+    expect(resolveMediaAnalysisModel(undefined)).toBe(EXPECTED_DEFAULT);
+    // Regression (LUM-3038): the default must not be the retired pinned model.
+    expect(resolveMediaAnalysisModel(undefined)).not.toBe("gemini-2.5-flash");
+    expect(resolveMediaAnalysisModel("custom-model")).toBe("custom-model");
+  });
+
+  test("keyframe mapping without a model override executes the resolved default", async () => {
+    const { pipelineDir, segments } = await createPipelineDir();
+
+    const output = await mapSegments(
+      "asset-1",
+      pipelineDir,
+      segments,
+      mapOptions(),
+    );
+
+    expect(capturedModels).toEqual([EXPECTED_DEFAULT]);
+    expect(output.model).toBe(EXPECTED_DEFAULT);
+    expect(output.successCount).toBe(1);
+  });
+
+  test("cache identity agrees with the execution default", async () => {
+    const { pipelineDir, segments } = await createPipelineDir();
+
+    await mapSegments("asset-1", pipelineDir, segments, mapOptions());
+    expect(capturedModels).toHaveLength(1);
+
+    // A rerun that pins the same model the default resolved to must hit the
+    // per-segment cache: the config hash and the executed model agree.
+    const rerun = await mapSegments(
+      "asset-1",
+      pipelineDir,
+      segments,
+      mapOptions(EXPECTED_DEFAULT),
+    );
+    expect(capturedModels).toHaveLength(1);
+    expect(rerun.successCount).toBe(1);
+
+    // A different model must miss the cache (hash covers the model).
+    await mapSegments(
+      "asset-1",
+      pipelineDir,
+      segments,
+      mapOptions("custom-model"),
+    );
+    expect(capturedModels).toEqual([EXPECTED_DEFAULT, "custom-model"]);
+  });
+
+  test("direct video analysis without a model override executes the resolved default", async () => {
+    const { pipelineDir } = await createPipelineDir();
+    const videoPath = join(pipelineDir, "video.mp4");
+    await writeFile(videoPath, Buffer.from("fake-mp4-bytes"));
+
+    const output = await analyzeVideoDirectly(
+      "asset-1",
+      pipelineDir,
+      mapOptions(),
+      videoPath,
+      12,
+      "video/mp4",
+    );
+
+    expect(capturedModels).toEqual([EXPECTED_DEFAULT]);
+    expect(output.model).toBe(EXPECTED_DEFAULT);
+  });
+
+  test("an explicit model override wins over the default", async () => {
+    const { pipelineDir, segments } = await createPipelineDir();
+
+    const output = await mapSegments(
+      "asset-1",
+      pipelineDir,
+      segments,
+      mapOptions("gemini-explicit-override"),
+    );
+
+    expect(capturedModels).toEqual(["gemini-explicit-override"]);
+    expect(output.model).toBe("gemini-explicit-override");
+  });
+});

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
@@ -15,6 +15,7 @@ import { ApiError, GoogleGenAI } from "@google/genai";
 import { computeRetryDelay, sleep } from "../../../../util/retry.js";
 import { ConcurrencyPool } from "./concurrency-pool.js";
 import { type CostSummary, CostTracker } from "./cost-tracker.js";
+import { resolveMediaAnalysisModel } from "./media-analysis-model.js";
 import type { Segment } from "./preprocess.js";
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ function computeConfigHash(options: GeminiMapOptions): string {
   const payload = JSON.stringify({
     systemPrompt: options.systemPrompt,
     outputSchema: options.outputSchema,
-    model: options.model ?? "gemini-2.5-flash",
+    model: resolveMediaAnalysisModel(options.model),
     context: options.context,
   });
   return createHash("sha256").update(payload).digest("hex").slice(0, 8);
@@ -137,7 +138,7 @@ async function processSegment(
 
   parts.push({ text: promptText });
 
-  const model = options.model ?? "gemini-2.5-flash";
+  const model = resolveMediaAnalysisModel(options.model);
 
   const response = await client.models.generateContent({
     model,
@@ -284,7 +285,7 @@ export async function mapSegments(
   options: GeminiMapOptions,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
-  const model = options.model ?? "gemini-2.5-flash";
+  const model = resolveMediaAnalysisModel(options.model);
   const concurrency = options.concurrency ?? 10;
   const maxRetries = options.maxRetries ?? 3;
 

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
@@ -15,6 +15,7 @@ import { ApiError, GoogleGenAI } from "@google/genai";
 import { computeRetryDelay, sleep } from "../../../../util/retry.js";
 import { CostTracker } from "./cost-tracker.js";
 import type { MapOutput, SegmentMapResult } from "./gemini-map.js";
+import { resolveMediaAnalysisModel } from "./media-analysis-model.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -76,7 +77,7 @@ export async function analyzeVideoDirectly(
   mimeType: string,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
-  const model = options.model ?? "gemini-2.5-flash";
+  const model = resolveMediaAnalysisModel(options.model);
   const maxRetries = options.maxRetries ?? 3;
 
   // Check file size before uploading

--- a/assistant/src/config/bundled-skills/media-processing/services/media-analysis-model.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/media-analysis-model.ts
@@ -1,0 +1,12 @@
+import { resolveModelIntent } from "../../../../providers/model-intents.js";
+
+/**
+ * Resolves the Gemini model used for media analysis. When no override is
+ * supplied (the automatic background-processing path), defaults to the
+ * catalog-backed vision intent so processing keeps working when a previously
+ * pinned model is retired. Every consumer (execution and cache identity)
+ * must resolve through this function so they agree on the default.
+ */
+export function resolveMediaAnalysisModel(model?: string): string {
+  return model ?? resolveModelIntent("gemini", "vision-optimized");
+}

--- a/assistant/src/config/bundled-skills/media-processing/services/media-analysis-model.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/media-analysis-model.ts
@@ -2,10 +2,10 @@ import { resolveModelIntent } from "../../../../providers/model-intents.js";
 
 /**
  * Resolves the Gemini model used for media analysis. When no override is
- * supplied (the automatic background-processing path), defaults to the
- * catalog-backed vision intent so processing keeps working when a previously
- * pinned model is retired. Every consumer (execution and cache identity)
- * must resolve through this function so they agree on the default.
+ * supplied (the automatic background-processing path), the default comes
+ * from the catalog-backed vision intent, which is validated against the
+ * provider catalog at module load. Execution and cache identity must both
+ * resolve through this function so they agree on the model.
  */
 export function resolveMediaAnalysisModel(model?: string): string {
   return model ?? resolveModelIntent("gemini", "vision-optimized");

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -31,7 +31,7 @@
     },
     "media-processing": {
       "docsSlug": "media-processing",
-      "sha256": "4c93682daa54a9f74ccb12306e82409ae5417fcae253b26f8364bdd28f90a3d4"
+      "sha256": "2355e860b9ae5c06036ca2ef206679647a9c73ff38af50a23268503959f189cd"
     },
     "messaging": {
       "docsSlug": "messaging",


### PR DESCRIPTION
## TL;DR

Automatic background video processing no longer fails when Google pulls a pinned Gemini model. The bundled media-processing services defaulted to a hardcoded `gemini-2.5-flash`, which the Gemini API has served model-not-found (404) for on affected accounts since July 9, 2026, contradicting its own docs and ahead of any announced shutdown ([forum thread](https://discuss.ai.google.dev/t/gemini-2-5-flash-and-gemini-2-5-flash-lite-returning-404-no-longer-available-today-july-9-contradicts-oct-16-2026-shutdown-date/174267); reproduced by the LUM-3038 canary on a real install). The default now resolves through the catalog-validated `vision-optimized` model intent (`resolveModelIntent("gemini", "vision-optimized")`) via a single shared helper.

Fixes LUM-3038

## What changed

- New `services/media-analysis-model.ts` exports `resolveMediaAnalysisModel(model?)`, the single resolution point for the media-analysis default.
- `gemini-map.ts` (cache hash, per-segment execution, run summary) and `gemini-video.ts` (direct-video execution) all resolve through that helper, so the model used for execution and the model baked into cache identity always agree.
- `TOOLS.json` / `SKILL.md` no longer document a hardcoded default; docs-sync fingerprint bumped (the public docs page does not mention the default model, so no platform-side edit is needed).
- New regression test `media-analysis-default-model.test.ts` exercises the automatic no-override path (the one the background job takes) with a mocked `@google/genai` for both keyframe and direct-video modes, verifies cache identity agrees with the execution default, and verifies explicit overrides still win.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Video ingested normally (no model override possible) | Background processing calls Gemini with retired `gemini-2.5-flash` and fails with model-not-found | Processing uses the catalog's recommended vision model and completes |
| Explicit `analyze_keyframes` call with a `model` | Uses the given model | Unchanged |
| Explicit call without a `model` | Retired hardcoded default | Same catalog-resolved default as the automatic path |
| Future model retirement | Requires editing the bundled skill source | Updating the model catalog / intent map fixes every consumer |

## Why this is safe

- The `vision-optimized` intent is validated against `PROVIDER_CATALOG` at module load (`model-intents.ts` throws on drift), and cost tracking prices any catalog model through the shared pricing resolver, so the new default is guaranteed to be a known, priced model.
- Explicit model overrides behave exactly as before; only the fallback changes.
- Segment cache keys hash the resolved model, so previously cached `gemini-2.5-flash` results are simply not reused; segments reprocess once under the new default and cache normally afterward.
- The regression test was sensitivity-checked: reinstating the hardcoded pin makes it fail.

## Relationship to the call-site / profile direction

The repo-wide direction is that LLM call sites name profiles and never bare model pins (#39075), with BYOK resolution flowing through the provider intent table. This pipeline cannot register as an `LLMCallSite` today: it deliberately bypasses `getConfiguredProvider` to use the raw `@google/genai` SDK (`responseSchema` structured output, Files API) with its own Gemini key, and it is Gemini-locked, so profile resolution could hand it a provider it cannot execute. Within that constraint, this PR resolves through the same intent x provider table the profile machinery uses for BYOK columns, which is the closest aligned seam. If the provider layer later gains structured-output and Files API support, the follow-on step is a real `mediaAnalysis` call site with capability-filtered profile resolution (the pattern the `vision` call site and image-fallback plugin use).

## Deferred

- The Gemini provider's catalog `defaultModel` is still `gemini-2.5-flash` and the model remains selectable in the catalog. That affects general provider defaults beyond media processing and deserves its own catalog-maintenance decision, so it is not changed here. Tracked in JARVIS-1430.
- Call-site registration for media analysis (above) is blocked on provider-layer structured-output / Files API support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
