### PR TITLE
docs(subagent): sync the inference_profile description with SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -35,7 +35,7 @@
           },
           "inference_profile": {
             "type": "string",
-            "description": "Optional llm.profiles key this subagent should run under. When omitted, the subagent inherits the parent turn's profile when one is active; otherwise it uses the subagentSpawn call site's default model selection."
+            "description": "Optional llm.profiles key this subagent should run under. When omitted, the subagent normally inherits the parent turn's profile if one is active, and otherwise uses the subagentSpawn call site's default model selection. When profile isolation is enabled, the subagent always takes the subagentSpawn default instead of the parent's profile, and a profile the model catalog does not report as tool-capable is replaced by that default with a note on the result. An output_contract of 'verdict' takes a cheaper profile ahead of either path unless you name a profile here."
           },
           "confirm_repeat": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
- The subagent_spawn manifest still described the pre-isolation profile rule. It now matches the corrected SKILL.md wording: normal inheritance, the isolation state, the not-tool-capable fallback note, and the verdict cheap tier.

Closes the handoff left by #39962, which corrected SKILL.md but did not own TOOLS.json.

Fixes a gap found during self-review of plan subagent-type-consolidation.md