### PR TITLE
feat(web): add the home feed category chip

### DIFF
--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -9,22 +9,11 @@ import {
 } from "lucide-react";
 
 import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
-import type {
-  FeedItem,
-  FeedItemCategory,
-  FeedItemStatus,
-} from "@vellumai/assistant-api";
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Tag, Typography } from "@vellumai/design-library";
-import { CATEGORY_STYLES } from "../home-feed-filter-bar";
+import { resolveCategoryStyle } from "../home-feed-filter-bar";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
-
-function resolveCategoryStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES.system;
-}
 
 // The header shows the item's own title when it has one. Many feed items omit
 // a distinct title — for those, falling back to `summary` (which is also the

--- a/clients/web/src/domains/home/feed-category-chip.test.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for `FeedCategoryChip`.
+ *
+ * Uses `renderToStaticMarkup` (SSR) like `notifications-bell.test.tsx`. The
+ * chip is a pure presentational component, so assertions cover rendered text
+ * and the absence of throwing. Class strings are deliberately not asserted.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FeedItemCategory } from "@vellumai/assistant-api";
+
+import { FeedCategoryChip } from "@/domains/home/feed-category-chip";
+
+const CATEGORY_LABELS = [
+  ["security", "Security"],
+  ["email", "Email"],
+  ["scheduling", "Scheduling"],
+  ["background", "Background"],
+  ["system", "System"],
+] as const satisfies readonly (readonly [FeedItemCategory, string])[];
+
+function stripTags(markup: string): string {
+  return markup.replace(/<[^>]*>/g, "");
+}
+
+describe("FeedCategoryChip", () => {
+  test.each(CATEGORY_LABELS)(
+    "renders %s in natural case",
+    (category, expected) => {
+      const markup = renderToStaticMarkup(
+        <FeedCategoryChip category={category} />,
+      );
+      expect(stripTags(markup)).toBe(expected);
+    },
+  );
+
+  test("falls back to the system label when no category is given", () => {
+    const markup = renderToStaticMarkup(<FeedCategoryChip />);
+    expect(stripTags(markup)).toBe("System");
+  });
+
+  test("does not throw for an unrecognized category", () => {
+    expect(() => {
+      renderToStaticMarkup(
+        <FeedCategoryChip category={"nonsense" as FeedItemCategory} />,
+      );
+    }).not.toThrow();
+  });
+
+  test("renders every category distinctly", () => {
+    const rendered = CATEGORY_LABELS.map(([category]) =>
+      renderToStaticMarkup(<FeedCategoryChip category={category} />),
+    );
+    expect(new Set(rendered).size).toBe(CATEGORY_LABELS.length);
+  });
+});

--- a/clients/web/src/domains/home/feed-category-chip.test.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for `FeedCategoryChip`.
+ * Tests for `FeedCategoryChip` and the shared `resolveCategoryStyle` it uses.
  *
  * Uses `renderToStaticMarkup` (SSR) like `notifications-bell.test.tsx`. The
  * chip is a pure presentational component, so assertions cover rendered text
@@ -12,6 +12,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { FeedItemCategory } from "@vellumai/assistant-api";
 
 import { FeedCategoryChip } from "@/domains/home/feed-category-chip";
+import {
+  CATEGORY_STYLES,
+  resolveCategoryStyle,
+} from "@/domains/home/home-feed-filter-bar";
 
 const CATEGORY_LABELS = [
   ["security", "Security"],
@@ -54,5 +58,21 @@ describe("FeedCategoryChip", () => {
       renderToStaticMarkup(<FeedCategoryChip category={category} />),
     );
     expect(new Set(rendered).size).toBe(CATEGORY_LABELS.length);
+  });
+});
+
+describe("resolveCategoryStyle", () => {
+  test.each(CATEGORY_LABELS)("returns the %s style", (category) => {
+    expect(resolveCategoryStyle(category)).toBe(CATEGORY_STYLES[category]);
+  });
+
+  test("falls back to the system style when no category is given", () => {
+    expect(resolveCategoryStyle()).toBe(CATEGORY_STYLES.system);
+  });
+
+  test("falls back to the system style for an unrecognized category", () => {
+    expect(resolveCategoryStyle("nonsense" as FeedItemCategory)).toBe(
+      CATEGORY_STYLES.system,
+    );
   });
 });

