### PR TITLE
feat(cli): ensureTunnelEdge starts/reuses the nginx edge as the canonical tunnel target

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -12,12 +12,22 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
+import * as featureFlags from "../lib/feature-flags.js";
 import * as httpClient from "../lib/http-client.js";
 
 const realChildProcess = { ...childProcess };
 const realFs = { ...fsModule };
+const realFeatureFlags = { ...featureFlags };
 const realHttpClient = { ...httpClient };
 
 const execFileSyncMock = mock(childProcess.execFileSync);
@@ -49,17 +59,28 @@ mock.module("../lib/http-client.js", () => ({
   waitForDaemonReady: waitForDaemonReadyMock,
 }));
 
+const isFeatureFlagEnabledMock = mock<
+  typeof featureFlags.isAssistantFeatureFlagEnabled
+>(async () => true);
+
+mock.module("../lib/feature-flags.js", () => ({
+  ...featureFlags,
+  isAssistantFeatureFlagEnabled: isFeatureFlagEnabledMock,
+}));
+
 // Restore the real modules once this file finishes so the mocks do not leak
 // into sibling test files in the same `bun test` run.
 afterAll(() => {
   mock.module("node:child_process", () => realChildProcess);
   mock.module("node:fs", () => realFs);
+  mock.module("../lib/feature-flags.js", () => realFeatureFlags);
   mock.module("../lib/http-client.js", () => realHttpClient);
 });
 
 import {
   buildIngressNginxConfig,
   buildRemoteWebIndexHtml,
+  ensureTunnelEdge,
   resolveTunnelTargetPort,
   startRemoteWebIngress,
   stopIngressNginx,
@@ -81,6 +102,8 @@ afterEach(() => {
   readFileSyncMock.mockImplementation(realFs.readFileSync);
   waitForDaemonReadyMock.mockReset();
   waitForDaemonReadyMock.mockImplementation(async () => true);
+  isFeatureFlagEnabledMock.mockReset();
+  isFeatureFlagEnabledMock.mockImplementation(async () => true);
   for (const dir of workspaces.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -486,54 +509,111 @@ describe("nginx ingress process state", () => {
   });
 });
 
+const NGINX_VERSION = "nginx version: nginx/1.29.0";
+const FAKE_INDEX_HTML = "<html><head></head><body></body></html>";
+const WEB_INDEX_SUFFIX = join("dist", "index.html");
+
+function ingressConfPath(workspaceDir: string): string {
+  return join(workspaceDir, "data", "ingress", "nginx.conf");
+}
+
+function mockNginxInstalled(): void {
+  spawnSyncMock.mockReturnValue({
+    pid: 4242,
+    output: [],
+    stdout: "",
+    stderr: NGINX_VERSION,
+    status: 0,
+    signal: null,
+  });
+}
+
+function mockNginxMissing(): void {
+  spawnSyncMock.mockReturnValue({
+    pid: 0,
+    output: [],
+    stdout: "",
+    stderr: "",
+    status: 1,
+    signal: null,
+  });
+}
+
+function mockNginxSpawn(): void {
+  spawnMock.mockReturnValue({
+    unref: () => {},
+    pid: 4243,
+  } as unknown as ChildProcess);
+}
+
+/** Force findWebDistDir() to resolve nothing, regardless of checkout state. */
+function mockWebDistMissing(): void {
+  existsSyncMock.mockImplementation((path) =>
+    String(path).endsWith("index.html") ? false : realFs.existsSync(path),
+  );
+}
+
+/** Force findWebDistDir() to resolve a dist dir, regardless of checkout state. */
+function mockWebDistPresent(): void {
+  existsSyncMock.mockImplementation((path) =>
+    String(path).endsWith(WEB_INDEX_SUFFIX) ? true : realFs.existsSync(path),
+  );
+  readFileSyncMock.mockImplementation(((path, options) =>
+    String(path).endsWith(WEB_INDEX_SUFFIX)
+      ? FAKE_INDEX_HTML
+      : realFs.readFileSync(
+          path as never,
+          options as never,
+        )) as typeof readFileSync);
+}
+
+/** Record a running edge: ingress state, live pidfile, matching ps output. */
+function mockRunningEdge(
+  ws: string,
+  opts: { listenPort: number; includeWebApp?: boolean },
+): number {
+  const pid = 123_460;
+  writeFileSync(
+    join(ws, "config.json"),
+    JSON.stringify({
+      ingress: {
+        nginx: {
+          listenPort: opts.listenPort,
+          ...(opts.includeWebApp === undefined
+            ? {}
+            : { includeWebApp: opts.includeWebApp }),
+        },
+      },
+    }) + "\n",
+  );
+  const dir = join(ws, "data", "ingress");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "nginx.pid"), `${pid}\n`);
+  execFileSyncMock.mockReturnValue(
+    `nginx: master process nginx -p ${dir} -c ${join(dir, "nginx.conf")} -g daemon off;`,
+  );
+  return pid;
+}
+
+/** SIGTERM to the given PID marks it dead; signal 0 reflects liveness. */
+function mockKillableNginx(pid: number): { killed: () => boolean } {
+  let alive = true;
+  process.kill = mock((targetPid: number, signal?: string | number) => {
+    if (targetPid !== pid) return originalKill(targetPid, signal);
+    if (signal === 0) {
+      if (!alive) throw new Error("dead");
+      return true;
+    }
+    if (signal === "SIGTERM") {
+      alive = false;
+      return true;
+    }
+    return true;
+  }) as unknown as typeof process.kill;
+  return { killed: () => !alive };
+}
+
 describe("startRemoteWebIngress", () => {
-  const NGINX_VERSION = "nginx version: nginx/1.29.0";
-  const FAKE_INDEX_HTML = "<html><head></head><body></body></html>";
-  const WEB_INDEX_SUFFIX = join("dist", "index.html");
-
-  function ingressConfPath(workspaceDir: string): string {
-    return join(workspaceDir, "data", "ingress", "nginx.conf");
-  }
-
-  function mockNginxInstalled(): void {
-    spawnSyncMock.mockReturnValue({
-      pid: 4242,
-      output: [],
-      stdout: "",
-      stderr: NGINX_VERSION,
-      status: 0,
-      signal: null,
-    });
-  }
-
-  function mockNginxSpawn(): void {
-    spawnMock.mockReturnValue({
-      unref: () => {},
-      pid: 4243,
-    } as unknown as ChildProcess);
-  }
-
-  /** Force findWebDistDir() to resolve nothing, regardless of checkout state. */
-  function mockWebDistMissing(): void {
-    existsSyncMock.mockImplementation((path) =>
-      String(path).endsWith("index.html") ? false : realFs.existsSync(path),
-    );
-  }
-
-  /** Force findWebDistDir() to resolve a dist dir, regardless of checkout state. */
-  function mockWebDistPresent(): void {
-    existsSyncMock.mockImplementation((path) =>
-      String(path).endsWith(WEB_INDEX_SUFFIX) ? true : realFs.existsSync(path),
-    );
-    readFileSyncMock.mockImplementation(((path, options) =>
-      String(path).endsWith(WEB_INDEX_SUFFIX)
-        ? FAKE_INDEX_HTML
-        : realFs.readFileSync(
-            path as never,
-            options as never,
-          )) as typeof readFileSync);
-  }
-
   test("webhooks-only mode starts the denylist+proxy edge without a web dist", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
@@ -647,52 +727,6 @@ describe("startRemoteWebIngress", () => {
     expect(spawnMock).not.toHaveBeenCalled();
     expect(realFs.existsSync(ingressConfPath(ws))).toBe(false);
   });
-
-  /** Record a running edge: ingress state, live pidfile, matching ps output. */
-  function mockRunningEdge(
-    ws: string,
-    opts: { listenPort: number; includeWebApp?: boolean },
-  ): number {
-    const pid = 123_460;
-    writeFileSync(
-      join(ws, "config.json"),
-      JSON.stringify({
-        ingress: {
-          nginx: {
-            listenPort: opts.listenPort,
-            ...(opts.includeWebApp === undefined
-              ? {}
-              : { includeWebApp: opts.includeWebApp }),
-          },
-        },
-      }) + "\n",
-    );
-    const dir = join(ws, "data", "ingress");
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "nginx.pid"), `${pid}\n`);
-    execFileSyncMock.mockReturnValue(
-      `nginx: master process nginx -p ${dir} -c ${join(dir, "nginx.conf")} -g daemon off;`,
-    );
-    return pid;
-  }
-
-  /** SIGTERM to the given PID marks it dead; signal 0 reflects liveness. */
-  function mockKillableNginx(pid: number): { killed: () => boolean } {
-    let alive = true;
-    process.kill = mock((targetPid: number, signal?: string | number) => {
-      if (targetPid !== pid) return originalKill(targetPid, signal);
-      if (signal === 0) {
-        if (!alive) throw new Error("dead");
-        return true;
-      }
-      if (signal === "SIGTERM") {
-        alive = false;
-        return true;
-      }
-      return true;
-    }) as unknown as typeof process.kill;
-    return { killed: () => !alive };
-  }
 
   test("short-circuits when the running edge already serves the requested mode", async () => {
     const ws = makeWorkspace();
@@ -852,5 +886,223 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: false,
     });
+  });
+});
+
+describe("ensureTunnelEdge", () => {
+  const ASSISTANT_ID = "assistant-1";
+  const REQUESTED_PORT = 7846;
+  const originalIngressPort = process.env.VELLUM_NGINX_INGRESS_PORT;
+
+  beforeEach(() => {
+    process.env.VELLUM_NGINX_INGRESS_PORT = String(REQUESTED_PORT);
+  });
+
+  afterEach(() => {
+    if (originalIngressPort === undefined) {
+      delete process.env.VELLUM_NGINX_INGRESS_PORT;
+    } else {
+      process.env.VELLUM_NGINX_INGRESS_PORT = originalIngressPort;
+    }
+  });
+
+  test("reuses a running edge that matches the flag-resolved mode", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    const edge = mockKillableNginx(pid);
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: 7845,
+      started: false,
+      includesWebApp: true,
+    });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts a mode-drifted edge into the flag-resolved mode", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    const edge = mockKillableNginx(pid);
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: REQUESTED_PORT,
+      started: true,
+      includesWebApp: false,
+    });
+    expect(edge.killed()).toBe(true);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: REQUESTED_PORT,
+      }),
+    );
+  });
+
+  test("flag enabled starts the SPA edge", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: REQUESTED_PORT,
+      started: true,
+      includesWebApp: true,
+    });
+    expect(isFeatureFlagEnabledMock).toHaveBeenCalledWith(
+      ASSISTANT_ID,
+      featureFlags.WEB_REMOTE_INGRESS_FLAG,
+      { runtimeUrl: "http://127.0.0.1:7830" },
+    );
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain("location ^~ /assistant/ {");
+    expect(conf).toContain("location ^~ /webhooks/ {");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: REQUESTED_PORT,
+      includeWebApp: true,
+    });
+  });
+
+  test("flag disabled starts the webhooks-only edge", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: REQUESTED_PORT,
+      started: true,
+      includesWebApp: false,
+    });
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain("location = /v1/pair { return 404; }");
+    expect(conf).not.toContain("location ^~ /assistant/ {");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: REQUESTED_PORT,
+      includeWebApp: false,
+    });
+  });
+
+  test("an entry without an assistant id gets the webhooks-only edge", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+
+    const result = await ensureTunnelEdge({
+      assistantId: undefined,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: REQUESTED_PORT,
+      started: true,
+      includesWebApp: false,
+    });
+    expect(isFeatureFlagEnabledMock).not.toHaveBeenCalled();
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).not.toContain("location ^~ /assistant/ {");
+  });
+
+  test("missing nginx throws with install instructions", async () => {
+    const ws = makeWorkspace();
+    mockNginxMissing();
+
+    const promise = ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    await expect(promise).rejects.toThrow("brew install nginx");
+    await expect(promise).rejects.toThrow("apt install nginx");
+    await expect(promise).rejects.toThrow("NGINX_BIN");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("flag lookup failure throws the wake hint", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    isFeatureFlagEnabledMock.mockImplementation(async () => {
+      throw new Error("connect ECONNREFUSED");
+    });
+
+    const promise = ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    await expect(promise).rejects.toThrow(
+      "Could not verify the `web-remote-ingress` feature flag",
+    );
+    await expect(promise).rejects.toThrow("Try `vellum wake` and retry");
+    await expect(promise).rejects.toThrow("connect ECONNREFUSED");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("missing web dist with the flag enabled throws build guidance", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockWebDistMissing();
+
+    await expect(
+      ensureTunnelEdge({
+        assistantId: ASSISTANT_ID,
+        workspaceDir: ws,
+        gatewayPort: 7830,
+      }),
+    ).rejects.toThrow("@vellumai/web");
+  });
+
+  test("an unreachable edge throws with the log path", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    waitForDaemonReadyMock.mockImplementation(async () => false);
+
+    await expect(
+      ensureTunnelEdge({
+        assistantId: ASSISTANT_ID,
+        workspaceDir: ws,
+        gatewayPort: 7830,
+      }),
+    ).rejects.toThrow(join(ws, "data", "logs", "nginx-ingress.log"));
   });
 });

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -746,7 +746,11 @@ describe("startRemoteWebIngress", () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
-    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
     const edge = mockKillableNginx(pid);
 
     const result = await startRemoteWebIngress({
@@ -823,10 +827,11 @@ describe("startRemoteWebIngress", () => {
     });
   });
 
-  test("reuses an edge whose state predates the recorded gateway port", async () => {
+  test("restarts an edge whose state predates the recorded gateway port", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
+    mockWebDistMissing();
     const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
     const edge = mockKillableNginx(pid);
 
@@ -837,16 +842,29 @@ describe("startRemoteWebIngress", () => {
       includeWebApp: false,
     });
 
-    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
-    expect(edge.killed()).toBe(false);
-    expect(spawnMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(edge.killed()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(realFs.readFileSync(ingressConfPath(ws), "utf-8")).toBe(
+      buildIngressNginxConfig({ gatewayPort: 7900, listenPort: 7845 }),
+    );
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7900,
+    });
   });
 
   test("treats recorded state without a mode as an SPA edge", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
-    const pid = mockRunningEdge(ws, { listenPort: 7845 });
+    const pid = mockRunningEdge(ws, { listenPort: 7845, gatewayPort: 7830 });
     const edge = mockKillableNginx(pid);
 
     const result = await startRemoteWebIngress({
@@ -1008,7 +1026,11 @@ describe("ensureTunnelEdge", () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
-    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+    });
     const edge = mockKillableNginx(pid);
 
     const result = await ensureTunnelEdge({
@@ -1032,7 +1054,11 @@ describe("ensureTunnelEdge", () => {
     mockNginxSpawn();
     mockWebDistMissing();
     isFeatureFlagEnabledMock.mockImplementation(async () => false);
-    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
     const edge = mockKillableNginx(pid);
 
     const result = await ensureTunnelEdge({

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -570,7 +570,7 @@ function mockWebDistPresent(): void {
 /** Record a running edge: ingress state, live pidfile, matching ps output. */
 function mockRunningEdge(
   ws: string,
-  opts: { listenPort: number; includeWebApp?: boolean },
+  opts: { listenPort: number; includeWebApp?: boolean; gatewayPort?: number },
 ): number {
   const pid = 123_460;
   writeFileSync(
@@ -582,6 +582,9 @@ function mockRunningEdge(
           ...(opts.includeWebApp === undefined
             ? {}
             : { includeWebApp: opts.includeWebApp }),
+          ...(opts.gatewayPort === undefined
+            ? {}
+            : { gatewayPort: opts.gatewayPort }),
         },
       },
     }) + "\n",
@@ -669,6 +672,7 @@ describe("startRemoteWebIngress", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: false,
+      gatewayPort: 7830,
     });
   });
 
@@ -714,6 +718,7 @@ describe("startRemoteWebIngress", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: true,
+      gatewayPort: 7830,
     });
   });
 
@@ -747,6 +752,87 @@ describe("startRemoteWebIngress", () => {
     const result = await startRemoteWebIngress({
       workspaceDir: ws,
       gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("short-circuits when the recorded gateway port matches the request", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts the edge when its recorded gateway port drifts from the request", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7900,
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(edge.killed()).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7845 }),
+    );
+    expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
+    expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
+  });
+
+  test("reuses an edge whose state predates the recorded gateway port", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const edge = mockKillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7900,
       listenPort: 7845,
       includeWebApp: false,
     });
@@ -804,6 +890,7 @@ describe("startRemoteWebIngress", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: false,
+      gatewayPort: 7830,
     });
   });
 
