### PR TITLE
fix(design-library): stop Button asChild + icon path dropping every button prop

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -29,6 +29,7 @@ import {
   appsGetQueryKey,
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-link-pill";
 import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
 import { ConversationActivityPill } from "@/domains/chat/components/conversation-activity-pill";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
@@ -209,9 +210,13 @@ function NotificationsStandIn() {
 function Harness({
   activity,
   isMobile,
+  channelBound = false,
 }: {
   activity: "none" | "mixed" | "completed" | "many";
   isMobile: boolean;
+  /** Renders the "Open in Slack" source-link pill leading the cluster, the
+   *  way `useChatHeaderRegistration` composes it for channel-bound chats. */
+  channelBound?: boolean;
 }) {
   const queryClient = useQueryClient();
   const [seeded] = useState(() => {
@@ -267,6 +272,12 @@ function Harness({
       }
       topBarRightSlot={
         <>
+          {channelBound ? (
+            <ChannelSourceLinkPill
+              href="https://example.slack.com/archives/C0123456789/p1720000000000000"
+              channelId="slack"
+            />
+          ) : null}
           <ConversationAssetsPill
             assistantId={ASSISTANT_ID}
             conversationId={CONVERSATION_ID}
@@ -397,6 +408,16 @@ export const DesktopCompletedClosed: Story = {
  */
 export const DesktopManyClosed: Story = {
   args: { activity: "many", isMobile: false },
+};
+
+/**
+ * The fullest right cluster a conversation can produce: a channel-bound chat
+ * ("Open in Slack" source-link pill) with assets, heavy agent activity, and
+ * Notifications, against the long title. Protects the squeeze behavior: the
+ * cluster is `shrink-0`, so only the centre title may give.
+ */
+export const DesktopChannelBoundManyClosed: Story = {
+  args: { activity: "many", isMobile: false, channelBound: true },
 };
 
 /**

--- a/clients/web/src/domains/chat/components/channel-source-link-pill.stories.tsx
+++ b/clients/web/src/domains/chat/components/channel-source-link-pill.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChannelSourceLinkPill } from "./channel-source-link-pill";
+
+/**
+ * Top-bar pill linking a channel-bound conversation back to its source
+ * thread. The decorator frames it on the header's `--surface-base`
+ * backdrop: the pill's active-ghost chrome is `--surface-lift`, so on the
+ * default story canvas (white) it would read as an unstyled label.
+ *
+ * Regression context: the Button `asChild` + `leftIcon` path used to drop
+ * every button class (LUM-1680 follow-up), which rendered this pill as a
+ * bare icon next to plain anchor text. If this story shows anything other
+ * than a rounded white pill, that seam has regressed.
+ */
+const meta = {
+  title: "chat/ChannelSourceLinkPill",
+  component: ChannelSourceLinkPill,
+  decorators: [
+    (Story) => (
+      <div
+        className="flex items-center gap-2 rounded-md p-6"
+        style={{ background: "var(--surface-base)" }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    channelId: {
+      control: "inline-radio",
+      options: ["slack", "telegram", "email", null],
+    },
+  },
+} satisfies Meta<typeof ChannelSourceLinkPill>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Slack origin: brand glyph + "Open in Slack". */
+export const Default: Story = {
+  args: {
+    href: "https://example.slack.com/archives/C0123456789/p1720000000000000",
+    channelId: "slack",
+  },
+};
+
+/** Non-Slack channels fall back to the generic external-link glyph. */
+export const NonSlackChannel: Story = {
+  args: {
+    href: "https://t.me/c/1234567890/42",
+    channelId: "telegram",
+  },
+};

--- a/clients/web/src/domains/chat/components/channel-source-link-pill.stories.tsx
+++ b/clients/web/src/domains/chat/components/channel-source-link-pill.stories.tsx
@@ -8,10 +8,10 @@ import { ChannelSourceLinkPill } from "./channel-source-link-pill";
  * backdrop: the pill's active-ghost chrome is `--surface-lift`, so on the
  * default story canvas (white) it would read as an unstyled label.
  *
- * Regression context: the Button `asChild` + `leftIcon` path used to drop
- * every button class (LUM-1680 follow-up), which rendered this pill as a
- * bare icon next to plain anchor text. If this story shows anything other
- * than a rounded white pill, that seam has regressed.
+ * The pill's chrome comes entirely from Button's `asChild` + `leftIcon`
+ * path, so the story doubles as a visual check on that seam (LUM-1680):
+ * anything other than a rounded white pill means the button props are not
+ * reaching the anchor.
  */
 const meta = {
   title: "chat/ChannelSourceLinkPill",

--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -43,14 +43,13 @@ describe("Button rendering", () => {
   });
 
   test("asChild + leftIcon styles the slotted anchor and nests the icon inside it", () => {
-    // Regression (LUM-1680 follow-up): the icon branch used to wrap the icon
-    // and `<Slottable>` in a Fragment. Radix Slot only finds a Slottable among
-    // its DIRECT children (`Children.toArray` does not descend into
-    // Fragments), so Slot cloned the Fragment instead: every button prop
-    // (className, style, type) was silently dropped and the markup came out
-    // as a bare icon <span> next to a completely unstyled <a>. Presence
-    // checks alone pass against that broken output, so these assertions pin
-    // the invariant: the anchor is the root, it carries the button classes,
+    // Radix Slot locates its Slottable via `Children.toArray(...).find`,
+    // which does not descend into Fragments: a Fragment wrapped around the
+    // icon and `<Slottable>` makes Slot clone the Fragment instead, silently
+    // dropping every button prop (className, style, type) and emitting a
+    // bare icon <span> next to an unstyled <a>. Presence checks alone pass
+    // against that broken output, so these assertions pin the invariant
+    // (LUM-1680): the anchor is the root, it carries the button classes,
     // and the icon lives inside it.
     const html = renderToStaticMarkup(
       <Button asChild leftIcon={<svg data-testid="left-icon" aria-hidden />}>

--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -42,35 +42,75 @@ describe("Button rendering", () => {
     expect(html).not.toContain("<button");
   });
 
-  test("asChild + leftIcon clones the slotted element with the icon as a sibling of its children", () => {
-    // Regression: previously the icon branch rendered children as a Fragment,
-    // which made Radix Slot try to forward `type` onto React.Fragment and
-    // hard-error on React 19. The fix wraps `children` in `<Slottable>` so
-    // Slot clones the caller's element and re-parents the icon as a sibling
-    // of the element's original children.
+  test("asChild + leftIcon styles the slotted anchor and nests the icon inside it", () => {
+    // Regression (LUM-1680 follow-up): the icon branch used to wrap the icon
+    // and `<Slottable>` in a Fragment. Radix Slot only finds a Slottable among
+    // its DIRECT children (`Children.toArray` does not descend into
+    // Fragments), so Slot cloned the Fragment instead: every button prop
+    // (className, style, type) was silently dropped and the markup came out
+    // as a bare icon <span> next to a completely unstyled <a>. Presence
+    // checks alone pass against that broken output, so these assertions pin
+    // the invariant: the anchor is the root, it carries the button classes,
+    // and the icon lives inside it.
     const html = renderToStaticMarkup(
       <Button asChild leftIcon={<svg data-testid="left-icon" aria-hidden />}>
         <a href="/back">Back</a>
       </Button>,
     );
-    expect(html).toContain("<a");
+    expect(html.startsWith("<a")).toBe(true);
     expect(html).toContain('href="/back"');
     expect(html).not.toContain("<button");
-    expect(html).toContain('data-testid="left-icon"');
-    expect(html).toContain("Back");
+    // The anchor root carries the button chrome and typography classes.
+    expect(html).toMatch(/^<a[^>]*class="[^"]*inline-flex[^"]*"/);
+    expect(html).toMatch(/^<a[^>]*class="[^"]*text-body-medium-default[^"]*"/);
+    // The icon is re-parented inside the anchor, before its original children.
+    expect(html.indexOf('data-testid="left-icon"')).toBeGreaterThan(
+      html.indexOf("<a"),
+    );
+    expect(html.indexOf('data-testid="left-icon"')).toBeLessThan(
+      html.indexOf("</a>"),
+    );
+    expect(html.indexOf('data-testid="left-icon"')).toBeLessThan(
+      html.indexOf("Back"),
+    );
   });
 
-  test("asChild + rightIcon also clones and re-parents the icon", () => {
+  test("asChild + rightIcon also styles the anchor and nests the icon inside it", () => {
     const html = renderToStaticMarkup(
       <Button asChild rightIcon={<svg data-testid="right-icon" aria-hidden />}>
         <a href="/next">Next</a>
       </Button>,
     );
-    expect(html).toContain("<a");
+    expect(html.startsWith("<a")).toBe(true);
     expect(html).toContain('href="/next"');
     expect(html).not.toContain("<button");
-    expect(html).toContain('data-testid="right-icon"');
-    expect(html).toContain("Next");
+    expect(html).toMatch(/^<a[^>]*class="[^"]*inline-flex[^"]*"/);
+    // The icon is re-parented inside the anchor, after its original children.
+    expect(html.indexOf('data-testid="right-icon"')).toBeLessThan(
+      html.indexOf("</a>"),
+    );
+    expect(html.indexOf('data-testid="right-icon"')).toBeGreaterThan(
+      html.indexOf("Next"),
+    );
+  });
+
+  test("asChild + leftIcon + className merges the caller's class onto the anchor", () => {
+    // ChannelSourceLinkPill's exact shape: ghost + active + rounded-full on
+    // an external link. The caller's className must land on the anchor
+    // alongside the variant classes, not be dropped with the rest.
+    const html = renderToStaticMarkup(
+      <Button
+        asChild
+        variant="ghost"
+        active
+        leftIcon={<svg aria-hidden />}
+        className="rounded-full"
+      >
+        <a href="/slack">Open in Slack</a>
+      </Button>,
+    );
+    expect(html).toMatch(/^<a[^>]*class="[^"]*rounded-full[^"]*"/);
+    expect(html).toMatch(/^<a[^>]*class="[^"]*bg-\[var\(--surface-lift\)\]/);
   });
 
   test("iconOnly ignores children and leftIcon/rightIcon", () => {

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -379,27 +379,29 @@ export function Button({
       ) : leftIcon == null && rightIcon == null ? (
         children
       ) : (
-        // When `asChild` is set, `Comp` is Radix's `Slot`, which forwards its
-        // props (e.g. `type`, `disabled`) onto its single React-element child.
-        // A bare Fragment can't accept those props — React 19 hard-errors with
-        // "Invalid prop `type` supplied to React.Fragment". `Slottable` marks
-        // `children` as the prop target so Slot clones the caller's element
-        // and re-parents the icons as its children. In the non-asChild path
-        // (`Comp === "button"`) Slottable is a transparent Fragment, so this
-        // is safe for both branches.
-        <>
-          {leftIcon != null ? (
-            <span aria-hidden="true" style={iconStyle}>
+        // When `asChild` is set, `Comp` is Radix's `Slot`, which looks for a
+        // `Slottable` among its DIRECT children (`Children.toArray(...).find`)
+        // to know which element receives the button props, then re-parents
+        // the sibling icons into that element. `Children.toArray` does not
+        // descend into Fragments, so these must be a keyed array: a `<>...</>`
+        // wrapper hides the Slottable and Slot falls back to cloning the
+        // Fragment itself, silently dropping className/style/type on it and
+        // leaving the caller's element unstyled. In the non-asChild path
+        // (`Comp === "button"`) Slottable renders as a transparent Fragment,
+        // so the array is safe for both branches.
+        [
+          leftIcon != null ? (
+            <span key="left-icon" aria-hidden="true" style={iconStyle}>
               {leftIcon}
             </span>
-          ) : null}
-          <Slottable>{children}</Slottable>
-          {rightIcon != null ? (
-            <span aria-hidden="true" style={iconStyle}>
+          ) : null,
+          <Slottable key="children">{children}</Slottable>,
+          rightIcon != null ? (
+            <span key="right-icon" aria-hidden="true" style={iconStyle}>
               {rightIcon}
             </span>
-          ) : null}
-        </>
+          ) : null,
+        ]
       )}
     </Comp>
   );

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -266,6 +266,13 @@ export interface ButtonProps
   tooltip?: string;
   /** Side the tooltip is placed on. Defaults to Radix's "top". */
   tooltipSide?: "top" | "right" | "bottom" | "left";
+  /**
+   * Render as the child element (e.g. a `Link`) while keeping button
+   * styling and accessibility semantics. When combined with `leftIcon` /
+   * `rightIcon`, `children` must be a single React element: Radix's Slot
+   * re-parents the icons into it and throws (`Children.only`) on
+   * multi-node children.
+   */
   asChild?: boolean;
   children?: ReactNode;
 }


### PR DESCRIPTION
## TL;DR

The design-library `Button`'s `asChild` + `leftIcon`/`rightIcon` path silently dropped **every** button prop (className, style, type, data-slot), rendering a bare icon `<span>` next to a completely unstyled anchor. Most visibly: the "Open in Slack" header pill rendered as loose plain text. One-line-of-JSX seam fix in `button.tsx`; no call-site changes.

## Root cause

The icon branch wrapped the icon spans and the `<Slottable>`-wrapped children in a Fragment. Radix `Slot` locates the `Slottable` via `Children.toArray(children).find(isSlottable)`, and `Children.toArray` does not descend into Fragments — so `Slot` never found it, fell back to cloning the Fragment itself, and dumped all button props onto `React.Fragment`, which ignores them (React logs `Invalid prop 'type' supplied to React.Fragment`).

The LUM-1680 fix added the `Slottable` for exactly this bug but left the Fragment wrapper in place, so it never took effect. Its regression tests asserted only presence (`<a` exists, icon svg exists) — both true in the broken output — so CI stayed green.

## The fix

Emit the icon spans and `<Slottable>` as a keyed array, i.e. direct children of the `Slot`. Radix then finds the `Slottable`, merges the button props onto the caller's element, and re-parents the icons inside it. The non-`asChild` path emits identical DOM to before (array children vs Fragment children of a `<button>`).

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| "Open in Slack" header pill | Loose Slack icon + plain 16px text, no pill, icon not part of the link | Rounded white pill, 14px/500 label, icon inside the link — matches the neighboring assets pill |
| Inspector "Back" link | Unstyled icon + text | Compact ghost button |
| Plugin detail "Download" | Bare underline-less text link | Primary button |
| Invoices "View" links | Unstyled icon + text | Compact ghost buttons |

## Why it's safe

- The only markup that changes is the `asChild` + icon path, which was unambiguously broken (props landing on a Fragment are never applied). All four call sites in the repo were audited and simply start rendering as their props always described.
- Regression tests now assert the invariant — the slotted anchor carries the variant classes and the caller's `className`, and icons are nested inside the anchor — and were sensitivity-checked: all three fail against the pre-fix code.
- Verified in Storybook: new `ChannelSourceLinkPill` story renders the pill correctly on the header's `--surface-base` backdrop with a clean console; per-file `bun test` runs for `button.test.tsx`, `channel-source-link-pill.test.tsx`, and all four call-site test files pass; design-library and clients/web typechecks pass.

Related to LUM-1680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->