### PR TITLE
feat(web): add home feed preview text resolution

### DIFF
--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -194,6 +194,24 @@ describe("resolvePreview", () => {
     ).toBe("Do this first: Then check the log.");
   });
 
+  test("does not close a top-level fence on a bulleted fence line of code", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Head:\n```text\n- ```\nsecret payload\n```",
+    );
+    expect(preview).toBe("Head:");
+    expect(preview).not.toContain("secret payload");
+  });
+
+  test("does not close a list-nested fence on a bulleted fence line of code", () => {
+    const preview = resolvePreview(
+      "Runbook",
+      "Do this first:\n\n- ```text\n  - ```\n  secret payload\n  ```\n\nThen check the log.",
+    );
+    expect(preview).toBe("Do this first: Then check the log.");
+    expect(preview).not.toContain("secret payload");
+  });
+
   test("treats a backtick run with a backticked info string as prose", () => {
     expect(
       resolvePreview("Status check", "```code``` is the reported value"),

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -61,6 +61,61 @@ describe("resolvePreview", () => {
     ).toBe("`api` never came up.");
   });
 
+  test("returns null when the summary only links the title text", () => {
+    expect(
+      resolvePreview("Read docs", "Read [docs](https://example.com)"),
+    ).toBeNull();
+  });
+
+  test("returns the continuation after a linked title prefix", () => {
+    expect(
+      resolvePreview(
+        "Read the docs",
+        "Read the [docs](https://example.com) before rerunning the deploy.",
+      ),
+    ).toBe("before rerunning the deploy.");
+  });
+
+  test("cuts past a whole link when the title ends inside its text", () => {
+    expect(
+      resolvePreview(
+        "Read docs",
+        "Read [docs and specs](https://example.com) before the next deploy.",
+      ),
+    ).toBe("before the next deploy.");
+  });
+
+  test("keeps a link the title does not cover", () => {
+    expect(
+      resolvePreview(
+        "Nightly backup",
+        "See [the report](https://example.com) for volume details.",
+      ),
+    ).toBe("See [the report](https://example.com) for volume details.");
+  });
+
+  test("returns null when strikethrough wraps the whole title", () => {
+    expect(resolvePreview("Deploy failed", "~~Deploy failed~~")).toBeNull();
+  });
+
+  test("returns the continuation after a struck-through title prefix", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "~~Deploy failed~~ because the api worker never reported healthy.",
+      ),
+    ).toBe("because the api worker never reported healthy.");
+  });
+
+  test("handles single-tilde strikethrough in the prefix", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "~Deploy failed~ and the pods stayed down.",
+      ),
+    ).toBe("and the pods stayed down.");
+  });
+
   test("returns null when the continuation is too short", () => {
     expect(resolvePreview("Deploy failed", "Deploy failed on api.")).toBeNull();
   });
@@ -103,9 +158,36 @@ describe("resolvePreview", () => {
     ).toBe("Two files changed. Rerun when ready.");
   });
 
+  test("keeps a fenced line with trailing text inside the block", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Compilation stopped early:\n```ts\n```not-a-close\nconst secret = 1;\n```\n\nSee the job output.",
+      ),
+    ).toBe("Compilation stopped early: See the job output.");
+  });
+
+  test("closes a fenced code block on a fence with trailing spaces", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n```\nstack trace\n```   \nRerun the job.",
+      ),
+    ).toBe("Head of the log: Rerun the job.");
+  });
+
   test("drops an unterminated fenced code block", () => {
     expect(
       resolvePreview("Build log", "Head of the log:\n```\nstack trace here"),
+    ).toBe("Head of the log:");
+  });
+
+  test("drops an unterminated block holding a fence-like line", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n```\n```not-a-close\nstack trace here",
+      ),
     ).toBe("Head of the log:");
   });
 

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -55,6 +55,24 @@ describe("resolvePreview", () => {
     ).toBe("The api worker never reported healthy.");
   });
 
+  test("drops an exclamation mark orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed!",
+        "Deploy failed! The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
+  test("drops a question mark orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed?",
+        "Deploy failed? The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
   test("keeps a code span that starts the continuation", () => {
     expect(
       resolvePreview("Deploy failed", "Deploy failed: `api` never came up."),
@@ -154,6 +172,39 @@ describe("resolvePreview", () => {
       resolvePreview(
         "Build log",
         "Two files changed.\n~~~\ndiff --git a b\n~~~\nRerun when ready.",
+      ),
+    ).toBe("Two files changed. Rerun when ready.");
+  });
+
+  test("drops a fenced code block nested in a blockquote", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n\n> ```\n> secret payload\n> ```\n\nRerun the job.",
+      ),
+    ).toBe("Head of the log: Rerun the job.");
+  });
+
+  test("drops a fenced code block nested in a list item", () => {
+    expect(
+      resolvePreview(
+        "Runbook",
+        "Do this first:\n\n- ```\n  vellum run\n  ```\n\nThen check the log.",
+      ),
+    ).toBe("Do this first: Then check the log.");
+  });
+
+  test("treats a backtick run with a backticked info string as prose", () => {
+    expect(
+      resolvePreview("Status check", "```code``` is the reported value"),
+    ).toBe("```code``` is the reported value");
+  });
+
+  test("still opens a tilde fence whose info string holds a backtick", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Two files changed.\n~~~`js`\ndiff --git a b\n~~~\nRerun when ready.",
       ),
     ).toBe("Two files changed. Rerun when ready.");
   });

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -1,0 +1,144 @@
+/** Tests for `resolvePreview`, the feed card's preview text resolver. */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolvePreview } from "./feed-preview";
+
+describe("resolvePreview", () => {
+  test("keeps inline emphasis in a flattened summary", () => {
+    expect(
+      resolvePreview(
+        "Watcher job failed",
+        "**Error:** message channel closed before a response was received.",
+      ),
+    ).toBe("**Error:** message channel closed before a response was received.");
+  });
+
+  test("passes a genuinely distinct summary through untouched", () => {
+    expect(
+      resolvePreview("Nightly backup", "All three volumes verified."),
+    ).toBe("All three volumes verified.");
+  });
+
+  test("returns null when the title and the summary are identical", () => {
+    const text = "Deploy finished without incident";
+    expect(resolvePreview(text, text)).toBeNull();
+  });
+
+  test("ignores emphasis and trailing punctuation when matching", () => {
+    expect(resolvePreview("Deploy failed", "**Deploy failed.**")).toBeNull();
+  });
+
+  test("returns the continuation when the title is a prefix of the summary", () => {
+    const preview = resolvePreview(
+      "Deploy failed",
+      "Deploy failed because the api worker never reported healthy.",
+    );
+    expect(preview).toBe("because the api worker never reported healthy.");
+  });
+
+  test("keeps emphasis intact in the continuation", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "**Deploy failed** because the `api` worker never reported healthy.",
+      ),
+    ).toBe("because the `api` worker never reported healthy.");
+  });
+
+  test("drops a closing emphasis marker orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "**Deploy failed.** The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
+  test("keeps a code span that starts the continuation", () => {
+    expect(
+      resolvePreview("Deploy failed", "Deploy failed: `api` never came up."),
+    ).toBe("`api` never came up.");
+  });
+
+  test("returns null when the continuation is too short", () => {
+    expect(resolvePreview("Deploy failed", "Deploy failed on api.")).toBeNull();
+  });
+
+  test("strips headings and bullets while preserving inline bold", () => {
+    expect(
+      resolvePreview(
+        "Deploy report",
+        "## Deploy failed\n\n- **api** timed out\n- worker OK",
+      ),
+    ).toBe("Deploy failed **api** timed out worker OK");
+  });
+
+  test("strips ordered list markers in both delimiter forms", () => {
+    expect(
+      resolvePreview("Steps", "1. Pull the image\n2) Restart the pod"),
+    ).toBe("Pull the image Restart the pod");
+  });
+
+  test("strips blockquote markers, including nested bullets", () => {
+    expect(
+      resolvePreview("Quoted", "> The check timed out\n> - retry scheduled"),
+    ).toBe("The check timed out retry scheduled");
+  });
+
+  test("drops fenced code block contents", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Compilation stopped early:\n\n```ts\nconst secret = 1;\n```\n\nSee the job output.",
+    );
+    expect(preview).toBe("Compilation stopped early: See the job output.");
+  });
+
+  test("drops tilde fenced code block contents", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Two files changed.\n~~~\ndiff --git a b\n~~~\nRerun when ready.",
+      ),
+    ).toBe("Two files changed. Rerun when ready.");
+  });
+
+  test("drops an unterminated fenced code block", () => {
+    expect(
+      resolvePreview("Build log", "Head of the log:\n```\nstack trace here"),
+    ).toBe("Head of the log:");
+  });
+
+  test("drops GFM table delimiter rows", () => {
+    expect(
+      resolvePreview(
+        "Table",
+        "| Job | State |\n| --- | :---: |\n| api | failed |",
+      ),
+    ).toBe("| Job | State | | api | failed |");
+  });
+
+  test("handles CRLF line endings", () => {
+    expect(
+      resolvePreview("Report", "## Deploy failed\r\n\r\n- api timed out"),
+    ).toBe("Deploy failed api timed out");
+  });
+
+  test("returns null for a whitespace-only summary", () => {
+    expect(resolvePreview("Anything", "   \n\t\r\n  ")).toBeNull();
+  });
+
+  test("returns null for an empty summary", () => {
+    expect(resolvePreview("Anything", "")).toBeNull();
+  });
+
+  test("returns null when the summary is only a fenced code block", () => {
+    expect(resolvePreview("Snippet", "```\nconst a = 1;\n```")).toBeNull();
+  });
+
+  test("does not treat a shared word prefix as a derived title", () => {
+    expect(resolvePreview("Deploy", "Deployment queue is backed up")).toBe(
+      "Deployment queue is backed up",
+    );
+  });
+});

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -4,6 +4,14 @@ import { describe, expect, test } from "bun:test";
 
 import { resolvePreview } from "./feed-preview";
 
