### PR TITLE
feat(web): move the subagent badge to a tinted pill with the glyph on the left

### DIFF
--- a/clients/web/src/components/avatar/subagent-avatar-badge.stories.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.stories.tsx
@@ -46,6 +46,21 @@ function seedEveryStatus() {
   }
 }
 
+/** One badge plus its status name, so the stories read without a legend. */
+function BadgeSample({ status }: { status: SubagentStatus }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <SubagentAvatarBadge subagentId={storyId(status)} />
+      <Typography
+        variant="label-small-default"
+        className="text-[var(--content-secondary)]"
+      >
+        {status}
+      </Typography>
+    </div>
+  );
+}
+
 const meta: Meta<typeof SubagentAvatarBadge> = {
   title: "Components/SubagentAvatarBadge",
   component: SubagentAvatarBadge,
@@ -73,15 +88,23 @@ export const AllStatuses: Story = {
   render: () => (
     <div className="flex flex-wrap items-start gap-1">
       {SubagentStatusSchema.options.map((status) => (
-        <div key={status} className="flex flex-col items-center gap-1">
-          <SubagentAvatarBadge subagentId={storyId(status)} />
-          <Typography
-            variant="label-small-default"
-            className="text-[var(--content-secondary)]"
-          >
-            {status}
-          </Typography>
-        </div>
+        <BadgeSample key={status} status={status} />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The three pill fills next to each other: the neutral `--surface-lift` while
+ * in flight, `--system-positive-weak` on success, `--system-negative-weak` on
+ * failure. Spaced apart so the a11y addon has each tint paired with its glyph
+ * colour, which the tightly packed `AllStatuses` row makes hard to compare.
+ */
+export const TerminalTints: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-6">
+      {(["running", "completed", "failed"] as const).map((status) => (
+        <BadgeSample key={status} status={status} />
       ))}
     </div>
   ),
@@ -89,7 +112,7 @@ export const AllStatuses: Story = {
 
 /**
  * Spawn race: the badge mounts for an id the store has no entry for yet, so
- * the circle renders with no status indicator.
+ * the pill renders with an empty glyph slot and its neutral fill.
  */
 export const SpawnRace: Story = {
   args: {

--- a/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
@@ -2,10 +2,11 @@
  * Tests for `SubagentAvatarBadge`.
  *
  * Drives the Zustand subagent store (spawn + changeStatus) and asserts the
- * under-avatar indicator reflects the subagent's real status: running dots
- * while in-flight, a green check on `completed`, and a red ! on `aborted`
- * (canceled) / `failed`. Confirms the deterministic avatar chip renders and
- * that state is exposed via `data-status` (not colour alone).
+ * glyph in the pill's fixed slot reflects the subagent's real status: running
+ * dots while in-flight, a check on `completed`, and a red X on `aborted`
+ * (canceled) / `failed`. Confirms the deterministic avatar chip renders, that
+ * state is exposed via `data-status` (not colour alone), and that the slot
+ * keeps the pill a constant width across every state.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -35,6 +36,13 @@ function spawn(id: string, status: SubagentStatus) {
   useSubagentStore.getState().changeStatus({ subagentId: id, status });
 }
 
+/** Which glyph the indicator rendered, independent of its Tailwind classes. */
+function renderedGlyph(indicator: Element): string | null {
+  return (
+    indicator.querySelector("[data-glyph]")?.getAttribute("data-glyph") ?? null
+  );
+}
+
 describe("SubagentAvatarBadge", () => {
   test("renders the deterministic avatar chip", () => {
     spawn("sa-avatar", "running");
@@ -56,11 +64,12 @@ describe("SubagentAvatarBadge", () => {
     expect(indicator.getAttribute("aria-label")).toBe("running");
     // `role="img"` exposes the aria-label as a stable accessible name.
     expect(indicator.getAttribute("role")).toBe("img");
+    expect(renderedGlyph(indicator)).toBe("dots");
     // Three pulsing dots use the shared busy-indicator class.
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(3);
   });
 
-  test("completed → green check, no dots", () => {
+  test("completed → check glyph, no dots", () => {
     spawn("sa-done", "completed");
     const { getByTestId } = render(
       <SubagentAvatarBadge subagentId="sa-done" />,
@@ -69,12 +78,10 @@ describe("SubagentAvatarBadge", () => {
     expect(indicator.getAttribute("data-status")).toBe("completed");
     expect(indicator.getAttribute("aria-label")).toBe("completed");
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
-    expect(
-      indicator.querySelector(".text-\\[var\\(--system-positive-strong\\)\\]"),
-    ).not.toBeNull();
+    expect(renderedGlyph(indicator)).toBe("check");
   });
 
-  test("aborted → red ! with data-status=aborted", () => {
+  test("aborted → red X with data-status=aborted", () => {
     spawn("sa-aborted", "aborted");
     const { getByTestId } = render(
       <SubagentAvatarBadge subagentId="sa-aborted" />,
@@ -84,12 +91,10 @@ describe("SubagentAvatarBadge", () => {
     // Canceled reads distinctly from failed for assistive tech.
     expect(indicator.getAttribute("aria-label")).toBe("canceled");
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
-    expect(
-      indicator.querySelector(".text-\\[var\\(--system-negative-strong\\)\\]"),
-    ).not.toBeNull();
+    expect(renderedGlyph(indicator)).toBe("cross");
   });
 
-  test("failed → red ! with data-status=failed", () => {
+  test("failed → red X with data-status=failed", () => {
     spawn("sa-failed", "failed");
     const { getByTestId } = render(
       <SubagentAvatarBadge subagentId="sa-failed" />,
@@ -97,20 +102,41 @@ describe("SubagentAvatarBadge", () => {
     const indicator = getByTestId("subagent-avatar-badge-status");
     expect(indicator.getAttribute("data-status")).toBe("failed");
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
-    expect(
-      indicator.querySelector(".text-\\[var\\(--system-negative-strong\\)\\]"),
-    ).not.toBeNull();
+    expect(renderedGlyph(indicator)).toBe("cross");
   });
 
-  test("the circle swaps background to --surface-active on hover (per Figma)", () => {
+  test("in-flight swaps background to --surface-active on hover, terminal tints do not", () => {
     spawn("sa-hover", "running");
-    const { getByTestId } = render(
-      <SubagentAvatarBadge subagentId="sa-hover" />,
+    spawn("sa-hover-done", "completed");
+    const { container } = render(
+      <>
+        <SubagentAvatarBadge subagentId="sa-hover" />
+        <SubagentAvatarBadge subagentId="sa-hover-done" />
+      </>,
     );
-    const circle = getByTestId("subagent-avatar-badge");
-    // The whole hover state is a background swap: --surface-lift → --surface-active.
-    expect(circle.className).toContain("bg-[var(--surface-lift)]");
-    expect(circle.className).toContain("hover:bg-[var(--surface-active)]");
+    const [pill, settledPill] = Array.from(
+      container.querySelectorAll('[data-testid="subagent-avatar-badge"]'),
+    );
+
+    // The whole in-flight hover state is a background swap.
+    expect(pill?.className).toContain("bg-[var(--surface-lift)]");
+    expect(pill?.className).toContain("hover:bg-[var(--surface-active)]");
+
+    expect(settledPill?.className).toContain(
+      "bg-[var(--system-positive-weak)]",
+    );
+    // A settled pill is not interactive, so it carries no hover variant.
+    expect(settledPill?.className).not.toContain("hover:");
+  });
+
+  test("errored tints the pill with the negative weak fill", () => {
+    spawn("sa-tint-failed", "failed");
+    const { getByTestId } = render(
+      <SubagentAvatarBadge subagentId="sa-tint-failed" />,
+    );
+    expect(getByTestId("subagent-avatar-badge").className).toContain(
+      "bg-[var(--system-negative-weak)]",
+    );
   });
 
   test("renders no status indicator before the entry lands in the store", () => {
@@ -118,7 +144,34 @@ describe("SubagentAvatarBadge", () => {
       <SubagentAvatarBadge subagentId="missing" />,
     );
     expect(queryByTestId("subagent-avatar-badge-status")).toBeNull();
-    // The circle wrapper still renders.
+    // The pill wrapper still renders.
     expect(queryByTestId("subagent-avatar-badge")).not.toBeNull();
+  });
+
+  test("the fixed glyph slot renders in every state so the pill never resizes", () => {
+    const cases: Array<{ id: string; status?: SubagentStatus }> = [
+      { id: "sa-slot-running", status: "running" },
+      { id: "sa-slot-completed", status: "completed" },
+      { id: "sa-slot-failed", status: "failed" },
+      // Spawn race: no store entry yet.
+      { id: "sa-slot-missing" },
+    ];
+
+    for (const { id, status } of cases) {
+      if (status) {
+        spawn(id, status);
+      }
+      const { container } = render(<SubagentAvatarBadge subagentId={id} />);
+      const pill = container.querySelector(
+        '[data-testid="subagent-avatar-badge"]',
+      );
+      const slot = container.querySelector(
+        '[data-testid="subagent-avatar-badge-slot"]',
+      );
+      // happy-dom cannot measure layout, so the fixed widths are the only
+      // available proof that the pill stays 46px wide in every state.
+      expect(pill?.className).toContain("w-[46px]");
+      expect(slot?.className).toContain("w-3.5");
+    }
   });
 });

--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -1,7 +1,8 @@
-// Collapsed-summary avatar unit: a 32px circle with an under-avatar status
-// indicator (running dots / green check / red !). Figma node 6063:148535.
+// Collapsed-summary avatar unit: a 46x32 pill carrying a status glyph
+// (running dots / check / X) in a fixed slot to the left of the subagent's
+// avatar. Terminal states tint the pill with the matching weak system fill.
 
-import { Check } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { SubagentAvatarChip } from "@/components/avatar/subagent-avatar-chip";
@@ -29,6 +30,25 @@ function deriveBadgeState(status: SubagentStatus): BadgeState {
   }
 }
 
+// Only a pill that can still change carries the hover swap, so the terminal
+// tints deliberately have none.
+function pillBackgroundClass(badgeState: BadgeState | undefined): string {
+  switch (badgeState) {
+    case "completed":
+      return "bg-[var(--system-positive-weak)]";
+    case "errored":
+      return "bg-[var(--system-negative-weak)]";
+    default:
+      return "bg-[var(--surface-lift)] hover:bg-[var(--surface-active)]";
+  }
+}
+
+const BADGE_STATE_GLYPH: Record<BadgeState, "dots" | "check" | "cross"> = {
+  "in-flight": "dots",
+  completed: "check",
+  errored: "cross",
+};
+
 // Per-status (not per-bucket) so "canceled" reads distinctly from "failed".
 const STATUS_ARIA_LABEL: Record<SubagentStatus, string> = {
   running: "running",
@@ -44,65 +64,66 @@ export function SubagentAvatarBadge({
   subagentId,
   className,
 }: SubagentAvatarBadgeProps) {
-  // Atomic selector — re-render only when this subagent's status changes.
+  // Atomic selector: re-render only when this subagent's status changes.
   const status = useSubagentStore((s) => s.byId[subagentId]?.status);
   const reduce = useReducedMotion();
 
-  // Spawn race: no entry yet → circle with no indicator.
+  // Spawn race: no entry yet → pill with an empty glyph slot.
   const badgeState = status ? deriveBadgeState(status) : undefined;
 
   return (
     <div
       data-testid="subagent-avatar-badge"
-      className={`relative flex h-8 w-8 items-center justify-center rounded-full bg-[var(--surface-lift)] transition-colors hover:bg-[var(--surface-active)] ${className ?? ""}`.trim()}
+      className={`inline-flex h-8 w-[46px] shrink-0 items-center gap-1 rounded-full px-1.5 transition-colors ${pillBackgroundClass(badgeState)} ${className ?? ""}`.trim()}
     >
-      <SubagentAvatarChip
-        subagentId={subagentId}
-        size={16}
-        className="absolute top-[6px]"
-      />
+      {/* The glyph slot is a fixed 14px and always renders, including before
+          the store entry lands. The three glyphs are different widths (13px
+          dots, 10px check, 10px X), so a slot that sized to its content would
+          change the pill's width every time a subagent settles and shift the
+          whole avatar row sideways. */}
+      <span
+        data-testid="subagent-avatar-badge-slot"
+        className="flex w-3.5 shrink-0 items-center justify-center"
+      >
+        {badgeState && (
+          <span
+            // role="img" exposes aria-label; the dots/glyphs are aria-hidden.
+            role="img"
+            data-testid="subagent-avatar-badge-status"
+            data-status={status}
+            aria-label={status && STATUS_ARIA_LABEL[status]}
+            className="flex items-center justify-center"
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.span
+                key={badgeState}
+                data-glyph={BADGE_STATE_GLYPH[badgeState]}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={
+                  reduce
+                    ? { duration: 0 }
+                    : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
+                }
+                className="flex items-center justify-center"
+              >
+                {badgeState === "in-flight" && (
+                  <ThreeDotIndicator dotSize={3} gap={2} />
+                )}
+                {badgeState === "completed" && (
+                  <Check className="h-2.5 w-2.5 text-[var(--system-positive-on-weak)]" />
+                )}
+                {badgeState === "errored" && (
+                  <X className="h-2.5 w-2.5 text-[var(--system-negative-on-weak)]" />
+                )}
+              </motion.span>
+            </AnimatePresence>
+          </span>
+        )}
+      </span>
 
-      {badgeState && (
-        <span
-          // role="img" exposes aria-label; the dots/glyphs are aria-hidden.
-          role="img"
-          data-testid="subagent-avatar-badge-status"
-          data-status={status}
-          aria-label={status && STATUS_ARIA_LABEL[status]}
-          // Running dots sit at bottom-[6px] per the mock (6063:148464);
-          // the terminal glyphs stay at bottom-[3px].
-          className={`absolute left-1/2 flex -translate-x-1/2 items-center justify-center ${
-            badgeState === "in-flight" ? "bottom-[6px]" : "bottom-[3px]"
-          }`}
-        >
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.span
-              key={badgeState}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={
-                reduce
-                  ? { duration: 0 }
-                  : { duration: 0.15, ease: [0.16, 1, 0.3, 1] }
-              }
-              className="flex items-center justify-center"
-            >
-              {badgeState === "in-flight" && (
-                <ThreeDotIndicator dotSize={3} gap={2} />
-              )}
-              {badgeState === "completed" && (
-                <Check className="h-2.5 w-2.5 text-[var(--system-positive-strong)]" />
-              )}
-              {badgeState === "errored" && (
-                <span className="text-[11px] font-bold leading-none text-[var(--system-negative-strong)]">
-                  !
-                </span>
-              )}
-            </motion.span>
-          </AnimatePresence>
-        </span>
-      )}
+      <SubagentAvatarChip subagentId={subagentId} size={16} />
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
@@ -90,4 +90,18 @@ describe("SubagentAvatarRow", () => {
     fireEvent.click(getAllByTestId("subagent-avatar-badge")[0]);
     expect(expanded).toBe(1);
   });
+
+  test("the row and its avatar stack both wrap so a full row cannot clip", () => {
+    const ids = spawnIds(MAX_VISIBLE_SUBAGENT_AVATARS + 3);
+    const { getByTestId } = render(
+      <SubagentAvatarRow subagentIds={ids} onExpand={() => {}} />,
+    );
+
+    // At the cap the row is wider than a 375px viewport leaves, and the
+    // transcript wrapper is `contain-content`, so without wrapping the
+    // Details affordance is clipped instead of overflowing visibly.
+    const row = getByTestId("subagent-avatar-row-details");
+    expect(row.className).toContain("flex-wrap");
+    expect(row.firstElementChild?.className).toContain("flex-wrap");
+  });
 });

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -24,16 +24,21 @@ export function SubagentAvatarRow({
 }: SubagentAvatarRowProps) {
   const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
 
+  // The row wraps because it can outgrow a phone-width transcript column. At
+  // the six-avatar cap the badges, the overflow chip, and the Details label
+  // need more than the 343px a 375px viewport leaves after the transcript's
+  // px-4, and the transcript wrapper is `contain-content`, so an unwrapped row
+  // loses the Details affordance to clipping rather than overflowing visibly.
   return (
     <button
       type="button"
       onClick={onExpand}
       aria-label="Show subagent details"
       data-testid="subagent-avatar-row-details"
-      className="flex cursor-pointer items-center gap-3"
+      className="flex cursor-pointer flex-wrap items-center gap-x-3 gap-y-2"
     >
       {/* pointer-events-none so clicking an avatar triggers the button, not the avatar. */}
-      <div className="pointer-events-none flex items-center gap-1">
+      <div className="pointer-events-none flex flex-wrap items-center gap-1">
         {subagentIds.slice(0, MAX_VISIBLE_SUBAGENT_AVATARS).map((id) => (
           <SubagentAvatarBadge key={id} subagentId={id} />
         ))}


### PR DESCRIPTION
## Summary
- The collapsed subagent group's badge becomes a 46x32 pill with the status glyph in a fixed 14px slot to the left of the avatar, so the check and the failure mark no longer overlap the creature by 3 to 4px.
- Terminal states tint the pill using the design system's weak fills, matching how `tag.tsx` already pairs a tone-matched background with a coloured leading icon.
- The failure glyph moves from a bold `!` text character to a lucide `X`.
- Visual comparison of every variant considered: https://claude.ai/code/artifact/be9bde60-812e-4361-9396-93b694c11516

Part of plan: subagent-badge-option-d.md (PR 4 of 4)