### PR TITLE
feat(local-mode): add an unpair host operation across the host bridge

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -34,6 +34,7 @@ import {
   isActiveAssistant,
   runHatch,
   runRetire,
+  unpairAssistant,
   getGuardianAccessToken,
   parseGatewayUrl,
   resolveGatewayProxyTarget,
@@ -445,6 +446,7 @@ function findWebSourceDir(): string | null {
 const LOCKFILE_PATTERN = /^(?:\/assistant)?\/__local\/lockfile$/;
 const HATCH_PATTERN = /^(?:\/assistant)?\/__local\/hatch$/;
 const RETIRE_PATTERN = /^(?:\/assistant)?\/__local\/retire$/;
+const UNPAIR_PATTERN = /^(?:\/assistant)?\/__local\/unpair$/;
 const GUARDIAN_TOKEN_PATTERN =
   /^(?:\/assistant)?\/__local\/guardian-token\/([^/]+)$/;
 const PLATFORM_SESSION_PATTERN =
@@ -500,6 +502,7 @@ async function handleLocalEndpoints(
     LOCKFILE_PATTERN.test(pathname) ||
     HATCH_PATTERN.test(pathname) ||
     RETIRE_PATTERN.test(pathname) ||
+    UNPAIR_PATTERN.test(pathname) ||
     GUARDIAN_TOKEN_PATTERN.test(pathname) ||
     PLATFORM_SESSION_PATTERN.test(pathname) ||
     parseGatewayUrl(pathname).match;
@@ -673,6 +676,38 @@ async function handleLocalEndpoints(
     const result = await runRetire(invocation, assistantId);
     if (result.ok) {
       return Response.json({ ok: true });
+    }
+    return Response.json(
+      { ok: false, error: result.error },
+      { status: result.status },
+    );
+  }
+
+  // Unpair: forget a paired assistant (lockfile entry + guardian token).
+  if (UNPAIR_PATTERN.test(pathname)) {
+    if (req.method !== "POST") return new Response(null, { status: 405 });
+
+    let assistantId: string | undefined;
+    try {
+      const body = (await req.json()) as { assistantId?: string };
+      assistantId = body.assistantId;
+    } catch {
+      return Response.json(
+        { ok: false, error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    }
+
+    if (!assistantId) {
+      return Response.json(
+        { ok: false, error: "Missing assistantId" },
+        { status: 400 },
+      );
+    }
+
+    const result = unpairAssistant(lockfilePaths, configDir, assistantId);
+    if (result.ok) {
+      return Response.json({ ok: true, lockfile: result.lockfile });
     }
     return Response.json(
       { ok: false, error: result.error },

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -685,7 +685,9 @@ async function handleLocalEndpoints(
 
   // Unpair: forget a paired assistant (lockfile entry + guardian token).
   if (UNPAIR_PATTERN.test(pathname)) {
-    if (req.method !== "POST") return new Response(null, { status: 405 });
+    if (req.method !== "POST") {
+      return new Response(null, { status: 405 });
+    }
 
     let assistantId: string | undefined;
     try {

--- a/clients/macos/src/main/bundle-flow.test.ts
+++ b/clients/macos/src/main/bundle-flow.test.ts
@@ -53,6 +53,7 @@ mock.module("@vellumai/local-mode", () => ({
   getGuardianAccessToken: getGuardianAccessTokenMock,
   replacePlatformAssistants: mock(() => ({ ok: false, error: "unused" })),
   upsertLockfileAssistant: mock(() => ({ ok: false, error: "unused" })),
+  unpairAssistant: mock(() => ({ ok: false, error: "unused" })),
   runHatch: mock(async () => ({ ok: false, error: "unused" })),
   runRetire: mock(async () => ({ ok: false, error: "unused" })),
   runSleep: mock(async () => ({ ok: false, error: "unused" })),

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -372,6 +372,8 @@ const retire = (assistantId?: unknown): Promise<unknown> =>
     allowedEvent,
     assistantId,
   ) as Promise<unknown>;
+const unpair = (assistantId?: unknown): WriteResult =>
+  handlers["vellum:localMode:unpair"](allowedEvent, assistantId) as WriteResult;
 const wake = (assistantId?: unknown, options?: unknown): Promise<unknown> =>
   handlers["vellum:localMode:wake"](
     allowedEvent,
@@ -594,6 +596,61 @@ describe("vellum:localMode:retire handler", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe("disk full");
     expect(spawnArgs).toHaveLength(0);
+  });
+});
+
+describe("vellum:localMode:unpair handler", () => {
+  // Matches the module's `resolveConfigDir(process.env)` under the
+  // production + XDG_CONFIG_HOME environment pinned above.
+  const configDir = path.join(configHomeDir, "vellum");
+  const tokenPath = (assistantId: string): string =>
+    path.join(configDir, "assistants", assistantId, "guardian-token.json");
+
+  beforeEach(() => {
+    fs.rmSync(lockfilePath, { force: true });
+    fs.rmSync(path.join(configDir, "assistants"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("removes a paired entry and deletes its guardian token", () => {
+    saveLockfileAssistant(
+      { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://h" },
+      "paired-1",
+    );
+    fs.mkdirSync(path.dirname(tokenPath("paired-1")), { recursive: true });
+    fs.writeFileSync(tokenPath("paired-1"), "{}");
+
+    const result = unpair("paired-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.lockfile.activeAssistant).toBeNull();
+    expect(result.lockfile.assistants).toEqual([]);
+    expect(fs.existsSync(tokenPath("paired-1"))).toBe(false);
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("refuses a non-paired entry", () => {
+    saveLockfileAssistant(
+      { assistantId: "local-1", cloud: "local" },
+      "local-1",
+    );
+
+    const result = unpair("local-1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("paired");
+  });
+
+  test("rejects a missing assistant id with a structured error", () => {
+    expect(unpair("")).toEqual({ ok: false, error: "Missing assistantId" });
+    expect(unpair(undefined)).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
   });
 });
 

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -625,7 +625,9 @@ describe("vellum:localMode:unpair handler", () => {
     const result = unpair("paired-1");
 
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    if (!result.ok) {
+      return;
+    }
     expect(result.lockfile.activeAssistant).toBeNull();
     expect(result.lockfile.assistants).toEqual([]);
     expect(fs.existsSync(tokenPath("paired-1"))).toBe(false);
@@ -641,7 +643,9 @@ describe("vellum:localMode:unpair handler", () => {
     const result = unpair("local-1");
 
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.error).toContain("paired");
   });
 

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -17,6 +17,7 @@ import {
   runSleep,
   runUpgrade,
   runWake,
+  unpairAssistant,
   upsertLockfileAssistant,
   type CliInvocation,
   type LockfileWriteResult,
@@ -213,9 +214,9 @@ async function upgrade(
 // fields pass through untouched.
 const assistantRecord = z.record(z.string(), z.unknown());
 
-// `retire` and `guardianToken` both take a single assistant id and keep a
-// never-reject contract: a missing id resolves with a structured error the
-// renderer renders, rather than rejecting the invoke. The id is therefore
+// `retire`, `unpair`, and `guardianToken` each take a single assistant id and
+// keep a never-reject contract: a missing id resolves with a structured error
+// the renderer renders, rather than rejecting the invoke. The id is therefore
 // optional on the wire and validated in the body.
 const assistantIdArgs = z.tuple([z.string().optional()]);
 
@@ -312,6 +313,18 @@ export const installLocalMode = (): void => {
     if (!assistantId) return { ok: false, error: "Missing assistantId" };
     return retire(assistantId);
   });
+
+  handle(
+    "vellum:localMode:unpair",
+    assistantIdArgs,
+    ([assistantId]): LockfileWriteResult => {
+      if (!assistantId) return { ok: false, error: "Missing assistantId" };
+      const result = unpairAssistant(lockfilePaths, configDir, assistantId);
+      return result.ok
+        ? { ok: true, lockfile: result.lockfile }
+        : { ok: false, error: result.error };
+    },
+  );
 
   handle("vellum:localMode:sleep", assistantIdArgs, ([assistantId]) => {
     if (!assistantId) return { ok: false, error: "Missing assistantId" };

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -318,7 +318,9 @@ export const installLocalMode = (): void => {
     "vellum:localMode:unpair",
     assistantIdArgs,
     ([assistantId]): LockfileWriteResult => {
-      if (!assistantId) return { ok: false, error: "Missing assistantId" };
+      if (!assistantId) {
+        return { ok: false, error: "Missing assistantId" };
+      }
       const result = unpairAssistant(lockfilePaths, configDir, assistantId);
       return result.ok
         ? { ok: true, lockfile: result.lockfile }

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -341,6 +341,11 @@ const bridge: VellumBridge = {
         ok: boolean;
         error?: string;
       }>,
+    unpair: (assistantId: string) =>
+      ipcRenderer.invoke(
+        "vellum:localMode:unpair",
+        assistantId,
+      ) as Promise<LockfileWriteResult>,
     sleep: (assistantId: string) =>
       ipcRenderer.invoke("vellum:localMode:sleep", assistantId) as Promise<{
         ok: boolean;

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -200,6 +200,7 @@ declare global {
           organizationId?: string,
         ): Promise<LockfileWriteResult>;
         retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+        unpair?(assistantId: string): Promise<LockfileWriteResult>;
         sleep?(assistantId: string): Promise<{ ok: boolean; error?: string }>;
         wake?(
           assistantId: string,

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -13,6 +13,7 @@ const {
   saveLockfileAssistantHost,
   replacePlatformAssistantsHost,
   retireLocalAssistantHost,
+  unpairAssistantHost,
   upgradeLocalAssistantHost,
   wakeLocalAssistantHost,
   getLocalAssistantStatusHost,
@@ -287,6 +288,65 @@ describe("retireLocalAssistantHost", () => {
     expect(await retireLocalAssistantHost("a-1")).toEqual({ ok: true });
     expect(retire).toHaveBeenCalledWith("a-1");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("unpairAssistantHost", () => {
+  const emptyLockfile = { assistants: [], activeAssistant: null };
+
+  test("web/dev host POSTs the assistant id to the unpair middleware", async () => {
+    const fetchMock = mock(async () => ({
+      json: async () => ({ ok: true, lockfile: emptyLockfile }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await unpairAssistantHost("a-1")).toEqual({
+      ok: true,
+      lockfile: emptyLockfile,
+    });
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/assistant/__local/unpair");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ assistantId: "a-1" });
+  });
+
+  test("web/dev host surfaces the host's structured refusal", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({ ok: false, error: "No such assistant" }),
+    })) as unknown as typeof fetch;
+
+    expect(await unpairAssistantHost("a-1")).toEqual({
+      ok: false,
+      error: "No such assistant",
+    });
+  });
+
+  test("Electron host unpairs through the bridge and never touches fetch", async () => {
+    const unpair = mock(async () => ({ ok: true, lockfile: emptyLockfile }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ unpair });
+
+    expect(await unpairAssistantHost("a-1")).toEqual({
+      ok: true,
+      lockfile: emptyLockfile,
+    });
+    expect(unpair).toHaveBeenCalledWith("a-1");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("older Electron shell without the unpair channel reports an unsupported failure", async () => {
+    setElectronBridge({});
+
+    expect(await unpairAssistantHost("a-1")).toEqual({
+      ok: false,
+      error: "Unpair is not supported by this app version",
+    });
   });
 });
 

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -298,6 +298,37 @@ export async function retireLocalAssistantHost(
 }
 
 /**
+ * Forget a paired assistant (`cloud: "paired"`): remove its lockfile entry and
+ * delete its stored guardian token on this machine. Client-side only: the
+ * remote assistant is never touched. Both hosts run the shared package op in a
+ * trusted process and return the same `LockfileWriteResult` contract; hosts
+ * refuse non-paired entries (local/managed assistants go through
+ * {@link retireLocalAssistantHost}). Older Electron hosts that predate the IPC
+ * channel degrade to a structured unsupported error, mirroring
+ * {@link sleepLocalAssistantHost}.
+ */
+export async function unpairAssistantHost(
+  assistantId: string,
+): Promise<LockfileWriteResult> {
+  if (isElectron()) {
+    const unpair = window.vellum!.localMode.unpair;
+    if (!unpair) {
+      return {
+        ok: false,
+        error: "Unpair is not supported by this app version",
+      };
+    }
+    return unpair(assistantId);
+  }
+
+  return postLocalCommand<LockfileWriteResult>(
+    "/assistant/__local/unpair",
+    { assistantId },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+}
+
+/**
  * Stop a local assistant's daemon and gateway. Both hosts drive the Vellum
  * CLI's `sleep --force` in a trusted process and return the same `{ ok, error }`
  * contract. Used as the first half of a restart (sleep → wake).

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -19,6 +19,7 @@ import {
   runSleep,
   runUpgrade,
   runWake,
+  unpairAssistant,
   getGuardianAccessToken,
   resolveGatewayProxyTarget,
   readAllowedGatewayPorts,
@@ -84,6 +85,9 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(lockfileMiddleware(config.lockfilePaths));
       server.middlewares.use(hatchMiddleware(baseDir));
       server.middlewares.use(retireMiddleware(baseDir, config.lockfilePaths));
+      server.middlewares.use(
+        unpairMiddleware(config.lockfilePaths, config.configDir),
+      );
       server.middlewares.use(sleepMiddleware(baseDir));
       server.middlewares.use(wakeMiddleware(baseDir));
       const upgradingLocalAssistantIds = new Set<string>();
@@ -459,6 +463,67 @@ function retireMiddleware(
           ),
         );
       });
+    });
+  };
+}
+
+function unpairMiddleware(
+  lockfilePaths: string[],
+  configDir: string,
+): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    if (
+      req.url !== "/assistant/__local/unpair" &&
+      req.url !== "/__local/unpair"
+    ) {
+      return next();
+    }
+
+    if (rejectUnlessLocalEndpointRequest(req, res)) {
+      return;
+    }
+
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let assistantId: string | undefined;
+      if (chunks.length > 0) {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            assistantId?: string;
+          };
+          assistantId = body.assistantId;
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
+          return;
+        }
+      }
+
+      if (!assistantId) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+        return;
+      }
+
+      const result = unpairAssistant(lockfilePaths, configDir, assistantId);
+      res.statusCode = result.ok ? 200 : result.status;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify(
+          result.ok
+            ? { ok: true, lockfile: result.lockfile }
+            : { ok: false, error: result.error },
+        ),
+      );
     });
   };
 }

--- a/clients/windows/src/preload/index.ts
+++ b/clients/windows/src/preload/index.ts
@@ -102,6 +102,8 @@ const bridge: Pick<
       Promise.resolve({ ok: false as const, status: 501, error: NOT_AVAILABLE }),
     retire: () => Promise.resolve({ ok: false, error: NOT_AVAILABLE }),
     sleep: () => Promise.resolve({ ok: false, error: NOT_AVAILABLE }),
+    unpair: () =>
+      Promise.resolve({ ok: false as const, error: NOT_AVAILABLE }),
     guardianToken: () =>
       Promise.resolve({ ok: false as const, status: 501, error: NOT_AVAILABLE }),
   },

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -172,6 +172,12 @@ export interface VellumBridge {
       organizationId?: string,
     ): Promise<LockfileWriteResult>;
     retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+    /**
+     * Forget a paired assistant (`cloud: "paired"`): remove its lockfile
+     * entry and stored guardian token on this machine. Client-side only:
+     * the remote assistant is never touched.
+     */
+    unpair(assistantId: string): Promise<LockfileWriteResult>;
     sleep(assistantId: string): Promise<{ ok: boolean; error?: string }>;
     wake(
       assistantId: string,

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -66,6 +66,7 @@ export const LOCAL_MODE_READ_LOCKFILE = "vellum:localMode:readLockfile";
 export const LOCAL_MODE_SAVE_ASSISTANT = "vellum:localMode:saveLockfileAssistant";
 export const LOCAL_MODE_REPLACE_PLATFORM = "vellum:localMode:replacePlatformAssistants";
 export const LOCAL_MODE_RETIRE = "vellum:localMode:retire";
+export const LOCAL_MODE_UNPAIR = "vellum:localMode:unpair";
 export const LOCAL_MODE_SLEEP = "vellum:localMode:sleep";
 export const LOCAL_MODE_WAKE = "vellum:localMode:wake";
 export const LOCAL_MODE_UPGRADE = "vellum:localMode:upgrade";

--- a/packages/local-mode/src/__tests__/unpair.test.ts
+++ b/packages/local-mode/src/__tests__/unpair.test.ts
@@ -35,7 +35,7 @@ const seedGuardianToken = (assistantId: string): string => {
 };
 
 describe("unpairAssistant", () => {
-  test("removes the paired entry, deletes its guardian token, and clears the active pointer", () => {
+  test("removes the paired entry, deletes its guardian token, and reassigns the active pointer", () => {
     writeLockfile({
       assistants: [
         { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://h" },
@@ -48,8 +48,12 @@ describe("unpairAssistant", () => {
     const result = unpairAssistant([lockfilePath], configDir, "paired-1");
 
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.lockfile.activeAssistant).toBeNull();
+    if (!result.ok) {
+      return;
+    }
+    // Active falls back to the first remaining entry, matching the CLI's
+    // removeAssistantEntry semantics.
+    expect(result.lockfile.activeAssistant).toBe("local-1");
     expect(result.lockfile.assistants.map((a) => a.assistantId)).toEqual([
       "local-1",
     ]);
@@ -60,7 +64,23 @@ describe("unpairAssistant", () => {
     expect(onDisk.assistants).toEqual([
       { assistantId: "local-1", cloud: "local", futureField: "keep-me" },
     ]);
-    expect(onDisk.activeAssistant).toBeNull();
+    expect(onDisk.activeAssistant).toBe("local-1");
+  });
+
+  test("removing the sole (active) entry leaves no active pointer", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: "paired-1",
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.lockfile.activeAssistant).toBeNull();
+    expect(result.lockfile.assistants).toEqual([]);
   });
 
   test("leaves the active pointer alone when it names another assistant", () => {
@@ -75,7 +95,9 @@ describe("unpairAssistant", () => {
     const result = unpairAssistant([lockfilePath], configDir, "paired-1");
 
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    if (!result.ok) {
+      return;
+    }
     expect(result.lockfile.activeAssistant).toBe("local-1");
   });
 
@@ -116,7 +138,9 @@ describe("unpairAssistant", () => {
     const result = unpairAssistant([lockfilePath], configDir, "local-1");
 
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.status).toBe(400);
     expect(result.error).toContain("paired");
     expect(fs.existsSync(tokenPath)).toBe(true);
@@ -134,7 +158,9 @@ describe("unpairAssistant", () => {
     const result = unpairAssistant([lockfilePath], configDir, "bare-1");
 
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.status).toBe(400);
   });
 });

--- a/packages/local-mode/src/__tests__/unpair.test.ts
+++ b/packages/local-mode/src/__tests__/unpair.test.ts
@@ -127,6 +127,28 @@ describe("unpairAssistant", () => {
     expect(readLockfileFromDisk().activeAssistant).toBe("paired-1");
   });
 
+  test("restores the guardian token when the lockfile write fails", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: null,
+    });
+    const tokenPath = seedGuardianToken("paired-1");
+    // A read-only lockfile directory makes the tmp-file write fail after the
+    // token has already been deleted.
+    fs.chmodSync(tmpDir, 0o500);
+    try {
+      const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+      expect(result.ok).toBe(false);
+      expect(fs.existsSync(tokenPath)).toBe(true);
+      expect(fs.readFileSync(tokenPath, "utf-8")).toBe(
+        JSON.stringify({ accessToken: "tok" }),
+      );
+    } finally {
+      fs.chmodSync(tmpDir, 0o700);
+    }
+  });
+
   test("leaves the active pointer alone when it names another assistant", () => {
     writeLockfile({
       assistants: [

--- a/packages/local-mode/src/__tests__/unpair.test.ts
+++ b/packages/local-mode/src/__tests__/unpair.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { guardianTokenPath } from "../config";
+import { unpairAssistant } from "../unpair";
+
+let tmpDir: string;
+let lockfilePath: string;
+let configDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-unpair-"));
+  lockfilePath = path.join(tmpDir, "lockfile.json");
+  configDir = path.join(tmpDir, "config");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const writeLockfile = (data: Record<string, unknown>): void => {
+  fs.writeFileSync(lockfilePath, JSON.stringify(data));
+};
+
+const readLockfileFromDisk = (): Record<string, unknown> =>
+  JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as Record<string, unknown>;
+
+const seedGuardianToken = (assistantId: string): string => {
+  const tokenPath = guardianTokenPath(configDir, assistantId);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(tokenPath, JSON.stringify({ accessToken: "tok" }));
+  return tokenPath;
+};
+
+describe("unpairAssistant", () => {
+  test("removes the paired entry, deletes its guardian token, and clears the active pointer", () => {
+    writeLockfile({
+      assistants: [
+        { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://h" },
+        { assistantId: "local-1", cloud: "local", futureField: "keep-me" },
+      ],
+      activeAssistant: "paired-1",
+    });
+    const tokenPath = seedGuardianToken("paired-1");
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.lockfile.activeAssistant).toBeNull();
+    expect(result.lockfile.assistants.map((a) => a.assistantId)).toEqual([
+      "local-1",
+    ]);
+    expect(fs.existsSync(tokenPath)).toBe(false);
+
+    // Unknown fields on the remaining entries survive the rewrite.
+    const onDisk = readLockfileFromDisk();
+    expect(onDisk.assistants).toEqual([
+      { assistantId: "local-1", cloud: "local", futureField: "keep-me" },
+    ]);
+    expect(onDisk.activeAssistant).toBeNull();
+  });
+
+  test("leaves the active pointer alone when it names another assistant", () => {
+    writeLockfile({
+      assistants: [
+        { assistantId: "paired-1", cloud: "paired" },
+        { assistantId: "local-1", cloud: "local" },
+      ],
+      activeAssistant: "local-1",
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.lockfile.activeAssistant).toBe("local-1");
+  });
+
+  test("succeeds when the guardian token file is already gone", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: null,
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("refuses an unknown assistant without touching disk", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: "paired-1",
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "nope");
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "No such assistant",
+    });
+    expect(readLockfileFromDisk().activeAssistant).toBe("paired-1");
+  });
+
+  test("refuses a non-paired assistant and leaves its entry and token alone", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "local-1", cloud: "local" }],
+      activeAssistant: "local-1",
+    });
+    const tokenPath = seedGuardianToken("local-1");
+
+    const result = unpairAssistant([lockfilePath], configDir, "local-1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(400);
+    expect(result.error).toContain("paired");
+    expect(fs.existsSync(tokenPath)).toBe(true);
+    expect(readLockfileFromDisk().assistants).toEqual([
+      { assistantId: "local-1", cloud: "local" },
+    ]);
+  });
+
+  test("refuses a cloudless entry (defaults to local) rather than treating it as paired", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "bare-1" }],
+      activeAssistant: null,
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "bare-1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(400);
+  });
+});

--- a/packages/local-mode/src/__tests__/unpair.test.ts
+++ b/packages/local-mode/src/__tests__/unpair.test.ts
@@ -83,6 +83,50 @@ describe("unpairAssistant", () => {
     expect(result.lockfile.assistants).toEqual([]);
   });
 
+  test("reassigns the active pointer past tolerated malformed entries", () => {
+    writeLockfile({
+      assistants: [
+        { assistantId: "paired-1", cloud: "paired" },
+        { notAnAssistant: true },
+        { assistantId: "local-1", cloud: "local" },
+      ],
+      activeAssistant: "paired-1",
+    });
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.lockfile.activeAssistant).toBe("local-1");
+  });
+
+  test("a failed token delete aborts before touching the lockfile", () => {
+    writeLockfile({
+      assistants: [{ assistantId: "paired-1", cloud: "paired" }],
+      activeAssistant: "paired-1",
+    });
+    // A non-empty directory at the token path makes rmSync (non-recursive)
+    // throw, standing in for EPERM-style failures.
+    const tokenPath = guardianTokenPath(configDir, "paired-1");
+    fs.mkdirSync(path.join(tokenPath, "oops"), { recursive: true });
+
+    const result = unpairAssistant([lockfilePath], configDir, "paired-1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.status).toBe(500);
+    expect(result.error).toContain("guardian token");
+    // The entry is untouched, so the unpair can be retried.
+    expect(readLockfileFromDisk().assistants).toEqual([
+      { assistantId: "paired-1", cloud: "paired" },
+    ]);
+    expect(readLockfileFromDisk().activeAssistant).toBe("paired-1");
+  });
+
   test("leaves the active pointer alone when it names another assistant", () => {
     writeLockfile({
       assistants: [

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -44,6 +44,7 @@ export { runHatch } from "./hatch";
 export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireOptions, RetireResult } from "./retire";
+export { unpairAssistant } from "./unpair";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -39,6 +39,53 @@ export type WriteResult =
   | { ok: true; lockfile: Lockfile }
   | { ok: false; status: number; error: string };
 
+/**
+ * Read the first parseable lockfile as raw JSON (unknown fields intact) for a
+ * read-modify-write cycle; an unreadable file yields an empty lockfile.
+ */
+export function readRawLockfile(
+  lockfilePaths: string[],
+): Record<string, unknown> {
+  for (const candidate of lockfilePaths) {
+    try {
+      return JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      // continue
+    }
+  }
+  return { assistants: [], activeAssistant: null };
+}
+
+/**
+ * Atomically persist a raw lockfile (write-to-temp + rename) and return the
+ * validated, sensitive-field-stripped view of what was written.
+ */
+export function writeRawLockfile(
+  lockfilePaths: string[],
+  lockfile: Record<string, unknown>,
+): WriteResult {
+  const writePath = lockfilePaths[0]!;
+  try {
+    const dir = path.dirname(writePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${writePath}.tmp.${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
+    fs.renameSync(tmp, writePath);
+  } catch (err) {
+    return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
+  }
+
+  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<
+    string,
+    unknown
+  >;
+  stripSensitiveFields(stripped);
+  return { ok: true, lockfile: parseLockfile(stripped) };
+}
+
 export function upsertLockfileAssistant(
   lockfilePaths: string[],
   assistant: Record<string, unknown>,
@@ -48,16 +95,7 @@ export function upsertLockfileAssistant(
     return { ok: false, status: 400, error: "Missing assistant.assistantId" };
   }
 
-  let lockfile: Record<string, unknown> = { assistants: [], activeAssistant: null };
-  for (const candidate of lockfilePaths) {
-    try {
-      lockfile = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
-      break;
-    } catch {
-      // continue
-    }
-  }
-
+  const lockfile = readRawLockfile(lockfilePaths);
   const assistants = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
   const existingIdx = assistants.findIndex(
     (a: Record<string, unknown>) => a?.assistantId === assistant.assistantId,
@@ -72,20 +110,7 @@ export function upsertLockfileAssistant(
     lockfile.activeAssistant = activeAssistant;
   }
 
-  const writePath = lockfilePaths[0]!;
-  try {
-    const dir = path.dirname(writePath);
-    fs.mkdirSync(dir, { recursive: true });
-    const tmp = `${writePath}.tmp.${process.pid}`;
-    fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
-    fs.renameSync(tmp, writePath);
-  } catch (err) {
-    return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
-  }
-
-  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<string, unknown>;
-  stripSensitiveFields(stripped);
-  return { ok: true, lockfile: parseLockfile(stripped) };
+  return writeRawLockfile(lockfilePaths, lockfile);
 }
 
 export function isActiveAssistant(
@@ -115,16 +140,7 @@ export function replacePlatformAssistants(
   platformAssistants: Array<Record<string, unknown>>,
   organizationId?: string,
 ): WriteResult {
-  let lockfile: Record<string, unknown> = { assistants: [], activeAssistant: null };
-  for (const candidate of lockfilePaths) {
-    try {
-      lockfile = JSON.parse(fs.readFileSync(candidate, "utf-8")) as Record<string, unknown>;
-      break;
-    } catch {
-      // continue
-    }
-  }
-
+  const lockfile = readRawLockfile(lockfilePaths);
   const existing = Array.isArray(lockfile.assistants) ? lockfile.assistants : [];
   const syncedIds = new Set(platformAssistants.map((a) => a.assistantId));
   // Org-scoped sync preserves other orgs' platform entries; no org full-replaces.
@@ -143,18 +159,5 @@ export function replacePlatformAssistants(
     if (!stillExists) lockfile.activeAssistant = null;
   }
 
-  const writePath = lockfilePaths[0]!;
-  try {
-    const dir = path.dirname(writePath);
-    fs.mkdirSync(dir, { recursive: true });
-    const tmp = `${writePath}.tmp.${process.pid}`;
-    fs.writeFileSync(tmp, JSON.stringify(lockfile, null, 2));
-    fs.renameSync(tmp, writePath);
-  } catch (err) {
-    return { ok: false, status: 500, error: `Failed to write lockfile: ${err}` };
-  }
-
-  const stripped = JSON.parse(JSON.stringify(lockfile)) as Record<string, unknown>;
-  stripSensitiveFields(stripped);
-  return { ok: true, lockfile: parseLockfile(stripped) };
+  return writeRawLockfile(lockfilePaths, lockfile);
 }

--- a/packages/local-mode/src/unpair.ts
+++ b/packages/local-mode/src/unpair.ts
@@ -39,13 +39,39 @@ export function unpairAssistant(
     };
   }
 
+  // Delete the token BEFORE committing the lockfile removal. A failed delete
+  // aborts with the entry intact, so unpair stays retryable; the reverse order
+  // would strand the credential on disk forever (the retry 404s on the
+  // already-removed entry and never reaches cleanup).
+  const tokenPath = guardianTokenPath(configDir, assistantId);
+  try {
+    fs.rmSync(tokenPath, { force: true });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      error: `Failed to delete the stored guardian token: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  try {
+    fs.rmdirSync(path.dirname(tokenPath));
+  } catch {
+    // Directory not empty or absent.
+  }
+
   const remaining = assistants.filter((a) => a?.assistantId !== assistantId);
   lockfile.assistants = remaining;
   // Reassign the active assistant like the CLI's removeAssistantEntry does, so
   // unpairing through the bridge and through `vellum unpair` leave the same
-  // active state.
+  // active state. Skip tolerated malformed entries (no string assistantId) —
+  // parseLockfile drops them from the returned lockfile, so pointing at one
+  // would report no active assistant while valid entries remain.
   if (lockfile.activeAssistant === assistantId) {
-    const next = remaining[0]?.assistantId;
+    const next = remaining.find(
+      (a) => typeof a?.assistantId === "string",
+    )?.assistantId;
     if (typeof next === "string") {
       lockfile.activeAssistant = next;
     } else {
@@ -53,24 +79,5 @@ export function unpairAssistant(
     }
   }
 
-  const result = writeRawLockfile(lockfilePaths, lockfile);
-  if (!result.ok) {
-    return result;
-  }
-
-  // Best-effort, like the CLI's deleteGuardianToken: the entry is already
-  // gone from the lockfile, so a failed token delete must not surface as a
-  // rejected invoke (retrying would 404 on the missing entry anyway).
-  const tokenPath = guardianTokenPath(configDir, assistantId);
-  try {
-    fs.rmSync(tokenPath, { force: true });
-  } catch {
-    // Stale token file remains; it is unusable without its lockfile entry.
-  }
-  try {
-    fs.rmdirSync(path.dirname(tokenPath));
-  } catch {
-    // Directory not empty or absent.
-  }
-  return result;
+  return writeRawLockfile(lockfilePaths, lockfile);
 }

--- a/packages/local-mode/src/unpair.ts
+++ b/packages/local-mode/src/unpair.ts
@@ -42,8 +42,15 @@ export function unpairAssistant(
   // Delete the token BEFORE committing the lockfile removal. A failed delete
   // aborts with the entry intact, so unpair stays retryable; the reverse order
   // would strand the credential on disk forever (the retry 404s on the
-  // already-removed entry and never reaches cleanup).
+  // already-removed entry and never reaches cleanup). The token contents are
+  // kept in memory so a failed lockfile write below can restore them.
   const tokenPath = guardianTokenPath(configDir, assistantId);
+  let savedToken: string | null = null;
+  try {
+    savedToken = fs.readFileSync(tokenPath, "utf-8");
+  } catch {
+    savedToken = null;
+  }
   try {
     fs.rmSync(tokenPath, { force: true });
   } catch (err) {
@@ -65,7 +72,7 @@ export function unpairAssistant(
   lockfile.assistants = remaining;
   // Reassign the active assistant like the CLI's removeAssistantEntry does, so
   // unpairing through the bridge and through `vellum unpair` leave the same
-  // active state. Skip tolerated malformed entries (no string assistantId) —
+  // active state. Skip tolerated malformed entries (no string assistantId):
   // parseLockfile drops them from the returned lockfile, so pointing at one
   // would report no active assistant while valid entries remain.
   if (lockfile.activeAssistant === assistantId) {
@@ -79,5 +86,16 @@ export function unpairAssistant(
     }
   }
 
-  return writeRawLockfile(lockfilePaths, lockfile);
+  const result = writeRawLockfile(lockfilePaths, lockfile);
+  if (!result.ok && savedToken !== null) {
+    // The entry is still listed, so put its credential back (best-effort;
+    // the write failure itself is what gets reported).
+    try {
+      fs.mkdirSync(path.dirname(tokenPath), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(tokenPath, savedToken, { mode: 0o600 });
+    } catch {
+      // Restore failed; the reported write error already covers the outcome.
+    }
+  }
+  return result;
 }

--- a/packages/local-mode/src/unpair.ts
+++ b/packages/local-mode/src/unpair.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+
+import { guardianTokenPath } from "./config";
+import {
+  readRawLockfile,
+  writeRawLockfile,
+  type WriteResult,
+} from "./lockfile";
+import { resolveCloud } from "./lockfile-contract";
+
+/**
+ * Forget a paired assistant on this machine: remove its lockfile entry and
+ * delete its stored guardian token. Client-side only, mirroring the CLI's
+ * `vellum unpair`: the remote assistant itself is never touched (host-side
+ * device revocation is `vellum devices`). Only pairing records
+ * (`cloud: "paired"`, created by `vellum connect import`) are forgettable this
+ * way; local and managed assistants go through retire.
+ */
+export function unpairAssistant(
+  lockfilePaths: string[],
+  configDir: string,
+  assistantId: string,
+): WriteResult {
+  const lockfile = readRawLockfile(lockfilePaths);
+  const assistants = Array.isArray(lockfile.assistants)
+    ? (lockfile.assistants as Array<Record<string, unknown>>)
+    : [];
+  const entry = assistants.find((a) => a?.assistantId === assistantId);
+  if (!entry) {
+    return { ok: false, status: 404, error: "No such assistant" };
+  }
+  if (resolveCloud(entry) !== "paired") {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        "Only paired assistants can be unpaired. Use retire for local or managed assistants.",
+    };
+  }
+
+  lockfile.assistants = assistants.filter(
+    (a) => a?.assistantId !== assistantId,
+  );
+  if (lockfile.activeAssistant === assistantId) {
+    lockfile.activeAssistant = null;
+  }
+
+  const result = writeRawLockfile(lockfilePaths, lockfile);
+  if (!result.ok) {
+    return result;
+  }
+
+  fs.rmSync(guardianTokenPath(configDir, assistantId), { force: true });
+  return result;
+}

--- a/packages/local-mode/src/unpair.ts
+++ b/packages/local-mode/src/unpair.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 
 import { guardianTokenPath } from "./config";
 import {
@@ -38,11 +39,18 @@ export function unpairAssistant(
     };
   }
 
-  lockfile.assistants = assistants.filter(
-    (a) => a?.assistantId !== assistantId,
-  );
+  const remaining = assistants.filter((a) => a?.assistantId !== assistantId);
+  lockfile.assistants = remaining;
+  // Reassign the active assistant like the CLI's removeAssistantEntry does, so
+  // unpairing through the bridge and through `vellum unpair` leave the same
+  // active state.
   if (lockfile.activeAssistant === assistantId) {
-    lockfile.activeAssistant = null;
+    const next = remaining[0]?.assistantId;
+    if (typeof next === "string") {
+      lockfile.activeAssistant = next;
+    } else {
+      delete lockfile.activeAssistant;
+    }
   }
 
   const result = writeRawLockfile(lockfilePaths, lockfile);
@@ -50,6 +58,19 @@ export function unpairAssistant(
     return result;
   }
 
-  fs.rmSync(guardianTokenPath(configDir, assistantId), { force: true });
+  // Best-effort, like the CLI's deleteGuardianToken: the entry is already
+  // gone from the lockfile, so a failed token delete must not surface as a
+  // rejected invoke (retrying would 404 on the missing entry anyway).
+  const tokenPath = guardianTokenPath(configDir, assistantId);
+  try {
+    fs.rmSync(tokenPath, { force: true });
+  } catch {
+    // Stale token file remains; it is unusable without its lockfile entry.
+  }
+  try {
+    fs.rmdirSync(path.dirname(tokenPath));
+  } catch {
+    // Directory not empty or absent.
+  }
   return result;
 }


### PR DESCRIPTION
## Summary
- New unpairAssistant package op: remove a paired lockfile entry + its guardian token
- Expose it via Electron IPC (main/preload/typing) and the dev/prod web hosts
- Renderer seam unpairAssistantHost with version-skew fallback

Part of plan: web-paired-entries.md (PR 6 of 7)