### PR TITLE
feat(web): require a daily credit limit while auto top-ups are enabled

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -14,6 +14,9 @@
  *  - Arriving with `?configure_top_up=1` replays the toggle-on path (reveal the
  *    form, or the add-card gate with no PM), no-ops while enabled, and never
  *    fires an update mutation.
+ *  - The enable form announces the default daily credit limit only when the org
+ *    has none, and a successful enable invalidates the daily-limit and billing
+ *    summary queries so the daily-limit card picks up the applied default.
  *
  * Strategy: the render-only cases pre-populate the React Query cache so the
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
@@ -31,12 +34,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
-import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+import type {
+  AutoTopUpConfigResponse,
+  DailyCreditLimitResponse,
+} from "@/generated/api/types.gen";
 
 let removeCalls: Array<Record<string, unknown>> = [];
 let updateCalls: Array<Record<string, unknown>> = [];
 let removeShouldFail = false;
 let retrieveResponse: AutoTopUpConfigResponse;
+let dailyLimitResponse: DailyCreditLimitResponse;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -73,9 +80,15 @@ mock.module("@/generated/api/sdk.gen", () => ({
   },
   organizationsBillingAutoTopUpRetrieve: () =>
     Promise.resolve({ data: retrieveResponse, response: { ok: true } }),
+  organizationsBillingDailyCreditLimitRetrieve: () =>
+    Promise.resolve({ data: dailyLimitResponse, response: { ok: true } }),
 }));
 
-import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import {
+  organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingDailyCreditLimitRetrieveQueryKey,
+  organizationsBillingSummaryRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
 
 const { AutoTopUpCard, DISABLED_CONFIG } = await import("./auto-top-up-card");
 
@@ -87,16 +100,26 @@ function makeClient(config: AutoTopUpConfigResponse): QueryClient {
     },
   });
   client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), config);
+  client.setQueryData(
+    organizationsBillingDailyCreditLimitRetrieveQueryKey(),
+    dailyLimitResponse,
+  );
   return client;
 }
 
 /**
- * Wrap the card in a QueryClientProvider (cache pre-seeded from `config`) and a
- * MemoryRouter at `route`, so both `useQuery` and `useSearchParams` resolve.
+ * Wrap the card in a QueryClientProvider (cache pre-seeded from `config` and
+ * the current `dailyLimitResponse`) and a MemoryRouter at `route`, so both
+ * `useQuery` and `useSearchParams` resolve. Pass `client` to observe the cache
+ * from the test.
  */
