### PR TITLE
test(web): assert bell unread state semantically instead of by class string

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -57,9 +57,11 @@ mock.module("@/stores/resolved-assistants-store", () => {
 
 import { NotificationsBell } from "@/domains/home/components/notifications-bell";
 
-// The trigger's aria-label flips on the same `hasUnread` that renders the dot,
-// so it stands in for the dot without pinning the dot's Tailwind classes. The
-// closing quote is load-bearing: it stops READ_LABEL matching the unread label.
+// The dot element itself, matched by a styling-independent test hook so the
+// assertions survive restyling. The accessible name is a separate concern, so
+// it is asserted alongside. The closing quote is load-bearing: it stops
+// READ_LABEL matching the unread label.
+const UNREAD_DOT = 'data-testid="notifications-bell-unread-dot"';
 const UNREAD_LABEL = 'aria-label="Notifications (unread)"';
 const READ_LABEL = 'aria-label="Notifications"';
 
@@ -89,6 +91,7 @@ describe("NotificationsBell unread dot", () => {
   test("shows the dot when an unread notification exists", () => {
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
+    expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
   });
 
@@ -98,12 +101,14 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "acted_on" }),
     ];
     const html = renderBell();
+    expect(html).not.toContain(UNREAD_DOT);
     expect(html).toContain(READ_LABEL);
     expect(html).not.toContain(UNREAD_LABEL);
   });
 
   test("hides the dot when the feed is empty", () => {
     const html = renderBell();
+    expect(html).not.toContain(UNREAD_DOT);
     expect(html).toContain(READ_LABEL);
   });
 
@@ -115,6 +120,7 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "new", urgency: "high" }),
     ];
     const html = renderBell();
+    expect(html).not.toContain(UNREAD_DOT);
     expect(html).toContain(READ_LABEL);
   });
 
@@ -122,6 +128,7 @@ describe("NotificationsBell unread dot", () => {
     isMobileRef.value = true;
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
+    expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
   });
 });

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -57,10 +57,11 @@ mock.module("@/stores/resolved-assistants-store", () => {
 
 import { NotificationsBell } from "@/domains/home/components/notifications-bell";
 
-// The same amber dot HomeRecapRow puts on unread rows, top-right of the bell,
-// ringed in the top-bar surface color to separate it from the bell outline.
-const UNREAD_DOT_CLASS =
-  "-right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
+// The trigger's aria-label flips on the same `hasUnread` that renders the dot,
+// so it stands in for the dot without pinning the dot's Tailwind classes. The
+// closing quote is load-bearing: it stops READ_LABEL matching the unread label.
+const UNREAD_LABEL = 'aria-label="Notifications (unread)"';
+const READ_LABEL = 'aria-label="Notifications"';
 
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
   return {
@@ -88,8 +89,7 @@ describe("NotificationsBell unread dot", () => {
   test("shows the dot when an unread notification exists", () => {
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
-    expect(html).toContain(UNREAD_DOT_CLASS);
-    expect(html).toContain("Notifications (unread)");
+    expect(html).toContain(UNREAD_LABEL);
   });
 
   test("hides the dot when every notification has been read", () => {
@@ -98,14 +98,13 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "acted_on" }),
     ];
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
-    expect(html).toContain("Notifications");
-    expect(html).not.toContain("(unread)");
+    expect(html).toContain(READ_LABEL);
+    expect(html).not.toContain(UNREAD_LABEL);
   });
 
   test("hides the dot when the feed is empty", () => {
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
+    expect(html).toContain(READ_LABEL);
   });
 
   test("ignores unread items that the popover never shows", () => {
@@ -116,13 +115,13 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "new", urgency: "high" }),
     ];
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
+    expect(html).toContain(READ_LABEL);
   });
 
   test("mobile trigger carries the same dot", () => {
     isMobileRef.value = true;
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
-    expect(html).toContain(UNREAD_DOT_CLASS);
+    expect(html).toContain(UNREAD_LABEL);
   });
 });

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -115,7 +115,10 @@ export function NotificationsBell() {
             // icon-only buttons grow on touch-mobile. The 2px ring eats into
             // the box (border-box), so size/offset grow by 2px each to keep
             // the 6px amber core in place.
-            <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]" />
+            <span
+              data-testid="notifications-bell-unread-dot"
+              className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+            />
           ) : null}
         </span>
       }


### PR DESCRIPTION
## Summary
- Replaces the brittle full-class-string assertion on the bell unread dot with an assertion on the trigger's aria-label, which is the semantic signal the component already exposes.
- Not a bug fix. The file passes on main; this removes an assertion that has already drifted once and that the card redesign later in this plan would break again.

Part of plan: home-feed-notification-cards.md (PR 4 of 7)