### PR TITLE
Give each onboarding avatar its own voice, and let you hear it (JARVIS-1431)

### DIFF
--- a/clients/web/src/components/onboarding-avatar-applier.test.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.test.tsx
@@ -24,6 +24,17 @@ mock.module("@/assistant/avatar-api", () => ({
   saveCharacterTraits: saveCharacterTraitsMock,
 }));
 
+let configPatchOk = true;
+const configPatchCalls: unknown[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  configPatch: async (opts: unknown) => {
+    configPatchCalls.push(opts);
+    return {
+      response: { ok: configPatchOk, status: configPatchOk ? 200 : 500 },
+    };
+  },
+}));
+
 const {
   OnboardingAvatarApplier,
   getAvatarApplyRetryDelayMs,
@@ -34,7 +45,12 @@ describe("OnboardingAvatarApplier", () => {
   beforeEach(() => {
     saveCharacterTraitsImpl = async () => true;
     saveCharacterTraitsMock.mockClear();
-    useOnboardingFocusStore.setState({ pendingAvatarTraits: null });
+    configPatchOk = true;
+    configPatchCalls.length = 0;
+    useOnboardingFocusStore.setState({
+      pendingAvatarTraits: null,
+      pendingAvatarVoice: null,
+    });
     useResolvedAssistantsStore.setState({ activeAssistantId: null });
   });
 
@@ -63,6 +79,60 @@ describe("OnboardingAvatarApplier", () => {
 
     await waitFor(() =>
       expect(saveCharacterTraitsMock).toHaveBeenCalledWith("asst-1", TRAITS),
+    );
+    expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toEqual(
+      TRAITS,
+    );
+  });
+
+  test("applies the avatar's voice alongside its face", async () => {
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(TRAITS);
+    useOnboardingFocusStore.getState().setPendingAvatarVoice("aura-2-luna-en");
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+
+    render(<OnboardingAvatarApplier />);
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]).toEqual({
+      path: { assistant_id: "asst-1" },
+      body: {
+        services: {
+          tts: { providers: { vellum: { model: "aura-2-luna-en" } } },
+        },
+      },
+      throwOnError: false,
+    });
+    await waitFor(() =>
+      expect(useOnboardingFocusStore.getState().pendingAvatarVoice).toBeNull(),
+    );
+  });
+
+  test("patches no voice when the catalog never resolved one", async () => {
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(TRAITS);
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+
+    render(<OnboardingAvatarApplier />);
+
+    await waitFor(() =>
+      expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toBeNull(),
+    );
+    // Nothing to say beyond the platform default the assistant already has.
+    expect(configPatchCalls.length).toBe(0);
+  });
+
+  test("keeps the handoff queued when the voice write fails", async () => {
+    configPatchOk = false;
+    useOnboardingFocusStore.getState().setPendingAvatarTraits(TRAITS);
+    useOnboardingFocusStore.getState().setPendingAvatarVoice("aura-2-luna-en");
+    useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
+
+    render(<OnboardingAvatarApplier />);
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    // Face and voice are one pick, so a half-landed handoff stays staged for
+    // the retry rather than clearing on the traits alone.
+    expect(useOnboardingFocusStore.getState().pendingAvatarVoice).toBe(
+      "aura-2-luna-en",
     );
     expect(useOnboardingFocusStore.getState().pendingAvatarTraits).toEqual(
       TRAITS,

--- a/clients/web/src/components/onboarding-avatar-applier.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.tsx
@@ -1,8 +1,8 @@
 /**
- * Applies the avatar chosen during research-onboarding to the assistant — both
- * halves of it: the face and the voice that face was auditioned in.
+ * Applies the avatar chosen during research-onboarding to the assistant: both
+ * halves of it, the face and the voice that face was auditioned in.
  *
- * SPIKE — research-onboarding flow.
+ * SPIKE: research-onboarding flow.
  *
  * Neither is part of the pre-chat handoff context, so neither can be set during
  * hatch. This invisible component (mounted in `ChatLayout`) watches for the
@@ -11,7 +11,7 @@
  * `config_patch`. Transient save failures retry with bounded backoff; the staged
  * values clear after a successful save or after the retry budget is exhausted.
  *
- * The two are applied as ONE handoff, under one retry budget, because they're
+ * The two are applied as ONE handoff, under one retry budget, because they are
  * one pick: an assistant wearing the face it was given but speaking in a voice
  * the user never heard is worse than neither landing.
  */
@@ -41,7 +41,7 @@ export function shouldDropAvatarHandoff(failedAttempts: number): boolean {
 
 /**
  * Persist the avatar's voice to the assistant's managed-TTS config. Onboarding
- * assistants are managed, so the voice lives on the `vellum` provider block —
+ * assistants are managed, so the voice lives on the `vellum` provider block,
  * the same field every voice picker writes.
  *
  * A null voice is a no-op success: the catalog never loaded, so there is

--- a/clients/web/src/components/onboarding-avatar-applier.tsx
+++ b/clients/web/src/components/onboarding-avatar-applier.tsx
@@ -1,19 +1,25 @@
 /**
- * Applies the avatar chosen during research-onboarding to the assistant.
+ * Applies the avatar chosen during research-onboarding to the assistant — both
+ * halves of it: the face and the voice that face was auditioned in.
  *
  * SPIKE — research-onboarding flow.
  *
- * The chosen avatar traits aren't part of the pre-chat handoff context, so they
- * can't be set during hatch. This invisible component (mounted in `ChatLayout`)
- * watches for the staged `pendingAvatarTraits` and the active assistant id, then
- * persists the traits via `saveCharacterTraits`. Transient save failures retry
- * with bounded backoff; the staged value clears after a successful save or after
- * the retry budget is exhausted.
+ * Neither is part of the pre-chat handoff context, so neither can be set during
+ * hatch. This invisible component (mounted in `ChatLayout`) watches for the
+ * staged `pendingAvatarTraits` / `pendingAvatarVoice` and the active assistant
+ * id, then persists the traits via `saveCharacterTraits` and the voice via
+ * `config_patch`. Transient save failures retry with bounded backoff; the staged
+ * values clear after a successful save or after the retry budget is exhausted.
+ *
+ * The two are applied as ONE handoff, under one retry budget, because they're
+ * one pick: an assistant wearing the face it was given but speaking in a voice
+ * the user never heard is worse than neither landing.
  */
 
 import { useEffect, useRef, useState } from "react";
 
 import { saveCharacterTraits } from "@/assistant/avatar-api";
+import { configPatch } from "@/generated/daemon/sdk.gen";
 import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterTraits } from "@/types/avatar";
@@ -33,10 +39,37 @@ export function shouldDropAvatarHandoff(failedAttempts: number): boolean {
   return failedAttempts >= AVATAR_APPLY_MAX_ATTEMPTS;
 }
 
+/**
+ * Persist the avatar's voice to the assistant's managed-TTS config. Onboarding
+ * assistants are managed, so the voice lives on the `vellum` provider block —
+ * the same field every voice picker writes.
+ *
+ * A null voice is a no-op success: the catalog never loaded, so there is
+ * nothing to say beyond the platform default the assistant already has.
+ */
+async function saveAvatarVoice(
+  assistantId: string,
+  model: string | null,
+): Promise<void> {
+  if (!model) {
+    return;
+  }
+  const { response } = await configPatch({
+    path: { assistant_id: assistantId },
+    body: { services: { tts: { providers: { vellum: { model } } } } },
+    throwOnError: false,
+  });
+  if (!response?.ok) {
+    throw new Error("Avatar voice was not saved");
+  }
+}
+
 export function OnboardingAvatarApplier() {
   const pendingAvatarTraits = useOnboardingFocusStore.use.pendingAvatarTraits();
   const setPendingAvatarTraits =
     useOnboardingFocusStore.use.setPendingAvatarTraits();
+  const setPendingAvatarVoice =
+    useOnboardingFocusStore.use.setPendingAvatarVoice();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const savingRef = useRef(false);
   const failedAttemptsRef = useRef(0);
@@ -65,15 +98,22 @@ export function OnboardingAvatarApplier() {
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     const traits = pendingAvatarTraits;
+    // The voice rides along with the traits rather than driving the effect
+    // itself: both are staged in the same turn, so re-running on the voice
+    // would only re-fire the handoff the traits already own. Read at apply
+    // time so a retry always carries the current pick.
+    const voice = useOnboardingFocusStore.getState().pendingAvatarVoice;
     void saveCharacterTraits(assistantId, traits)
-      .then((saved) => {
+      .then(async (saved) => {
         if (!saved) {
           throw new Error("Avatar traits were not saved");
         }
+        await saveAvatarVoice(assistantId, voice);
         if (!cancelled) {
           currentHandoffRef.current = null;
           failedAttemptsRef.current = 0;
           setPendingAvatarTraits(null);
+          setPendingAvatarVoice(null);
         }
       })
       .catch(() => {
@@ -85,6 +125,7 @@ export function OnboardingAvatarApplier() {
         if (shouldDropAvatarHandoff(failedAttempts)) {
           currentHandoffRef.current = null;
           setPendingAvatarTraits(null);
+          setPendingAvatarVoice(null);
           return;
         }
         retryTimer = setTimeout(() => {
@@ -104,7 +145,13 @@ export function OnboardingAvatarApplier() {
         clearTimeout(retryTimer);
       }
     };
-  }, [pendingAvatarTraits, assistantId, retryNonce, setPendingAvatarTraits]);
+  }, [
+    pendingAvatarTraits,
+    assistantId,
+    retryNonce,
+    setPendingAvatarTraits,
+    setPendingAvatarVoice,
+  ]);
 
   return null;
 }

--- a/clients/web/src/components/speech/use-voice-sample-preview.ts
+++ b/clients/web/src/components/speech/use-voice-sample-preview.ts
@@ -1,13 +1,13 @@
 /**
  * On-demand preview of a managed voice via its hosted sample.
  *
- * Lives on its own (rather than inside `voice-list`) because two unrelated
- * surfaces audition voices: the voice pickers, which preview a row of a list,
- * and the onboarding face step, which previews the one voice belonging to the
- * centered avatar. Both need the same teardown discipline, so it exists once.
+ * Stands on its own because two unrelated surfaces audition voices: the voice
+ * pickers, which preview a row of a list, and the onboarding face step, which
+ * previews the one voice belonging to the centered avatar. Both need the same
+ * teardown discipline, so it exists once.
  *
  * Hosted samples are static provider-side assets, so a preview costs no
- * synthesis and no credits — the only thing the caller needs is the catalog.
+ * synthesis and no credits. All a caller needs is the catalog.
  */
 
 import { useEffect, useRef, useState } from "react";

--- a/clients/web/src/components/speech/use-voice-sample-preview.ts
+++ b/clients/web/src/components/speech/use-voice-sample-preview.ts
@@ -1,0 +1,78 @@
+/**
+ * On-demand preview of a managed voice via its hosted sample.
+ *
+ * Lives on its own (rather than inside `voice-list`) because two unrelated
+ * surfaces audition voices: the voice pickers, which preview a row of a list,
+ * and the onboarding face step, which previews the one voice belonging to the
+ * centered avatar. Both need the same teardown discipline, so it exists once.
+ *
+ * Hosted samples are static provider-side assets, so a preview costs no
+ * synthesis and no credits — the only thing the caller needs is the catalog.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { type ManagedVoiceOption } from "@/lib/tts/use-managed-voices";
+
+export interface UseVoiceSamplePreview {
+  /** The model currently playing, or null. */
+  previewingModel: string | null;
+  play: (voice: ManagedVoiceOption) => void;
+  stop: () => void;
+}
+
+/**
+ * Tracks which voice is playing so a surface can swap its play affordance for
+ * a stop one; tears down on a new play and on unmount so a late-resolving
+ * `play()` can't leak onto a gone component.
+ */
+export function useVoiceSamplePreview(): UseVoiceSamplePreview {
+  const [previewingModel, setPreviewingModel] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const tokenRef = useRef(0);
+
+  const stop = () => {
+    // Bump the token so a late-resolving play() bails, then tear down.
+    tokenRef.current++;
+    audioRef.current?.pause();
+    audioRef.current = null;
+    setPreviewingModel(null);
+  };
+
+  useEffect(
+    () => () => {
+      tokenRef.current++;
+      audioRef.current?.pause();
+      audioRef.current = null;
+    },
+    [],
+  );
+
+  function play(voice: ManagedVoiceOption): void {
+    if (!voice.sampleUrl) {
+      return;
+    }
+    audioRef.current?.pause();
+    const token = ++tokenRef.current;
+    const audio = new Audio(voice.sampleUrl);
+    audioRef.current = audio;
+    setPreviewingModel(voice.model);
+    const clear = () => {
+      if (tokenRef.current === token) {
+        setPreviewingModel(null);
+      }
+    };
+    audio.onended = clear;
+    audio.onerror = clear;
+    void audio.play().catch(() => {
+      if (tokenRef.current === token) {
+        toast.error("Could not play the voice sample.");
+        setPreviewingModel(null);
+      }
+    });
+  }
+
+  return { previewingModel, play, stop };
+}

--- a/clients/web/src/components/speech/voice-list.tsx
+++ b/clients/web/src/components/speech/voice-list.tsx
@@ -27,16 +27,15 @@ import { Check, Square, Volume2 } from "lucide-react";
 import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
-import { toast } from "@vellumai/design-library/components/toast";
 
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+import { useVoiceSamplePreview } from "@/components/speech/use-voice-sample-preview";
 import {
   groupVoicesByAccent,
   MANAGED_VOICE_SOURCE_LABELS,
   splitVoiceDescription,
   voiceTraitsLabel,
 } from "@/lib/tts/managed-voice-catalog";
-import { type ManagedVoiceOption } from "@/lib/tts/use-managed-voices";
 
 /**
  * A voice's label: its character traits lead (sentence-cased), with the accent
@@ -60,64 +59,6 @@ export function VoiceLabel({
       )}
     </span>
   );
-}
-
-/**
- * On-demand preview of a single voice via its hosted sample. Tracks which
- * voice is playing so the row can show a spinner; tears down on a new play and
- * on unmount so a late-resolving `play()` can't leak onto a gone component.
- */
-function useVoiceSamplePreview(): {
-  previewingModel: string | null;
-  play: (voice: ManagedVoiceOption) => void;
-  stop: () => void;
-} {
-  const [previewingModel, setPreviewingModel] = useState<string | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const tokenRef = useRef(0);
-
-  const stop = () => {
-    // Bump the token so a late-resolving play() bails, then tear down.
-    tokenRef.current++;
-    audioRef.current?.pause();
-    audioRef.current = null;
-    setPreviewingModel(null);
-  };
-
-  useEffect(
-    () => () => {
-      tokenRef.current++;
-      audioRef.current?.pause();
-      audioRef.current = null;
-    },
-    [],
-  );
-
-  function play(voice: ManagedVoiceOption): void {
-    if (!voice.sampleUrl) {
-      return;
-    }
-    audioRef.current?.pause();
-    const token = ++tokenRef.current;
-    const audio = new Audio(voice.sampleUrl);
-    audioRef.current = audio;
-    setPreviewingModel(voice.model);
-    const clear = () => {
-      if (tokenRef.current === token) {
-        setPreviewingModel(null);
-      }
-    };
-    audio.onended = clear;
-    audio.onerror = clear;
-    void audio.play().catch(() => {
-      if (tokenRef.current === token) {
-        toast.error("Could not play the voice sample.");
-        setPreviewingModel(null);
-      }
-    });
-  }
-
-  return { previewingModel, play, stop };
 }
 
 export interface VoiceListProps {

--- a/clients/web/src/domains/onboarding/onboarding-avatar-voices.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-avatar-voices.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the avatar→voice pairing. The pairing is a *preference* resolved
+ * against whatever the platform actually serves, so what needs guarding is the
+ * degradation: a delisted voice must cost the pairing, not the audition.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { AVATAR_POOL_SIZE } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import {
+  AVATAR_VOICE_MODELS,
+  resolveAvatarVoice,
+} from "@/domains/onboarding/onboarding-avatar-voices";
+import { type ManagedVoiceOption } from "@/lib/tts/use-managed-voices";
+
+function voice(model: string): ManagedVoiceOption {
+  return {
+    model,
+    label: model,
+    description: "American · test",
+    sampleUrl: `https://example.test/${model}.mp3`,
+    source: "deepgram",
+  };
+}
+
+describe("avatar voice pairing", () => {
+  test("pairs every avatar in the cast, with no voice used twice", () => {
+    expect(AVATAR_VOICE_MODELS.length).toBe(AVATAR_POOL_SIZE);
+    // Cycling the carousel has to sound like meeting different characters.
+    expect(new Set(AVATAR_VOICE_MODELS).size).toBe(AVATAR_VOICE_MODELS.length);
+  });
+
+  test("resolves each avatar's own voice from the catalog", () => {
+    const catalog = AVATAR_VOICE_MODELS.map(voice);
+    for (const [index, model] of AVATAR_VOICE_MODELS.entries()) {
+      expect(resolveAvatarVoice(index, catalog)?.model).toBe(model);
+    }
+  });
+
+  test("falls back to a catalog voice when the pairing is delisted", () => {
+    const catalog = [voice("aura-2-orion-en"), voice("aura-2-vesta-en")];
+    const resolved = resolveAvatarVoice(0, catalog);
+
+    expect(resolved).not.toBeNull();
+    // Stable across visits, and different from a neighbour's, so the step keeps
+    // its shape even on a catalog the pairing predates.
+    expect(resolveAvatarVoice(0, catalog)?.model).toBe(resolved!.model);
+    expect(resolveAvatarVoice(1, catalog)?.model).not.toBe(resolved!.model);
+  });
+
+  test("resolves nothing without a catalog", () => {
+    expect(resolveAvatarVoice(0, [])).toBeNull();
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarding-avatar-voices.ts
+++ b/clients/web/src/domains/onboarding/onboarding-avatar-voices.ts
@@ -1,25 +1,23 @@
 /**
  * Which managed voice belongs to which onboarding avatar.
  *
- * The face step's audition existed once before and was pulled (#39073) because
- * every avatar auditioned the same default voice: hearing one generic voice out
- * of twelve different characters taught the opposite of what it was for. So the
- * pairing is the feature — the button says what *this* character sounds like,
- * and the answer changes as you cycle the carousel.
+ * The pairing is the point. The face step's audition answers "what does THIS
+ * character sound like", so the answer has to change as you cycle the carousel;
+ * one shared voice across twelve faces teaches the opposite.
  *
  * Index-aligned with `HARDCODED_POOL` in `onboarding-avatar-pool-store`: the
- * cast is hand-picked and fixed, so the voices can be hand-picked too. Voices
- * are matched to each character's body/eyes/color (grumpy purple blob → dry and
- * formal; goofy teal urchin → bright and energetic), and spread across accents
- * and registers so cycling actually sounds like meeting different characters.
+ * cast is hand-picked and fixed, so the voices are hand-picked too. Each voice
+ * is matched to its character's body/eyes/color (grumpy purple blob: dry and
+ * formal; goofy teal urchin: bright and energetic), and the set spans accents
+ * and registers so cycling sounds like meeting different characters.
  *
- * Index 0 — the avatar the picker centers first — deliberately takes the
- * platform default voice, so a user who never touches the carousel gets exactly
- * the voice onboarding assistants got before per-avatar voices existed.
+ * Index 0, the avatar the picker centers first, takes the platform default
+ * voice, so an untouched carousel hands off the voice the platform picks on its
+ * own.
  *
  * Model ids come from the platform catalog (`speech_proxy/voice_catalog.py`),
- * which is the source of truth for what's offered and rate-carded. This list is
- * a *preference*, not a contract: `resolveAvatarVoice` falls back when the
+ * which is the source of truth for what is offered and rate-carded. This list
+ * is a preference, not a contract: `resolveAvatarVoice` falls back when the
  * platform stops offering one, so delisting a voice degrades the pairing
  * instead of breaking the step.
  */
@@ -28,30 +26,30 @@ import { type ManagedVoiceOption } from "@/lib/tts/use-managed-voices";
 
 /** Preferred managed voice per avatar, indexed by position in the cast. */
 export const AVATAR_VOICE_MODELS: readonly string[] = [
-  "EXAVITQu4vr4xnSDxMaL", // 0 teal goofy urchin — Sarah, the platform default
-  "onwK4e9ZLuTAKqWW03F9", // 1 purple grumpy blob — Daniel, formal and flat
-  "TX3LPaxmHKxFdv7VOQHJ", // 2 orange surprised star — Liam, young and eager
-  "aura-2-helena-en", //     3 pink gentle blob — Helena, caring
-  "pNInz6obpgDQGcFmaJgB", // 4 yellow angry ninja — Adam, deep and firm
-  "aura-2-luna-en", //       5 pink curious urchin — Luna, friendly
-  "IKne3meq5aSn9XLyUdCD", // 6 orange quirky burst — Charlie, loose and lively
-  "aura-2-pandora-en", //    7 green bashful ghost — Pandora, soft and calm
-  "aura-2-apollo-en", //     8 orange dazed sprout — Apollo, unhurried
-  "aura-2-thalia-en", //     9 teal goofy star — Thalia, bright
-  "Xb7hH8MSUJpSbSDYk0k2", // 10 pink angry flower — Alice, crisp and pointed
-  "aura-2-theia-en", //      11 yellow curious cloud — Theia, expressive
+  "EXAVITQu4vr4xnSDxMaL", // 0 teal goofy urchin: Sarah, the platform default
+  "onwK4e9ZLuTAKqWW03F9", // 1 purple grumpy blob: Daniel, formal and flat
+  "TX3LPaxmHKxFdv7VOQHJ", // 2 orange surprised star: Liam, young and eager
+  "aura-2-helena-en", //     3 pink gentle blob: Helena, caring
+  "pNInz6obpgDQGcFmaJgB", // 4 yellow angry ninja: Adam, deep and firm
+  "aura-2-luna-en", //       5 pink curious urchin: Luna, friendly
+  "IKne3meq5aSn9XLyUdCD", // 6 orange quirky burst: Charlie, loose and lively
+  "aura-2-pandora-en", //    7 green bashful ghost: Pandora, soft and calm
+  "aura-2-apollo-en", //     8 orange dazed sprout: Apollo, unhurried
+  "aura-2-thalia-en", //     9 teal goofy star: Thalia, bright
+  "Xb7hH8MSUJpSbSDYk0k2", // 10 pink angry flower: Alice, crisp and pointed
+  "aura-2-theia-en", //      11 yellow curious cloud: Theia, expressive
 ];
 
 /**
  * The voice for the avatar at `index`, resolved against the catalog the
  * platform actually serves.
  *
- * Prefers this avatar's pairing. When the platform no longer offers it (a
+ * Prefers this avatar's pairing. When the platform does not offer it (a
  * delisting, or a rate card the pairing predates) any catalog voice beats no
- * audition at all, so fall back to a stable position in the catalog — stable so
+ * audition at all, so fall back to a stable position in the catalog: stable so
  * two visits to the same avatar audition the same voice, and offset by `index`
- * so neighbouring avatars still differ. Null only when the catalog is empty
- * (not yet fetched, or the fetch failed).
+ * so neighbouring avatars still differ. Null only when the catalog is empty,
+ * either unfetched or failed.
  */
 export function resolveAvatarVoice(
   index: number,

--- a/clients/web/src/domains/onboarding/onboarding-avatar-voices.ts
+++ b/clients/web/src/domains/onboarding/onboarding-avatar-voices.ts
@@ -1,0 +1,69 @@
+/**
+ * Which managed voice belongs to which onboarding avatar.
+ *
+ * The face step's audition existed once before and was pulled (#39073) because
+ * every avatar auditioned the same default voice: hearing one generic voice out
+ * of twelve different characters taught the opposite of what it was for. So the
+ * pairing is the feature — the button says what *this* character sounds like,
+ * and the answer changes as you cycle the carousel.
+ *
+ * Index-aligned with `HARDCODED_POOL` in `onboarding-avatar-pool-store`: the
+ * cast is hand-picked and fixed, so the voices can be hand-picked too. Voices
+ * are matched to each character's body/eyes/color (grumpy purple blob → dry and
+ * formal; goofy teal urchin → bright and energetic), and spread across accents
+ * and registers so cycling actually sounds like meeting different characters.
+ *
+ * Index 0 — the avatar the picker centers first — deliberately takes the
+ * platform default voice, so a user who never touches the carousel gets exactly
+ * the voice onboarding assistants got before per-avatar voices existed.
+ *
+ * Model ids come from the platform catalog (`speech_proxy/voice_catalog.py`),
+ * which is the source of truth for what's offered and rate-carded. This list is
+ * a *preference*, not a contract: `resolveAvatarVoice` falls back when the
+ * platform stops offering one, so delisting a voice degrades the pairing
+ * instead of breaking the step.
+ */
+
+import { type ManagedVoiceOption } from "@/lib/tts/use-managed-voices";
+
+/** Preferred managed voice per avatar, indexed by position in the cast. */
+export const AVATAR_VOICE_MODELS: readonly string[] = [
+  "EXAVITQu4vr4xnSDxMaL", // 0 teal goofy urchin — Sarah, the platform default
+  "onwK4e9ZLuTAKqWW03F9", // 1 purple grumpy blob — Daniel, formal and flat
+  "TX3LPaxmHKxFdv7VOQHJ", // 2 orange surprised star — Liam, young and eager
+  "aura-2-helena-en", //     3 pink gentle blob — Helena, caring
+  "pNInz6obpgDQGcFmaJgB", // 4 yellow angry ninja — Adam, deep and firm
+  "aura-2-luna-en", //       5 pink curious urchin — Luna, friendly
+  "IKne3meq5aSn9XLyUdCD", // 6 orange quirky burst — Charlie, loose and lively
+  "aura-2-pandora-en", //    7 green bashful ghost — Pandora, soft and calm
+  "aura-2-apollo-en", //     8 orange dazed sprout — Apollo, unhurried
+  "aura-2-thalia-en", //     9 teal goofy star — Thalia, bright
+  "Xb7hH8MSUJpSbSDYk0k2", // 10 pink angry flower — Alice, crisp and pointed
+  "aura-2-theia-en", //      11 yellow curious cloud — Theia, expressive
+];
+
+/**
+ * The voice for the avatar at `index`, resolved against the catalog the
+ * platform actually serves.
+ *
+ * Prefers this avatar's pairing. When the platform no longer offers it (a
+ * delisting, or a rate card the pairing predates) any catalog voice beats no
+ * audition at all, so fall back to a stable position in the catalog — stable so
+ * two visits to the same avatar audition the same voice, and offset by `index`
+ * so neighbouring avatars still differ. Null only when the catalog is empty
+ * (not yet fetched, or the fetch failed).
+ */
+export function resolveAvatarVoice(
+  index: number,
+  voices: readonly ManagedVoiceOption[],
+): ManagedVoiceOption | null {
+  if (voices.length === 0) {
+    return null;
+  }
+  const preferred = AVATAR_VOICE_MODELS[index % AVATAR_VOICE_MODELS.length];
+  return (
+    voices.find((voice) => voice.model === preferred) ??
+    voices[index % voices.length] ??
+    null
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -236,6 +236,7 @@ mock.module("@/stores/onboarding-focus-store", () => ({
       enterFocus: () => noop,
       exitFocus: () => noop,
       setPendingAvatarTraits: () => noop,
+      setPendingAvatarVoice: () => noop,
       requestSidebarCollapse: () => noop,
     },
   },

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -778,9 +778,9 @@ export function ResearchOnboardingRoute() {
     // Stage the chosen avatar traits; OnboardingAvatarApplier applies them once
     // the assistant is hatched (they're not part of the pre-chat context).
     setPendingAvatarTraits(face?.traits ?? null);
-    // …and the voice that avatar was auditioned in, so the assistant speaks as
-    // the character the user picked rather than in the platform default. Null
-    // (no catalog) leaves the default in place.
+    // ...and the voice that avatar was auditioned in, so the assistant speaks
+    // as the character the user picked rather than in the platform default.
+    // Null (no catalog) leaves the default in place.
     setPendingAvatarVoice(face?.voiceModel ?? null);
 
     // The research pass renders in the focused presentation; entering from a

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -139,6 +139,8 @@ export function ResearchOnboardingRoute() {
   const exitFocus = useOnboardingFocusStore.use.exitFocus();
   const setPendingAvatarTraits =
     useOnboardingFocusStore.use.setPendingAvatarTraits();
+  const setPendingAvatarVoice =
+    useOnboardingFocusStore.use.setPendingAvatarVoice();
   const requestSidebarCollapse =
     useOnboardingFocusStore.use.requestSidebarCollapse();
   // Research/personality onboarding is now THE onboarding — it fully replaces
@@ -370,8 +372,9 @@ export function ResearchOnboardingRoute() {
   useEffect(() => {
     exitFocus();
     setPendingAvatarTraits(null);
+    setPendingAvatarVoice(null);
     startHatch();
-  }, [exitFocus, setPendingAvatarTraits, startHatch]);
+  }, [exitFocus, setPendingAvatarTraits, setPendingAvatarVoice, startHatch]);
 
   // Resolve whether the hatched assistant already has a life BEFORE the flow
   // can fire anything at it: the research turn writes memory and the
@@ -775,8 +778,10 @@ export function ResearchOnboardingRoute() {
     // Stage the chosen avatar traits; OnboardingAvatarApplier applies them once
     // the assistant is hatched (they're not part of the pre-chat context).
     setPendingAvatarTraits(face?.traits ?? null);
-    // Onboarding assistants use the default Vellum managed voice via their TTS
-    // config; per-avatar voice selection is a planned follow-up.
+    // …and the voice that avatar was auditioned in, so the assistant speaks as
+    // the character the user picked rather than in the platform default. Null
+    // (no catalog) leaves the default in place.
+    setPendingAvatarVoice(face?.voiceModel ?? null);
 
     // The research pass renders in the focused presentation; entering from a
     // suggestion (or skipping) is a normal chat, so only focus for research.
@@ -1324,6 +1329,7 @@ export function ResearchOnboardingRoute() {
         }}
         onBack={() => goBackTo("form")}
         onForward={onForward}
+        assistantId={hatchedAssistantId}
       />,
     );
   }

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
@@ -1,15 +1,15 @@
 /**
- * Tests for the face/name step's voice surface — the only place voice appears
- * in onboarding: a "Hear my voice" audition of the CENTERED avatar's own voice.
+ * Tests for the face/name step's voice surface, the only place voice appears in
+ * onboarding: a "Hear my voice" audition of the CENTERED avatar's own voice.
  *
- * The pairing is the whole point (an audition that sounded identical on every
- * character is why the previous one was pulled), so the tests that matter are
- * about which voice belongs to which face: that cycling the carousel changes
- * what plays, that it stops what was playing, and that Continue carries the
- * voice the user actually heard.
+ * The pairing is the whole point, so the tests that matter are about which
+ * voice belongs to which face: that cycling the carousel changes what plays,
+ * that it stops what was playing, and that Continue carries the voice the user
+ * actually heard.
  *
- * The decorative avatar layer + audio playback are mocked so the test exercises
- * the voice affordance and wiring, not the carousel or a real <audio> element.
+ * The decorative avatar layer and audio playback are mocked so the test
+ * exercises the voice affordance and wiring, not the carousel or a real
+ * <audio> element.
  */
 
 import {
@@ -61,13 +61,15 @@ let catalog: Array<typeof SARAH> = [];
 mock.module("@/lib/tts/use-managed-voices", () => ({
   useManagedVoices: (assistantId: string | null) => ({
     // The catalog is served through the hatched assistant's daemon, so an
-    // unhatched assistant has no voices — the same shape the real hook returns.
+    // unhatched assistant has no voices, the same shape the real hook returns.
     voices: assistantId ? catalog : [],
     defaultModel: catalog[0]?.model ?? null,
     fetched: !!assistantId,
   }),
 }));
 
+const { useOnboardingAvatarPoolStore } =
+  await import("@/domains/onboarding/onboarding-avatar-pool-store");
 const { GiveMeAFaceScreen } =
   await import("@/domains/onboarding/screens/give-me-a-face-screen");
 
@@ -95,6 +97,11 @@ beforeEach(() => {
   catalog = [SARAH, DANIEL];
   played = [];
   paused = 0;
+  // The avatar pool is a module-level store, so `cleanup` unmounts the screen
+  // but leaves whichever avatar the last test cycled to still selected. Every
+  // test here asserts on the voice of a KNOWN avatar, so each one starts from
+  // the centered-first avatar.
+  useOnboardingAvatarPoolStore.setState({ selectedIndex: 0 });
 });
 
 afterEach(cleanup);
@@ -120,8 +127,7 @@ describe("GiveMeAFaceScreen voice audition", () => {
     expect(played).toEqual([]);
 
     fireEvent.click(hearButton());
-    // The first-centered avatar takes the platform default voice, so an
-    // untouched carousel sounds exactly like it did before per-avatar voices.
+    // The first-centered avatar is paired with the platform default voice.
     await waitFor(() => expect(played).toEqual([SARAH.sampleUrl]));
   });
 

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for the face/name step's voice surface — the only place voice appears
+ * in onboarding: a "Hear my voice" audition of the CENTERED avatar's own voice.
+ *
+ * The pairing is the whole point (an audition that sounded identical on every
+ * character is why the previous one was pulled), so the tests that matter are
+ * about which voice belongs to which face: that cycling the carousel changes
+ * what plays, that it stops what was playing, and that Continue carries the
+ * voice the user actually heard.
+ *
+ * The decorative avatar layer + audio playback are mocked so the test exercises
+ * the voice affordance and wiring, not the carousel or a real <audio> element.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  // Truthy so the scene renders + the pool generates; `colors: []` keeps
+  // `useOnboardingTone` (read by the shared top bar) happy.
+  useBundledAvatarComponents: () => ({ colors: [] }),
+}));
+mock.module(
+  "@/domains/onboarding/components/onboarding-character-stage",
+  () => ({
+    OnboardingCharacterStage: () => null,
+  }),
+);
+
+// A stand-in catalog: enough of the real one to cover both a voice the pairing
+// asks for by name and the fallback when it doesn't.
+const SARAH = {
+  model: "EXAVITQu4vr4xnSDxMaL",
+  label: "Sarah",
+  description: "American · professional, reassuring, confident",
+  sampleUrl: "https://example.test/sarah.mp3",
+  source: "elevenlabs",
+};
+const DANIEL = {
+  model: "onwK4e9ZLuTAKqWW03F9",
+  label: "Daniel",
+  description: "British · authoritative, steady, formal",
+  sampleUrl: "https://example.test/daniel.mp3",
+  source: "elevenlabs",
+};
+let catalog: Array<typeof SARAH> = [];
+mock.module("@/lib/tts/use-managed-voices", () => ({
+  useManagedVoices: (assistantId: string | null) => ({
+    // The catalog is served through the hatched assistant's daemon, so an
+    // unhatched assistant has no voices — the same shape the real hook returns.
+    voices: assistantId ? catalog : [],
+    defaultModel: catalog[0]?.model ?? null,
+    fetched: !!assistantId,
+  }),
+}));
+
+const { GiveMeAFaceScreen } =
+  await import("@/domains/onboarding/screens/give-me-a-face-screen");
+
+let played: string[] = [];
+let paused = 0;
+
+beforeAll(() => {
+  // happy-dom doesn't implement media playback.
+  (
+    window.HTMLMediaElement.prototype as unknown as {
+      play: () => Promise<void>;
+    }
+  ).play = function (this: HTMLAudioElement) {
+    played.push(this.src);
+    return Promise.resolve();
+  };
+  (
+    window.HTMLMediaElement.prototype as unknown as { pause: () => void }
+  ).pause = () => {
+    paused++;
+  };
+});
+
+beforeEach(() => {
+  catalog = [SARAH, DANIEL];
+  played = [];
+  paused = 0;
+});
+
+afterEach(cleanup);
+
+function renderScreen(
+  props: Partial<Parameters<typeof GiveMeAFaceScreen>[0]> = {},
+) {
+  return render(
+    <GiveMeAFaceScreen
+      onContinue={() => {}}
+      onBack={() => {}}
+      assistantId="asst_1"
+      {...props}
+    />,
+  );
+}
+
+const hearButton = () => screen.getByRole("button", { name: "Hear my voice" });
+
+describe("GiveMeAFaceScreen voice audition", () => {
+  test("auditions the centered avatar's voice on click, never on landing", async () => {
+    renderScreen();
+    expect(played).toEqual([]);
+
+    fireEvent.click(hearButton());
+    // The first-centered avatar takes the platform default voice, so an
+    // untouched carousel sounds exactly like it did before per-avatar voices.
+    await waitFor(() => expect(played).toEqual([SARAH.sampleUrl]));
+  });
+
+  test("cycling the carousel auditions a different voice", async () => {
+    renderScreen();
+    fireEvent.click(screen.getByRole("button", { name: "Next character" }));
+
+    fireEvent.click(hearButton());
+    await waitFor(() => expect(played).toEqual([DANIEL.sampleUrl]));
+  });
+
+  test("cycling away stops the audition mid-play", async () => {
+    renderScreen();
+    fireEvent.click(hearButton());
+    await waitFor(() => expect(played.length).toBe(1));
+    // Playing, so the control offers to stop instead.
+    expect(
+      screen.getByRole("button", { name: "Stop the voice sample" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next character" }));
+
+    // The voice that belonged to the old face doesn't run over the new one.
+    expect(paused).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: "Stop the voice sample" }),
+    ).toBeNull();
+  });
+
+  test("the control stops a playing audition", async () => {
+    renderScreen();
+    fireEvent.click(hearButton());
+    const stop = await screen.findByRole("button", {
+      name: "Stop the voice sample",
+    });
+
+    fireEvent.click(stop);
+    expect(paused).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: "Stop the voice sample" }),
+    ).toBeNull();
+  });
+
+  test("carries the auditioned voice through Continue", () => {
+    const onContinue = mock(() => {});
+    renderScreen({ onContinue });
+    fireEvent.click(screen.getByRole("button", { name: "Next character" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+
+    expect(
+      (
+        onContinue.mock.calls[0] as unknown as [{ voiceModel: string | null }]
+      )[0].voiceModel,
+    ).toBe(DANIEL.model);
+  });
+
+  test("stays inert, and reports no voice, without a catalog", () => {
+    const onContinue = mock(() => {});
+    // No hatched assistant yet, so no catalog to audition from.
+    renderScreen({ assistantId: null, onContinue });
+
+    fireEvent.click(hearButton());
+    expect(played).toEqual([]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    expect(
+      (
+        onContinue.mock.calls[0] as unknown as [{ voiceModel: string | null }]
+      )[0].voiceModel,
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -43,9 +43,9 @@ export interface GiveMeAFaceValues {
   traits: CharacterTraits;
   name: string;
   /**
-   * The managed voice belonging to the chosen avatar — what the user just
-   * auditioned, so the assistant has to speak in it. Null when the catalog
-   * never loaded, in which case the assistant keeps the platform default.
+   * The managed voice belonging to the chosen avatar: what the user auditioned,
+   * so the assistant has to speak in it. Null when the catalog never loaded, in
+   * which case the assistant keeps the platform default.
    */
   voiceModel: string | null;
 }
@@ -57,8 +57,8 @@ interface GiveMeAFaceScreenProps {
   onForward?: () => void;
   /**
    * The background-hatched assistant, whose daemon serves the managed voice
-   * catalog the audition previews from. Null until the hatch lands — the
-   * audition stays disabled until then.
+   * catalog the audition previews from. Null until the hatch lands, which
+   * leaves the audition disabled.
    */
   assistantId?: string | null;
 }
@@ -153,10 +153,10 @@ export function GiveMeAFaceScreen({
   }, [editingName]);
 
   // Each avatar has its own voice (see onboarding-avatar-voices), auditioned
-  // from the catalog's hosted sample — a static asset, so previewing costs no
-  // synthesis and no credits. The catalog is served through the hatched
-  // assistant's daemon, so the button waits on the hatch rather than on a
-  // request of its own.
+  // from the catalog's hosted sample. Samples are static provider-side assets,
+  // so an audition costs no synthesis and no credits. The catalog is served
+  // through the hatched assistant's daemon, so the button waits on the hatch
+  // rather than on a request of its own.
   const { voices } = useManagedVoices(assistantId);
   const centeredVoice = useMemo(
     () => (centerChar == null ? null : resolveAvatarVoice(centerChar, voices)),
@@ -192,8 +192,8 @@ export function GiveMeAFaceScreen({
     if (slot < 0) {
       return;
     }
-    // The audition belongs to the avatar that was centered; letting it run over
-    // the next one would pair a voice with a face it isn't.
+    // The audition belongs to the avatar leaving the center; letting it run on
+    // would pair a voice with a face it isn't.
     stopVoice();
     const edgeOrder = [...arrangement.edgeOrder];
     edgeOrder[slot] = arrangement.centerChar;
@@ -368,8 +368,7 @@ export function GiveMeAFaceScreen({
 
             {/* The only place voice is surfaced in onboarding. It auditions the
                 CENTERED avatar's own voice, so cycling the carousel is also how
-                you shop for a voice — an audition that sounded the same on every
-                character is why the previous one was pulled. */}
+                you shop for a voice. */}
             <button
               type="button"
               onClick={toggleVoice}

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -381,7 +381,7 @@ export function GiveMeAFaceScreen({
               className="flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default disabled:opacity-40"
             >
               {auditioning ? (
-                <Square className="h-4 w-4 fill-current" />
+                <Square className="h-4 w-4" />
               ) : (
                 <Volume2 className="h-4 w-4" />
               )}

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -15,8 +15,16 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, ArrowRight, Dices, Pencil } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Dices,
+  Pencil,
+  Square,
+  Volume2,
+} from "lucide-react";
 
+import { useVoiceSamplePreview } from "@/components/speech/use-voice-sample-preview";
 import { OnboardingCharacterStage } from "@/domains/onboarding/components/onboarding-character-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
 import {
@@ -24,6 +32,8 @@ import {
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { resolveAvatarVoice } from "@/domains/onboarding/onboarding-avatar-voices";
+import { useManagedVoices } from "@/lib/tts/use-managed-voices";
 import { randomCharacterTraits } from "@/utils/avatar-random";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import type { CharacterTraits } from "@/types/avatar";
@@ -32,6 +42,12 @@ import { Button } from "@vellumai/design-library/components/button";
 export interface GiveMeAFaceValues {
   traits: CharacterTraits;
   name: string;
+  /**
+   * The managed voice belonging to the chosen avatar — what the user just
+   * auditioned, so the assistant has to speak in it. Null when the catalog
+   * never loaded, in which case the assistant keeps the platform default.
+   */
+  voiceModel: string | null;
 }
 
 interface GiveMeAFaceScreenProps {
@@ -39,6 +55,12 @@ interface GiveMeAFaceScreenProps {
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * The background-hatched assistant, whose daemon serves the managed voice
+   * catalog the audition previews from. Null until the hatch lands — the
+   * audition stays disabled until then.
+   */
+  assistantId?: string | null;
 }
 
 /** Prefill names, cycled across the pool and swapped in as you change avatars. */
@@ -64,6 +86,7 @@ export function GiveMeAFaceScreen({
   onContinue,
   onBack,
   onForward,
+  assistantId = null,
 }: GiveMeAFaceScreenProps) {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
@@ -129,6 +152,35 @@ export function GiveMeAFaceScreen({
     }
   }, [editingName]);
 
+  // Each avatar has its own voice (see onboarding-avatar-voices), auditioned
+  // from the catalog's hosted sample — a static asset, so previewing costs no
+  // synthesis and no credits. The catalog is served through the hatched
+  // assistant's daemon, so the button waits on the hatch rather than on a
+  // request of its own.
+  const { voices } = useManagedVoices(assistantId);
+  const centeredVoice = useMemo(
+    () => (centerChar == null ? null : resolveAvatarVoice(centerChar, voices)),
+    [centerChar, voices],
+  );
+  const {
+    previewingModel,
+    play: playVoice,
+    stop: stopVoice,
+  } = useVoiceSamplePreview();
+  const auditioning =
+    centeredVoice !== null && previewingModel === centeredVoice.model;
+
+  function toggleVoice() {
+    if (!centeredVoice) {
+      return;
+    }
+    if (auditioning) {
+      stopVoice();
+      return;
+    }
+    playVoice(centeredVoice);
+  }
+
   // Swap `targetChar` into the center; the old center takes its vacated slot.
   // The incoming avatar flies off-screen then pops into the center; the old
   // center shrinks away then reappears at `slot` (both tracked via `swap`).
@@ -140,6 +192,9 @@ export function GiveMeAFaceScreen({
     if (slot < 0) {
       return;
     }
+    // The audition belongs to the avatar that was centered; letting it run over
+    // the next one would pair a voice with a face it isn't.
+    stopVoice();
     const edgeOrder = [...arrangement.edgeOrder];
     edgeOrder[slot] = arrangement.centerChar;
     setSwap({
@@ -163,7 +218,11 @@ export function GiveMeAFaceScreen({
 
   function handleContinue() {
     if (centeredTraits) {
-      onContinue({ traits: centeredTraits, name: name.trim() });
+      onContinue({
+        traits: centeredTraits,
+        name: name.trim(),
+        voiceModel: centeredVoice?.model ?? null,
+      });
     }
   }
 
@@ -306,6 +365,28 @@ export function GiveMeAFaceScreen({
                 </button>
               </div>
             )}
+
+            {/* The only place voice is surfaced in onboarding. It auditions the
+                CENTERED avatar's own voice, so cycling the carousel is also how
+                you shop for a voice — an audition that sounded the same on every
+                character is why the previous one was pulled. */}
+            <button
+              type="button"
+              onClick={toggleVoice}
+              disabled={!centeredVoice}
+              title="Hear my voice"
+              aria-label={
+                auditioning ? "Stop the voice sample" : "Hear my voice"
+              }
+              className="flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default disabled:opacity-40"
+            >
+              {auditioning ? (
+                <Square className="h-4 w-4 fill-current" />
+              ) : (
+                <Volume2 className="h-4 w-4" />
+              )}
+              Hear my voice
+            </button>
           </div>
 
           <Button

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -44,9 +44,10 @@ interface OnboardingFocusState {
   pendingAvatarTraits: CharacterTraits | null;
   setPendingAvatarTraits: (traits: CharacterTraits | null) => void;
   /**
-   * The managed voice belonging to that avatar, staged and applied alongside it
-   * — the face and the voice are one pick, so they land together. Null when the
-   * voice catalog never loaded, leaving the assistant on the platform default.
+   * The managed voice belonging to that avatar, staged and applied alongside
+   * it. The face and the voice are one pick, so they land together. Null when
+   * the voice catalog never loaded, leaving the assistant on the platform
+   * default.
    */
   pendingAvatarVoice: string | null;
   setPendingAvatarVoice: (model: string | null) => void;

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -44,6 +44,13 @@ interface OnboardingFocusState {
   pendingAvatarTraits: CharacterTraits | null;
   setPendingAvatarTraits: (traits: CharacterTraits | null) => void;
   /**
+   * The managed voice belonging to that avatar, staged and applied alongside it
+   * — the face and the voice are one pick, so they land together. Null when the
+   * voice catalog never loaded, leaving the assistant on the platform default.
+   */
+  pendingAvatarVoice: string | null;
+  setPendingAvatarVoice: (model: string | null) => void;
+  /**
    * A follow-up message the focused results overlay wants sent into the same
    * conversation (e.g. the "deeper dive" research request). The overlay lives
    * outside `ActiveChatView`, which owns `sendMessage`; ActiveChatView watches
@@ -91,6 +98,8 @@ const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
     }),
   pendingAvatarTraits: null,
   setPendingAvatarTraits: (traits) => set({ pendingAvatarTraits: traits }),
+  pendingAvatarVoice: null,
+  setPendingAvatarVoice: (model) => set({ pendingAvatarVoice: model }),
   pendingFollowupMessage: null,
   requestFollowup: (message) => set({ pendingFollowupMessage: message }),
   clearFollowup: () => set({ pendingFollowupMessage: null }),


### PR DESCRIPTION
## What

Brings the **"Hear my voice"** audition back to the "Give me a face and a name" step of research-onboarding — this time auditioning the **centered avatar's own voice**, so cycling the carousel is also how you shop for a voice.

## Why now

The audition shipped in #38460 and was pulled in #39073 for a specific reason: it synthesized the *default* managed voice, so every one of the twelve characters sounded identical. One generic voice on every face taught the opposite of what the button was for. Per-avatar voices were named as the fast-follow; this is it.

Two things changed since that make it much cheaper than the deferral assumed:

- **Previews are hosted samples, not synthesis.** The platform catalog (`speech_proxy/voice_catalog.py`) carries a `sampleUrl` per voice, so an audition is `new Audio(url)` — no TTS call, no credits, no round trip. The old loading state and the "still warming up" toast both go away; the button is simply inert until the catalog is there.
- **The platform owns the catalog**, so the pairing can be a *preference* rather than a contract.

## How

- **`onboarding-avatar-voices.ts`** (new) — a voice per avatar, index-aligned with the hand-picked `HARDCODED_POOL`, matched to each character's body/eyes/color and spread across accents and registers. Index 0 (the first-centered avatar) takes the platform default, so an untouched carousel sounds exactly like onboarding did before per-avatar voices existed.
- **`resolveAvatarVoice`** resolves that preference against the catalog the platform actually serves, falling back to a stable catalog position when a voice is delisted — a rate-card change degrades the pairing instead of breaking the step.
- **Face screen** — the button auditions the centered voice, flips to a stop affordance while playing, and stops when you cycle away (a voice running over the next face would pair a voice with a face it isn't). The chosen voice rides up through `onContinue`.
- **Persistence** — staged as `pendingAvatarVoice` and applied post-hatch by `OnboardingAvatarApplier` to `services.tts.providers.vellum.model`, in the **same handoff as the avatar traits and under one retry budget**. An assistant wearing the face it was given but speaking in a voice the user never heard is worse than neither landing.
- **`use-voice-sample-preview.ts`** (new) — the playback teardown extracted from `voice-list.tsx`, so the two surfaces that audition voices share one copy instead of growing a second.

No feature flag: `voice-mode` is GA'd and its flag is gone.

## Test plan

- New `give-me-a-face-screen.test.tsx` (6) — auditions the centered voice and never on landing, cycling auditions a *different* voice, cycling away stops playback mid-play, the control stops it, Continue carries the voice actually heard, inert + null without a catalog.
- New `onboarding-avatar-voices.test.ts` (4) — every avatar paired, no voice used twice, each resolves to its own, and the delisted-voice fallback stays stable and distinct.
- `onboarding-avatar-applier.test.tsx` — three added: voice applied alongside the face, no patch when no voice resolved, handoff stays queued when the voice write fails.
- 9 test files green (49 tests), including the three other voice surfaces that consume the extracted hook. `bun run typecheck` and eslint clean.

⚠️ **Not verified in a browser.** The one runtime question the tests can't answer is whether the managed-voice catalog resolves before a user reaches the face step — the background hatch fires on route mount and the face step is two screens in, so it should, but a slow hatch leaves the button disabled with no explanation.

Closes JARVIS-1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)