### PR TITLE
fix(web): make home feed row actions valid and keyboard reachable

### DIFF
--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for `HomeRecapRow`.
+ *
+ * Rendered into happy-dom via `@testing-library/react` so clicks can be
+ * dispatched. Assertions target text, roles, `aria-label`s, and DOM structure,
+ * never class strings: those drift with styling and turn behaviour tests into
+ * styling tests.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
+
+import { HomeRecapRow, type HomeRecapRowProps } from "./home-recap-row";
+
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  const timestamp = new Date(Date.now() - THREE_DAYS_MS).toISOString();
+  return {
+    id: "feed-1",
+    type: "notification",
+    priority: 50,
+    category: "background",
+    status: "new",
+    title: "Watcher job failed",
+    summary: "The watcher job could not reach the upstream service.",
+    timestamp,
+    createdAt: timestamp,
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function renderRow(props: Partial<HomeRecapRowProps> = {}) {
+  const selected: FeedItem[] = [];
+  const dismissed: string[] = [];
+  const readToggles: Array<[string, FeedItemStatus]> = [];
+  const threads: string[] = [];
+  const item = props.item ?? makeItem();
+
+  render(
+    <HomeRecapRow
+      item={item}
+      onSelect={(selectedItem) => selected.push(selectedItem)}
+      onDismiss={(itemId) => dismissed.push(itemId)}
+      onToggleRead={(itemId, status) => readToggles.push([itemId, status])}
+      onGoToThread={(conversationId) => threads.push(conversationId)}
+      {...props}
+    />,
+  );
+
+  return { item, selected, dismissed, readToggles, threads };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HomeRecapRow", () => {
+  test("renders no button inside another button", () => {
+    renderRow();
+
+    expect(document.querySelectorAll("button button").length).toBe(0);
+  });
+
+  test("exposes one click target named after the title", () => {
+    const { item, selected } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Watcher job failed" }));
+
+    expect(selected).toEqual([item]);
+  });
+
+  test("falls back to the summary for the click target's name", () => {
+    renderRow({ item: makeItem({ title: undefined }) });
+
+    expect(
+      screen.getByRole("button", {
+        name: "The watcher job could not reach the upstream service.",
+      }),
+    ).toBeTruthy();
+  });
+
+  test("renders the actions without any hover simulation", () => {
+    renderRow();
+
+    expect(screen.getByRole("button", { name: "Mark as read" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Go to thread" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  test("renders the timestamp alongside the actions", () => {
+    renderRow();
+
+    expect(screen.getByText("3d ago")).toBeTruthy();
+  });
+
+  test("labels the read toggle for an already-read item", () => {
+    renderRow({ item: makeItem({ status: "seen" }) });
+
+    expect(screen.getByRole("button", { name: "Mark as unread" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+  });
+
+  test("dismiss fires its callback without selecting the row", () => {
+    const { selected, dismissed } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(dismissed).toEqual(["feed-1"]);
+    expect(selected).toEqual([]);
+  });
+
+  test("mark as read fires its callback without selecting the row", () => {
+    const { selected, readToggles } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark as read" }));
+
+    expect(readToggles).toEqual([["feed-1", "seen"]]);
+    expect(selected).toEqual([]);
+  });
+
+  test("go to thread marks an unread item read and navigates", () => {
+    const { selected, readToggles, threads } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to thread" }));
+
+    expect(readToggles).toEqual([["feed-1", "seen"]]);
+    expect(threads).toEqual(["conversation-1"]);
+    expect(selected).toEqual([]);
+  });
+
+  test("hides go to thread when the conversation is not listed as valid", () => {
+    renderRow({ validConversationIds: new Set(["other-conversation"]) });
+
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+  });
+
+  test("hides go to thread when the item has no conversation", () => {
+    renderRow({ item: makeItem({ conversationId: undefined }) });
+
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+  });
+
+  test("omits the read toggle when no handler is supplied", () => {
+    render(
+      <HomeRecapRow
+        item={makeItem()}
+        onSelect={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+  });
+
+  test("the restore variant renders only the restore control", () => {
+    const { dismissed } = renderRow({ trailingAction: "restore" });
+
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    expect(dismissed).toEqual(["feed-1"]);
+  });
+});

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -1,5 +1,5 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
 
 import { formatRelativeDate } from "@/utils/format-date";
 import type {
@@ -73,31 +73,38 @@ export function HomeRecapRow({
   onGoToThread,
   trailingAction = "dismiss",
 }: HomeRecapRowProps) {
-  const [isHovering, setIsHovering] = useState(false);
   const style = resolveStyle(item.category);
   const Icon = style.icon;
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
+  const label = item.title ?? item.summary;
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(item)}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
+    <div
       className={cn(
-        "flex min-h-[48px] w-full cursor-pointer items-center gap-[var(--app-spacing-sm)]",
+        "group relative flex min-h-[48px] w-full items-center gap-[var(--app-spacing-sm)]",
         "rounded-[var(--radius-md)] px-[var(--app-spacing-md)] py-[var(--app-spacing-sm)]",
         "transition-[background-color,opacity] duration-150",
         isActive
           ? "bg-[var(--surface-active)]"
-          : isHovering
-            ? "bg-[var(--surface-hover)]"
-            : "bg-[var(--surface-overlay)]",
+          : "bg-[var(--surface-overlay)] hover:bg-[var(--surface-hover)]",
         !isUnread && !isActive && "opacity-70",
       )}
     >
-      <span className="relative shrink-0" aria-hidden="true">
+      {/* Stretched link: the row's single click target. Everything else stacks
+          above it and so must stay `pointer-events-none` unless it is itself
+          interactive, or clicks meant for the row get swallowed. */}
+      <button
+        type="button"
+        aria-label={label}
+        onClick={() => onSelect(item)}
+        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-md)]"
+      />
+
+      <span
+        className="pointer-events-none relative shrink-0"
+        aria-hidden="true"
+      >
         <span
           className="flex items-center justify-center rounded-full"
           style={{
@@ -115,61 +122,86 @@ export function HomeRecapRow({
 
       <span
         className={cn(
-          "text-body-medium-default min-w-0 flex-1 truncate text-left",
+          "text-body-medium-default pointer-events-none relative min-w-0 flex-1 truncate text-left",
           "text-[var(--content-secondary)]",
         )}
       >
-        {item.title ?? item.summary}
+        {label}
       </span>
 
-      {isHovering && !isRestore ? (
-        <span className="flex shrink-0 items-center gap-[var(--app-spacing-sm)]">
-          {onToggleRead && (
-            <HoverIconButton
-              label={isUnread ? "Mark as read" : "Mark as unread"}
-              onClick={() => onToggleRead(item.id, isUnread ? "seen" : "new")}
-            >
-              {isUnread ? (
-                <MailOpen width={16} height={16} />
-              ) : (
-                <Mail width={16} height={16} />
-              )}
-            </HoverIconButton>
+      {/* Timestamp and actions share one grid cell so the row keeps a stable
+          width as they cross-fade. */}
+      <span className="pointer-events-none relative grid shrink-0 items-center justify-items-end">
+        <span
+          className={cn(
+            "col-start-1 row-start-1",
+            "text-body-small-default text-[var(--content-tertiary)]",
+            "transition-opacity duration-150",
+            "group-hover:opacity-0 group-focus-within:opacity-0",
           )}
-          {onGoToThread &&
-            item.conversationId &&
-            (!validConversationIds ||
-              validConversationIds.has(item.conversationId)) && (
-              <HoverIconButton
-                label="Go to thread"
-                onClick={() => {
-                  if (isUnread && onToggleRead) {
-                    onToggleRead(item.id, "seen");
-                  }
-                  onGoToThread(item.conversationId!);
-                }}
-              >
-                <MessageSquare width={16} height={16} />
-              </HoverIconButton>
-            )}
-          <HoverIconButton label="Dismiss" onClick={() => onDismiss(item.id)}>
-            <Trash2 width={16} height={16} />
-          </HoverIconButton>
-        </span>
-      ) : isHovering && isRestore ? (
-        <HoverIconButton
-          label="Restore"
-          onClick={() => onDismiss(item.id)}
-          className="w-auto gap-[var(--app-spacing-xs)] px-2"
         >
-          <RotateCcw width={16} height={16} aria-hidden="true" />
-          <span className="text-body-small-default">Restore</span>
-        </HoverIconButton>
-      ) : (
-        <span className="shrink-0 text-body-small-default text-[var(--content-tertiary)]">
           {formatRelativeDate(item.timestamp)}
         </span>
-      )}
-    </button>
+
+        <span
+          className={cn(
+            "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
+            "pointer-events-none opacity-0 transition-opacity duration-150",
+            "group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+          )}
+        >
+          {isRestore ? (
+            <HoverIconButton
+              label="Restore"
+              onClick={() => onDismiss(item.id)}
+              className="w-auto gap-[var(--app-spacing-xs)] px-2"
+            >
+              <RotateCcw width={16} height={16} aria-hidden="true" />
+              <span className="text-body-small-default">Restore</span>
+            </HoverIconButton>
+          ) : (
+            <>
+              {onToggleRead && (
+                <HoverIconButton
+                  label={isUnread ? "Mark as read" : "Mark as unread"}
+                  onClick={() =>
+                    onToggleRead(item.id, isUnread ? "seen" : "new")
+                  }
+                >
+                  {isUnread ? (
+                    <MailOpen width={16} height={16} />
+                  ) : (
+                    <Mail width={16} height={16} />
+                  )}
+                </HoverIconButton>
+              )}
+              {onGoToThread &&
+                item.conversationId &&
+                (!validConversationIds ||
+                  validConversationIds.has(item.conversationId)) && (
+                  <HoverIconButton
+                    label="Go to thread"
+                    onClick={() => {
+                      if (isUnread && onToggleRead) {
+                        onToggleRead(item.id, "seen");
+                      }
+                      onGoToThread(item.conversationId!);
+                    }}
+                  >
+                    <MessageSquare width={16} height={16} />
+                  </HoverIconButton>
+                )}
+              <HoverIconButton
+                label="Dismiss"
+                onClick={() => onDismiss(item.id)}
+              >
+                <Trash2 width={16} height={16} />
+              </HoverIconButton>
+            </>
+          )}
+        </span>
+      </span>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the nested-button row markup with a stretched-link overlay, so action buttons are no longer descendants of another button.
- Cross-fades the timestamp and action cluster via CSS instead of hover state, which also makes mark-read, go-to-thread, and dismiss reachable by keyboard.

Part of plan: home-feed-notification-cards.md (PR 3 of 7)