### PR TITLE
fix: guard on-weak token drift, tighten theme discovery, sync widget allowlists

### DIFF
--- a/assistant/src/config/bundled-skills/visualize/SKILL.md
+++ b/assistant/src/config/bundled-skills/visualize/SKILL.md
@@ -67,7 +67,7 @@ Semantic tokens flip automatically between light and dark. Use them for every su
 - Surfaces: --surface-base (page), --surface-lift (card), --surface-overlay, --surface-sunken (recessed tile), --surface-hover, --surface-active.
 - Text, strongest to faintest: --content-emphasised, --content-strong, --content-default (body), --content-secondary (labels and any text under 14px), --content-tertiary (14px and up only), --content-quiet, --content-faint, --content-disabled, --content-inset (on inverted fills). Text at 11 to 13px always takes --content-secondary or stronger.
 - Borders: --border-base (hairline), --border-subtle, --border-element (visible control edge), --border-hover, --border-active, --border-disabled.
-- Status pairs: --system-positive-strong/-weak, --system-negative-strong/-weak (and --system-negative-hover), --system-mid-strong/-weak, --system-info-strong/-weak.
+- Status pairs: --system-positive-strong/-weak, --system-negative-strong/-weak (and --system-negative-hover), --system-mid-strong/-weak, --system-info-strong/-weak. A glyph or label sitting on its own -weak fill takes --system-positive-on-weak or --system-negative-on-weak rather than the -strong tone, which drops under 3:1 on that fill in the dark theme.
 - Type: --font-sans (default), --font-mono (identifiers, code, tabular numbers only), --font-serif (editorial pull-quotes only).
 - Radius: --radius-xs 2, --radius-sm 4, --radius-md 8, --radius-lg 12, --radius-xl 16, --radius-xxl 20, --radius-pill 999.
 

