### PR TITLE
feat(cli): startRemoteWebIngress supports a webhooks-only edge (no SPA)

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -1,4 +1,6 @@
 import * as childProcess from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import * as fsModule from "node:fs";
 import {
   existsSync,
   mkdirSync,
@@ -12,28 +14,83 @@ import { join } from "node:path";
 
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
+import * as httpClient from "../lib/http-client.js";
+
 const realChildProcess = { ...childProcess };
+const realFs = { ...fsModule };
+const realHttpClient = { ...httpClient };
+
 const execFileSyncMock = mock(childProcess.execFileSync);
+const spawnSyncMock = mock(childProcess.spawnSync);
+const spawnMock = mock(childProcess.spawn);
 
 mock.module("node:child_process", () => ({
   ...childProcess,
   execFileSync: execFileSyncMock,
+  spawnSync: spawnSyncMock,
+  spawn: spawnMock,
 }));
 
-// Restore the real module once this file finishes so the mock does not leak
+const existsSyncMock = mock(fsModule.existsSync);
+const readFileSyncMock = mock(fsModule.readFileSync);
+
+mock.module("node:fs", () => ({
+  ...fsModule,
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+const waitForDaemonReadyMock = mock<typeof httpClient.waitForDaemonReady>(
+  async () => true,
+);
+
+mock.module("../lib/http-client.js", () => ({
+  ...httpClient,
+  waitForDaemonReady: waitForDaemonReadyMock,
+}));
+
+// Restore the real modules once this file finishes so the mocks do not leak
 // into sibling test files in the same `bun test` run.
 afterAll(() => {
   mock.module("node:child_process", () => realChildProcess);
+  mock.module("node:fs", () => realFs);
+  mock.module("../lib/http-client.js", () => realHttpClient);
 });
 
 import {
   buildIngressNginxConfig,
   buildRemoteWebIndexHtml,
   resolveTunnelTargetPort,
+  startRemoteWebIngress,
   stopIngressNginx,
 } from "../lib/nginx-ingress.js";
 
 const originalKill = process.kill;
+const workspaces: string[] = [];
+
+afterEach(() => {
+  process.kill = originalKill;
+  execFileSyncMock.mockReset();
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockImplementation(realChildProcess.spawnSync);
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(realChildProcess.spawn);
+  existsSyncMock.mockReset();
+  existsSyncMock.mockImplementation(realFs.existsSync);
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockImplementation(realFs.readFileSync);
+  waitForDaemonReadyMock.mockReset();
+  waitForDaemonReadyMock.mockImplementation(async () => true);
+  for (const dir of workspaces.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "vellum-ingress-test-"));
+  workspaces.push(dir);
+  return dir;
+}
 
 describe("buildIngressNginxConfig", () => {
   const conf = buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7840 });
@@ -234,22 +291,6 @@ describe("buildRemoteWebIndexHtml", () => {
 });
 
 describe("nginx ingress process state", () => {
-  const workspaces: string[] = [];
-
-  afterEach(() => {
-    process.kill = originalKill;
-    execFileSyncMock.mockReset();
-    for (const dir of workspaces.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  function makeWorkspace(): string {
-    const dir = mkdtempSync(join(tmpdir(), "vellum-ingress-test-"));
-    workspaces.push(dir);
-    return dir;
-  }
-
   function writeIngressState(workspaceDir: string, listenPort: number): void {
     writeFileSync(
       join(workspaceDir, "config.json"),
@@ -442,5 +483,160 @@ describe("nginx ingress process state", () => {
     const config = readConfig(ws);
     expect((config.ingress as Record<string, unknown>).nginx).toBeUndefined();
     expect(existsSync(pidPath(ws))).toBe(false);
+  });
+});
+
+describe("startRemoteWebIngress", () => {
+  const NGINX_VERSION = "nginx version: nginx/1.29.0";
+  const FAKE_INDEX_HTML = "<html><head></head><body></body></html>";
+  const WEB_INDEX_SUFFIX = join("dist", "index.html");
+
+  function ingressConfPath(workspaceDir: string): string {
+    return join(workspaceDir, "data", "ingress", "nginx.conf");
+  }
+
+  function mockNginxInstalled(): void {
+    spawnSyncMock.mockReturnValue({
+      pid: 4242,
+      output: [],
+      stdout: "",
+      stderr: NGINX_VERSION,
+      status: 0,
+      signal: null,
+    });
+  }
+
+  function mockNginxSpawn(): void {
+    spawnMock.mockReturnValue({
+      unref: () => {},
+      pid: 4243,
+    } as unknown as ChildProcess);
+  }
+
+  /** Force findWebDistDir() to resolve nothing, regardless of checkout state. */
+  function mockWebDistMissing(): void {
+    existsSyncMock.mockImplementation((path) =>
+      String(path).endsWith("index.html") ? false : realFs.existsSync(path),
+    );
+  }
+
+  /** Force findWebDistDir() to resolve a dist dir, regardless of checkout state. */
+  function mockWebDistPresent(): void {
+    existsSyncMock.mockImplementation((path) =>
+      String(path).endsWith(WEB_INDEX_SUFFIX) ? true : realFs.existsSync(path),
+    );
+    readFileSyncMock.mockImplementation(((path, options) =>
+      String(path).endsWith(WEB_INDEX_SUFFIX)
+        ? FAKE_INDEX_HTML
+        : realFs.readFileSync(
+            path as never,
+            options as never,
+          )) as typeof readFileSync);
+  }
+
+  test("webhooks-only mode starts the denylist+proxy edge without a web dist", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+
+    const onStarting = mock(
+      (_info: {
+        version: string;
+        webDistDir: string | null;
+        listenPort: number;
+      }) => {},
+    );
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+      onStarting,
+    });
+
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(onStarting).toHaveBeenCalledWith({
+      version: NGINX_VERSION,
+      webDistDir: null,
+      listenPort: 7845,
+    });
+
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+    );
+    expect(conf).toContain("location = /auth/token { return 404; }");
+    expect(conf).toContain("location = /v1/pair { return 404; }");
+    expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
+    expect(conf).not.toContain("__remote-index.html");
+    expect(conf).not.toContain("location ^~ /assistant/assets/");
+    expect(conf).not.toContain("alias ");
+  });
+
+  test("default mode serves the SPA config unchanged", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    if (result.status !== "started") {
+      throw new Error(`expected started, got ${result.status}`);
+    }
+    const { webDistDir } = result;
+    if (webDistDir === null) {
+      throw new Error("expected a web dist dir in SPA mode");
+    }
+
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: 7845,
+        remoteWebIngress: {
+          webDistDir,
+          indexHtmlPath: join(ws, "data", "ingress", "assistant-index.html"),
+        },
+      }),
+    );
+    expect(conf).toContain("location ^~ /assistant/ {");
+    expect(conf).toContain("location ^~ /webhooks/ {");
+    expect(
+      realFs.readFileSync(
+        join(ws, "data", "ingress", "assistant-index.html"),
+        "utf-8",
+      ),
+    ).toContain("remote-gateway");
+  });
+
+  test("default mode still requires the web dist", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+
+    const onStarting = mock(() => {});
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      onStarting,
+    });
+
+    expect(result).toEqual({ status: "web-dist-missing" });
+    expect(onStarting).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(realFs.existsSync(ingressConfPath(ws))).toBe(false);
   });
 });

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -764,6 +764,45 @@ describe("startRemoteWebIngress", () => {
     });
   });
 
