### PR TITLE
fix(intelligence): mint the identity-rewrite thread as background

### DIFF
--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -1,7 +1,7 @@
 /**
- * Pins the shape of the identity-rewrite send: the side conversation is
- * minted `background` so it is invisible by construction, the prompt goes out
- * hidden (see `lib/side-conversation-message.ts`), and the thread is archived.
+ * Pins the shape of the identity-rewrite send: the side conversation is minted
+ * `background`, the prompt goes out hidden (see
+ * `lib/side-conversation-message.ts`), and the thread is archived.
  *
  * NOTE: `bun mock.module` can leak across files. Run this file singly:
  *   bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -1,6 +1,7 @@
 /**
- * Pins the shape of the identity-rewrite send: it goes out hidden (see
- * `lib/side-conversation-message.ts`) and the side conversation is archived.
+ * Pins the shape of the identity-rewrite send: the side conversation is
+ * minted `background` so it is invisible by construction, the prompt goes out
+ * hidden (see `lib/side-conversation-message.ts`), and the thread is archived.
  *
  * NOTE: `bun mock.module` can leak across files. Run this file singly:
  *   bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -15,6 +16,12 @@ interface PostCall {
   body: { conversationId: string; content: string; hidden?: boolean };
 }
 
+interface CreateCall {
+  path: { assistant_id: string };
+  body: { conversationType?: string; title?: string };
+}
+
+let createCalls: CreateCall[] = [];
 let postCalls: PostCall[] = [];
 let archiveCalls: Array<{ path: { assistant_id: string; id: string } }> = [];
 
@@ -23,7 +30,10 @@ const ok = <T>(data: T) =>
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
-  conversationsPost: () => ok({ id: "conv-1" }),
+  conversationsPost: (opts: CreateCall) => {
+    createCalls.push(opts);
+    return ok({ id: "conv-1" });
+  },
   messagesPost: (opts: PostCall) => {
     postCalls.push(opts);
     return ok({});
@@ -47,17 +57,25 @@ mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
 const { runIdentityRewrite } = await import("./run-identity-rewrite");
 
 afterEach(() => {
+  createCalls = [];
   postCalls = [];
   archiveCalls = [];
 });
 
 describe("runIdentityRewrite", () => {
-  test("posts the rewrite prompt hidden and archives the side conversation", async () => {
+  test("mints a background thread, posts the prompt hidden, and archives it", async () => {
     await runIdentityRewrite({
       assistantId: "ast-1",
       content: "<system-message>rewrite</system-message>",
       title: "Updating personality",
       context: "test",
+    });
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]?.path).toEqual({ assistant_id: "ast-1" });
+    expect(createCalls[0]?.body).toEqual({
+      conversationType: "background",
+      title: "Updating personality",
     });
 
     expect(postCalls).toHaveLength(1);

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -3,10 +3,16 @@
  *
  * The About Assistant surfaces reshape the assistant's persona the same way
  * research onboarding does: post a system-message that asks the assistant to
- * rewrite its own identity files (IDENTITY.md / SOUL.md), wait for the turn
- * to settle, then archive the conversation so it never shows in the user's
- * sidebar. The identity files feed every future conversation's system
+ * rewrite its own identity files (IDENTITY.md / SOUL.md) and wait for the
+ * turn to settle. The identity files feed every future conversation's system
  * prompt, which is what makes this durable.
+ *
+ * The thread is minted as a `background` conversation, so it is invisible by
+ * construction: the daemon's conversation list defaults to
+ * `conversationType: "standard"`, which keeps a background row out of Recents
+ * and out of the landing-conversation pick. A daemon predating that support
+ * ignores the field and falls back to the previous behavior, where the
+ * trailing archive is what hides the thread — so no version gate is needed.
  *
  * Unlike onboarding's fire-and-forget `applyPersonality`, callers here drive
  * visible UI (a saving state and a success/failure toast), so this resolves
@@ -36,7 +42,10 @@ export interface RunIdentityRewriteOptions {
   assistantId: string;
   /** The full `<system-message>…</system-message>` content to post. */
   content: string;
-  /** Sidebar-invisible conversation title (useful in logs/inspector). */
+  /**
+   * Conversation title. Background threads stay out of the sidebar, so this
+   * only ever surfaces in logs/inspector.
+   */
   title: string;
   /** Sentry context tag for failures. */
   context: string;
@@ -53,7 +62,7 @@ export async function runIdentityRewrite({
   try {
     const conversation = await conversationsPost({
       path: { assistant_id: assistantId },
-      body: { conversationType: "standard", title },
+      body: { conversationType: "background", title },
       throwOnError: false,
     });
     conversationId = conversation.data?.id;

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -7,12 +7,9 @@
  * turn to settle. The identity files feed every future conversation's system
  * prompt, which is what makes this durable.
  *
- * The thread is minted as a `background` conversation, so it is invisible by
- * construction: the daemon's conversation list defaults to
- * `conversationType: "standard"`, which keeps a background row out of Recents
- * and out of the landing-conversation pick. A daemon predating that support
- * ignores the field and falls back to the previous behavior, where the
- * trailing archive is what hides the thread — so no version gate is needed.
+ * The thread is minted `background`, a type the daemon keeps out of its
+ * default `standard` conversation list, so it never appears in Recents and is
+ * never selectable as the landing conversation.
  *
  * Unlike onboarding's fire-and-forget `applyPersonality`, callers here drive
  * visible UI (a saving state and a success/failure toast), so this resolves
@@ -42,10 +39,7 @@ export interface RunIdentityRewriteOptions {
   assistantId: string;
   /** The full `<system-message>…</system-message>` content to post. */
   content: string;
-  /**
-   * Conversation title. Background threads stay out of the sidebar, so this
-   * only ever surfaces in logs/inspector.
-   */
+  /** Conversation title, surfaced only in logs/inspector. */
   title: string;
   /** Sentry context tag for failures. */
   context: string;


### PR DESCRIPTION
## Summary
- Mint the throwaway identity-rewrite conversation as `background` so it is invisible by construction instead of being hidden later by a racy archive.
- Covers both entry points (rename and personality update), which share this one helper.

Part of plan: bg-side-conversations.md (PR 4 of 5)