### PR TITLE
feat(web): classify paired lockfile entries in the resolved-assistants store

### DIFF
--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -122,6 +122,7 @@ mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: getSelectedAssistantMock,
   hasAssistants: () => false,
   isLocalAssistant: () => false,
+  isPairedAssistant: () => false,
   isLocalClient: isLocalClientMock,
   isPlatformAssistant: () => false,
   isPlatformDisabled: () => false,

--- a/clients/web/src/assistant/operational-status.test.tsx
+++ b/clients/web/src/assistant/operational-status.test.tsx
@@ -176,6 +176,7 @@ describe("useAssistantOperationalStatus", () => {
           id: "assistant-platform",
           isLocal: false,
           isPlatformHosted: true,
+          isPaired: false,
         },
       ],
       selectedAssistantId: "assistant-platform",

--- a/clients/web/src/assistant/selection.test.ts
+++ b/clients/web/src/assistant/selection.test.ts
@@ -55,7 +55,13 @@ function platformAssistant(
   id: string,
   organizationId?: string,
 ): ResolvedAssistant {
-  return { id, isLocal: false, isPlatformHosted: true, organizationId };
+  return {
+    id,
+    isLocal: false,
+    isPlatformHosted: true,
+    isPaired: false,
+    organizationId,
+  };
 }
 
 function lockfileAssistant(assistantId: string): LockfileAssistant {

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -292,7 +292,9 @@ describe("CheckoutPage", () => {
     // Capture only stashes for a hydrated list holding exactly one assistant.
     useResolvedAssistantsStore.setState({
       activeAssistantId: "a1",
-      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistants: [
+        { id: "a1", isLocal: false, isPlatformHosted: true, isPaired: false },
+      ],
       assistantsHydrated: true,
     });
     render(checkoutTree("/assistant/checkout?package=super", client));

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -992,7 +992,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     // Capture only stashes for a hydrated list holding exactly one assistant.
     useResolvedAssistantsStore.setState({
       activeAssistantId: "a1",
-      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistants: [
+        { id: "a1", isLocal: false, isPlatformHosted: true, isPaired: false },
+      ],
       assistantsHydrated: true,
     });
     client.setQueryData([...avatarQueryKey("a1"), true], {

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -352,7 +352,9 @@ describe("AdjustPlanModal upgrade — checkout intent stash", () => {
     // stashes for a hydrated list holding exactly one assistant.
     useResolvedAssistantsStore.setState({
       activeAssistantId: "a1",
-      assistants: [{ id: "a1", isLocal: false, isPlatformHosted: true }],
+      assistants: [
+        { id: "a1", isLocal: false, isPlatformHosted: true, isPaired: false },
+      ],
       assistantsHydrated: true,
     });
     client.setQueryData([...avatarQueryKey("a1"), true], {

--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -424,6 +424,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
           id: localAssistant.assistantId,
           isLocal: true,
           isPlatformHosted: false,
+          isPaired: false,
         },
       ],
       assistantsHydrated: true,
@@ -452,6 +453,7 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
           id: localAssistant.assistantId,
           isLocal: true,
           isPlatformHosted: false,
+          isPaired: false,
         },
       ],
       assistantsHydrated: true,
@@ -464,7 +466,9 @@ describe("authMiddleware — post-checkout return with nothing provisioned", () 
   test("admits the return once a platform-hosted assistant exists", async () => {
     makePaidPlatformReturn();
     useResolvedAssistantsStore.setState({
-      assistants: [{ id: "a-1", isLocal: false, isPlatformHosted: true }],
+      assistants: [
+        { id: "a-1", isLocal: false, isPlatformHosted: true, isPaired: false },
+      ],
     });
     useAssistantLifecycleStore.setState({
       assistantState: { kind: "active", isLocal: false },

--- a/clients/web/src/lib/billing/takeover-avatar-stash.test.ts
+++ b/clients/web/src/lib/billing/takeover-avatar-stash.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 });
 
 function assistant(id: string): ResolvedAssistant {
-  return { id, isLocal: false, isPlatformHosted: true };
+  return { id, isLocal: false, isPlatformHosted: true, isPaired: false };
 }
 
 /** A hydrated list holding exactly one assistant: the only shape capture stashes. */

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -43,6 +43,7 @@ import {
   isCliWakeableAssistant,
   isLocalAssistant,
   isLocalGatewayAssistant,
+  isPairedAssistant,
   isPlatformAssistant,
   isRemoteGatewayMode,
   loadLockfile,
@@ -401,6 +402,13 @@ describe("assistant classification", () => {
       const remote = { assistantId: `r-${cloud}`, cloud } as LockfileAssistant;
       expect(isLocalAssistant(remote)).toBe(false);
       expect(isPlatformAssistant(remote)).toBe(false);
+    }
+  });
+
+  test("only paired-cloud entries are paired assistants", () => {
+    expect(isPairedAssistant({ cloud: "paired" })).toBe(true);
+    for (const cloud of ["local", "docker", "vellum", undefined]) {
+      expect(isPairedAssistant({ cloud })).toBe(false);
     }
   });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -450,6 +450,17 @@ export function isPlatformAssistant(a: LockfileAssistant): boolean {
 }
 
 /**
+ * A remote assistant paired from another machine via `vellum connect import`
+ * (`cloud === "paired"`): reached directly at its own `runtimeUrl` with the
+ * stored guardian access token as the bearer. Not local (no lifecycle flows,
+ * wake/retire refuse it) and not platform (no platform session involved).
+ * See the `KNOWN_CLOUDS` taxonomy in `@vellumai/local-mode/contract`.
+ */
+export function isPairedAssistant(a: { cloud?: string }): boolean {
+  return a.cloud === "paired";
+}
+
+/**
  * Whether `vellum wake` can start or repair the assistant with this id. Wake
  * operates only on plain local assistants (the {@link isLocalAssistant} set) —
  * it refuses Docker and apple-container entries — so the "Wake up" and

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -121,12 +121,23 @@ describe("buildNavigationState — hasPlatformHostedAssistant", () => {
   const ORG_A = "org-a";
   const ORG_B = "org-b";
 
-  const local = { id: "local-1", isLocal: true, isPlatformHosted: false };
-  const docker = { id: "docker-1", isLocal: false, isPlatformHosted: false };
+  const local = {
+    id: "local-1",
+    isLocal: true,
+    isPlatformHosted: false,
+    isPaired: false,
+  };
+  const docker = {
+    id: "docker-1",
+    isLocal: false,
+    isPlatformHosted: false,
+    isPaired: false,
+  };
   const managedInOrgA = {
     id: "managed-a",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
     organizationId: ORG_A,
   };
   // API-sourced entries carry no org — the platform list is already org-scoped.
@@ -134,6 +145,7 @@ describe("buildNavigationState — hasPlatformHostedAssistant", () => {
     id: "managed-api",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
   };
 
   test("false with nothing resolved", () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -198,6 +198,7 @@ mock.module("@/lib/local-mode", () => ({
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
   isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+  isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],
   getSelectedAssistant: () => mockSelectedAssistant,

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -228,6 +228,33 @@ describe("upsertFromApi", () => {
     expect(entry.releaseChannel).toBe("preview");
   });
 
+  it("preserves paired classification and runtimeUrl on refresh", () => {
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [
+        {
+          assistantId: "paired-desk",
+          cloud: "paired",
+          runtimeUrl: "https://desk.example.com",
+        },
+      ],
+      activeAssistant: null,
+    });
+
+    useResolvedAssistantsStore.getState().upsertFromApi({
+      id: "paired-desk",
+      name: "Desk (refreshed)",
+      created: "2026-01-01T00:00:00Z",
+      is_local: false,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.isPaired).toBe(true);
+    expect(entry.runtimeUrl).toBe("https://desk.example.com");
+    expect(entry.cloud).toBe("paired");
+  });
+
   it("preserves a lockfile-seeded runtimeVersion on refresh", () => {
     useResolvedAssistantsStore.getState().setFromLockfile({
       assistants: [localAssistant],

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -40,6 +40,13 @@ const otherLocalAssistant: LockfileAssistant = {
   },
 };
 
+const pairedAssistant: LockfileAssistant = {
+  assistantId: "paired-desk",
+  name: "Desk",
+  cloud: "paired",
+  runtimeUrl: "https://desk.example.com",
+};
+
 beforeEach(() => {
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   useLockfileStore.setState({ lockfile: null, committed: false });
@@ -73,6 +80,7 @@ describe("setFromLockfile", () => {
           id: "asst-platform",
           isLocal: false,
           isPlatformHosted: true,
+          isPaired: false,
           currentReleaseVersion: "0.9.0",
           releaseChannel: "preview",
         },
@@ -134,6 +142,21 @@ describe("setFromLockfile", () => {
     expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 
+  it("classifies a paired entry and carries its runtimeUrl", () => {
+    const lockfile: Lockfile = {
+      assistants: [pairedAssistant],
+      activeAssistant: null,
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("paired-desk");
+    expect(entry.isPaired).toBe(true);
+    expect(entry.isLocal).toBe(false);
+    expect(entry.isPlatformHosted).toBe(false);
+    expect(entry.runtimeUrl).toBe("https://desk.example.com");
+  });
+
   it("treats a sole local entry as active when the lockfile active pointer is stale", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant],
@@ -176,6 +199,7 @@ describe("upsertFromApi", () => {
     expect(entry.releaseChannel).toBe("stable");
     expect(entry.isActiveLockfileAssistant).toBe(true);
     expect(entry.organizationId).toBeUndefined();
+    expect(entry.isPaired).toBe(false);
   });
 
   it("preserves a lockfile-seeded organizationId on refresh (API has no org)", () => {
@@ -272,23 +296,27 @@ describe("assistantsValidForOrg", () => {
     id: "local",
     isLocal: true,
     isPlatformHosted: false,
+    isPaired: false,
   };
   const activeOrg: ResolvedAssistant = {
     id: "active-org",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
     organizationId: "org-1",
   };
   const otherOrg: ResolvedAssistant = {
     id: "other-org",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
     organizationId: "org-2",
   };
   const legacy: ResolvedAssistant = {
     id: "legacy",
     isLocal: false,
     isPlatformHosted: true,
+    isPaired: false,
   };
 
   it("always keeps local entries", () => {

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -253,6 +253,9 @@ describe("upsertFromApi", () => {
     expect(entry.isPaired).toBe(true);
     expect(entry.runtimeUrl).toBe("https://desk.example.com");
     expect(entry.cloud).toBe("paired");
+    // The API's is_local claim must not reclassify a paired entry.
+    expect(entry.isLocal).toBe(false);
+    expect(entry.isPlatformHosted).toBe(false);
   });
 
   it("preserves a lockfile-seeded runtimeVersion on refresh", () => {

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -201,6 +201,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             organizationId: next[idx]!.organizationId,
             runtimeVersion:
               lockfileFields.runtimeVersion ?? next[idx]!.runtimeVersion,
+            runtimeUrl: lockfileFields.runtimeUrl ?? next[idx]!.runtimeUrl,
+            isPaired: lockfileFields.isPaired ?? next[idx]!.isPaired,
             isActiveLockfileAssistant:
               lockfileFields.isActiveLockfileAssistant ??
               next[idx]!.isActiveLockfileAssistant,
@@ -218,6 +220,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               cloud: lockfileFields.cloud,
               organizationId: lockfileFields.organizationId,
               runtimeVersion: lockfileFields.runtimeVersion,
+              runtimeUrl: lockfileFields.runtimeUrl,
+              isPaired: lockfileFields.isPaired ?? false,
               isActiveLockfileAssistant:
                 lockfileFields.isActiveLockfileAssistant,
             },
@@ -280,6 +284,8 @@ function getLockfileFields(assistantId: string): {
   cloud?: string;
   organizationId?: string;
   runtimeVersion?: string;
+  runtimeUrl?: string;
+  isPaired?: boolean;
   isActiveLockfileAssistant?: boolean;
 } {
   const lockfile = useLockfileStore.getState().lockfile;
@@ -291,6 +297,8 @@ function getLockfileFields(assistantId: string): {
     cloud: entry?.cloud,
     organizationId: entry?.organizationId,
     runtimeVersion: entry?.resources?.runtimeVersion,
+    runtimeUrl: entry?.runtimeUrl,
+    isPaired: entry ? isPairedAssistant(entry) : undefined,
     isActiveLockfileAssistant: lockfile
       ? activeLockfileAssistantId === assistantId
       : undefined,

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -29,6 +29,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   isLocalClient,
   isLocalAssistant,
+  isPairedAssistant,
   isPlatformAssistant,
 } from "@/lib/local-mode";
 import {
@@ -52,6 +53,9 @@ export interface ResolvedAssistant {
   isActiveLockfileAssistant?: boolean;
   isLocal: boolean;
   isPlatformHosted: boolean;
+  isPaired: boolean;
+  /** Remote gateway URL for paired entries; only the lockfile carries it. */
+  runtimeUrl?: string;
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
@@ -133,6 +137,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         isActiveLockfileAssistant: activeLockfileAssistantId === a.assistantId,
         isLocal: isLocalAssistant(a),
         isPlatformHosted: isPlatformAssistant(a),
+        isPaired: isPairedAssistant(a),
+        runtimeUrl: a.runtimeUrl,
         organizationId: a.organizationId,
       }));
       set({ assistants, assistantsHydrated: true });
@@ -162,6 +168,9 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             isActiveLockfileAssistant: lockfileFields.isActiveLockfileAssistant,
             isLocal: a.is_local,
             isPlatformHosted: !a.is_local,
+            // API-sourced entries are never paired; paired entries only ever
+            // arrive via the lockfile subscription.
+            isPaired: false,
           };
         }),
       }),