@@ -843,6 +930,7 @@ describe("startRemoteWebIngress", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: false,
+      gatewayPort: 7830,
     });
   });
 
@@ -871,6 +959,7 @@ describe("startRemoteWebIngress", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: true,
+      gatewayPort: 7830,
     });
   });
 
@@ -983,6 +1072,66 @@ describe("ensureTunnelEdge", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  test("a port-drifted edge that survives the restart attempt throws", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7900,
+    });
+    mockUnkillableNginx(pid);
+
+    const promise = ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    await expect(promise).rejects.toThrow(
+      "still proxying gateway port 7900 and could not be restarted against port 7830",
+    );
+    await expect(promise).rejects.toThrow("vellum nginx-ingress down");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("restarts a port-drifted edge against the requested gateway port", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7900,
+    });
+    const edge = mockKillableNginx(pid);
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: REQUESTED_PORT,
+      started: true,
+      includesWebApp: false,
+    });
+    expect(edge.killed()).toBe(true);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toBe(
+      buildIngressNginxConfig({
+        gatewayPort: 7830,
+        listenPort: REQUESTED_PORT,
+      }),
+    );
+  });
+
   test("restarts a mode-drifted edge into the flag-resolved mode", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
@@ -1041,6 +1190,7 @@ describe("ensureTunnelEdge", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: REQUESTED_PORT,
       includeWebApp: true,
+      gatewayPort: 7830,
     });
   });
 
