### PR TITLE
State sidebar test comments in the present tense (LUM-3040 follow-up)

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.test.tsx
+++ b/clients/web/src/components/collapsible-nav-section.test.tsx
@@ -112,12 +112,12 @@ describe("CollapsibleNavSection", () => {
     expect(html).not.toContain("lucide-clock");
   });
 
-  // Regression: a polish pass once made the title a plain drag-only label,
-  // leaving the small chevron as the sole toggle target. The whole title
-  // row must be the accordion trigger - click toggles,
+  // The whole title row is the accordion trigger - click toggles,
   // click-and-hold-and-move drags - and it must be the ONLY trigger:
   // a second Radix trigger for the same item duplicates the trigger id
-  // and gives keyboard/screen-reader users two stops per section.
+  // and gives keyboard/screen-reader users two stops per section, and a
+  // title that is not a trigger leaves the chevron as the sole, tiny
+  // toggle target.
   test("the title is the section's one accessible trigger; the chevron is decorative", () => {
     const html = renderSingleSection({ value: "recents", label: "Recents" });
     const container = document.createElement("div");

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1092,9 +1092,8 @@ describe("AssistantSideMenu · equal section treatment", () => {
   // rows (user-curated, expected to stay short). Every derived section -
   // Chats and each channel section - caps at SIDEBAR_SECTION_MAX_HEIGHT
   // and scrolls within itself, so a busy section can never push its
-  // neighbours out of reach. Regression guard: a polish pass once unbound
-  // Chats onto the sidebar body, which parked the channel sections below
-  // hundreds of rows.
+  // neighbours out of reach: an uncapped Chats would scroll against the
+  // sidebar body and park the channel sections below hundreds of rows.
   test("Chats and channel sections cap/scroll internally; Pinned doesn't", () => {
     // A real DOM render, not `parse`: `scrollParent` only takes effect once
     // the sidebar body's ref has mounted.


### PR DESCRIPTION
## TL;DR

Comment-only follow-up to #39966: two test comments described how prior changes regressed the sidebar rather than the invariant the tests protect, which the repo's comment rules forbid. They now state present behavior. Zero code changes, so no release cherry-pick.

Addresses the post-merge Codex P2 on #39966.

Related to LUM-3040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->