### PR TITLE
fix(cli): keep tools list --json emitting the tool array

### DIFF
--- a/assistant/src/__tests__/tools-list-cli.test.ts
+++ b/assistant/src/__tests__/tools-list-cli.test.ts
@@ -36,11 +36,18 @@ const TOOL_ENTRY = {
   source: "core",
 };
 
-async function runList(args: string[]): Promise<string> {
-  const lines: string[] = [];
+async function runListStreams(
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
   const originalLog = console.log;
+  const originalError = console.error;
   console.log = (...parts: unknown[]) => {
-    lines.push(parts.map(String).join(" "));
+    out.push(parts.map(String).join(" "));
+  };
+  console.error = (...parts: unknown[]) => {
+    err.push(parts.map(String).join(" "));
   };
   try {
     const program = new Command();
@@ -49,8 +56,13 @@ async function runList(args: string[]): Promise<string> {
     await program.parseAsync(["node", "assistant", "tools", "list", ...args]);
   } finally {
     console.log = originalLog;
+    console.error = originalError;
   }
-  return lines.join("\n");
+  return { stdout: out.join("\n"), stderr: err.join("\n") };
+}
+
+async function runList(args: string[]): Promise<string> {
+  return (await runListStreams(args)).stdout;
 }
 
 describe("assistant tools list --agent", () => {
@@ -121,7 +133,7 @@ describe("assistant tools list --agent", () => {
     expect(output.startsWith("NAME")).toBe(true);
   });
 
-  test("--json carries the whole payload, resolution block included", async () => {
+  test("--json stdout stays the tool array, with the resolution line on stderr", async () => {
     const result = {
       names: [TOOL_ENTRY.name],
       schemas: { file_read: { type: "object" } },
@@ -134,8 +146,26 @@ describe("assistant tools list --agent", () => {
     };
     ipcResponse = { ok: true, result };
 
-    const output = await runList(["--agent", "subagent_typo", "--json"]);
+    const { stdout, stderr } = await runListStreams([
+      "--agent",
+      "subagent_typo",
+      "--json",
+    ]);
 
-    expect(JSON.parse(output)).toEqual(result);
+    // Piping stdout must keep yielding a bare array: scripts iterate it.
+    expect(JSON.parse(stdout)).toEqual([TOOL_ENTRY]);
+    expect(stderr).toContain("is not a subagent type");
+  });
+
+  test("--json without --agent prints the tool array and nothing else", async () => {
+    ipcResponse = {
+      ok: true,
+      result: { names: [TOOL_ENTRY.name], schemas: {}, tools: [TOOL_ENTRY] },
+    };
+
+    const { stdout, stderr } = await runListStreams(["--json"]);
+
+    expect(JSON.parse(stdout)).toEqual([TOOL_ENTRY]);
+    expect(stderr).toBe("");
   });
 });

--- a/assistant/src/cli/commands/tools.help.ts
+++ b/assistant/src/cli/commands/tools.help.ts
@@ -40,7 +40,8 @@ Examples:
       options: [
         {
           flags: "--json",
-          description: "Emit machine-readable JSON instead of a table",
+          description:
+            "Emit the tool array as machine-readable JSON instead of a table; a note about how --agent resolved goes to stderr so stdout stays pipeable",
         },
         {
           flags: "--conversation <id>",

--- a/assistant/src/cli/commands/tools.ts
+++ b/assistant/src/cli/commands/tools.ts
@@ -40,13 +40,15 @@ interface ToolsGetResponse {
 }
 
 /**
- * What to print above the table when `--agent` landed on a different subagent
- * type than the value asked for, or `undefined` when it named a type outright
- * (or resolved a live subagent id, which carries no resolution block).
+ * What to report when `--agent` landed on a different subagent type than the
+ * value asked for, or `undefined` when it named a type outright (or resolved a
+ * live subagent id, which carries no resolution block).
  *
  * A listing that came from an older name or from a persona fallback looks
  * exactly like one asked for by name, so without this line a typo reads as a
- * researcher's tool surface with nothing saying the value was not a type.
+ * researcher's tool surface with nothing saying the value was not a type. It
+ * goes to stderr so it reaches a person without entering the `--json` stream,
+ * whose stdout contract is the tool array on its own.
  */
 function agentResolutionLine(agent?: ResolvedAgentInfo): string | undefined {
   if (agent?.alias) {
@@ -89,13 +91,16 @@ export function registerToolsCommand(program: Command): void {
             }
 
             const tools = response.result?.tools ?? [];
+            const resolutionLine = agentResolutionLine(response.result?.agent);
 
             if (opts.json) {
-              console.log(JSON.stringify(response.result ?? {}, null, 2));
+              if (resolutionLine) {
+                console.error(resolutionLine);
+              }
+              console.log(JSON.stringify(tools, null, 2));
               return;
             }
 
-            const resolutionLine = agentResolutionLine(response.result?.agent);
             if (resolutionLine) {
               console.log(`${resolutionLine}\n`);
             }


### PR DESCRIPTION
## Summary
- `tools list --json` stdout goes back to the bare tool array it emitted on main. Serializing the whole response object broke the documented shape for every JSON invocation, including calls without `--agent`.
- The agent-resolution note now goes to stderr, so an interactive run still reports that a legacy name or persona was resolved while a piped stdout stays parseable as an array.
- Help text for `--json` states the contract.

Addresses the P1 on #39990.