### PR TITLE
fix(web): scale the subagent pill with root font size, cover every status, fix story teardown

### DIFF
--- a/clients/web/src/components/avatar/subagent-avatar-badge.stories.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.stories.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
 
 import { SubagentAvatarBadge } from "@/components/avatar/subagent-avatar-badge";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -16,34 +17,10 @@ import {
 } from "@vellumai/assistant-api";
 import { Typography } from "@vellumai/design-library";
 
-/** Fixed so seeded entries never vary between renders. */
 const SPAWNED_AT = 1_717_000_000_000;
 
 function storyId(status: SubagentStatus): string {
   return `story-subagent-${status}`;
-}
-
-/**
- * Reset the store, then seed one entry per status. Resetting first is what
- * keeps entries from accumulating as stories re-render or swap.
- *
- * The seeded entries carry no `parentConversationId`, and `useActiveSubagentIds`
- * deliberately treats those as visible in every conversation, so they have to be
- * torn down after each story or the three active ones leak into unrelated
- * stories and make them render activity affordances they do not expect.
- */
-function seedEveryStatus() {
-  const store = useSubagentStore.getState();
-  store.reset();
-  for (const status of SubagentStatusSchema.options) {
-    store.spawnSubagent({
-      subagentId: storyId(status),
-      label: "Research Agent",
-      objective: "Find the answer",
-      timestamp: SPAWNED_AT,
-    });
-    store.changeStatus({ subagentId: storyId(status), status });
-  }
 }
 
 /** One badge plus its status name, so the stories read without a legend. */
@@ -61,17 +38,58 @@ function BadgeSample({ status }: { status: SubagentStatus }) {
   );
 }
 
