### PR TITLE
fix(onboarding): mint the research side conversation as background

### DIFF
--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for how the research runner opens its side conversation: the prompt is
- * posted hidden (see `lib/side-conversation-message.ts`), and a resumed run
- * re-posts only when the turn never started.
+ * Tests for how the research runner opens its side conversation: it is minted
+ * `background` so it never enters the foreground list, the prompt is posted
+ * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
+ * only when the turn never started.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -25,7 +26,13 @@ interface PostCall {
   body: { conversationId: string; hidden?: boolean };
 }
 
+interface CreateCall {
+  path: { assistant_id: string };
+  body: { conversationType?: string; title?: string };
+}
+
 let postCalls: PostCall[] = [];
+let createCalls: CreateCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
 
@@ -37,7 +44,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   pluginsSearchGet: () => ok({ matches: [] }),
   pluginsInstallPost: () => ok({}),
   telemetryIngestPost: () => ok({}),
-  conversationsPost: () => ok({ id: "conv-fresh" }),
+  conversationsPost: (opts: CreateCall) => {
+    createCalls.push(opts);
+    return ok({ id: "conv-fresh" });
+  },
   conversationsByIdArchivePost: () => ok({}),
   messagesGet: () => {
     getCalls += 1;
@@ -71,6 +81,7 @@ function renderRunner() {
 
 afterEach(() => {
   postCalls = [];
+  createCalls = [];
   getCalls = 0;
   listed = { messages: [] };
 });
@@ -87,6 +98,31 @@ async function whenResumeDecided(): Promise<void> {
 }
 
 describe("research prompt send", () => {
+  test("mints the side conversation as background", async () => {
+    // The regression this guards: a `standard` row is visible until the
+    // end-of-run archive wins the race, so the user can land on a thread whose
+    // only rendered content is an assistant intro.
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        conversationTitle: "Getting to know Alice",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createCalls).toHaveLength(1);
+    });
+    expect(createCalls[0]?.body.conversationType).toBe("background");
+    expect(createCalls[0]?.body.title).toBe("Getting to know Alice");
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
   test("posts the prompt as a hidden machine signal", async () => {
     const { result } = renderRunner();
 

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -621,10 +621,17 @@ export function useResearchRunner(): UseResearchRunner {
           const startFreshConversation = async (): Promise<
             string | undefined
           > => {
+            // `background` puts the thread outside the foreground list — the
+            // daemon's default conversation filter is `standard` — so it can
+            // never be the landing conversation nor appear in Recents. That
+            // makes the archive below cleanup rather than the thing that hides
+            // it. A daemon predating this field ignores it and falls back to a
+            // standard row plus the archive (the previous behavior), so no
+            // version gate is needed.
             const conversation = await conversationsPost({
               path: { assistant_id: assistantId },
               body: {
-                conversationType: "standard",
+                conversationType: "background",
                 ...(conversationTitle ? { title: conversationTitle } : {}),
               },
               throwOnError: false,

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -621,13 +621,9 @@ export function useResearchRunner(): UseResearchRunner {
           const startFreshConversation = async (): Promise<
             string | undefined
           > => {
-            // `background` puts the thread outside the foreground list — the
-            // daemon's default conversation filter is `standard` — so it can
-            // never be the landing conversation nor appear in Recents. That
-            // makes the archive below cleanup rather than the thing that hides
-            // it. A daemon predating this field ignores it and falls back to a
-            // standard row plus the archive (the previous behavior), so no
-            // version gate is needed.
+            // `background` creates the row outside the daemon's default
+            // `standard` list, so it never appears in Recents and can never be
+            // selected as the landing conversation.
             const conversation = await conversationsPost({
               path: { assistant_id: assistantId },
               body: {


### PR DESCRIPTION
## Summary
- Mint the behind-the-scenes research conversation as `background` so it is invisible by construction instead of being hidden later by a racy archive.
- An older daemon ignores the field and falls back to the previous behavior, so no version gate is needed.

Part of plan: bg-side-conversations.md (PR 2 of 5)