--- a/clients/web/src/domains/home/feed-category-chip.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.tsx
@@ -1,0 +1,46 @@
+import { type CSSProperties } from "react";
+
+import type { FeedItemCategory } from "@vellumai/assistant-api";
+import { Tag } from "@vellumai/design-library";
+
+import { CATEGORY_STYLES } from "./home-feed-filter-bar";
+
+const FALLBACK_CATEGORY: FeedItemCategory = "system";
+
+function resolveStyle(category?: FeedItemCategory) {
+  if (category && CATEGORY_STYLES[category]) {
+    return CATEGORY_STYLES[category];
+  }
+  return CATEGORY_STYLES[FALLBACK_CATEGORY];
+}
+
+export interface FeedCategoryChipProps {
+  category?: FeedItemCategory;
+}
+
+/**
+ * Text-only chip naming a feed item's category, toned from `CATEGORY_STYLES`.
+ *
+ * The category tokens are runtime values, so they go in as local custom
+ * properties that static Tailwind utilities read back. Those static utilities
+ * land in the same `tailwind-merge` conflict groups as `Tag`'s own
+ * `bg-[var(...)]` / `text-[color:var(...)]` base classes, so they win.
+ */
+export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
+  const style = resolveStyle(category);
+  const label = category ?? FALLBACK_CATEGORY;
+
+  return (
+    <Tag
+      className="bg-[var(--feed-chip-weak)] text-[color:var(--feed-chip-strong)] uppercase tracking-wide leading-none"
+      style={
+        {
+          "--feed-chip-weak": style.weak,
+          "--feed-chip-strong": style.strong,
+        } as CSSProperties
+      }
+    >
+      {label.charAt(0).toUpperCase() + label.slice(1)}
+    </Tag>
+  );
+}

--- a/clients/web/src/domains/home/feed-category-chip.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.tsx
@@ -14,10 +14,12 @@ export interface FeedCategoryChipProps {
 /**
  * Text-only chip naming a feed item's category, toned from `CATEGORY_STYLES`.
  *
- * The category tokens are runtime values, so they go in as local custom
- * properties that static Tailwind utilities read back. Those static utilities
- * land in the same `tailwind-merge` conflict groups as `Tag`'s own
- * `bg-[var(...)]` / `text-[color:var(...)]` base classes, so they win.
+ * The background alone carries the category hue: the `weak` token is a runtime
+ * value, so it goes in as a local custom property that a static Tailwind
+ * utility reads back, landing in the same `tailwind-merge` conflict group as
+ * `Tag`'s own `bg-[var(...)]` base class so it wins. The label deliberately
+ * keeps `Tag`'s `--content-default` text color, which clears WCAG AA against
+ * every category background at this 12px/600 size.
  */
 export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
   const style = resolveCategoryStyle(category);
@@ -25,13 +27,8 @@ export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
 
   return (
     <Tag
-      className="bg-[var(--feed-chip-weak)] text-[color:var(--feed-chip-strong)] uppercase tracking-wide leading-none"
-      style={
-        {
-          "--feed-chip-weak": style.weak,
-          "--feed-chip-strong": style.strong,
-        } as CSSProperties
-      }
+      className="bg-[var(--feed-chip-weak)] uppercase tracking-wide leading-none"
+      style={{ "--feed-chip-weak": style.weak } as CSSProperties}
     >
       {label.charAt(0).toUpperCase() + label.slice(1)}
     </Tag>

--- a/clients/web/src/domains/home/feed-category-chip.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.tsx
@@ -3,16 +3,9 @@ import { type CSSProperties } from "react";
 import type { FeedItemCategory } from "@vellumai/assistant-api";
 import { Tag } from "@vellumai/design-library";
 
-import { CATEGORY_STYLES } from "./home-feed-filter-bar";
+import { resolveCategoryStyle } from "./home-feed-filter-bar";
 
 const FALLBACK_CATEGORY: FeedItemCategory = "system";
-
-function resolveStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES[FALLBACK_CATEGORY];
-}
 
 export interface FeedCategoryChipProps {
   category?: FeedItemCategory;
@@ -27,7 +20,7 @@ export interface FeedCategoryChipProps {
  * `bg-[var(...)]` / `text-[color:var(...)]` base classes, so they win.
  */
 export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
-  const style = resolveStyle(category);
+  const style = resolveCategoryStyle(category);
   const label = category ?? FALLBACK_CATEGORY;
 
   return (

--- a/clients/web/src/domains/home/home-feed-filter-bar.tsx
+++ b/clients/web/src/domains/home/home-feed-filter-bar.tsx
@@ -43,6 +43,16 @@ export const CATEGORY_STYLES: Record<FeedItemCategory, CategoryStyle> = {
   },
 };
 
+/** Resolves a category to its style, falling back to `system`. */
+export function resolveCategoryStyle(
+  category?: FeedItemCategory,
+): CategoryStyle {
+  if (category && CATEGORY_STYLES[category]) {
+    return CATEGORY_STYLES[category];
+  }
+  return CATEGORY_STYLES.system;
+}
+
 export const CATEGORY_ORDER: FeedItemCategory[] = [
   "security",
   "email",


### PR DESCRIPTION
## Summary
- Adds `FeedCategoryChip`, a text-only chip built on the design-library `Tag` and toned from the existing `CATEGORY_STYLES` tokens.
- Replaces the category icon circle the feed row used, ahead of the card redesign.

Part of plan: home-feed-notification-cards.md (PR 2 of 7)