+/** The daemon's `NOTIFICATION_TITLE_MAX_LENGTH`, the clamp `deriveTitle` uses. */
+const DERIVED_TITLE_MAX_LENGTH = 60;
+
+/** Build a title the way the daemon's `deriveTitle` builds an over-long one. */
+function deriveTruncatedTitle(body: string, ellipsis: string): string {
+  return body.slice(0, DERIVED_TITLE_MAX_LENGTH).trim() + ellipsis;
+}
+
 describe("resolvePreview", () => {
   test("unwraps inline emphasis in a flattened summary", () => {
     expect(
@@ -366,6 +374,36 @@ describe("resolvePreview", () => {
     expect(resolvePreview("Deploy", "Deployment queue is backed up")).toBe(
       "Deployment queue is backed up",
     );
+  });
+
+  test("matches a derived title clamped with a horizontal ellipsis", () => {
+    const summary =
+      "Deploy failed because the api worker never reported healthy after three restarts.";
+    const title = deriveTruncatedTitle(summary, "…");
+    // The first sentence runs past the clamp, which is what appends the ellipsis.
+    expect(summary.length).toBeGreaterThan(DERIVED_TITLE_MAX_LENGTH);
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("after three restarts.");
+    expect(preview).not.toContain("Deploy failed");
+    expect(preview).not.toContain("api worker");
+  });
+
+  test("matches a derived title clamped with three periods", () => {
+    const summary =
+      "Deploy failed because the api worker never reported healthy after three restarts.";
+    const title = deriveTruncatedTitle(summary, "...");
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("after three restarts.");
+    expect(preview).not.toContain("Deploy failed");
+  });
+
+  test("keeps the whole preview when an ellipsized title is not a prefix", () => {
+    const summary =
+      "The api worker never reported healthy after three restarts.";
+    expect(resolvePreview("Waiting on the deploy…", summary)).toBe(summary);
+    expect(resolvePreview("Waiting on the deploy...", summary)).toBe(summary);
   });
 
   test("does not split a decomposed letter away from its combining mark", () => {

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -94,22 +94,40 @@ describe("resolvePreview", () => {
     ).toBe("before rerunning the deploy.");
   });
 
-  test("cuts past a whole link when the title ends inside its text", () => {
+  test("keeps link text the title only partly covers", () => {
     expect(
       resolvePreview(
         "Read docs",
         "Read [docs and specs](https://example.com) before the next deploy.",
       ),
-    ).toBe("before the next deploy.");
+    ).toBe("and specs before the next deploy.");
   });
 
-  test("keeps a link the title does not cover", () => {
+  test("unwraps a link the title does not cover", () => {
     expect(
       resolvePreview(
         "Nightly backup",
         "See [the report](https://example.com) for volume details.",
       ),
-    ).toBe("See [the report](https://example.com) for volume details.");
+    ).toBe("See the report for volume details.");
+  });
+
+  test("unwraps a reference link to its text", () => {
+    expect(
+      resolvePreview(
+        "Nightly backup",
+        "See [the report][r] for volume details.\n\n[r]: https://example.com",
+      ),
+    ).toBe("See the report for volume details.");
+  });
+
+  test("does not strand a destination holding an escaped closing paren", () => {
+    const preview = resolvePreview(
+      "Read docs",
+      "Read [docs](a\\)) before rerunning the deploy.",
+    );
+    expect(preview).toBe("before rerunning the deploy.");
+    expect(preview?.startsWith(")")).toBe(false);
   });
 
   test("returns null when strikethrough wraps the whole title", () => {
@@ -185,6 +203,15 @@ describe("resolvePreview", () => {
     ).toBe("Head of the log: Rerun the job.");
   });
 
+  test("closes a blockquoted fence whose marker carries no space", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Head:\n> ```\n> payload\n>```\nAfter",
+    );
+    expect(preview).toBe("Head: After");
+    expect(preview).not.toContain("payload");
+  });
+
   test("drops a fenced code block nested in a list item", () => {
     expect(
       resolvePreview(
@@ -212,10 +239,10 @@ describe("resolvePreview", () => {
     expect(preview).not.toContain("secret payload");
   });
 
-  test("treats a backtick run with a backticked info string as prose", () => {
+  test("treats a backtick run with a backticked info string as an inline span", () => {
     expect(
       resolvePreview("Status check", "```code``` is the reported value"),
-    ).toBe("```code``` is the reported value");
+    ).toBe("`code` is the reported value");
   });
 
   test("still opens a tilde fence whose info string holds a backtick", () => {
@@ -260,13 +287,25 @@ describe("resolvePreview", () => {
     ).toBe("Head of the log:");
   });
 
-  test("drops GFM table delimiter rows", () => {
-    expect(
-      resolvePreview(
-        "Table",
-        "| Job | State |\n| --- | :---: |\n| api | failed |",
-      ),
-    ).toBe("| Job | State | | api | failed |");
+  test("flattens a GFM table to its cell text", () => {
+    const preview = resolvePreview(
+      "Table",
+      "| Job | State |\n| --- | :---: |\n| api | failed |",
+    );
+    expect(preview).toBe("Job State api failed");
+    expect(preview).not.toContain("---");
+  });
+
+  test("drops thematic breaks written with asterisks", () => {
+    const preview = resolvePreview("Rollout notes", "Before\n\n***\n\nAfter");
+    expect(preview).toBe("Before After");
+    expect(preview).not.toContain("***");
+  });
+
+  test("drops thematic breaks written with underscores", () => {
+    const preview = resolvePreview("Rollout notes", "Before\n\n___\n\nAfter");
+    expect(preview).toBe("Before After");
+    expect(preview).not.toContain("___");
   });
 
   test("handles CRLF line endings", () => {
@@ -291,5 +330,15 @@ describe("resolvePreview", () => {
     expect(resolvePreview("Deploy", "Deployment queue is backed up")).toBe(
       "Deployment queue is backed up",
     );
+  });
+
+  test("does not split a decomposed letter away from its combining mark", () => {
+    const combiningAcute = "\u0301";
+    const summary = `Cafe${combiningAcute} outage affected the api worker`;
+    expect(summary).toBe(summary.normalize("NFD"));
+
+    const preview = resolvePreview("Cafe", summary);
+    expect(preview).toBe(summary);
+    expect(preview?.startsWith(combiningAcute)).toBe(false);
   });
 });

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -5,13 +5,13 @@ import { describe, expect, test } from "bun:test";
 import { resolvePreview } from "./feed-preview";
 
 describe("resolvePreview", () => {
-  test("keeps inline emphasis in a flattened summary", () => {
+  test("unwraps inline emphasis in a flattened summary", () => {
     expect(
       resolvePreview(
         "Watcher job failed",
         "**Error:** message channel closed before a response was received.",
       ),
-    ).toBe("**Error:** message channel closed before a response was received.");
+    ).toBe("Error: message channel closed before a response was received.");
   });
 
   test("passes a genuinely distinct summary through untouched", () => {
@@ -37,16 +37,16 @@ describe("resolvePreview", () => {
     expect(preview).toBe("because the api worker never reported healthy.");
   });
 
-  test("keeps emphasis intact in the continuation", () => {
+  test("unwraps emphasis and code spans in the continuation", () => {
     expect(
       resolvePreview(
         "Deploy failed",
         "**Deploy failed** because the `api` worker never reported healthy.",
       ),
-    ).toBe("because the `api` worker never reported healthy.");
+    ).toBe("because the api worker never reported healthy.");
   });
 
-  test("drops a closing emphasis marker orphaned by the slice", () => {
+  test("drops a bold title's trailing period orphaned by the slice", () => {
     expect(
       resolvePreview(
         "Deploy failed",
@@ -73,10 +73,10 @@ describe("resolvePreview", () => {
     ).toBe("The api worker never reported healthy.");
   });
 
-  test("keeps a code span that starts the continuation", () => {
+  test("unwraps a code span that starts the continuation", () => {
     expect(
       resolvePreview("Deploy failed", "Deploy failed: `api` never came up."),
-    ).toBe("`api` never came up.");
+    ).toBe("api never came up.");
   });
 
   test("returns null when the summary only links the title text", () => {
@@ -156,13 +156,13 @@ describe("resolvePreview", () => {
     expect(resolvePreview("Deploy failed", "Deploy failed on api.")).toBeNull();
   });
 
-  test("strips headings and bullets while preserving inline bold", () => {
+  test("strips headings and bullets and unwraps inline bold", () => {
     expect(
       resolvePreview(
         "Deploy report",
         "## Deploy failed\n\n- **api** timed out\n- worker OK",
       ),
-    ).toBe("Deploy failed **api** timed out worker OK");
+    ).toBe("Deploy failed api timed out worker OK");
   });
 
   test("strips ordered list markers in both delimiter forms", () => {
@@ -242,7 +242,43 @@ describe("resolvePreview", () => {
   test("treats a backtick run with a backticked info string as an inline span", () => {
     expect(
       resolvePreview("Status check", "```code``` is the reported value"),
-    ).toBe("`code` is the reported value");
+    ).toBe("code is the reported value");
+  });
+
+  test("unwraps a code span whose content holds a backtick", () => {
+    const preview = resolvePreview(
+      "Shell tip",
+      "Use ``a ` b`` in the shell without escaping.",
+    );
+    expect(preview).toBe("Use a ` b in the shell without escaping.");
+  });
+
+  test("keeps escaped asterisks as literal text", () => {
+    expect(
+      resolvePreview(
+        "Export formatting",
+        "The label reads \\* literal stars \\* exactly as typed.",
+      ),
+    ).toBe("The label reads * literal stars * exactly as typed.");
+    expect(
+      resolvePreview(
+        "Export formatting",
+        "The label reads \\*literal stars\\* exactly as typed.",
+      ),
+    ).toBe("The label reads *literal stars* exactly as typed.");
+  });
+
+  test("returns a markdown-rich summary as plain text", () => {
+    const preview = resolvePreview(
+      "Release notes",
+      "## Rollout\n\n- **api** is `healthy` after the [runbook](https://example.com) steps\n- *worker* recovered",
+    );
+    expect(preview).toBe(
+      "Rollout api is healthy after the runbook steps worker recovered",
+    );
+    for (const character of ["*", "`", "#", "[", "]"]) {
+      expect(preview).not.toContain(character);
+    }
   });
 
   test("still opens a tilde fence whose info string holds a backtick", () => {

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -371,9 +371,9 @@ describe("resolvePreview", () => {
   });
 
   test("does not treat a shared word prefix as a derived title", () => {
-    expect(resolvePreview("Deploy", "Deployment queue is backed up")).toBe(
-      "Deployment queue is backed up",
-    );
+    const preview = resolvePreview("Deploy", "Deployment queue is backed up");
+    expect(preview).toBe("Deployment queue is backed up");
+    expect(preview).not.toBe("ment queue is backed up");
   });
 
   test("matches a derived title clamped with a horizontal ellipsis", () => {
@@ -397,6 +397,30 @@ describe("resolvePreview", () => {
     const preview = resolvePreview(title, summary);
     expect(preview).toBe("after three restarts.");
     expect(preview).not.toContain("Deploy failed");
+  });
+
+  test("keeps the straddled word whole when the clamp cuts mid-word", () => {
+    const summary =
+      "Deploy failed because the api worker never reported unhealthy after restarts.";
+    const title = deriveTruncatedTitle(summary, "…");
+    // The clamp lands inside "unhealthy", which is what the marker signals.
+    expect(title).toBe(
+      "Deploy failed because the api worker never reported unhealth…",
+    );
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("unhealthy after restarts.");
+    expect(preview?.startsWith("y ")).toBe(false);
+  });
+
+  test("keeps the straddled word whole for a three-period clamp", () => {
+    const summary =
+      "Deploy failed because the api worker never reported unhealthy after restarts.";
+    const title = deriveTruncatedTitle(summary, "...");
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("unhealthy after restarts.");
+    expect(preview?.startsWith("y ")).toBe(false);
   });
 
   test("keeps the whole preview when an ellipsized title is not a prefix", () => {

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -17,8 +17,13 @@ const MIN_PREVIEW_LENGTH = 12;
  * Sentence punctuation, ignored at the end of a comparison form and left
  * dangling once a title prefix is sliced away. Both sites read this one set,
  * so the slice can never strand a character the comparison already discounted.
+ *
+ * The horizontal ellipsis is in here so a title the producer truncated compares
+ * as its unellipsized text and is still recognized as derived from the summary.
+ * The three-period form falls out of `.` already being a member, since the
+ * trailing trim runs over the whole punctuation run.
  */
-const SENTENCE_PUNCTUATION = ".,;:!?-";
+const SENTENCE_PUNCTUATION = ".,;:!?-…";
 
 /**
  * The parts of a markdown node the flattener reads. Structural rather than
@@ -172,8 +177,8 @@ function normalizedCharacters(value: string): NormalizedCharacter[] {
 
 /**
  * Reduce a string to the form used for title-versus-preview comparison, so
- * that case, spacing, and a trailing period never make two equivalent strings
- * look different.
+ * that case, spacing, and trailing sentence punctuation never make two
+ * equivalent strings look different.
  */
 function normalizeForCompare(value: string): string {
   const flattened = normalizedCharacters(value)

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -1,7 +1,9 @@
 /**
  * Preview text resolution for home feed cards. A feed item's `summary` is
- * markdown, so it has to be flattened to a single line before it can sit under
- * the title, and suppressed entirely when it would only restate that title.
+ * markdown, so it has to be flattened to a single line of plain text before it
+ * can sit under the title, and suppressed entirely when it would only restate
+ * that title. The returned string carries no markdown syntax and is meant to be
+ * rendered directly.
  */
 
 import remarkGfm from "remark-gfm";
@@ -10,12 +12,6 @@ import { unified } from "unified";
 
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
-
-/**
- * Inline punctuation ignored when comparing a preview to a title: emphasis,
- * code span, and strikethrough markers.
- */
-const INLINE_MARK_PUNCTUATION = "*_`~";
 
 /**
  * Sentence punctuation, ignored at the end of a comparison form and left
@@ -69,10 +65,9 @@ function trimTrailingSentencePunctuation(value: string): string {
 }
 
 /**
- * Turn multi-line markdown into a single line, dropping block structure and
- * code while keeping inline emphasis (`**bold**`, `*em*`, backtick code) so
- * the result can be rendered as inline markdown. A link contributes its text
- * and drops its destination.
+ * Turn multi-line markdown into a single line of plain text, dropping block
+ * structure and code blocks and unwrapping every inline marker. A link
+ * contributes its text and drops its destination.
  */
 function flattenMarkdownBlocks(summary: string): string {
   const tree = markdownParser.parse(summary) as MarkdownNode;
@@ -88,27 +83,18 @@ function flattenNode(node: MarkdownNode): string {
     case "yaml": {
       return "";
     }
+    case "inlineCode":
     case "text": {
       return node.value ?? "";
-    }
-    case "inlineCode": {
-      const value = node.value ?? "";
-      return value.length === 0 ? "" : `\`${value}\``;
     }
     case "break": {
       return " ";
     }
-    case "strong": {
-      const inner = flattenChildren(node);
-      return inner.length === 0 ? "" : `**${inner}**`;
-    }
-    case "emphasis": {
-      const inner = flattenChildren(node);
-      return inner.length === 0 ? "" : `*${inner}*`;
-    }
     case "delete":
+    case "emphasis":
     case "link":
-    case "linkReference": {
+    case "linkReference":
+    case "strong": {
       return flattenChildren(node);
     }
     case "image":
@@ -154,12 +140,11 @@ interface NormalizedCharacter {
 
 /**
  * Emit the comparison form of `value` one character at a time, recording where
- * each character ends in the source. Emphasis, code span, and strikethrough
- * punctuation is dropped, whitespace runs collapse to a single space, and
- * leading whitespace is skipped.
+ * each character ends in the source. Whitespace runs collapse to a single
+ * space, leading whitespace is skipped, and letters are lowercased.
  *
  * Comparison and slicing both read this one walk, so the offset a slice cuts
- * at can never drift from what the comparison removed.
+ * at can never drift from what the comparison collapsed.
  */
 function normalizedCharacters(value: string): NormalizedCharacter[] {
   const characters: NormalizedCharacter[] = [];
@@ -167,9 +152,6 @@ function normalizedCharacters(value: string): NormalizedCharacter[] {
 
   for (let index = 0; index < value.length; index += 1) {
     const char = value[index];
-    if (INLINE_MARK_PUNCTUATION.includes(char)) {
-      continue;
-    }
     const end = index + 1;
     if (/\s/.test(char)) {
       if (previousWasSpace || characters.length === 0) {
@@ -190,8 +172,8 @@ function normalizedCharacters(value: string): NormalizedCharacter[] {
 
 /**
  * Reduce a string to the form used for title-versus-preview comparison, so
- * that inline markup, spacing, and a trailing period never make two equivalent
- * strings look different.
+ * that case, spacing, and a trailing period never make two equivalent strings
+ * look different.
  */
 function normalizeForCompare(value: string): string {
   const flattened = normalizedCharacters(value)
@@ -224,24 +206,17 @@ function sliceAfterNormalizedPrefix(
 }
 
 /**
- * Clean up the join between a sliced-off title and the text that follows it:
- * leading whitespace, sentence punctuation, and any inline markers left
- * closing a run whose opener went with the title. A marker is only debris
- * while it abuts the cut, so a backtick after a space (the start of a real
- * inline code span) is kept.
+ * Clean up the join between a sliced-off title and the text that follows it,
+ * dropping the leading whitespace and sentence punctuation the cut leaves
+ * behind.
  */
 function stripSliceDebris(value: string): string {
   let index = 0;
-  let sawWhitespace = false;
   while (index < value.length) {
     const char = value[index];
-    const isWhitespace = /\s/.test(char);
-    const isClosingMark =
-      !sawWhitespace && INLINE_MARK_PUNCTUATION.includes(char);
-    if (!isWhitespace && !isClosingMark && !isSentencePunctuation(char)) {
+    if (!/\s/.test(char) && !isSentencePunctuation(char)) {
       break;
     }
-    sawWhitespace = sawWhitespace || isWhitespace;
     index += 1;
   }
   return value.slice(index);

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -4,27 +4,12 @@
  * the title, and suppressed entirely when it would only restate that title.
  */
 
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
-
-/**
- * Opening fence of a code block, allowing up to 3 leading spaces. The second
- * group is the info string, which decides whether a backtick run really opens
- * a block (see `matchFenceOpen`).
- */
-const CODE_FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
-
-/**
- * Closing fence of a code block. Nothing but whitespace may follow the fence
- * run, so a line that carries trailing text is code rather than a close.
- */
-const CODE_FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})\s*$/;
-
-/** ATX heading, blockquote, or list bullet at the start of a line. */
-const BLOCK_MARKER_PATTERN = /^ {0,3}(?:#{1,6}\s+|>\s?|[-*+]\s+|\d+[.)]\s+)/;
-
-/** A GFM table delimiter row, plus thematic breaks and blank lines. */
-const STRUCTURAL_ROW_PATTERN = /^[\s|:-]*$/;
 
 /**
  * Inline punctuation ignored when comparing a preview to a title: emphasis,
@@ -39,6 +24,38 @@ const INLINE_MARK_PUNCTUATION = "*_`~";
  */
 const SENTENCE_PUNCTUATION = ".,;:!?-";
 
+/**
+ * The parts of a markdown node the flattener reads. Structural rather than
+ * imported so the walk stays tolerant of node types remark adds.
+ */
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  alt?: string | null;
+  children?: MarkdownNode[];
+}
+
+/**
+ * Node types that carry inline content. Inline siblings run together with no
+ * separator; every other node is a block and is spaced away from its
+ * neighbours.
+ */
+const INLINE_NODE_TYPES = new Set([
+  "break",
+  "delete",
+  "emphasis",
+  "footnoteReference",
+  "image",
+  "imageReference",
+  "inlineCode",
+  "link",
+  "linkReference",
+  "strong",
+  "text",
+]);
+
+const markdownParser = unified().use(remarkParse).use(remarkGfm);
+
 function isSentencePunctuation(char: string): boolean {
   return SENTENCE_PUNCTUATION.includes(char);
 }
@@ -52,107 +69,78 @@ function trimTrailingSentencePunctuation(value: string): string {
 }
 
 /**
- * Turn multi-line markdown into a single line, dropping block syntax while
- * keeping inline emphasis (`**bold**`, `*em*`, backtick code, links) so the
- * result can be rendered as inline markdown.
- *
- * This is the web-side counterpart to the deblocking in
- * `assistant/src/util/short-title.ts`. Web cannot import daemon code, so the
- * two are kept in step by hand.
+ * Turn multi-line markdown into a single line, dropping block structure and
+ * code while keeping inline emphasis (`**bold**`, `*em*`, backtick code) so
+ * the result can be rendered as inline markdown. A link contributes its text
+ * and drops its destination.
  */
 function flattenMarkdownBlocks(summary: string): string {
-  const lines = summary.replace(/\r\n?/g, "\n").split("\n");
-  const kept: string[] = [];
-  let openFence: string | null = null;
-  let openFenceContainer = "";
+  const tree = markdownParser.parse(summary) as MarkdownNode;
+  return flattenNode(tree).replace(/\s+/g, " ").trim();
+}
 
-  for (const line of lines) {
-    if (openFence !== null) {
-      const inside = stripFenceContainer(line, openFenceContainer);
-      const close =
-        inside === null
-          ? undefined
-          : CODE_FENCE_CLOSE_PATTERN.exec(inside)?.[1];
-      if (
-        close !== undefined &&
-        close[0] === openFence[0] &&
-        close.length >= openFence.length
-      ) {
-        openFence = null;
+/** The single-line text a node contributes to the preview. */
+function flattenNode(node: MarkdownNode): string {
+  switch (node.type) {
+    case "code":
+    case "html":
+    case "thematicBreak":
+    case "yaml": {
+      return "";
+    }
+    case "text": {
+      return node.value ?? "";
+    }
+    case "inlineCode": {
+      const value = node.value ?? "";
+      return value.length === 0 ? "" : `\`${value}\``;
+    }
+    case "break": {
+      return " ";
+    }
+    case "strong": {
+      const inner = flattenChildren(node);
+      return inner.length === 0 ? "" : `**${inner}**`;
+    }
+    case "emphasis": {
+      const inner = flattenChildren(node);
+      return inner.length === 0 ? "" : `*${inner}*`;
+    }
+    case "delete":
+    case "link":
+    case "linkReference": {
+      return flattenChildren(node);
+    }
+    case "image":
+    case "imageReference": {
+      const alt = node.alt ?? "";
+      return alt.trim().length === 0 ? "" : alt;
+    }
+    default: {
+      if (node.children !== undefined) {
+        return flattenChildren(node);
       }
-      // A block that never closes swallows the rest of the summary.
-      continue;
+      return node.value ?? "";
     }
-    // Container markers come off first so a fence nested in a blockquote or a
-    // list item is recognized the same way a top-level one is.
-    const stripped = stripBlockMarkers(line);
-    const opener = matchFenceOpen(stripped);
-    if (opener !== null) {
-      openFence = opener;
-      openFenceContainer = line.slice(0, line.length - stripped.length);
-      continue;
-    }
-    if (STRUCTURAL_ROW_PATTERN.test(stripped)) {
-      continue;
-    }
-    kept.push(stripped);
   }
-
-  return kept.join(" ").replace(/\s+/g, " ").trim();
 }
 
 /**
- * The fence run that opens a code block on `line`, or `null` when the line is
- * ordinary text.
- *
- * A backtick fence's info string may not itself contain a backtick, so a line
- * that opens with a backtick run and carries another one later is prose around
- * an inline code span. Tilde fences carry no such restriction.
+ * Concatenate what a node's children contribute, separating each block from
+ * the one before it with a single space. Children that contribute nothing,
+ * such as a dropped code block, never introduce a separator of their own.
  */
-function matchFenceOpen(line: string): string | null {
-  const match = CODE_FENCE_OPEN_PATTERN.exec(line);
-  if (match === null) {
-    return null;
-  }
-  const [, fence, info] = match;
-  if (fence.startsWith("`") && info.includes("`")) {
-    return null;
-  }
-  return fence;
-}
-
-/**
- * The part of `line` that sits inside the container holding an open fence, or
- * `null` when the line is not a continuation of that container and so cannot
- * close the fence.
- *
- * `container` is the literal marker run that preceded the opening fence. A
- * continuation line either repeats it verbatim, the way a blockquote does, or
- * replaces it with indentation of the same width, the way a list item does.
- * Only those two forms are accepted, so a line of code that happens to look
- * like a bulleted fence is never mistaken for the closing delimiter.
- */
-function stripFenceContainer(line: string, container: string): string | null {
-  if (container.length === 0) {
-    return line;
-  }
-  if (line.startsWith(container)) {
-    return line.slice(container.length);
-  }
-  const lead = line.slice(0, container.length);
-  if (lead.length === container.length && /^[ \t]+$/.test(lead)) {
-    return line.slice(container.length);
-  }
-  return null;
-}
-
-/** Peel leading block markers off a line, including nested ones like `> - x`. */
-function stripBlockMarkers(line: string): string {
-  let result = line;
-  let previous = "";
-  while (result !== previous) {
-    previous = result;
-    result = result.replace(BLOCK_MARKER_PATTERN, "");
+function flattenChildren(node: MarkdownNode): string {
+  let result = "";
+  for (const child of node.children ?? []) {
+    const text = flattenNode(child);
+    if (text.length === 0) {
+      continue;
+    }
+    if (result.length > 0 && !INLINE_NODE_TYPES.has(child.type)) {
+      result += " ";
+    }
+    result += text;
   }
   return result;
 }
@@ -164,54 +152,25 @@ interface NormalizedCharacter {
   end: number;
 }
 
-/** Text range of an inline link and the end of the whole `[text](url)` run. */
-interface InlineLinkSpan {
-  textStart: number;
-  textEnd: number;
-  end: number;
-}
-
 /**
  * Emit the comparison form of `value` one character at a time, recording where
  * each character ends in the source. Emphasis, code span, and strikethrough
- * punctuation is dropped, a link is reduced to its text, whitespace runs
- * collapse to a single space, and leading whitespace is skipped.
+ * punctuation is dropped, whitespace runs collapse to a single space, and
+ * leading whitespace is skipped.
  *
  * Comparison and slicing both read this one walk, so the offset a slice cuts
- * at can never drift from what the comparison removed. Every character of a
- * link's text reports the end of the whole link, which keeps a cut inside that
- * text from stranding the destination in the output.
+ * at can never drift from what the comparison removed.
  */
 function normalizedCharacters(value: string): NormalizedCharacter[] {
   const characters: NormalizedCharacter[] = [];
-  let index = 0;
   let previousWasSpace = false;
-  let linkTextEnd = -1;
-  let linkEnd = -1;
 
-  while (index < value.length) {
-    if (index === linkTextEnd) {
-      index = linkEnd;
-      linkTextEnd = -1;
-      linkEnd = -1;
-      continue;
-    }
-    if (linkEnd === -1) {
-      const link = matchInlineLink(value, index);
-      if (link !== null) {
-        linkTextEnd = link.textEnd;
-        linkEnd = link.end;
-        index = link.textStart;
-        continue;
-      }
-    }
-
+  for (let index = 0; index < value.length; index += 1) {
     const char = value[index];
-    index += 1;
     if (INLINE_MARK_PUNCTUATION.includes(char)) {
       continue;
     }
-    const end = linkEnd === -1 ? index : linkEnd;
+    const end = index + 1;
     if (/\s/.test(char)) {
       if (previousWasSpace || characters.length === 0) {
         continue;
@@ -227,48 +186,6 @@ function normalizedCharacters(value: string): NormalizedCharacter[] {
   }
 
   return characters;
-}
-
-/**
- * Match an inline link `[text](destination)` at `start`, or return `null` when
- * the brackets never close into one.
- */
-function matchInlineLink(value: string, start: number): InlineLinkSpan | null {
-  if (value[start] !== "[") {
-    return null;
-  }
-
-  let bracketDepth = 0;
-  let textEnd = -1;
-  for (let index = start; index < value.length; index += 1) {
-    const char = value[index];
-    if (char === "[") {
-      bracketDepth += 1;
-    } else if (char === "]") {
-      bracketDepth -= 1;
-      if (bracketDepth === 0) {
-        textEnd = index;
-        break;
-      }
-    }
-  }
-  if (textEnd === -1 || value[textEnd + 1] !== "(") {
-    return null;
-  }
-
-  let parenDepth = 0;
-  for (let index = textEnd + 1; index < value.length; index += 1) {
-    const char = value[index];
-    if (char === "(") {
-      parenDepth += 1;
-    } else if (char === ")") {
-      parenDepth -= 1;
-      if (parenDepth === 0) {
-        return { textStart: start + 1, textEnd, end: index + 1 };
-      }
-    }
-  }
-  return null;
 }
 
 /**
@@ -334,13 +251,16 @@ function stripSliceDebris(value: string): string {
  * True when `value` opens with `prefix` and that prefix ends on a word
  * boundary, so a title of "Deploy" is not read as a prefix of "Deployment
  * queue is backed up".
+ *
+ * Combining marks count as part of the preceding word, so a decomposed letter
+ * straddling the cut ("Cafe" against "Café") is not a boundary.
  */
 function startsWithWholeWords(value: string, prefix: string): boolean {
   if (!value.startsWith(prefix)) {
     return false;
   }
   const next = value[prefix.length];
-  return next === undefined || !/[\p{L}\p{N}]/u.test(next);
+  return next === undefined || !/[\p{L}\p{M}\p{N}]/u.test(next);
 }
 
 /**

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -1,0 +1,209 @@
+/**
+ * Preview text resolution for home feed cards. A feed item's `summary` is
+ * markdown, so it has to be flattened to a single line before it can sit under
+ * the title, and suppressed entirely when it would only restate that title.
+ */
+
+/** Shortest continuation worth showing after the title's prefix is removed. */
+const MIN_PREVIEW_LENGTH = 12;
+
+/** Opening or closing fence of a code block, allowing up to 3 leading spaces. */
+const CODE_FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+
+/** ATX heading, blockquote, or list bullet at the start of a line. */
+const BLOCK_MARKER_PATTERN = /^ {0,3}(?:#{1,6}\s+|>\s?|[-*+]\s+|\d+[.)]\s+)/;
+
+/** A GFM table delimiter row, plus thematic breaks and blank lines. */
+const STRUCTURAL_ROW_PATTERN = /^[\s|:-]*$/;
+
+/**
+ * Inline emphasis punctuation ignored when comparing a preview to a title.
+ * The set and the pattern share one source so the comparison and the
+ * character walk that maps back into the original string cannot drift.
+ */
+const EMPHASIS_PUNCTUATION = "*_`";
+const EMPHASIS_PUNCTUATION_PATTERN = new RegExp(
+  `[${EMPHASIS_PUNCTUATION}]`,
+  "g",
+);
+
+/** Sentence punctuation left dangling once a title prefix is sliced away. */
+const SENTENCE_PUNCTUATION = ".,;:-";
+
+/** Sentence punctuation ignored at the end of a comparison. */
+const TRAILING_PUNCTUATION_PATTERN = /[.,;:!?-]+$/;
+
+/**
+ * Turn multi-line markdown into a single line, dropping block syntax while
+ * keeping inline emphasis (`**bold**`, `*em*`, backtick code, links) so the
+ * result can be rendered as inline markdown.
+ *
+ * This is the web-side counterpart to the deblocking in
+ * `assistant/src/util/short-title.ts`. Web cannot import daemon code, so the
+ * two are kept in step by hand.
+ */
+function flattenMarkdownBlocks(summary: string): string {
+  const lines = summary.replace(/\r\n?/g, "\n").split("\n");
+  const kept: string[] = [];
+  let openFence: string | null = null;
+
+  for (const line of lines) {
+    const fence = CODE_FENCE_PATTERN.exec(line)?.[1];
+    if (openFence !== null) {
+      if (
+        fence !== undefined &&
+        fence[0] === openFence[0] &&
+        fence.length >= openFence.length
+      ) {
+        openFence = null;
+      }
+      continue;
+    }
+    if (fence !== undefined) {
+      openFence = fence;
+      continue;
+    }
+    const stripped = stripBlockMarkers(line);
+    if (STRUCTURAL_ROW_PATTERN.test(stripped)) {
+      continue;
+    }
+    kept.push(stripped);
+  }
+
+  return kept.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/** Peel leading block markers off a line, including nested ones like `> - x`. */
+function stripBlockMarkers(line: string): string {
+  let result = line;
+  let previous = "";
+  while (result !== previous) {
+    previous = result;
+    result = result.replace(BLOCK_MARKER_PATTERN, "");
+  }
+  return result;
+}
+
+/**
+ * Reduce a string to the form used for title-versus-preview comparison, so
+ * that emphasis, spacing, and a trailing period never make two equivalent
+ * strings look different.
+ */
+function normalizeForCompare(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(EMPHASIS_PUNCTUATION_PATTERN, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(TRAILING_PUNCTUATION_PATTERN, "")
+    .trim();
+}
+
+/**
+ * Drop the first `normalizedLength` normalized characters from `original` and
+ * return what is left of the untouched string.
+ *
+ * Normalization changes length, so the offset cannot be reused directly. The
+ * two strings are walked in parallel instead: every original character is
+ * consumed in turn, and the normalized counter only advances for characters
+ * that survive normalization.
+ */
+function sliceAfterNormalizedPrefix(
+  original: string,
+  normalizedLength: number,
+): string {
+  let consumed = 0;
+  let index = 0;
+  let previousWasSpace = false;
+
+  while (index < original.length && consumed < normalizedLength) {
+    const char = original[index];
+    index += 1;
+    if (EMPHASIS_PUNCTUATION.includes(char)) {
+      continue;
+    }
+    if (/\s/.test(char)) {
+      // Runs of whitespace collapse to one space, and leading whitespace is
+      // trimmed away entirely, so neither advances the normalized counter.
+      if (previousWasSpace || consumed === 0) {
+        continue;
+      }
+      previousWasSpace = true;
+    } else {
+      previousWasSpace = false;
+    }
+    consumed += 1;
+  }
+
+  return original.slice(index);
+}
+
+/**
+ * Clean up the join between a sliced-off title and the text that follows it:
+ * leading whitespace, sentence punctuation, and any emphasis markers left
+ * closing a run whose opener went with the title. Emphasis is only debris
+ * while it abuts the cut, so a backtick after a space (the start of a real
+ * inline code span) is kept.
+ */
+function stripSliceDebris(value: string): string {
+  let index = 0;
+  let sawWhitespace = false;
+  while (index < value.length) {
+    const char = value[index];
+    const isWhitespace = /\s/.test(char);
+    const isClosingEmphasis =
+      !sawWhitespace && EMPHASIS_PUNCTUATION.includes(char);
+    if (
+      !isWhitespace &&
+      !isClosingEmphasis &&
+      !SENTENCE_PUNCTUATION.includes(char)
+    ) {
+      break;
+    }
+    sawWhitespace = sawWhitespace || isWhitespace;
+    index += 1;
+  }
+  return value.slice(index);
+}
+
+/**
+ * True when `value` opens with `prefix` and that prefix ends on a word
+ * boundary, so a title of "Deploy" is not read as a prefix of "Deployment
+ * queue is backed up".
+ */
+function startsWithWholeWords(value: string, prefix: string): boolean {
+  if (!value.startsWith(prefix)) {
+    return false;
+  }
+  const next = value[prefix.length];
+  return next === undefined || !/[\p{L}\p{N}]/u.test(next);
+}
+
+/**
+ * The preview line for a feed card, or `null` when there is nothing worth
+ * showing beneath the title.
+ *
+ * Returns `null` when the flattened summary is empty, when it matches the
+ * title, and when the title is a prefix of it (a title derived from the
+ * summary) with too short a continuation left over.
+ */
+export function resolvePreview(title: string, summary: string): string | null {
+  const preview = flattenMarkdownBlocks(summary);
+  if (preview.length === 0) {
+    return null;
+  }
+
+  const normalizedPreview = normalizeForCompare(preview);
+  const normalizedTitle = normalizeForCompare(title);
+  if (normalizedPreview === normalizedTitle) {
+    return null;
+  }
+  if (!startsWithWholeWords(normalizedPreview, normalizedTitle)) {
+    return preview;
+  }
+
+  const remainder = stripSliceDebris(
+    sliceAfterNormalizedPrefix(preview, normalizedTitle.length),
+  );
+  return remainder.length < MIN_PREVIEW_LENGTH ? null : remainder;
+}

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -64,13 +64,15 @@ function flattenMarkdownBlocks(summary: string): string {
   const lines = summary.replace(/\r\n?/g, "\n").split("\n");
   const kept: string[] = [];
   let openFence: string | null = null;
+  let openFenceContainer = "";
 
   for (const line of lines) {
-    // Container markers come off first so a fence nested in a blockquote or a
-    // list item is recognized the same way a top-level one is.
-    const stripped = stripBlockMarkers(line);
     if (openFence !== null) {
-      const close = CODE_FENCE_CLOSE_PATTERN.exec(stripped)?.[1];
+      const inside = stripFenceContainer(line, openFenceContainer);
+      const close =
+        inside === null
+          ? undefined
+          : CODE_FENCE_CLOSE_PATTERN.exec(inside)?.[1];
       if (
         close !== undefined &&
         close[0] === openFence[0] &&
@@ -81,9 +83,13 @@ function flattenMarkdownBlocks(summary: string): string {
       // A block that never closes swallows the rest of the summary.
       continue;
     }
+    // Container markers come off first so a fence nested in a blockquote or a
+    // list item is recognized the same way a top-level one is.
+    const stripped = stripBlockMarkers(line);
     const opener = matchFenceOpen(stripped);
     if (opener !== null) {
       openFence = opener;
+      openFenceContainer = line.slice(0, line.length - stripped.length);
       continue;
     }
     if (STRUCTURAL_ROW_PATTERN.test(stripped)) {
@@ -113,6 +119,31 @@ function matchFenceOpen(line: string): string | null {
     return null;
   }
   return fence;
+}
+
+/**
+ * The part of `line` that sits inside the container holding an open fence, or
+ * `null` when the line is not a continuation of that container and so cannot
+ * close the fence.
+ *
+ * `container` is the literal marker run that preceded the opening fence. A
+ * continuation line either repeats it verbatim, the way a blockquote does, or
+ * replaces it with indentation of the same width, the way a list item does.
+ * Only those two forms are accepted, so a line of code that happens to look
+ * like a bulleted fence is never mistaken for the closing delimiter.
+ */
+function stripFenceContainer(line: string, container: string): string | null {
+  if (container.length === 0) {
+    return line;
+  }
+  if (line.startsWith(container)) {
+    return line.slice(container.length);
+  }
+  const lead = line.slice(0, container.length);
+  if (lead.length === container.length && /^[ \t]+$/.test(lead)) {
+    return line.slice(container.length);
+  }
+  return null;
 }
 
 /** Peel leading block markers off a line, including nested ones like `> - x`. */

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -7,8 +7,12 @@
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
 
-/** Opening fence of a code block, allowing up to 3 leading spaces. */
-const CODE_FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+/**
+ * Opening fence of a code block, allowing up to 3 leading spaces. The second
+ * group is the info string, which decides whether a backtick run really opens
+ * a block (see `matchFenceOpen`).
+ */
+const CODE_FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
 
 /**
  * Closing fence of a code block. Nothing but whitespace may follow the fence
@@ -28,11 +32,24 @@ const STRUCTURAL_ROW_PATTERN = /^[\s|:-]*$/;
  */
 const INLINE_MARK_PUNCTUATION = "*_`~";
 
-/** Sentence punctuation left dangling once a title prefix is sliced away. */
-const SENTENCE_PUNCTUATION = ".,;:-";
+/**
+ * Sentence punctuation, ignored at the end of a comparison form and left
+ * dangling once a title prefix is sliced away. Both sites read this one set,
+ * so the slice can never strand a character the comparison already discounted.
+ */
+const SENTENCE_PUNCTUATION = ".,;:!?-";
 
-/** Sentence punctuation ignored at the end of a comparison. */
-const TRAILING_PUNCTUATION_PATTERN = /[.,;:!?-]+$/;
+function isSentencePunctuation(char: string): boolean {
+  return SENTENCE_PUNCTUATION.includes(char);
+}
+
+function trimTrailingSentencePunctuation(value: string): string {
+  let end = value.length;
+  while (end > 0 && isSentencePunctuation(value[end - 1])) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
 
 /**
  * Turn multi-line markdown into a single line, dropping block syntax while
@@ -49,8 +66,11 @@ function flattenMarkdownBlocks(summary: string): string {
   let openFence: string | null = null;
 
   for (const line of lines) {
+    // Container markers come off first so a fence nested in a blockquote or a
+    // list item is recognized the same way a top-level one is.
+    const stripped = stripBlockMarkers(line);
     if (openFence !== null) {
-      const close = CODE_FENCE_CLOSE_PATTERN.exec(line)?.[1];
+      const close = CODE_FENCE_CLOSE_PATTERN.exec(stripped)?.[1];
       if (
         close !== undefined &&
         close[0] === openFence[0] &&
@@ -61,12 +81,11 @@ function flattenMarkdownBlocks(summary: string): string {
       // A block that never closes swallows the rest of the summary.
       continue;
     }
-    const opener = CODE_FENCE_OPEN_PATTERN.exec(line)?.[1];
-    if (opener !== undefined) {
+    const opener = matchFenceOpen(stripped);
+    if (opener !== null) {
       openFence = opener;
       continue;
     }
-    const stripped = stripBlockMarkers(line);
     if (STRUCTURAL_ROW_PATTERN.test(stripped)) {
       continue;
     }
@@ -74,6 +93,26 @@ function flattenMarkdownBlocks(summary: string): string {
   }
 
   return kept.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * The fence run that opens a code block on `line`, or `null` when the line is
+ * ordinary text.
+ *
+ * A backtick fence's info string may not itself contain a backtick, so a line
+ * that opens with a backtick run and carries another one later is prose around
+ * an inline code span. Tilde fences carry no such restriction.
+ */
+function matchFenceOpen(line: string): string | null {
+  const match = CODE_FENCE_OPEN_PATTERN.exec(line);
+  if (match === null) {
+    return null;
+  }
+  const [, fence, info] = match;
+  if (fence.startsWith("`") && info.includes("`")) {
+    return null;
+  }
+  return fence;
 }
 
 /** Peel leading block markers off a line, including nested ones like `> - x`. */
@@ -207,12 +246,11 @@ function matchInlineLink(value: string, start: number): InlineLinkSpan | null {
  * strings look different.
  */
 function normalizeForCompare(value: string): string {
-  return normalizedCharacters(value)
+  const flattened = normalizedCharacters(value)
     .map((entry) => entry.char)
     .join("")
-    .trimEnd()
-    .replace(TRAILING_PUNCTUATION_PATTERN, "")
     .trimEnd();
+  return trimTrailingSentencePunctuation(flattened).trimEnd();
 }
 
 /**
@@ -252,11 +290,7 @@ function stripSliceDebris(value: string): string {
     const isWhitespace = /\s/.test(char);
     const isClosingMark =
       !sawWhitespace && INLINE_MARK_PUNCTUATION.includes(char);
-    if (
-      !isWhitespace &&
-      !isClosingMark &&
-      !SENTENCE_PUNCTUATION.includes(char)
-    ) {
+    if (!isWhitespace && !isClosingMark && !isSentencePunctuation(char)) {
       break;
     }
     sawWhitespace = sawWhitespace || isWhitespace;

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -26,6 +26,14 @@ const MIN_PREVIEW_LENGTH = 12;
 const SENTENCE_PUNCTUATION = ".,;:!?-…";
 
 /**
+ * A trailing truncation marker: a horizontal ellipsis or a run of three or more
+ * ASCII periods. The producer appends one when it clamps a title at a fixed
+ * character offset, which makes the marker its explicit signal that the title
+ * was cut in the middle of the text it came from.
+ */
+const TRUNCATION_MARKER = /(?:…|\.{3,})$/;
+
+/**
  * The parts of a markdown node the flattener reads. Structural rather than
  * imported so the walk stays tolerant of node types remark adds.
  */
@@ -228,19 +236,35 @@ function stripSliceDebris(value: string): string {
 }
 
 /**
+ * Whether a character belongs to a word. Combining marks count, so a
+ * decomposed letter is never split away from its accent.
+ */
+function isWordCharacter(char: string | undefined): boolean {
+  return char !== undefined && /[\p{L}\p{M}\p{N}]/u.test(char);
+}
+
+/**
  * True when `value` opens with `prefix` and that prefix ends on a word
  * boundary, so a title of "Deploy" is not read as a prefix of "Deployment
  * queue is backed up".
- *
- * Combining marks count as part of the preceding word, so a decomposed letter
- * straddling the cut ("Cafe" against "Café") is not a boundary.
  */
 function startsWithWholeWords(value: string, prefix: string): boolean {
   if (!value.startsWith(prefix)) {
     return false;
   }
-  const next = value[prefix.length];
-  return next === undefined || !/[\p{L}\p{M}\p{N}]/u.test(next);
+  return !isWordCharacter(value[prefix.length]);
+}
+
+/**
+ * Walk `index` back to where its word starts in `value`, so a cut taken there
+ * opens on a whole word rather than on the tail of one.
+ */
+function startOfWordAt(value: string, index: number): number {
+  let start = index;
+  while (start > 0 && isWordCharacter(value[start - 1])) {
+    start -= 1;
+  }
+  return start;
 }
 
 /**
@@ -250,6 +274,15 @@ function startsWithWholeWords(value: string, prefix: string): boolean {
  * Returns `null` when the flattened summary is empty, when it matches the
  * title, and when the title is a prefix of it (a title derived from the
  * summary) with too short a continuation left over.
+ *
+ * A title carrying a trailing truncation marker is exempt from the word
+ * boundary check, because a clamp at a fixed offset lands mid-word often and
+ * the marker is the producer saying so. Its cut then moves back to the start of
+ * the straddled word, which repeats one visibly truncated word rather than
+ * dropping the rest of it.
+ *
+ * The marker has to be read off the untouched title, since normalization
+ * discards it along with the rest of the trailing sentence punctuation.
  */
 export function resolvePreview(title: string, summary: string): string | null {
   const preview = flattenMarkdownBlocks(summary);
@@ -262,12 +295,20 @@ export function resolvePreview(title: string, summary: string): string | null {
   if (normalizedPreview === normalizedTitle) {
     return null;
   }
-  if (!startsWithWholeWords(normalizedPreview, normalizedTitle)) {
+
+  const isTruncated = TRUNCATION_MARKER.test(title.trimEnd());
+  const isDerived = isTruncated
+    ? normalizedPreview.startsWith(normalizedTitle)
+    : startsWithWholeWords(normalizedPreview, normalizedTitle);
+  if (!isDerived) {
     return preview;
   }
 
-  const remainder = stripSliceDebris(
-    sliceAfterNormalizedPrefix(preview, normalizedTitle.length),
-  );
+  const cut =
+    isTruncated && isWordCharacter(normalizedPreview[normalizedTitle.length])
+      ? startOfWordAt(normalizedPreview, normalizedTitle.length)
+      : normalizedTitle.length;
+
+  const remainder = stripSliceDebris(sliceAfterNormalizedPrefix(preview, cut));
   return remainder.length < MIN_PREVIEW_LENGTH ? null : remainder;
 }

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -7,8 +7,14 @@
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
 
-/** Opening or closing fence of a code block, allowing up to 3 leading spaces. */
-const CODE_FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+/** Opening fence of a code block, allowing up to 3 leading spaces. */
+const CODE_FENCE_OPEN_PATTERN = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Closing fence of a code block. Nothing but whitespace may follow the fence
+ * run, so a line that carries trailing text is code rather than a close.
+ */
+const CODE_FENCE_CLOSE_PATTERN = /^ {0,3}(`{3,}|~{3,})\s*$/;
 
 /** ATX heading, blockquote, or list bullet at the start of a line. */
 const BLOCK_MARKER_PATTERN = /^ {0,3}(?:#{1,6}\s+|>\s?|[-*+]\s+|\d+[.)]\s+)/;
@@ -17,15 +23,10 @@ const BLOCK_MARKER_PATTERN = /^ {0,3}(?:#{1,6}\s+|>\s?|[-*+]\s+|\d+[.)]\s+)/;
 const STRUCTURAL_ROW_PATTERN = /^[\s|:-]*$/;
 
 /**
- * Inline emphasis punctuation ignored when comparing a preview to a title.
- * The set and the pattern share one source so the comparison and the
- * character walk that maps back into the original string cannot drift.
+ * Inline punctuation ignored when comparing a preview to a title: emphasis,
+ * code span, and strikethrough markers.
  */
-const EMPHASIS_PUNCTUATION = "*_`";
-const EMPHASIS_PUNCTUATION_PATTERN = new RegExp(
-  `[${EMPHASIS_PUNCTUATION}]`,
-  "g",
-);
+const INLINE_MARK_PUNCTUATION = "*_`~";
 
 /** Sentence punctuation left dangling once a title prefix is sliced away. */
 const SENTENCE_PUNCTUATION = ".,;:-";
@@ -48,19 +49,21 @@ function flattenMarkdownBlocks(summary: string): string {
   let openFence: string | null = null;
 
   for (const line of lines) {
-    const fence = CODE_FENCE_PATTERN.exec(line)?.[1];
     if (openFence !== null) {
+      const close = CODE_FENCE_CLOSE_PATTERN.exec(line)?.[1];
       if (
-        fence !== undefined &&
-        fence[0] === openFence[0] &&
-        fence.length >= openFence.length
+        close !== undefined &&
+        close[0] === openFence[0] &&
+        close.length >= openFence.length
       ) {
         openFence = null;
       }
+      // A block that never closes swallows the rest of the summary.
       continue;
     }
-    if (fence !== undefined) {
-      openFence = fence;
+    const opener = CODE_FENCE_OPEN_PATTERN.exec(line)?.[1];
+    if (opener !== undefined) {
+      openFence = opener;
       continue;
     }
     const stripped = stripBlockMarkers(line);
@@ -84,64 +87,160 @@ function stripBlockMarkers(line: string): string {
   return result;
 }
 
-/**
- * Reduce a string to the form used for title-versus-preview comparison, so
- * that emphasis, spacing, and a trailing period never make two equivalent
- * strings look different.
- */
-function normalizeForCompare(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(EMPHASIS_PUNCTUATION_PATTERN, "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(TRAILING_PUNCTUATION_PATTERN, "")
-    .trim();
+/** One character of the comparison form and where it ends in the source. */
+interface NormalizedCharacter {
+  char: string;
+  /** Offset in the source string just past the text this character came from. */
+  end: number;
+}
+
+/** Text range of an inline link and the end of the whole `[text](url)` run. */
+interface InlineLinkSpan {
+  textStart: number;
+  textEnd: number;
+  end: number;
 }
 
 /**
- * Drop the first `normalizedLength` normalized characters from `original` and
+ * Emit the comparison form of `value` one character at a time, recording where
+ * each character ends in the source. Emphasis, code span, and strikethrough
+ * punctuation is dropped, a link is reduced to its text, whitespace runs
+ * collapse to a single space, and leading whitespace is skipped.
+ *
+ * Comparison and slicing both read this one walk, so the offset a slice cuts
+ * at can never drift from what the comparison removed. Every character of a
+ * link's text reports the end of the whole link, which keeps a cut inside that
+ * text from stranding the destination in the output.
+ */
+function normalizedCharacters(value: string): NormalizedCharacter[] {
+  const characters: NormalizedCharacter[] = [];
+  let index = 0;
+  let previousWasSpace = false;
+  let linkTextEnd = -1;
+  let linkEnd = -1;
+
+  while (index < value.length) {
+    if (index === linkTextEnd) {
+      index = linkEnd;
+      linkTextEnd = -1;
+      linkEnd = -1;
+      continue;
+    }
+    if (linkEnd === -1) {
+      const link = matchInlineLink(value, index);
+      if (link !== null) {
+        linkTextEnd = link.textEnd;
+        linkEnd = link.end;
+        index = link.textStart;
+        continue;
+      }
+    }
+
+    const char = value[index];
+    index += 1;
+    if (INLINE_MARK_PUNCTUATION.includes(char)) {
+      continue;
+    }
+    const end = linkEnd === -1 ? index : linkEnd;
+    if (/\s/.test(char)) {
+      if (previousWasSpace || characters.length === 0) {
+        continue;
+      }
+      previousWasSpace = true;
+      characters.push({ char: " ", end });
+      continue;
+    }
+    previousWasSpace = false;
+    // A case fold that changes length would break the one-to-one mapping.
+    const lowered = char.toLowerCase();
+    characters.push({ char: lowered.length === 1 ? lowered : char, end });
+  }
+
+  return characters;
+}
+
+/**
+ * Match an inline link `[text](destination)` at `start`, or return `null` when
+ * the brackets never close into one.
+ */
+function matchInlineLink(value: string, start: number): InlineLinkSpan | null {
+  if (value[start] !== "[") {
+    return null;
+  }
+
+  let bracketDepth = 0;
+  let textEnd = -1;
+  for (let index = start; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "[") {
+      bracketDepth += 1;
+    } else if (char === "]") {
+      bracketDepth -= 1;
+      if (bracketDepth === 0) {
+        textEnd = index;
+        break;
+      }
+    }
+  }
+  if (textEnd === -1 || value[textEnd + 1] !== "(") {
+    return null;
+  }
+
+  let parenDepth = 0;
+  for (let index = textEnd + 1; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        return { textStart: start + 1, textEnd, end: index + 1 };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Reduce a string to the form used for title-versus-preview comparison, so
+ * that inline markup, spacing, and a trailing period never make two equivalent
+ * strings look different.
+ */
+function normalizeForCompare(value: string): string {
+  return normalizedCharacters(value)
+    .map((entry) => entry.char)
+    .join("")
+    .trimEnd()
+    .replace(TRAILING_PUNCTUATION_PATTERN, "")
+    .trimEnd();
+}
+
+/**
+ * Drop the first `normalizedLength` comparison characters from `original` and
  * return what is left of the untouched string.
  *
  * Normalization changes length, so the offset cannot be reused directly. The
- * two strings are walked in parallel instead: every original character is
- * consumed in turn, and the normalized counter only advances for characters
- * that survive normalization.
+ * walk that produced those characters recorded where each one ends, and the
+ * cut is taken from that record.
  */
 function sliceAfterNormalizedPrefix(
   original: string,
   normalizedLength: number,
 ): string {
-  let consumed = 0;
-  let index = 0;
-  let previousWasSpace = false;
-
-  while (index < original.length && consumed < normalizedLength) {
-    const char = original[index];
-    index += 1;
-    if (EMPHASIS_PUNCTUATION.includes(char)) {
-      continue;
-    }
-    if (/\s/.test(char)) {
-      // Runs of whitespace collapse to one space, and leading whitespace is
-      // trimmed away entirely, so neither advances the normalized counter.
-      if (previousWasSpace || consumed === 0) {
-        continue;
-      }
-      previousWasSpace = true;
-    } else {
-      previousWasSpace = false;
-    }
-    consumed += 1;
+  if (normalizedLength <= 0) {
+    return original;
   }
-
-  return original.slice(index);
+  const characters = normalizedCharacters(original);
+  if (normalizedLength > characters.length) {
+    return "";
+  }
+  return original.slice(characters[normalizedLength - 1].end);
 }
 
 /**
  * Clean up the join between a sliced-off title and the text that follows it:
- * leading whitespace, sentence punctuation, and any emphasis markers left
- * closing a run whose opener went with the title. Emphasis is only debris
+ * leading whitespace, sentence punctuation, and any inline markers left
+ * closing a run whose opener went with the title. A marker is only debris
  * while it abuts the cut, so a backtick after a space (the start of a real
  * inline code span) is kept.
  */
@@ -151,11 +250,11 @@ function stripSliceDebris(value: string): string {
   while (index < value.length) {
     const char = value[index];
     const isWhitespace = /\s/.test(char);
-    const isClosingEmphasis =
-      !sawWhitespace && EMPHASIS_PUNCTUATION.includes(char);
+    const isClosingMark =
+      !sawWhitespace && INLINE_MARK_PUNCTUATION.includes(char);
     if (
       !isWhitespace &&
-      !isClosingEmphasis &&
+      !isClosingMark &&
       !SENTENCE_PUNCTUATION.includes(char)
     ) {
       break;


### PR DESCRIPTION
## Summary
- Adds `resolvePreview(title, summary)`, which flattens a markdown summary to a single line of **plain text** for the feed card preview slot.
- Suppresses the preview when it would restate the title, including the derived-title case where the title is a truncated prefix of the summary.
- Flattening walks the markdown AST (`unified` + `remark-parse` + `remark-gfm`, all already direct dependencies of `clients/web`). Code blocks, thematic breaks and raw HTML are dropped; links, strikethrough and emphasis are unwrapped to their text. Nothing downstream re-parses the result, so escapes and code-span delimiters cannot be corrupted.

53 tests.

## Known limitations

Both stem from the client having to infer where the daemon truncated a derived title, rather than being told:

1. **Possessives and version prefixes.** An authored title that is a bare stem of its own summary slices at the punctuation, so title `Worker` against summary `Worker's queue is backed up.` yields `'s queue is backed up.` Cosmetic; no content loss.
2. **Flattener mismatch.** `deriveTitle` runs on the daemon's own flattened text while this runs on the markdown AST, so the two are not character-identical and a derived title is not always an exact prefix. When the prefix test fails the full preview is returned, which is the safe direction.

The upstream fix for both is for the daemon to ship derivation metadata alongside the title, removing the client-side inference. Cross-repo, out of scope here.

Part of plan: home-feed-notification-cards.md (PR 1 of 6)