+  test("starts the requested mode when the old edge exits during the stop", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    // Alive for the initial running check, dead by the time the stop helper
+    // probes it: the race where the old edge exits on its own mid-switch.
+    let liveChecks = 0;
+    process.kill = mock((targetPid: number, signal?: string | number) => {
+      if (targetPid !== pid) return originalKill(targetPid, signal);
+      if (signal === 0 && ++liveChecks === 1) return true;
+      throw new Error("dead");
+    }) as unknown as typeof process.kill;
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+    );
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+  });
+
   test("restarts a webhooks-only edge when SPA mode is requested", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -92,6 +92,12 @@ function makeWorkspace(): string {
   return dir;
 }
 
+function readConfig(workspaceDir: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+  ) as Record<string, unknown>;
+}
+
 describe("buildIngressNginxConfig", () => {
   const conf = buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7840 });
   const remoteConf = buildIngressNginxConfig({
@@ -302,12 +308,6 @@ describe("nginx ingress process state", () => {
     const dir = join(workspaceDir, "data", "ingress");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "nginx.pid"), `${pid}\n`);
-  }
-
-  function readConfig(workspaceDir: string): Record<string, unknown> {
-    return JSON.parse(
-      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
-    ) as Record<string, unknown>;
   }
 
   function pidPath(workspaceDir: string): string {
@@ -577,6 +577,10 @@ describe("startRemoteWebIngress", () => {
     expect(conf).not.toContain("__remote-index.html");
     expect(conf).not.toContain("location ^~ /assistant/assets/");
     expect(conf).not.toContain("alias ");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+    });
   });
 
   test("default mode serves the SPA config unchanged", async () => {
@@ -618,6 +622,10 @@ describe("startRemoteWebIngress", () => {
         "utf-8",
       ),
     ).toContain("remote-gateway");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: true,
+    });
   });
 
   test("default mode still requires the web dist", async () => {
@@ -638,5 +646,172 @@ describe("startRemoteWebIngress", () => {
     expect(onStarting).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
     expect(realFs.existsSync(ingressConfPath(ws))).toBe(false);
+  });
+
+  /** Record a running edge: ingress state, live pidfile, matching ps output. */
+  function mockRunningEdge(
+    ws: string,
+    opts: { listenPort: number; includeWebApp?: boolean },
+  ): number {
+    const pid = 123_460;
+    writeFileSync(
+      join(ws, "config.json"),
+      JSON.stringify({
+        ingress: {
+          nginx: {
+            listenPort: opts.listenPort,
+            ...(opts.includeWebApp === undefined
+              ? {}
+              : { includeWebApp: opts.includeWebApp }),
+          },
+        },
+      }) + "\n",
+    );
+    const dir = join(ws, "data", "ingress");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "nginx.pid"), `${pid}\n`);
+    execFileSyncMock.mockReturnValue(
+      `nginx: master process nginx -p ${dir} -c ${join(dir, "nginx.conf")} -g daemon off;`,
+    );
+    return pid;
+  }
+
+  /** SIGTERM to the given PID marks it dead; signal 0 reflects liveness. */
+  function mockKillableNginx(pid: number): { killed: () => boolean } {
+    let alive = true;
+    process.kill = mock((targetPid: number, signal?: string | number) => {
+      if (targetPid !== pid) return originalKill(targetPid, signal);
+      if (signal === 0) {
+        if (!alive) throw new Error("dead");
+        return true;
+      }
+      if (signal === "SIGTERM") {
+        alive = false;
+        return true;
+      }
+      return true;
+    }) as unknown as typeof process.kill;
+    return { killed: () => !alive };
+  }
+
+  test("short-circuits when the running edge already serves the requested mode", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("treats recorded state without a mode as an SPA edge", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    const pid = mockRunningEdge(ws, { listenPort: 7845 });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts an SPA edge when webhooks-only mode is requested", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(edge.killed()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+    );
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+  });
+
+  test("restarts a webhooks-only edge when SPA mode is requested", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    if (result.status !== "started") {
+      throw new Error(`expected started, got ${result.status}`);
+    }
+    expect(result.webDistDir).not.toBeNull();
+    expect(edge.killed()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain("location ^~ /assistant/ {");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: true,
+    });
+  });
+
+  test("keeps a webhooks-only edge running when SPA mode is requested without a web dist", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    expect(result).toEqual({ status: "web-dist-missing" });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+    });
   });
 });

