### PR TITLE
feat(daemon): allow background conversations via POST /v1/conversations

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6796,9 +6796,15 @@ paths:
                     `id`.
                   type: string
                 conversationType:
-                  description: Only standard conversations are created by this endpoint
+                  description:
+                    Conversation type for the new row. "background" keeps it out of the foreground list and the sidebar's
+                    Recents grouping, used by internal side-channel flows (onboarding research, persona/identity
+                    rewrites) that mint a throwaway thread the user should never see. "scheduled" is not accepted here;
+                    scheduled rows are owned by the schedule pipeline.
                   type: string
-                  const: standard
+                  enum:
+                    - standard
+                    - background
                 title:
                   description:
                     Explicit title for the conversation. When provided on creation, it is persisted as a user-set title (never

--- a/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `getOrCreateConversation` doubles as the first-conversation bootstrap
+ * bookkeeper: the first standard conversation is the onboarding one (keep
+ * BOOTSTRAP.md), and the second means onboarding is over (delete it).
+ *
+ * Onboarding also mints internal side threads — research, personality rewrite,
+ * identity rewrite — as `conversationType: "background"` rows that the user
+ * never opens. Those must be completely inert with respect to this bookkeeping:
+ * if a hidden side thread consumed the first-conversation slot, the user's
+ * FIRST visible chat would look like the second conversation and lose
+ * BOOTSTRAP.md before its opening turn.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const testDir = process.env.VELLUM_WORKSPACE_DIR!;
+const conversationsDir = join(testDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+import {
+  _resetFirstConversationSeenForTesting,
+  getOrCreateConversation,
+} from "../persistence/conversation-key-store.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  conversationKeys,
+  conversations,
+} from "../persistence/schema/index.js";
+
+await initializeDb();
+
+const bootstrapPath = join(testDir, "BOOTSTRAP.md");
+const bootstrapReferencePath = join(testDir, "BOOTSTRAP-REFERENCE.md");
+
+function seedBootstrapFiles(): void {
+  writeFileSync(bootstrapPath, "# First run\n", "utf-8");
+  writeFileSync(bootstrapReferencePath, "# Reference\n", "utf-8");
+}
+
+beforeEach(() => {
+  const db = getDb();
+  db.delete(conversationKeys).run();
+  db.delete(conversations).run();
+
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+
+  // `firstConversationSeen` is module-level (process-global) state, so each
+  // test has to replay the fresh-install sequence from a known-clean flag.
+  _resetFirstConversationSeenForTesting();
+  seedBootstrapFiles();
+});
+
+describe("getOrCreateConversation bootstrap bookkeeping", () => {
+  test("background side threads do not consume the first-conversation slot", () => {
+    // The exact onboarding sequence: three hidden side threads, then the
+    // user's first real chat.
+    for (const key of ["onboarding-research", "personality", "identity"]) {
+      const created = getOrCreateConversation(key, {
+        conversationType: "background",
+      });
+      expect(created.created).toBe(true);
+      expect(created.conversationType).toBe("background");
+      expect(existsSync(bootstrapPath)).toBe(true);
+    }
+
+    const firstVisible = getOrCreateConversation("user-first-chat");
+    expect(firstVisible.created).toBe(true);
+    expect(firstVisible.conversationType).toBe("standard");
+
+    // The user's first visible chat is still the FIRST conversation as far as
+    // onboarding is concerned, so its first-run context survives.
+    expect(existsSync(bootstrapPath)).toBe(true);
+    expect(existsSync(bootstrapReferencePath)).toBe(true);
+  });
+
+  test("a background create after the first standard one is still inert", () => {
+    getOrCreateConversation("user-first-chat");
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    getOrCreateConversation("side-thread", { conversationType: "background" });
+    expect(existsSync(bootstrapPath)).toBe(true);
+    expect(existsSync(bootstrapReferencePath)).toBe(true);
+  });
+
+  test("the second standard conversation still deletes the bootstrap files", () => {
+    getOrCreateConversation("first-chat");
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    getOrCreateConversation("second-chat");
+    expect(existsSync(bootstrapPath)).toBe(false);
+    expect(existsSync(bootstrapReferencePath)).toBe(false);
+  });
+
+  test("background creates interleaved with standard ones do not shift the slot", () => {
+    getOrCreateConversation("bg-a", { conversationType: "background" });
+    getOrCreateConversation("first-chat");
+    getOrCreateConversation("bg-b", { conversationType: "background" });
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    // Only the second STANDARD conversation ends onboarding.
+    getOrCreateConversation("second-chat");
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
+  test("resolving an existing key never re-runs the bookkeeping", () => {
+    const first = getOrCreateConversation("first-chat");
+    const again = getOrCreateConversation("first-chat");
+    expect(again.created).toBe(false);
+    expect(again.conversationId).toBe(first.conversationId);
+    expect(existsSync(bootstrapPath)).toBe(true);
+  });
+});

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -20,8 +20,19 @@ import { conversationKeys, conversations } from "./schema/index.js";
 
 const log = getLogger("conversation-key-store");
 
-/** Set after the first conversation is created so BOOTSTRAP.md is deleted on the second. */
+/**
+ * Set after the first *standard* conversation is created so BOOTSTRAP.md is
+ * deleted on the second. Background/scheduled creates never touch it.
+ */
 let firstConversationSeen = false;
+
+/**
+ * Test-only reset of the process-global first-conversation flag, so a test file
+ * can replay the "fresh install" sequence more than once.
+ */
+export function _resetFirstConversationSeenForTesting(): void {
+  firstConversationSeen = false;
+}
 
 export interface ConversationKeyMapping {
   id: string;
@@ -209,14 +220,26 @@ export function getOrCreateConversation(
       };
     }
 
-    // Delete BOOTSTRAP.md when a non-first conversation is created.
-    // The first conversation is the onboarding one; keep BOOTSTRAP.md
-    // for its entire duration. Any subsequent conversation means
+    // Delete BOOTSTRAP.md when a non-first *standard* conversation is created.
+    // The first standard conversation is the onboarding one; keep BOOTSTRAP.md
+    // for its entire duration. Any subsequent standard conversation means
     // onboarding is over.
-    if (firstConversationSeen) {
-      cleanupBootstrapFiles("new conversation created after onboarding");
+    //
+    // Background/scheduled rows are skipped entirely — they are internal side
+    // channels (onboarding research, personality/identity rewrites, heartbeat
+    // and scheduled runs) that the user never opens, so they are neither the
+    // onboarding conversation nor evidence that onboarding ended. Being inert
+    // here is what stops a hidden side thread minted before the user's first
+    // visible chat from consuming the first-conversation slot and deleting
+    // BOOTSTRAP.md out from under that chat's first turn. The type is read from
+    // the same `conversationType` the insert below persists, so the guard
+    // cannot drift from the stored row.
+    if (conversationType === "standard") {
+      if (firstConversationSeen) {
+        cleanupBootstrapFiles("new conversation created after onboarding");
+      }
+      firstConversationSeen = true;
     }
-    firstConversationSeen = true;
 
     const now = Date.now();
     const conversationId = uuid();

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -142,7 +142,7 @@ export function resolveConversationId(idOrKey: string): string | null {
 export function getOrCreateConversation(
   conversationKey: string,
   opts?: {
-    conversationType?: "standard";
+    conversationType?: "standard" | "background";
     /**
      * Caller-supplied title for the conversation, used only when this call
      * actually creates the row. Treated as a user-set title (`isAutoTitle = 0`)

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -25,6 +25,7 @@ import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { conversations } from "../../../persistence/schema/index.js";
+import { ROUTES as CONVERSATION_LIST_ROUTES } from "../conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "../inference-profile-session-routes.js";
 import type { RouteDefinition } from "../types.js";
@@ -60,6 +61,10 @@ function findHandler(routes: RouteDefinition[], operationId: string) {
 const createHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "createConversation",
+);
+const listHandlerForConversations = findHandler(
+  CONVERSATION_LIST_ROUTES,
+  "listConversations",
 );
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
@@ -111,10 +116,20 @@ describe("POST /v1/conversations (createConversation)", () => {
       .select({
         title: conversations.title,
         isAutoTitle: conversations.isAutoTitle,
+        conversationType: conversations.conversationType,
       })
       .from(conversations)
       .where(eq(conversations.id, id))
       .get();
+  }
+
+  async function listConversationIds(
+    queryParams: Record<string, string>,
+  ): Promise<string[]> {
+    const result = (await listHandlerForConversations({ queryParams })) as {
+      conversations: Array<{ id: string }>;
+    };
+    return result.conversations.map((c) => c.id);
   }
 
   test("with a title → persists it as a user-set title (isAutoTitle = 0)", async () => {
@@ -160,6 +175,64 @@ describe("POST /v1/conversations (createConversation)", () => {
     ).toThrow(/title must be a string/);
     expect(getDb().select().from(conversations).all()).toHaveLength(0);
   });
+
+  test("conversationType: background → persists a background row and echoes it back", async () => {
+    const result = (await createHandler({
+      body: {
+        conversationType: "background",
+        title: "Updating personality",
+      },
+    })) as { id: string; conversationType: string; created: boolean };
+
+    expect(result.created).toBe(true);
+    expect(result.conversationType).toBe("background");
+    const row = readConversation(result.id);
+    expect(row?.conversationType).toBe("background");
+    // An explicit title stays user-set on a background row too.
+    expect(row?.title).toBe("Updating personality");
+    expect(row?.isAutoTitle).toBe(0);
+  });
+
+  test("a background row is absent from the foreground list and present under conversationType=background", async () => {
+    const background = (await createHandler({
+      body: { conversationType: "background", title: "Updating personality" },
+    })) as { id: string };
+    const foreground = (await createHandler({
+      body: { title: "Visible thread" },
+    })) as { id: string };
+
+    // This is the invariant the onboarding side-thread flows rest on: a
+    // background row can never be landed on or enter Recents, no matter how
+    // the retroactive archive races.
+    const foregroundIds = await listConversationIds({});
+    expect(foregroundIds).toContain(foreground.id);
+    expect(foregroundIds).not.toContain(background.id);
+
+    const backgroundIds = await listConversationIds({
+      conversationType: "background",
+    });
+    expect(backgroundIds).toContain(background.id);
+    expect(backgroundIds).not.toContain(foreground.id);
+  });
+
+  test("omitted conversationType still creates a standard row", async () => {
+    const result = (await createHandler({
+      body: { title: "Visible thread" },
+    })) as { id: string; conversationType: string };
+
+    expect(result.conversationType).toBe("standard");
+    expect(readConversation(result.id)?.conversationType).toBe("standard");
+  });
+
+  test.each(["scheduled", "nonsense"])(
+    "conversationType: %p → BadRequestError, no row created",
+    (conversationType) => {
+      expect(() => createHandler({ body: { conversationType } })).toThrow(
+        /conversationType must be one of standard, background/,
+      );
+      expect(getDb().select().from(conversations).all()).toHaveLength(0);
+    },
+  );
 });
 
 describe("PUT /v1/conversations/:id/inference-profile", () => {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -100,6 +100,12 @@ const log = getLogger("conversation-management-routes");
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Conversation types this endpoint may mint. Deliberately narrower than
+ * `ConversationType`: scheduled rows are owned by the schedule pipeline.
+ */
+const createConversationTypeSchema = z.enum(["standard", "background"]);
+
 function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
   if (!id) {
@@ -126,14 +132,24 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   const conversationKey =
     (body.conversationKey as string | undefined) ?? crypto.randomUUID();
   // The shared route adapter does not runtime-validate the body against the
-  // Zod requestBody (it's codegen-only), so guard the type before trimming —
-  // a malformed `{ title: 123 }` would otherwise throw on `.trim()` and 500.
+  // Zod requestBody (it's codegen-only), so guard the types here: a malformed
+  // `{ title: 123 }` would otherwise throw on `.trim()` and 500, and an
+  // unsupported conversationType would reach the store unchecked.
+  const requestedType = createConversationTypeSchema
+    .optional()
+    .safeParse(body.conversationType);
+  if (!requestedType.success) {
+    throw new BadRequestError(
+      `conversationType must be one of ${createConversationTypeSchema.options.join(", ")}`,
+    );
+  }
   if (body.title !== undefined && typeof body.title !== "string") {
     throw new BadRequestError("title must be a string");
   }
   const customTitle = body.title?.trim() || undefined;
+  const conversationType = requestedType.data ?? "standard";
   const result = getOrCreateConversation(conversationKey, {
-    conversationType: "standard",
+    conversationType,
   });
   if (result.created) {
     // A caller-supplied title is user-set: persist it with isAutoTitle = 0 so
@@ -155,6 +171,7 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
     {
       conversationId: result.conversationId,
       conversationKey,
+      conversationType,
       created: result.created,
     },
     "Created conversation via POST",
@@ -863,10 +880,11 @@ export const ROUTES: RouteDefinition[] = [
         .describe(
           "Optional external key. Echoed back in the response. Non-vellum channels (Telegram, WhatsApp) use this to scope to a logical channel thread; vellum-web clients can omit it and rely on the assistant-minted `id`.",
         ),
-      conversationType: z
-        .literal("standard")
+      conversationType: createConversationTypeSchema
         .optional()
-        .describe("Only standard conversations are created by this endpoint"),
+        .describe(
+          'Conversation type for the new row. "background" keeps it out of the foreground list and the sidebar\'s Recents grouping, used by internal side-channel flows (onboarding research, persona/identity rewrites) that mint a throwaway thread the user should never see. "scheduled" is not accepted here; scheduled rows are owned by the schedule pipeline.',
+        ),
       title: z
         .string()
         .optional()


### PR DESCRIPTION
## Summary
- Widen the create-conversation route to accept `conversationType: "background"` (was hardcoded to `standard`); the daemon store already supported it.
- Runtime-validate the field (the shared route adapter does not validate bodies against the Zod requestBody) and pass it through to `getOrCreateConversation`.
- Regenerate `assistant/openapi.yaml`; add route tests covering the background/foreground list split.

Part of plan: bg-side-conversations.md (PR 1 of 5)