@@ -178,6 +187,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           releaseChannel: assistant.release_channel,
           isLocal: assistant.is_local,
           isPlatformHosted: !assistant.is_local,
+          isPaired: false,
         };
         const idx = state.assistants.findIndex((a) => a.id === assistant.id);
         if (idx >= 0) {

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -157,7 +157,6 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         assistantsHydrated: true,
         assistants: assistants.map((a) => {
           const lockfileFields = getLockfileFields(a.id);
-          const isPaired = lockfileFields.isPaired ?? false;
           return {
             id: a.id,
             name: a.name,
@@ -168,11 +167,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             currentReleaseVersion: a.current_release_version,
             releaseChannel: a.release_channel,
             isActiveLockfileAssistant: lockfileFields.isActiveLockfileAssistant,
-            // A paired entry is neither local nor platform-hosted, whatever
-            // the API's is_local claims — classification follows the lockfile.
-            isLocal: isPaired ? false : a.is_local,
-            isPlatformHosted: isPaired ? false : !a.is_local,
-            isPaired,
+            ...classifyApiEntry(a.is_local, lockfileFields.isPaired),
           };
         }),
       }),
@@ -185,18 +180,18 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         const prior = idx >= 0 ? state.assistants[idx] : undefined;
         const lockfileFields = getLockfileFields(assistant.id);
         // The API payload omits lockfile-sourced fields; preserve them across