--- a/assistant/src/tools/ui-surface/visual-validation.ts
+++ b/assistant/src/tools/ui-surface/visual-validation.ts
@@ -79,8 +79,10 @@ export const WIDGET_TOKEN_PROPERTIES: readonly string[] = [
   // System / status
   "--system-positive-strong",
   "--system-positive-weak",
+  "--system-positive-on-weak",
   "--system-negative-strong",
   "--system-negative-weak",
+  "--system-negative-on-weak",
   "--system-negative-hover",
   "--system-mid-strong",
   "--system-mid-weak",

--- a/clients/web/src/utils/widget-tokens.ts
+++ b/clients/web/src/utils/widget-tokens.ts
@@ -117,8 +117,10 @@ export const WIDGET_TOKEN_PROPERTIES: readonly string[] = [
   // System / status
   "--system-positive-strong",
   "--system-positive-weak",
+  "--system-positive-on-weak",
   "--system-negative-strong",
   "--system-negative-weak",
+  "--system-negative-on-weak",
   "--system-negative-hover",
   "--system-mid-strong",
   "--system-mid-weak",

--- a/packages/design-library/src/tokens.test.ts
+++ b/packages/design-library/src/tokens.test.ts
@@ -16,13 +16,6 @@ const MIN_CONTRAST = 3;
 const KNOWN_THEMES = ["light", "dark", "velvet"];
 const TONES = ["positive", "negative"];
 
-/**
- * The `theme:tone` pairings whose `-on-weak` token is not a copy of `-strong`:
- * dark `--system-negative-strong` does not clear 3:1 on the dark
- * `--system-negative-weak` fill, so the on-weak token is a lighter tone there.
- */
-const DIVERGENT_ON_WEAK = new Set(["dark:negative"]);
-
 const css = readFileSync(join(import.meta.dir, "tokens.css"), "utf8").replace(
   /\/\*[\s\S]*?\*\//g,
   "",
@@ -103,20 +96,28 @@ describe("system on-weak tokens", () => {
 
   // Contrast alone cannot catch this: an on-weak token left behind by an edit
   // to its -strong counterpart can still clear 3:1 while showing the wrong
-  // colour next to every other use of that tone.
-  test("each -on-weak token copies its -strong counterpart", () => {
-    const onWeak: Record<string, string> = {};
-    const strong: Record<string, string> = {};
+  // colour next to every other use of that tone. The exception is derived
+  // rather than listed, so a pairing only escapes the equality check while its
+  // -strong tone genuinely fails on the -weak fill. Lighten a -weak fill until
+  // -strong clears the floor and the pairing is held to equality again.
+  test("each -on-weak token copies its -strong counterpart unless -strong fails", () => {
+    const actual: Record<string, string> = {};
+    const expected: Record<string, string> = {};
     for (const [theme, tokens] of themes) {
       for (const tone of TONES) {
+        const strong = tokens[`--system-${tone}-strong`];
+        const weak = tokens[`--system-${tone}-weak`];
+        const onWeak = tokens[`--system-${tone}-on-weak`];
         const pairing = `${theme}:${tone}`;
-        if (DIVERGENT_ON_WEAK.has(pairing)) {
-          continue;
+        if (contrastRatio(strong, weak) >= MIN_CONTRAST) {
+          actual[pairing] = onWeak;
+          expected[pairing] = strong;
+        } else {
+          actual[pairing] = onWeak === strong ? "copies -strong" : "diverges";
+          expected[pairing] = "diverges";
         }
-        onWeak[pairing] = tokens[`--system-${tone}-on-weak`];
-        strong[pairing] = tokens[`--system-${tone}-strong`];
       }
     }
-    expect(onWeak).toEqual(strong);
+    expect(actual).toEqual(expected);
   });
 });

--- a/packages/design-library/src/tokens.test.ts
+++ b/packages/design-library/src/tokens.test.ts
@@ -14,10 +14,14 @@ import { join } from "node:path";
 
 const MIN_CONTRAST = 3;
 const KNOWN_THEMES = ["light", "dark", "velvet"];
-const PAIRS = [
-  { glyph: "--system-positive-on-weak", fill: "--system-positive-weak" },
-  { glyph: "--system-negative-on-weak", fill: "--system-negative-weak" },
-];
+const TONES = ["positive", "negative"];
+
+/**
+ * The `theme:tone` pairings whose `-on-weak` token is not a copy of `-strong`:
+ * dark `--system-negative-strong` does not clear 3:1 on the dark
+ * `--system-negative-weak` fill, so the on-weak token is a lighter tone there.
+ */
+const DIVERGENT_ON_WEAK = new Set(["dark:negative"]);
 
 const css = readFileSync(join(import.meta.dir, "tokens.css"), "utf8").replace(
   /\/\*[\s\S]*?\*\//g,
@@ -78,12 +82,16 @@ function contrastRatio(a: string, b: string): number {
 const themes = parseThemes(css);
 
 describe("system on-weak tokens", () => {
-  test("tokens.css exposes the known theme blocks", () => {
-    expect([...themes.keys()]).toEqual(expect.arrayContaining(KNOWN_THEMES));
+  // Exact rather than a superset, so adding a theme block forces an update
+  // here and with it a look at the rows the loop below generates for it.
+  test("tokens.css exposes exactly the known theme blocks", () => {
+    expect([...themes.keys()].sort()).toEqual([...KNOWN_THEMES].sort());
   });
 
   for (const [theme, tokens] of themes) {
-    for (const { glyph, fill } of PAIRS) {
+    for (const tone of TONES) {
+      const glyph = `--system-${tone}-on-weak`;
+      const fill = `--system-${tone}-weak`;
       test(`${theme} ${glyph} clears ${MIN_CONTRAST}:1 on ${fill}`, () => {
         expect(tokens[glyph]).toBeDefined();
         expect(
@@ -93,19 +101,22 @@ describe("system on-weak tokens", () => {
     }
   }
 
-  test("dark --system-negative-on-weak stays divergent from --system-negative-strong", () => {
-    const dark = themes.get("dark")!;
-    // Do not "tidy up" this divergence: --system-negative-strong measures
-    // 2.86:1 on the dark --system-negative-weak, under the 3:1 floor, which
-    // is why the dark on-weak token is a lighter tone than the other themes'.
-    expect(
-      contrastRatio(
-        dark["--system-negative-strong"],
-        dark["--system-negative-weak"],
-      ),
-    ).toBeLessThan(MIN_CONTRAST);
-    expect(dark["--system-negative-on-weak"]).not.toBe(
-      dark["--system-negative-strong"],
-    );
+  // Contrast alone cannot catch this: an on-weak token left behind by an edit
+  // to its -strong counterpart can still clear 3:1 while showing the wrong
+  // colour next to every other use of that tone.
+  test("each -on-weak token copies its -strong counterpart", () => {
+    const onWeak: Record<string, string> = {};
+    const strong: Record<string, string> = {};
+    for (const [theme, tokens] of themes) {
+      for (const tone of TONES) {
+        const pairing = `${theme}:${tone}`;
+        if (DIVERGENT_ON_WEAK.has(pairing)) {
+          continue;
+        }
+        onWeak[pairing] = tokens[`--system-${tone}-on-weak`];
+        strong[pairing] = tokens[`--system-${tone}-strong`];
+      }
+    }
+    expect(onWeak).toEqual(strong);
   });
 });


### PR DESCRIPTION
## Summary
- The theme list is now an exact match rather than `arrayContaining`, so a new theme cannot escape contrast coverage.
- Adds a drift guard: every `-on-weak` token must equal its `-strong` counterpart except dark negative, which is the one pairing that does not clear 3:1.
- Drops the divergence test, whose assertion that dark `-strong` measures under 3:1 would go red if the palette were improved.
- Adds the new tokens to both `WIDGET_TOKEN_PROPERTIES` mirrors so a widget referencing them resolves.

Addresses self-review findings for plan subagent-badge-option-d.md