--- a/cli/src/commands/nginx-ingress.ts
+++ b/cli/src/commands/nginx-ingress.ts
@@ -166,8 +166,9 @@ async function up(target: NginxIngressTarget): Promise<void> {
     gatewayPort,
     onStarting: ({ version, webDistDir, listenPort }) => {
       console.log(`Using ${version}`);
+      const webSegment = webDistDir ? `web ${webDistDir} + ` : "";
       console.log(
-        `Starting nginx ingress on 127.0.0.1:${listenPort} → web ${webDistDir} + gateway 127.0.0.1:${gatewayPort}...`,
+        `Starting nginx ingress on 127.0.0.1:${listenPort} → ${webSegment}gateway 127.0.0.1:${gatewayPort}...`,
       );
     },
   });

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -651,8 +651,13 @@ export async function startRemoteWebIngress(opts: {
   }
 
   // The running edge serves the other mode; restart it with the requested
-  // config. If the stop fails, the old edge is still the one serving.
-  if (running && !(await stopIngressNginx(opts.workspaceDir))) {
+  // config. A false stop can mean the old edge exited on its own after the
+  // check above, so recheck liveness and only bail when it is still serving.
+  if (
+    running &&
+    !(await stopIngressNginx(opts.workspaceDir)) &&
+    isIngressRunning(opts.workspaceDir)
+  ) {
     return { status: "already-running", listenPort };
   }
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -421,8 +421,7 @@ function readIngressState(workspaceDir: string): IngressState | null {
   const nginx = ingress?.nginx as Record<string, unknown> | undefined;
   const listenPort = nginx?.listenPort;
   if (typeof listenPort !== "number") return null;
-  // A missing includeWebApp means an SPA edge (older state records only
-  // listenPort, and those edges always serve the SPA).
+  // A state record without includeWebApp represents an SPA edge.
   return { listenPort, includeWebApp: nginx?.includeWebApp !== false };
 }
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -568,7 +568,8 @@ export type StartRemoteWebIngressResult =
   | {
       status: "started";
       listenPort: number;
-      webDistDir: string;
+      /** SPA dist directory served by the edge; null in webhooks-only mode. */
+      webDistDir: string | null;
       version: string;
     }
   | { status: "already-running"; listenPort: number }
@@ -592,18 +593,26 @@ export async function startRemoteWebIngress(opts: {
   listenPort?: number;
   readyTimeoutMs?: number;
   /**
+   * Serve the web SPA from the edge (default true). When false the web-dist
+   * preflight is skipped and the edge only proxies gateway traffic behind the
+   * sensitive-route denylist (webhooks-only mode).
+   */
+  includeWebApp?: boolean;
+  /**
    * Invoked once, after every preflight check passes and immediately before
    * nginx is spawned, so callers can emit their own "starting" progress line
-   * with the resolved version/dist/port. Never fires on a preflight bail-out
-   * (nginx-missing, already-running, web-dist-missing).
+   * with the resolved version/dist/port (webDistDir is null in webhooks-only
+   * mode). Never fires on a preflight bail-out (nginx-missing,
+   * already-running, web-dist-missing).
    */
   onStarting?: (info: {
     version: string;
-    webDistDir: string;
+    webDistDir: string | null;
     listenPort: number;
   }) => void;
 }): Promise<StartRemoteWebIngressResult> {
   const listenPort = opts.listenPort ?? getNginxIngressPort();
+  const includeWebApp = opts.includeWebApp ?? true;
 
   const version = getNginxVersion();
   if (!version) {
@@ -614,9 +623,12 @@ export async function startRemoteWebIngress(opts: {
     return { status: "already-running", listenPort };
   }
 
-  const webDistDir = findWebDistDir();
-  if (!webDistDir) {
-    return { status: "web-dist-missing" };
+  let webDistDir: string | null = null;
+  if (includeWebApp) {
+    webDistDir = findWebDistDir();
+    if (!webDistDir) {
+      return { status: "web-dist-missing" };
+    }
   }
 
   opts.onStarting?.({ version, webDistDir, listenPort });
@@ -625,7 +637,7 @@ export async function startRemoteWebIngress(opts: {
     workspaceDir: opts.workspaceDir,
     gatewayPort: opts.gatewayPort,
     listenPort,
-    remoteWebIngress: { webDistDir },
+    remoteWebIngress: webDistDir ? { webDistDir } : undefined,
   });
   child.unref();
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -411,6 +411,8 @@ export function isIngressRunning(workspaceDir: string): boolean {
 
 interface IngressState {
   listenPort: number;
+  /** Edge mode: SPA + proxy (true) or webhooks-only proxy (false). */
+  includeWebApp: boolean;
 }
 
 function readIngressState(workspaceDir: string): IngressState | null {
@@ -419,13 +421,18 @@ function readIngressState(workspaceDir: string): IngressState | null {
   const nginx = ingress?.nginx as Record<string, unknown> | undefined;
   const listenPort = nginx?.listenPort;
   if (typeof listenPort !== "number") return null;
-  return { listenPort };
+  // A missing includeWebApp means an SPA edge (older state records only
+  // listenPort, and those edges always serve the SPA).
+  return { listenPort, includeWebApp: nginx?.includeWebApp !== false };
 }
 
 function saveIngressState(workspaceDir: string, state: IngressState): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  ingress.nginx = { listenPort: state.listenPort };
+  ingress.nginx = {
+    listenPort: state.listenPort,
+    includeWebApp: state.includeWebApp,
+  };
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
 }
@@ -492,7 +499,10 @@ export function startIngressNginx(opts: {
   );
   closeSync(fd);
 
-  saveIngressState(opts.workspaceDir, { listenPort: opts.listenPort });
+  saveIngressState(opts.workspaceDir, {
+    listenPort: opts.listenPort,
+    includeWebApp: opts.remoteWebIngress !== undefined,
+  });
   return child;
 }
 
@@ -583,6 +593,10 @@ export type StartRemoteWebIngressResult =
  * but unreachable nginx is rolled back so a failed attempt leaves no half-up
  * edge behind.
  *
+ * An edge already running in the requested mode short-circuits as
+ * `already-running`; one running in the other mode (SPA vs webhooks-only) is
+ * stopped and restarted with the requested config.
+ *
  * Pure mechanism: it performs no console output and never exits the process, so
  * both the `nginx-ingress up` command and the wake restore path can share one
  * implementation and map the returned result to their own UX.
@@ -619,8 +633,13 @@ export async function startRemoteWebIngress(opts: {
     return { status: "nginx-missing" };
   }
 
-  if (isIngressRunning(opts.workspaceDir)) {
-    return { status: "already-running", listenPort };
+  const running = isIngressRunning(opts.workspaceDir);
+  if (running) {
+    const recordedMode =
+      readIngressState(opts.workspaceDir)?.includeWebApp ?? true;
+    if (recordedMode === includeWebApp) {
+      return { status: "already-running", listenPort };
+    }
   }
 
   let webDistDir: string | null = null;
@@ -629,6 +648,12 @@ export async function startRemoteWebIngress(opts: {
     if (!webDistDir) {
       return { status: "web-dist-missing" };
     }
+  }
+
+  // The running edge serves the other mode; restart it with the requested
+  // config. If the stop fails, the old edge is still the one serving.
+  if (running && !(await stopIngressNginx(opts.workspaceDir))) {
+    return { status: "already-running", listenPort };
   }
 
   opts.onStarting?.({ version, webDistDir, listenPort });


### PR DESCRIPTION
## Summary
- Add includeWebApp option (default true) to startRemoteWebIngress; false skips the web-dist preflight and starts the denylist+proxy edge without SPA locations
- webDistDir becomes string | null in onStarting and the started result; callers omit the dist segment when null

Part of plan: tunnel-edge-unify.md (PR 3 of 7)