### PR TITLE
fix(onboarding): mint the personality-rewrite thread as background

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -7,15 +7,18 @@
  * message-builder tests stay free of module mocks.
  *
  * Also pins that the rewrite send goes out hidden (see
- * `lib/side-conversation-message.ts`).
+ * `lib/side-conversation-message.ts`) and that the throwaway thread is minted
+ * `background` rather than relying on the retroactive archive to hide it.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const conversationsPostMock = mock(async () => ({
-  data: { id: "conv-1" },
-  response: { ok: true },
-}));
+const conversationsPostMock = mock(
+  async (_opts: { body: { conversationType?: string } }) => ({
+    data: { id: "conv-1" },
+    response: { ok: true },
+  }),
+);
 const messagesPostMock = mock(
   async (_opts: { body: { hidden?: boolean } }) => ({
     response: { ok: true },
@@ -58,6 +61,26 @@ beforeEach(() => {
   conversationsPostMock.mockClear();
   messagesPostMock.mockClear();
   saveSlidersMock.mockClear();
+});
+
+describe("applyPersonality side conversation", () => {
+  test("mints the throwaway thread as background even when the archive fails", async () => {
+    // The thread's only visible content is the assistant's first-person
+    // self-description (the prompt posts hidden), so a `standard` mint that
+    // outran the archive surfaced as a stray intro message on first chat load.
+    // Failing the archive here pins that the hiding comes from the mint.
+    archivePostMock.mockRejectedValueOnce(new Error("archive failed"));
+
+    await applyPersonality({
+      awaitAssistantId: async () => "ast-1",
+      values: {},
+    });
+
+    expect(conversationsPostMock.mock.calls[0]?.[0].body).toMatchObject({
+      conversationType: "background",
+      title: "Updating personality",
+    });
+  });
 });
 
 describe("applyPersonality rewrite prompt", () => {

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -8,7 +8,7 @@
  *
  * Also pins that the rewrite send goes out hidden (see
  * `lib/side-conversation-message.ts`) and that the throwaway thread is minted
- * `background` rather than relying on the retroactive archive to hide it.
+ * `background`, which is what keeps it out of the conversation list.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -65,10 +65,10 @@ beforeEach(() => {
 
 describe("applyPersonality side conversation", () => {
   test("mints the throwaway thread as background even when the archive fails", async () => {
-    // The thread's only visible content is the assistant's first-person
-    // self-description (the prompt posts hidden), so a `standard` mint that
-    // outran the archive surfaced as a stray intro message on first chat load.
-    // Failing the archive here pins that the hiding comes from the mint.
+    // The thread's only renderable content is the assistant's first-person
+    // self-description (the prompt posts hidden), so the `background` mint is
+    // what keeps it out of the user's view. Failing the archive here pins that
+    // the hiding comes from the mint alone.
     archivePostMock.mockRejectedValueOnce(new Error("archive failed"));
 
     await applyPersonality({

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -16,17 +16,11 @@
  * and let the rewrite turn settle. Talks to the daemon through the generated
  * SDK directly (`@/domains/chat/api/*` is import-banned from onboarding).
  *
- * The thread is minted `conversationType: "background"`, which hides it from
- * creation: the daemon's conversation list defaults to `standard`, so a
- * background thread can never be the landing conversation or enter Recents.
- * That matters here because the rewrite prompt asks for a first-person
- * self-description (see `@/assistant/personality-rewrite`) and the prompt
- * itself posts hidden, so the thread's only visible content is an
- * assistant-authored intro message — the stray intro users hit on first chat
- * load back when a retroactive archive was the only thing hiding the thread.
- * The archive below is best-effort cleanup, not the hiding mechanism. A daemon
- * predating this field ignores it and leaves the thread visible until the
- * archive lands, which is exactly the previous behavior, so no version gate.
+ * The thread is minted `conversationType: "background"`, which keeps it out of
+ * the daemon's default `standard` conversation list: it never enters Recents
+ * and is never selectable as the landing conversation. The prompt posts hidden,
+ * so the thread's only renderable content is the assistant's reply. The archive
+ * below is best-effort cleanup.
  *
  * Best-effort and fire-and-forget: a failure here must never block or surface
  * in the onboarding flow. Every error is swallowed (reported to Sentry).
@@ -159,8 +153,8 @@ export async function applyPersonality({
   } catch (err) {
     captureError(err, { context: "research_onboarding_personality" });
   } finally {
-    // Best-effort cleanup of the throwaway thread. Hiding it does not depend on
-    // this landing — it was minted `background` (see the module header).
+    // Best-effort cleanup of the throwaway thread. The `background` mint (see
+    // the module header) is what keeps it hidden, not this call.
     if (assistantId && conversationId) {
       try {
         await conversationsByIdArchivePost({

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -13,9 +13,20 @@
  * Like the research turn (`research-runner.ts`) and the check-in
  * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
  * conversation: we await hatch readiness, mint a conversation, post the prompt,
- * let the rewrite turn settle, then archive it so it never shows in the user's
- * sidebar. Talks to the daemon through the generated SDK directly
- * (`@/domains/chat/api/*` is import-banned from onboarding).
+ * and let the rewrite turn settle. Talks to the daemon through the generated
+ * SDK directly (`@/domains/chat/api/*` is import-banned from onboarding).
+ *
+ * The thread is minted `conversationType: "background"`, which hides it from
+ * creation: the daemon's conversation list defaults to `standard`, so a
+ * background thread can never be the landing conversation or enter Recents.
+ * That matters here because the rewrite prompt asks for a first-person
+ * self-description (see `@/assistant/personality-rewrite`) and the prompt
+ * itself posts hidden, so the thread's only visible content is an
+ * assistant-authored intro message — the stray intro users hit on first chat
+ * load back when a retroactive archive was the only thing hiding the thread.
+ * The archive below is best-effort cleanup, not the hiding mechanism. A daemon
+ * predating this field ignores it and leaves the thread visible until the
+ * archive lands, which is exactly the previous behavior, so no version gate.
  *
  * Best-effort and fire-and-forget: a failure here must never block or surface
  * in the onboarding flow. Every error is swallowed (reported to Sentry).
@@ -83,7 +94,7 @@ export async function applyPersonality({
 
     const conversation = await conversationsPost({
       path: { assistant_id: assistantId },
-      body: { conversationType: "standard", title: "Updating personality" },
+      body: { conversationType: "background", title: "Updating personality" },
       throwOnError: false,
     });
     conversationId = conversation.data?.id;
@@ -148,7 +159,8 @@ export async function applyPersonality({
   } catch (err) {
     captureError(err, { context: "research_onboarding_personality" });
   } finally {
-    // Archive the throwaway thread so it never appears in the sidebar.
+    // Best-effort cleanup of the throwaway thread. Hiding it does not depend on
+    // this landing — it was minted `background` (see the module header).
     if (assistantId && conversationId) {
       try {
         await conversationsByIdArchivePost({


### PR DESCRIPTION
## Summary
- Mint the throwaway personality-rewrite conversation as `background` so it is invisible by construction instead of being hidden later by a racy archive.
- Its assistant reply is a first-person self-description, which is what surfaced as an unintended intro message on first chat load when the archive lost the race.

Part of plan: bg-side-conversations.md (PR 3 of 5)