+/**
+ * Seeds one entry per status on mount and removes exactly those ids on
+ * unmount. Seeding belongs to the story's own lifecycle rather than a shared
+ * `beforeEach` because the project renders `autodocs`, which mounts every
+ * story in this file at once: a teardown that reset the whole store would
+ * blank the badges of whichever stories were still on screen.
+ *
+ * The removal is not optional. The seeded entries carry no
+ * `parentConversationId`, and `useActiveSubagentIds` deliberately treats those
+ * as visible in every conversation, so any that outlived this story would make
+ * unrelated stories render activity affordances they do not expect. An entry
+ * with no parent message and no tool-use id sits only in `byId` and
+ * `orderedIds`, so those two are the whole cleanup.
+ */
+function EveryStatusRow() {
+  useEffect(() => {
+    const { spawnSubagent } = useSubagentStore.getState();
+    for (const status of SubagentStatusSchema.options) {
+      spawnSubagent({
+        subagentId: storyId(status),
+        label: "Research Agent",
+        objective: "Find the answer",
+        timestamp: SPAWNED_AT,
+        status,
+      });
+    }
+
+    return () => {
+      const seeded = new Set(SubagentStatusSchema.options.map(storyId));
+      useSubagentStore.setState((state) => ({
+        byId: Object.fromEntries(
+          Object.entries(state.byId).filter(([id]) => !seeded.has(id)),
+        ),
+        orderedIds: state.orderedIds.filter((id) => !seeded.has(id)),
+      }));
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-wrap items-start gap-1">
+      {SubagentStatusSchema.options.map((status) => (
+        <BadgeSample key={status} status={status} />
+      ))}
+    </div>
+  );
+}
+
 const meta: Meta<typeof SubagentAvatarBadge> = {
   title: "Components/SubagentAvatarBadge",
   component: SubagentAvatarBadge,
   parameters: {
     layout: "padded",
-  },
-  beforeEach: () => {
-    seedEveryStatus();
-    return () => {
-      useSubagentStore.getState().reset();
-    };
   },
 };
 
@@ -85,29 +103,7 @@ type Story = StoryObj<typeof SubagentAvatarBadge>;
  * collapsed avatar row ships with (`subagent-avatar-row.tsx`).
  */
 export const AllStatuses: Story = {
-  render: () => (
-    <div className="flex flex-wrap items-start gap-1">
-      {SubagentStatusSchema.options.map((status) => (
-        <BadgeSample key={status} status={status} />
-      ))}
-    </div>
-  ),
-};
-
-/**
- * The three pill fills next to each other: the neutral `--surface-lift` while
- * in flight, `--system-positive-weak` on success, `--system-negative-weak` on
- * failure. Spaced apart so the a11y addon has each tint paired with its glyph
- * colour, which the tightly packed `AllStatuses` row makes hard to compare.
- */
-export const TerminalTints: Story = {
-  render: () => (
-    <div className="flex flex-wrap items-start gap-6">
-      {(["running", "completed", "failed"] as const).map((status) => (
-        <BadgeSample key={status} status={status} />
-      ))}
-    </div>
-  ),
+  render: () => <EveryStatusRow />,
 };
 
 /**

--- a/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.test.tsx
@@ -1,12 +1,13 @@
 /**
  * Tests for `SubagentAvatarBadge`.
  *
- * Drives the Zustand subagent store (spawn + changeStatus) and asserts the
+ * Seeds the Zustand subagent store with one entry per case and asserts the
  * glyph in the pill's fixed slot reflects the subagent's real status: running
  * dots while in-flight, a check on `completed`, and a red X on `aborted`
  * (canceled) / `failed`. Confirms the deterministic avatar chip renders, that
- * state is exposed via `data-status` (not colour alone), and that the slot
- * keeps the pill a constant width across every state.
+ * state is exposed via `data-status` (not colour alone), that every status
+ * lands in its expected tint bucket, and that the fixed slot renders in every
+ * state so the avatar's horizontal position never moves.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -17,6 +18,25 @@ import { useSubagentStore } from "@/domains/chat/subagent-store";
 import type { SubagentStatus } from "@vellumai/assistant-api";
 
 const NOW = 1700000000000;
+
+/**
+ * Every status paired with the pill fill it must produce. Typed as a total
+ * `Record<SubagentStatus, ...>` so adding a status to the wire schema fails to
+ * compile until its tint bucket is declared here.
+ */
+const EXPECTED_PILL_BACKGROUND: Record<SubagentStatus, string> = {
+  completed: "bg-[var(--system-positive-weak)]",
+  failed: "bg-[var(--system-negative-weak)]",
+  aborted: "bg-[var(--system-negative-weak)]",
+  interrupted: "bg-[var(--system-negative-weak)]",
+  running: "bg-[var(--surface-lift)]",
+  pending: "bg-[var(--surface-lift)]",
+  awaiting_input: "bg-[var(--surface-lift)]",
+};
+
+const TINT_CASES = Object.entries(EXPECTED_PILL_BACKGROUND) as Array<
+  [SubagentStatus, string]
+>;
 
 beforeEach(() => {
   useSubagentStore.getState().reset();
@@ -32,8 +52,8 @@ function spawn(id: string, status: SubagentStatus) {
     label: "Research Agent",
     objective: "Find the answer",
     timestamp: NOW,
+    status,
   });
-  useSubagentStore.getState().changeStatus({ subagentId: id, status });
 }
 
 /** Which glyph the indicator rendered, independent of its Tailwind classes. */
@@ -41,6 +61,11 @@ function renderedGlyph(indicator: Element): string | null {
   return (
     indicator.querySelector("[data-glyph]")?.getAttribute("data-glyph") ?? null
   );
+}
+
+/** The class list on the glyph icon, where its colour token is applied. */
+function glyphClasses(indicator: Element): string {
+  return indicator.querySelector("svg")?.getAttribute("class") ?? "";
 }
 
 describe("SubagentAvatarBadge", () => {
@@ -69,7 +94,7 @@ describe("SubagentAvatarBadge", () => {
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(3);
   });
 
-  test("completed → check glyph, no dots", () => {
+  test("completed → check glyph in the positive on-weak token, no dots", () => {
     spawn("sa-done", "completed");
     const { getByTestId } = render(
       <SubagentAvatarBadge subagentId="sa-done" />,
@@ -79,6 +104,10 @@ describe("SubagentAvatarBadge", () => {
     expect(indicator.getAttribute("aria-label")).toBe("completed");
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
     expect(renderedGlyph(indicator)).toBe("check");
+    // The on-weak pairing is what clears contrast against the weak pill fill.
+    expect(glyphClasses(indicator)).toContain(
+      "text-[var(--system-positive-on-weak)]",
+    );
   });
 
   test("aborted → red X with data-status=aborted", () => {
@@ -94,7 +123,7 @@ describe("SubagentAvatarBadge", () => {
     expect(renderedGlyph(indicator)).toBe("cross");
   });
 
-  test("failed → red X with data-status=failed", () => {
+  test("failed → X glyph in the negative on-weak token, data-status=failed", () => {
     spawn("sa-failed", "failed");
     const { getByTestId } = render(
       <SubagentAvatarBadge subagentId="sa-failed" />,
@@ -103,9 +132,23 @@ describe("SubagentAvatarBadge", () => {
     expect(indicator.getAttribute("data-status")).toBe("failed");
     expect(indicator.querySelectorAll(".busy-indicator").length).toBe(0);
     expect(renderedGlyph(indicator)).toBe("cross");
+    expect(glyphClasses(indicator)).toContain(
+      "text-[var(--system-negative-on-weak)]",
+    );
   });
 
-  test("in-flight swaps background to --surface-active on hover, terminal tints do not", () => {
+  for (const [status, expected] of TINT_CASES) {
+    test(`${status} tints the pill with ${expected}`, () => {
+      const id = `sa-tint-${status}`;
+      spawn(id, status);
+      const { getByTestId } = render(<SubagentAvatarBadge subagentId={id} />);
+      expect(getByTestId("subagent-avatar-badge").className).toContain(
+        expected,
+      );
+    });
+  }
+
+  test("the in-flight pill declares a hover fill and terminal tints declare none", () => {
     spawn("sa-hover", "running");
     spawn("sa-hover-done", "completed");
     const { container } = render(
@@ -118,25 +161,18 @@ describe("SubagentAvatarBadge", () => {
       container.querySelectorAll('[data-testid="subagent-avatar-badge"]'),
     );
 
-    // The whole in-flight hover state is a background swap.
+    // `SubagentAvatarRow` renders the badges inside a `pointer-events-none`
+    // wrapper, so the hover fill is inert there. This pins the class contract,
+    // not an observable hover: a badge mounted outside that wrapper is the
+    // case the fill exists for.
     expect(pill?.className).toContain("bg-[var(--surface-lift)]");
     expect(pill?.className).toContain("hover:bg-[var(--surface-active)]");
 
     expect(settledPill?.className).toContain(
       "bg-[var(--system-positive-weak)]",
     );
-    // A settled pill is not interactive, so it carries no hover variant.
+    // A settled pill can no longer change, so it carries no hover variant.
     expect(settledPill?.className).not.toContain("hover:");
-  });
-
-  test("errored tints the pill with the negative weak fill", () => {
-    spawn("sa-tint-failed", "failed");
-    const { getByTestId } = render(
-      <SubagentAvatarBadge subagentId="sa-tint-failed" />,
-    );
-    expect(getByTestId("subagent-avatar-badge").className).toContain(
-      "bg-[var(--system-negative-weak)]",
-    );
   });
 
   test("renders no status indicator before the entry lands in the store", () => {
@@ -148,7 +184,7 @@ describe("SubagentAvatarBadge", () => {
     expect(queryByTestId("subagent-avatar-badge")).not.toBeNull();
   });
 
-  test("the fixed glyph slot renders in every state so the pill never resizes", () => {
+  test("the fixed glyph slot renders in every state so the avatar never shifts", () => {
     const cases: Array<{ id: string; status?: SubagentStatus }> = [
       { id: "sa-slot-running", status: "running" },
       { id: "sa-slot-completed", status: "completed" },
@@ -162,16 +198,11 @@ describe("SubagentAvatarBadge", () => {
         spawn(id, status);
       }
       const { container } = render(<SubagentAvatarBadge subagentId={id} />);
-      const pill = container.querySelector(
-        '[data-testid="subagent-avatar-badge"]',
-      );
-      const slot = container.querySelector(
-        '[data-testid="subagent-avatar-badge-slot"]',
-      );
-      // happy-dom cannot measure layout, so the fixed widths are the only
-      // available proof that the pill stays 46px wide in every state.
-      expect(pill?.className).toContain("w-[46px]");
-      expect(slot?.className).toContain("w-3.5");
+      // The slot is what holds the avatar's horizontal position constant:
+      // drop it in any one state and the narrower glyph pulls the avatar left.
+      expect(
+        container.querySelector('[data-testid="subagent-avatar-badge-slot"]'),
+      ).not.toBeNull();
     }
   });
 });

--- a/clients/web/src/components/avatar/subagent-avatar-badge.tsx
+++ b/clients/web/src/components/avatar/subagent-avatar-badge.tsx
@@ -74,13 +74,13 @@ export function SubagentAvatarBadge({
   return (
     <div
       data-testid="subagent-avatar-badge"
-      className={`inline-flex h-8 w-[46px] shrink-0 items-center gap-1 rounded-full px-1.5 transition-colors ${pillBackgroundClass(badgeState)} ${className ?? ""}`.trim()}
+      className={`inline-flex h-8 w-[2.875rem] shrink-0 items-center gap-1 rounded-full px-1.5 transition-colors ${pillBackgroundClass(badgeState)} ${className ?? ""}`.trim()}
     >
       {/* The glyph slot is a fixed 14px and always renders, including before
           the store entry lands. The three glyphs are different widths (13px
-          dots, 10px check, 10px X), so a slot that sized to its content would
-          change the pill's width every time a subagent settles and shift the
-          whole avatar row sideways. */}
+          dots, 10px check, 10px X), and the pill packs its items at
+          flex-start, so a slot that sized to its content would slide the
+          avatar about 3px left the moment a subagent settles. */}
       <span
         data-testid="subagent-avatar-badge-slot"
         className="flex w-3.5 shrink-0 items-center justify-center"
@@ -123,7 +123,11 @@ export function SubagentAvatarBadge({
         )}
       </span>
 
-      <SubagentAvatarChip subagentId={subagentId} size={16} />
+      <SubagentAvatarChip
+        subagentId={subagentId}
+        size={16}
+        className="shrink-0"
+      />
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.test.tsx
@@ -97,7 +97,7 @@ describe("SubagentAvatarRow", () => {
       <SubagentAvatarRow subagentIds={ids} onExpand={() => {}} />,
     );
 
-    // At the cap the row is wider than a 375px viewport leaves, and the
+    // At the cap the row is wider than any phone in portrait leaves, and the
     // transcript wrapper is `contain-content`, so without wrapping the
     // Details affordance is clipped instead of overflowing visibly.
     const row = getByTestId("subagent-avatar-row-details");

--- a/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
+++ b/clients/web/src/domains/chat/components/subagent-inline-progress-card/subagent-avatar-row.tsx
@@ -24,11 +24,14 @@ export function SubagentAvatarRow({
 }: SubagentAvatarRowProps) {
   const overflowCount = subagentIds.length - MAX_VISIBLE_SUBAGENT_AVATARS;
 
-  // The row wraps because it can outgrow a phone-width transcript column. At
-  // the six-avatar cap the badges, the overflow chip, and the Details label
-  // need more than the 343px a 375px viewport leaves after the transcript's
-  // px-4, and the transcript wrapper is `contain-content`, so an unwrapped row
-  // loses the Details affordance to clipping rather than overflowing visibly.
+  // The row wraps because it can outgrow the transcript column. At the
+  // six-avatar cap the badges, the overflow chip, and the Details label need
+  // about 401px, more than every phone in portrait leaves after the
+  // transcript's px-4 (a 430px viewport leaves ~398px), and more than a narrow
+  // transcript leaves on desktop once the detail panel is dragged out to
+  // `minLeftWidth` (`chat-content-layout.tsx`). The transcript wrapper is
+  // `contain-content`, so an unwrapped row loses the Details affordance to
+  // clipping rather than overflowing visibly.
   return (
     <button
       type="button"
@@ -43,10 +46,11 @@ export function SubagentAvatarRow({
           <SubagentAvatarBadge key={id} subagentId={id} />
         ))}
 
+        {/* Carries the badges' own footprint so the row reads as one family. */}
         {overflowCount > 0 && (
           <div
             data-testid="subagent-avatar-row-overflow"
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--surface-active)]"
+            className="flex h-8 w-[2.875rem] items-center justify-center rounded-full bg-[var(--surface-active)]"
           >
             <Typography
               variant="body-small-default"


### PR DESCRIPTION
## Summary
- The pill width becomes rem-based, so it no longer overflows by up to 15px at larger browser font sizes.
- Restores assertions that the glyphs actually carry the `-on-weak` tokens, which nothing verified.
- Rewrites the fixed-slot comment and test to the real invariant, the avatar's horizontal position, since the pill width is pinned and cannot change.
- Covers all seven statuses' tint buckets, including `interrupted`.
- Seeds the store per story so an autodocs page cannot blank co-mounted stories.
- Gives the overflow chip the pill footprint.

Addresses self-review findings for plan subagent-badge-option-d.md