@@ -1068,6 +1218,7 @@ describe("ensureTunnelEdge", () => {
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: REQUESTED_PORT,
       includeWebApp: false,
+      gatewayPort: 7830,
     });
   });
 

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -613,6 +613,15 @@ function mockKillableNginx(pid: number): { killed: () => boolean } {
   return { killed: () => !alive };
 }
 
+/** The given PID stays alive: liveness probes succeed, kill signals fail. */
+function mockUnkillableNginx(pid: number): void {
+  process.kill = mock((targetPid: number, signal?: string | number) => {
+    if (targetPid !== pid) return originalKill(targetPid, signal);
+    if (signal === 0) return true;
+    throw new Error("operation not permitted");
+  }) as unknown as typeof process.kill;
+}
+
 describe("startRemoteWebIngress", () => {
   test("webhooks-only mode starts the denylist+proxy edge without a web dist", async () => {
     const ws = makeWorkspace();
@@ -925,6 +934,52 @@ describe("ensureTunnelEdge", () => {
       includesWebApp: true,
     });
     expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("reuses a running webhooks-only edge and reports the recorded mode", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: false });
+    const edge = mockKillableNginx(pid);
+
+    const result = await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    expect(result).toEqual({
+      port: 7845,
+      started: false,
+      includesWebApp: false,
+    });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("a mode-drifted edge that survives the restart attempt throws", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const pid = mockRunningEdge(ws, { listenPort: 7845, includeWebApp: true });
+    mockUnkillableNginx(pid);
+
+    const promise = ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+    });
+
+    await expect(promise).rejects.toThrow(
+      "still running in web app mode and could not be restarted in webhooks-only mode",
+    );
+    await expect(promise).rejects.toThrow("vellum nginx-ingress down");
     expect(spawnMock).not.toHaveBeenCalled();
   });
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -417,6 +417,13 @@ interface IngressState {
   listenPort: number;
   /** Edge mode: SPA + proxy (true) or webhooks-only proxy (false). */
   includeWebApp: boolean;
+  /**
+   * Gateway port the edge's proxy_pass targets. Undefined in state records
+   * that predate the field; callers treat an unknown port as matching the
+   * request, since the running edge was almost certainly started against the
+   * same still-valid port and a restart would be gratuitous.
+   */
+  gatewayPort?: number;
 }
 
 function readIngressState(workspaceDir: string): IngressState | null {
@@ -425,8 +432,13 @@ function readIngressState(workspaceDir: string): IngressState | null {
   const nginx = ingress?.nginx as Record<string, unknown> | undefined;
   const listenPort = nginx?.listenPort;
   if (typeof listenPort !== "number") return null;
+  const gatewayPort = nginx?.gatewayPort;
   // A state record without includeWebApp represents an SPA edge.
-  return { listenPort, includeWebApp: nginx?.includeWebApp !== false };
+  return {
+    listenPort,
+    includeWebApp: nginx?.includeWebApp !== false,
+    ...(typeof gatewayPort === "number" ? { gatewayPort } : {}),
+  };
 }
 
 function saveIngressState(workspaceDir: string, state: IngressState): void {
@@ -435,6 +447,9 @@ function saveIngressState(workspaceDir: string, state: IngressState): void {
   ingress.nginx = {
     listenPort: state.listenPort,
     includeWebApp: state.includeWebApp,
+    ...(state.gatewayPort !== undefined
+      ? { gatewayPort: state.gatewayPort }
+      : {}),
   };
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
@@ -505,6 +520,7 @@ export function startIngressNginx(opts: {
   saveIngressState(opts.workspaceDir, {
     listenPort: opts.listenPort,
     includeWebApp: opts.remoteWebIngress !== undefined,
+    gatewayPort: opts.gatewayPort,
   });
   return child;
 }
@@ -596,9 +612,10 @@ export type StartRemoteWebIngressResult =
  * but unreachable nginx is rolled back so a failed attempt leaves no half-up
  * edge behind.
  *
- * An edge already running in the requested mode short-circuits as
- * `already-running`; one running in the other mode (SPA vs webhooks-only) is
- * stopped and restarted with the requested config.
+ * An edge already running in the requested mode against the requested gateway
+ * port short-circuits as `already-running`; one running in the other mode
+ * (SPA vs webhooks-only) or against a different gateway port is stopped and
+ * restarted with the requested config.
  *
  * Pure mechanism: it performs no console output and never exits the process, so
  * both the `nginx-ingress up` command and the wake restore path can share one
@@ -638,9 +655,13 @@ export async function startRemoteWebIngress(opts: {
 
   const running = isIngressRunning(opts.workspaceDir);
   if (running) {
-    const recordedMode =
-      readIngressState(opts.workspaceDir)?.includeWebApp ?? true;
-    if (recordedMode === includeWebApp) {
+    const state = readIngressState(opts.workspaceDir);
+    const recordedMode = state?.includeWebApp ?? true;
+    // An unknown recorded gateway port matches any request (see IngressState).
+    const gatewayPortMatches =
+      state?.gatewayPort === undefined ||
+      state.gatewayPort === opts.gatewayPort;
+    if (recordedMode === includeWebApp && gatewayPortMatches) {
       return { status: "already-running", listenPort };
     }
   }
@@ -653,9 +674,10 @@ export async function startRemoteWebIngress(opts: {
     }
   }
 
-  // The running edge serves the other mode; restart it with the requested
-  // config. A false stop can mean the old edge exited on its own after the
-  // check above, so recheck liveness and only bail when it is still serving.
+  // The running edge serves the other mode or targets a different gateway
+  // port; restart it with the requested config. A false stop can mean the old
+  // edge exited on its own after the check above, so recheck liveness and only
+  // bail when it is still serving.
   if (
     running &&
     !(await stopIngressNginx(opts.workspaceDir)) &&
@@ -721,11 +743,12 @@ async function resolveEdgeIncludesWebApp(
  * proxy, disabled: webhooks-only proxy); an entry without an assistant id
  * cannot have the flag verified and gets the webhooks-only edge. The resolved
  * mode is always delegated to `startRemoteWebIngress`, which reuses a running
- * edge that already serves that mode and restarts one that drifted, so the
- * returned port always fronts the flag-resolved config. `started` is false when
- * a matching edge was reused; a drifted edge that survives the restart attempt
- * throws rather than reporting the wrong mode. Failures throw with actionable
- * install or diagnostic text.
+ * edge that already serves that mode against the requested gateway port and
+ * restarts one that drifted in either respect, so the returned port always
+ * fronts the flag-resolved config. `started` is false when a matching edge was
+ * reused; a drifted edge that survives the restart attempt throws rather than
+ * reporting the wrong config. Failures throw with actionable install or
+ * diagnostic text.
  */
 export async function ensureTunnelEdge(opts: {
   assistantId: string | undefined;
@@ -750,9 +773,10 @@ export async function ensureTunnelEdge(opts: {
         includesWebApp: includeWebApp,
       };
     case "already-running": {
-      // `already-running` also covers a mode-drifted edge whose restart
-      // failed, so trust the recorded state over the requested mode. A state
-      // record without includeWebApp represents an SPA edge.
+      // `already-running` also covers a drifted edge whose restart failed, so
+      // trust the recorded state over the requested config. A state record
+      // without includeWebApp represents an SPA edge; one without a gateway
+      // port matches any requested port (see IngressState).
       const state = readIngressState(opts.workspaceDir);
       const recordedIncludesWebApp = state?.includeWebApp ?? true;
       if (recordedIncludesWebApp !== includeWebApp) {
@@ -760,6 +784,16 @@ export async function ensureTunnelEdge(opts: {
         throw new Error(
           `The nginx edge is still running in ${describe(recordedIncludesWebApp)} mode ` +
             `and could not be restarted in ${describe(includeWebApp)} mode. ` +
+            "Run `vellum nginx-ingress down` and retry.",
+        );
+      }
+      if (
+        state?.gatewayPort !== undefined &&
+        state.gatewayPort !== opts.gatewayPort
+      ) {
+        throw new Error(
+          `The nginx edge is still proxying gateway port ${state.gatewayPort} ` +
+            `and could not be restarted against port ${opts.gatewayPort}. ` +
             "Run `vellum nginx-ingress down` and retry.",
         );
       }

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -17,6 +17,10 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
+import {
+  isAssistantFeatureFlagEnabled,
+  WEB_REMOTE_INGRESS_FLAG,
+} from "./feature-flags.js";
 import { waitForDaemonReady } from "./http-client.js";
 import { loadRawConfig, saveRawConfig } from "./ingress-config.js";
 
@@ -683,6 +687,94 @@ export async function startRemoteWebIngress(opts: {
   }
 
   return { status: "started", listenPort, webDistDir, version };
+}
+
+/**
+ * Resolve the edge mode for an assistant: the `web-remote-ingress` flag selects
+ * the SPA edge when enabled and the webhooks-only edge when disabled. The
+ * lookup requires a reachable assistant, so a failure throws with a wake hint.
+ */
+async function resolveEdgeIncludesWebApp(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<boolean> {
+  try {
+    return await isAssistantFeatureFlagEnabled(
+      assistantId,
+      WEB_REMOTE_INGRESS_FLAG,
+      { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
+    );
+  } catch (err) {
+    throw new Error(
+      `Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` feature flag before starting the tunnel. Is the assistant running? Try \`vellum wake\` and retry. ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+/**
+ * Bring up the nginx edge as the canonical tunnel target and return the listen
+ * port a tunnel should front.
+ *
+ * The `web-remote-ingress` flag picks the edge mode (enabled: SPA + gateway
+ * proxy, disabled: webhooks-only proxy); an entry without an assistant id
+ * cannot have the flag verified and gets the webhooks-only edge. The resolved
+ * mode is always delegated to `startRemoteWebIngress`, which reuses a running
+ * edge that already serves that mode and restarts one that drifted, so the
+ * returned port always fronts the flag-resolved config. `started` is false when
+ * a matching edge was reused. Failures throw with actionable install or
+ * diagnostic text.
+ */
+export async function ensureTunnelEdge(opts: {
+  assistantId: string | undefined;
+  workspaceDir: string;
+  gatewayPort: number;
+}): Promise<{ port: number; started: boolean; includesWebApp: boolean }> {
+  const includeWebApp = opts.assistantId
+    ? await resolveEdgeIncludesWebApp(opts.assistantId, opts.gatewayPort)
+    : false;
+
+  const result = await startRemoteWebIngress({
+    workspaceDir: opts.workspaceDir,
+    gatewayPort: opts.gatewayPort,
+    includeWebApp,
+  });
+
+  switch (result.status) {
+    case "started":
+      return {
+        port: result.listenPort,
+        started: true,
+        includesWebApp: includeWebApp,
+      };
+    case "already-running":
+      // The reused edge's recorded listen port is the target; the result's
+      // listenPort is only the port this call would have requested.
+      return {
+        port:
+          readIngressState(opts.workspaceDir)?.listenPort ?? result.listenPort,
+        started: false,
+        includesWebApp: includeWebApp,
+      };
+    case "nginx-missing":
+      throw new Error(
+        "nginx is not installed, so the tunnel edge cannot start. " +
+          "Install it (macOS: `brew install nginx`, Linux: `sudo apt install nginx`) " +
+          "or point NGINX_BIN at an existing binary.",
+      );
+    case "web-dist-missing":
+      throw new Error(
+        "Unable to locate built web assets for the remote web edge. " +
+          "Build the SPA (`cd clients/web && VITE_PLATFORM_MODE=false bun run build`) " +
+          "or install @vellumai/web so its packaged dist directory is available.",
+      );
+    case "unreachable":
+      throw new Error(
+        `nginx edge did not become reachable on 127.0.0.1:${result.listenPort}. ` +
+          `Check the nginx log: ${result.logPath}`,
+      );
+  }
 }
 
 /**

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -723,8 +723,9 @@ async function resolveEdgeIncludesWebApp(
  * mode is always delegated to `startRemoteWebIngress`, which reuses a running
  * edge that already serves that mode and restarts one that drifted, so the
  * returned port always fronts the flag-resolved config. `started` is false when
- * a matching edge was reused. Failures throw with actionable install or
- * diagnostic text.
+ * a matching edge was reused; a drifted edge that survives the restart attempt
+ * throws rather than reporting the wrong mode. Failures throw with actionable
+ * install or diagnostic text.
  */
 export async function ensureTunnelEdge(opts: {
   assistantId: string | undefined;
@@ -748,15 +749,28 @@ export async function ensureTunnelEdge(opts: {
         started: true,
         includesWebApp: includeWebApp,
       };
-    case "already-running":
+    case "already-running": {
+      // `already-running` also covers a mode-drifted edge whose restart
+      // failed, so trust the recorded state over the requested mode. A state
+      // record without includeWebApp represents an SPA edge.
+      const state = readIngressState(opts.workspaceDir);
+      const recordedIncludesWebApp = state?.includeWebApp ?? true;
+      if (recordedIncludesWebApp !== includeWebApp) {
+        const describe = (spa: boolean) => (spa ? "web app" : "webhooks-only");
+        throw new Error(
+          `The nginx edge is still running in ${describe(recordedIncludesWebApp)} mode ` +
+            `and could not be restarted in ${describe(includeWebApp)} mode. ` +
+            "Run `vellum nginx-ingress down` and retry.",
+        );
+      }
       // The reused edge's recorded listen port is the target; the result's
       // listenPort is only the port this call would have requested.
       return {
-        port:
-          readIngressState(opts.workspaceDir)?.listenPort ?? result.listenPort,
+        port: state?.listenPort ?? result.listenPort,
         started: false,
-        includesWebApp: includeWebApp,
+        includesWebApp: recordedIncludesWebApp,
       };
+    }
     case "nginx-missing":
       throw new Error(
         "nginx is not installed, so the tunnel edge cannot start. " +

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -419,9 +419,9 @@ interface IngressState {
   includeWebApp: boolean;
   /**
    * Gateway port the edge's proxy_pass targets. Undefined in state records
-   * that predate the field; callers treat an unknown port as matching the
-   * request, since the running edge was almost certainly started against the
-   * same still-valid port and a restart would be gratuitous.
+   * that predate the field; callers treat an unknown port as unverified and
+   * restart the edge so the running config provably targets the requested
+   * port and the state is stamped for future comparisons.
    */
   gatewayPort?: number;
 }
@@ -657,11 +657,11 @@ export async function startRemoteWebIngress(opts: {
   if (running) {
     const state = readIngressState(opts.workspaceDir);
     const recordedMode = state?.includeWebApp ?? true;
-    // An unknown recorded gateway port matches any request (see IngressState).
-    const gatewayPortMatches =
-      state?.gatewayPort === undefined ||
-      state.gatewayPort === opts.gatewayPort;
-    if (recordedMode === includeWebApp && gatewayPortMatches) {
+    // An unknown recorded gateway port is unverified (see IngressState).
+    if (
+      recordedMode === includeWebApp &&
+      state?.gatewayPort === opts.gatewayPort
+    ) {
       return { status: "already-running", listenPort };
     }
   }
@@ -776,7 +776,7 @@ export async function ensureTunnelEdge(opts: {
       // `already-running` also covers a drifted edge whose restart failed, so
       // trust the recorded state over the requested config. A state record
       // without includeWebApp represents an SPA edge; one without a gateway
-      // port matches any requested port (see IngressState).
+      // port is unverified (see IngressState).
       const state = readIngressState(opts.workspaceDir);
       const recordedIncludesWebApp = state?.includeWebApp ?? true;
       if (recordedIncludesWebApp !== includeWebApp) {
@@ -787,12 +787,13 @@ export async function ensureTunnelEdge(opts: {
             "Run `vellum nginx-ingress down` and retry.",
         );
       }
-      if (
-        state?.gatewayPort !== undefined &&
-        state.gatewayPort !== opts.gatewayPort
-      ) {
+      if (state?.gatewayPort !== opts.gatewayPort) {
+        const upstream =
+          state?.gatewayPort !== undefined
+            ? `still proxying gateway port ${state.gatewayPort}`
+            : "proxying an unknown gateway port";
         throw new Error(
-          `The nginx edge is still proxying gateway port ${state.gatewayPort} ` +
+          `The nginx edge is ${upstream} ` +
             `and could not be restarted against port ${opts.gatewayPort}. ` +
             "Run `vellum nginx-ingress down` and retry.",
         );


### PR DESCRIPTION
## Summary
- ensureTunnelEdge resolves the web-remote-ingress flag to pick SPA vs webhooks-only mode and starts or reuses the edge via startRemoteWebIngress
- nginx-missing maps to a thrown error with install instructions; web-dist-missing/unreachable name the log path
- No callers yet; vellum tunnel (PR 5) and wake/upgrade (PR 6) adopt it next

Part of plan: tunnel-edge-unify.md (PR 4 of 7)