### PR TITLE
feat(cli): vellum tunnel --domain for reserved ngrok domains, honored by wake restores

### DIFF
--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -1,6 +1,7 @@
 import {
   afterAll,
   afterEach,
+  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -8,7 +9,16 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as childProcess from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,6 +28,7 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 
 const realCloudflareTunnel = { ...cloudflareTunnel };
 const realNgrok = { ...ngrok };
+const realChildProcess = { ...childProcess };
 
 const runCloudflareTunnelMock = mock<
   typeof cloudflareTunnel.runCloudflareTunnel
@@ -73,6 +84,35 @@ function writeLockfile(entry: AssistantEntry): void {
       2,
     ),
   );
+}
+
+/** Run tunnel() expecting exit(1); returns the joined console.error output. */
+async function runTunnelExpectingExit1(): Promise<{
+  exited: boolean;
+  errors: string;
+}> {
+  const errors: string[] = [];
+  const errSpy = spyOn(console, "error").mockImplementation(
+    (...a: unknown[]) => {
+      errors.push(a.join(" "));
+    },
+  );
+  const exitSpy = spyOn(process, "exit").mockImplementation(((
+    code?: number,
+  ) => {
+    throw new Error(`exit:${code}`);
+  }) as never);
+
+  let exited = false;
+  try {
+    await tunnel();
+  } catch (e) {
+    exited = (e as Error).message === "exit:1";
+  } finally {
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+  return { exited, errors: errors.join("\n") };
 }
 
 function mockEnabledFlagFetch() {
@@ -166,35 +206,78 @@ describe("tunnel nginx ingress feature flag", () => {
 
   test("rejects an unknown --provider with a stale-CLI hint", async () => {
     process.argv = ["bun", "vellum", "tunnel", "--provider", "bogus"];
-    const errors: string[] = [];
-    const errSpy = spyOn(console, "error").mockImplementation(
-      (...a: unknown[]) => {
-        errors.push(a.join(" "));
-      },
-    );
-    const exitSpy = spyOn(process, "exit").mockImplementation(((
-      code?: number,
-    ) => {
-      throw new Error(`exit:${code}`);
-    }) as never);
 
-    let exited = false;
-    try {
-      await tunnel();
-    } catch (e) {
-      exited = (e as Error).message === "exit:1";
-    } finally {
-      errSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
+    const { exited, errors } = await runTunnelExpectingExit1();
 
     expect(exited).toBe(true);
-    const joined = errors.join("\n");
-    expect(joined).toContain("unknown tunnel provider 'bogus'");
-    expect(joined).toContain("your CLI may be out of date");
-    expect(joined).toContain("bun install -g vellum@latest");
+    expect(errors).toContain("unknown tunnel provider 'bogus'");
+    expect(errors).toContain("your CLI may be out of date");
+    expect(errors).toContain("bun install -g vellum@latest");
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("threads --domain through to runNgrokTunnel", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--domain",
+      "foo.ngrok.app",
+    ];
+    mockEnabledFlagFetch();
+
+    await tunnel();
+
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: 7830,
+      assistantId: "assistant-1",
+      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
+      domain: "foo.ngrok.app",
+      preferNginxIngress: true,
+    });
+  });
+
+  test("rejects --domain with a non-ngrok provider", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "cloudflare",
+      "--domain",
+      "foo.ngrok.app",
+    ];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "--domain is only supported with --provider ngrok",
+    );
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("errors when --domain is missing its value", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--domain",
+    ];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("--domain requires a value");
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
   });
 
   test("a not-yet-implemented provider error carries the stale-CLI hint", async () => {
@@ -214,5 +297,136 @@ describe("tunnel nginx ingress feature flag", () => {
     expect(err?.message).toContain("bun install -g vellum@latest");
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ngrok --domain spawn args", () => {
+  const originalContainerized = process.env.IS_CONTAINERIZED;
+  let lastChild: EventEmitter | null = null;
+
+  const spawnMock = mock((..._args: unknown[]) => {
+    const emitter = new EventEmitter();
+    lastChild = Object.assign(emitter, {
+      stdout: null,
+      stderr: null,
+      killed: false,
+      kill: () => true,
+      unref: () => {},
+      pid: 4242,
+    });
+    return lastChild as unknown as ChildProcess;
+  });
+  const execFileSyncMock = mock(() => "ngrok version 3.9.0");
+
+  beforeAll(() => {
+    mock.module("node:child_process", () => ({
+      ...realChildProcess,
+      spawn: spawnMock,
+      execFileSync: execFileSyncMock,
+    }));
+  });
+
+  afterAll(() => {
+    mock.module("node:child_process", () => realChildProcess);
+  });
+
+  beforeEach(() => {
+    spawnMock.mockClear();
+    lastChild = null;
+    delete process.env.IS_CONTAINERIZED;
+    // ngrok local API stub: one tunnel on an unrelated port, so
+    // findExistingTunnel adopts nothing while waitForNgrokUrl immediately
+    // sees an HTTPS URL for the freshly spawned process.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          tunnels: [
+            {
+              public_url: "https://foo.ngrok.app",
+              config: { addr: "localhost:65500" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalContainerized === undefined) {
+      delete process.env.IS_CONTAINERIZED;
+    } else {
+      process.env.IS_CONTAINERIZED = originalContainerized;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeWorkspace(config: Record<string, unknown>): string {
+    const ws = mkdtempSync(join(tmpdir(), "vellum-ngrok-domain-test-"));
+    tempDirs.push(ws);
+    writeFileSync(join(ws, "config.json"), JSON.stringify(config, null, 2));
+    return ws;
+  }
+
+  test("runNgrokTunnel spawns ngrok with --domain and persists the domain", async () => {
+    const ws = makeWorkspace({});
+
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      domain: "foo.ngrok.app",
+    });
+    // runNgrokTunnel blocks until the ngrok process exits; pump exit events
+    // until its final exit listener is registered and the promise settles.
+    const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+    }
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+    ];
+    expect(cmd).toBe("ngrok");
+    expect(args).toEqual([
+      "http",
+      "7831",
+      "--log=stdout",
+      "--domain=foo.ngrok.app",
+    ]);
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+
+  test("maybeStartNgrokTunnel passes the saved domain to the spawn args", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { domain: "foo.ngrok.app" } },
+    });
+
+    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+
+    expect(child).not.toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+    ];
+    expect(cmd).toBe("ngrok");
+    expect(args).toEqual([
+      "http",
+      "7830",
+      "--log=stdout",
+      "--domain=foo.ngrok.app",
+    ]);
   });
 });

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -407,6 +407,126 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
+  function mockTunnelListFetch(publicUrl: string, addr: string): void {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          tunnels: [{ public_url: publicUrl, config: { addr } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+  }
+
+  test("runNgrokTunnel rejects an existing tunnel that mismatches the requested domain", async () => {
+    const ws = makeWorkspace({});
+    mockTunnelListFetch("https://other.ngrok-free.app", "localhost:7831");
+
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    try {
+      await expect(
+        realNgrok.runNgrokTunnel({
+          port: 7831,
+          workspaceDir: ws,
+          domain: "foo.ngrok.app",
+        }),
+      ).rejects.toThrow("exit:1");
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    const combined = errors.join("\n");
+    expect(combined).toContain("https://other.ngrok-free.app");
+    expect(combined).toContain(
+      "does not match the requested domain 'foo.ngrok.app'",
+    );
+    expect(combined).toContain("Stop the existing ngrok agent");
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress?: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
+    expect(config.ingress?.publicBaseUrl).toBeUndefined();
+    expect(config.ingress?.ngrok).toBeUndefined();
+  });
+
+  test("runNgrokTunnel adopts an existing tunnel that matches the requested domain", async () => {
+    const ws = makeWorkspace({});
+    mockTunnelListFetch("https://foo.ngrok.app", "localhost:7831");
+
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      domain: "foo.ngrok.app",
+    });
+    // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
+    // listener is registered and the promise settles. Earlier tests leak
+    // SIGINT handlers that call process.exit — no-op it while pumping.
+    const exitSpy = spyOn(process, "exit").mockImplementation((() =>
+      undefined) as never);
+    const pump = setInterval(() => process.emit("SIGINT"), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+      exitSpy.mockRestore();
+    }
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+
+  test("maybeStartNgrokTunnel warns and adopts a mismatched existing tunnel without spawning", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { domain: "foo.ngrok.app" } },
+    });
+    mockTunnelListFetch("https://other.ngrok-free.app", "localhost:7830");
+
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
+      (...a: unknown[]) => {
+        warnings.push(a.join(" "));
+      },
+    );
+
+    let child: unknown;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(child).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(warnings.join("\n")).toContain(
+      "does not match the reserved domain 'foo.ngrok.app'",
+    );
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
+    // The working tunnel is still adopted so webhooks keep flowing…
+    expect(config.ingress.publicBaseUrl).toBe("https://other.ngrok-free.app");
+    // …and the reserved domain stays saved as standing intent.
+    expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+
   test("maybeStartNgrokTunnel passes the saved domain to the spawn args", async () => {
     const ws = makeWorkspace({
       telegram: { botUsername: "example_bot" },

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -334,21 +334,7 @@ describe("ngrok --domain spawn args", () => {
     spawnMock.mockClear();
     lastChild = null;
     delete process.env.IS_CONTAINERIZED;
-    // ngrok local API stub: one tunnel on an unrelated port, so
-    // findExistingTunnel adopts nothing while waitForNgrokUrl immediately
-    // sees an HTTPS URL for the freshly spawned process.
-    globalThis.fetch = (async () =>
-      new Response(
-        JSON.stringify({
-          tunnels: [
-            {
-              public_url: "https://foo.ngrok.app",
-              config: { addr: "localhost:65500" },
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as unknown as typeof globalThis.fetch;
+    mockNgrokApiFetch([{ tunnels: [] }]);
   });
 
   afterEach(() => {
@@ -370,8 +356,45 @@ describe("ngrok --domain spawn args", () => {
     return ws;
   }
 
+  interface StubTunnel {
+    public_url: string;
+    config: { addr: string };
+  }
+
+  /** ngrok local API stub replaying one response per call, last one repeated. */
+  function mockNgrokApiFetch(responses: { tunnels: StubTunnel[] }[]): void {
+    let call = 0;
+    globalThis.fetch = (async () => {
+      const body = responses[Math.min(call, responses.length - 1)];
+      call++;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  const unrelatedPortTunnel: StubTunnel = {
+    public_url: "https://unrelated.ngrok.app",
+    config: { addr: "localhost:65500" },
+  };
+
   test("runNgrokTunnel spawns ngrok with --domain and persists the domain", async () => {
     const ws = makeWorkspace({});
+    // The unrelated-port tunnel is listed first both before and after the
+    // spawn; only the tunnel matching the target port and domain may be saved.
+    mockNgrokApiFetch([
+      { tunnels: [unrelatedPortTunnel] },
+      {
+        tunnels: [
+          unrelatedPortTunnel,
+          {
+            public_url: "https://foo.ngrok.app",
+            config: { addr: "localhost:7831" },
+          },
+        ],
+      },
+    ]);
 
     const run = realNgrok.runNgrokTunnel({
       port: 7831,
@@ -472,7 +495,7 @@ describe("ngrok --domain spawn args", () => {
     });
     // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
     // listener is registered and the promise settles. Earlier tests leak
-    // SIGINT handlers that call process.exit — no-op it while pumping.
+    // SIGINT handlers that call process.exit, so no-op it while pumping.
     const exitSpy = spyOn(process, "exit").mockImplementation((() =>
       undefined) as never);
     const pump = setInterval(() => process.emit("SIGINT"), 10);
@@ -491,7 +514,7 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
-  test("maybeStartNgrokTunnel warns and adopts a mismatched existing tunnel without spawning", async () => {
+  test("maybeStartNgrokTunnel rejects a mismatched existing tunnel without adopting or spawning", async () => {
     const ws = makeWorkspace({
       telegram: { botUsername: "example_bot" },
       ingress: { ngrok: { domain: "foo.ngrok.app" } },
@@ -514,15 +537,20 @@ describe("ngrok --domain spawn args", () => {
 
     expect(child).toBeNull();
     expect(spawnMock).not.toHaveBeenCalled();
-    expect(warnings.join("\n")).toContain(
+    const combined = warnings.join("\n");
+    expect(combined).toContain("https://other.ngrok-free.app");
+    expect(combined).toContain(
       "does not match the reserved domain 'foo.ngrok.app'",
+    );
+    expect(combined).toContain(
+      "vellum tunnel --provider ngrok --domain foo.ngrok.app",
     );
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
     ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
-    // The working tunnel is still adopted so webhooks keep flowing…
-    expect(config.ingress.publicBaseUrl).toBe("https://other.ngrok-free.app");
+    // The mismatched tunnel is not blessed in config…
+    expect(config.ingress.publicBaseUrl).toBeUndefined();
     // …and the reserved domain stays saved as standing intent.
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
@@ -532,6 +560,18 @@ describe("ngrok --domain spawn args", () => {
       telegram: { botUsername: "example_bot" },
       ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
+    mockNgrokApiFetch([
+      { tunnels: [] },
+      {
+        tunnels: [
+          unrelatedPortTunnel,
+          {
+            public_url: "https://foo.ngrok.app",
+            config: { addr: "localhost:7830" },
+          },
+        ],
+      },
+    ]);
 
     const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
 
@@ -548,5 +588,50 @@ describe("ngrok --domain spawn args", () => {
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress: { publicBaseUrl?: string } };
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+  });
+
+  test("runNgrokTunnel without --domain reuses the saved domain and does not delete it", async () => {
+    const ws = makeWorkspace({
+      ingress: { ngrok: { domain: "foo.ngrok.app" } },
+    });
+    mockNgrokApiFetch([
+      { tunnels: [] },
+      {
+        tunnels: [
+          {
+            public_url: "https://foo.ngrok.app",
+            config: { addr: "localhost:7831" },
+          },
+        ],
+      },
+    ]);
+
+    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+    }
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args).toEqual([
+      "http",
+      "7831",
+      "--log=stdout",
+      "--domain=foo.ngrok.app",
+    ]);
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 });

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -19,12 +19,14 @@ const DEFAULT_PROVIDER: TunnelProvider = "vellum";
 interface TunnelArgs {
   assistantName: string | null;
   provider: TunnelProvider;
+  domain: string | null;
 }
 
 function parseArgs(): TunnelArgs {
   const args = process.argv.slice(3);
   let assistantName: string | null = null;
   let provider: TunnelProvider = DEFAULT_PROVIDER;
+  let domain: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -50,6 +52,12 @@ function parseArgs(): TunnelArgs {
       console.log(
         `  --provider <provider>         Tunnel provider: ${VALID_PROVIDERS.join(", ")} (default: ${DEFAULT_PROVIDER})`,
       );
+      console.log(
+        "  --domain <domain>             Reserved ngrok domain to bind (ngrok provider only).",
+      );
+      console.log(
+        "                                Saved to the workspace config so `vellum wake` restores reuse it.",
+      );
       console.log("");
       console.log("Providers:");
       console.log(
@@ -74,6 +82,9 @@ function parseArgs(): TunnelArgs {
       console.log("Examples:");
       console.log("  $ vellum tunnel");
       console.log("  $ vellum tunnel --provider ngrok");
+      console.log(
+        "  $ vellum tunnel --provider ngrok --domain my-assistant.ngrok.app",
+      );
       console.log("  $ vellum tunnel --provider cloudflare");
       console.log("  $ vellum tunnel my-assistant --provider tailscale");
       process.exit(0);
@@ -96,6 +107,16 @@ function parseArgs(): TunnelArgs {
       }
       provider = next as TunnelProvider;
       i++;
+    } else if (arg === "--domain") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error(
+          "Error: --domain requires a value, e.g. --domain my-assistant.ngrok.app",
+        );
+        process.exit(1);
+      }
+      domain = next;
+      i++;
     } else if (arg.startsWith("-")) {
       console.error(`Error: Unknown option '${arg}'.`);
       process.exit(1);
@@ -107,7 +128,14 @@ function parseArgs(): TunnelArgs {
     }
   }
 
-  return { assistantName, provider };
+  if (domain && provider !== "ngrok") {
+    console.error(
+      `Error: --domain is only supported with --provider ngrok (got '${provider}').`,
+    );
+    process.exit(1);
+  }
+
+  return { assistantName, provider, domain };
 }
 
 function parsePortFromUrl(url: unknown): number | undefined {
@@ -151,7 +179,7 @@ async function shouldPreferNginxIngress(
 }
 
 export async function tunnel(): Promise<void> {
-  const { assistantName, provider } = parseArgs();
+  const { assistantName, provider, domain } = parseArgs();
 
   const entry = resolveAssistant(assistantName ?? undefined);
 
@@ -179,6 +207,7 @@ export async function tunnel(): Promise<void> {
   if (provider === "ngrok") {
     await runNgrokTunnel({
       ...baseTunnelOpts,
+      ...(domain ? { domain } : {}),
       preferNginxIngress: await shouldPreferNginxIngress(
         entry.assistantId,
         gatewayPort,

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -85,6 +85,31 @@ export function saveIngressUrl(
   }
 }
 
+/** Persist a reserved ngrok domain under `ingress.ngrok.domain`; null clears it. */
+export function saveNgrokDomain(
+  workspaceDir: string,
+  domain: string | null,
+): void {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  if (domain) {
+    ingress.ngrok = { domain };
+  } else {
+    delete ingress.ngrok;
+  }
+  config.ingress = ingress;
+  saveRawConfig(workspaceDir, config);
+}
+
+/** Read the reserved ngrok domain from the workspace config, if saved. */
+export function loadNgrokDomain(workspaceDir: string): string | null {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = config.ingress as Record<string, unknown> | undefined;
+  const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
+  const domain = ngrok?.domain;
+  return typeof domain === "string" && domain.trim() ? domain : null;
+}
+
 /** Clear the ingress public base URL from the workspace config. */
 export function clearIngressUrl(
   workspaceDir: string,

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -6,8 +6,10 @@ import { GATEWAY_PORT } from "./constants.js";
 import {
   clearIngressUrl,
   getDefaultWorkspaceDir,
+  loadNgrokDomain,
   loadRawConfig,
   saveIngressUrl,
+  saveNgrokDomain,
 } from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 import { resolveTunnelTargetPort } from "./nginx-ingress.js";
@@ -103,11 +105,15 @@ export async function findExistingTunnel(
  * parent process — which would either prevent the CLI from exiting (if
  * handles are left open) or send SIGPIPE to ngrok (if destroyed).
  *
+ * When `domain` is set, the tunnel binds that reserved ngrok domain via
+ * `--domain=<domain>`.
+ *
  * Returns the spawned child process.
  */
 export function startNgrokProcess(
   targetPort: number,
   logFilePath?: string,
+  domain?: string,
 ): ChildProcess {
   let stdio: ("ignore" | "pipe" | number)[] = ["ignore", "pipe", "pipe"];
   let fd: number | undefined;
@@ -118,7 +124,12 @@ export function startNgrokProcess(
     stdio = ["ignore", fd, fd];
   }
 
-  const child = spawn("ngrok", ["http", String(targetPort), "--log=stdout"], {
+  const args = ["http", String(targetPort), "--log=stdout"];
+  if (domain) {
+    args.push(`--domain=${domain}`);
+  }
+
+  const child = spawn("ngrok", args, {
     detached: true,
     stdio,
   });
@@ -232,7 +243,8 @@ export async function maybeStartNgrokTunnel(
   // Writing to a log file sidesteps both issues — the file descriptor is
   // inherited by the detached ngrok process and remains valid after CLI exit.
   const ngrokLogPath = join(workspaceDir, "data", "logs", "ngrok.log");
-  const ngrokProcess = startNgrokProcess(targetPort, ngrokLogPath);
+  const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
+  const ngrokProcess = startNgrokProcess(targetPort, ngrokLogPath, savedDomain);
   ngrokProcess.unref();
 
   try {
@@ -259,6 +271,8 @@ export interface RunNgrokTunnelOptions {
   preferNginxIngress?: boolean;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
+  /** Reserved ngrok domain to bind. Persisted so wake restores reuse it. */
+  domain?: string;
 }
 
 /**
@@ -303,6 +317,7 @@ export async function runNgrokTunnel(
   if (existingUrl) {
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
+    saveNgrokDomain(workspaceDir, opts.domain ?? null);
     console.log("Ingress URL saved to config.");
     console.log("");
     console.log(
@@ -321,7 +336,7 @@ export async function runNgrokTunnel(
 
   let publicUrl: string | undefined;
 
-  const ngrokProcess = startNgrokProcess(port);
+  const ngrokProcess = startNgrokProcess(port, undefined, opts.domain);
 
   const cleanup = () => {
     if (!ngrokProcess.killed) {
@@ -378,7 +393,10 @@ export async function runNgrokTunnel(
   console.log(`Tunnel established: ${publicUrl}`);
   console.log(`Forwarding to:     localhost:${port}`);
 
+  // The domain is standing intent, not tunnel state: cleanup clears the
+  // ingress URL but leaves the domain saved for wake/daemon restores.
   saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
+  saveNgrokDomain(workspaceDir, opts.domain ?? null);
   console.log("Ingress URL saved to config.");
   console.log("");
   console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -97,6 +97,17 @@ export async function findExistingTunnel(
   return null;
 }
 
+/** Whether a tunnel public URL's host equals the given reserved domain. */
+function urlMatchesDomain(publicUrl: string, domain: string): boolean {
+  try {
+    return (
+      new URL(publicUrl).hostname.toLowerCase() === domain.trim().toLowerCase()
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Start an ngrok process tunneling HTTP traffic to the given local port.
  *
@@ -226,9 +237,19 @@ export async function maybeStartNgrokTunnel(
   const version = getNgrokVersion();
   if (!version) return null;
 
+  const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
+
   // Reuse an existing tunnel if one is already running
   const existingUrl = await findExistingTunnel(targetPort);
   if (existingUrl) {
+    if (savedDomain && !urlMatchesDomain(existingUrl, savedDomain)) {
+      // Spawning a second agent with --domain would not help: the local API
+      // polling would still surface the old tunnel. Adopt the working tunnel
+      // so webhooks keep flowing, but make the mismatch visible.
+      console.warn(
+        `   ⚠ Existing ngrok tunnel ${existingUrl} does not match the reserved domain '${savedDomain}'. Using it anyway — stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
+      );
+    }
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl);
     return null;
@@ -243,7 +264,6 @@ export async function maybeStartNgrokTunnel(
   // Writing to a log file sidesteps both issues — the file descriptor is
   // inherited by the detached ngrok process and remains valid after CLI exit.
   const ngrokLogPath = join(workspaceDir, "data", "logs", "ngrok.log");
-  const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
   const ngrokProcess = startNgrokProcess(targetPort, ngrokLogPath, savedDomain);
   ngrokProcess.unref();
 
@@ -315,6 +335,15 @@ export async function runNgrokTunnel(
   // Check for an existing ngrok tunnel pointing at the gateway
   const existingUrl = await findExistingTunnel(port);
   if (existingUrl) {
+    if (opts.domain && !urlMatchesDomain(existingUrl, opts.domain)) {
+      console.error(
+        `Error: an ngrok tunnel is already running on port ${port} at ${existingUrl}, which does not match the requested domain '${opts.domain}'.`,
+      );
+      console.error(
+        "Stop the existing ngrok agent first, then re-run this command to bind the reserved domain.",
+      );
+      process.exit(1);
+    }
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
     saveNgrokDomain(workspaceDir, opts.domain ?? null);

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -61,6 +61,33 @@ async function queryNgrokTunnels(): Promise<NgrokTunnel[] | null> {
   }
 }
 
+/** Whether a tunnel targets the given local port, under any addr spelling. */
+function tunnelTargetsPort(tunnel: NgrokTunnel, targetPort: number): boolean {
+  const targetAddrs = [
+    `localhost:${targetPort}`,
+    `127.0.0.1:${targetPort}`,
+    `http://localhost:${targetPort}`,
+    `http://127.0.0.1:${targetPort}`,
+  ];
+  return targetAddrs.includes(tunnel.config?.addr ?? "");
+}
+
+/** Pick the tunnel for the target port (and domain, when set), HTTPS first. */
+function pickMatchingTunnel(
+  tunnels: NgrokTunnel[],
+  targetPort: number,
+  domain?: string,
+): string | null {
+  const matches = tunnels.filter(
+    (t) =>
+      tunnelTargetsPort(t, targetPort) &&
+      (!domain || urlMatchesDomain(t.public_url, domain)),
+  );
+  const httpsTunnel = matches.find((t) => t.public_url.startsWith("https://"));
+  if (httpsTunnel) return httpsTunnel.public_url;
+  return matches.find((t) => t.public_url)?.public_url ?? null;
+}
+
 /**
  * Find an existing ngrok tunnel that targets the given local address.
  * Returns the HTTPS public URL if found, null otherwise.
@@ -70,31 +97,7 @@ export async function findExistingTunnel(
 ): Promise<string | null> {
   const tunnels = await queryNgrokTunnels();
   if (!tunnels || tunnels.length === 0) return null;
-
-  const targetAddrs = [
-    `localhost:${targetPort}`,
-    `127.0.0.1:${targetPort}`,
-    `http://localhost:${targetPort}`,
-    `http://127.0.0.1:${targetPort}`,
-  ];
-
-  // Prefer HTTPS tunnel
-  for (const t of tunnels) {
-    const addr = t.config?.addr ?? "";
-    if (targetAddrs.includes(addr) && t.public_url.startsWith("https://")) {
-      return t.public_url;
-    }
-  }
-
-  // Fall back to any tunnel pointing at the target
-  for (const t of tunnels) {
-    const addr = t.config?.addr ?? "";
-    if (targetAddrs.includes(addr) && t.public_url) {
-      return t.public_url;
-    }
-  }
-
-  return null;
+  return pickMatchingTunnel(tunnels, targetPort);
 }
 
 /** Whether a tunnel public URL's host equals the given reserved domain. */
@@ -156,22 +159,21 @@ export function startNgrokProcess(
 }
 
 /**
- * Poll the ngrok local API until an HTTPS tunnel URL appears.
+ * Poll the ngrok local API until a tunnel appears for the target port (and
+ * reserved domain, when one is requested), preferring HTTPS.
  * Returns the public URL, or throws if the timeout is exceeded.
  */
 export async function waitForNgrokUrl(
+  targetPort: number,
+  domain?: string,
   timeoutMs: number = NGROK_POLL_TIMEOUT_MS,
 ): Promise<string> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const tunnels = await queryNgrokTunnels();
     if (tunnels && tunnels.length > 0) {
-      // Prefer HTTPS
-      const httpsTunnel = tunnels.find((t) =>
-        t.public_url.startsWith("https://"),
-      );
-      if (httpsTunnel) return httpsTunnel.public_url;
-      if (tunnels[0]?.public_url) return tunnels[0].public_url;
+      const url = pickMatchingTunnel(tunnels, targetPort, domain);
+      if (url) return url;
     }
     await new Promise((r) => setTimeout(r, NGROK_POLL_INTERVAL_MS));
   }
@@ -243,12 +245,13 @@ export async function maybeStartNgrokTunnel(
   const existingUrl = await findExistingTunnel(targetPort);
   if (existingUrl) {
     if (savedDomain && !urlMatchesDomain(existingUrl, savedDomain)) {
-      // Spawning a second agent with --domain would not help: the local API
-      // polling would still surface the old tunnel. Adopt the working tunnel
-      // so webhooks keep flowing, but make the mismatch visible.
+      // Spawning a second agent would collide (ERR_NGROK_334), and saving the
+      // mismatched URL would clobber the reserved-domain intent. Leave the
+      // tunnel running but refuse to bless it in config.
       console.warn(
-        `   ⚠ Existing ngrok tunnel ${existingUrl} does not match the reserved domain '${savedDomain}'. Using it anyway — stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
+        `   ⚠ Existing ngrok tunnel ${existingUrl} does not match the reserved domain '${savedDomain}'. Ignoring it. Stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
       );
+      return null;
     }
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl);
@@ -268,7 +271,7 @@ export async function maybeStartNgrokTunnel(
   ngrokProcess.unref();
 
   try {
-    const publicUrl = await waitForNgrokUrl();
+    const publicUrl = await waitForNgrokUrl(targetPort, savedDomain);
     saveIngressUrl(workspaceDir, publicUrl);
     console.log(`   Tunnel established: ${publicUrl}`);
 
@@ -291,7 +294,10 @@ export interface RunNgrokTunnelOptions {
   preferNginxIngress?: boolean;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
-  /** Reserved ngrok domain to bind. Persisted so wake restores reuse it. */
+  /**
+   * Reserved ngrok domain to bind. Persisted so wake restores reuse it.
+   * When omitted, a previously saved domain is reused without being rewritten.
+   */
   domain?: string;
 }
 
@@ -332,12 +338,19 @@ export async function runNgrokTunnel(
     );
   }
 
+  // The saved domain is standing intent: a run without --domain reuses it,
+  // and only an explicit --domain rewrites it.
+  const domain = opts.domain ?? loadNgrokDomain(workspaceDir) ?? undefined;
+  if (domain && !opts.domain) {
+    console.log(`Using saved ngrok domain: ${domain}`);
+  }
+
   // Check for an existing ngrok tunnel pointing at the gateway
   const existingUrl = await findExistingTunnel(port);
   if (existingUrl) {
-    if (opts.domain && !urlMatchesDomain(existingUrl, opts.domain)) {
+    if (domain && !urlMatchesDomain(existingUrl, domain)) {
       console.error(
-        `Error: an ngrok tunnel is already running on port ${port} at ${existingUrl}, which does not match the requested domain '${opts.domain}'.`,
+        `Error: an ngrok tunnel is already running on port ${port} at ${existingUrl}, which does not match the ${opts.domain ? "requested" : "saved"} domain '${domain}'.`,
       );
       console.error(
         "Stop the existing ngrok agent first, then re-run this command to bind the reserved domain.",
@@ -346,7 +359,9 @@ export async function runNgrokTunnel(
     }
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
-    saveNgrokDomain(workspaceDir, opts.domain ?? null);
+    if (opts.domain) {
+      saveNgrokDomain(workspaceDir, opts.domain);
+    }
     console.log("Ingress URL saved to config.");
     console.log("");
     console.log(
@@ -365,7 +380,7 @@ export async function runNgrokTunnel(
 
   let publicUrl: string | undefined;
 
-  const ngrokProcess = startNgrokProcess(port, undefined, opts.domain);
+  const ngrokProcess = startNgrokProcess(port, undefined, domain);
 
   const cleanup = () => {
     if (!ngrokProcess.killed) {
@@ -412,7 +427,7 @@ export async function runNgrokTunnel(
   });
 
   try {
-    publicUrl = await waitForNgrokUrl();
+    publicUrl = await waitForNgrokUrl(port, domain);
   } catch (err) {
     cleanup();
     throw err;
@@ -425,7 +440,9 @@ export async function runNgrokTunnel(
   // The domain is standing intent, not tunnel state: cleanup clears the
   // ingress URL but leaves the domain saved for wake/daemon restores.
   saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
-  saveNgrokDomain(workspaceDir, opts.domain ?? null);
+  if (opts.domain) {
+    saveNgrokDomain(workspaceDir, opts.domain);
+  }
   console.log("Ingress URL saved to config.");
   console.log("");
   console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");


### PR DESCRIPTION
## Summary
- Add --domain flag to vellum tunnel (ngrok only) that spawns ngrok with --domain=<value>
- Persist the domain under ingress.ngrok.domain so wake/daemon auto-restores reuse the reserved domain (avoids ERR_NGROK_334 collisions)
- Reject --domain for non-ngrok providers with a clear error

Part of plan: tunnel-edge-unify.md (PR 2 of 7)