-function wrap(config: AutoTopUpConfigResponse, route = "/") {
+function wrap(
+  config: AutoTopUpConfigResponse,
+  route = "/",
+  client: QueryClient = makeClient(config),
+) {
   return (
-    <QueryClientProvider client={makeClient(config)}>
+    <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[route]}>
         <AutoTopUpCard />
       </MemoryRouter>
@@ -133,6 +156,11 @@ beforeEach(() => {
   updateCalls = [];
   removeShouldFail = false;
   retrieveResponse = { ...DISABLED_CONFIG };
+  dailyLimitResponse = {
+    daily_credit_limit_usd: null,
+    current_day_spent_usd: "0.00",
+    day_bucket: null,
+  };
 });
 
 afterEach(cleanup);
@@ -619,5 +647,110 @@ describe("AutoTopUpCard configure_top_up deeplink", () => {
       container.querySelector('[data-testid="auto-top-up-save-button"]'),
     ).toBeNull();
     expect(updateCalls.length).toBe(0);
+  });
+});
+
+describe("AutoTopUpCard default daily credit limit", () => {
+  const NOTE = '[data-testid="auto-top-up-default-daily-limit-note"]';
+
+  test("announces the applied default when enabling with no daily limit", () => {
+    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
+
+    fireEvent.click(getByLabelText("Enable Extra Usage"));
+
+    const note = container.querySelector(NOTE);
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain(
+      "A default daily credit limit of $25 per day will be applied.",
+    );
+  });
+
+  test("stays quiet when the org already has a daily limit", () => {
+    dailyLimitResponse = {
+      daily_credit_limit_usd: "40.00",
+      current_day_spent_usd: "0.00",
+      day_bucket: "2026-07-20",
+    };
+    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
+
+    fireEvent.click(getByLabelText("Enable Extra Usage"));
+
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).not.toBeNull();
+    expect(container.querySelector(NOTE)).toBeNull();
+  });
+
+  test("stays quiet when adjusting an already-enabled config", () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container, getByTestId } = render(wrap(ENABLED_WITH_CARD));
+
+    fireEvent.click(getByTestId("auto-top-up-edit-button"));
+
+    expect(container.querySelector(NOTE)).toBeNull();
+  });
+
+  test("invalidates the daily-limit and summary queries after a successful enable", async () => {
+    const client = makeClient(DISABLED_WITH_CARD);
+    const invalidated: string[] = [];
+    const invalidateQueries = client.invalidateQueries.bind(client);
+    client.invalidateQueries = (filters, options) => {
+      invalidated.push(JSON.stringify(filters?.queryKey));
+      return invalidateQueries(filters, options);
+    };
+
+    const { getByLabelText, getByTestId } = render(
+      wrap(DISABLED_WITH_CARD, "/", client),
+    );
+
+    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByTestId("auto-top-up-save-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("update endpoint not called");
+      }
+    });
+
+    // The server applies its default daily limit on enable, so both the
+    // daily-limit card's query and the summary that carries the derived limit
+    // fields are refreshed.
+    await waitFor(() => {
+      const expected = [
+        JSON.stringify(organizationsBillingDailyCreditLimitRetrieveQueryKey()),
+        JSON.stringify(organizationsBillingSummaryRetrieveQueryKey()),
+      ];
+      for (const key of expected) {
+        if (!invalidated.includes(key)) {
+          throw new Error(`missing invalidation for ${key}`);
+        }
+      }
+    });
+  });
+
+  test("does not invalidate the daily-limit query when adjusting an enabled config", async () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const client = makeClient(ENABLED_WITH_CARD);
+    const invalidated: string[] = [];
+    const invalidateQueries = client.invalidateQueries.bind(client);
+    client.invalidateQueries = (filters, options) => {
+      invalidated.push(JSON.stringify(filters?.queryKey));
+      return invalidateQueries(filters, options);
+    };
+
+    const { getByTestId } = render(wrap(ENABLED_WITH_CARD, "/", client));
+
+    fireEvent.click(getByTestId("auto-top-up-edit-button"));
+    fireEvent.click(getByTestId("auto-top-up-save-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("update endpoint not called");
+      }
+    });
+
+    expect(invalidated).not.toContain(
+      JSON.stringify(organizationsBillingDailyCreditLimitRetrieveQueryKey()),
+    );
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -10,6 +10,9 @@ import {
   organizationsBillingAutoTopUpRetrieveQueryKey,
   organizationsBillingAutoTopUpRetrieveSetQueryData,
   organizationsBillingAutoTopUpUpdateMutation,
+  organizationsBillingDailyCreditLimitRetrieveOptions,
+  organizationsBillingDailyCreditLimitRetrieveQueryKey,
+  organizationsBillingSummaryRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
@@ -25,6 +28,7 @@ import {
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
+import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 
 type Mode = "view" | "form";
 
@@ -90,26 +94,6 @@ export const DISABLED_CONFIG: AutoTopUpConfigResponse = {
 };
 
 /**
- * Flatten DRF field errors (`{ field: [msg, ...] }`) into a single message
- * per field. Exported so unit tests can exercise the parsing without
- * rendering the card.
- */
-export function extractAutoTopUpServerErrors(
-  err: unknown,
-): Record<string, string> {
-  if (!err || typeof err !== "object" || Array.isArray(err)) {
-    return {};
-  }
-  const out: Record<string, string> = {};
-  for (const [key, messages] of Object.entries(err)) {
-    if (Array.isArray(messages) && typeof messages[0] === "string") {
-      out[key] = messages[0];
-    }
-  }
-  return out;
-}
-
-/**
  * Neutral pill shared by the enabled-state summary row — the "add $X under
  * $Y" chip and the monthly-cap progress chip use identical chrome so they
  * read as one control group.
@@ -150,6 +134,12 @@ function SummaryChip({
 export function AutoTopUpCard() {
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
+  // Drives the "we'll apply the default daily limit" note in the enable form:
+  // the backend applies its default limit when auto top-up is turned on and the
+  // org has none.
+  const dailyLimitQuery = useQuery(
+    organizationsBillingDailyCreditLimitRetrieveOptions(),
+  );
   const updateMutation = useMutation(
     organizationsBillingAutoTopUpUpdateMutation(),
   );
@@ -340,6 +330,17 @@ export function AutoTopUpCard() {
           void queryClient.invalidateQueries({
             queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
           });
+          if (!enabled) {
+            // Turning auto top-up on makes the backend apply its default daily
+            // credit limit when the org has none, so refresh the daily-limit
+            // card and the summary that carries the derived limit fields.
+            void queryClient.invalidateQueries({
+              queryKey: organizationsBillingDailyCreditLimitRetrieveQueryKey(),
+            });
+            void queryClient.invalidateQueries({
+              queryKey: organizationsBillingSummaryRetrieveQueryKey(),
+            });
+          }
           exitFormMode();
         },
       },
@@ -515,7 +516,7 @@ export function AutoTopUpCard() {
   };
 
   const isFormMode = mode === "form";
-  const fieldErrors = extractAutoTopUpServerErrors(updateMutation.error);
+  const fieldErrors = extractDrfFieldErrors(updateMutation.error);
   // Surface a generic notice when the mutation failed but no field-level
   // DRF errors were parsed (network failure, 5xx, non-DRF body, etc.).
   // Without this, a failed Save can otherwise look like a silent no-op.
@@ -523,6 +524,11 @@ export function AutoTopUpCard() {
     updateMutation.isError && Object.keys(fieldErrors).length === 0;
 
   const toggleChecked = enabled || pendingEnable;
+  // Only claim the default will be applied once the daily-limit config has
+  // loaded and reports no limit; a loading or failed query stays quiet.
+  const dailyLimitMissing =
+    dailyLimitQuery.data != null &&
+    dailyLimitQuery.data.daily_credit_limit_usd == null;
 
   return (
     <div ref={cardRef} data-testid="auto-top-up-card">
@@ -700,6 +706,7 @@ export function AutoTopUpCard() {
           }
           submitting={updateMutation.isPending}
           serverErrors={fieldErrors}
+          showDefaultDailyLimitNote={!enabled && dailyLimitMissing}
           onCancel={exitFormMode}
           onSave={handleSave}
         />

--- a/clients/web/src/domains/settings/components/auto-top-up-form.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-form.tsx
@@ -2,6 +2,7 @@ import { useState, type ChangeEvent } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
+import { Notice } from "@vellumai/design-library/components/notice";
 
 export interface AutoTopUpFormValues {
   threshold_usd: string;
@@ -13,9 +14,17 @@ export interface AutoTopUpFormProps {
   initialValues?: AutoTopUpFormValues;
   submitting: boolean;
   serverErrors: Record<string, string>;
+  /**
+   * Announce that saving will apply the default daily credit limit. Set while
+   * the user is turning auto top-up on and the org has no daily limit yet.
+   */
+  showDefaultDailyLimitNote?: boolean;
   onSave: (values: AutoTopUpFormValues) => void;
   onCancel: () => void;
 }
+
+/** Mirrors the backend `BILLING_DEFAULT_DAILY_CREDIT_LIMIT_USD` default. */
+const DEFAULT_DAILY_CREDIT_LIMIT_USD = 25;
 
 export type AutoTopUpFormErrors = Partial<
   Record<keyof AutoTopUpFormValues, string>
@@ -114,6 +123,7 @@ export function AutoTopUpForm({
   initialValues = DEFAULTS,
   submitting,
   serverErrors,
+  showDefaultDailyLimitNote = false,
   onSave,
   onCancel,
 }: AutoTopUpFormProps) {
@@ -243,6 +253,17 @@ export function AutoTopUpForm({
           </Button>
         </div>
       </div>
+
+      {showDefaultDailyLimitNote && (
+        <Notice
+          tone="info"
+          className="mt-3"
+          data-testid="auto-top-up-default-daily-limit-note"
+        >
+          A default daily credit limit of ${DEFAULT_DAILY_CREDIT_LIMIT_USD} per
+          day will be applied. You can adjust it under Daily credit limit.
+        </Notice>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -4,15 +4,23 @@
  *  - saving a new value PUTs the two-decimal limit body
  *  - turning the toggle off PUTs `daily_credit_limit_usd: null` to clear it
  *  - below-minimum input shows an inline error and does NOT call the API
- *  - the toggle is locked (with explanatory copy) while auto top-up is enabled
+ *  - the toggle is locked (with explanatory copy) while a saved limit is what
+ *    enabled auto top-ups depend on
+ *  - an org with auto top-up on but no saved limit can still take back an
+ *    unsaved enable
  *  - a server-rejected clear renders the DRF field error, not the generic copy
- *  - a failed auto top-up query fails open so the toggle still clears the limit
+ *  - an errored auto top-up query fails open so the toggle still clears the
+ *    limit, including when the error lands on top of stale cached data
  *  - `validateDailyLimit` bounds checks (pure)
  *  - the exported anchor id stays in sync with the deep-link route constant
  *
- * The GET is seeded directly into the React Query cache so `useQuery` resolves
- * synchronously; the PUT and the auto top-up GET are mocked at the SDK boundary
- * to capture the request body and to drive the auto top-up dependency.
+ * Every response the card reads is seeded into the React Query cache so the
+ * first render resolves synchronously, and *every* SDK call the card makes is
+ * mocked at the SDK boundary. Both halves are load-bearing: React Query
+ * refetches seeded entries on mount, so an unmocked endpoint would reach the
+ * real network, and a failed refetch flips the query to `error` (keeping the
+ * stale data), which renders the card's load-failure notice and breaks any
+ * assertion that waits.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -22,11 +30,14 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   AutoTopUpConfigResponse,
+  BillingSummaryResponse,
   DailyCreditLimitResponse,
 } from "@/generated/api/types.gen";
 
 let updateCalls: Array<Record<string, unknown>> = [];
 let updateError: unknown = null;
+let limitResponse: DailyCreditLimitResponse;
+let summaryResponse: BillingSummaryResponse;
 let autoTopUpResponse: AutoTopUpConfigResponse;
 let autoTopUpShouldFail = false;
 
@@ -55,11 +66,16 @@ mock.module("@/generated/api/sdk.gen", () => ({
     }
     return Promise.resolve({ data: autoTopUpResponse, response: { ok: true } });
   },
+  organizationsBillingDailyCreditLimitRetrieve: () =>
+    Promise.resolve({ data: limitResponse, response: { ok: true } }),
+  organizationsBillingSummaryRetrieve: () =>
+    Promise.resolve({ data: summaryResponse, response: { ok: true } }),
 }));
 
 import {
   organizationsBillingAutoTopUpRetrieveQueryKey,
   organizationsBillingDailyCreditLimitRetrieveQueryKey,
+  organizationsBillingSummaryRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 
 import { routes } from "@/utils/routes";
@@ -95,6 +111,33 @@ const AUTO_TOP_UP_ON: AutoTopUpConfigResponse = {
   has_payment_method: true,
 };
 
+/**
+ * The card reads only `daily_spend_usd` / `daily_limit_reached` off the billing
+ * summary, but the endpoint returns the whole balance payload, so the fixture
+ * carries it.
+ */
+const SUMMARY: BillingSummaryResponse = {
+  settled_balance: "20.00",
+  minimum_top_up: "5.00",
+  maximum_top_up: "100.00",
+  maximum_balance: "500.00",
+  allowed_top_up_amounts: ["5.00", "10.00", "25.00"],
+  settled_balance_usd: "20.00",
+  minimum_top_up_usd: "5.00",
+  maximum_top_up_usd: "100.00",
+  maximum_balance_usd: "500.00",
+  pending_compute: "0.00",
+  pending_compute_usd: "0.00",
+  effective_balance: "20.00",
+  effective_balance_usd: "20.00",
+  is_degraded: false,
+  daily_credit_limit_usd: null,
+  daily_spend_usd: "0.00",
+  daily_limit_reached: false,
+  low_balance_threshold_usd: "5.00",
+  low_balance_warning: false,
+};
+
 function makeClient(
   config: DailyCreditLimitResponse,
   autoTopUp?: AutoTopUpConfigResponse,
@@ -106,6 +149,10 @@ function makeClient(
     organizationsBillingDailyCreditLimitRetrieveQueryKey(),
     config,
   );
+  client.setQueryData(
+    organizationsBillingSummaryRetrieveQueryKey(),
+    summaryResponse,
+  );
   if (autoTopUp) {
     client.setQueryData(
       organizationsBillingAutoTopUpRetrieveQueryKey(),
@@ -116,14 +163,15 @@ function makeClient(
 }
 
 /**
- * Render the card with the daily-limit GET pre-seeded. `autoTopUp` seeds the
- * auto top-up GET too (and backs its refetch). Omit it to leave that query
- * unresolved, which is the fail-open path.
+ * Render the card with the daily-limit and billing-summary GETs pre-seeded.
+ * `autoTopUp` seeds the auto top-up GET too (and backs its refetch). Omit it to
+ * leave that query unseeded, so the mocked GET drives it from scratch.
  */
 function renderCard(
   config: DailyCreditLimitResponse,
   autoTopUp?: AutoTopUpConfigResponse,
 ): ReturnType<typeof render> & { client: QueryClient } {
+  limitResponse = config;
   if (autoTopUp) {
     autoTopUpResponse = autoTopUp;
   }
@@ -136,6 +184,23 @@ function renderCard(
       </QueryClientProvider>,
     ),
   };
+}
+
+/** Let queued promise callbacks (a fired mutation) run before asserting. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Wait for the mocked auto top-up GET to reject and settle the query. */
+function settleAutoTopUpError(client: QueryClient): Promise<void> {
+  return waitFor(() => {
+    const state = client.getQueryState(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+    );
+    if (state?.status !== "error") {
+      throw new Error("auto top-up query not settled");
+    }
+  });
 }
 
 const OFF: DailyCreditLimitResponse = {
@@ -152,6 +217,8 @@ const ON: DailyCreditLimitResponse = {
 beforeEach(() => {
   updateCalls = [];
   updateError = null;
+  limitResponse = { ...OFF };
+  summaryResponse = { ...SUMMARY };
   autoTopUpResponse = { ...AUTO_TOP_UP_OFF };
   autoTopUpShouldFail = false;
 });
@@ -259,6 +326,27 @@ describe("DailyCreditLimitCard auto top-up dependency", () => {
     expect(updateCalls.length).toBe(0);
   });
 
+  test("lets an org with no saved limit take back an unsaved enable", async () => {
+    // Predates the backend default: auto top-ups are on, but no limit was ever
+    // persisted, so nothing the backend depends on is at stake yet.
+    const { getByRole, queryByTestId } = renderCard(OFF, AUTO_TOP_UP_ON);
+
+    const toggle = getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+
+    fireEvent.click(toggle);
+    expect(queryByTestId("daily-credit-limit-input")).not.toBeNull();
+    expect(toggle.disabled).toBe(false);
+
+    fireEvent.click(toggle);
+    expect(queryByTestId("daily-credit-limit-input")).toBeNull();
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    // There was no saved limit to clear, so the off-flip is local only.
+    await flushMicrotasks();
+    expect(updateCalls.length).toBe(0);
+  });
+
   test("leaves the toggle usable and the note hidden while auto top-up is off", () => {
     const { getByRole, queryByTestId } = renderCard(ON, AUTO_TOP_UP_OFF);
 
@@ -301,17 +389,37 @@ describe("DailyCreditLimitCard auto top-up dependency", () => {
     autoTopUpShouldFail = true;
     const { client, getByRole, queryByTestId } = renderCard(ON);
 
-    await waitFor(() => {
-      const state = client.getQueryState(
-        organizationsBillingAutoTopUpRetrieveQueryKey(),
-      );
-      if (state?.status !== "error") {
-        throw new Error("auto top-up query not settled");
-      }
-    });
+    await settleAutoTopUpError(client);
 
     // The server still enforces the invariant, so an unknown auto top-up state
     // must not strand the user with a toggle they cannot turn off.
+    expect(queryByTestId("daily-credit-limit-required-note")).toBeNull();
+    const toggle = getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
+    });
+    expect(updateCalls[0]!.body).toEqual({ daily_credit_limit_usd: null });
+  });
+
+  test("fails open when an errored refetch lands on top of stale enabled data", async () => {
+    // React Query keeps serving the cached config alongside the error, so
+    // reading `data.enabled` alone would keep enforcing an auto top-up the
+    // user may have already disabled from another client.
+    autoTopUpShouldFail = true;
+    const { client, getByRole, queryByTestId } = renderCard(ON, AUTO_TOP_UP_ON);
+
+    await settleAutoTopUpError(client);
+    expect(
+      client.getQueryState(organizationsBillingAutoTopUpRetrieveQueryKey())
+        ?.data,
+    ).toEqual(AUTO_TOP_UP_ON);
+
     expect(queryByTestId("daily-credit-limit-required-note")).toBeNull();
     const toggle = getByRole("switch") as HTMLButtonElement;
     expect(toggle.disabled).toBe(false);

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -4,10 +4,15 @@
  *  - saving a new value PUTs the two-decimal limit body
  *  - turning the toggle off PUTs `daily_credit_limit_usd: null` to clear it
  *  - below-minimum input shows an inline error and does NOT call the API
+ *  - the toggle is locked (with explanatory copy) while auto top-up is enabled
+ *  - a server-rejected clear renders the DRF field error, not the generic copy
+ *  - a failed auto top-up query fails open so the toggle still clears the limit
  *  - `validateDailyLimit` bounds checks (pure)
+ *  - the exported anchor id stays in sync with the deep-link route constant
  *
  * The GET is seeded directly into the React Query cache so `useQuery` resolves
- * synchronously; the PUT SDK function is mocked to capture the request body.
+ * synchronously; the PUT and the auto top-up GET are mocked at the SDK boundary
+ * to capture the request body and to drive the auto top-up dependency.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -15,8 +20,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
+import type {
+  AutoTopUpConfigResponse,
+  DailyCreditLimitResponse,
+} from "@/generated/api/types.gen";
 
 let updateCalls: Array<Record<string, unknown>> = [];
+let updateError: unknown = null;
+let autoTopUpResponse: AutoTopUpConfigResponse;
+let autoTopUpShouldFail = false;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -24,6 +36,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
     opts: Record<string, unknown>,
   ) => {
     updateCalls.push(opts);
+    if (updateError !== null) {
+      return Promise.reject(updateError);
+    }
     const body = (opts.body ?? {}) as { daily_credit_limit_usd: string | null };
     return Promise.resolve({
       data: {
@@ -34,17 +49,56 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
+  organizationsBillingAutoTopUpRetrieve: () => {
+    if (autoTopUpShouldFail) {
+      return Promise.reject(new Error("auto top-up unavailable"));
+    }
+    return Promise.resolve({ data: autoTopUpResponse, response: { ok: true } });
+  },
 }));
 
-import { organizationsBillingDailyCreditLimitRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
-import type { DailyCreditLimitResponse } from "@/generated/api/types.gen";
+import {
+  organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingDailyCreditLimitRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
 
 import { routes } from "@/utils/routes";
 
 const { DAILY_CREDIT_LIMIT_ANCHOR_ID, DailyCreditLimitCard, validateDailyLimit } =
   await import("./daily-credit-limit-card");
 
-function makeClient(config: DailyCreditLimitResponse): QueryClient {
+const AUTO_TOP_UP_OFF: AutoTopUpConfigResponse = {
+  enabled: false,
+  threshold_usd: null,
+  amount_usd: null,
+  monthly_cap_usd: null,
+  has_payment_method: false,
+  payment_method_brand: null,
+  payment_method_last4: null,
+  stripe_payment_method_updated_at: null,
+  last_charge_at: null,
+  last_failure_at: null,
+  last_failure_reason: null,
+  disabled_due_to_repeated_failures: false,
+  paused_until: null,
+  current_month_credits_purchased_usd: "0.00",
+  current_month_charged_usd: "0.00",
+  next_trigger_amount_usd: null,
+  stubbed: false,
+};
+
+const AUTO_TOP_UP_ON: AutoTopUpConfigResponse = {
+  ...AUTO_TOP_UP_OFF,
+  enabled: true,
+  threshold_usd: "50.00",
+  amount_usd: "200.00",
+  has_payment_method: true,
+};
+
+function makeClient(
+  config: DailyCreditLimitResponse,
+  autoTopUp?: AutoTopUpConfigResponse,
+): QueryClient {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -52,17 +106,36 @@ function makeClient(config: DailyCreditLimitResponse): QueryClient {
     organizationsBillingDailyCreditLimitRetrieveQueryKey(),
     config,
   );
+  if (autoTopUp) {
+    client.setQueryData(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+      autoTopUp,
+    );
+  }
   return client;
 }
 
+/**
+ * Render the card with the daily-limit GET pre-seeded. `autoTopUp` seeds the
+ * auto top-up GET too (and backs its refetch). Omit it to leave that query
+ * unresolved, which is the fail-open path.
+ */
 function renderCard(
   config: DailyCreditLimitResponse,
-): ReturnType<typeof render> {
-  return render(
-    <QueryClientProvider client={makeClient(config)}>
-      <DailyCreditLimitCard />
-    </QueryClientProvider>,
-  );
+  autoTopUp?: AutoTopUpConfigResponse,
+): ReturnType<typeof render> & { client: QueryClient } {
+  if (autoTopUp) {
+    autoTopUpResponse = autoTopUp;
+  }
+  const client = makeClient(config, autoTopUp);
+  return {
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <DailyCreditLimitCard />
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 const OFF: DailyCreditLimitResponse = {
@@ -71,8 +144,16 @@ const OFF: DailyCreditLimitResponse = {
   day_bucket: null,
 };
 
+const ON: DailyCreditLimitResponse = {
+  ...OFF,
+  daily_credit_limit_usd: "25.00",
+};
+
 beforeEach(() => {
   updateCalls = [];
+  updateError = null;
+  autoTopUpResponse = { ...AUTO_TOP_UP_OFF };
+  autoTopUpShouldFail = false;
 });
 
 afterEach(cleanup);
@@ -153,6 +234,95 @@ describe("DailyCreditLimitCard", () => {
 
 describe("DAILY_CREDIT_LIMIT_ANCHOR_ID", () => {
   test("matches the hash in the deep-link route constant", () => {
-    expect(routes.settings.usageBillingDailyLimit.endsWith(`#${DAILY_CREDIT_LIMIT_ANCHOR_ID}`)).toBe(true);
+    expect(
+      routes.settings.usageBillingDailyLimit.endsWith(
+        `#${DAILY_CREDIT_LIMIT_ANCHOR_ID}`,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("DailyCreditLimitCard auto top-up dependency", () => {
+  test("locks the toggle and explains why while auto top-up is enabled", () => {
+    const { getByRole, getByTestId } = renderCard(ON, AUTO_TOP_UP_ON);
+
+    const toggle = getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(getByTestId("daily-credit-limit-required-note").textContent).toBe(
+      "A daily credit limit is required while automatic top-ups are enabled.",
+    );
+
+    // The guard holds even if the click lands (e.g. a programmatic change):
+    // the limit is never cleared.
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(updateCalls.length).toBe(0);
+  });
+
+  test("leaves the toggle usable and the note hidden while auto top-up is off", () => {
+    const { getByRole, queryByTestId } = renderCard(ON, AUTO_TOP_UP_OFF);
+
+    expect((getByRole("switch") as HTMLButtonElement).disabled).toBe(false);
+    expect(queryByTestId("daily-credit-limit-required-note")).toBeNull();
+  });
+
+  test("renders the server field error when the clear is rejected", async () => {
+    updateError = {
+      daily_credit_limit_usd: [
+        "Disable automatic top-ups before removing the daily credit limit.",
+      ],
+    };
+    const { getByRole, getByTestId } = renderCard(ON, AUTO_TOP_UP_OFF);
+
+    fireEvent.click(getByRole("switch"));
+
+    const notice = await waitFor(() =>
+      getByTestId("daily-credit-limit-update-error"),
+    );
+    expect(notice.textContent).toContain(
+      "Disable automatic top-ups before removing the daily credit limit.",
+    );
+    expect(notice.textContent).not.toContain("Failed to save");
+  });
+
+  test("falls back to the generic error when the failure carries no field errors", async () => {
+    updateError = new Error("network down");
+    const { getByRole, getByTestId } = renderCard(ON, AUTO_TOP_UP_OFF);
+
+    fireEvent.click(getByRole("switch"));
+
+    const notice = await waitFor(() =>
+      getByTestId("daily-credit-limit-update-error"),
+    );
+    expect(notice.textContent).toContain("Failed to save daily credit limit.");
+  });
+
+  test("fails open when the auto top-up query errors", async () => {
+    autoTopUpShouldFail = true;
+    const { client, getByRole, queryByTestId } = renderCard(ON);
+
+    await waitFor(() => {
+      const state = client.getQueryState(
+        organizationsBillingAutoTopUpRetrieveQueryKey(),
+      );
+      if (state?.status !== "error") {
+        throw new Error("auto top-up query not settled");
+      }
+    });
+
+    // The server still enforces the invariant, so an unknown auto top-up state
+    // must not strand the user with a toggle they cannot turn off.
+    expect(queryByTestId("daily-credit-limit-required-note")).toBeNull();
+    const toggle = getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
+    });
+    expect(updateCalls[0]!.body).toEqual({ daily_credit_limit_usd: null });
   });
 });

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ChangeEvent } from "react";
 
+import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 import {
+  organizationsBillingAutoTopUpRetrieveOptions,
   organizationsBillingDailyCreditLimitRetrieveOptions,
   organizationsBillingDailyCreditLimitRetrieveQueryKey,
   organizationsBillingDailyCreditLimitRetrieveSetQueryData,
@@ -58,7 +60,8 @@ export function validateDailyLimit(raw: string): string | undefined {
  * Credit Balance card by `BillingPanel.tsx`, under its own enable toggle. When
  * on, an always-visible input caps how much Vellum credit the org can spend per
  * UTC day; the spend counter resets at midnight UTC. Turning the toggle off
- * clears the limit (`null`).
+ * clears the limit (`null`), except while automatic top-ups are enabled: the
+ * backend requires a limit in that state, so the toggle stays locked on.
  *
  * The editable limit comes from the daily-credit-limit endpoint; today's spend
  * for the progress readout comes from the billing summary. Saving invalidates
@@ -70,6 +73,9 @@ export function DailyCreditLimitCard() {
     organizationsBillingDailyCreditLimitRetrieveOptions(),
   );
   const summaryQuery = useQuery(organizationsBillingSummaryRetrieveOptions());
+  const autoTopUpQuery = useQuery(
+    organizationsBillingAutoTopUpRetrieveOptions(),
+  );
   const updateMutation = useMutation(
     organizationsBillingDailyCreditLimitUpdateMutation(),
   );
@@ -122,6 +128,11 @@ export function DailyCreditLimitCard() {
   const limitReached = summary?.daily_limit_reached === true;
   const resetPhrase = dailyResetTimePhrase();
 
+  // The backend requires a daily limit while automatic top-ups are on, so the
+  // clearing PUT is blocked here too. Fail open while the auto top-up config is
+  // loading or failed: the server rejects the clear on its own.
+  const requiredByAutoTopUp = autoTopUpQuery.data?.enabled === true;
+
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDraft(e.target.value);
   };
@@ -160,6 +171,9 @@ export function DailyCreditLimitCard() {
       setPendingEnable(true);
       return;
     }
+    if (requiredByAutoTopUp) {
+      return;
+    }
     // Turning off: clear a saved limit; if it was only pending (never saved),
     // just drop the intent without hitting the API.
     setPendingEnable(false);
@@ -178,7 +192,15 @@ export function DailyCreditLimitCard() {
     persist(parseFloat(value.trim()).toFixed(2));
   };
 
-  const showGenericError = updateMutation.isError;
+  // A rejected clear comes back as a DRF field error explaining the auto
+  // top-up dependency; show it verbatim instead of the generic copy.
+  const serverLimitError =
+    extractDrfFieldErrors(updateMutation.error).daily_credit_limit_usd;
+  const saveError =
+    serverLimitError ??
+    (updateMutation.isError
+      ? "Failed to save daily credit limit. Please try again."
+      : undefined);
   const visibleError = touched ? clientError : undefined;
 
   return (
@@ -189,10 +211,22 @@ export function DailyCreditLimitCard() {
           onChange={handleToggleChange}
           // Locked while a save is in flight: toggling off during a pending
           // enable would skip the clearing PUT, then the save's onSuccess
-          // would re-enable the limit against the user's last action.
-          disabled={updateMutation.isPending}
+          // would re-enable the limit against the user's last action. Also
+          // locked while automatic top-ups depend on the limit, where the only
+          // available move is the one the backend rejects.
+          disabled={updateMutation.isPending || (enabled && requiredByAutoTopUp)}
           label="Set a daily credit limit"
         />
+
+        {requiredByAutoTopUp && (
+          <p
+            className="text-body-small-default text-[var(--content-tertiary)]"
+            data-testid="daily-credit-limit-required-note"
+          >
+            A daily credit limit is required while automatic top-ups are
+            enabled.
+          </p>
+        )}
 
         {enabled && (
           <>
@@ -255,13 +289,13 @@ export function DailyCreditLimitCard() {
         API keys isn&apos;t limited. Resets daily at {resetPhrase}.
       </p>
 
-      {showGenericError && (
+      {saveError != null && (
         <Notice
           tone="error"
           className="mt-4"
           data-testid="daily-credit-limit-update-error"
         >
-          Failed to save daily credit limit. Please try again.
+          {saveError}
         </Notice>
       )}
     </div>

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -60,8 +60,9 @@ export function validateDailyLimit(raw: string): string | undefined {
  * Credit Balance card by `BillingPanel.tsx`, under its own enable toggle. When
  * on, an always-visible input caps how much Vellum credit the org can spend per
  * UTC day; the spend counter resets at midnight UTC. Turning the toggle off
- * clears the limit (`null`), except while automatic top-ups are enabled: the
- * backend requires a limit in that state, so the toggle stays locked on.
+ * clears the limit (`null`), except when a saved limit is holding up enabled
+ * automatic top-ups: the backend requires one in that state, so the toggle
+ * stays locked on.
  *
  * The editable limit comes from the daily-credit-limit endpoint; today's spend
  * for the progress readout comes from the billing summary. Saving invalidates
@@ -129,9 +130,13 @@ export function DailyCreditLimitCard() {
   const resetPhrase = dailyResetTimePhrase();
 
   // The backend requires a daily limit while automatic top-ups are on, so the
-  // clearing PUT is blocked here too. Fail open while the auto top-up config is
-  // loading or failed: the server rejects the clear on its own.
-  const requiredByAutoTopUp = autoTopUpQuery.data?.enabled === true;
+  // clearing PUT is blocked here too. Fail open whenever that state is not
+  // known to be current: while the config is loading, and on any query error
+  // (an errored refetch keeps serving the previous value, which may describe
+  // an auto top-up the user has since disabled elsewhere). The server enforces
+  // the invariant on its own, so the cost of failing open is a rejected PUT.
+  const requiredByAutoTopUp =
+    autoTopUpQuery.data?.enabled === true && !autoTopUpQuery.isError;
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDraft(e.target.value);
@@ -171,7 +176,10 @@ export function DailyCreditLimitCard() {
       setPendingEnable(true);
       return;
     }
-    if (requiredByAutoTopUp) {
+    // Only a saved limit is protected by the auto top-up dependency. An
+    // unsaved `pendingEnable` has nothing for the backend to keep, so the user
+    // can still take it back.
+    if (hasLimit && requiredByAutoTopUp) {
       return;
     }
     // Turning off: clear a saved limit; if it was only pending (never saved),
@@ -212,9 +220,11 @@ export function DailyCreditLimitCard() {
           // Locked while a save is in flight: toggling off during a pending
           // enable would skip the clearing PUT, then the save's onSuccess
           // would re-enable the limit against the user's last action. Also
-          // locked while automatic top-ups depend on the limit, where the only
-          // available move is the one the backend rejects.
-          disabled={updateMutation.isPending || (enabled && requiredByAutoTopUp)}
+          // locked once a saved limit is what automatic top-ups depend on,
+          // where the only available move is the one the backend rejects.
+          disabled={
+            updateMutation.isPending || (hasLimit && requiredByAutoTopUp)
+          }
           label="Set a daily credit limit"
         />
 

--- a/clients/web/src/domains/settings/utils/drf-errors.test.ts
+++ b/clients/web/src/domains/settings/utils/drf-errors.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for `extractDrfFieldErrors`: DRF bodies flatten to one message per
+ * field, and anything that isn't a field-keyed object yields `{}` so callers
+ * fall back to their generic error copy.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { extractDrfFieldErrors } from "./drf-errors";
+
+describe("extractDrfFieldErrors", () => {
+  test("flattens a DRF field-error body to the first message per field", () => {
+    expect(
+      extractDrfFieldErrors({
+        amount_usd: ["Must be between $10 and $500", "second message"],
+        threshold_usd: ["Must be between $1 and $100"],
+      }),
+    ).toEqual({
+      amount_usd: "Must be between $10 and $500",
+      threshold_usd: "Must be between $1 and $100",
+    });
+  });
+
+  test("returns an empty map for non-DRF error shapes", () => {
+    expect(extractDrfFieldErrors(null)).toEqual({});
+    expect(extractDrfFieldErrors(undefined)).toEqual({});
+    expect(extractDrfFieldErrors(new Error("network"))).toEqual({});
+    expect(extractDrfFieldErrors("boom")).toEqual({});
+    expect(extractDrfFieldErrors(["a"])).toEqual({});
+  });
+
+  test("skips fields whose value is not a non-empty string array", () => {
+    expect(
+      extractDrfFieldErrors({
+        good: ["kept"],
+        empty: [],
+        numeric: [42],
+        scalar: "dropped",
+      }),
+    ).toEqual({ good: "kept" });
+  });
+});

--- a/clients/web/src/domains/settings/utils/drf-errors.ts
+++ b/clients/web/src/domains/settings/utils/drf-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Flatten a DRF validation-error body (`{ field: [msg, ...] }`) into a single
+ * message per field. Non-object bodies, arrays, and fields whose value isn't a
+ * non-empty array of strings are skipped, so a network failure or a 5xx HTML
+ * body yields `{}` and callers can fall back to a generic message.
+ */
+export function extractDrfFieldErrors(err: unknown): Record<string, string> {
+  if (!err || typeof err !== "object" || Array.isArray(err)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, messages] of Object.entries(err)) {
+    if (Array.isArray(messages) && typeof messages[0] === "string") {
+      out[key] = messages[0];
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Companion UI for vellum-ai/vellum-assistant-platform#9767 (backend deploys first; this PR is safe to merge independently since the server enforces the invariant either way).

- **Daily credit limit card**: the toggle locks (with explanatory copy) while auto top-up is enabled, since the only move it offers is the clear the backend now rejects. Fails open if the auto top-up query is loading or errored. A rejected clear renders the server's DRF field error verbatim instead of the generic failure copy.
- **Auto top-up card/form**: enabling auto top-up with no daily limit shows an info notice that the $25/day default will be applied, and a successful enable invalidates the daily-limit and billing-summary queries so the limit card reflects the server-applied default.
- Extracts the DRF field-error flattener out of `auto-top-up-card.tsx` into shared `settings/utils/drf-errors.ts` (single source of truth; both cards import it).

## Testing

- `bunx tsc --noEmit` clean, `bun run lint` 0 errors, `bun run audit:cross-domain:check` clean
- 58 tests pass across the settings/billing suites, including new cases: toggle locked + copy when auto top-up on, server error rendered, fail-open on auto top-up query error, default-limit note only on enable-with-null-limit, query invalidation on enable but not on adjust

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->