-        // lifecycle refreshes. A paired entry is neither local nor
-        // platform-hosted, whatever the API's is_local claims.
-        const isPaired = lockfileFields.isPaired ?? prior?.isPaired ?? false;
+        // lifecycle refreshes.
         const entry: ResolvedAssistant = {
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
-          isLocal: isPaired ? false : assistant.is_local,
-          isPlatformHosted: isPaired ? false : !assistant.is_local,
-          isPaired,
+          ...classifyApiEntry(
+            assistant.is_local,
+            lockfileFields.isPaired,
+            prior?.isPaired,
+          ),
         };
         if (prior) {
           const next = [...state.assistants];
@@ -281,6 +276,25 @@ function reconcileSelection(
 export const useResolvedAssistantsStore = createSelectors(
   useResolvedAssistantsStoreBase,
 );
+
+/**
+ * Classification triplet for an API-shaped entry, honoring the lockfile: a
+ * paired entry is neither local nor platform-hosted, whatever the API's
+ * `is_local` claims. `priorIsPaired` carries an already-resolved entry's
+ * classification through refreshes where the lockfile is unavailable.
+ */
+function classifyApiEntry(
+  isLocalFromApi: boolean,
+  lockfileIsPaired: boolean | undefined,
+  priorIsPaired?: boolean,
+): Pick<ResolvedAssistant, "isLocal" | "isPlatformHosted" | "isPaired"> {
+  const isPaired = lockfileIsPaired ?? priorIsPaired ?? false;
+  return {
+    isPaired,
+    isLocal: isPaired ? false : isLocalFromApi,
+    isPlatformHosted: isPaired ? false : !isLocalFromApi,
+  };
+}
 
 function getLockfileFields(assistantId: string): {
   cloud?: string;

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -157,20 +157,22 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         assistantsHydrated: true,
         assistants: assistants.map((a) => {
           const lockfileFields = getLockfileFields(a.id);
+          const isPaired = lockfileFields.isPaired ?? false;
           return {
             id: a.id,
             name: a.name,
             hatchedAt: a.created,
             cloud: lockfileFields.cloud,
             runtimeVersion: lockfileFields.runtimeVersion,
+            runtimeUrl: lockfileFields.runtimeUrl,
             currentReleaseVersion: a.current_release_version,
             releaseChannel: a.release_channel,
             isActiveLockfileAssistant: lockfileFields.isActiveLockfileAssistant,
-            isLocal: a.is_local,
-            isPlatformHosted: !a.is_local,
-            // API-sourced entries are never paired; paired entries only ever
-            // arrive via the lockfile subscription.
-            isPaired: false,
+            // A paired entry is neither local nor platform-hosted, whatever
+            // the API's is_local claims — classification follows the lockfile.
+            isLocal: isPaired ? false : a.is_local,
+            isPlatformHosted: isPaired ? false : !a.is_local,
+            isPaired,
           };
         }),
       }),
@@ -179,39 +181,40 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
 
     upsertFromApi: (assistant) =>
       set((state) => {
+        const idx = state.assistants.findIndex((a) => a.id === assistant.id);
+        const prior = idx >= 0 ? state.assistants[idx] : undefined;
+        const lockfileFields = getLockfileFields(assistant.id);
+        // The API payload omits lockfile-sourced fields; preserve them across
+        // lifecycle refreshes. A paired entry is neither local nor
+        // platform-hosted, whatever the API's is_local claims.
+        const isPaired = lockfileFields.isPaired ?? prior?.isPaired ?? false;
         const entry: ResolvedAssistant = {
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
-          isLocal: assistant.is_local,
-          isPlatformHosted: !assistant.is_local,
-          isPaired: false,
+          isLocal: isPaired ? false : assistant.is_local,
+          isPlatformHosted: isPaired ? false : !assistant.is_local,
+          isPaired,
         };
-        const idx = state.assistants.findIndex((a) => a.id === assistant.id);
-        if (idx >= 0) {
+        if (prior) {
           const next = [...state.assistants];
-          const lockfileFields = getLockfileFields(assistant.id);
-          // The API payload omits lockfile-sourced fields; preserve them across
-          // lifecycle refreshes.
           next[idx] = {
             ...entry,
-            cloud: lockfileFields.cloud ?? next[idx]!.cloud,
-            organizationId: next[idx]!.organizationId,
+            cloud: lockfileFields.cloud ?? prior.cloud,
+            organizationId: prior.organizationId,
             runtimeVersion:
-              lockfileFields.runtimeVersion ?? next[idx]!.runtimeVersion,
-            runtimeUrl: lockfileFields.runtimeUrl ?? next[idx]!.runtimeUrl,
-            isPaired: lockfileFields.isPaired ?? next[idx]!.isPaired,
+              lockfileFields.runtimeVersion ?? prior.runtimeVersion,
+            runtimeUrl: lockfileFields.runtimeUrl ?? prior.runtimeUrl,
             isActiveLockfileAssistant:
               lockfileFields.isActiveLockfileAssistant ??
-              next[idx]!.isActiveLockfileAssistant,
+              prior.isActiveLockfileAssistant,
           };
           return { assistants: next };
         }
         // New entry: the API payload omits lockfile-sourced fields, but the
         // lockfile may already know them.
-        const lockfileFields = getLockfileFields(assistant.id);
         return {
           assistants: [
             ...state.assistants,
@@ -221,7 +224,6 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               organizationId: lockfileFields.organizationId,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
-              isPaired: lockfileFields.isPaired ?? false,
               isActiveLockfileAssistant:
                 lockfileFields.isActiveLockfileAssistant,
             },


### PR DESCRIPTION
## Summary
- Add isPairedAssistant helper for cloud: "paired" lockfile entries
- Carry isPaired + runtimeUrl through ResolvedAssistant from the lockfile

Part of plan: web-paired-entries.md (PR 1 of 7)