### PR TITLE
perf(daemon): move blocking child_process calls off the event loop

### DIFF
--- a/assistant/src/__tests__/agent-image-optimize.test.ts
+++ b/assistant/src/__tests__/agent-image-optimize.test.ts
@@ -126,7 +126,7 @@ describe("upscaleImageToMinimum", () => {
 });
 
 describe("optimizeImageForTransport", () => {
-  it("passes an undersized image through unchanged — the minimum floor is rejection-path only", async () => {
+  it("passes an undersized image through unchanged: the minimum floor is rejection-path only", async () => {
     // The floor is undocumented provider behavior, so pre-send transport
     // never enforces it; only the image-recovery plugin reacts to an actual
     // "Could not process image" rejection.

--- a/assistant/src/__tests__/agent-image-optimize.test.ts
+++ b/assistant/src/__tests__/agent-image-optimize.test.ts
@@ -115,9 +115,9 @@ describe("upscaleTargetDimensions", () => {
 });
 
 describe("upscaleImageToMinimum", () => {
-  it("returns null when dimensions are unparseable", () => {
+  it("returns null when dimensions are unparseable", async () => {
     expect(
-      upscaleImageToMinimum(
+      await upscaleImageToMinimum(
         Buffer.from("not an image").toString("base64"),
         "image/png",
       ),
@@ -126,12 +126,12 @@ describe("upscaleImageToMinimum", () => {
 });
 
 describe("optimizeImageForTransport", () => {
-  it("passes an undersized image through unchanged — the minimum floor is rejection-path only", () => {
+  it("passes an undersized image through unchanged — the minimum floor is rejection-path only", async () => {
     // The floor is undocumented provider behavior, so pre-send transport
     // never enforces it; only the image-recovery plugin reacts to an actual
     // "Could not process image" rejection.
     const tiny = makePngBase64(16, 14);
-    expect(optimizeImageForTransport(tiny, "image/png")).toEqual({
+    expect(await optimizeImageForTransport(tiny, "image/png")).toEqual({
       data: tiny,
       mediaType: "image/png",
     });

--- a/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
+++ b/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
@@ -100,8 +100,8 @@ describe("HEIC upload normalization wiring", () => {
     await initializeDb();
   }, 30_000);
 
-  test("uploadAttachmentFromBytes stores a JPEG master for HEIC", () => {
-    const stored = uploadAttachmentFromBytes(
+  test("uploadAttachmentFromBytes stores a JPEG master for HEIC", async () => {
+    const stored = await uploadAttachmentFromBytes(
       "IMG_5487.HEIC",
       "image/heic",
       HEIC_BYTES,
@@ -115,8 +115,8 @@ describe("HEIC upload normalization wiring", () => {
     expect(readFileSync(stagedPath!).equals(FAKE_JPEG)).toBe(true);
   });
 
-  test("uploadAttachmentFromBytes leaves non-HEIC uploads verbatim", () => {
-    const stored = uploadAttachmentFromBytes(
+  test("uploadAttachmentFromBytes leaves non-HEIC uploads verbatim", async () => {
+    const stored = await uploadAttachmentFromBytes(
       "photo.png",
       "image/png",
       HEIC_BYTES,
@@ -127,8 +127,8 @@ describe("HEIC upload normalization wiring", () => {
     expect(stored.sizeBytes).toBe(HEIC_BYTES.length);
   });
 
-  test("uploadAttachment (base64) stores a JPEG master for HEIC", () => {
-    const stored = uploadAttachment("IMG_1.heic", "image/heic", HEIC_B64);
+  test("uploadAttachment (base64) stores a JPEG master for HEIC", async () => {
+    const stored = await uploadAttachment("IMG_1.heic", "image/heic", HEIC_B64);
 
     expect(stored.originalFilename).toBe("IMG_1.jpg");
     expect(stored.mimeType).toBe("image/jpeg");
@@ -137,16 +137,20 @@ describe("HEIC upload normalization wiring", () => {
     expect(row?.dataBase64).toBe(FAKE_JPEG_B64);
   });
 
-  test("uploadAttachment (base64) leaves non-HEIC uploads verbatim", () => {
-    const stored = uploadAttachment("photo.png", "image/png", HEIC_B64);
+  test("uploadAttachment (base64) leaves non-HEIC uploads verbatim", async () => {
+    const stored = await uploadAttachment("photo.png", "image/png", HEIC_B64);
 
     expect(stored.originalFilename).toBe("photo.png");
     expect(stored.mimeType).toBe("image/png");
     expect(stored.sizeBytes).toBe(HEIC_BYTES.length);
   });
 
-  test("uploadAttachment (base64) propagates a MIME-only sniff correction", () => {
-    const stored = uploadAttachment("photo.png", "image/mislabeled", HEIC_B64);
+  test("uploadAttachment (base64) propagates a MIME-only sniff correction", async () => {
+    const stored = await uploadAttachment(
+      "photo.png",
+      "image/mislabeled",
+      HEIC_B64,
+    );
 
     // Corrected MIME is stored; filename and payload stay verbatim.
     expect(stored.originalFilename).toBe("photo.png");
@@ -163,7 +167,7 @@ describe("HEIC upload normalization wiring", () => {
       JSON.stringify([{ type: "text", text: "photos" }]),
     );
 
-    const normalized = attachInlineAttachmentToMessage(
+    const normalized = await attachInlineAttachmentToMessage(
       msg.id,
       0,
       "IMG_2.HEIC",
@@ -176,7 +180,7 @@ describe("HEIC upload normalization wiring", () => {
 
     // Assistant-outbound attachments are stored verbatim: no normalizeImage
     // flag, no rewrite, even for HEIC content.
-    const verbatim = attachInlineAttachmentToMessage(
+    const verbatim = await attachInlineAttachmentToMessage(
       msg.id,
       1,
       "IMG_3.HEIC",

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -168,39 +168,41 @@ describe("uploadAttachment", () => {
     expect(second.id).not.toBe(first.id);
   });
 
-  test("rejects payloads exceeding MAX_UPLOAD_BYTES", () => {
+  test("rejects payloads exceeding MAX_UPLOAD_BYTES", async () => {
     // Build a base64 string that decodes to just over the limit.
     // 4 base64 chars -> 3 bytes, so we need ceil((MAX_UPLOAD_BYTES+1)/3)*4 chars.
     const oversizedLength = Math.ceil((MAX_UPLOAD_BYTES + 1) / 3) * 4;
     const oversizedData = "A".repeat(oversizedLength);
 
-    expect(() =>
+    await expect(
       uploadAttachment("huge.bin", "application/octet-stream", oversizedData),
-    ).toThrow(AttachmentUploadError);
+    ).rejects.toThrow(AttachmentUploadError);
   });
 
-  test("rejects invalid base64 data", () => {
-    expect(() =>
+  test("rejects invalid base64 data", async () => {
+    await expect(
       uploadAttachment("bad.txt", "text/plain", "!!!not-base64!!!"),
-    ).toThrow(AttachmentUploadError);
+    ).rejects.toThrow(AttachmentUploadError);
   });
 
-  test("accepts base64 with non-standard padding/length", () => {
+  test("accepts base64 with non-standard padding/length", async () => {
     // Lenient on length -- only character set is validated
-    expect(() => uploadAttachment("ok.txt", "text/plain", "AAA")).not.toThrow();
+    await expect(
+      uploadAttachment("ok.txt", "text/plain", "AAA"),
+    ).resolves.toBeDefined();
   });
 
   // Inserting the 100 MB payload into SQLite can take several seconds on
   // slow CI runners, so this test needs more than the default 5s timeout.
-  test("accepts payload exactly at MAX_UPLOAD_BYTES", () => {
+  test("accepts payload exactly at MAX_UPLOAD_BYTES", async () => {
     // MAX_UPLOAD_BYTES (100 MB) is divisible by 3, so (MAX/3)*4 base64 chars
     // decodes to exactly MAX bytes with no padding.
     const exactLength = (MAX_UPLOAD_BYTES / 3) * 4;
     const exactData = "A".repeat(exactLength);
 
-    expect(() =>
+    await expect(
       uploadAttachment("exact.bin", "application/octet-stream", exactData),
-    ).not.toThrow();
+    ).resolves.toBeDefined();
   }, 30_000);
 });
 

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -65,8 +65,8 @@ function getLegacyConversationDirPath(
 describe("uploadAttachment", () => {
   beforeEach(resetTables);
 
-  test("stores attachment and returns metadata", () => {
-    const stored = uploadAttachment("chart.png", "image/png", "iVBORw0K");
+  test("stores attachment and returns metadata", async () => {
+    const stored = await uploadAttachment("chart.png", "image/png", "iVBORw0K");
 
     expect(stored.id).toBeDefined();
     expect(stored.originalFilename).toBe("chart.png");
@@ -76,16 +76,20 @@ describe("uploadAttachment", () => {
     expect(stored.createdAt).toBeGreaterThan(0);
   });
 
-  test("keeps uploads staged until linked", () => {
-    const stored = uploadAttachment("small.txt", "text/plain", "aGVsbG8=");
+  test("keeps uploads staged until linked", async () => {
+    const stored = await uploadAttachment(
+      "small.txt",
+      "text/plain",
+      "aGVsbG8=",
+    );
     const filePath = getFilePathForAttachment(stored.id);
 
     expect(filePath).toBeNull();
     expect(getAttachmentContent(stored.id)?.toString()).toBe("hello");
   });
 
-  test("stores base64 in the DB row until linked", () => {
-    const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
+  test("stores base64 in the DB row until linked", async () => {
+    const stored = await uploadAttachment("test.txt", "text/plain", "dGVzdA==");
 
     // Staged uploads keep the payload inline until they are attached to a message.
     const rawRow = rawGet<{ data_base64: string }>(
@@ -100,35 +104,43 @@ describe("uploadAttachment", () => {
     expect(row!.dataBase64).toBe("dGVzdA==");
   });
 
-  test("classifies image MIME as image kind", () => {
-    const stored = uploadAttachment("pic.jpg", "image/jpeg", "AAAA");
+  test("classifies image MIME as image kind", async () => {
+    const stored = await uploadAttachment("pic.jpg", "image/jpeg", "AAAA");
     expect(stored.kind).toBe("image");
   });
 
-  test("classifies non-image MIME as document kind", () => {
-    const stored = uploadAttachment("doc.pdf", "application/pdf", "JVBER");
+  test("classifies non-image MIME as document kind", async () => {
+    const stored = await uploadAttachment(
+      "doc.pdf",
+      "application/pdf",
+      "JVBER",
+    );
     expect(stored.kind).toBe("document");
   });
 
-  test("generates unique IDs for each upload", () => {
-    const a = uploadAttachment("a.txt", "text/plain", "AA==");
-    const b = uploadAttachment("b.txt", "text/plain", "QQ==");
+  test("generates unique IDs for each upload", async () => {
+    const a = await uploadAttachment("a.txt", "text/plain", "AA==");
+    const b = await uploadAttachment("b.txt", "text/plain", "QQ==");
     expect(a.id).not.toBe(b.id);
   });
 
-  test("computes sizeBytes from base64 correctly", () => {
+  test("computes sizeBytes from base64 correctly", async () => {
     // "hello" = "aGVsbG8=" (8 chars, 1 pad -> 5 bytes)
-    const stored = uploadAttachment("hello.txt", "text/plain", "aGVsbG8=");
+    const stored = await uploadAttachment(
+      "hello.txt",
+      "text/plain",
+      "aGVsbG8=",
+    );
     expect(stored.sizeBytes).toBe(5);
   });
 
-  test("does not deduplicate identical uploads before linking", () => {
-    const first = uploadAttachment(
+  test("does not deduplicate identical uploads before linking", async () => {
+    const first = await uploadAttachment(
       "photo.png",
       "image/png",
       "iVBORw0KGgoAAAANSUh",
     );
-    const second = uploadAttachment(
+    const second = await uploadAttachment(
       "photo.png",
       "image/png",
       "iVBORw0KGgoAAAANSUh",
@@ -136,13 +148,13 @@ describe("uploadAttachment", () => {
     expect(second.id).not.toBe(first.id);
   });
 
-  test("does not deduplicate identical content when filenames differ", () => {
-    const first = uploadAttachment(
+  test("does not deduplicate identical content when filenames differ", async () => {
+    const first = await uploadAttachment(
       "original.png",
       "image/png",
       "DUPECONTENT123",
     );
-    const second = uploadAttachment(
+    const second = await uploadAttachment(
       "renamed.png",
       "image/png",
       "DUPECONTENT123",
@@ -150,9 +162,9 @@ describe("uploadAttachment", () => {
     expect(second.id).not.toBe(first.id);
   });
 
-  test("does not deduplicate different content", () => {
-    const first = uploadAttachment("a.txt", "text/plain", "CONTENTA");
-    const second = uploadAttachment("b.txt", "text/plain", "CONTENTB");
+  test("does not deduplicate different content", async () => {
+    const first = await uploadAttachment("a.txt", "text/plain", "CONTENTA");
+    const second = await uploadAttachment("b.txt", "text/plain", "CONTENTB");
     expect(second.id).not.toBe(first.id);
   });
 
@@ -199,8 +211,12 @@ describe("uploadAttachment", () => {
 describe("getAttachmentContent", () => {
   beforeEach(resetTables);
 
-  test("returns staged content before the attachment is linked", () => {
-    const stored = uploadAttachment("hello.txt", "text/plain", "aGVsbG8=");
+  test("returns staged content before the attachment is linked", async () => {
+    const stored = await uploadAttachment(
+      "hello.txt",
+      "text/plain",
+      "aGVsbG8=",
+    );
     const content = getAttachmentContent(stored.id);
 
     expect(content).not.toBeNull();
@@ -215,7 +231,7 @@ describe("getAttachmentContent", () => {
   test("returns null when a materialized on-disk file is missing (ENOENT)", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "File");
-    const stored = uploadAttachment("test.txt", "text/plain", "dGVzdA==");
+    const stored = await uploadAttachment("test.txt", "text/plain", "dGVzdA==");
     linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
 
@@ -259,8 +275,8 @@ describe("isValidBase64", () => {
 describe("deleteAttachment", () => {
   beforeEach(resetTables);
 
-  test("deletes existing attachment and returns deleted", () => {
-    const stored = uploadAttachment("file.txt", "text/plain", "dGVzdA==");
+  test("deletes existing attachment and returns deleted", async () => {
+    const stored = await uploadAttachment("file.txt", "text/plain", "dGVzdA==");
     const result = deleteAttachment(stored.id);
     expect(result).toBe("deleted");
 
@@ -271,7 +287,11 @@ describe("deleteAttachment", () => {
   test("cleans up on-disk file when deleting", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "cleanup");
-    const stored = uploadAttachment("cleanup.txt", "text/plain", "dGVzdA==");
+    const stored = await uploadAttachment(
+      "cleanup.txt",
+      "text/plain",
+      "dGVzdA==",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
     expect(existsSync(filePath!)).toBe(true);
@@ -296,7 +316,11 @@ describe("deleteAttachment", () => {
     const msg1 = await addMessage(conv.id, "user", "First upload");
     const msg2 = await addMessage(conv.id, "user", "Duplicate upload");
 
-    const first = uploadAttachment("photo.png", "image/png", "SHAREDCONTENT1");
+    const first = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      "SHAREDCONTENT1",
+    );
     linkAttachmentToMessage(msg1.id, first.id, 0);
     linkAttachmentToMessage(msg2.id, first.id, 0);
 
@@ -315,8 +339,12 @@ describe("deleteAttachment", () => {
     expect(linked2).toHaveLength(1);
   });
 
-  test("deletes attachment when no messages reference it", () => {
-    const stored = uploadAttachment("lonely.txt", "text/plain", "UNREFERENCED");
+  test("deletes attachment when no messages reference it", async () => {
+    const stored = await uploadAttachment(
+      "lonely.txt",
+      "text/plain",
+      "UNREFERENCED",
+    );
     // No linkAttachmentToMessage call -- zero references
     const result = deleteAttachment(stored.id);
     expect(result).toBe("deleted");
@@ -333,9 +361,9 @@ describe("deleteAttachment", () => {
 describe("getAttachmentsByIds", () => {
   beforeEach(resetTables);
 
-  test("returns matching attachments with hydrated dataBase64", () => {
-    const a = uploadAttachment("a.txt", "text/plain", "AAAA");
-    const b = uploadAttachment("b.txt", "text/plain", "BBBB");
+  test("returns matching attachments with hydrated dataBase64", async () => {
+    const a = await uploadAttachment("a.txt", "text/plain", "AAAA");
+    const b = await uploadAttachment("b.txt", "text/plain", "BBBB");
 
     const results = getAttachmentsByIds([a.id, b.id], {
       hydrateFileData: true,
@@ -350,8 +378,8 @@ describe("getAttachmentsByIds", () => {
     expect(results).toHaveLength(0);
   });
 
-  test("skips IDs that do not exist", () => {
-    const a = uploadAttachment("a.txt", "text/plain", "AAAA");
+  test("skips IDs that do not exist", async () => {
+    const a = await uploadAttachment("a.txt", "text/plain", "AAAA");
     const results = getAttachmentsByIds([a.id, "nonexistent"]);
     expect(results).toHaveLength(1);
   });
@@ -364,8 +392,12 @@ describe("getAttachmentsByIds", () => {
 describe("getAttachmentById", () => {
   beforeEach(resetTables);
 
-  test("returns attachment with hydrated dataBase64 when found", () => {
-    const stored = uploadAttachment("report.pdf", "application/pdf", "JVBER");
+  test("returns attachment with hydrated dataBase64 when found", async () => {
+    const stored = await uploadAttachment(
+      "report.pdf",
+      "application/pdf",
+      "JVBER",
+    );
     const result = getAttachmentById(stored.id, { hydrateFileData: true });
 
     expect(result).not.toBeNull();
@@ -392,7 +424,7 @@ describe("createInlineAttachment (workspace_ref persistence)", () => {
     const msg = await addMessage(conv.id, "user", "hi");
 
     // "aGVsbG8=" = "hello"
-    const stored = createInlineAttachment(
+    const stored = await createInlineAttachment(
       conv.id,
       conv.createdAt,
       "note.txt",
@@ -431,14 +463,14 @@ describe("attachInlineAttachmentToMessage filename collisions", () => {
     const msg2 = await addMessage(conv.id, "user", "re-upload after editing");
 
     // "aGVsbG8=" = "hello", "d29ybGQ=" = "world"
-    const first = attachInlineAttachmentToMessage(
+    const first = await attachInlineAttachmentToMessage(
       msg1.id,
       0,
       "report.csv",
       "text/csv",
       "aGVsbG8=",
     );
-    const second = attachInlineAttachmentToMessage(
+    const second = await attachInlineAttachmentToMessage(
       msg2.id,
       0,
       "report.csv",
@@ -463,7 +495,7 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
   test("links attachment and retrieves it by message", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "Here is a chart");
-    const stored = uploadAttachment("chart.png", "image/png", "iVBORw0K");
+    const stored = await uploadAttachment("chart.png", "image/png", "iVBORw0K");
 
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
@@ -482,7 +514,11 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     const legacyDir = getLegacyConversationDirPath(conv.id, conv.createdAt);
     rmSync(legacyDir, { recursive: true, force: true });
 
-    const stored = uploadAttachment("repaired.png", "image/png", "iVBORw0K");
+    const stored = await uploadAttachment(
+      "repaired.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     const filePath = getFilePathForAttachment(stored.id);
@@ -501,7 +537,11 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
     rmSync(canonicalDir, { recursive: true, force: true });
     mkdirSync(legacyDir, { recursive: true });
 
-    const stored = uploadAttachment("legacy.png", "image/png", "iVBORw0K");
+    const stored = await uploadAttachment(
+      "legacy.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     const filePath = getFilePathForAttachment(stored.id);
@@ -514,8 +554,8 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
   test("returns attachments in position order", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "Multiple files");
-    const a = uploadAttachment("first.txt", "text/plain", "AAAA");
-    const b = uploadAttachment("second.txt", "text/plain", "BBBB");
+    const a = await uploadAttachment("first.txt", "text/plain", "AAAA");
+    const b = await uploadAttachment("second.txt", "text/plain", "BBBB");
 
     // Link in reverse order
     linkAttachmentToMessage(msg.id, b.id, 1);
@@ -543,8 +583,12 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
 describe("deleteOrphanAttachments", () => {
   beforeEach(resetTables);
 
-  test("removes candidate attachments with no message links", () => {
-    const stored = uploadAttachment("orphan.txt", "text/plain", "ZGF0YQ==");
+  test("removes candidate attachments with no message links", async () => {
+    const stored = await uploadAttachment(
+      "orphan.txt",
+      "text/plain",
+      "ZGF0YQ==",
+    );
 
     const removed = deleteOrphanAttachments([stored.id]);
     expect(removed).toBe(1);
@@ -553,7 +597,11 @@ describe("deleteOrphanAttachments", () => {
   test("cleans up on-disk files when removing orphaned materialized attachments", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "Orphan me");
-    const stored = uploadAttachment("orphan.txt", "text/plain", "ZGF0YQ==");
+    const stored = await uploadAttachment(
+      "orphan.txt",
+      "text/plain",
+      "ZGF0YQ==",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
     const filePath = getFilePathForAttachment(stored.id);
     expect(existsSync(filePath!)).toBe(true);
@@ -571,7 +619,11 @@ describe("deleteOrphanAttachments", () => {
   test("preserves attachments that are still linked", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "With attachment");
-    const stored = uploadAttachment("linked.txt", "text/plain", "ZGF0YQ==");
+    const stored = await uploadAttachment(
+      "linked.txt",
+      "text/plain",
+      "ZGF0YQ==",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     const removed = deleteOrphanAttachments([stored.id]);
@@ -584,8 +636,8 @@ describe("deleteOrphanAttachments", () => {
   test("removes only orphans when mixed candidates provided", async () => {
     const conv = createConversation();
     const msg = await addMessage(conv.id, "assistant", "Mixed");
-    const linked = uploadAttachment("linked.txt", "text/plain", "AAAA");
-    const orphan = uploadAttachment("orphan.txt", "text/plain", "BBBB");
+    const linked = await uploadAttachment("linked.txt", "text/plain", "AAAA");
+    const orphan = await uploadAttachment("orphan.txt", "text/plain", "BBBB");
     linkAttachmentToMessage(msg.id, linked.id, 0);
 
     const removed = deleteOrphanAttachments([linked.id, orphan.id]);
@@ -600,9 +652,17 @@ describe("deleteOrphanAttachments", () => {
     expect(removed).toBe(0);
   });
 
-  test("does not delete attachments outside the candidate set", () => {
-    const unrelated = uploadAttachment("unrelated.txt", "text/plain", "AAAA");
-    const candidate = uploadAttachment("candidate.txt", "text/plain", "BBBB");
+  test("does not delete attachments outside the candidate set", async () => {
+    const unrelated = await uploadAttachment(
+      "unrelated.txt",
+      "text/plain",
+      "AAAA",
+    );
+    const candidate = await uploadAttachment(
+      "candidate.txt",
+      "text/plain",
+      "BBBB",
+    );
 
     const removed = deleteOrphanAttachments([candidate.id]);
     expect(removed).toBe(1);

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -88,8 +88,8 @@ describe("attachmentsToReferenceBlocks", () => {
 // ---------------------------------------------------------------------------
 
 describe("attachmentsToContentBlocks", () => {
-  test("creates image content block for image/jpeg", () => {
-    const blocks = attachmentsToContentBlocks([
+  test("creates image content block for image/jpeg", async () => {
+    const blocks = await attachmentsToContentBlocks([
       { filename: "photo.jpg", mimeType: "image/jpeg", data: "base64data" },
     ]);
 
@@ -104,8 +104,8 @@ describe("attachmentsToContentBlocks", () => {
     expect(block.source.data).toBe("base64data");
   });
 
-  test("creates image content block for image/png", () => {
-    const blocks = attachmentsToContentBlocks([
+  test("creates image content block for image/png", async () => {
+    const blocks = await attachmentsToContentBlocks([
       { filename: "screenshot.png", mimeType: "image/png", data: "pngdata" },
     ]);
 
@@ -113,8 +113,8 @@ describe("attachmentsToContentBlocks", () => {
     expect(blocks[0].type).toBe("image");
   });
 
-  test("creates image content block for image/webp", () => {
-    const blocks = attachmentsToContentBlocks([
+  test("creates image content block for image/webp", async () => {
+    const blocks = await attachmentsToContentBlocks([
       { filename: "sticker.webp", mimeType: "image/webp", data: "webpdata" },
     ]);
 
@@ -122,8 +122,8 @@ describe("attachmentsToContentBlocks", () => {
     expect(blocks[0].type).toBe("image");
   });
 
-  test("creates file content block for non-image mime types", () => {
-    const blocks = attachmentsToContentBlocks([
+  test("creates file content block for non-image mime types", async () => {
+    const blocks = await attachmentsToContentBlocks([
       { filename: "doc.pdf", mimeType: "application/pdf", data: "pdfdata" },
     ]);
 
@@ -137,8 +137,8 @@ describe("attachmentsToContentBlocks", () => {
     expect(block.source.media_type).toBe("application/pdf");
   });
 
-  test("handles multiple attachments including mixed types", () => {
-    const blocks = attachmentsToContentBlocks([
+  test("handles multiple attachments including mixed types", async () => {
+    const blocks = await attachmentsToContentBlocks([
       { filename: "photo.jpg", mimeType: "image/jpeg", data: "imgdata" },
       { filename: "notes.txt", mimeType: "text/plain", data: "txtdata" },
     ]);
@@ -148,8 +148,8 @@ describe("attachmentsToContentBlocks", () => {
     expect(blocks[1].type).toBe("file");
   });
 
-  test("returns empty array for no attachments", () => {
-    const blocks = attachmentsToContentBlocks([]);
+  test("returns empty array for no attachments", async () => {
+    const blocks = await attachmentsToContentBlocks([]);
     expect(blocks).toHaveLength(0);
   });
 });
@@ -159,8 +159,8 @@ describe("attachmentsToContentBlocks", () => {
 // ---------------------------------------------------------------------------
 
 describe("createUserMessage with image attachments", () => {
-  test("includes both text and image blocks", () => {
-    const msg = createUserMessage("what is this?", [
+  test("includes both text and image blocks", async () => {
+    const msg = await createUserMessage("what is this?", [
       { filename: "photo.jpg", mimeType: "image/jpeg", data: "base64img" },
     ]);
 
@@ -173,8 +173,8 @@ describe("createUserMessage with image attachments", () => {
     expect(msg.content[1].type).toBe("image");
   });
 
-  test("includes only image block when text is empty", () => {
-    const msg = createUserMessage("", [
+  test("includes only image block when text is empty", async () => {
+    const msg = await createUserMessage("", [
       { filename: "photo.jpg", mimeType: "image/jpeg", data: "base64img" },
     ]);
 
@@ -183,8 +183,8 @@ describe("createUserMessage with image attachments", () => {
     expect(msg.content[0].type).toBe("image");
   });
 
-  test("includes only image block when text is whitespace", () => {
-    const msg = createUserMessage("   ", [
+  test("includes only image block when text is whitespace", async () => {
+    const msg = await createUserMessage("   ", [
       { filename: "photo.jpg", mimeType: "image/jpeg", data: "base64img" },
     ]);
 
@@ -193,8 +193,8 @@ describe("createUserMessage with image attachments", () => {
     expect(msg.content[0].type).toBe("image");
   });
 
-  test("includes multiple image blocks", () => {
-    const msg = createUserMessage("compare these", [
+  test("includes multiple image blocks", async () => {
+    const msg = await createUserMessage("compare these", [
       { filename: "a.jpg", mimeType: "image/jpeg", data: "img1" },
       { filename: "b.png", mimeType: "image/png", data: "img2" },
     ]);
@@ -206,9 +206,9 @@ describe("createUserMessage with image attachments", () => {
     expect(msg.content[2].type).toBe("image");
   });
 
-  test("preserves base64 data in image content block", () => {
+  test("preserves base64 data in image content block", async () => {
     const base64 = "dGVzdC1pbWFnZS1kYXRh";
-    const msg = createUserMessage("test", [
+    const msg = await createUserMessage("test", [
       { filename: "photo.jpg", mimeType: "image/jpeg", data: base64 },
     ]);
 
@@ -227,7 +227,7 @@ describe("createUserMessage with image attachments", () => {
 // ---------------------------------------------------------------------------
 
 describe("enrichMessageWithSourcePaths", () => {
-  test("appends a source path annotation for images with filePath", () => {
+  test("appends a source path annotation for images with filePath", async () => {
     const attachments = [
       {
         filename: "photo.jpg",
@@ -236,7 +236,7 @@ describe("enrichMessageWithSourcePaths", () => {
         filePath: "/Users/me/Desktop/photo.jpg",
       },
     ];
-    const original = createUserMessage("what is this?", attachments);
+    const original = await createUserMessage("what is this?", attachments);
     const enriched = enrichMessageWithSourcePaths(original, attachments);
 
     expect(enriched).not.toBe(original);
@@ -249,7 +249,7 @@ describe("enrichMessageWithSourcePaths", () => {
     );
   });
 
-  test("returns the original message (same reference) when no images have filePath", () => {
+  test("returns the original message (same reference) when no images have filePath", async () => {
     const attachments = [
       {
         filename: "photo.jpg",
@@ -257,13 +257,13 @@ describe("enrichMessageWithSourcePaths", () => {
         data: "base64img",
       },
     ];
-    const original = createUserMessage("what is this?", attachments);
+    const original = await createUserMessage("what is this?", attachments);
     const result = enrichMessageWithSourcePaths(original, attachments);
 
     expect(result).toBe(original);
   });
 
-  test("skips non-image attachments with filePath", () => {
+  test("skips non-image attachments with filePath", async () => {
     const attachments = [
       {
         filename: "doc.pdf",
@@ -272,14 +272,14 @@ describe("enrichMessageWithSourcePaths", () => {
         filePath: "/Users/me/Documents/doc.pdf",
       },
     ];
-    const original = createUserMessage("review this", attachments);
+    const original = await createUserMessage("review this", attachments);
     const result = enrichMessageWithSourcePaths(original, attachments);
 
     // Non-image attachments are not annotated, so we get back the same ref
     expect(result).toBe(original);
   });
 
-  test("handles multiple images with file paths", () => {
+  test("handles multiple images with file paths", async () => {
     const attachments = [
       {
         filename: "a.jpg",
@@ -294,7 +294,7 @@ describe("enrichMessageWithSourcePaths", () => {
         filePath: "/path/to/b.png",
       },
     ];
-    const original = createUserMessage("compare", attachments);
+    const original = await createUserMessage("compare", attachments);
     const enriched = enrichMessageWithSourcePaths(original, attachments);
 
     expect(enriched).not.toBe(original);
@@ -307,7 +307,7 @@ describe("enrichMessageWithSourcePaths", () => {
     );
   });
 
-  test("only annotates images that have filePath, skips those without", () => {
+  test("only annotates images that have filePath, skips those without", async () => {
     const attachments = [
       {
         filename: "a.jpg",
@@ -322,7 +322,7 @@ describe("enrichMessageWithSourcePaths", () => {
         // no filePath — e.g. pasted screenshot
       },
     ];
-    const original = createUserMessage("compare", attachments);
+    const original = await createUserMessage("compare", attachments);
     const enriched = enrichMessageWithSourcePaths(original, attachments);
 
     expect(enriched).not.toBe(original);
@@ -332,7 +332,7 @@ describe("enrichMessageWithSourcePaths", () => {
     expect(annotation.text).toBe("[Attached image source: /path/to/a.jpg]");
   });
 
-  test("annotates non-image attachments that have storedPath", () => {
+  test("annotates non-image attachments that have storedPath", async () => {
     const attachments = [
       {
         filename: "report.pdf",
@@ -342,7 +342,7 @@ describe("enrichMessageWithSourcePaths", () => {
         storedPath: "/conv/attachments/report-2.pdf",
       },
     ];
-    const original = createUserMessage("review my edits", attachments);
+    const original = await createUserMessage("review my edits", attachments);
     const enriched = enrichMessageWithSourcePaths(original, attachments);
 
     expect(enriched).not.toBe(original);
@@ -355,7 +355,7 @@ describe("enrichMessageWithSourcePaths", () => {
     );
   });
 
-  test("emits image source lines before stored path lines in one block", () => {
+  test("emits image source lines before stored path lines in one block", async () => {
     const attachments = [
       {
         filename: "data.csv",
@@ -371,7 +371,7 @@ describe("enrichMessageWithSourcePaths", () => {
         storedPath: "/conv/attachments/photo.jpg",
       },
     ];
-    const original = createUserMessage("compare", attachments);
+    const original = await createUserMessage("compare", attachments);
     const enriched = enrichMessageWithSourcePaths(original, attachments);
 
     const annotation = enriched.content.at(-1) as {

--- a/assistant/src/__tests__/compactor-image-manifest-trust.test.ts
+++ b/assistant/src/__tests__/compactor-image-manifest-trust.test.ts
@@ -51,7 +51,7 @@ async function addImageMessage(
       skipIndexing: true,
     },
   );
-  attachInlineAttachmentToMessage(
+  await attachInlineAttachmentToMessage(
     inserted.id,
     0,
     filename,

--- a/assistant/src/__tests__/conversation-disk-view-integration.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view-integration.test.ts
@@ -128,7 +128,11 @@ describe("addMessage + syncMessageToDisk → disk view", () => {
       skipIndexing: true,
     });
 
-    const att = uploadAttachment("screenshot.png", "image/png", "iVBORw0K");
+    const att = await uploadAttachment(
+      "screenshot.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(msg.id, att.id, 0);
 
     syncMessageToDisk(conv.id, msg.id, conv.createdAt);

--- a/assistant/src/__tests__/conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-disk-view.test.ts
@@ -434,7 +434,7 @@ describe("syncMessageToDisk", () => {
     });
 
     // Upload an attachment and link to the message
-    const att = uploadAttachment("photo.png", "image/png", "iVBORw0K");
+    const att = await uploadAttachment("photo.png", "image/png", "iVBORw0K");
     linkAttachmentToMessage(msg.id, att.id, 0);
 
     syncMessageToDisk(conv.id, msg.id, conv.createdAt);
@@ -498,7 +498,7 @@ describe("syncMessageToDisk", () => {
       skipIndexing: true,
     });
 
-    const att = uploadAttachment("legacy.png", "image/png", "iVBORw0K");
+    const att = await uploadAttachment("legacy.png", "image/png", "iVBORw0K");
     linkAttachmentToMessage(msg.id, att.id, 0);
 
     syncMessageToDisk(conv.id, msg.id, createdAt);
@@ -525,7 +525,7 @@ describe("syncMessageToDisk", () => {
     const msg = await addMessage(conv.id, "user", "Disk repair", {
       skipIndexing: true,
     });
-    const att = uploadAttachment("repair.png", "image/png", "iVBORw0K");
+    const att = await uploadAttachment("repair.png", "image/png", "iVBORw0K");
     rawRun(
       "test:linkAttachment",
       `INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
@@ -603,7 +603,7 @@ describe("rebuildConversationDiskViewFromDbState", () => {
       { skipIndexing: true },
     );
 
-    const att = uploadAttachment("result.txt", "text/plain", "ok");
+    const att = await uploadAttachment("result.txt", "text/plain", "ok");
     linkAttachmentToMessage(assistantPart2.id, att.id, 0);
 
     // Simulate stale disk view generated before consolidation.

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -702,7 +702,11 @@ describe("forkConversation", () => {
       "Attached the updated mock.",
       { skipIndexing: true },
     );
-    const uploaded = uploadAttachment("wireframe.png", "image/png", "iVBORw0K");
+    const uploaded = await uploadAttachment(
+      "wireframe.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(sourceAssistant.id, uploaded.id, 0);
 
     const sourceAttachments = getAttachmentsForMessage(sourceAssistant.id);

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -198,7 +198,11 @@ describe("forkConversationForRetrospective", () => {
     const assistant = await addMessage(source.id, "assistant", "see mockup", {
       skipIndexing: true,
     });
-    const uploaded = uploadAttachment("wireframe.png", "image/png", "iVBORw0K");
+    const uploaded = await uploadAttachment(
+      "wireframe.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(assistant.id, uploaded.id, 0);
 
     const asyncFork = await forkConversationForRetrospective({

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -304,7 +304,7 @@ describe("attachment orphan cleanup", () => {
       "Here is a file",
     );
 
-    const stored = uploadAttachment("chart.png", "image/png", "iVBOR");
+    const stored = await uploadAttachment("chart.png", "image/png", "iVBOR");
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     // Verify attachment is linked
@@ -331,7 +331,7 @@ describe("attachment orphan cleanup", () => {
     await addMessage(conv.id, "user", "question");
     const msg2 = await addMessage(conv.id, "assistant", "second");
 
-    const shared = uploadAttachment("shared.png", "image/png", "AAAA");
+    const shared = await uploadAttachment("shared.png", "image/png", "AAAA");
     linkAttachmentToMessage(msg1.id, shared.id, 0);
     linkAttachmentToMessage(msg2.id, shared.id, 0);
 
@@ -353,7 +353,11 @@ describe("attachment orphan cleanup", () => {
   test("clearAll removes all attachments", async () => {
     const conv = createConversation("test");
     const msg = await addMessage(conv.id, "assistant", "file");
-    const stored = uploadAttachment("doc.pdf", "application/pdf", "JVBER");
+    const stored = await uploadAttachment(
+      "doc.pdf",
+      "application/pdf",
+      "JVBER",
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
     await clearAll();
@@ -441,11 +445,11 @@ describe("attachment orphan cleanup", () => {
     );
 
     // An attachment linked to the assistant message (should be cleaned up)
-    const linked = uploadAttachment("chart.png", "image/png", "iVBOR");
+    const linked = await uploadAttachment("chart.png", "image/png", "iVBOR");
     linkAttachmentToMessage(assistantMsg.id, linked.id, 0);
 
     // A freshly uploaded attachment not linked to any message (should survive)
-    uploadAttachment("pending.png", "image/png", "AAAA");
+    await uploadAttachment("pending.png", "image/png", "AAAA");
 
     deleteLastExchange(conv.id);
 
@@ -543,7 +547,7 @@ describe("attachment reuse across conversation lifecycles", () => {
   test("attachment uploaded in conversation A is retrievable by ID without any conversation reference", async () => {
     const convA = createConversation("Conversation A");
     const msgA = await addMessage(convA.id, "assistant", "Here is a file");
-    const stored = uploadAttachment(
+    const stored = await uploadAttachment(
       "report.pdf",
       "application/pdf",
       "JVBERA==",
@@ -570,7 +574,11 @@ describe("attachment reuse across conversation lifecycles", () => {
     const msgB = await addMessage(convB.id, "assistant", "Reused file");
 
     // Upload once, link to both conversations
-    const stored = uploadAttachment("shared.png", "image/png", "iVBORw0K");
+    const stored = await uploadAttachment(
+      "shared.png",
+      "image/png",
+      "iVBORw0K",
+    );
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
 
@@ -595,7 +603,7 @@ describe("attachment reuse across conversation lifecycles", () => {
     await addMessage(convB.id, "user", "Show me the chart");
     const msgB = await addMessage(convB.id, "assistant", "Reused");
 
-    const stored = uploadAttachment("chart.png", "image/png", "AAAA");
+    const stored = await uploadAttachment("chart.png", "image/png", "AAAA");
     linkAttachmentToMessage(msgA.id, stored.id, 0);
     linkAttachmentToMessage(msgB.id, stored.id, 0);
     const linkedB = getAttachmentsForMessage(msgB.id);
@@ -621,8 +629,16 @@ describe("attachment reuse across conversation lifecycles", () => {
     await addMessage(convA.id, "user", "upload in A");
     await addMessage(convB.id, "user", "upload in B");
 
-    const first = uploadAttachment("photo.png", "image/png", "DEDUPCROSS");
-    const second = uploadAttachment("photo.png", "image/png", "DEDUPCROSS");
+    const first = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      "DEDUPCROSS",
+    );
+    const second = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      "DEDUPCROSS",
+    );
 
     expect(second.id).not.toBe(first.id);
   });

--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -7,7 +7,7 @@ let diskSample: DiskUsageInfo | null = null;
 let diskSampleError: unknown = null;
 
 mock.module("../util/disk-usage.js", () => ({
-  getDiskUsageInfo: () => {
+  getDiskUsageInfo: async () => {
     if (diskSampleError) {
       throw diskSampleError;
     }
@@ -84,10 +84,10 @@ afterEach(() => {
 });
 
 describe("disk pressure guard", () => {
-  test("locks when sampled usage reaches the threshold", () => {
+  test("locks when sampled usage reaches the threshold", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT);
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.enabled).toBe(true);
     expect(status.state).toBe("critical");
@@ -103,9 +103,9 @@ describe("disk pressure guard", () => {
     expect(status.blockedCapabilities.length).toBeGreaterThan(0);
   });
 
-  test("acknowledges an active lock without overriding it", () => {
+  test("acknowledges an active lock without overriding it", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = acknowledgeDiskPressureLock();
 
@@ -115,14 +115,14 @@ describe("disk pressure guard", () => {
     expect(result.status.effectivelyLocked).toBe(true);
   });
 
-  test("unlocks and clears acknowledgement and override when usage falls below threshold", () => {
+  test("unlocks and clears acknowledgement and override when usage falls below threshold", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     acknowledgeDiskPressureLock();
     overrideDiskPressureLock(DISK_PRESSURE_OVERRIDE_CONFIRMATION);
 
     setDiskUsage(20);
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("ok");
     expect(status.locked).toBe(false);
@@ -133,25 +133,25 @@ describe("disk pressure guard", () => {
     expect(status.blockedCapabilities).toEqual([]);
   });
 
-  test("does not lock within the deadband until usage reaches the critical threshold", () => {
+  test("does not lock within the deadband until usage reaches the critical threshold", async () => {
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("warning");
     expect(status.locked).toBe(false);
     expect(status.effectivelyLocked).toBe(false);
   });
 
-  test("stays locked while usage stays within the hysteresis deadband", () => {
+  test("stays locked while usage stays within the hysteresis deadband", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    const locked = evaluateDiskPressureNow();
+    const locked = await evaluateDiskPressureNow();
     expect(locked.locked).toBe(true);
     const { lockId } = locked;
 
     // Below critical (95) but above clear (90): must hold, not flap.
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("critical");
     expect(status.locked).toBe(true);
@@ -160,29 +160,29 @@ describe("disk pressure guard", () => {
     expect(status.lockId).toBe(lockId);
   });
 
-  test("preserves acknowledgement across a dip within the deadband", () => {
+  test("preserves acknowledgement across a dip within the deadband", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     acknowledgeDiskPressureLock();
 
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.locked).toBe(true);
     expect(status.acknowledged).toBe(true);
   });
 
-  test("clears the lock only once usage falls below the clear threshold", () => {
+  test("clears the lock only once usage falls below the clear threshold", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     // Still within the deadband: locked.
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT + 2);
-    expect(evaluateDiskPressureNow().locked).toBe(true);
+    expect((await evaluateDiskPressureNow()).locked).toBe(true);
 
     // Below the clear threshold: released.
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT - 2);
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.locked).toBe(false);
     expect(status.effectivelyLocked).toBe(false);
@@ -190,9 +190,9 @@ describe("disk pressure guard", () => {
     expect(status.blockedCapabilities).toEqual([]);
   });
 
-  test("overrides an active lock only with the exact confirmation after trimming whitespace", () => {
+  test("overrides an active lock only with the exact confirmation after trimming whitespace", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const invalid = overrideDiskPressureLock("I accept the risks");
     expectRejected(invalid, "invalid_confirmation");
@@ -208,9 +208,9 @@ describe("disk pressure guard", () => {
     expect(valid.status.effectivelyLocked).toBe(false);
   });
 
-  test("rejects acknowledgement when no lock is active", () => {
+  test("rejects acknowledgement when no lock is active", async () => {
     setDiskUsage(10);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = acknowledgeDiskPressureLock();
 
@@ -218,9 +218,9 @@ describe("disk pressure guard", () => {
     expect(result.status.locked).toBe(false);
   });
 
-  test("rejects override when no lock is active", () => {
+  test("rejects override when no lock is active", async () => {
     setDiskUsage(10);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = overrideDiskPressureLock(
       DISK_PRESSURE_OVERRIDE_CONFIRMATION,
@@ -230,9 +230,9 @@ describe("disk pressure guard", () => {
     expect(result.status.locked).toBe(false);
   });
 
-  test("rejects repeated override while preserving the existing override", () => {
+  test("rejects repeated override while preserving the existing override", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     const first = overrideDiskPressureLock(DISK_PRESSURE_OVERRIDE_CONFIRMATION);
     expect(first.ok).toBe(true);
 
@@ -245,13 +245,13 @@ describe("disk pressure guard", () => {
     expect(second.status.effectivelyLocked).toBe(false);
   });
 
-  test("sample failures degrade open and do not preserve a prior lock", () => {
+  test("sample failures degrade open and do not preserve a prior lock", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     expect(getDiskPressureStatus().locked).toBe(true);
 
     diskSampleError = new Error("sample failed");
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.enabled).toBe(true);
     expect(status.state).toBe("unknown");
@@ -278,71 +278,71 @@ describe("disk pressure guard", () => {
     expect(__getDiskPressureGuardTimerForTests()).toBeNull();
   });
 
-  test("does not enter warning until usage reaches the warning threshold", () => {
+  test("does not enter warning until usage reaches the warning threshold", async () => {
     // Below 80% and never previously in a pressure state.
     setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT - 2);
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("ok");
   });
 
-  test("holds the warning state across a dip within the warning clear deadband", () => {
+  test("holds the warning state across a dip within the warning clear deadband", async () => {
     setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT + 2);
-    expect(evaluateDiskPressureNow().state).toBe("warning");
+    expect((await evaluateDiskPressureNow()).state).toBe("warning");
 
     // Below the 80% warning threshold but at/above the 77% clear threshold.
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
-    expect(evaluateDiskPressureNow().state).toBe("warning");
+    expect((await evaluateDiskPressureNow()).state).toBe("warning");
   });
 
-  test("clears the warning state once usage falls below the warning clear threshold", () => {
+  test("clears the warning state once usage falls below the warning clear threshold", async () => {
     setDiskUsage(DISK_PRESSURE_WARNING_THRESHOLD_PERCENT + 2);
-    expect(evaluateDiskPressureNow().state).toBe("warning");
+    expect((await evaluateDiskPressureNow()).state).toBe("warning");
 
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT - 1);
-    expect(evaluateDiskPressureNow().state).toBe("ok");
+    expect((await evaluateDiskPressureNow()).state).toBe("ok");
   });
 
-  test("steps a critical lock down into a held warning state", () => {
+  test("steps a critical lock down into a held warning state", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    expect(evaluateDiskPressureNow().state).toBe("critical");
+    expect((await evaluateDiskPressureNow()).state).toBe("critical");
 
     // Below the 90% critical clear but above the 80% warning threshold.
     setDiskUsage(DISK_PRESSURE_CLEAR_THRESHOLD_PERCENT - 2);
-    const stepped = evaluateDiskPressureNow();
+    const stepped = await evaluateDiskPressureNow();
     expect(stepped.state).toBe("warning");
     expect(stepped.locked).toBe(false);
 
     // Now within the warning clear deadband — warning must hold, not flap to ok.
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
-    expect(evaluateDiskPressureNow().state).toBe("warning");
+    expect((await evaluateDiskPressureNow()).state).toBe("warning");
   });
 
-  test("holds warning when a critical lock drops straight into the warning deadband", () => {
+  test("holds warning when a critical lock drops straight into the warning deadband", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    expect(evaluateDiskPressureNow().state).toBe("critical");
+    expect((await evaluateDiskPressureNow()).state).toBe("critical");
 
     // A single large cleanup drops usage directly from critical to below the
     // 80% warning threshold but still at/above the 77% clear threshold. The
     // deadband must apply when stepping down out of critical too, so this holds
     // as warning rather than flapping to ok (which would reopen the flap window).
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT + 1);
-    const stepped = evaluateDiskPressureNow();
+    const stepped = await evaluateDiskPressureNow();
     expect(stepped.state).toBe("warning");
     expect(stepped.locked).toBe(false);
   });
 
-  test("clears straight to ok when a critical lock drops below the warning clear threshold", () => {
+  test("clears straight to ok when a critical lock drops below the warning clear threshold", async () => {
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT + 1);
-    expect(evaluateDiskPressureNow().state).toBe("critical");
+    expect((await evaluateDiskPressureNow()).state).toBe("critical");
 
     // A drop below even the warning-clear threshold is a genuine recovery.
     setDiskUsage(DISK_PRESSURE_WARNING_CLEAR_THRESHOLD_PERCENT - 1);
-    expect(evaluateDiskPressureNow().state).toBe("ok");
+    expect((await evaluateDiskPressureNow()).state).toBe("ok");
   });
 
-  test("stays ok at a critical usage percentage while ample free space remains", () => {
+  test("stays ok at a critical usage percentage while ample free space remains", async () => {
     // 99% used of a large volume still leaves gigabytes free — above the floor.
     const totalMb = 1_000_000;
     const usedMb = Math.round(totalMb * 0.99); // freeMb ~= 10_000 MiB
@@ -351,31 +351,31 @@ describe("disk pressure guard", () => {
       DISK_PRESSURE_MIN_FREE_FLOOR_MB,
     );
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("ok");
     expect(status.locked).toBe(false);
     expect(status.effectivelyLocked).toBe(false);
   });
 
-  test("stays ok at a warning usage percentage while ample free space remains", () => {
+  test("stays ok at a warning usage percentage while ample free space remains", async () => {
     const totalMb = 1_000_000;
     const usedMb = Math.round(totalMb * 0.85); // 85% used, freeMb ~= 150_000 MiB
     setDiskUsage(usedMb, totalMb);
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("ok");
   });
 
-  test("locks at a critical usage percentage once free space drops below the floor", () => {
+  test("locks at a critical usage percentage once free space drops below the floor", async () => {
     // High percentage AND little absolute headroom: floor does not apply.
     const totalMb = 100_000;
     const freeMb = DISK_PRESSURE_MIN_FREE_FLOOR_MB - 1;
     setDiskUsage(totalMb - freeMb, totalMb);
     expect(diskSample!.freeMb).toBeLessThan(DISK_PRESSURE_MIN_FREE_FLOOR_MB);
 
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.state).toBe("critical");
     expect(status.locked).toBe(true);

--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -170,7 +170,7 @@ describe("disk pressure routes", () => {
 
   test("returns the full status shape for an active lock", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = await callRoute("disk-pressure/status", "GET");
 
@@ -223,7 +223,7 @@ describe("disk pressure routes", () => {
 
   test("acknowledges an active lock without overriding it", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = await callRoute("disk-pressure/acknowledge", "POST");
 
@@ -234,7 +234,7 @@ describe("disk pressure routes", () => {
 
   test("overrides an active lock only after the confirmation phrase", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     const result = await callRoute("disk-pressure/override", "POST", {
       confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
@@ -247,7 +247,7 @@ describe("disk pressure routes", () => {
 
   test("rejects an invalid override phrase with INVALID_CONFIRMATION", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     await expectRouteRejects(
       "disk-pressure/override",
@@ -260,7 +260,7 @@ describe("disk pressure routes", () => {
 
   test("rejects acknowledgement and override when no lock is active", async () => {
     setDiskUsage(10);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
 
     await expectRouteRejects(
       "disk-pressure/acknowledge",
@@ -280,7 +280,7 @@ describe("disk pressure routes", () => {
 
   test("rejects repeated acknowledgement", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     await callRoute("disk-pressure/acknowledge", "POST");
 
     await expectRouteRejects(
@@ -294,7 +294,7 @@ describe("disk pressure routes", () => {
 
   test("rejects repeated override", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
+    await evaluateDiskPressureNow();
     await callRoute("disk-pressure/override", "POST", {
       confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
     });
@@ -321,15 +321,15 @@ describe("disk pressure routes", () => {
 
     try {
       setDiskUsage(99);
-      evaluateDiskPressureNow();
+      await evaluateDiskPressureNow();
       await callRoute("disk-pressure/acknowledge", "POST");
       await callRoute("disk-pressure/override", "POST", {
         confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
       });
       setDiskUsage(98);
-      evaluateDiskPressureNow();
+      await evaluateDiskPressureNow();
       setDiskUsage(10);
-      evaluateDiskPressureNow();
+      await evaluateDiskPressureNow();
       await flushPublishedEvents();
     } finally {
       subscription.dispose();

--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -196,7 +196,7 @@ describe("disk pressure cleanup tool restrictions", () => {
     expect(result.tool.name).toBe("skill_load");
   });
 
-  test("locking cancels registered terminal background tools with disk pressure reason", () => {
+  test("locking cancels registered terminal background tools with disk pressure reason", async () => {
     const bashCancel = mock((_reason?: string) => undefined);
     const hostCancel = mock((_reason?: string) => undefined);
     const otherCancel = mock((_reason?: string) => undefined);
@@ -227,7 +227,7 @@ describe("disk pressure cleanup tool restrictions", () => {
     });
 
     setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT);
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
 
     expect(status.locked).toBe(true);
     expect(bashCancel).toHaveBeenCalledWith("disk_pressure");

--- a/assistant/src/__tests__/disk-usage.test.ts
+++ b/assistant/src/__tests__/disk-usage.test.ts
@@ -1,3 +1,4 @@
+import { promisify } from "node:util";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const MIB = 1024 * 1024;
@@ -27,11 +28,25 @@ mock.module("node:fs", () => ({
   statfsSync: () => statfsResult,
 }));
 
-mock.module("node:child_process", () => ({
-  spawnSync: (command: string, args: string[]) => {
-    spawnCalls.push({ command, args });
-    return spawnResult;
+// The module under test calls `promisify(execFile)`, so the mock only needs
+// to provide the promisified implementation via the promisify.custom symbol.
+const execFileMock = Object.assign(
+  () => {
+    throw new Error("callback-style execFile is not used by disk-usage");
   },
+  {
+    [promisify.custom]: async (command: string, args: string[]) => {
+      spawnCalls.push({ command, args });
+      if (spawnResult.status !== 0) {
+        throw new Error(`Command failed with exit code ${spawnResult.status}`);
+      }
+      return { stdout: spawnResult.stdout, stderr: "" };
+    },
+  },
+);
+
+mock.module("node:child_process", () => ({
+  execFile: execFileMock,
 }));
 
 mock.module("../config/env-registry.js", () => ({
@@ -67,8 +82,8 @@ describe("disk usage sampler", () => {
     __resetDiskUsageCacheForTests();
   });
 
-  test("reports regular statfs usage", () => {
-    const usage = getDiskUsageInfo();
+  test("reports regular statfs usage", async () => {
+    const usage = await getDiskUsageInfo();
 
     expect(usage).toEqual({
       path: "/workspace",
@@ -79,15 +94,15 @@ describe("disk usage sampler", () => {
     expect(spawnCalls).toHaveLength(0);
   });
 
-  test("falls back to root when the workspace path does not exist", () => {
+  test("falls back to root when the workspace path does not exist", async () => {
     existingPaths = new Set();
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage?.path).toBe("/");
   });
 
-  test("uses PVC capacity and du usage when host filesystem is larger", () => {
+  test("uses PVC capacity and du usage when host filesystem is larger", async () => {
     minikubeStorageSize = "1Gi";
     statfsResult = statfsFor(10 * GIB, 8 * GIB);
     spawnResult = {
@@ -95,7 +110,7 @@ describe("disk usage sampler", () => {
       stdout: `${100 * MIB}\t/workspace\n`,
     };
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage).toEqual({
       path: "/workspace",
@@ -108,7 +123,7 @@ describe("disk usage sampler", () => {
     ]);
   });
 
-  test("includes /data in PVC du usage when it exists separately", () => {
+  test("includes /data in PVC du usage when it exists separately", async () => {
     existingPaths = new Set([workspaceDir, "/data"]);
     minikubeStorageSize = "1Gi";
     statfsResult = statfsFor(10 * GIB, 8 * GIB);
@@ -117,7 +132,7 @@ describe("disk usage sampler", () => {
       stdout: `${100 * MIB}\t/workspace\n${20 * MIB}\t/data\n`,
     };
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage?.usedMb).toBe(120);
     expect(spawnCalls).toEqual([
@@ -125,7 +140,7 @@ describe("disk usage sampler", () => {
     ]);
   });
 
-  test("measures workspace du usage on a local Docker hatch", () => {
+  test("measures workspace du usage on a local Docker hatch", async () => {
     isContainerized = true;
     isPlatform = false;
     statfsResult = statfsFor(100 * GIB, 40 * GIB);
@@ -134,7 +149,7 @@ describe("disk usage sampler", () => {
       stdout: `${2 * GIB}\t/workspace\n`,
     };
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     // Used reflects only the workspace (du), free reflects the host headroom
     // the volume can grow into, and total is their sum.
@@ -149,12 +164,12 @@ describe("disk usage sampler", () => {
     ]);
   });
 
-  test("does not use du for platform-managed containerized instances", () => {
+  test("does not use du for platform-managed containerized instances", async () => {
     isContainerized = true;
     isPlatform = true;
     statfsResult = statfsFor(10 * GIB, 6 * GIB);
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage).toEqual({
       path: "/workspace",
@@ -165,13 +180,13 @@ describe("disk usage sampler", () => {
     expect(spawnCalls).toHaveLength(0);
   });
 
-  test("falls back to statfs when du fails on a local Docker hatch", () => {
+  test("falls back to statfs when du fails on a local Docker hatch", async () => {
     isContainerized = true;
     isPlatform = false;
     statfsResult = statfsFor(100 * GIB, 40 * GIB);
     spawnResult = { status: 1, stdout: "" };
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage).toEqual({
       path: "/workspace",
@@ -192,7 +207,7 @@ describe("disk usage sampler", () => {
     expect(parseK8sMemoryBytes("0Gi")).toBeNull();
   });
 
-  test("falls back to statfs when du fails in PVC mode", () => {
+  test("falls back to statfs when du fails in PVC mode", async () => {
     minikubeStorageSize = "1Gi";
     statfsResult = statfsFor(10 * GIB, 8 * GIB);
     spawnResult = {
@@ -200,7 +215,7 @@ describe("disk usage sampler", () => {
       stdout: "",
     };
 
-    const usage = getDiskUsageInfo();
+    const usage = await getDiskUsageInfo();
 
     expect(usage).toEqual({
       path: "/workspace",

--- a/assistant/src/__tests__/dynamic-skill-background-guard.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-background-guard.test.ts
@@ -137,7 +137,7 @@ async function checkSkillLoad(skill: string) {
     skillLoadTool,
     makeBackgroundGuardianContext(),
     Date.now(),
-    () => undefined,
+    async () => undefined,
   );
 }
 
@@ -176,7 +176,7 @@ async function checkSkillLoadWith(
     skillLoadTool,
     context,
     Date.now(),
-    () => undefined,
+    async () => undefined,
   );
 }
 

--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -50,7 +50,7 @@ function sandboxPolicyFor(boundary: string): PathPolicy {
 // ---------------------------------------------------------------------------
 
 describe("FileSystemOps.listDirSafe", () => {
-  test("lists directory contents with type indicators (dirs end with /)", () => {
+  test("lists directory contents with type indicators (dirs end with /)", async () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "subdir-a"));
     mkdirSync(join(dir, "subdir-b"));
@@ -58,7 +58,7 @@ describe("FileSystemOps.listDirSafe", () => {
     writeFileSync(join(dir, "file-b.md"), "world");
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
-    const result = ops.listDirSafe({ path: dir });
+    const result = await ops.listDirSafe({ path: dir });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -73,7 +73,7 @@ describe("FileSystemOps.listDirSafe", () => {
     expect(lines[3]).toMatch(/^file-b\.md\s+\d+\s*B$/);
   });
 
-  test("glob filtering works (e.g. '*.md' only returns .md files)", () => {
+  test("glob filtering works (e.g. '*.md' only returns .md files)", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "readme.md"), "# Title");
     writeFileSync(join(dir, "notes.md"), "some notes");
@@ -81,7 +81,7 @@ describe("FileSystemOps.listDirSafe", () => {
     writeFileSync(join(dir, "config.json"), "{}");
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
-    const result = ops.listDirSafe({ path: dir, glob: "*.md" });
+    const result = await ops.listDirSafe({ path: dir, glob: "*.md" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -93,12 +93,14 @@ describe("FileSystemOps.listDirSafe", () => {
     expect(lines[1]).toMatch(/^readme\.md/);
   });
 
-  test("returns NOT_A_DIRECTORY error for file paths", () => {
+  test("returns NOT_A_DIRECTORY error for file paths", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "regular-file.txt"), "content");
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
-    const result = ops.listDirSafe({ path: join(dir, "regular-file.txt") });
+    const result = await ops.listDirSafe({
+      path: join(dir, "regular-file.txt"),
+    });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -106,11 +108,11 @@ describe("FileSystemOps.listDirSafe", () => {
     expect(result.error.code).toBe("NOT_A_DIRECTORY");
   });
 
-  test("returns NOT_FOUND error for nonexistent paths", () => {
+  test("returns NOT_FOUND error for nonexistent paths", async () => {
     const dir = makeTempDir();
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
-    const result = ops.listDirSafe({ path: join(dir, "nonexistent") });
+    const result = await ops.listDirSafe({ path: join(dir, "nonexistent") });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -118,11 +120,11 @@ describe("FileSystemOps.listDirSafe", () => {
     expect(result.error.code).toBe("NOT_FOUND");
   });
 
-  test("sandbox policy rejects paths outside boundary", () => {
+  test("sandbox policy rejects paths outside boundary", async () => {
     const dir = makeTempDir();
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
-    const result = ops.listDirSafe({ path: "../../../etc" });
+    const result = await ops.listDirSafe({ path: "../../../etc" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;

--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -44,12 +44,12 @@ function sandboxPolicyFor(boundary: string): PathPolicy {
 // ---------------------------------------------------------------------------
 
 describe("FileSystemOps.readFileSafe", () => {
-  test("reads a file successfully", () => {
+  test("reads a file successfully", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "hello.txt"), "line one\nline two\nline three\n");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "hello.txt" });
+    const result = await ops.readFileSafe({ path: "hello.txt" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -59,11 +59,11 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.value.content).toContain("line three");
   });
 
-  test("returns NOT_FOUND for missing file", () => {
+  test("returns NOT_FOUND for missing file", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "nonexistent.txt" });
+    const result = await ops.readFileSafe({ path: "nonexistent.txt" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -71,12 +71,12 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.error.code).toBe("NOT_FOUND");
   });
 
-  test("returns NOT_A_FILE for a directory", () => {
+  test("returns NOT_A_FILE for a directory", async () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "subdir"));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "subdir" });
+    const result = await ops.readFileSafe({ path: "subdir" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -84,13 +84,13 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.error.code).toBe("NOT_A_FILE");
   });
 
-  test("returns SIZE_LIMIT_EXCEEDED for oversized file", () => {
+  test("returns SIZE_LIMIT_EXCEEDED for oversized file", async () => {
     const dir = makeTempDir();
     const filePath = join(dir, "big.txt");
     writeFileSync(filePath, "x".repeat(200));
 
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
-    const result = ops.readFileSafe({ path: "big.txt" });
+    const result = await ops.readFileSafe({ path: "big.txt" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -98,11 +98,11 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.error.code).toBe("SIZE_LIMIT_EXCEEDED");
   });
 
-  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", () => {
+  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "../../../etc/passwd" });
+    const result = await ops.readFileSafe({ path: "../../../etc/passwd" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -110,12 +110,16 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("respects offset and limit", () => {
+  test("respects offset and limit", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "lines.txt"), "a\nb\nc\nd\ne\n");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "lines.txt", offset: 2, limit: 2 });
+    const result = await ops.readFileSafe({
+      path: "lines.txt",
+      offset: 2,
+      limit: 2,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -132,11 +136,11 @@ describe("FileSystemOps.readFileSafe", () => {
 // ---------------------------------------------------------------------------
 
 describe("FileSystemOps.writeFileSafe", () => {
-  test("writes a new file", () => {
+  test("writes a new file", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "new.txt",
       content: "hello world",
     });
@@ -150,12 +154,12 @@ describe("FileSystemOps.writeFileSafe", () => {
     expect(existsSync(join(dir, "new.txt"))).toBe(true);
   });
 
-  test("overwrites an existing file and returns old content", () => {
+  test("overwrites an existing file and returns old content", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "existing.txt"), "old stuff");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "existing.txt",
       content: "new stuff",
     });
@@ -168,11 +172,11 @@ describe("FileSystemOps.writeFileSafe", () => {
     expect(result.value.newContent).toBe("new stuff");
   });
 
-  test("creates parent directories when needed", () => {
+  test("creates parent directories when needed", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "a/b/c/deep.txt",
       content: "deep",
     });
@@ -184,11 +188,11 @@ describe("FileSystemOps.writeFileSafe", () => {
     expect(existsSync(join(dir, "a/b/c/deep.txt"))).toBe(true);
   });
 
-  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", () => {
+  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "../../../tmp/evil.txt",
       content: "bad",
     });
@@ -199,11 +203,11 @@ describe("FileSystemOps.writeFileSafe", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("returns SIZE_LIMIT_EXCEEDED for oversized content", () => {
+  test("returns SIZE_LIMIT_EXCEEDED for oversized content", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 10 });
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "big.txt",
       content: "x".repeat(50),
     });
@@ -220,11 +224,11 @@ describe("FileSystemOps.writeFileSafe", () => {
 // ---------------------------------------------------------------------------
 
 describe("FileSystemOps.editFileSafe", () => {
-  test("returns NOT_FOUND for nonexistent file", () => {
+  test("returns NOT_FOUND for nonexistent file", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "nope.txt",
       oldString: "a",
       newString: "b",
@@ -237,12 +241,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("NOT_FOUND");
   });
 
-  test("returns NOT_A_FILE when target is a directory", () => {
+  test("returns NOT_A_FILE when target is a directory", async () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "subdir"));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "subdir",
       oldString: "a",
       newString: "b",
@@ -255,12 +259,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("NOT_A_FILE");
   });
 
-  test("returns MATCH_NOT_FOUND when old_string is absent", () => {
+  test("returns MATCH_NOT_FOUND when old_string is absent", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "hello world");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "xyz",
       newString: "abc",
@@ -273,12 +277,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("MATCH_NOT_FOUND");
   });
 
-  test("returns MATCH_AMBIGUOUS when old_string matches multiple times", () => {
+  test("returns MATCH_AMBIGUOUS when old_string matches multiple times", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "foo bar foo baz foo");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "foo",
       newString: "qux",
@@ -291,12 +295,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("MATCH_AMBIGUOUS");
   });
 
-  test("replaces all occurrences when replaceAll is true", () => {
+  test("replaces all occurrences when replaceAll is true", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "foo bar foo baz foo");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "foo",
       newString: "qux",
@@ -312,12 +316,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.value.matchMethod).toBe("exact");
   });
 
-  test("performs a unique edit successfully", () => {
+  test("performs a unique edit successfully", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "one two three");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "two",
       newString: "TWO",
@@ -333,12 +337,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.value.filePath).toContain("file.txt");
   });
 
-  test("returns MATCH_NOT_FOUND for empty oldString", () => {
+  test("returns MATCH_NOT_FOUND for empty oldString", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "hello world");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "",
       newString: "injected",
@@ -351,12 +355,12 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("MATCH_NOT_FOUND");
   });
 
-  test("returns SIZE_LIMIT_EXCEEDED for oversized file on edit", () => {
+  test("returns SIZE_LIMIT_EXCEEDED for oversized file on edit", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "big.txt"), "x".repeat(200));
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "big.txt",
       oldString: "x",
       newString: "y",
@@ -369,11 +373,11 @@ describe("FileSystemOps.editFileSafe", () => {
     expect(result.error.code).toBe("SIZE_LIMIT_EXCEEDED");
   });
 
-  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", () => {
+  test("returns PATH_OUT_OF_BOUNDS for path outside sandbox", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "../../../etc/passwd",
       oldString: "root",
       newString: "toor",

--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -224,6 +224,38 @@ describe("FileSystemOps.writeFileSafe", () => {
 // ---------------------------------------------------------------------------
 
 describe("FileSystemOps.editFileSafe", () => {
+  test("concurrent edits of the same file both land", async () => {
+    const dir = makeTempDir();
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    writeFileSync(join(dir, "shared.txt"), "alpha\nbeta\n");
+
+    // Without per-path serialization, both edits read the same original
+    // content and the later write drops the earlier edit.
+    const [first, second] = await Promise.all([
+      ops.editFileSafe({
+        path: "shared.txt",
+        oldString: "alpha",
+        newString: "ALPHA",
+        replaceAll: false,
+      }),
+      ops.editFileSafe({
+        path: "shared.txt",
+        oldString: "beta",
+        newString: "BETA",
+        replaceAll: false,
+      }),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    const read = await ops.readFileSafe({ path: "shared.txt" });
+    expect(read.ok).toBe(true);
+    if (read.ok) {
+      expect(read.value.content).toContain("ALPHA");
+      expect(read.value.content).toContain("BETA");
+    }
+  });
+
   test("returns NOT_FOUND for nonexistent file", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));

--- a/assistant/src/__tests__/filesystem-tools.test.ts
+++ b/assistant/src/__tests__/filesystem-tools.test.ts
@@ -49,7 +49,7 @@ function sandboxPolicyFor(boundary: string): PathPolicy {
 // ===========================================================================
 
 describe("FileSystemOps symlink handling", () => {
-  test("read blocks symlink pointing outside boundary", () => {
+  test("read blocks symlink pointing outside boundary", async () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();
     const outsideFile = join(outside, "secret.txt");
@@ -58,7 +58,7 @@ describe("FileSystemOps symlink handling", () => {
     symlinkSync(outsideFile, join(boundary, "link.txt"));
     const ops = new FileSystemOps(sandboxPolicyFor(boundary));
 
-    const result = ops.readFileSafe({ path: "link.txt" });
+    const result = await ops.readFileSafe({ path: "link.txt" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -66,14 +66,14 @@ describe("FileSystemOps symlink handling", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("read allows symlink within boundary", () => {
+  test("read allows symlink within boundary", async () => {
     const boundary = makeTempDir();
     const realFile = join(boundary, "real.txt");
     writeFileSync(realFile, "hello");
     symlinkSync(realFile, join(boundary, "link.txt"));
 
     const ops = new FileSystemOps(sandboxPolicyFor(boundary));
-    const result = ops.readFileSafe({ path: "link.txt" });
+    const result = await ops.readFileSafe({ path: "link.txt" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -81,13 +81,13 @@ describe("FileSystemOps symlink handling", () => {
     expect(result.value.content).toContain("hello");
   });
 
-  test("write blocks creating file under symlinked dir pointing outside", () => {
+  test("write blocks creating file under symlinked dir pointing outside", async () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();
     symlinkSync(outside, join(boundary, "link-dir"));
 
     const ops = new FileSystemOps(sandboxPolicyFor(boundary));
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "link-dir/evil.txt",
       content: "bad",
     });
@@ -100,7 +100,7 @@ describe("FileSystemOps symlink handling", () => {
     expect(existsSync(join(outside, "evil.txt"))).toBe(false);
   });
 
-  test("edit blocks symlink pointing outside boundary", () => {
+  test("edit blocks symlink pointing outside boundary", async () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();
     const outsideFile = join(outside, "target.txt");
@@ -108,7 +108,7 @@ describe("FileSystemOps symlink handling", () => {
     symlinkSync(outsideFile, join(boundary, "link.txt"));
 
     const ops = new FileSystemOps(sandboxPolicyFor(boundary));
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "link.txt",
       oldString: "original",
       newString: "modified",
@@ -129,12 +129,12 @@ describe("FileSystemOps symlink handling", () => {
 // ===========================================================================
 
 describe("FileSystemOps read offset/limit edge cases", () => {
-  test("offset beyond file length returns empty content", () => {
+  test("offset beyond file length returns empty content", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "short.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "short.txt", offset: 100 });
+    const result = await ops.readFileSafe({ path: "short.txt", offset: 100 });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -142,12 +142,12 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).toBe("");
   });
 
-  test("limit of zero returns empty content", () => {
+  test("limit of zero returns empty content", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb\nc");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "file.txt", limit: 0 });
+    const result = await ops.readFileSafe({ path: "file.txt", limit: 0 });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -155,12 +155,16 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).toBe("");
   });
 
-  test("offset=1 reads from first line (1-indexed)", () => {
+  test("offset=1 reads from first line (1-indexed)", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "first\nsecond\nthird");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "file.txt", offset: 1, limit: 1 });
+    const result = await ops.readFileSafe({
+      path: "file.txt",
+      offset: 1,
+      limit: 1,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -169,12 +173,12 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).not.toContain("second");
   });
 
-  test("limit exceeding file length returns all remaining lines", () => {
+  test("limit exceeding file length returns all remaining lines", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({
+    const result = await ops.readFileSafe({
       path: "file.txt",
       offset: 1,
       limit: 1000,
@@ -187,12 +191,16 @@ describe("FileSystemOps read offset/limit edge cases", () => {
     expect(result.value.content).toContain("b");
   });
 
-  test("read adds line numbers starting from offset", () => {
+  test("read adds line numbers starting from offset", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "a\nb\nc\nd\ne");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "file.txt", offset: 3, limit: 2 });
+    const result = await ops.readFileSafe({
+      path: "file.txt",
+      offset: 3,
+      limit: 2,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -210,7 +218,7 @@ describe("FileSystemOps read offset/limit edge cases", () => {
 // ===========================================================================
 
 describe("FileSystemOps edit match methods", () => {
-  test("whitespace-normalized match succeeds", () => {
+  test("whitespace-normalized match succeeds", async () => {
     const dir = makeTempDir();
     writeFileSync(
       join(dir, "file.txt"),
@@ -218,7 +226,7 @@ describe("FileSystemOps edit match methods", () => {
     );
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "function foo() {\n  return 1;\n}",
       newString: "function bar() {\n  return 2;\n}",
@@ -233,12 +241,12 @@ describe("FileSystemOps edit match methods", () => {
     expect(result.value.newContent).toContain("bar");
   });
 
-  test("fuzzy match succeeds with near-match", () => {
+  test("fuzzy match succeeds with near-match", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "function fooo() {\n  return 1;\n}\n");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "function foo() {\n  return 1;\n}",
       newString: "function bar() {\n  return 2;\n}",
@@ -253,12 +261,12 @@ describe("FileSystemOps edit match methods", () => {
     expect(result.value.similarity).toBeLessThan(1);
   });
 
-  test("edit returns actualOld and actualNew for fuzzy match", () => {
+  test("edit returns actualOld and actualNew for fuzzy match", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "function fooo() {\n  return 1;\n}\n");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "file.txt",
       oldString: "function foo() {\n  return 1;\n}",
       newString: "function bar() {\n  return 2;\n}",
@@ -278,11 +286,14 @@ describe("FileSystemOps edit match methods", () => {
 // ===========================================================================
 
 describe("FileSystemOps write content tracking", () => {
-  test("new file has empty oldContent", () => {
+  test("new file has empty oldContent", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({ path: "brand-new.txt", content: "new" });
+    const result = await ops.writeFileSafe({
+      path: "brand-new.txt",
+      content: "new",
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -291,12 +302,12 @@ describe("FileSystemOps write content tracking", () => {
     expect(result.value.isNewFile).toBe(true);
   });
 
-  test("overwrite tracks oldContent and newContent", () => {
+  test("overwrite tracks oldContent and newContent", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "existing.txt"), "version 1");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "existing.txt",
       content: "version 2",
     });
@@ -309,11 +320,14 @@ describe("FileSystemOps write content tracking", () => {
     expect(result.value.isNewFile).toBe(false);
   });
 
-  test("write returns resolved absolute path", () => {
+  test("write returns resolved absolute path", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({ path: "output.txt", content: "data" });
+    const result = await ops.writeFileSafe({
+      path: "output.txt",
+      content: "data",
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -395,11 +409,11 @@ describe("formatWriteSummary", () => {
 // ===========================================================================
 
 describe("FileSystemOps path traversal prevention", () => {
-  test("rejects absolute path outside boundary on read", () => {
+  test("rejects absolute path outside boundary on read", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "/etc/passwd" });
+    const result = await ops.readFileSafe({ path: "/etc/passwd" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -407,11 +421,11 @@ describe("FileSystemOps path traversal prevention", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("rejects absolute path outside boundary on write", () => {
+  test("rejects absolute path outside boundary on write", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "/tmp/evil-write.txt",
       content: "bad",
     });
@@ -422,11 +436,11 @@ describe("FileSystemOps path traversal prevention", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("rejects absolute path outside boundary on edit", () => {
+  test("rejects absolute path outside boundary on edit", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "/etc/hosts",
       oldString: "a",
       newString: "b",
@@ -439,12 +453,12 @@ describe("FileSystemOps path traversal prevention", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("rejects dot-dot traversal embedded in path on read", () => {
+  test("rejects dot-dot traversal embedded in path on read", async () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "sub"));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "sub/../../etc/passwd" });
+    const result = await ops.readFileSafe({ path: "sub/../../etc/passwd" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -452,12 +466,12 @@ describe("FileSystemOps path traversal prevention", () => {
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 
-  test("accepts absolute path inside boundary", () => {
+  test("accepts absolute path inside boundary", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "inside.txt"), "safe content");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: join(dir, "inside.txt") });
+    const result = await ops.readFileSafe({ path: join(dir, "inside.txt") });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -471,13 +485,13 @@ describe("FileSystemOps path traversal prevention", () => {
 // ===========================================================================
 
 describe("FileSystemOps binary file read", () => {
-  test("reads binary content as utf-8 without crashing", () => {
+  test("reads binary content as utf-8 without crashing", async () => {
     const dir = makeTempDir();
     const binaryContent = Buffer.from([0x00, 0xff, 0x89, 0x50, 0x4e, 0x47]);
     writeFileSync(join(dir, "binary.bin"), binaryContent);
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "binary.bin" });
+    const result = await ops.readFileSafe({ path: "binary.bin" });
     // Should succeed — the file is readable, even if content has replacement chars
     expect(result.ok).toBe(true);
   });
@@ -488,12 +502,12 @@ describe("FileSystemOps binary file read", () => {
 // ===========================================================================
 
 describe("FileSystemOps empty file operations", () => {
-  test("reads empty file successfully", () => {
+  test("reads empty file successfully", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "empty.txt"), "");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "empty.txt" });
+    const result = await ops.readFileSafe({ path: "empty.txt" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -502,11 +516,11 @@ describe("FileSystemOps empty file operations", () => {
     expect(result.value.content).toBeDefined();
   });
 
-  test("write empty content creates empty file", () => {
+  test("write empty content creates empty file", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({ path: "empty.txt", content: "" });
+    const result = await ops.writeFileSafe({ path: "empty.txt", content: "" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -515,12 +529,12 @@ describe("FileSystemOps empty file operations", () => {
     expect(readFileSync(join(dir, "empty.txt"), "utf-8")).toBe("");
   });
 
-  test("edit on empty file returns MATCH_NOT_FOUND", () => {
+  test("edit on empty file returns MATCH_NOT_FOUND", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "empty.txt"), "");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "empty.txt",
       oldString: "something",
       newString: "else",
@@ -539,12 +553,12 @@ describe("FileSystemOps empty file operations", () => {
 // ===========================================================================
 
 describe("FileSystemOps /workspace path remapping", () => {
-  test("read remaps /workspace/ path to boundary", () => {
+  test("read remaps /workspace/ path to boundary", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "workspace content");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "/workspace/file.txt" });
+    const result = await ops.readFileSafe({ path: "/workspace/file.txt" });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
@@ -552,11 +566,11 @@ describe("FileSystemOps /workspace path remapping", () => {
     expect(result.value.content).toContain("workspace content");
   });
 
-  test("write remaps /workspace/ path to boundary", () => {
+  test("write remaps /workspace/ path to boundary", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "/workspace/new.txt",
       content: "remapped",
     });
@@ -568,12 +582,12 @@ describe("FileSystemOps /workspace path remapping", () => {
     expect(readFileSync(join(dir, "new.txt"), "utf-8")).toBe("remapped");
   });
 
-  test("edit remaps /workspace/ path to boundary", () => {
+  test("edit remaps /workspace/ path to boundary", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "old content");
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "/workspace/file.txt",
       oldString: "old content",
       newString: "new content",
@@ -587,11 +601,13 @@ describe("FileSystemOps /workspace path remapping", () => {
     expect(readFileSync(join(dir, "file.txt"), "utf-8")).toBe("new content");
   });
 
-  test("/workspace traversal escape is blocked", () => {
+  test("/workspace traversal escape is blocked", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "/workspace/../../../etc/passwd" });
+    const result = await ops.readFileSafe({
+      path: "/workspace/../../../etc/passwd",
+    });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -605,12 +621,12 @@ describe("FileSystemOps /workspace path remapping", () => {
 // ===========================================================================
 
 describe("FileSystemOps custom size limit", () => {
-  test("read rejects file exceeding custom limit", () => {
+  test("read rejects file exceeding custom limit", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "big.txt"), "x".repeat(500));
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
 
-    const result = ops.readFileSafe({ path: "big.txt" });
+    const result = await ops.readFileSafe({ path: "big.txt" });
     expect(result.ok).toBe(false);
     if (result.ok) {
       return;
@@ -618,20 +634,20 @@ describe("FileSystemOps custom size limit", () => {
     expect(result.error.code).toBe("SIZE_LIMIT_EXCEEDED");
   });
 
-  test("read accepts file within custom limit", () => {
+  test("read accepts file within custom limit", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "small.txt"), "x".repeat(50));
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
 
-    const result = ops.readFileSafe({ path: "small.txt" });
+    const result = await ops.readFileSafe({ path: "small.txt" });
     expect(result.ok).toBe(true);
   });
 
-  test("write rejects content exceeding custom limit", () => {
+  test("write rejects content exceeding custom limit", async () => {
     const dir = makeTempDir();
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
 
-    const result = ops.writeFileSafe({
+    const result = await ops.writeFileSafe({
       path: "big.txt",
       content: "x".repeat(500),
     });
@@ -642,12 +658,12 @@ describe("FileSystemOps custom size limit", () => {
     expect(result.error.code).toBe("SIZE_LIMIT_EXCEEDED");
   });
 
-  test("edit rejects file exceeding custom limit", () => {
+  test("edit rejects file exceeding custom limit", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "big.txt"), "x".repeat(500));
     const ops = new FileSystemOps(sandboxPolicyFor(dir), { sizeLimit: 100 });
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: "big.txt",
       oldString: "x",
       newString: "y",
@@ -660,12 +676,12 @@ describe("FileSystemOps custom size limit", () => {
     expect(result.error.code).toBe("SIZE_LIMIT_EXCEEDED");
   });
 
-  test("no size limit when not specified (defaults to 100MB)", () => {
+  test("no size limit when not specified (defaults to 100MB)", async () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, "file.txt"), "x".repeat(1000));
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
 
-    const result = ops.readFileSafe({ path: "file.txt" });
+    const result = await ops.readFileSafe({ path: "file.txt" });
     expect(result.ok).toBe(true);
   });
 });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -151,7 +151,7 @@ afterEach(() => {
 describe("identity routes — health endpoint", () => {
   describe("backward compatibility (profiler disabled)", () => {
     test("/v1/health returns expected shape without profiler key when env vars are absent", async () => {
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       expect(res.status).toBe(200);
 
       const body = (await res.json()) as Record<string, unknown>;
@@ -179,7 +179,7 @@ describe("identity routes — health endpoint", () => {
 
     test("/v1/healthz returns the same shape as /v1/health", async () => {
       // Both endpoints call handleDetailedHealth, so the shape must match
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
 
       expect(body.status).toBe("healthy");
@@ -188,7 +188,7 @@ describe("identity routes — health endpoint", () => {
     });
 
     test("includes ces.connected=false when no CES client is registered", async () => {
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
 
       expect(body.ces).toBeDefined();
@@ -197,7 +197,7 @@ describe("identity routes — health endpoint", () => {
 
     test("detailed health reports MIGRATING while DB migrations are running", async () => {
       setDbMigrating();
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       expect(res.status).toBe(200);
 
       const body = (await res.json()) as Record<string, unknown>;
@@ -229,7 +229,7 @@ describe("identity routes — health endpoint", () => {
         close: () => {},
       } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
 
       expect(body.ces).toBeDefined();
@@ -242,7 +242,7 @@ describe("identity routes — health endpoint", () => {
         close: () => {},
       } as unknown as import("../credential-execution/client.js").CesClient;
       setCesClient(mockClient);
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
 
       expect(body.ces).toBeDefined();
@@ -258,7 +258,7 @@ describe("identity routes — health endpoint", () => {
       });
       ensureProfilerRunDir("run-health-test-1");
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
 
       expect(body.profiler).toBeDefined();
@@ -278,7 +278,7 @@ describe("identity routes — health endpoint", () => {
       });
       ensureProfilerRunDir("run-budget-test");
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
       const budget = profiler.budget as Record<string, unknown>;
@@ -301,7 +301,7 @@ describe("identity routes — health endpoint", () => {
       // Non-artifact file should not count
       writeArtifactFile("run-artifact-count", "log.txt", 512);
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
 
@@ -316,7 +316,7 @@ describe("identity routes — health endpoint", () => {
       // Write a file larger than the budget
       writeArtifactFile("run-over-budget", "big.cpuprofile", 5000);
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
       const budget = profiler.budget as Record<string, unknown>;
@@ -334,7 +334,7 @@ describe("identity routes — health endpoint", () => {
       });
       ensureProfilerRunDir("run-no-completed");
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
 
@@ -361,7 +361,7 @@ describe("identity routes — health endpoint", () => {
       writeArtifactFile(completedId, "profile.cpuprofile", 3072);
       writeArtifactFile(completedId, "summary.md", 256);
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
       const last = profiler.lastCompletedRun as Record<string, unknown>;
@@ -398,7 +398,7 @@ describe("identity routes — health endpoint", () => {
       });
       writeArtifactFile("newer-completed", "new.heapsnapshot", 1024);
 
-      const res = handleDetailedHealth();
+      const res = await handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;
       const profiler = body.profiler as Record<string, unknown>;
       const last = profiler.lastCompletedRun as Record<string, unknown>;

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -132,17 +132,17 @@ describe("sniffImageMimeType", () => {
 });
 
 describe("normalizeImageBytes passthrough", () => {
-  test("non-HEIF bytes pass through untouched", () => {
-    const result = normalizeImageBytes("image/png", PNG_1PX_BYTES);
+  test("non-HEIF bytes pass through untouched", async () => {
+    const result = await normalizeImageBytes("image/png", PNG_1PX_BYTES);
     expect(result.converted).toBe(false);
     expect(result.mimeType).toBe("image/png");
     expect(result.bytes).toBe(PNG_1PX_BYTES);
   });
 
-  test("HEIF header with undecodable payload passes through", () => {
+  test("HEIF header with undecodable payload passes through", async () => {
     // sips fails (or is absent off-macOS) → the original bytes are kept.
     const fake = fakeHeifHeaderBytes();
-    const result = normalizeImageBytes("image/heic", fake);
+    const result = await normalizeImageBytes("image/heic", fake);
     expect(result.converted).toBe(false);
     expect(result.mimeType).toBe("image/heic");
     expect(result.bytes).toBe(fake);
@@ -150,35 +150,35 @@ describe("normalizeImageBytes passthrough", () => {
 });
 
 describe("normalizeImageBase64 passthrough", () => {
-  test("non-HEIF payloads skip conversion", () => {
+  test("non-HEIF payloads skip conversion", async () => {
     const b64 = PNG_1PX_BYTES.toString("base64");
-    const result = normalizeImageBase64("image/png", b64);
+    const result = await normalizeImageBase64("image/png", b64);
     expect(result.converted).toBe(false);
     expect(result.dataBase64).toBe(b64);
   });
 });
 
 describe("declared-MIME correction from sniffed bytes", () => {
-  test("normalizeImageBytes relabels a mislabeled image, bytes untouched", () => {
+  test("normalizeImageBytes relabels a mislabeled image, bytes untouched", async () => {
     // A JPEG renamed to .png arrives declared as image/png; providers reject
     // the mismatch, so the sniffed format wins.
-    const result = normalizeImageBytes("image/png", JPEG_HEADER_BYTES);
+    const result = await normalizeImageBytes("image/png", JPEG_HEADER_BYTES);
     expect(result.converted).toBe(false);
     expect(result.mimeType).toBe("image/jpeg");
     expect(result.bytes).toBe(JPEG_HEADER_BYTES);
   });
 
-  test("normalizeImageBase64 relabels a mislabeled image, payload untouched", () => {
+  test("normalizeImageBase64 relabels a mislabeled image, payload untouched", async () => {
     const b64 = PNG_1PX_BYTES.toString("base64");
-    const result = normalizeImageBase64("image/jpeg", b64);
+    const result = await normalizeImageBase64("image/jpeg", b64);
     expect(result.converted).toBe(false);
     expect(result.mimeType).toBe("image/png");
     expect(result.dataBase64).toBe(b64);
   });
 
-  test("unrecognized bytes keep the declared MIME", () => {
+  test("unrecognized bytes keep the declared MIME", async () => {
     const bytes = Buffer.from("plain text content");
-    const result = normalizeImageBytes("text/plain", bytes);
+    const result = await normalizeImageBytes("text/plain", bytes);
     expect(result.mimeType).toBe("text/plain");
     expect(result.bytes).toBe(bytes);
   });
@@ -201,17 +201,17 @@ describe.skipIf(process.platform !== "darwin")(
       expect(isHeifImage(heicBytes)).toBe(true);
     });
 
-    test("convertImageToJpeg produces JPEG bytes", () => {
-      const converted = convertImageToJpeg(heicBytes);
+    test("convertImageToJpeg produces JPEG bytes", async () => {
+      const converted = await convertImageToJpeg(heicBytes);
       expect(converted).not.toBeNull();
       expect(startsWithJpegMagic(converted!)).toBe(true);
     });
 
-    test("conversion options produce distinct outputs (cache key isolation)", () => {
+    test("conversion options produce distinct outputs (cache key isolation)", async () => {
       // A hash-only cache key would make the second call return the first
       // call's cached full-resolution output.
-      const fullRes = convertImageToJpeg(heicBytes, { quality: 90 });
-      const downscaled = convertImageToJpeg(heicBytes, {
+      const fullRes = await convertImageToJpeg(heicBytes, { quality: 90 });
+      const downscaled = await convertImageToJpeg(heicBytes, {
         maxDimensionPx: 16,
         quality: 90,
       });
@@ -220,31 +220,34 @@ describe.skipIf(process.platform !== "darwin")(
       expect(fullRes!.equals(downscaled!)).toBe(false);
     });
 
-    test("repeated conversion is stable (cache round-trip)", () => {
-      const first = convertImageToJpeg(heicBytes, { quality: 90 });
-      const second = convertImageToJpeg(heicBytes, { quality: 90 });
+    test("repeated conversion is stable (cache round-trip)", async () => {
+      const first = await convertImageToJpeg(heicBytes, { quality: 90 });
+      const second = await convertImageToJpeg(heicBytes, { quality: 90 });
       expect(first).not.toBeNull();
       expect(second).not.toBeNull();
       expect(first!.equals(second!)).toBe(true);
     });
 
-    test("normalizeImageBytes converts to a JPEG master", () => {
-      const result = normalizeImageBytes("image/heic", heicBytes);
+    test("normalizeImageBytes converts to a JPEG master", async () => {
+      const result = await normalizeImageBytes("image/heic", heicBytes);
       expect(result.converted).toBe(true);
       expect(result.mimeType).toBe("image/jpeg");
       expect(startsWithJpegMagic(result.bytes)).toBe(true);
     });
 
-    test("normalizeImageBytes converts even when the declared mime is wrong", () => {
+    test("normalizeImageBytes converts even when the declared mime is wrong", async () => {
       // Chromium reports empty file.type for .heic; clients coerce it to
       // application/octet-stream. Detection is content-based.
-      const result = normalizeImageBytes("application/octet-stream", heicBytes);
+      const result = await normalizeImageBytes(
+        "application/octet-stream",
+        heicBytes,
+      );
       expect(result.converted).toBe(true);
       expect(result.mimeType).toBe("image/jpeg");
     });
 
-    test("normalizeImageBase64 converts and re-encodes", () => {
-      const result = normalizeImageBase64(
+    test("normalizeImageBase64 converts and re-encodes", async () => {
+      const result = await normalizeImageBase64(
         "image/heic",
         heicBytes.toString("base64"),
       );

--- a/assistant/src/__tests__/image-source-path-reinject.test.ts
+++ b/assistant/src/__tests__/image-source-path-reinject.test.ts
@@ -233,7 +233,7 @@ describe("reinjectAttachmentPathAnnotations", () => {
     );
   });
 
-  test("rebuilds the exact annotation block enrichMessageWithSourcePaths appends", () => {
+  test("rebuilds the exact annotation block enrichMessageWithSourcePaths appends", async () => {
     // Prefix-cache parity tripwire: the block appended at persist time (from
     // live attachment inputs) and the block rebuilt on history reload (from
     // persisted metadata) must be byte-identical.
@@ -253,7 +253,7 @@ describe("reinjectAttachmentPathAnnotations", () => {
       },
     ];
     const enriched = enrichMessageWithSourcePaths(
-      createUserMessage("compare", attachments),
+      await createUserMessage("compare", attachments),
       attachments,
     );
     const liveBlock = enriched.content.at(-1) as {

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -103,10 +103,14 @@ describe("handleListMessages attachments", () => {
       "user",
       JSON.stringify([{ type: "text", text: "check this image" }]),
     );
-    const stored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
+    const stored = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
@@ -124,14 +128,14 @@ describe("handleListMessages attachments", () => {
       "user",
       JSON.stringify([{ type: "text", text: "check this doc" }]),
     );
-    const stored = uploadAttachment(
+    const stored = await uploadAttachment(
       "report.pdf",
       "application/pdf",
       DOC_BASE64,
     );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
@@ -150,10 +154,14 @@ describe("handleListMessages attachments", () => {
       "assistant",
       JSON.stringify([{ type: "text", text: "here is an image" }]),
     );
-    const stored = uploadAttachment("result.png", "image/png", IMAGE_BASE64);
+    const stored = await uploadAttachment(
+      "result.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
@@ -172,8 +180,12 @@ describe("handleListMessages attachments", () => {
       "user",
       JSON.stringify([{ type: "text", text: "here are files" }]),
     );
-    const imgStored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
-    const docStored = uploadAttachment(
+    const imgStored = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
+    const docStored = await uploadAttachment(
       "doc.pdf",
       "application/pdf",
       DOC_BASE64,
@@ -181,7 +193,7 @@ describe("handleListMessages attachments", () => {
     linkAttachmentToMessage(msg.id, imgStored.id, 0);
     linkAttachmentToMessage(msg.id, docStored.id, 1);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     const attachments = body.messages[0].attachments!;
@@ -200,7 +212,11 @@ describe("handleListMessages attachments", () => {
     // duplicating it doubles every image in the response and in client
     // memory.
     const conv = createConversation();
-    const stored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
+    const stored = await uploadAttachment(
+      "photo.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
     const msg = await addMessage(
       conv.id,
       "user",
@@ -216,7 +232,7 @@ describe("handleListMessages attachments", () => {
     );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: {
         attachments?: AttachmentPayload[];
@@ -257,10 +273,14 @@ describe("handleListMessages attachments", () => {
       "assistant",
       JSON.stringify([{ type: "text", text: "" }]),
     );
-    const stored = uploadAttachment("output.png", "image/png", IMAGE_BASE64);
+    const stored = await uploadAttachment(
+      "output.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: {
         attachments?: AttachmentPayload[];
@@ -294,10 +314,14 @@ describe("handleListMessages attachments", () => {
       "assistant",
       JSON.stringify([{ type: "text", text: "" }]),
     );
-    const stored = uploadAttachment("output.png", "image/png", IMAGE_BASE64);
+    const stored = await uploadAttachment(
+      "output.png",
+      "image/png",
+      IMAGE_BASE64,
+    );
     linkAttachmentToMessage(msg.id, stored.id, 0);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: {
         attachments?: AttachmentPayload[];
@@ -335,7 +359,7 @@ describe("handleListMessages HEIC display normalization", () => {
     const heicB64 = fakeHeifHeaderBytes().toString("base64");
     insertLegacyAttachmentRow(msg.id, "IMG_1.HEIC", "image/heic", heicB64);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     const attachments = body.messages[0].attachments!;
@@ -364,7 +388,7 @@ describe("handleListMessages HEIC display normalization", () => {
       "document",
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     const attachments = body.messages[0].attachments!;
@@ -394,7 +418,7 @@ describe("handleListMessages HEIC display normalization", () => {
           heic!.toString("base64"),
         );
 
-        const response = handleListMessages(createTestArgs(conv.id));
+        const response = await handleListMessages(createTestArgs(conv.id));
         const body = response as { messages: MessagePayload[] };
 
         const attachments = body.messages[0].attachments!;
@@ -428,7 +452,7 @@ describe("handleListMessages HEIC display normalization", () => {
           "document",
         );
 
-        const response = handleListMessages(createTestArgs(conv.id));
+        const response = await handleListMessages(createTestArgs(conv.id));
         const body = response as { messages: MessagePayload[] };
 
         const attachments = body.messages[0].attachments!;
@@ -455,7 +479,7 @@ describe("handleListMessages no_response filtering", () => {
       JSON.stringify([{ type: "text", text: "<no_response/>" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: { textSegments?: string[] }[];
     };
@@ -476,7 +500,7 @@ describe("handleListMessages no_response filtering", () => {
       ]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: { textSegments?: string[] }[];
     };
@@ -504,7 +528,7 @@ describe("handleListMessages no_response filtering", () => {
       ]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: {
         textSegments: string[];
@@ -527,7 +551,7 @@ describe("handleListMessages no_response filtering", () => {
       JSON.stringify([{ type: "text", text: "What does <no_response/> do?" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as {
       messages: { textSegments?: string[] }[];
     };
@@ -588,7 +612,7 @@ describe("handleListMessages pagination", () => {
     const conv = createConversation();
     await insertMessages(conv.id, 5);
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as unknown as PaginatedResponse;
 
     expect(body.messages).toHaveLength(5);
@@ -602,7 +626,7 @@ describe("handleListMessages pagination", () => {
     await insertMessages(conv.id, 5);
 
     const args = createPaginatedArgs(conv.id, { limit: "3" });
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     // Option A: without beforeTimestamp, all messages are returned regardless of limit
@@ -619,7 +643,7 @@ describe("handleListMessages pagination", () => {
       beforeTimestamp: String(msgs[7].createdAt),
       limit: "3",
     });
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     expect(body.messages).toHaveLength(3);
@@ -640,7 +664,7 @@ describe("handleListMessages pagination", () => {
       beforeTimestamp: String(msgs[1].createdAt),
       limit: "10",
     });
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     const ids = body.messages.map((m) => m.id);
@@ -658,7 +682,7 @@ describe("handleListMessages pagination", () => {
       beforeTimestamp: String(msgs[4].createdAt + 1),
       limit: "10",
     });
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     expect(body.messages).toHaveLength(5);
@@ -674,7 +698,7 @@ describe("handleListMessages pagination", () => {
       beforeTimestamp: String(msgs[4].createdAt + 1),
       limit: "3",
     });
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     expect(body.messages).toHaveLength(3);
@@ -685,7 +709,7 @@ describe("handleListMessages pagination", () => {
 
   test("empty / nonexistent conversation → empty messages, no pagination metadata", async () => {
     const args = createPaginatedArgs("nonexistent-conv-id");
-    const response = handleListMessages(args);
+    const response = await handleListMessages(args);
     const body = response as unknown as PaginatedResponse;
 
     expect(body.messages).toEqual([]);

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -722,7 +722,7 @@ describe("handleListMessages pagination", () => {
     const conv = createConversation();
     const args = createPaginatedArgs(conv.id, { limit: "abc" });
 
-    expect(() => handleListMessages(args)).toThrow(
+    await expect(handleListMessages(args)).rejects.toThrow(
       "limit must be a valid number",
     );
   });
@@ -731,7 +731,7 @@ describe("handleListMessages pagination", () => {
     const conv = createConversation();
     const args = createPaginatedArgs(conv.id, { beforeTimestamp: "abc" });
 
-    expect(() => handleListMessages(args)).toThrow(
+    await expect(handleListMessages(args)).rejects.toThrow(
       "beforeTimestamp must be a valid number",
     );
   });

--- a/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
+++ b/assistant/src/__tests__/list-messages-background-tool-completion.test.ts
@@ -85,9 +85,9 @@ describe("handleListMessages background-tool completion projection", () => {
       },
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     // Every projected message validates against the wire schema.
     for (const message of response.messages) {
@@ -115,9 +115,9 @@ describe("handleListMessages background-tool completion projection", () => {
       JSON.stringify([{ type: "text", text: "hi there" }]),
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     expect(response.messages).toHaveLength(2);
     for (const message of response.messages) {

--- a/assistant/src/__tests__/list-messages-client-message-id.test.ts
+++ b/assistant/src/__tests__/list-messages-client-message-id.test.ts
@@ -48,7 +48,7 @@ describe("handleListMessages clientMessageId", () => {
     );
 
     // WHEN the messages snapshot is built
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -70,7 +70,7 @@ describe("handleListMessages clientMessageId", () => {
     );
 
     // WHEN the messages snapshot is built
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };

--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -70,7 +70,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
       JSON.stringify([{ type: "text", text: "second visible" }]),
     );
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -109,7 +109,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
     );
 
     // WHEN the UI history list is serialized
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -140,7 +140,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
       { metadata: { hidden: false } },
     );
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -177,9 +177,9 @@ describe("handleListMessages metadata.hidden filtering", () => {
       );
     }
 
-    const latest = handleListMessages({
+    const latest = (await handleListMessages({
       queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
-    }) as {
+    })) as {
       messages: MessagePayload[];
       hasMore: boolean;
       oldestTimestamp: number | null;
@@ -196,13 +196,13 @@ describe("handleListMessages metadata.hidden filtering", () => {
 
     // Older page request — anchored before the latest page's oldest row —
     // should skip the hidden block entirely and return the next 2 visible rows.
-    const older = handleListMessages({
+    const older = (await handleListMessages({
       queryParams: {
         conversationId: conv.id,
         beforeTimestamp: String(latest.oldestTimestamp),
         limit: "2",
       },
-    }) as {
+    })) as {
       messages: MessagePayload[];
       hasMore: boolean;
     };
@@ -214,7 +214,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
     expect(older.hasMore).toBe(true);
   });
 
-  test("pagination keeps hasMore + a cursor when a >cap hidden block truncates the scan", () => {
+  test("pagination keeps hasMore + a cursor when a >cap hidden block truncates the scan", async () => {
     // Exercise cap-truncation with a small cap + a few hundred rows rather than
     // >10k: the large seed made the post-test resetTables DELETE slow enough to
     // time out the next test's beforeEach under parallel CI load.
@@ -258,9 +258,9 @@ describe("handleListMessages metadata.hidden filtering", () => {
         }
       });
 
-      const latest = handleListMessages({
+      const latest = (await handleListMessages({
         queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
-      }) as {
+      })) as {
         messages: MessagePayload[];
         hasMore: boolean;
         oldestTimestamp: number | null;
@@ -274,13 +274,13 @@ describe("handleListMessages metadata.hidden filtering", () => {
 
       // Resuming from the surfaced cursor drains the remaining hidden rows and
       // surfaces the visible ones below the cap.
-      const older = handleListMessages({
+      const older = (await handleListMessages({
         queryParams: {
           conversationId: conv.id,
           beforeTimestamp: String(latest.oldestTimestamp),
           limit: "2",
         },
-      }) as { messages: MessagePayload[]; hasMore: boolean };
+      })) as { messages: MessagePayload[]; hasMore: boolean };
 
       expect(older.messages.map(plainText)).toEqual(["visible 0", "visible 1"]);
       expect(older.hasMore).toBe(false);
@@ -311,9 +311,9 @@ describe("handleListMessages metadata.hidden filtering", () => {
       );
     }
 
-    const latest = handleListMessages({
+    const latest = (await handleListMessages({
       queryParams: { conversationId: conv.id, page: "latest", limit: "2" },
-    }) as {
+    })) as {
       messages: MessagePayload[];
       hasMore: boolean;
       oldestTimestamp: number | null;
@@ -357,7 +357,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
       JSON.stringify([{ type: "text", text: "retrospective review" }]),
     );
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -405,7 +405,7 @@ describe("handleListMessages metadata.hidden filtering", () => {
       JSON.stringify([{ type: "text", text: "retrospective review" }]),
     );
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -617,16 +617,16 @@ describe("handleListMessages page=latest", () => {
   test("page=invalid throws BadRequestError", async () => {
     const conv = createConversation();
 
-    expect(() =>
+    await expect(
       handleListMessages({
         queryParams: { conversationId: conv.id, page: "invalid" },
       }),
-    ).toThrow(BadRequestError);
-    expect(() =>
+    ).rejects.toThrow(BadRequestError);
+    await expect(
       handleListMessages({
         queryParams: { conversationId: conv.id, page: "invalid" },
       }),
-    ).toThrow("page must be 'latest' when provided");
+    ).rejects.toThrow("page must be 'latest' when provided");
   });
 
   test("no-param GET returns full history without pagination metadata", async () => {

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -134,10 +134,10 @@ function advanceGlobalSeq(count: number): void {
   }
 }
 
-function callList(query: Record<string, string>): ListResponse {
-  return handleListMessages({
+async function callList(query: Record<string, string>): Promise<ListResponse> {
+  return (await handleListMessages({
     queryParams: query,
-  }) as unknown as ListResponse;
+  })) as unknown as ListResponse;
 }
 
 describe("handleListMessages page=latest", () => {
@@ -148,7 +148,7 @@ describe("handleListMessages page=latest", () => {
   });
 
   describe("persisted seq", () => {
-    test("getMaxPersistedConversationSeq reports the highest anchor across conversations", () => {
+    test("getMaxPersistedConversationSeq reports the highest anchor across conversations", async () => {
       /**
        * The startup seq floor resumes issuance above this value, so it
        * must reflect the highest anchor any conversation has served.
@@ -161,7 +161,7 @@ describe("handleListMessages page=latest", () => {
       expect(getMaxPersistedConversationSeq()).toBe(907779);
     });
 
-    test("returns the recorded persisted seq for the conversation", () => {
+    test("returns the recorded persisted seq for the conversation", async () => {
       /**
        * The snapshot must advertise the `seq` of the last durably-persisted
        * event so a client can align it with the `/events` stream.
@@ -174,13 +174,13 @@ describe("handleListMessages page=latest", () => {
       recordConversationPersistedSeq(conv.id, 42);
 
       // WHEN the snapshot is fetched
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN the response carries that seq
       expect(body.seq).toBe(42);
     });
 
-    test("returns null seq when nothing has been persisted in-process", () => {
+    test("returns null seq when nothing has been persisted in-process", async () => {
       /**
        * A cold conversation (or one aged out / post-restart) reports no seq,
        * signalling the client to cold-start rather than align to a stale
@@ -192,13 +192,13 @@ describe("handleListMessages page=latest", () => {
       seedMessages(conv.id, 2);
 
       // WHEN the snapshot is fetched
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN seq is null
       expect(body.seq).toBeNull();
     });
 
-    test("the no-pagination path also returns the persisted seq", () => {
+    test("the no-pagination path also returns the persisted seq", async () => {
       /** `seq` is present on every resolved-conversation response shape. */
 
       // GIVEN a conversation with a recorded persisted seq
@@ -207,13 +207,13 @@ describe("handleListMessages page=latest", () => {
       recordConversationPersistedSeq(conv.id, 7);
 
       // WHEN fetched with no pagination params
-      const body = callList({ conversationId: conv.id });
+      const body = await callList({ conversationId: conv.id });
 
       // THEN the seq still rides along
       expect(body.seq).toBe(7);
     });
 
-    test("recording advances the seq monotonically and never regresses", () => {
+    test("recording advances the seq monotonically and never regresses", async () => {
       /**
        * Out-of-order async commits must not lower the high-water mark — the
        * `WHERE seq < ?` guard on the persist UPDATE keeps it monotonic.
@@ -227,14 +227,14 @@ describe("handleListMessages page=latest", () => {
       recordConversationPersistedSeq(conv.id, 8);
 
       // THEN the high-water seq is unchanged
-      expect(callList({ conversationId: conv.id }).seq).toBe(12);
+      expect((await callList({ conversationId: conv.id })).seq).toBe(12);
 
       // AND a higher seq still advances it
       recordConversationPersistedSeq(conv.id, 20);
-      expect(callList({ conversationId: conv.id }).seq).toBe(20);
+      expect((await callList({ conversationId: conv.id })).seq).toBe(20);
     });
 
-    test("recording ignores non-positive and non-finite seq values", () => {
+    test("recording ignores non-positive and non-finite seq values", async () => {
       // GIVEN a freshly created conversation (no stream activity → null seed)
       const conv = createConversation();
 
@@ -245,10 +245,10 @@ describe("handleListMessages page=latest", () => {
       recordConversationPersistedSeq(conv.id, Number.POSITIVE_INFINITY);
 
       // THEN none take effect and seq stays null
-      expect(callList({ conversationId: conv.id }).seq).toBeNull();
+      expect((await callList({ conversationId: conv.id })).seq).toBeNull();
     });
 
-    test("a freshly created conversation is anchored to the current global seq", () => {
+    test("a freshly created conversation is anchored to the current global seq", async () => {
       /**
        * Conversations created after some stream activity must not report a
        * null `seq` — that would force the client to cold-start with no
@@ -262,13 +262,13 @@ describe("handleListMessages page=latest", () => {
 
       // WHEN a brand-new conversation is created and its snapshot fetched
       const conv = createConversation();
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN the snapshot is anchored to the global seq at creation time
       expect(body.seq).toBe(5);
     });
 
-    test("a conversation created before any stream activity stays null", () => {
+    test("a conversation created before any stream activity stays null", async () => {
       /**
        * With nothing stamped this process, `getCurrentSeq()` is 0 and the
        * creation seed stores NULL (non-positive seqs aren't recorded), so the
@@ -280,7 +280,7 @@ describe("handleListMessages page=latest", () => {
 
       // WHEN a conversation is created and its snapshot fetched
       const conv = createConversation();
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN seq remains null
       expect(body.seq).toBeNull();
@@ -288,7 +288,7 @@ describe("handleListMessages page=latest", () => {
   });
 
   describe("processing state", () => {
-    test("reports processing=true while the conversation is mid-turn", () => {
+    test("reports processing=true while the conversation is mid-turn", async () => {
       /**
        * The authoritative processing flag lets a client recover from a
        * dropped stream: it can ask the server whether a turn is still
@@ -301,25 +301,25 @@ describe("handleListMessages page=latest", () => {
       setConversationProcessingStartedAt(conv.id, Date.now());
 
       // WHEN the snapshot is fetched
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN it reports the conversation is processing
       expect(body.processing).toBe(true);
     });
 
-    test("reports processing=false when the conversation is idle", () => {
+    test("reports processing=false when the conversation is idle", async () => {
       // GIVEN an idle conversation (processing_started_at is null)
       const conv = createConversation();
       seedMessages(conv.id, 2);
 
       // WHEN the snapshot is fetched
-      const body = callList({ conversationId: conv.id, page: "latest" });
+      const body = await callList({ conversationId: conv.id, page: "latest" });
 
       // THEN it reports the conversation is not processing
       expect(body.processing).toBe(false);
     });
 
-    test("the no-pagination path also reports processing state", () => {
+    test("the no-pagination path also reports processing state", async () => {
       /** `processing` is present on every resolved-conversation shape. */
 
       // GIVEN a processing conversation
@@ -328,15 +328,15 @@ describe("handleListMessages page=latest", () => {
       setConversationProcessingStartedAt(conv.id, Date.now());
 
       // WHEN fetched with no pagination params
-      const body = callList({ conversationId: conv.id });
+      const body = await callList({ conversationId: conv.id });
 
       // THEN processing rides along
       expect(body.processing).toBe(true);
     });
 
-    test("an unresolved conversationKey reports processing=false (page=latest)", () => {
+    test("an unresolved conversationKey reports processing=false (page=latest)", async () => {
       // WHEN a never-created key is fetched with the stable contract
-      const body = callList({
+      const body = await callList({
         conversationKey: "no-such-key",
         page: "latest",
       });
@@ -346,11 +346,11 @@ describe("handleListMessages page=latest", () => {
     });
   });
 
-  test("page=latest with no limit returns all messages chronologically", () => {
+  test("page=latest with no limit returns all messages chronologically", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 120);
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages).toHaveLength(120);
     expect(body.messages[0].id).toBe("msg-1");
@@ -360,11 +360,11 @@ describe("handleListMessages page=latest", () => {
     expect(body.oldestMessageId).toBe("msg-1");
   });
 
-  test("page=latest&limit=50 with 120 seeded messages returns newest 50 chronologically", () => {
+  test("page=latest&limit=50 with 120 seeded messages returns newest 50 chronologically", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 120);
 
-    const body = callList({
+    const body = await callList({
       conversationId: conv.id,
       page: "latest",
       limit: "50",
@@ -379,11 +379,11 @@ describe("handleListMessages page=latest", () => {
     expect(body.oldestMessageId).toBe("msg-71");
   });
 
-  test("page=latest&limit=50 with 10 seeded messages returns all 10 with hasMore=false", () => {
+  test("page=latest&limit=50 with 10 seeded messages returns all 10 with hasMore=false", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 10);
 
-    const body = callList({
+    const body = await callList({
       conversationId: conv.id,
       page: "latest",
       limit: "50",
@@ -397,20 +397,20 @@ describe("handleListMessages page=latest", () => {
     expect(body.oldestMessageId).toBe("msg-1");
   });
 
-  test("beforeTimestamp wins when combined with page=latest", () => {
+  test("beforeTimestamp wins when combined with page=latest", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 120);
 
     // beforeTimestamp=100 + limit=50 should return msgs 50..99 (the 50 messages
     // immediately older than ts=100), regardless of the page=latest signal.
-    const combinedBody = callList({
+    const combinedBody = await callList({
       conversationId: conv.id,
       page: "latest",
       limit: "50",
       beforeTimestamp: "100",
     });
 
-    const beforeOnlyBody = callList({
+    const beforeOnlyBody = await callList({
       conversationId: conv.id,
       limit: "50",
       beforeTimestamp: "100",
@@ -428,10 +428,10 @@ describe("handleListMessages page=latest", () => {
     expect(combinedBody.messages[49].id).toBe("msg-99");
   });
 
-  test("page=latest on empty conversation returns null pagination metadata", () => {
+  test("page=latest on empty conversation returns null pagination metadata", async () => {
     const conv = createConversation();
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages).toEqual([]);
     expect(body.hasMore).toBe(false);
@@ -439,7 +439,7 @@ describe("handleListMessages page=latest", () => {
     expect(body.oldestMessageId).toBeNull();
   });
 
-  test("messages expose Slack message and thread links from slackMeta", () => {
+  test("messages expose Slack message and thread links from slackMeta", async () => {
     const conv = createConversation();
     const db = getDb();
     db.insert(messages)
@@ -464,7 +464,7 @@ describe("handleListMessages page=latest", () => {
       })
       .run();
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages[0].slackMessage).toEqual({
       channelId: "C123ABCDEF",
@@ -491,7 +491,7 @@ describe("handleListMessages page=latest", () => {
     });
   });
 
-  test("top-level Slack messages with matching threadTs use plain permalinks", () => {
+  test("top-level Slack messages with matching threadTs use plain permalinks", async () => {
     const conv = createConversation();
     const db = getDb();
     db.insert(messages)
@@ -516,7 +516,7 @@ describe("handleListMessages page=latest", () => {
       })
       .run();
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages[0].slackMessage).toEqual({
       channelId: "C123ABCDEF",
@@ -537,7 +537,7 @@ describe("handleListMessages page=latest", () => {
     });
   });
 
-  test("assistant Slack messages without stored sender use the assistant name", () => {
+  test("assistant Slack messages without stored sender use the assistant name", async () => {
     mockAssistantName = "Nova";
     const conv = createConversation();
     const db = getDb();
@@ -559,14 +559,14 @@ describe("handleListMessages page=latest", () => {
       })
       .run();
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages[0].slackMessage?.sender).toEqual({
       displayName: "Nova",
     });
   });
 
-  test("user Slack messages without stored sender do not use the assistant name", () => {
+  test("user Slack messages without stored sender do not use the assistant name", async () => {
     mockAssistantName = "Nova";
     const conv = createConversation();
     const db = getDb();
@@ -588,13 +588,13 @@ describe("handleListMessages page=latest", () => {
       })
       .run();
 
-    const body = callList({ conversationId: conv.id, page: "latest" });
+    const body = await callList({ conversationId: conv.id, page: "latest" });
 
     expect(body.messages[0].slackMessage?.sender).toBeUndefined();
   });
 
-  test("page=latest on unresolved conversationKey returns null metadata contract", () => {
-    const body = callList({
+  test("page=latest on unresolved conversationKey returns null metadata contract", async () => {
+    const body = await callList({
       conversationKey: "no-such-key",
       page: "latest",
     });
@@ -605,8 +605,8 @@ describe("handleListMessages page=latest", () => {
     expect(body.oldestMessageId).toBeNull();
   });
 
-  test("no-page GET on unresolved conversationKey keeps minimal shape", () => {
-    const body = callList({ conversationKey: "no-such-key" });
+  test("no-page GET on unresolved conversationKey keeps minimal shape", async () => {
+    const body = await callList({ conversationKey: "no-such-key" });
 
     expect(body.messages).toEqual([]);
     expect("hasMore" in body).toBe(false);
@@ -614,7 +614,7 @@ describe("handleListMessages page=latest", () => {
     expect("oldestMessageId" in body).toBe(false);
   });
 
-  test("page=invalid throws BadRequestError", () => {
+  test("page=invalid throws BadRequestError", async () => {
     const conv = createConversation();
 
     expect(() =>
@@ -629,11 +629,11 @@ describe("handleListMessages page=latest", () => {
     ).toThrow("page must be 'latest' when provided");
   });
 
-  test("no-param GET returns full history without pagination metadata", () => {
+  test("no-param GET returns full history without pagination metadata", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 5);
 
-    const body = callList({ conversationId: conv.id });
+    const body = await callList({ conversationId: conv.id });
 
     expect(body.messages).toHaveLength(5);
     expect(body.messages[0].id).toBe("msg-1");
@@ -644,12 +644,12 @@ describe("handleListMessages page=latest", () => {
     expect("oldestMessageId" in body).toBe(false);
   });
 
-  test("beforeTimestamp-only GET keeps existing conditional-metadata shape (no results)", () => {
+  test("beforeTimestamp-only GET keeps existing conditional-metadata shape (no results)", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 5);
 
     // beforeTimestamp before all seeded rows => no results, metadata omitted.
-    const body = callList({
+    const body = await callList({
       conversationId: conv.id,
       limit: "10",
       beforeTimestamp: "0",
@@ -662,11 +662,11 @@ describe("handleListMessages page=latest", () => {
     expect("oldestMessageId" in body).toBe(false);
   });
 
-  test("beforeTimestamp-only GET keeps existing conditional-metadata shape (with results)", () => {
+  test("beforeTimestamp-only GET keeps existing conditional-metadata shape (with results)", async () => {
     const conv = createConversation();
     seedMessages(conv.id, 5);
 
-    const body = callList({
+    const body = await callList({
       conversationId: conv.id,
       limit: "10",
       beforeTimestamp: "100",

--- a/assistant/src/__tests__/list-messages-provider-error.test.ts
+++ b/assistant/src/__tests__/list-messages-provider-error.test.ts
@@ -72,9 +72,9 @@ describe("handleListMessages provider-error projection", () => {
       },
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     // Every projected message validates against the wire schema.
     for (const message of response.messages) {
@@ -106,9 +106,9 @@ describe("handleListMessages provider-error projection", () => {
       },
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     expect(response.messages).toHaveLength(1);
     expect(response.messages[0]?.providerError).toEqual({});
@@ -130,9 +130,9 @@ describe("handleListMessages provider-error projection", () => {
       JSON.stringify([{ type: "text", text: "hi there" }]),
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     expect(response.messages).toHaveLength(2);
     for (const message of response.messages) {

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -91,7 +91,7 @@ describe("handleListMessages in-memory queue", () => {
     ]);
 
     // WHEN the messages snapshot is built for the newest page
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -128,7 +128,7 @@ describe("handleListMessages in-memory queue", () => {
       }),
     ]);
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -156,7 +156,7 @@ describe("handleListMessages in-memory queue", () => {
       }),
     ]);
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -182,7 +182,7 @@ describe("handleListMessages in-memory queue", () => {
       makeQueued({ requestId: "req-visible", content: "a real message" }),
     ]);
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };
@@ -204,7 +204,7 @@ describe("handleListMessages in-memory queue", () => {
     registerLiveConversation(conv.id, [makeQueued({ requestId: "req-old" })]);
 
     // WHEN paging older history
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: {
         conversationId: conv.id,
         beforeTimestamp: String(Date.now() + 1_000),
@@ -226,7 +226,7 @@ describe("handleListMessages in-memory queue", () => {
       { skipIndexing: true },
     );
 
-    const response = handleListMessages({
+    const response = await handleListMessages({
       queryParams: { conversationId: conv.id },
     });
     const body = response as { messages: MessagePayload[] };

--- a/assistant/src/__tests__/list-messages-system-card.test.ts
+++ b/assistant/src/__tests__/list-messages-system-card.test.ts
@@ -60,9 +60,9 @@ describe("handleListMessages system-card projection", () => {
       { metadata: { messageKind: SYSTEM_CARD_MESSAGE_KIND } },
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     // Every projected message validates against the wire schema.
     for (const message of response.messages) {
@@ -87,9 +87,9 @@ describe("handleListMessages system-card projection", () => {
       JSON.stringify([{ type: "text", text: "hi there" }]),
     );
 
-    const response = handleListMessages({
+    const response = (await handleListMessages({
       queryParams: { conversationId: conv.id },
-    }) as { messages: ProjectedMessage[] };
+    })) as { messages: ProjectedMessage[] };
 
     expect(response.messages).toHaveLength(2);
     for (const message of response.messages) {

--- a/assistant/src/__tests__/list-messages-tool-merge.test.ts
+++ b/assistant/src/__tests__/list-messages-tool-merge.test.ts
@@ -86,7 +86,7 @@ describe("handleListMessages tool_result merging", () => {
       ]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     // Should be 2 messages: user prompt + assistant (tool_result user msg suppressed)
@@ -150,7 +150,7 @@ describe("handleListMessages tool_result merging", () => {
       ]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(2);
@@ -180,7 +180,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "how are you?" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(3);
@@ -206,7 +206,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "Done." }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(2);
@@ -241,7 +241,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "response" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     // User row dropped entirely; only the assistant survives.
@@ -273,7 +273,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "answering" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(2);
@@ -307,7 +307,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "ok" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(1);
@@ -364,7 +364,7 @@ describe("handleListMessages tool_result merging", () => {
       JSON.stringify([{ type: "text", text: "thanks" }]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     // Consecutive assistant messages are merged at query time so the client
@@ -414,7 +414,7 @@ describe("handleListMessages tool_result merging", () => {
       ]),
     );
 
-    const response = handleListMessages(createTestArgs(conv.id));
+    const response = await handleListMessages(createTestArgs(conv.id));
     const body = response as { messages: MessagePayload[] };
 
     expect(body.messages).toHaveLength(2);

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -563,7 +563,7 @@ describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
     const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleDetailedHealth();
+    const res = await handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -1171,7 +1171,7 @@ describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
     const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleDetailedHealth();
+    const res = await handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -737,7 +737,7 @@ describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
     const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleDetailedHealth();
+    const res = await handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -634,7 +634,7 @@ describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
     const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleDetailedHealth();
+    const res = await handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/persist-media-references.test.ts
+++ b/assistant/src/__tests__/persist-media-references.test.ts
@@ -49,7 +49,7 @@ describe("referenceMediaBlocksForPersist", () => {
       },
     ];
 
-    const referenced = referenceMediaBlocksForPersist(
+    const referenced = await referenceMediaBlocksForPersist(
       conv.id,
       conv.createdAt,
       msg.id,
@@ -101,7 +101,7 @@ describe("referenceMediaBlocksForPersist", () => {
       },
     ];
 
-    const referenced = referenceMediaBlocksForPersist(
+    const referenced = await referenceMediaBlocksForPersist(
       conv.id,
       conv.createdAt,
       msg.id,

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -28,8 +28,8 @@ mock.module("../agent/image-optimize.js", () => ({
   // oversized (never undersized), so the min-dimension gate never matches
   // and the rejection-path upscale is never reached.
   isBelowMinDimension: () => false,
-  upscaleImageToMinimum: () => null,
-  optimizeImageForTransport: () => ({
+  upscaleImageToMinimum: async () => null,
+  optimizeImageForTransport: async () => ({
     data: SHRUNK_DATA,
     mediaType: "image/jpeg",
   }),
@@ -133,7 +133,7 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN the nested block stays an image, rewritten to the downscaled payload
     expect(rewritten).toBe(1);
@@ -159,10 +159,10 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
       JSON.stringify([toolResultWithImage(oversizedPngBase64())]),
       { skipIndexing: true },
     );
-    expect(persistUnsendableImageDowngrades(conv.id)).toBe(1);
+    expect(await persistUnsendableImageDowngrades(conv.id)).toBe(1);
 
     // WHEN the downgrade runs again
-    const secondRun = persistUnsendableImageDowngrades(conv.id);
+    const secondRun = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN nothing further is rewritten
     expect(secondRun).toBe(0);

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -132,7 +132,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN one message is rewritten with no image block left
     expect(rewritten).toBe(1);
@@ -162,7 +162,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN only the rejected original is removed
     expect(rewritten).toBe(1);
@@ -184,7 +184,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN nothing is rewritten and the image remains
     expect(rewritten).toBe(0);
@@ -202,7 +202,7 @@ describe("persistUnsendableImageDowngrades", () => {
     });
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN the oversized-payload image is removed
     expect(rewritten).toBe(1);
@@ -224,7 +224,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN the undersized image is removed (upscale is a no-op on this host)
     expect(rewritten).toBe(1);
@@ -248,7 +248,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN the message is rewritten with the nested image swapped for a note
     expect(rewritten).toBe(1);
@@ -274,7 +274,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN nothing is rewritten and the nested image remains
     expect(rewritten).toBe(0);
@@ -302,7 +302,7 @@ describe("persistUnsendableImageDowngrades", () => {
     );
 
     // WHEN the downgrade is persisted
-    const rewritten = persistUnsendableImageDowngrades(conv.id);
+    const rewritten = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN the image survives with its media type corrected to the sniffed one
     expect(rewritten).toBe(1);
@@ -319,7 +319,7 @@ describe("persistUnsendableImageDowngrades", () => {
     });
 
     // AND a second run is a no-op (the corrected block no longer mismatches)
-    expect(persistUnsendableImageDowngrades(conv.id)).toBe(0);
+    expect(await persistUnsendableImageDowngrades(conv.id)).toBe(0);
   });
 
   /** Re-running after a rewrite is a safe no-op (no image blocks remain). */
@@ -332,10 +332,10 @@ describe("persistUnsendableImageDowngrades", () => {
       JSON.stringify([imageBlock(makePngBase64(10000, 10000))]),
       { skipIndexing: true },
     );
-    expect(persistUnsendableImageDowngrades(conv.id)).toBe(1);
+    expect(await persistUnsendableImageDowngrades(conv.id)).toBe(1);
 
     // WHEN the downgrade runs a second time
-    const secondRun = persistUnsendableImageDowngrades(conv.id);
+    const secondRun = await persistUnsendableImageDowngrades(conv.id);
 
     // THEN nothing further is rewritten
     expect(secondRun).toBe(0);
@@ -346,46 +346,46 @@ describe("unsendableImageReplacement", () => {
   /** A still-sendable image must be left alone — never replaced with a note.
    *  This is the gate that keeps the in-memory recovery from discarding valid
    *  screenshots when only one image in the turn was actually oversized. */
-  test("returns null for an image within the provider caps", () => {
+  test("returns null for an image within the provider caps", async () => {
     const sendable = imageBlock(makePngBase64(1024, 768)) as Extract<
       ContentBlock,
       { type: "image" }
     >;
-    expect(unsendableImageReplacement(sendable)).toBeNull();
+    expect(await unsendableImageReplacement(sendable)).toBeNull();
   });
 
   /** An image past the provider caps that cannot be shrunk on this host (fake
    *  PNG that sips cannot decode) collapses to the unsendable note. */
-  test("returns the unsendable note when an oversized image cannot be shrunk", () => {
+  test("returns the unsendable note when an oversized image cannot be shrunk", async () => {
     const oversized = imageBlock(makePngBase64(12000, 9000)) as Extract<
       ContentBlock,
       { type: "image" }
     >;
-    const replacement = unsendableImageReplacement(oversized);
+    const replacement = await unsendableImageReplacement(oversized);
     expect(replacement?.type).toBe("text");
   });
 
   /** An image below the provider's minimum-size floor (rejected with "Could
    *  not process image") that cannot be upscaled on this host collapses to
    *  the unsendable note, same as the oversized direction. */
-  test("returns the unsendable note when an undersized image cannot be upscaled", () => {
+  test("returns the unsendable note when an undersized image cannot be upscaled", async () => {
     const undersized = imageBlock(makePngBase64(16, 14)) as Extract<
       ContentBlock,
       { type: "image" }
     >;
-    const replacement = unsendableImageReplacement(undersized);
+    const replacement = await unsendableImageReplacement(undersized);
     expect(replacement?.type).toBe("text");
   });
 
   /** A within-limits image whose declared media type disagrees with its bytes
    *  is relabeled with the sniffed type instead of being noted out. */
-  test("relabels a mislabeled image with its sniffed media type", () => {
+  test("relabels a mislabeled image with its sniffed media type", async () => {
     const pngData = makePngBase64(1024, 768);
     const mislabeled = imageBlock(pngData, "image/jpeg") as Extract<
       ContentBlock,
       { type: "image" }
     >;
-    const replacement = unsendableImageReplacement(mislabeled);
+    const replacement = await unsendableImageReplacement(mislabeled);
     expect(replacement).toMatchObject({
       type: "image",
       source: { type: "base64", media_type: "image/png", data: pngData },
@@ -394,9 +394,9 @@ describe("unsendableImageReplacement", () => {
 
   /** Relabeling a persisted (workspace_ref) image keeps the reference shape —
    *  inlining it would bake the full payload into the stored message row. */
-  test("relabels a mislabeled workspace_ref without inlining the payload", () => {
+  test("relabels a mislabeled workspace_ref without inlining the payload", async () => {
     const pngData = makePngBase64(1024, 768);
-    const stored = uploadAttachment("photo.png", "image/png", pngData);
+    const stored = await uploadAttachment("photo.png", "image/png", pngData);
     const mislabeledRef = {
       type: "image",
       source: {
@@ -407,7 +407,7 @@ describe("unsendableImageReplacement", () => {
       },
     } as Extract<ContentBlock, { type: "image" }>;
 
-    const replacement = unsendableImageReplacement(mislabeledRef);
+    const replacement = await unsendableImageReplacement(mislabeledRef);
 
     expect(replacement).toMatchObject({
       type: "image",
@@ -419,7 +419,7 @@ describe("unsendableImageReplacement", () => {
     });
     // AND the corrected reference no longer matches on a second pass
     expect(
-      unsendableImageReplacement(
+      await unsendableImageReplacement(
         replacement as Extract<ContentBlock, { type: "image" }>,
       ),
     ).toBeNull();

--- a/assistant/src/__tests__/profiler-routes.test.ts
+++ b/assistant/src/__tests__/profiler-routes.test.ts
@@ -277,16 +277,16 @@ describe("Profiler routes", () => {
       ).toThrow(NotFoundError);
     });
 
-    test("returns tar.gz bytes for a valid run", () => {
+    test("returns tar.gz bytes for a valid run", async () => {
       createRun("exportable-run", {
         sizeBytes: 512,
         manifest: { status: "completed" },
       });
 
       const route = findRoute("profiler_runs_by_runId_export_post")!;
-      const result = route.handler({
+      const result = (await route.handler({
         pathParams: { runId: "exportable-run" },
-      }) as Uint8Array;
+      })) as Uint8Array;
 
       expect(result).toBeInstanceOf(Uint8Array);
       expect(result.byteLength).toBeGreaterThan(0);

--- a/assistant/src/__tests__/profiler-routes.test.ts
+++ b/assistant/src/__tests__/profiler-routes.test.ts
@@ -185,11 +185,11 @@ describe("Profiler routes", () => {
         );
       });
 
-      test(`POST export rejects runId "${payload}"`, () => {
+      test(`POST export rejects runId "${payload}"`, async () => {
         const route = findRoute("profiler_runs_by_runId_export_post")!;
-        expect(() => route.handler({ pathParams: { runId: payload } })).toThrow(
-          BadRequestError,
-        );
+        await expect(
+          route.handler({ pathParams: { runId: payload } }),
+        ).rejects.toThrow(BadRequestError);
       });
 
       test(`DELETE rejects runId "${payload}"`, () => {
@@ -270,11 +270,11 @@ describe("Profiler routes", () => {
   });
 
   describe("POST /v1/profiler/runs/:runId/export", () => {
-    test("returns 404 for missing run", () => {
+    test("returns 404 for missing run", async () => {
       const route = findRoute("profiler_runs_by_runId_export_post")!;
-      expect(() =>
+      await expect(
         route.handler({ pathParams: { runId: "nonexistent" } }),
-      ).toThrow(NotFoundError);
+      ).rejects.toThrow(NotFoundError);
     });
 
     test("returns tar.gz bytes for a valid run", async () => {
@@ -292,7 +292,7 @@ describe("Profiler routes", () => {
       expect(result.byteLength).toBeGreaterThan(0);
     });
 
-    test("returns 500 when archive exceeds size limit", () => {
+    test("returns 500 when archive exceeds size limit", async () => {
       // Create a run with a very large file that will exceed the 50MB archive cap.
       const runDir = join(runsDir, "huge-run");
       mkdirSync(runDir, { recursive: true });
@@ -325,9 +325,9 @@ describe("Profiler routes", () => {
       }
 
       const route = findRoute("profiler_runs_by_runId_export_post")!;
-      expect(() =>
+      await expect(
         route.handler({ pathParams: { runId: "huge-run" } }),
-      ).toThrow(InternalError);
+      ).rejects.toThrow(InternalError);
     }, 30000);
   });
 

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -97,7 +97,7 @@ describe("Runtime attachment metadata", () => {
     );
 
     // Upload and link an attachment using "self" as the assistantId
-    const stored = uploadAttachment("chart.png", "image/png", "iVBORw==");
+    const stored = await uploadAttachment("chart.png", "image/png", "iVBORw==");
     linkAttachmentToMessage(assistantMsg.id, stored.id, 0);
 
     const res = await fetch(
@@ -162,7 +162,7 @@ describe("Runtime attachment metadata", () => {
   });
 
   test("GET /attachments/:id returns attachment with payload", async () => {
-    const stored = uploadAttachment(
+    const stored = await uploadAttachment(
       "report.pdf",
       "application/pdf",
       "JVBERA==",
@@ -191,7 +191,11 @@ describe("Runtime attachment metadata", () => {
   });
 
   test('GET /attachments/:id returns attachment stored under "self"', async () => {
-    const stored = uploadAttachment("shared.txt", "text/plain", "c2hhcmVk");
+    const stored = await uploadAttachment(
+      "shared.txt",
+      "text/plain",
+      "c2hhcmVk",
+    );
 
     const res = await fetch(
       `http://127.0.0.1:${port}/v1/attachments/${stored.id}`,
@@ -303,12 +307,16 @@ describe("WhatsApp channel ingress attachment resolution", () => {
   test("inbound handler accepts request with valid gateway-uploaded attachment IDs", async () => {
     // Simulate what the gateway does: upload attachments then forward the
     // inbound event with attachmentIds. The handler must resolve them.
-    const img = uploadAttachment(
+    const img = await uploadAttachment(
       "whatsapp-photo.jpg",
       "image/jpeg",
       "/9j/4AAQ",
     );
-    const doc = uploadAttachment("receipt.pdf", "application/pdf", "JVBERi0x");
+    const doc = await uploadAttachment(
+      "receipt.pdf",
+      "application/pdf",
+      "JVBERi0x",
+    );
 
     const res = await fetch(
       `http://127.0.0.1:${ingressPort}/v1/channels/inbound`,
@@ -329,7 +337,7 @@ describe("WhatsApp channel ingress attachment resolution", () => {
   test("inbound handler rejects request when some attachment IDs are missing", async () => {
     // When the gateway fails to upload one attachment, the handler detects
     // the missing ID and returns a 400.
-    const valid = uploadAttachment("ok.jpg", "image/jpeg", "base64ok");
+    const valid = await uploadAttachment("ok.jpg", "image/jpeg", "base64ok");
 
     const res = await fetch(
       `http://127.0.0.1:${ingressPort}/v1/channels/inbound`,
@@ -355,7 +363,7 @@ describe("WhatsApp channel ingress attachment resolution", () => {
 
   test("inbound handler accepts attachment-only message with no text content", async () => {
     // WhatsApp allows sending images/documents without caption text.
-    const img = uploadAttachment("photo.jpg", "image/jpeg", "/9j/4AAQ");
+    const img = await uploadAttachment("photo.jpg", "image/jpeg", "/9j/4AAQ");
 
     const res = await fetch(
       `http://127.0.0.1:${ingressPort}/v1/channels/inbound`,

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -298,9 +298,9 @@ describe("renderHistoryContent", () => {
     expect(output.toolCalls[0].errorCode).toBe("acp_claude_oauth_missing");
   });
 
-  test("emits the attachment id for a workspace_ref tool-result image", () => {
+  test("emits the attachment id for a workspace_ref tool-result image", async () => {
     // "aGVsbG8=" = "hello" — a stand-in for screenshot bytes.
-    const stored = uploadAttachment("shot.png", "image/png", "aGVsbG8=");
+    const stored = await uploadAttachment("shot.png", "image/png", "aGVsbG8=");
     const output = renderHistoryContent([
       { type: "tool_use", id: "tu_1", name: "browser_screenshot", input: {} },
       {
@@ -1084,7 +1084,7 @@ describe("getAttachmentsForMessage", () => {
 
   test("returns attachments linked to a message", async () => {
     const msgId = await createMessage("assistant", "Here is a chart");
-    const stored = uploadAttachment("chart.png", "image/png", "iVBORw==");
+    const stored = await uploadAttachment("chart.png", "image/png", "iVBORw==");
     linkAttachmentToMessage(msgId, stored.id, 0);
 
     const result = getAttachmentsForMessage(msgId);
@@ -1101,8 +1101,8 @@ describe("getAttachmentsForMessage", () => {
 
   test("returns multiple attachments in position order", async () => {
     const msgId = await createMessage("assistant", "Two files");
-    const a1 = uploadAttachment("first.txt", "text/plain", "AAAA");
-    const a2 = uploadAttachment("second.txt", "text/plain", "BBBB");
+    const a1 = await uploadAttachment("first.txt", "text/plain", "AAAA");
+    const a2 = await uploadAttachment("second.txt", "text/plain", "BBBB");
 
     linkAttachmentToMessage(msgId, a2.id, 1);
     linkAttachmentToMessage(msgId, a1.id, 0);
@@ -1115,8 +1115,8 @@ describe("getAttachmentsForMessage", () => {
 
   test("returns all attachments linked to a message", async () => {
     const msgId = await createMessage("assistant", "Mixed");
-    const a1 = uploadAttachment("a.png", "image/png", "AAAA");
-    const a2 = uploadAttachment("b.png", "image/png", "BBBB");
+    const a1 = await uploadAttachment("a.png", "image/png", "AAAA");
+    const a2 = await uploadAttachment("b.png", "image/png", "BBBB");
 
     linkAttachmentToMessage(msgId, a1.id, 0);
     linkAttachmentToMessage(msgId, a2.id, 1);

--- a/assistant/src/__tests__/size-guard.test.ts
+++ b/assistant/src/__tests__/size-guard.test.ts
@@ -38,41 +38,41 @@ describe("MAX_FILE_SIZE_BYTES", () => {
 // ---------------------------------------------------------------------------
 
 describe("checkFileSizeOnDisk", () => {
-  test("returns undefined for a file within the default limit", () => {
+  test("returns undefined for a file within the default limit", async () => {
     const dir = makeTempDir();
     const filePath = join(dir, "small.txt");
     writeFileSync(filePath, "hello");
 
-    expect(checkFileSizeOnDisk(filePath)).toBeUndefined();
+    expect(await checkFileSizeOnDisk(filePath)).toBeUndefined();
   });
 
-  test("returns error string for a file exceeding a custom limit", () => {
+  test("returns error string for a file exceeding a custom limit", async () => {
     const dir = makeTempDir();
     const filePath = join(dir, "big.txt");
     writeFileSync(filePath, "x".repeat(200));
 
-    const result = checkFileSizeOnDisk(filePath, 100);
+    const result = await checkFileSizeOnDisk(filePath, 100);
     expect(result).toBeDefined();
     expect(result).toContain("exceeds");
     expect(result).toContain("limit");
     expect(result).toContain(filePath);
   });
 
-  test("returns undefined for a file exactly at the custom limit", () => {
+  test("returns undefined for a file exactly at the custom limit", async () => {
     const dir = makeTempDir();
     const filePath = join(dir, "exact.txt");
     writeFileSync(filePath, "x".repeat(100));
 
-    expect(checkFileSizeOnDisk(filePath, 100)).toBeUndefined();
+    expect(await checkFileSizeOnDisk(filePath, 100)).toBeUndefined();
   });
 
-  test("uses default limit when none is provided", () => {
+  test("uses default limit when none is provided", async () => {
     const dir = makeTempDir();
     const filePath = join(dir, "tiny.txt");
     writeFileSync(filePath, "a");
 
     // Should not error since 1 byte is well under 100 MB
-    expect(checkFileSizeOnDisk(filePath)).toBeUndefined();
+    expect(await checkFileSizeOnDisk(filePath)).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/skills-install-staging.test.ts
+++ b/assistant/src/__tests__/skills-install-staging.test.ts
@@ -11,10 +11,22 @@ import { join } from "node:path";
 import { gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-const mockExecSync = mock(() => {});
+// Emits `error` on the returned child so the dependency install's spawn
+// promise rejects with the injected failure.
+const mockSpawn = mock(() => {
+  const child = {
+    on(event: string, cb: (arg: unknown) => void) {
+      if (event === "error") {
+        queueMicrotask(() => cb(new Error("dependency install failed")));
+      }
+      return child;
+    },
+  };
+  return child;
+});
 
 mock.module("node:child_process", () => ({
-  execSync: mockExecSync,
+  spawn: mockSpawn,
 }));
 
 import { loadSkillCatalog } from "../config/skills.js";
@@ -48,10 +60,7 @@ beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "skills-install-staging-"));
   process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
   mkdirSync(join(workspaceDir, "skills"), { recursive: true });
-  mockExecSync.mockReset();
-  mockExecSync.mockImplementation(() => {
-    throw new Error("dependency install failed");
-  });
+  mockSpawn.mockClear();
 });
 
 afterEach(() => {

--- a/assistant/src/__tests__/tools-audio-read.test.ts
+++ b/assistant/src/__tests__/tools-audio-read.test.ts
@@ -23,12 +23,12 @@ afterAll(() => {
 });
 
 describe("readAudioFile", () => {
-  test("reads an mp3 into a base64 file block with audio/mpeg", () => {
+  test("reads an mp3 into a base64 file block with audio/mpeg", async () => {
     const p = join(dir, "clip.mp3");
     const bytes = Buffer.from("fake-audio-bytes");
     writeFileSync(p, bytes);
 
-    const result = readAudioFile(p);
+    const result = await readAudioFile(p);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Audio loaded");
@@ -45,7 +45,7 @@ describe("readAudioFile", () => {
     ]);
   });
 
-  test("maps each extension to the canonical MIME (matches migration 191)", () => {
+  test("maps each extension to the canonical MIME (matches migration 191)", async () => {
     const cases: Record<string, string> = {
       "a.mp3": "audio/mpeg",
       "a.wav": "audio/wav",
@@ -58,7 +58,7 @@ describe("readAudioFile", () => {
     for (const [name, mime] of Object.entries(cases)) {
       const p = join(dir, name);
       writeFileSync(p, Buffer.from("x"));
-      const result = readAudioFile(p);
+      const result = await readAudioFile(p);
       expect(result.isError).toBe(false);
       const block = result.contentBlocks?.[0] as {
         source: { media_type: string };
@@ -67,28 +67,28 @@ describe("readAudioFile", () => {
     }
   });
 
-  test("rejects audio larger than the 12 MB inline cap", () => {
+  test("rejects audio larger than the 12 MB inline cap", async () => {
     const p = join(dir, "big.mp3");
     writeFileSync(p, "");
     truncateSync(p, 13 * 1024 * 1024); // sparse — no 13 MB allocation
 
-    const result = readAudioFile(p);
+    const result = await readAudioFile(p);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("too large");
     expect(result.contentBlocks).toBeUndefined();
   });
 
-  test("errors on a missing file", () => {
-    const result = readAudioFile(join(dir, "nope.mp3"));
+  test("errors on a missing file", async () => {
+    const result = await readAudioFile(join(dir, "nope.mp3"));
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not found");
   });
 
-  test("errors when the path is a directory", () => {
+  test("errors when the path is a directory", async () => {
     const p = join(dir, "adir.mp3");
     mkdirSync(p);
-    const result = readAudioFile(p);
+    const result = await readAudioFile(p);
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not a file");
   });

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -76,35 +76,37 @@ export function attachmentsToReferenceBlocks(
 
 export function attachmentsToContentBlocks(
   attachments: MessageAttachmentInput[],
-): ContentBlock[] {
-  return attachments.map((attachment) => {
-    if (attachment.mimeType.toLowerCase().startsWith("image/")) {
-      const { data, mediaType } = optimizeImageForTransport(
-        attachment.data,
-        attachment.mimeType,
-      );
+): Promise<ContentBlock[]> {
+  return Promise.all(
+    attachments.map(async (attachment) => {
+      if (attachment.mimeType.toLowerCase().startsWith("image/")) {
+        const { data, mediaType } = await optimizeImageForTransport(
+          attachment.data,
+          attachment.mimeType,
+        );
+        return {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data,
+          },
+        } as ContentBlock;
+      }
+
       return {
-        type: "image",
+        type: "file",
         source: {
           type: "base64",
-          media_type: mediaType,
-          data,
+          media_type: attachment.mimeType,
+          data: attachment.data,
+          filename: attachment.filename,
         },
+        extracted_text: attachment.extractedText,
+        ...(attachment.id ? { _attachmentId: attachment.id } : {}),
       } as ContentBlock;
-    }
-
-    return {
-      type: "file",
-      source: {
-        type: "base64",
-        media_type: attachment.mimeType,
-        data: attachment.data,
-        filename: attachment.filename,
-      },
-      extracted_text: attachment.extractedText,
-      ...(attachment.id ? { _attachmentId: attachment.id } : {}),
-    } as ContentBlock;
-  });
+    }),
+  );
 }
 
 /**

--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -110,10 +110,10 @@ export function upscaleTargetDimensions(dims: {
  * Reactive only: called by the image-recovery plugin after an actual
  * "Could not process image" rejection, never on the pre-send path.
  */
-export function upscaleImageToMinimum(
+export async function upscaleImageToMinimum(
   base64Data: string,
   mediaType: string,
-): { data: string; mediaType: string } | null {
+): Promise<{ data: string; mediaType: string } | null> {
   const dims = parseImageDimensions(base64Data, mediaType);
   if (!dims) {
     return null;
@@ -122,7 +122,7 @@ export function upscaleImageToMinimum(
   if (!target) {
     return null;
   }
-  const upscaled = convertImageToJpeg(Buffer.from(base64Data, "base64"), {
+  const upscaled = await convertImageToJpeg(Buffer.from(base64Data, "base64"), {
     resizeToPx: target,
     quality: JPEG_QUALITY,
   });
@@ -144,10 +144,10 @@ export function upscaleImageToMinimum(
  * Conversion (and its content-addressed disk cache) is shared with attachment
  * storage normalization — see `util/image-conversion.ts`.
  */
-export function optimizeImageForTransport(
+export async function optimizeImageForTransport(
   base64Data: string,
   mediaType: string,
-): { data: string; mediaType: string } {
+): Promise<{ data: string; mediaType: string }> {
   const rawBytes = Buffer.from(base64Data, "base64");
   const dims = parseImageDimensions(base64Data, mediaType);
 
@@ -155,7 +155,7 @@ export function optimizeImageForTransport(
     return { data: base64Data, mediaType };
   }
 
-  const optimized = convertImageToJpeg(rawBytes, {
+  const optimized = await convertImageToJpeg(rawBytes, {
     maxDimensionPx: MAX_DIMENSION,
     quality: JPEG_QUALITY,
   });

--- a/assistant/src/agent/message-types.ts
+++ b/assistant/src/agent/message-types.ts
@@ -4,15 +4,15 @@ import {
   type MessageAttachmentInput,
 } from "./attachments.js";
 
-export function createUserMessage(
+export async function createUserMessage(
   text: string,
   attachments: MessageAttachmentInput[] = [],
-): Message {
+): Promise<Message> {
   const content = [] as Message["content"];
   if (text.trim().length > 0) {
     content.push({ type: "text", text });
   }
-  content.push(...attachmentsToContentBlocks(attachments));
+  content.push(...(await attachmentsToContentBlocks(attachments)));
   return { role: "user", content };
 }
 

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -864,10 +864,10 @@ function resolveTailFloorIndex(messages: Message[], tailIndex: number): number {
 // Retained-image hydration
 // ---------------------------------------------------------------------------
 
-function buildRetainedImageBlocks(
+async function buildRetainedImageBlocks(
   filenames: string[],
   manifest: ManifestEntry[],
-): { blocks: ImageContent[]; resolved: string[]; missing: string[] } {
+): Promise<{ blocks: ImageContent[]; resolved: string[]; missing: string[] }> {
   const blocks: ImageContent[] = [];
   const resolved: string[] = [];
   const missing: string[] = [];
@@ -886,7 +886,7 @@ function buildRetainedImageBlocks(
     // Run the same downscale pass the agent uses when first sending an
     // image. Without this, attachments that exceed the provider's per-image
     // byte limit (Anthropic: 5 MB) crash the next turn after compaction.
-    const optimized = optimizeImageForTransport(
+    const optimized = await optimizeImageForTransport(
       content.toString("base64"),
       sourceMime,
     );
@@ -1356,7 +1356,7 @@ export async function runAssistantDrivenCompaction(
     blocks: retainedImageBlocks,
     resolved,
     missing,
-  } = buildRetainedImageBlocks(parsed.retainedImageFilenames, manifest);
+  } = await buildRetainedImageBlocks(parsed.retainedImageFilenames, manifest);
   if (missing.length > 0) {
     log.warn(
       { missing },

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -2011,7 +2011,7 @@ export async function finalizePendingToolResultRow(
   );
   const contentJson = JSON.stringify(
     conv != null
-      ? referenceMediaBlocksForPersist(
+      ? await referenceMediaBlocksForPersist(
           conversationId,
           conv.createdAt,
           rowId,

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -163,7 +163,7 @@ export async function resolveAssistantAttachments(
       const draft = assistantAttachments[i];
       let stored;
       try {
-        stored = attachInlineAttachmentToMessage(
+        stored = await attachInlineAttachmentToMessage(
           lastAssistantMessageId,
           i,
           draft.filename,

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -254,15 +254,15 @@ function serializeUserContentBlocks(
  * by the attachments as inline base64 blocks. The regular upload path persists
  * `workspace_ref` blocks instead (see `persistQueuedMessageBody`).
  */
-export function serializePersistedUserMessageContent(
+export async function serializePersistedUserMessageContent(
   content: string,
   displayContent: string | undefined,
   attachments: MessageAttachmentInput[],
-): string {
+): Promise<string> {
   return serializeUserContentBlocks(
     content,
     displayContent,
-    attachmentsToContentBlocks(attachments),
+    await attachmentsToContentBlocks(attachments),
   );
 }
 
@@ -273,15 +273,15 @@ export function serializePersistedUserMessageContent(
  * the stored original — keeping the per-turn token estimate accurate without a
  * disk read on the hot path.
  */
-function computeReferenceImageDimensions(
+async function computeReferenceImageDimensions(
   attachmentId: string,
   mediaType: string,
-): { width: number; height: number } | null {
+): Promise<{ width: number; height: number } | null> {
   const bytes = getAttachmentContent(attachmentId);
   if (!bytes) {
     return null;
   }
-  const optimized = optimizeImageForTransport(
+  const optimized = await optimizeImageForTransport(
     bytes.toString("base64"),
     mediaType,
   );
@@ -321,11 +321,11 @@ type MaterializeOutcome =
  * endpoint's own rejection); only a recoverable store-write failure is
  * `transient` (inline fallback).
  */
-function materializeUserAttachment(
+async function materializeUserAttachment(
   conversationId: string,
   conversationCreatedAt: number,
   a: MessageAttachmentInput,
-): MaterializeOutcome {
+): Promise<MaterializeOutcome> {
   try {
     if (a.id && attachmentExists(a.id)) {
       const stored = scopeAttachmentToMessageConversation(
@@ -348,7 +348,7 @@ function materializeUserAttachment(
     }
     return {
       kind: "stored",
-      stored: createInlineAttachment(
+      stored: await createInlineAttachment(
         conversationId,
         conversationCreatedAt,
         a.filename,
@@ -376,10 +376,10 @@ function materializeUserAttachment(
 }
 
 /** Build the `workspace_ref` content block for a materialized attachment. */
-function referenceBlockForAttachment(
+async function referenceBlockForAttachment(
   a: MessageAttachmentInput,
   stored: { id: string; mimeType: string; sizeBytes: number },
-): ContentBlock {
+): Promise<ContentBlock> {
   const ref: AttachmentReferenceInput = {
     attachmentId: stored.id,
     filename: a.filename,
@@ -388,7 +388,10 @@ function referenceBlockForAttachment(
     extractedText: a.extractedText,
   };
   if (stored.mimeType.toLowerCase().startsWith("image/")) {
-    const dims = computeReferenceImageDimensions(stored.id, stored.mimeType);
+    const dims = await computeReferenceImageDimensions(
+      stored.id,
+      stored.mimeType,
+    );
     if (dims) {
       ref.width = dims.width;
       ref.height = dims.height;
@@ -399,13 +402,13 @@ function referenceBlockForAttachment(
 
 /** Inline base64 fallback block for an attachment that could not be stored as
  * a reference, so the upload survives a reload. Null when there are no bytes. */
-function inlineBlockForAttachment(
+async function inlineBlockForAttachment(
   a: MessageAttachmentInput,
-): ContentBlock | null {
+): Promise<ContentBlock | null> {
   if (!a.data) {
     return null;
   }
-  return attachmentsToContentBlocks([a])[0] ?? null;
+  return (await attachmentsToContentBlocks([a]))[0] ?? null;
 }
 
 /**
@@ -419,15 +422,15 @@ function inlineBlockForAttachment(
  * survives; a validation/upload rejection is dropped (never reaches content or
  * the model).
  */
-function prepareUserAttachmentReferences(
+async function prepareUserAttachmentReferences(
   conversationId: string,
   conversationCreatedAt: number,
   attachments: MessageAttachmentInput[],
-): PreparedUserAttachment[] {
+): Promise<PreparedUserAttachment[]> {
   const prepared: PreparedUserAttachment[] = [];
   for (let i = 0; i < attachments.length; i++) {
     const a = attachments[i];
-    const outcome = materializeUserAttachment(
+    const outcome = await materializeUserAttachment(
       conversationId,
       conversationCreatedAt,
       a,
@@ -435,7 +438,7 @@ function prepareUserAttachmentReferences(
     if (outcome.kind === "stored") {
       prepared.push({
         position: i,
-        block: referenceBlockForAttachment(a, outcome.stored),
+        block: await referenceBlockForAttachment(a, outcome.stored),
         link: { attachmentId: outcome.stored.id },
       });
       continue;
@@ -445,7 +448,7 @@ function prepareUserAttachmentReferences(
     }
     // transient: keep the upload by inlining its bytes (dropped only when the
     // recoverable failure left us with no bytes to inline).
-    const inline = inlineBlockForAttachment(a);
+    const inline = await inlineBlockForAttachment(a);
     if (inline) {
       prepared.push({ position: i, block: inline });
     } else {
@@ -818,7 +821,7 @@ export async function persistQueuedMessageBody(
       filePath: attachment.filePath,
     }),
   );
-  const cleanMessage = createUserMessage(content, attachmentInputs);
+  const cleanMessage = await createUserMessage(content, attachmentInputs);
   let pushedToHistory = false;
 
   try {
@@ -944,7 +947,7 @@ export async function persistQueuedMessageBody(
     // once the message id exists.
     const conversationCreatedAt =
       getConversation(ctx.conversationId)?.createdAt ?? Date.now();
-    const preparedAttachments = prepareUserAttachmentReferences(
+    const preparedAttachments = await prepareUserAttachmentReferences(
       ctx.conversationId,
       conversationCreatedAt,
       attachmentInputs,
@@ -1011,9 +1014,9 @@ export async function persistQueuedMessageBody(
     // by rewriting that block to inline base64 so the upload survives even
     // though the store anchor was lost, then persist the corrected content.
     let repairedBlocks: ContentBlock[] | null = null;
-    preparedAttachments.forEach((p, idx) => {
+    for (const [idx, p] of preparedAttachments.entries()) {
       if (!p.link) {
-        return;
+        continue;
       }
       try {
         const scopedAttachmentId = linkAttachmentToMessage(
@@ -1024,7 +1027,9 @@ export async function persistQueuedMessageBody(
         attachmentInputs[p.position].storedPath =
           getFilePathForAttachment(scopedAttachmentId) ?? undefined;
       } catch (err) {
-        const inline = inlineBlockForAttachment(attachmentInputs[p.position]);
+        const inline = await inlineBlockForAttachment(
+          attachmentInputs[p.position],
+        );
         log.error(
           { attachmentId: p.link.attachmentId, err, repaired: inline != null },
           "Failed to link user attachment; repairing persisted content to inline",
@@ -1034,7 +1039,7 @@ export async function persistQueuedMessageBody(
           repairedBlocks[idx] = inline;
         }
       }
-    });
+    }
     if (repairedBlocks) {
       updateMessageContent(
         persistedUserMessage.id,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -819,7 +819,10 @@ async function drainSingleMessage(
           : {}),
         sentAt: next.sentAt,
       };
-      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      const cleanUserMsg = await createUserMessage(
+        next.content,
+        next.attachments,
+      );
       const llmUserMsg = enrichMessageWithSourcePaths(
         cleanUserMsg,
         next.attachments,
@@ -827,7 +830,7 @@ async function drainSingleMessage(
       // When displayContent is provided (e.g. original text before recording
       // intent stripping), persist that to DB so users see the full message.
       // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-      const contentToPersist = serializePersistedUserMessageContent(
+      const contentToPersist = await serializePersistedUserMessageContent(
         next.content,
         next.displayContent,
         next.attachments,
@@ -919,11 +922,14 @@ async function drainSingleMessage(
           : {}),
         sentAt: next.sentAt,
       };
-      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      const cleanUserMsg = await createUserMessage(
+        next.content,
+        next.attachments,
+      );
       await addMessage(
         conversation.conversationId,
         "user",
-        serializePersistedUserMessageContent(
+        await serializePersistedUserMessageContent(
           next.content,
           next.displayContent,
           next.attachments,
@@ -1009,11 +1015,14 @@ async function drainSingleMessage(
           : {}),
         sentAt: next.sentAt,
       };
-      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      const cleanUserMsg = await createUserMessage(
+        next.content,
+        next.attachments,
+      );
       await addMessage(
         conversation.conversationId,
         "user",
-        serializePersistedUserMessageContent(
+        await serializePersistedUserMessageContent(
           next.content,
           next.displayContent,
           next.attachments,
@@ -1879,7 +1888,7 @@ export async function processMessage(
           : {}),
       };
 
-      const cleanUserMsg = createUserMessage(content, attachments);
+      const cleanUserMsg = await createUserMessage(content, attachments);
       const llmUserMsg = enrichMessageWithSourcePaths(
         cleanUserMsg,
         attachments,
@@ -1887,7 +1896,7 @@ export async function processMessage(
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        serializePersistedUserMessageContent(
+        await serializePersistedUserMessageContent(
           content,
           displayContent,
           attachments,
@@ -1971,12 +1980,12 @@ export async function processMessage(
         ? { imageSourcePaths: pmImageSourcePaths }
         : {}),
     };
-    const cleanUserMsg = createUserMessage(content, attachments);
+    const cleanUserMsg = await createUserMessage(content, attachments);
     const llmUserMsg = enrichMessageWithSourcePaths(cleanUserMsg, attachments);
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message.
     // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-    const contentToPersist = serializePersistedUserMessageContent(
+    const contentToPersist = await serializePersistedUserMessageContent(
       content,
       displayContent,
       attachments,
@@ -2055,11 +2064,11 @@ export async function processMessage(
             }
           : {}),
       };
-      const cleanUserMsg = createUserMessage(content, attachments);
+      const cleanUserMsg = await createUserMessage(content, attachments);
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        serializePersistedUserMessageContent(
+        await serializePersistedUserMessageContent(
           content,
           displayContent,
           attachments,
@@ -2133,11 +2142,11 @@ export async function processMessage(
             }
           : {}),
       };
-      const cleanUserMsg = createUserMessage(content, attachments);
+      const cleanUserMsg = await createUserMessage(content, attachments);
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        serializePersistedUserMessageContent(
+        await serializePersistedUserMessageContent(
           content,
           displayContent,
           attachments,

--- a/assistant/src/daemon/disk-pressure-guard-lifecycle.ts
+++ b/assistant/src/daemon/disk-pressure-guard-lifecycle.ts
@@ -16,10 +16,10 @@ const log = getLogger("disk-pressure-guard-lifecycle");
 
 let diskPressureStartupSampleTimer: ReturnType<typeof setTimeout> | null = null;
 
-function runDeferredDiskPressureStartupSample(): void {
+async function runDeferredDiskPressureStartupSample(): Promise<void> {
   diskPressureStartupSampleTimer = null;
   try {
-    const status = evaluateDiskPressureNow();
+    const status = await evaluateDiskPressureNow();
     if (status.error) {
       log.warn(
         { error: status.error },

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -202,12 +202,12 @@ export function stopDiskPressureGuard(): void {
   state.timer = null;
 }
 
-export function evaluateDiskPressureNow(): DiskPressureStatus {
+export async function evaluateDiskPressureNow(): Promise<DiskPressureStatus> {
   ensureEnabledStatus();
 
-  let usageInfo: ReturnType<typeof getDiskUsageInfo>;
+  let usageInfo: Awaited<ReturnType<typeof getDiskUsageInfo>>;
   try {
-    usageInfo = getDiskUsageInfo();
+    usageInfo = await getDiskUsageInfo();
   } catch (error) {
     return replaceStatus(sampleFailureStatus(error));
   }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1340,7 +1340,7 @@ export async function installSkill(spec: {
       skillId = result.skillId;
 
       const stagedSkillDir = result.skillDir;
-      installSkillDependenciesIfPresent(stagedSkillDir);
+      await installSkillDependenciesIfPresent(stagedSkillDir);
       commitStagedSkillInstall(skillId, stagedSkillDir);
     } finally {
       rmSync(clawhubProjectRoot, { recursive: true, force: true });

--- a/assistant/src/daemon/persist-media-references.ts
+++ b/assistant/src/daemon/persist-media-references.ts
@@ -43,11 +43,11 @@ function imageFilename(mediaType: string): string {
  * transport-optimized image (`resolveMediaReferences` applies the same
  * optimization at send time), so hint the optimized dimensions.
  */
-function optimizedImageDimensions(
+async function optimizedImageDimensions(
   dataBase64: string,
   mediaType: string,
-): { width: number; height: number } | null {
-  const optimized = optimizeImageForTransport(dataBase64, mediaType);
+): Promise<{ width: number; height: number } | null> {
+  const optimized = await optimizeImageForTransport(dataBase64, mediaType);
   return parseImageDimensions(optimized.data, optimized.mediaType);
 }
 
@@ -56,13 +56,13 @@ function optimizedImageDimensions(
  * `messageId`, returning the block with a `workspace_ref` source — or null when
  * the store write fails (caller keeps the inline base64 block).
  */
-function referenceMediaBlock(
+async function referenceMediaBlock(
   conversationId: string,
   conversationCreatedAt: number,
   messageId: string,
   block: ImageContent | FileContent,
   position: number,
-): ContentBlock | null {
+): Promise<ContentBlock | null> {
   if (block.source.type !== "base64") {
     return block;
   }
@@ -73,7 +73,7 @@ function referenceMediaBlock(
 
   let stored: { id: string; sizeBytes: number };
   try {
-    stored = createInlineAttachment(
+    stored = await createInlineAttachment(
       conversationId,
       conversationCreatedAt,
       filename,
@@ -99,7 +99,7 @@ function referenceMediaBlock(
       : {}),
   };
   if (block.type === "image") {
-    const dims = optimizedImageDimensions(data, media_type);
+    const dims = await optimizedImageDimensions(data, media_type);
     if (dims) {
       source.width = dims.width;
       source.height = dims.height;
@@ -122,34 +122,43 @@ function referenceMediaBlock(
  * `workspace_ref`. Blocks that are already references, carry no media, or fail
  * to store are returned unchanged.
  */
-export function referenceMediaBlocksForPersist(
+export async function referenceMediaBlocksForPersist(
   conversationId: string,
   conversationCreatedAt: number,
   messageId: string,
   blocks: ContentBlock[],
-): ContentBlock[] {
+): Promise<ContentBlock[]> {
   // A single link position counter across all attachments in the message so
   // their `message_attachments` rows keep content order.
   let position = 0;
-  const convert = (block: ContentBlock): ContentBlock => {
+  const convert = async (block: ContentBlock): Promise<ContentBlock> => {
     if (block.type === "image" || block.type === "file") {
       if (block.source.type !== "base64") {
         return block;
       }
       return (
-        referenceMediaBlock(
+        (await referenceMediaBlock(
           conversationId,
           conversationCreatedAt,
           messageId,
           block,
           position++,
-        ) ?? block
+        )) ?? block
       );
     }
     if (block.type === "tool_result" && block.contentBlocks?.length) {
-      return { ...block, contentBlocks: block.contentBlocks.map(convert) };
+      const contentBlocks: ContentBlock[] = [];
+      for (const cb of block.contentBlocks) {
+        contentBlocks.push(await convert(cb));
+      }
+      return { ...block, contentBlocks };
     }
     return block;
   };
-  return blocks.map(convert);
+  // Sequential so the shared position counter keeps content order.
+  const result: ContentBlock[] = [];
+  for (const block of blocks) {
+    result.push(await convert(block));
+  }
+  return result;
 }

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -484,12 +484,12 @@ export async function processMessage(
     const userMetaWithSlack = slackMeta
       ? { ...serverChannelMeta, slackMeta }
       : serverChannelMeta;
-    const cleanMsg = createUserMessage(content, attachments);
+    const cleanMsg = await createUserMessage(content, attachments);
     const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
     const persisted = await addMessage(
       conversationId,
       "user",
-      serializePersistedUserMessageContent(
+      await serializePersistedUserMessageContent(
         content,
         options?.displayContent,
         attachments,
@@ -578,11 +578,11 @@ export async function processMessage(
     const compactUserMeta = slackMeta
       ? { ...compactChannelMeta, slackMeta }
       : compactChannelMeta;
-    const cleanMsg = createUserMessage(content, attachments);
+    const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
       "user",
-      serializePersistedUserMessageContent(
+      await serializePersistedUserMessageContent(
         content,
         options?.displayContent,
         attachments,
@@ -633,11 +633,11 @@ export async function processMessage(
     const cleanUserMeta = slackMeta
       ? { ...cleanChannelMeta, slackMeta }
       : cleanChannelMeta;
-    const cleanMsg = createUserMessage(content, attachments);
+    const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
       "user",
-      serializePersistedUserMessageContent(
+      await serializePersistedUserMessageContent(
         content,
         options?.displayContent,
         attachments,

--- a/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
@@ -96,7 +96,7 @@ describe("live voice audio archive", () => {
     const { message } = await createMessage("user");
     const audio = Buffer.from("user audio bytes");
 
-    const result = archiveLiveVoiceUserUtteranceAudio({
+    const result = await archiveLiveVoiceUserUtteranceAudio({
       messageId: message.id,
       sessionId: "session-123",
       turnId: "turn-abc",
@@ -148,7 +148,7 @@ describe("live voice audio archive", () => {
     const audio = Buffer.from("assistant audio bytes");
     writeFileSync(sourcePath, audio);
 
-    const result = archiveLiveVoiceAssistantResponseAudio({
+    const result = await archiveLiveVoiceAssistantResponseAudio({
       messageId: message.id,
       sessionId: "session-456",
       turnId: "turn-def",
@@ -202,7 +202,7 @@ describe("live voice audio archive", () => {
   test("links user utterance audio to a persisted user message id", async () => {
     const { message } = await createMessage("user");
 
-    const result = linkLiveVoiceUserUtteranceAudioToMessage({
+    const result = await linkLiveVoiceUserUtteranceAudioToMessage({
       messageId: message.id,
       sessionId: "session-user-link",
       turnId: "turn-user-link",
@@ -228,7 +228,7 @@ describe("live voice audio archive", () => {
   test("links assistant response audio when the assistant message id is available", async () => {
     const { message } = await createMessage("assistant");
 
-    const result = linkLiveVoiceAssistantResponseAudioToMessage({
+    const result = await linkLiveVoiceAssistantResponseAudioToMessage({
       messageId: message.id,
       sessionId: "session-assistant-link",
       turnId: "turn-assistant-link",
@@ -254,8 +254,8 @@ describe("live voice audio archive", () => {
     expect(getLiveVoiceArtifacts(message.id)).toEqual([result.artifact]);
   });
 
-  test("returns an unlinked result when the assistant message id is unavailable", () => {
-    const result = linkLiveVoiceAssistantResponseAudioToMessage({
+  test("returns an unlinked result when the assistant message id is unavailable", async () => {
+    const result = await linkLiveVoiceAssistantResponseAudioToMessage({
       messageId: undefined,
       sessionId: "session-assistant-unlinked",
       turnId: "turn-assistant-unlinked",
@@ -283,7 +283,7 @@ describe("live voice audio archive", () => {
   test("is idempotent for the session turn role key", async () => {
     const { message } = await createMessage("user");
 
-    const first = archiveLiveVoiceAudioArtifact({
+    const first = await archiveLiveVoiceAudioArtifact({
       messageId: message.id,
       sessionId: "session-repeat",
       turnId: "turn-repeat",
@@ -295,7 +295,7 @@ describe("live voice audio archive", () => {
         dataBase64: Buffer.from("first audio").toString("base64"),
       },
     });
-    const second = archiveLiveVoiceAudioArtifact({
+    const second = await archiveLiveVoiceAudioArtifact({
       messageId: message.id,
       sessionId: "session-repeat",
       turnId: "turn-repeat",
@@ -320,7 +320,7 @@ describe("live voice audio archive", () => {
       "first audio",
     );
 
-    const assistantResult = archiveLiveVoiceAudioArtifact({
+    const assistantResult = await archiveLiveVoiceAudioArtifact({
       messageId: message.id,
       sessionId: "session-repeat",
       turnId: "turn-repeat",
@@ -337,7 +337,7 @@ describe("live voice audio archive", () => {
 
   test("restores metadata idempotency from the deterministic attachment filename", async () => {
     const { message } = await createMessage("assistant");
-    const first = archiveLiveVoiceAssistantResponseAudio({
+    const first = await archiveLiveVoiceAssistantResponseAudio({
       messageId: message.id,
       sessionId: "session-crash",
       turnId: "turn-crash",
@@ -360,7 +360,7 @@ describe("live voice audio archive", () => {
       message.id,
     );
 
-    const second = archiveLiveVoiceAssistantResponseAudio({
+    const second = await archiveLiveVoiceAssistantResponseAudio({
       messageId: message.id,
       sessionId: "session-crash",
       turnId: "turn-crash",
@@ -408,7 +408,7 @@ describe("live voice audio archive", () => {
       },
     );
 
-    const archived = archiveLiveVoiceUserUtteranceAudio({
+    const archived = await archiveLiveVoiceUserUtteranceAudio({
       messageId: sourceMessage.id,
       sessionId: "session-artifact-link",
       turnId: "turn-artifact-link",
@@ -452,7 +452,7 @@ describe("live voice audio archive", () => {
   test("returns typed warnings for non-fatal archive failures", async () => {
     const { message } = await createMessage("user");
 
-    const missingFile = archiveLiveVoiceUserUtteranceAudio({
+    const missingFile = await archiveLiveVoiceUserUtteranceAudio({
       messageId: message.id,
       sessionId: "session-warning",
       turnId: "turn-warning",
@@ -470,7 +470,7 @@ describe("live voice audio archive", () => {
       },
     });
 
-    const unsupportedMime = archiveLiveVoiceUserUtteranceAudio({
+    const unsupportedMime = await archiveLiveVoiceUserUtteranceAudio({
       messageId: message.id,
       sessionId: "session-warning",
       turnId: "turn-warning-2",
@@ -488,7 +488,7 @@ describe("live voice audio archive", () => {
       },
     });
 
-    const missingMessage = archiveLiveVoiceUserUtteranceAudio({
+    const missingMessage = await archiveLiveVoiceUserUtteranceAudio({
       messageId: "missing-message",
       sessionId: "session-warning",
       turnId: "turn-warning-3",
@@ -509,7 +509,7 @@ describe("live voice audio archive", () => {
   test("keeps archive metadata scoped to allowed live voice fields", async () => {
     const { message } = await createMessage("assistant");
 
-    const result = archiveLiveVoiceAssistantResponseAudio({
+    const result = await archiveLiveVoiceAssistantResponseAudio({
       messageId: message.id,
       sessionId: "session-metadata",
       turnId: "turn-metadata",

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -736,9 +736,9 @@ describe("live-voice audio archiving default (JARVIS-1283)", () => {
 
   test("liveVoice.archiveAudio=true wires the default archiver through the factory", async () => {
     // The real linkers write to the DB; these are role-less inputs, so stub
-    // them (synchronously — the linkers are sync) with a valid archived result
-    // per role. The point under test is the config→default-archiver wiring, not
-    // the DB write, which the injected-archiver tests above already cover.
+    // them with a valid archived result per role. The point under test is the
+    // config→default-archiver wiring, not the DB write, which the
+    // injected-archiver tests above already cover.
     const audioInput = {
       sessionId: "session-123",
       turnId: "live-turn-1",
@@ -751,11 +751,13 @@ describe("live-voice audio archiving default (JARVIS-1283)", () => {
     const userSpy = spyOn(
       liveVoiceArchive,
       "linkLiveVoiceUserUtteranceAudioToMessage",
-    ).mockReturnValue(makeArchiveResult({ ...audioInput, role: "user" }));
+    ).mockResolvedValue(makeArchiveResult({ ...audioInput, role: "user" }));
     const assistantSpy = spyOn(
       liveVoiceArchive,
       "linkLiveVoiceAssistantResponseAudioToMessage",
-    ).mockReturnValue(makeArchiveResult({ ...audioInput, role: "assistant" }));
+    ).mockResolvedValue(
+      makeArchiveResult({ ...audioInput, role: "assistant" }),
+    );
     const originalRaw = loadRawConfig();
     saveRawConfig({ ...originalRaw, liveVoice: { archiveAudio: true } });
 

--- a/assistant/src/live-voice/live-voice-archive.ts
+++ b/assistant/src/live-voice/live-voice-archive.ts
@@ -468,9 +468,9 @@ function artifactFromAttachment(input: {
   };
 }
 
-export function archiveLiveVoiceAudioArtifact(
+export async function archiveLiveVoiceAudioArtifact(
   input: ArchiveLiveVoiceAudioInput,
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   const validated = validateInput(input);
   if ("type" in validated) {
     return validated;
@@ -529,7 +529,7 @@ export function archiveLiveVoiceAudioArtifact(
     const position = input.position ?? nextAttachmentPosition(input.messageId);
     const stored =
       input.audio.type === "base64"
-        ? attachInlineAttachmentToMessage(
+        ? await attachInlineAttachmentToMessage(
             input.messageId,
             position,
             validated.filename,
@@ -614,15 +614,15 @@ interface LinkLiveVoiceAudioArtifactInput {
   position?: number;
 }
 
-export function archiveLiveVoiceUserUtteranceAudio(
+export async function archiveLiveVoiceUserUtteranceAudio(
   input: ArchiveLiveVoiceRolelessAudioInput,
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   return archiveLiveVoiceAudioArtifact({ ...input, role: "user" });
 }
 
-export function archiveLiveVoiceAssistantResponseAudio(
+export async function archiveLiveVoiceAssistantResponseAudio(
   input: ArchiveLiveVoiceRolelessAudioInput,
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   return archiveLiveVoiceAudioArtifact({ ...input, role: "assistant" });
 }
 
@@ -630,11 +630,11 @@ function normalizeMessageId(messageId: string | null | undefined): string {
   return messageId?.trim() ?? "";
 }
 
-function linkLiveVoiceAudioToMessage(
+async function linkLiveVoiceAudioToMessage(
   input: LinkLiveVoiceRolelessAudioInput & {
     role: LiveVoiceAudioArchiveRole;
   },
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   const messageId = normalizeMessageId(input.messageId);
   if (!messageId) {
     return resultUnlinked(
@@ -651,15 +651,15 @@ function linkLiveVoiceAudioToMessage(
   });
 }
 
-export function linkLiveVoiceUserUtteranceAudioToMessage(
+export async function linkLiveVoiceUserUtteranceAudioToMessage(
   input: LinkLiveVoiceRolelessAudioInput,
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   return linkLiveVoiceAudioToMessage({ ...input, role: "user" });
 }
 
-export function linkLiveVoiceAssistantResponseAudioToMessage(
+export async function linkLiveVoiceAssistantResponseAudioToMessage(
   input: LinkLiveVoiceRolelessAudioInput,
-): LiveVoiceAudioArchiveResult {
+): Promise<LiveVoiceAudioArchiveResult> {
   return linkLiveVoiceAudioToMessage({ ...input, role: "assistant" });
 }
 

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -236,7 +236,23 @@ export function startResourceSampler(
   // thread's kernel state mid-stall when the heartbeat goes stale.
   const stallCapture = createStallCaptureMonitor(dataDir);
 
+  // Skip ticks while a sample is in flight: the disk measurement can take
+  // seconds (du over the workspace), and overlapping ticks would all delta
+  // against the same stale prevSample and land in one burst.
+  let sampleInFlight = false;
   const tick = async () => {
+    if (sampleInFlight) {
+      return;
+    }
+    sampleInFlight = true;
+    try {
+      await runTick();
+    } finally {
+      sampleInFlight = false;
+    }
+  };
+
+  const runTick = async () => {
     const now = clock();
     let sample: ResourceSample;
     try {

--- a/assistant/src/monitoring/resource-sampler.ts
+++ b/assistant/src/monitoring/resource-sampler.ts
@@ -83,10 +83,10 @@ export function computeSampleDeltas(
  * Take a single point-in-time sample of memory + disk. When `prev` is given,
  * the sample carries counter deltas relative to it.
  */
-export function takeSample(
+export async function takeSample(
   now: number,
   prev: ResourceSample | null = null,
-): ResourceSample {
+): Promise<ResourceSample> {
   const currentBytes = getContainerMemoryUsageBytes();
   const limitBytes = getContainerMemoryLimitBytes();
   const memory: ResourceSampleMemory | null =
@@ -99,7 +99,7 @@ export function takeSample(
         }
       : null;
 
-  const disk = getDiskUsageInfo();
+  const disk = await getDiskUsageInfo();
 
   // One read feeds both parsers so the breakdown and counters are coherent.
   const statRaw = readMemoryStatRaw();
@@ -236,11 +236,11 @@ export function startResourceSampler(
   // thread's kernel state mid-stall when the heartbeat goes stale.
   const stallCapture = createStallCaptureMonitor(dataDir);
 
-  const tick = () => {
+  const tick = async () => {
     const now = clock();
     let sample: ResourceSample;
     try {
-      sample = takeSample(now, prevSample);
+      sample = await takeSample(now, prevSample);
       prevSample = sample;
       buffer.append(sample);
     } catch (err) {

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -590,12 +590,12 @@ export function validateAttachmentUpload(
  * @param bytes     Raw file content
  * @returns The stored attachment record
  */
-export function uploadAttachmentFromBytes(
+export async function uploadAttachmentFromBytes(
   filename: string,
   mimeType: string,
   bytes: Uint8Array,
-): StoredAttachment {
-  let norm = normalizeImageBytes(mimeType, bytes);
+): Promise<StoredAttachment> {
+  let norm = await normalizeImageBytes(mimeType, bytes);
   if (norm.converted && norm.bytes.length > MAX_UPLOAD_BYTES) {
     norm = { mimeType, bytes, converted: false };
   }
@@ -803,12 +803,12 @@ function validateAttachmentPayload(
  * conversion whose output would break the upload size limit — passes through
  * verbatim.
  */
-function normalizeUploadedImageBase64(
+async function normalizeUploadedImageBase64(
   filename: string,
   mimeType: string,
   dataBase64: string,
-): { filename: string; mimeType: string; dataBase64: string } {
-  const norm = normalizeImageBase64(mimeType, dataBase64);
+): Promise<{ filename: string; mimeType: string; dataBase64: string }> {
+  const norm = await normalizeImageBase64(mimeType, dataBase64);
   if (!norm.converted) {
     // Bytes untouched, but the declared MIME may have been sniff-corrected.
     return { filename, mimeType: norm.mimeType, dataBase64 };
@@ -823,15 +823,15 @@ function normalizeUploadedImageBase64(
   };
 }
 
-export function uploadAttachment(
+export async function uploadAttachment(
   filename: string,
   mimeType: string,
   dataBase64: string,
   sourcePath?: string,
-): StoredAttachment {
+): Promise<StoredAttachment> {
   validateAttachmentPayload(dataBase64);
 
-  ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
+  ({ filename, mimeType, dataBase64 } = await normalizeUploadedImageBase64(
     filename,
     mimeType,
     dataBase64,
@@ -896,16 +896,16 @@ export interface CreateInlineAttachmentOptions {
  * normalized MIME type, and byte size) before it serializes the message
  * content into a workspace reference.
  */
-export function createInlineAttachment(
+export async function createInlineAttachment(
   conversationId: string,
   conversationCreatedAt: number,
   filename: string,
   mimeType: string,
   dataBase64: string,
   options?: CreateInlineAttachmentOptions,
-): StoredAttachment & { filePath: string } {
+): Promise<StoredAttachment & { filePath: string }> {
   if (options?.normalizeImage) {
-    ({ filename, mimeType, dataBase64 } = normalizeUploadedImageBase64(
+    ({ filename, mimeType, dataBase64 } = await normalizeUploadedImageBase64(
       filename,
       mimeType,
       dataBase64,
@@ -965,20 +965,20 @@ export function createInlineAttachment(
   };
 }
 
-export function attachInlineAttachmentToMessage(
+export async function attachInlineAttachmentToMessage(
   messageId: string,
   position: number,
   filename: string,
   mimeType: string,
   dataBase64: string,
   options?: CreateInlineAttachmentOptions,
-): StoredAttachment & { filePath: string } {
+): Promise<StoredAttachment & { filePath: string }> {
   const ctx = getMessageConversationContext(messageId);
   if (!ctx) {
     throw new Error(`Message not found: ${messageId}`);
   }
 
-  const stored = createInlineAttachment(
+  const stored = await createInlineAttachment(
     ctx.conversationId,
     ctx.conversationCreatedAt,
     filename,

--- a/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
@@ -44,7 +44,7 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
     isRecoverableImageError(ctx.error.message) &&
     !isImageRecoveryAttempted(ctx.conversationId)
   ) {
-    const { messages, changed } = recoverUnsendableImages(ctx.messages);
+    const { messages, changed } = await recoverUnsendableImages(ctx.messages);
     // A rejection can be classified as recoverable yet leave nothing to fix —
     // e.g. a media-type mismatch on a format the sniffer cannot identify. Retrying
     // an unchanged history would resend the identical rejected image and surface a
@@ -59,7 +59,9 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
     // turns, so a persistence failure must never abort the retry that is about
     // to run — log it and continue with the in-memory recovery.
     try {
-      const rewritten = persistUnsendableImageDowngrades(ctx.conversationId);
+      const rewritten = await persistUnsendableImageDowngrades(
+        ctx.conversationId,
+      );
       if (rewritten > 0) {
         ctx.logger.info(
           { plugin: "image-recovery", rewritten },

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -75,9 +75,9 @@ export const UNSENDABLE_IMAGE_NOTE =
  * in context, so without it the original rejected block rehydrates and
  * re-rejects on every later turn.
  */
-export function unsendableImageReplacement(
+export async function unsendableImageReplacement(
   block: Extract<ContentBlock, { type: "image" }>,
-): ContentBlock | null {
+): Promise<ContentBlock | null> {
   // Resolve reference sources to their bytes so a reloaded (referenced) image
   // is gated on the same payload/dimension caps as an inline one. When the
   // attachment can no longer be read, leave the block untouched.
@@ -118,8 +118,8 @@ export function unsendableImageReplacement(
   // pre-send — the upscale runs only here, in response to an actual
   // provider rejection. Oversized images reuse the transport downscale.
   const optimized = belowMinDimension
-    ? upscaleImageToMinimum(resolved.data, effectiveMediaType)
-    : optimizeImageForTransport(resolved.data, effectiveMediaType);
+    ? await upscaleImageToMinimum(resolved.data, effectiveMediaType)
+    : await optimizeImageForTransport(resolved.data, effectiveMediaType);
   if (optimized && optimized.data !== resolved.data) {
     return {
       type: "image",
@@ -145,9 +145,9 @@ export function unsendableImageReplacement(
  * image, so neither matches on a second run. Returns the number of rewritten
  * messages.
  */
-export function persistUnsendableImageDowngrades(
+export async function persistUnsendableImageDowngrades(
   conversationId: string,
-): number {
+): Promise<number> {
   let rewritten = 0;
   for (const row of getMessages(conversationId)) {
     const hasImageBlock = row.content.some(
@@ -163,39 +163,47 @@ export function persistUnsendableImageDowngrades(
     const parsed = row.content;
 
     let changed = false;
-    const next = (parsed as ContentBlock[]).map((block): ContentBlock => {
+    const next: ContentBlock[] = [];
+    for (const block of parsed as ContentBlock[]) {
       if (block.type === "image") {
-        const replacement = unsendableImageReplacement(block);
+        const replacement = await unsendableImageReplacement(block);
         if (!replacement) {
-          return block;
+          next.push(block);
+          continue;
         }
         changed = true;
-        return replacement;
+        next.push(replacement);
+        continue;
       }
       // Images returned by a tool (e.g. browser_screenshot) live inside the
       // tool_result's contentBlocks, not as top-level blocks. Downgrade them
       // in place so the tool_use/tool_result pairing stays intact.
       if (block.type === "tool_result" && block.contentBlocks?.length) {
         let nestedChanged = false;
-        const contentBlocks = block.contentBlocks.map((cb): ContentBlock => {
+        const contentBlocks: ContentBlock[] = [];
+        for (const cb of block.contentBlocks) {
           if (cb.type !== "image") {
-            return cb;
+            contentBlocks.push(cb);
+            continue;
           }
-          const replacement = unsendableImageReplacement(cb);
+          const replacement = await unsendableImageReplacement(cb);
           if (!replacement) {
-            return cb;
+            contentBlocks.push(cb);
+            continue;
           }
           nestedChanged = true;
-          return replacement;
-        });
+          contentBlocks.push(replacement);
+        }
         if (!nestedChanged) {
-          return block;
+          next.push(block);
+          continue;
         }
         changed = true;
-        return { ...block, contentBlocks };
+        next.push({ ...block, contentBlocks });
+        continue;
       }
-      return block;
-    });
+      next.push(block);
+    }
     if (!changed) {
       continue;
     }
@@ -240,50 +248,52 @@ function messageHasImageBlock(content: ReadonlyArray<ContentBlock>): boolean {
  * caller must not retry an unchanged history: it would resend the identical
  * rejected image and falsely report a correction.
  */
-export function recoverUnsendableImages(messages: ReadonlyArray<Message>): {
+export async function recoverUnsendableImages(
+  messages: ReadonlyArray<Message>,
+): Promise<{
   messages: Message[];
   changed: boolean;
-} {
+}> {
   let changed = false;
-  const recovered = messages.map((msg) => {
-    if (!Array.isArray(msg.content)) {
-      return msg;
+  const recovered: Message[] = [];
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content) || !messageHasImageBlock(msg.content)) {
+      recovered.push(msg);
+      continue;
     }
-    if (!messageHasImageBlock(msg.content)) {
-      return msg;
-    }
-    return {
-      ...msg,
-      content: msg.content.flatMap((b): ContentBlock[] => {
-        if (b.type === "image") {
-          const replacement = unsendableImageReplacement(b);
+    const content: ContentBlock[] = [];
+    for (const b of msg.content) {
+      if (b.type === "image") {
+        const replacement = await unsendableImageReplacement(b);
+        if (replacement) {
+          changed = true;
+          content.push(replacement);
+        } else {
+          content.push(b);
+        }
+        continue;
+      }
+      if (b.type === "tool_result" && b.contentBlocks?.length) {
+        const contentBlocks: ContentBlock[] = [];
+        for (const cb of b.contentBlocks) {
+          if (cb.type !== "image") {
+            contentBlocks.push(cb);
+            continue;
+          }
+          const replacement = await unsendableImageReplacement(cb);
           if (replacement) {
             changed = true;
-            return [replacement];
+            contentBlocks.push(replacement);
+          } else {
+            contentBlocks.push(cb);
           }
-          return [b];
         }
-        if (b.type === "tool_result" && b.contentBlocks?.length) {
-          return [
-            {
-              ...b,
-              contentBlocks: b.contentBlocks.map((cb) => {
-                if (cb.type !== "image") {
-                  return cb;
-                }
-                const replacement = unsendableImageReplacement(cb);
-                if (replacement) {
-                  changed = true;
-                  return replacement;
-                }
-                return cb;
-              }),
-            },
-          ];
-        }
-        return [b];
-      }),
-    };
-  });
+        content.push({ ...b, contentBlocks });
+        continue;
+      }
+      content.push(b);
+    }
+    recovered.push({ ...msg, content });
+  }
   return { messages: recovered, changed };
 }

--- a/assistant/src/plugins/defaults/memory/v1/graph/injection.ts
+++ b/assistant/src/plugins/defaults/memory/v1/graph/injection.ts
@@ -349,7 +349,7 @@ export async function resolveInjectionImages(
         continue;
       }
 
-      const optimized = optimizeImageForTransport(
+      const optimized = await optimizeImageForTransport(
         data.data.toString("base64"),
         data.mimeType,
       );

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -976,7 +976,7 @@ export class AnthropicProvider implements Provider {
     // edge LB, NAT idle) — only the latter should be retried.
     let innerTimeoutSignal: AbortSignal | undefined;
     try {
-      sentMessages = this.buildSentMessages(messages);
+      sentMessages = await this.buildSentMessages(messages);
       const {
         effort,
         speed,
@@ -1801,7 +1801,7 @@ export class AnthropicProvider implements Provider {
     systemPrompt: string,
     tools?: ToolDefinition[],
   ): Promise<number> {
-    const sentMessages = this.buildSentMessages(messages);
+    const sentMessages = await this.buildSentMessages(messages);
 
     const system = systemPrompt
       ? systemPrompt
@@ -1837,10 +1837,12 @@ export class AnthropicProvider implements Provider {
    * `cache_control` breakpoints (which don't affect token counts) are the
    * only thing layered on top in `sendMessage`.
    */
-  private buildSentMessages(messages: Message[]): Anthropic.MessageParam[] {
+  private async buildSentMessages(
+    messages: Message[],
+  ): Promise<Anthropic.MessageParam[]> {
     // Swap any persisted attachment references back to inline base64 before
     // serializing, so the block transforms below can read `source.data`.
-    messages = resolveMediaReferences(messages);
+    messages = await resolveMediaReferences(messages);
     const formatted = messages
       .map((m) => {
         // Track whether an unknown block was dropped during filtering

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -434,7 +434,7 @@ export class GeminiProvider implements Provider {
 
     try {
       recordProviderRequestDiagnostics({ model_id: activeModel });
-      const geminiContents = this.toGeminiContents(messages, activeModel);
+      const geminiContents = await this.toGeminiContents(messages, activeModel);
 
       const geminiConfig: genai.GenerateContentConfig = {};
 
@@ -658,7 +658,7 @@ export class GeminiProvider implements Provider {
     systemPrompt: string,
     tools?: ToolDefinition[],
   ): Promise<number> {
-    const contents = this.toGeminiContents(messages, this.model);
+    const contents = await this.toGeminiContents(messages, this.model);
     const config: genai.CountTokensConfig = {};
     if (systemPrompt) {
       config.systemInstruction = systemPrompt.replaceAll(
@@ -689,13 +689,13 @@ export class GeminiProvider implements Provider {
   }
 
   /** Convert neutral messages to Gemini Content[] format. */
-  private toGeminiContents(
+  private async toGeminiContents(
     messages: Message[],
     model: string,
-  ): genai.Content[] {
+  ): Promise<genai.Content[]> {
     // Swap any persisted attachment references back to inline base64 before
     // building parts, so the transforms below can read `source.data`.
-    messages = resolveMediaReferences(messages);
+    messages = await resolveMediaReferences(messages);
     const result: genai.Content[] = [];
 
     // Build a map from tool_use id → function name so tool_result blocks

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -96,7 +96,7 @@ export function resolveMediaSourceData(
   return { data: bytes.toString("base64"), media_type: source.media_type };
 }
 
-function resolveImageBlock(block: ImageContent): ContentBlock {
+async function resolveImageBlock(block: ImageContent): Promise<ContentBlock> {
   if (block.source.type === "base64") {
     return block;
   }
@@ -113,7 +113,7 @@ function resolveImageBlock(block: ImageContent): ContentBlock {
   }
   // Apply the same transport optimization the inline-base64 path used, so a
   // reloaded (reference) turn sends the model the same bytes a live turn would.
-  const { data, mediaType } = optimizeImageForTransport(
+  const { data, mediaType } = await optimizeImageForTransport(
     bytes.toString("base64"),
     block.source.media_type,
   );
@@ -161,7 +161,7 @@ function resolveFileBlock(block: FileContent): ContentBlock {
   };
 }
 
-function resolveBlock(block: ContentBlock): ContentBlock {
+async function resolveBlock(block: ContentBlock): Promise<ContentBlock> {
   switch (block.type) {
     case "image":
       return resolveImageBlock(block);
@@ -172,7 +172,10 @@ function resolveBlock(block: ContentBlock): ContentBlock {
       if (!block.contentBlocks?.length) {
         return block;
       }
-      return { ...block, contentBlocks: block.contentBlocks.map(resolveBlock) };
+      return {
+        ...block,
+        contentBlocks: await Promise.all(block.contentBlocks.map(resolveBlock)),
+      };
     }
     default:
       return block;
@@ -197,11 +200,18 @@ function contentHasReference(content: ContentBlock[]): boolean {
  * (same object reference) so the common all-base64 live turn does no allocation
  * or disk I/O.
  */
-export function resolveMediaReferences(messages: Message[]): Message[] {
-  return messages.map((message) => {
-    if (!contentHasReference(message.content)) {
-      return message;
-    }
-    return { ...message, content: message.content.map(resolveBlock) };
-  });
+export function resolveMediaReferences(
+  messages: Message[],
+): Promise<Message[]> {
+  return Promise.all(
+    messages.map(async (message) => {
+      if (!contentHasReference(message.content)) {
+        return message;
+      }
+      return {
+        ...message,
+        content: await Promise.all(message.content.map(resolveBlock)),
+      };
+    }),
+  );
 }

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -382,7 +382,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const coercedObjectKeys = new Map<string, string[]>();
 
     try {
-      const openaiMessages = this.toOpenAIMessages(
+      const openaiMessages = await this.toOpenAIMessages(
         messages,
         systemPrompt,
         modelSupportsAudioInput(modelOverride ?? this.model),
@@ -939,14 +939,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
   }
 
   /** Convert neutral messages + system prompt to OpenAI message format. */
-  private toOpenAIMessages(
+  private async toOpenAIMessages(
     messages: Message[],
     systemPrompt?: string,
     audioInputEnabled = false,
-  ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+  ): Promise<OpenAI.Chat.Completions.ChatCompletionMessageParam[]> {
     // Swap any persisted attachment references back to inline base64 before
     // serializing, so the block transforms below can read `source.data`.
-    messages = resolveMediaReferences(messages);
+    messages = await resolveMediaReferences(messages);
     const result: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
 
     if (systemPrompt) {

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -243,7 +243,7 @@ export class OpenAIResponsesProvider implements Provider {
     try {
       const effectiveModel = modelOverride ?? this.model;
       recordProviderRequestDiagnostics({ model_id: effectiveModel });
-      const input = this.toResponsesInput(messages);
+      const input = await this.toResponsesInput(messages);
 
       const params: Record<string, unknown> = {
         model: effectiveModel,
@@ -752,10 +752,10 @@ export class OpenAIResponsesProvider implements Provider {
    *
    * System prompt is NOT included here — it goes into the `instructions` param.
    */
-  private toResponsesInput(messages: Message[]): unknown[] {
+  private async toResponsesInput(messages: Message[]): Promise<unknown[]> {
     // Swap any persisted attachment references back to inline base64 before
     // serializing, so the block transforms below can read `source.data`.
-    messages = resolveMediaReferences(messages);
+    messages = await resolveMediaReferences(messages);
     const result: unknown[] = [];
 
     for (const msg of messages) {

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -3,7 +3,10 @@
  * log export and profiler export routes.
  */
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 /** Maximum compressed archive size (50 MB). */
 export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
@@ -13,19 +16,20 @@ export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
  * Returns the Buffer on success, or `undefined` if the archive exceeds
  * the size limit or tar otherwise fails.
  */
-export function createTarGz(
+export async function createTarGz(
   staging: string,
   maxBytes: number = MAX_ARCHIVE_BYTES,
-): ArrayBuffer | undefined {
-  const proc = spawnSync("tar", ["czf", "-", "-C", staging, "."], {
-    maxBuffer: maxBytes,
-    timeout: 30_000,
-  });
-  if (proc.status !== 0) {
+): Promise<ArrayBuffer | undefined> {
+  try {
+    // Exceeding maxBuffer rejects, which maps to the undefined failure return.
+    const { stdout } = await execFileAsync(
+      "tar",
+      ["czf", "-", "-C", staging, "."],
+      { maxBuffer: maxBytes, timeout: 30_000, encoding: "buffer" },
+    );
+    const buf = Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  } catch {
     return undefined;
   }
-  const buf = Buffer.isBuffer(proc.stdout)
-    ? proc.stdout
-    : Buffer.from(proc.stdout);
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 }

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -238,7 +238,7 @@ async function handleMultipartUpload(
 
   const bytes = new Uint8Array(await file.arrayBuffer());
 
-  const attachment = uploadAttachmentFromBytes(filename, mimeType, bytes);
+  const attachment = await uploadAttachmentFromBytes(filename, mimeType, bytes);
   return attachmentPayload(attachment);
 }
 
@@ -248,7 +248,7 @@ async function handleMultipartUpload(
  *
  * See `handleMultipartUpload` for `gatewayTrustedSource` semantics.
  */
-function handleOctetStreamUpload(
+async function handleOctetStreamUpload(
   rawBody: Uint8Array,
   headers: Record<string, string>,
   queryParams: Record<string, string>,
@@ -287,7 +287,11 @@ function handleOctetStreamUpload(
     throw new UnsupportedMediaTypeError(validation.error);
   }
 
-  const attachment = uploadAttachmentFromBytes(filename, mimeType, rawBody);
+  const attachment = await uploadAttachmentFromBytes(
+    filename,
+    mimeType,
+    rawBody,
+  );
   return attachmentPayload(attachment);
 }
 
@@ -296,7 +300,7 @@ function handleOctetStreamUpload(
  *
  * See `handleMultipartUpload` for `gatewayTrustedSource` semantics.
  */
-function handleJsonUpload(
+async function handleJsonUpload(
   body: Record<string, unknown>,
   rawBody: Uint8Array | undefined,
   gatewayTrustedSource: boolean,
@@ -369,7 +373,10 @@ function handleJsonUpload(
       // non-HEIF files (e.g. large videos) from being read into memory.
       try {
         if (isHeifImage(readFileHead(destPath, 12))) {
-          const norm = normalizeImageBytes(mimeType, readFileSync(destPath));
+          const norm = await normalizeImageBytes(
+            mimeType,
+            readFileSync(destPath),
+          );
           if (
             norm.converted &&
             norm.bytes.length <= MAX_FILE_BACKED_UPLOAD_BYTES
@@ -407,7 +414,7 @@ function handleJsonUpload(
     }
 
     try {
-      attachment = uploadAttachment(
+      attachment = await uploadAttachment(
         filename,
         mimeType,
         data,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -639,7 +639,7 @@ async function tryConsumeGuardianReply(params: {
       attachments,
     });
 
-    const cleanUserMessage = createUserMessage(content, attachments);
+    const cleanUserMessage = await createUserMessage(content, attachments);
     const llmUserMessage = enrichMessageWithSourcePaths(
       cleanUserMessage,
       attachments,
@@ -761,9 +761,9 @@ function buildQueuedMessagePayloads(
     });
 }
 
-export function handleListMessages({
+export async function handleListMessages({
   queryParams,
-}: RouteHandlerArgs): Record<string, unknown> {
+}: RouteHandlerArgs): Promise<Record<string, unknown>> {
   const conversationId = queryParams?.conversationId;
   const conversationKey = queryParams?.conversationKey;
 
@@ -1046,196 +1046,207 @@ export function handleListMessages({
   );
   const pendingQuestions = collectPendingQuestions(resolvedConversationId);
 
-  const messages: RuntimeMessagePayload[] = parsed.map((m) => {
-    const mergedMessageIds = m.id ? (mergedIdMap.get(m.id) ?? []) : [];
+  const messages: RuntimeMessagePayload[] = await Promise.all(
+    parsed.map(async (m) => {
+      const mergedMessageIds = m.id ? (mergedIdMap.get(m.id) ?? []) : [];
 
-    // Hydrate the row's attachments from the DB. A metadata-only query avoids
-    // loading large base64 blobs for non-image attachments (documents, audio);
-    // full data is fetched only for images so the client can generate
-    // thumbnails for inline display on history restore. Merged messages
-    // (consecutive assistant merge) are queried too so their attachments
-    // aren't lost before DB compaction relinks them.
-    let msgAttachments: RuntimeAttachmentMetadata[] = [];
-    if (m.id) {
-      const idsToQuery = [m.id, ...mergedMessageIds];
-      const linked = idsToQuery.flatMap((id) =>
-        getAttachmentMetadataForMessage(id),
-      );
-      if (linked.length > 0) {
-        msgAttachments = linked.map((a) => {
-          // Hydrate image rows for inline thumbnails. Legacy HEIC can be
-          // stored under application/octet-stream (empty File.type fallback),
-          // so `.heic`/`.heif` rows are hydrated by filename too;
-          // normalizeImageBase64 sniffs the bytes and rewrites only genuine
-          // HEIF, which Chromium-based clients cannot decode. Filename and
-          // sizeBytes keep describing the stored original, which
-          // /attachments/:id/content serves verbatim for downloads.
-          const isImage = a.mimeType.startsWith("image/");
-          const isLegacyHeic = !isImage && isHeicFilename(a.originalFilename);
-          const full =
-            isImage || isLegacyHeic
-              ? getAttachmentById(a.id, { hydrateFileData: true })
-              : null;
-          const display = full?.dataBase64
-            ? normalizeImageBase64(a.mimeType, full.dataBase64)
-            : null;
-          // Image rows carry data even when unconverted (thumbnails); a
-          // non-image row only becomes renderable once conversion yields a
-          // JPEG, so it stays metadata-only when conversion is unavailable.
-          const useDisplay =
-            display && (isImage || display.converted) ? display : null;
-          return {
-            id: a.id,
-            filename: a.originalFilename,
-            mimeType: useDisplay?.mimeType ?? a.mimeType,
-            sizeBytes: a.sizeBytes,
-            kind: useDisplay?.converted
-              ? classifyKind(useDisplay.mimeType)
-              : a.kind,
-            ...(useDisplay ? { data: useDisplay.dataBase64 } : {}),
-            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
-            fileBacked: true,
-          };
-        });
-      }
-    }
-
-    // Align the hydrated rows with the file-block refs, then render. Rendering
-    // after alignment lets renderHistoryContent inline each `attachment` block
-    // during its single content walk, so `contentBlocks` comes back ready to
-    // ship with no post-processing. The aligned reorder/rewrite keeps the
-    // legacy `attachments` array and `contentOrder` positions consistent.
-    const attachmentRefs = collectAttachmentRefs(m.content);
-    const aligned = alignAttachments(attachmentRefs, msgAttachments);
-    msgAttachments = aligned.attachments;
-    const attachmentBlocks = attachmentRefs.map((_ref, refIdx) => {
-      const att = aligned.refIndexToAttachment.get(refIdx);
-      return att ? toAttachmentBlockRef(att) : null;
-    });
-    const rendered = renderHistoryContent(
-      m.content,
-      attachmentBlocks,
-      m.id ?? undefined,
-    );
-
-    const toolCalls = enrichToolCallsWithQuestion(
-      enrichToolCallsWithConfirmation(rendered.toolCalls, {
-        workspaceDir,
-        pendingConfirmations,
-      }),
-      { pendingQuestions },
-    );
-
-    // Strip <no_response/> markers from assistant messages so web/API clients
-    // never see the raw sentinel. Only assistant messages produce it; user
-    // messages are untouched. The filter is applied consistently to the
-    // segments, the contentOrder text refs, and the text blocks of
-    // contentBlocks.
-    let textSegments = rendered.textSegments;
-    let contentOrder = rendered.contentOrder;
-    let contentBlocks = rendered.contentBlocks;
-    if (m.role === "assistant") {
-      const keepIndices: number[] = [];
-      const filteredSegments: string[] = [];
-      for (let i = 0; i < rendered.textSegments.length; i++) {
-        const cleaned = rendered.textSegments[i]
-          .replace(NO_RESPONSE_INLINE_RE, "")
-          .trim();
-        if (cleaned.length > 0) {
-          keepIndices.push(i);
-          filteredSegments.push(cleaned);
+      // Hydrate the row's attachments from the DB. A metadata-only query avoids
+      // loading large base64 blobs for non-image attachments (documents, audio);
+      // full data is fetched only for images so the client can generate
+      // thumbnails for inline display on history restore. Merged messages
+      // (consecutive assistant merge) are queried too so their attachments
+      // aren't lost before DB compaction relinks them.
+      let msgAttachments: RuntimeAttachmentMetadata[] = [];
+      if (m.id) {
+        const idsToQuery = [m.id, ...mergedMessageIds];
+        const linked = idsToQuery.flatMap((id) =>
+          getAttachmentMetadataForMessage(id),
+        );
+        if (linked.length > 0) {
+          msgAttachments = await Promise.all(
+            linked.map(async (a) => {
+              // Hydrate image rows for inline thumbnails. Legacy HEIC can be
+              // stored under application/octet-stream (empty File.type fallback),
+              // so `.heic`/`.heif` rows are hydrated by filename too;
+              // normalizeImageBase64 sniffs the bytes and rewrites only genuine
+              // HEIF, which Chromium-based clients cannot decode. Filename and
+              // sizeBytes keep describing the stored original, which
+              // /attachments/:id/content serves verbatim for downloads.
+              const isImage = a.mimeType.startsWith("image/");
+              const isLegacyHeic =
+                !isImage && isHeicFilename(a.originalFilename);
+              const full =
+                isImage || isLegacyHeic
+                  ? getAttachmentById(a.id, { hydrateFileData: true })
+                  : null;
+              const display = full?.dataBase64
+                ? await normalizeImageBase64(a.mimeType, full.dataBase64)
+                : null;
+              // Image rows carry data even when unconverted (thumbnails); a
+              // non-image row only becomes renderable once conversion yields a
+              // JPEG, so it stays metadata-only when conversion is unavailable.
+              const useDisplay =
+                display && (isImage || display.converted) ? display : null;
+              return {
+                id: a.id,
+                filename: a.originalFilename,
+                mimeType: useDisplay?.mimeType ?? a.mimeType,
+                sizeBytes: a.sizeBytes,
+                kind: useDisplay?.converted
+                  ? classifyKind(useDisplay.mimeType)
+                  : a.kind,
+                ...(useDisplay ? { data: useDisplay.dataBase64 } : {}),
+                ...(a.thumbnailBase64
+                  ? { thumbnailData: a.thumbnailBase64 }
+                  : {}),
+                fileBacked: true,
+              };
+            }),
+          );
         }
       }
-      const indexMap = new Map<number, number>();
-      keepIndices.forEach((oldIdx, newIdx) => indexMap.set(oldIdx, newIdx));
-      contentOrder = rendered.contentOrder
-        .map((entry) => {
-          const tm = entry.match(/^text:(\d+)$/);
-          if (!tm) {
-            return entry;
+
+      // Align the hydrated rows with the file-block refs, then render. Rendering
+      // after alignment lets renderHistoryContent inline each `attachment` block
+      // during its single content walk, so `contentBlocks` comes back ready to
+      // ship with no post-processing. The aligned reorder/rewrite keeps the
+      // legacy `attachments` array and `contentOrder` positions consistent.
+      const attachmentRefs = collectAttachmentRefs(m.content);
+      const aligned = alignAttachments(attachmentRefs, msgAttachments);
+      msgAttachments = aligned.attachments;
+      const attachmentBlocks = attachmentRefs.map((_ref, refIdx) => {
+        const att = aligned.refIndexToAttachment.get(refIdx);
+        return att ? toAttachmentBlockRef(att) : null;
+      });
+      const rendered = renderHistoryContent(
+        m.content,
+        attachmentBlocks,
+        m.id ?? undefined,
+      );
+
+      const toolCalls = enrichToolCallsWithQuestion(
+        enrichToolCallsWithConfirmation(rendered.toolCalls, {
+          workspaceDir,
+          pendingConfirmations,
+        }),
+        { pendingQuestions },
+      );
+
+      // Strip <no_response/> markers from assistant messages so web/API clients
+      // never see the raw sentinel. Only assistant messages produce it; user
+      // messages are untouched. The filter is applied consistently to the
+      // segments, the contentOrder text refs, and the text blocks of
+      // contentBlocks.
+      let textSegments = rendered.textSegments;
+      let contentOrder = rendered.contentOrder;
+      let contentBlocks = rendered.contentBlocks;
+      if (m.role === "assistant") {
+        const keepIndices: number[] = [];
+        const filteredSegments: string[] = [];
+        for (let i = 0; i < rendered.textSegments.length; i++) {
+          const cleaned = rendered.textSegments[i]
+            .replace(NO_RESPONSE_INLINE_RE, "")
+            .trim();
+          if (cleaned.length > 0) {
+            keepIndices.push(i);
+            filteredSegments.push(cleaned);
           }
-          const newIdx = indexMap.get(Number(tm[1]));
-          return newIdx !== undefined ? `text:${newIdx}` : undefined;
-        })
-        .filter((e): e is string => e !== undefined);
-      textSegments = filteredSegments;
-      contentBlocks = rendered.contentBlocks
-        .map((block) =>
-          block.type === "text"
-            ? {
-                type: "text" as const,
-                text: block.text.replace(NO_RESPONSE_INLINE_RE, "").trim(),
-              }
-            : block,
-        )
-        .filter((block) => block.type !== "text" || block.text.length > 0);
-    }
-
-    // Ensure every hydrated attachment has a corresponding content block.
-    // renderHistoryContent inlines attachment blocks only when it has
-    // file-block refs with matching DB rows; directives (assistant-authored
-    // <vellum-attachment/> tags) don't leave a file block after stripping,
-    // so their attachments end up in the flat `attachments` array but not in
-    // `contentBlocks`. Append any that are missing so the canonical
-    // projection is complete.
-    const existingAttachmentIds = new Set(
-      contentBlocks
-        .filter(
-          (b): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
-            b.type === "attachment",
-        )
-        .map((b) => b.attachment.id),
-    );
-    for (const att of msgAttachments) {
-      if (!existingAttachmentIds.has(att.id)) {
-        contentBlocks.push({
-          type: "attachment",
-          attachment: toAttachmentBlockRef(att),
-        });
+        }
+        const indexMap = new Map<number, number>();
+        keepIndices.forEach((oldIdx, newIdx) => indexMap.set(oldIdx, newIdx));
+        contentOrder = rendered.contentOrder
+          .map((entry) => {
+            const tm = entry.match(/^text:(\d+)$/);
+            if (!tm) {
+              return entry;
+            }
+            const newIdx = indexMap.get(Number(tm[1]));
+            return newIdx !== undefined ? `text:${newIdx}` : undefined;
+          })
+          .filter((e): e is string => e !== undefined);
+        textSegments = filteredSegments;
+        contentBlocks = rendered.contentBlocks
+          .map((block) =>
+            block.type === "text"
+              ? {
+                  type: "text" as const,
+                  text: block.text.replace(NO_RESPONSE_INLINE_RE, "").trim(),
+                }
+              : block,
+          )
+          .filter((block) => block.type !== "text" || block.text.length > 0);
       }
-    }
 
-    const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
+      // Ensure every hydrated attachment has a corresponding content block.
+      // renderHistoryContent inlines attachment blocks only when it has
+      // file-block refs with matching DB rows; directives (assistant-authored
+      // <vellum-attachment/> tags) don't leave a file block after stripping,
+      // so their attachments end up in the flat `attachments` array but not in
+      // `contentBlocks`. Append any that are missing so the canonical
+      // projection is complete.
+      const existingAttachmentIds = new Set(
+        contentBlocks
+          .filter(
+            (
+              b,
+            ): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
+              b.type === "attachment",
+          )
+          .map((b) => b.attachment.id),
+      );
+      for (const att of msgAttachments) {
+        if (!existingAttachmentIds.has(att.id)) {
+          contentBlocks.push({
+            type: "attachment",
+            attachment: toAttachmentBlockRef(att),
+          });
+        }
+      }
 
-    // Use sentAt (actual event time) for the display timestamp when available,
-    // falling back to createdAt (persistence time). Clients use this display
-    // timestamp as their pagination cursor after memory-pressure trimming,
-    // while server-side pagination filters on createdAt. The mismatch is
-    // benign — it may return slightly extra data on a page boundary but never
-    // loses messages.
-    const displayTimestamp = m.sentAt ?? m.createdAt;
-    return {
-      id: m.id ?? "",
-      ...(mergedMessageIds.length > 0 ? { mergedMessageIds } : {}),
-      ...(m.clientMessageId ? { clientMessageId: m.clientMessageId } : {}),
-      role: m.role,
-      timestamp: new Date(displayTimestamp).toISOString(),
-      attachments: msgAttachments,
-      ...(toolCalls.length > 0 ? { toolCalls } : {}),
-      ...(rendered.surfaces.length > 0 ? { surfaces: rendered.surfaces } : {}),
-      ...(textSegments.length > 0 ? { textSegments } : {}),
-      ...(rendered.thinkingSegments.length > 0
-        ? { thinkingSegments: rendered.thinkingSegments }
-        : {}),
-      ...(alignedContentOrder.length > 0
-        ? { contentOrder: alignedContentOrder }
-        : {}),
-      contentBlocks,
-      ...(m.subagentNotification
-        ? { subagentNotification: m.subagentNotification }
-        : {}),
-      ...(m.acpNotification ? { acpNotification: m.acpNotification } : {}),
-      ...(m.backgroundEventNotification
-        ? { backgroundEventNotification: true }
-        : {}),
-      ...(m.backgroundToolCompletion
-        ? { backgroundToolCompletion: m.backgroundToolCompletion }
-        : {}),
-      ...(m.systemCard ? { systemCard: true } : {}),
-      ...(m.providerError ? { providerError: m.providerError } : {}),
-      ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
-    };
-  });
+      const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
+
+      // Use sentAt (actual event time) for the display timestamp when available,
+      // falling back to createdAt (persistence time). Clients use this display
+      // timestamp as their pagination cursor after memory-pressure trimming,
+      // while server-side pagination filters on createdAt. The mismatch is
+      // benign — it may return slightly extra data on a page boundary but never
+      // loses messages.
+      const displayTimestamp = m.sentAt ?? m.createdAt;
+      return {
+        id: m.id ?? "",
+        ...(mergedMessageIds.length > 0 ? { mergedMessageIds } : {}),
+        ...(m.clientMessageId ? { clientMessageId: m.clientMessageId } : {}),
+        role: m.role,
+        timestamp: new Date(displayTimestamp).toISOString(),
+        attachments: msgAttachments,
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(rendered.surfaces.length > 0
+          ? { surfaces: rendered.surfaces }
+          : {}),
+        ...(textSegments.length > 0 ? { textSegments } : {}),
+        ...(rendered.thinkingSegments.length > 0
+          ? { thinkingSegments: rendered.thinkingSegments }
+          : {}),
+        ...(alignedContentOrder.length > 0
+          ? { contentOrder: alignedContentOrder }
+          : {}),
+        contentBlocks,
+        ...(m.subagentNotification
+          ? { subagentNotification: m.subagentNotification }
+          : {}),
+        ...(m.acpNotification ? { acpNotification: m.acpNotification } : {}),
+        ...(m.backgroundEventNotification
+          ? { backgroundEventNotification: true }
+          : {}),
+        ...(m.backgroundToolCompletion
+          ? { backgroundToolCompletion: m.backgroundToolCompletion }
+          : {}),
+        ...(m.systemCard ? { systemCard: true } : {}),
+        ...(m.providerError ? { providerError: m.providerError } : {}),
+        ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
+      };
+    }),
+  );
 
   // Snapshot↔stream alignment token: the `seq` of the last event whose
   // content is durably persisted for this conversation, read from the

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1209,7 +1209,7 @@ export async function handleListMessages({
       // falling back to createdAt (persistence time). Clients use this display
       // timestamp as their pagination cursor after memory-pressure trimming,
       // while server-side pagination filters on createdAt. The mismatch is
-      // benign — it may return slightly extra data on a page boundary but never
+      // benign: it may return slightly extra data on a page boundary but never
       // loses messages.
       const displayTimestamp = m.sentAt ?? m.createdAt;
       return {

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -230,15 +230,15 @@ export function handleHealth(): Response {
 }
 
 /** Disk usage for the health payload; null when it can't be measured. */
-function sampleDiskUsageInfo(): ReturnType<typeof getDiskUsageInfo> {
+async function sampleDiskUsageInfo(): ReturnType<typeof getDiskUsageInfo> {
   try {
-    return getDiskUsageInfo();
+    return await getDiskUsageInfo();
   } catch {
     return null;
   }
 }
 
-function getDetailedHealth() {
+async function getDetailedHealth() {
   let profiler: ReturnType<typeof getProfilerRuntimeStatus> | undefined;
   try {
     profiler = getProfilerRuntimeStatus();
@@ -260,7 +260,7 @@ function getDetailedHealth() {
     status: "healthy",
     timestamp: new Date().toISOString(),
     version: APP_VERSION,
-    disk: sampleDiskUsageInfo(),
+    disk: await sampleDiskUsageInfo(),
     memory: getMemoryInfo(),
     cpu: getCpuInfo(),
     migrations: {
@@ -280,8 +280,8 @@ function getDetailedHealth() {
   };
 }
 
-export function handleDetailedHealth(): Response {
-  return Response.json(getDetailedHealth());
+export async function handleDetailedHealth(): Promise<Response> {
+  return Response.json(await getDetailedHealth());
 }
 
 type UnreadyDbMigrationReadiness = Extract<

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1816,7 +1816,7 @@ async function persistBackfilledSlackMessage(params: {
             );
             continue;
           }
-          attachInlineAttachmentToMessage(
+          await attachInlineAttachmentToMessage(
             persisted.id,
             i,
             downloaded.filename,
@@ -1863,21 +1863,21 @@ async function persistBackfilledSlackMessage(params: {
     updateMessageContent(
       persisted.id,
       JSON.stringify(
-        buildBackfilledSlackContentBlocks(rawText, hydratedAttachments),
+        await buildBackfilledSlackContentBlocks(rawText, hydratedAttachments),
       ),
     );
   }
 }
 
-function buildBackfilledSlackContentBlocks(
+async function buildBackfilledSlackContentBlocks(
   text: string,
   attachments: MessageAttachmentInput[],
-): ContentBlock[] {
+): Promise<ContentBlock[]> {
   const blocks: ContentBlock[] = [];
   if (text.trim().length > 0) {
     blocks.push({ type: "text", text });
   }
-  blocks.push(...attachmentsToContentBlocks(attachments));
+  blocks.push(...(await attachmentsToContentBlocks(attachments)));
   return blocks;
 }
 

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -465,7 +465,7 @@ async function handleExport({
     );
 
     // --- Create tar.gz archive ---
-    const archiveBuffer = createTarGz(staging);
+    const archiveBuffer = await createTarGz(staging);
     if (!archiveBuffer) {
       throw new InternalError("Failed to create archive");
     }

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -127,7 +127,9 @@ function handleGetRun({ pathParams = {} }: RouteHandlerArgs) {
   };
 }
 
-function handleExportRun({ pathParams = {} }: RouteHandlerArgs): Uint8Array {
+async function handleExportRun({
+  pathParams = {},
+}: RouteHandlerArgs): Promise<Uint8Array> {
   const runId = validateRunId(pathParams.runId);
 
   const runDir = getProfilerRunDir(runId);
@@ -140,7 +142,7 @@ function handleExportRun({ pathParams = {} }: RouteHandlerArgs): Uint8Array {
   try {
     copyDirContents(runDir, staging);
 
-    const archiveBuf = createTarGz(staging);
+    const archiveBuf = await createTarGz(staging);
     if (!archiveBuf) {
       log.error(
         { runId },

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -395,15 +395,28 @@ function assertStagedSkillRoot(skillId: string, stagedDir: string): void {
   }
 }
 
-export function installSkillDependenciesIfPresent(skillDir: string): void {
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
+export async function installSkillDependenciesIfPresent(
+  skillDir: string,
+): Promise<void> {
+  if (!existsSync(join(skillDir, "package.json"))) {
+    return;
+  }
+  const bunPath = `${homedir()}/.bun/bin`;
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("bun", ["install"], {
       cwd: skillDir,
       stdio: "inherit",
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
-  }
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`bun install exited with code ${code}`));
+      }
+    });
+  });
 }
 
 function restoreOrRemoveFailedSkillInstall(
@@ -518,7 +531,7 @@ export async function installSkillLocally(
       contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
 
-    installSkillDependenciesIfPresent(stagedDir);
+    await installSkillDependenciesIfPresent(stagedDir);
     commitStagedSkillInstall(skillId, stagedDir);
 
     log.info(

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -480,7 +480,7 @@ export async function installExternalSkill(
       contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
 
-    installSkillDependenciesIfPresent(stagedDir);
+    await installSkillDependenciesIfPresent(stagedDir);
     commitStagedSkillInstall(skillSlug, stagedDir);
   } catch (err) {
     rmSync(stagedDir, { recursive: true, force: true });

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -1410,7 +1410,7 @@ export async function executeBrowserScreenshot(
     // capture of a tall or high-DPI page can exceed Anthropic's 5 MB
     // per-image cap, which would otherwise persist into the conversation
     // history inside this tool_result and reject every subsequent turn.
-    const { data: base64Data, mediaType } = optimizeImageForTransport(
+    const { data: base64Data, mediaType } = await optimizeImageForTransport(
       rawBase64,
       "image/jpeg",
     );

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 
 import { getConfig } from "../config/loader.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
@@ -484,18 +484,19 @@ export function computePerToolTimeoutMs(
  * confirmation payload — ahead of approval. Host file tools have no preview
  * for the same reason.
  */
-function computePreviewDiff(
+async function computePreviewDiff(
   toolName: string,
   input: Record<string, unknown>,
   workingDir: string,
-):
+): Promise<
   | {
       filePath: string;
       oldContent: string;
       newContent: string;
       isNewFile: boolean;
     }
-  | undefined {
+  | undefined
+> {
   try {
     if (toolName === "file_write") {
       // Parse with the tool's own schema so the preview reads the same shape
@@ -519,7 +520,7 @@ function computePreviewDiff(
           return undefined;
         }
       }
-      const oldContent = isNewFile ? "" : readFileSync(filePath, "utf-8");
+      const oldContent = isNewFile ? "" : await readFile(filePath, "utf-8");
       return { filePath, oldContent, newContent: content, isNewFile };
     }
 
@@ -545,7 +546,7 @@ function computePreviewDiff(
       if (stat.size > MAX_FILE_SIZE_BYTES) {
         return undefined;
       }
-      const content = readFileSync(filePath, "utf-8");
+      const content = await readFile(filePath, "utf-8");
       const replaceAll = parsed.data.replace_all === true;
       const result = applyEdit(content, oldString, newString, replaceAll);
       if (!result.ok) {

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -88,7 +88,7 @@ export const fileEditTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: rawPath,
       oldString,
       newString,

--- a/assistant/src/tools/filesystem/list.ts
+++ b/assistant/src/tools/filesystem/list.ts
@@ -61,7 +61,7 @@ export const fileListTool = {
       sandboxPolicy(path, context.workingDir, opts),
     );
 
-    const result = ops.listDirSafe({ path: rawPath, glob });
+    const result = await ops.listDirSafe({ path: rawPath, glob });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -112,7 +112,7 @@ export const fileReadTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
-    const result = ops.readFileSafe({ path: rawPath, offset, limit });
+    const result = await ops.readFileSafe({ path: rawPath, offset, limit });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/filesystem/search.ts
+++ b/assistant/src/tools/filesystem/search.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 
 import { minimatch } from "minimatch";
@@ -48,11 +48,10 @@ const MAX_DISPLAY_LINE_LENGTH = 2000;
 // report the result as truncated.
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024; // 4 MiB
 
-// Wall-clock deadline for the whole search. The synchronous scan never yields,
-// so the promise-based tool timeout / abort signal can't fire mid-scan. Checking
-// this deadline (and the abort signal) once per line bounds how long a search
-// over a very large tree can block the event loop and lets an external abort
-// stop the walk promptly.
+// Wall-clock deadline for the whole search. File I/O yields between files,
+// but the per-file line loop is CPU-bound; checking this deadline (and the
+// abort signal) once per line bounds how long a search over a very large tree
+// can occupy the event loop and lets an external abort stop the walk promptly.
 const MAX_SEARCH_MS = 10_000; // 10 s
 
 const DEFAULT_MAX_RESULTS = 200;
@@ -150,7 +149,7 @@ export const codeSearchTool = {
     // Match with the linear-time RE2 engine (via re2js) instead of V8's
     // backtracking RegExp. RE2 guarantees linear-time matching, so a
     // user/subagent-supplied pattern cannot trigger catastrophic backtracking
-    // and block the synchronous scan. The trade-off is that RE2 rejects
+    // and pin the event loop inside the per-file line loop. The trade-off is that RE2 rejects
     // backreferences and lookarounds; compile() throws on those, surfaced as a
     // clean error below.
     let regex: RE2JS;
@@ -189,7 +188,7 @@ export const codeSearchTool = {
     // NOT_FOUND / NOT_A_DIRECTORY reporting in file_list.
     let rootStat: import("node:fs").Stats;
     try {
-      rootStat = statSync(root);
+      rootStat = await stat(root);
     } catch {
       return {
         content: `Error: path not found: ${rawPath}`,
@@ -198,8 +197,8 @@ export const codeSearchTool = {
     }
 
     // Start the wall-clock deadline before walking so a pathological regex
-    // (or an external abort) can stop the synchronous scan mid-flight instead
-    // of blocking the event loop until the whole tree is exhausted.
+    // (or an external abort) can stop the scan mid-flight instead of running
+    // until the whole tree is exhausted.
     const searchStart = Date.now();
 
     const lines: string[] = [];
@@ -228,7 +227,7 @@ export const codeSearchTool = {
     let totalBytes = 0;
     // Number of directory entries visited during the walk (files + subdirs),
     // bounded by MAX_ENTRIES_TRAVERSED so a pathological tree can't run the
-    // synchronous readdir/stat work unbounded even when no file is ever read.
+    // readdir/stat work unbounded even when no file is ever read.
     let entriesTraversed = 0;
     // Set when an EXPLICIT file root (not a child discovered mid-walk) can't be
     // read — e.g. EACCES/EPERM. A child file's read failure is optional and
@@ -264,7 +263,10 @@ export const codeSearchTool = {
 
     // Scan a single regular file for matches. Applies the denied-basename guard
     // and per-file size caps. Returns nothing; mutates the shared accumulators.
-    const scanFile = (full: string, isExplicitRoot = false): void => {
+    const scanFile = async (
+      full: string,
+      isExplicitRoot = false,
+    ): Promise<void> => {
       if (truncated) {
         return;
       }
@@ -306,7 +308,7 @@ export const codeSearchTool = {
 
       let size: number;
       try {
-        size = statSync(full).size;
+        size = (await stat(full)).size;
       } catch {
         return;
       }
@@ -323,7 +325,7 @@ export const codeSearchTool = {
 
       let buf: Buffer;
       try {
-        buf = readFileSync(full);
+        buf = await readFile(full);
       } catch (err) {
         // A child file discovered mid-walk is optional — skip it silently. But
         // an explicit file root that can't be read was never searched, so record
@@ -407,13 +409,13 @@ export const codeSearchTool = {
       }
     };
 
-    const walk = (dir: string, isExplicitRoot = false): void => {
+    const walk = async (dir: string, isExplicitRoot = false): Promise<void> => {
       if (truncated) {
         return;
       }
       // Bound the traversal itself, not just file reads: a deep/wide tree of
       // directories (or many entries that never get read) could otherwise run
-      // the synchronous readdir/stat work far past the advertised deadline.
+      // the readdir/stat work far past the advertised deadline.
       if (Date.now() - searchStart > MAX_SEARCH_MS || context.signal?.aborted) {
         truncated = true;
         timedOut = true;
@@ -421,7 +423,7 @@ export const codeSearchTool = {
       }
       let entries: import("node:fs").Dirent[];
       try {
-        entries = readdirSync(dir, { withFileTypes: true });
+        entries = await readdir(dir, { withFileTypes: true });
       } catch (err) {
         // A child directory discovered mid-walk is optional — skip it silently.
         // But an explicit directory root that can't be read (e.g. EACCES/EPERM)
@@ -458,18 +460,18 @@ export const codeSearchTool = {
           if (IGNORED_DIRS.has(entry.name)) {
             continue;
           }
-          walk(full);
+          await walk(full);
           continue;
         }
         if (!entry.isFile()) {
           continue;
         }
-        scanFile(full);
+        await scanFile(full);
       }
     };
 
     if (rootStat.isDirectory()) {
-      walk(root, true);
+      await walk(root, true);
       // An explicit directory root that statSync sees but readdirSync can't read
       // (EACCES/EPERM) was never searched — surface a hard error instead of a
       // false "No matches found", mirroring the unreadable explicit-file root.
@@ -487,7 +489,7 @@ export const codeSearchTool = {
           isError: true,
         };
       }
-      scanFile(root, true);
+      await scanFile(root, true);
       if (rootReadError) {
         return { content: rootReadError, isError: true };
       }

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -129,7 +129,10 @@ export const fileWriteTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
-    const result = ops.writeFileSafe({ path: rawPath, content: fileContent });
+    const result = await ops.writeFileSafe({
+      path: rawPath,
+      content: fileContent,
+    });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -158,7 +158,7 @@ export const hostFileEditTool = {
 
     const ops = new FileSystemOps(hostPolicy);
 
-    const result = ops.editFileSafe({
+    const result = await ops.editFileSafe({
       path: rawPath,
       oldString,
       newString,

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -170,7 +170,7 @@ export const hostFileReadTool = {
 
     const ops = new FileSystemOps(hostPolicy);
 
-    const result = ops.readFileSafe({ path: rawPath, offset, limit });
+    const result = await ops.readFileSafe({ path: rawPath, offset, limit });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -131,7 +131,10 @@ export const hostFileWriteTool = {
 
     const ops = new FileSystemOps(hostPolicy);
 
-    const result = ops.writeFileSafe({ path: rawPath, content: fileContent });
+    const result = await ops.writeFileSafe({
+      path: rawPath,
+      content: fileContent,
+    });
 
     if (!result.ok) {
       const { error } = result;

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -104,14 +104,15 @@ export class PermissionChecker {
       toolName: string,
       input: Record<string, unknown>,
       workingDir: string,
-    ) =>
+    ) => Promise<
       | {
           filePath: string;
           oldContent: string;
           newContent: string;
           isNewFile: boolean;
         }
-      | undefined,
+      | undefined
+    >,
   ): Promise<PermissionDecision> {
     // Sandbox/host routing for the prompt comes from the tool's manifest.
     const executionTarget = resolveExecutionTarget(tool);
@@ -378,7 +379,11 @@ export class PermissionChecker {
           };
         }
 
-        const previewDiff = computePreviewDiff(name, input, context.workingDir);
+        const previewDiff = await computePreviewDiff(
+          name,
+          input,
+          context.workingDir,
+        );
         const promptOptions = {
           allowlistOptions: await generateAllowlistOptions(
             name,

--- a/assistant/src/tools/shared/filesystem/audio-read.ts
+++ b/assistant/src/tools/shared/filesystem/audio-read.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { readFile, stat as fsStat } from "node:fs/promises";
 import { basename, extname } from "node:path";
 
 import { GEMINI_MAX_INLINE_AUDIO_BYTES } from "../../../providers/gemini/inline-media.js";
@@ -67,7 +67,9 @@ function buildAudioToolResult(
  * The caller is responsible for path resolution and sandbox enforcement —
  * `resolvedPath` must be an already-validated absolute path.
  */
-export function readAudioFile(resolvedPath: string): ToolExecutionResult {
+export async function readAudioFile(
+  resolvedPath: string,
+): Promise<ToolExecutionResult> {
   const mimeType = EXTENSION_MIME[extname(resolvedPath).toLowerCase()];
   if (!mimeType) {
     // Defensive: callers gate on AUDIO_EXTENSIONS, so this is unreachable.
@@ -79,7 +81,7 @@ export function readAudioFile(resolvedPath: string): ToolExecutionResult {
 
   let stat;
   try {
-    stat = statSync(resolvedPath);
+    stat = await fsStat(resolvedPath);
   } catch {
     return { content: `Error: file not found: ${resolvedPath}`, isError: true };
   }
@@ -96,7 +98,7 @@ export function readAudioFile(resolvedPath: string): ToolExecutionResult {
 
   let buffer: Buffer;
   try {
-    buffer = readFileSync(resolvedPath) as Buffer;
+    buffer = (await readFile(resolvedPath)) as Buffer;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error reading file: ${msg}`, isError: true };

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -1,10 +1,4 @@
-import {
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { lstat, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { minimatch } from "minimatch";
@@ -70,7 +64,7 @@ export class FileSystemOps {
   // Read
   // -------------------------------------------------------------------------
 
-  readFileSafe(input: ReadInput): ReadResult {
+  async readFileSafe(input: ReadInput): Promise<ReadResult> {
     const pathCheck = this.policy(input.path, { mustExist: true });
     if (!pathCheck.ok) {
       return {
@@ -84,18 +78,18 @@ export class FileSystemOps {
       return { ok: false, error: Err.notFound(filePath) };
     }
 
-    const stat = statSync(filePath);
-    if (!stat.isFile()) {
+    const pathStat = await stat(filePath);
+    if (!pathStat.isFile()) {
       return { ok: false, error: Err.notAFile(filePath) };
     }
 
-    const sizeErr = checkFileSizeOnDisk(filePath, this.sizeLimit);
+    const sizeErr = await checkFileSizeOnDisk(filePath, this.sizeLimit);
     if (sizeErr) {
       return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
     try {
-      const raw = readFileSync(filePath, "utf-8");
+      const raw = await readFile(filePath, "utf-8");
       const lines = raw.split("\n");
 
       const offset = (input.offset ?? 1) - 1;
@@ -120,7 +114,7 @@ export class FileSystemOps {
   // Write
   // -------------------------------------------------------------------------
 
-  writeFileSafe(input: WriteInput): WriteResult {
+  async writeFileSafe(input: WriteInput): Promise<WriteResult> {
     const pathCheck = this.policy(input.path, { mustExist: false });
     if (!pathCheck.ok) {
       return {
@@ -142,13 +136,13 @@ export class FileSystemOps {
       const isNewFile = !pathExists(filePath);
       if (!isNewFile) {
         try {
-          oldContent = readFileSync(filePath, "utf-8");
+          oldContent = await readFile(filePath, "utf-8");
         } catch {
           // Unreadable existing file - keep oldContent as empty string.
         }
       }
 
-      writeFileSync(filePath, input.content);
+      await writeFile(filePath, input.content);
 
       return {
         ok: true,
@@ -169,7 +163,7 @@ export class FileSystemOps {
   // Edit
   // -------------------------------------------------------------------------
 
-  editFileSafe(input: EditInput): EditResult {
+  async editFileSafe(input: EditInput): Promise<EditResult> {
     const pathCheck = this.policy(input.path, { mustExist: true });
     if (!pathCheck.ok) {
       return {
@@ -181,7 +175,7 @@ export class FileSystemOps {
 
     // Size-check the file on disk (swallow ENOENT - readFileSync gives a clearer error)
     try {
-      const sizeErr = checkFileSizeOnDisk(filePath, this.sizeLimit);
+      const sizeErr = await checkFileSizeOnDisk(filePath, this.sizeLimit);
       if (sizeErr) {
         return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
       }
@@ -191,7 +185,7 @@ export class FileSystemOps {
 
     let content: string;
     try {
-      content = readFileSync(filePath, "utf-8");
+      content = await readFile(filePath, "utf-8");
     } catch (err) {
       const code =
         err instanceof Error && "code" in err
@@ -229,7 +223,7 @@ export class FileSystemOps {
     }
 
     try {
-      writeFileSync(filePath, result.updatedContent);
+      await writeFile(filePath, result.updatedContent);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { ok: false, error: Err.ioError(filePath, msg) };
@@ -254,7 +248,7 @@ export class FileSystemOps {
   // List
   // -------------------------------------------------------------------------
 
-  listDirSafe(input: ListInput): ListResult {
+  async listDirSafe(input: ListInput): Promise<ListResult> {
     const pathCheck = this.policy(input.path, { mustExist: true });
     if (!pathCheck.ok) {
       return {
@@ -268,13 +262,13 @@ export class FileSystemOps {
       return { ok: false, error: Err.notFound(resolved) };
     }
 
-    const stat = statSync(resolved);
-    if (!stat.isDirectory()) {
+    const pathStat = await stat(resolved);
+    if (!pathStat.isDirectory()) {
       return { ok: false, error: Err.notADirectory(resolved) };
     }
 
     try {
-      let entries = readdirSync(resolved, { withFileTypes: true });
+      let entries = await readdir(resolved, { withFileTypes: true });
 
       if (input.glob) {
         const pattern = input.glob;
@@ -294,16 +288,18 @@ export class FileSystemOps {
       const truncated = sorted.length > MAX_ENTRIES;
       const visible = sorted.slice(0, MAX_ENTRIES);
 
-      const lines = visible.map((entry) => {
-        if (entry.isDirectory()) {
-          return `${entry.name}/`;
-        }
-        if (entry.isSymbolicLink()) {
-          return `${entry.name}@`;
-        }
-        const fileStat = lstatSync(join(resolved, entry.name));
-        return `${entry.name}  ${formatSize(fileStat.size)}`;
-      });
+      const lines = await Promise.all(
+        visible.map(async (entry) => {
+          if (entry.isDirectory()) {
+            return `${entry.name}/`;
+          }
+          if (entry.isSymbolicLink()) {
+            return `${entry.name}@`;
+          }
+          const fileStat = await lstat(join(resolved, entry.name));
+          return `${entry.name}  ${formatSize(fileStat.size)}`;
+        }),
+      );
 
       if (truncated) {
         lines.push(

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -36,6 +36,32 @@ export type PathPolicy = (
 // Service
 // ---------------------------------------------------------------------------
 
+// Serialize mutations per resolved path. The agent loop executes sibling
+// tool calls in parallel, and the async read -> apply -> write window would
+// otherwise let two edits of the same file both read the same old content and
+// have the later write silently drop the earlier edit (the previous
+// synchronous service made each mutation atomic within the event loop).
+const fileWriteLocks = new Map<string, Promise<void>>();
+
+async function withFileWriteLock<T>(
+  filePath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = fileWriteLocks.get(filePath) ?? Promise.resolve();
+  const run = prev.then(fn, fn);
+  const tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  fileWriteLocks.set(filePath, tail);
+  void tail.then(() => {
+    if (fileWriteLocks.get(filePath) === tail) {
+      fileWriteLocks.delete(filePath);
+    }
+  });
+  return run;
+}
+
 function pathError(
   path: string,
   reason: PathFailureReason,
@@ -129,34 +155,36 @@ export class FileSystemOps {
       return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
     }
 
-    try {
-      ensureDir(dirname(filePath));
+    return withFileWriteLock(filePath, async (): Promise<WriteResult> => {
+      try {
+        ensureDir(dirname(filePath));
 
-      let oldContent = "";
-      const isNewFile = !pathExists(filePath);
-      if (!isNewFile) {
-        try {
-          oldContent = await readFile(filePath, "utf-8");
-        } catch {
-          // Unreadable existing file - keep oldContent as empty string.
+        let oldContent = "";
+        const isNewFile = !pathExists(filePath);
+        if (!isNewFile) {
+          try {
+            oldContent = await readFile(filePath, "utf-8");
+          } catch {
+            // Unreadable existing file - keep oldContent as empty string.
+          }
         }
+
+        await writeFile(filePath, input.content);
+
+        return {
+          ok: true,
+          value: {
+            filePath,
+            isNewFile,
+            oldContent,
+            newContent: input.content,
+          },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: Err.ioError(filePath, msg) };
       }
-
-      await writeFile(filePath, input.content);
-
-      return {
-        ok: true,
-        value: {
-          filePath,
-          isNewFile,
-          oldContent,
-          newContent: input.content,
-        },
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { ok: false, error: Err.ioError(filePath, msg) };
-    }
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -173,75 +201,78 @@ export class FileSystemOps {
     }
     const filePath = pathCheck.resolved;
 
-    // Size-check the file on disk (swallow ENOENT - readFileSync gives a clearer error)
-    try {
-      const sizeErr = await checkFileSizeOnDisk(filePath, this.sizeLimit);
-      if (sizeErr) {
-        return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
+    return withFileWriteLock(filePath, async (): Promise<EditResult> => {
+      // Size-check the file on disk (swallow ENOENT - the read below gives a
+      // clearer error)
+      try {
+        const sizeErr = await checkFileSizeOnDisk(filePath, this.sizeLimit);
+        if (sizeErr) {
+          return { ok: false, error: Err.sizeLimitExceeded(filePath, sizeErr) };
+        }
+      } catch {
+        // Fall through - the read below will surface NOT_FOUND.
       }
-    } catch {
-      // Fall through - the readFileSync below will surface NOT_FOUND.
-    }
 
-    let content: string;
-    try {
-      content = await readFile(filePath, "utf-8");
-    } catch (err) {
-      const code =
-        err instanceof Error && "code" in err
-          ? (err as NodeJS.ErrnoException).code
-          : undefined;
-      if (code === "EISDIR") {
-        return { ok: false, error: Err.notAFile(filePath) };
+      let content: string;
+      try {
+        content = await readFile(filePath, "utf-8");
+      } catch (err) {
+        const code =
+          err instanceof Error && "code" in err
+            ? (err as NodeJS.ErrnoException).code
+            : undefined;
+        if (code === "EISDIR") {
+          return { ok: false, error: Err.notAFile(filePath) };
+        }
+        if (code === "ENOENT") {
+          return { ok: false, error: Err.notFound(filePath) };
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: Err.ioError(filePath, msg) };
       }
-      if (code === "ENOENT") {
-        return { ok: false, error: Err.notFound(filePath) };
-      }
-      const msg = err instanceof Error ? err.message : String(err);
-      return { ok: false, error: Err.ioError(filePath, msg) };
-    }
 
-    if (input.oldString.length === 0) {
-      return { ok: false, error: Err.matchNotFound(filePath) };
-    }
-
-    const result = applyEdit(
-      content,
-      input.oldString,
-      input.newString,
-      input.replaceAll,
-    );
-
-    if (!result.ok) {
-      if (result.reason === "not_found") {
+      if (input.oldString.length === 0) {
         return { ok: false, error: Err.matchNotFound(filePath) };
       }
+
+      const result = applyEdit(
+        content,
+        input.oldString,
+        input.newString,
+        input.replaceAll,
+      );
+
+      if (!result.ok) {
+        if (result.reason === "not_found") {
+          return { ok: false, error: Err.matchNotFound(filePath) };
+        }
+        return {
+          ok: false,
+          error: Err.matchAmbiguous(filePath, result.matchCount),
+        };
+      }
+
+      try {
+        await writeFile(filePath, result.updatedContent);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: Err.ioError(filePath, msg) };
+      }
+
       return {
-        ok: false,
-        error: Err.matchAmbiguous(filePath, result.matchCount),
+        ok: true,
+        value: {
+          filePath,
+          matchCount: result.matchCount,
+          oldContent: content,
+          newContent: result.updatedContent,
+          matchMethod: result.matchMethod,
+          similarity: result.similarity,
+          actualOld: result.actualOld,
+          actualNew: result.actualNew,
+        },
       };
-    }
-
-    try {
-      await writeFile(filePath, result.updatedContent);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { ok: false, error: Err.ioError(filePath, msg) };
-    }
-
-    return {
-      ok: true,
-      value: {
-        filePath,
-        matchCount: result.matchCount,
-        oldContent: content,
-        newContent: result.updatedContent,
-        matchMethod: result.matchMethod,
-        similarity: result.similarity,
-        actualOld: result.actualOld,
-        actualNew: result.actualNew,
-      },
-    };
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -63,10 +63,10 @@ export function detectMediaType(buf: Buffer): string | null {
   return null;
 }
 
-function buildImageToolResult(
+async function buildImageToolResult(
   buffer: Buffer,
   sourceLabel: string,
-): ToolExecutionResult {
+): Promise<ToolExecutionResult> {
   if (buffer.length > MAX_SOURCE_SIZE_BYTES) {
     const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
     return {
@@ -87,10 +87,8 @@ function buildImageToolResult(
 
   // Optimize before size-checking — oversized images may compress under the limit.
   const rawBase64 = buffer.toString("base64");
-  const { data: base64Data, mediaType: finalType } = optimizeImageForTransport(
-    rawBase64,
-    detectedType,
-  );
+  const { data: base64Data, mediaType: finalType } =
+    await optimizeImageForTransport(rawBase64, detectedType);
   const optimized = base64Data !== rawBase64;
 
   const optimizedBytes = Buffer.from(base64Data, "base64").length;
@@ -124,10 +122,10 @@ function buildImageToolResult(
   };
 }
 
-export function readImageBase64(
+export async function readImageBase64(
   base64Data: string,
   sourceLabel: string,
-): ToolExecutionResult {
+): Promise<ToolExecutionResult> {
   return buildImageToolResult(Buffer.from(base64Data, "base64"), sourceLabel);
 }
 
@@ -138,7 +136,9 @@ export function readImageBase64(
  * The caller is responsible for path resolution and sandbox enforcement -
  * `resolvedPath` must be an already-validated absolute path.
  */
-export function readImageFile(resolvedPath: string): ToolExecutionResult {
+export async function readImageFile(
+  resolvedPath: string,
+): Promise<ToolExecutionResult> {
   let stat;
   try {
     stat = statSync(resolvedPath);

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { readFile, stat as fsStat } from "node:fs/promises";
 
 import { optimizeImageForTransport } from "../../../agent/image-optimize.js";
 import type { ImageContent } from "../../../providers/types.js";
@@ -141,7 +141,7 @@ export async function readImageFile(
 ): Promise<ToolExecutionResult> {
   let stat;
   try {
-    stat = statSync(resolvedPath);
+    stat = await fsStat(resolvedPath);
   } catch {
     return {
       content: `Error: file not found: ${resolvedPath}`,
@@ -163,7 +163,7 @@ export async function readImageFile(
 
   let buffer: Buffer;
   try {
-    buffer = readFileSync(resolvedPath) as Buffer;
+    buffer = (await readFile(resolvedPath)) as Buffer;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error reading file: ${msg}`, isError: true };

--- a/assistant/src/tools/shared/filesystem/size-guard.ts
+++ b/assistant/src/tools/shared/filesystem/size-guard.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import { stat } from "node:fs/promises";
 
 /** Default maximum file size: 100 MB */
 export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
@@ -17,13 +17,13 @@ function formatBytes(bytes: number): string {
  * Check whether a file on disk exceeds the size limit.
  * Returns an error string if the file is too large, or undefined if OK.
  */
-export function checkFileSizeOnDisk(
+export async function checkFileSizeOnDisk(
   filePath: string,
   limit: number = MAX_FILE_SIZE_BYTES,
-): string | undefined {
-  const stat = statSync(filePath);
-  if (stat.size > limit) {
-    return `File size (${formatBytes(stat.size)}) exceeds the ${formatBytes(
+): Promise<string | undefined> {
+  const fileStat = await stat(filePath);
+  if (fileStat.size > limit) {
+    return `File size (${formatBytes(fileStat.size)}) exceeds the ${formatBytes(
       limit,
     )} limit: ${filePath}`;
   }

--- a/assistant/src/util/disk-usage.ts
+++ b/assistant/src/util/disk-usage.ts
@@ -1,5 +1,6 @@
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, statfsSync } from "node:fs";
+import { promisify } from "node:util";
 
 import {
   getIsContainerized,
@@ -7,6 +8,8 @@ import {
   getMinikubeStorageSize,
 } from "../config/env-registry.js";
 import { getWorkspaceDir } from "./platform.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface DiskUsageInfo {
   path: string;
@@ -19,21 +22,17 @@ export interface DiskUsageInfo {
  * Measure the on-disk usage of one or more directory paths using `du -sb`.
  * Returns the sum of all paths in bytes, or null on failure.
  */
-function getDirectorySizeBytes(paths: string[]): number | null {
+async function getDirectorySizeBytes(paths: string[]): Promise<number | null> {
   try {
     const existing = paths.filter((p) => existsSync(p));
     if (existing.length === 0) {
       return null;
     }
-    const result = spawnSync("du", ["-sb", ...existing], {
-      encoding: "utf-8",
+    const { stdout } = await execFileAsync("du", ["-sb", ...existing], {
       timeout: 30_000,
     });
-    if (result.status !== 0) {
-      return null;
-    }
     let total = 0;
-    for (const line of result.stdout.trim().split("\n")) {
+    for (const line of stdout.trim().split("\n")) {
       const size = parseInt(line.split("\t")[0], 10);
       if (!isNaN(size) && size > 0) {
         total += size;
@@ -46,14 +45,19 @@ function getDirectorySizeBytes(paths: string[]): number | null {
 }
 
 const DU_CACHE_TTL_MS = 60_000;
-let duCacheValue: number | null = null;
+// Caches the in-flight promise so concurrent callers share one `du` run.
+let duCacheValue: Promise<number | null> | null = null;
 let duCacheTime = 0;
 let duCachePaths: string | null = null;
 
-function getCachedDirectorySizeBytes(paths: string[]): number | null {
+function getCachedDirectorySizeBytes(paths: string[]): Promise<number | null> {
   const key = paths.join("\0");
   const now = Date.now();
-  if (duCachePaths === key && now - duCacheTime < DU_CACHE_TTL_MS) {
+  if (
+    duCacheValue !== null &&
+    duCachePaths === key &&
+    now - duCacheTime < DU_CACHE_TTL_MS
+  ) {
     return duCacheValue;
   }
   duCacheValue = getDirectorySizeBytes(paths);
@@ -119,7 +123,7 @@ function classifyWorkspaceVolume(
   return { kind: "none" };
 }
 
-export function getDiskUsageInfo(): DiskUsageInfo | null {
+export async function getDiskUsageInfo(): Promise<DiskUsageInfo | null> {
   try {
     const wsDir = getWorkspaceDir();
     const diskPath = existsSync(wsDir) ? wsDir : "/";
@@ -135,7 +139,7 @@ export function getDiskUsageInfo(): DiskUsageInfo | null {
       if (diskPath !== "/data" && existsSync("/data")) {
         volumePaths.push("/data");
       }
-      const usedBytes = getCachedDirectorySizeBytes(volumePaths);
+      const usedBytes = await getCachedDirectorySizeBytes(volumePaths);
       if (usedBytes !== null) {
         const totalBytes =
           reporting.kind === "fixed-cap"

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -13,7 +13,6 @@
  * conversions of the same image (or daemon restarts) skip the sips call.
  */
 
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   closeSync,
@@ -101,10 +100,10 @@ export interface ConvertToJpegOptions {
   quality?: number;
 }
 
-function runSips(
+async function runSips(
   inputBytes: Uint8Array,
   options: ConvertToJpegOptions,
-): Buffer | null {
+): Promise<Buffer | null> {
   const stamp = `${Date.now()}-${uuid().slice(0, 8)}`;
   const srcPath = join(tmpdir(), `vellum-img-opt-${stamp}-src`);
   const outPath = join(tmpdir(), `vellum-img-opt-${stamp}-out.jpg`);
@@ -133,7 +132,15 @@ function runSips(
       "--out",
       outPath,
     );
-    execFileSync("sips", args, { stdio: "pipe", timeout: 15_000 });
+    const proc = Bun.spawn(["sips", ...args], {
+      stdout: "ignore",
+      stderr: "ignore",
+      timeout: 15_000,
+    });
+    await proc.exited;
+    if (proc.exitCode !== 0) {
+      return null;
+    }
     return readFileSync(outPath) as Buffer;
   } catch {
     return null;
@@ -155,10 +162,10 @@ function runSips(
  * Convert an image to JPEG, optionally downscaling. Returns null when
  * conversion is unavailable (non-macOS) or fails; callers keep the original.
  */
-export function convertImageToJpeg(
+export async function convertImageToJpeg(
   bytes: Uint8Array,
   options: ConvertToJpegOptions = {},
-): Buffer | null {
+): Promise<Buffer | null> {
   const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
   // Options qualify the key so full-resolution storage conversions and
   // resized transport conversions of the same source never collide.
@@ -173,7 +180,7 @@ export function convertImageToJpeg(
     return cached;
   }
 
-  const converted = runSips(bytes, options);
+  const converted = await runSips(bytes, options);
   if (!converted) {
     return null;
   }
@@ -346,12 +353,12 @@ export interface NormalizedImageBytes {
  * {@link jpegFilenameFor} when `converted` is true — a MIME-only correction
  * sets `converted: false` and keeps the filename.
  */
-export function normalizeImageBytes(
+export async function normalizeImageBytes(
   mimeType: string,
   bytes: Uint8Array,
-): NormalizedImageBytes {
+): Promise<NormalizedImageBytes> {
   if (isHeifImage(bytes)) {
-    const converted = convertImageToJpeg(bytes, {
+    const converted = await convertImageToJpeg(bytes, {
       quality: STORAGE_JPEG_QUALITY,
     });
     if (!converted) {
@@ -376,14 +383,14 @@ export interface NormalizedImageBase64 {
  * Base64 variant of {@link normalizeImageBytes}. Sniffs the decoded head
  * first so non-HEIF payloads skip the full decode.
  */
-export function normalizeImageBase64(
+export async function normalizeImageBase64(
   mimeType: string,
   dataBase64: string,
-): NormalizedImageBase64 {
+): Promise<NormalizedImageBase64> {
   // 16 base64 chars decode to the 12 bytes the ftyp/signature sniffs need.
   const head = Buffer.from(dataBase64.slice(0, 16), "base64");
   if (isHeifImage(head)) {
-    const normalized = normalizeImageBytes(
+    const normalized = await normalizeImageBytes(
       mimeType,
       Buffer.from(dataBase64, "base64"),
     );

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -100,33 +100,6 @@ export interface ConvertToJpegOptions {
   quality?: number;
 }
 
-// Bound concurrent sips child processes. Callers fan out per image
-// (provider media resolution, attachment serialization, history hydration),
-// so an image-heavy conversation would otherwise spawn one process per image
-// at once. Slot-transfer semaphore: a releasing task hands its slot straight
-// to the next waiter so the count can never overshoot the cap.
-const MAX_CONCURRENT_CONVERSIONS = 4;
-let activeConversions = 0;
-const conversionWaiters: (() => void)[] = [];
-
-async function acquireConversionSlot(): Promise<void> {
-  if (activeConversions < MAX_CONCURRENT_CONVERSIONS) {
-    activeConversions++;
-    return;
-  }
-  await new Promise<void>((resolve) => conversionWaiters.push(resolve));
-}
-
-function releaseConversionSlot(): void {
-  const next = conversionWaiters.shift();
-  if (next) {
-    // The slot transfers to the waiter; activeConversions stays unchanged.
-    next();
-  } else {
-    activeConversions--;
-  }
-}
-
 async function runSips(
   inputBytes: Uint8Array,
   options: ConvertToJpegOptions,
@@ -207,13 +180,7 @@ export async function convertImageToJpeg(
     return cached;
   }
 
-  await acquireConversionSlot();
-  let converted: Buffer | null;
-  try {
-    converted = await runSips(bytes, options);
-  } finally {
-    releaseConversionSlot();
-  }
+  const converted = await runSips(bytes, options);
   if (!converted) {
     return null;
   }

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -100,6 +100,33 @@ export interface ConvertToJpegOptions {
   quality?: number;
 }
 
+// Bound concurrent sips child processes. Callers fan out per image
+// (provider media resolution, attachment serialization, history hydration),
+// so an image-heavy conversation would otherwise spawn one process per image
+// at once. Slot-transfer semaphore: a releasing task hands its slot straight
+// to the next waiter so the count can never overshoot the cap.
+const MAX_CONCURRENT_CONVERSIONS = 4;
+let activeConversions = 0;
+const conversionWaiters: (() => void)[] = [];
+
+async function acquireConversionSlot(): Promise<void> {
+  if (activeConversions < MAX_CONCURRENT_CONVERSIONS) {
+    activeConversions++;
+    return;
+  }
+  await new Promise<void>((resolve) => conversionWaiters.push(resolve));
+}
+
+function releaseConversionSlot(): void {
+  const next = conversionWaiters.shift();
+  if (next) {
+    // The slot transfers to the waiter; activeConversions stays unchanged.
+    next();
+  } else {
+    activeConversions--;
+  }
+}
+
 async function runSips(
   inputBytes: Uint8Array,
   options: ConvertToJpegOptions,
@@ -180,7 +207,13 @@ export async function convertImageToJpeg(
     return cached;
   }
 
-  const converted = await runSips(bytes, options);
+  await acquireConversionSlot();
+  let converted: Buffer | null;
+  try {
+    converted = await runSips(bytes, options);
+  } finally {
+    releaseConversionSlot();
+  }
   if (!converted) {
     return null;
   }

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn, spawnSync } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -413,18 +413,19 @@ export class WorkspaceGitService {
    * open, we leave it alone. If no process holds it, it's stale (crashed
    * process) and safe to remove.
    */
-  private cleanStaleLockFile(): void {
+  private async cleanStaleLockFile(): Promise<void> {
     const lockPath = join(this.workspaceDir, ".git", "index.lock");
     if (!existsSync(lockPath)) {
       return;
     }
 
     try {
-      const result = spawnSync("lsof", ["-t", lockPath], {
+      // lsof exits non-zero when no process holds the file, which rejects the
+      // promise and falls through to removal below.
+      const { stdout } = await execFileAsync("lsof", ["-t", lockPath], {
         timeout: 3000,
-        stdio: ["ignore", "pipe", "ignore"],
       });
-      if (result.status === 0 && result.stdout?.length > 0) {
+      if (stdout.length > 0) {
         log.debug("index.lock held by an active process, skipping removal");
         return;
       }
@@ -490,7 +491,7 @@ export class WorkspaceGitService {
 
           // Clean up stale lock files before any git operations.
           if (existsSync(gitDir)) {
-            this.cleanStaleLockFile();
+            await this.cleanStaleLockFile();
           }
 
           if (existsSync(gitDir)) {
@@ -657,7 +658,7 @@ export class WorkspaceGitService {
     await this.ensureInitialized();
 
     await this.mutex.withLock(async () => {
-      this.cleanStaleLockFile();
+      await this.cleanStaleLockFile();
 
       // Stage all changes (minus oversized files)
       await this.stageAllLocked();
@@ -734,7 +735,7 @@ export class WorkspaceGitService {
 
     try {
       const result = await this.mutex.withLock(async () => {
-        this.cleanStaleLockFile();
+        await this.cleanStaleLockFile();
 
         // Re-check breaker under lock: a queued call that started before the
         // breaker opened should not proceed with expensive git work now that
@@ -2003,7 +2004,7 @@ export class WorkspaceGitService {
   ): Promise<void> {
     await this.ensureInitialized();
     await this.mutex.withLock(async () => {
-      this.cleanStaleLockFile();
+      await this.cleanStaleLockFile();
       await fn((args) => {
         // Intercept commit commands to enforce hook hardening.
         if (args[0] === "commit") {


### PR DESCRIPTION
## Summary

A user reported needing blocking tool/DB work moved off the daemon's event loop. An audit found every `child_process` call on a daemon-reachable path was synchronous (`execSync`/`spawnSync`/`execFileSync`), freezing the event loop — health checks, SSE streams, and every in-flight turn — for the duration:

| Call site | Blocking cost | Now |
|---|---|---|
| `util/image-conversion.ts` — `sips` conversion | up to 15s per image, on the provider send path, attachment ingress, history hydration, and screenshot tools | `Bun.spawn` + `await proc.exited` |
| `util/disk-usage.ts` — `du -sb` over the workspace | up to 30s | async `execFile`; cache stores the in-flight promise so concurrent callers share one `du` |
| `runtime/routes/archive-utils.ts` — `tar czf` log/profiler exports | up to 30s / 50 MB | async `execFile` |
| `skills/catalog-install.ts` — `bun install` on skill install | unbounded (network) | `spawn` + close promise |
| `workspace/git-service.ts` — `lsof` stale-lock probe | 3s timeout, inside the git mutex | the file's existing `execFileAsync` |

The image converter's async-ness propagates through its call graph (`optimizeImageForTransport`, `normalizeImageBytes/Base64`, `createUserMessage`, `resolveMediaReferences` + the four provider serializers, attachment stores/routes, image-recovery plugin, compactor, live-voice archive) — mechanical `async`/`await` threading, no behavior change. ~30 test files updated to await the new signatures.

`sips` specifically uses native `Bun.spawn` rather than promisified `execFile`: under the bun test runner, `promisify(execFile)` showed an intermittent (~1-in-4 runs) multi-second stall on short-lived failing spawns; `Bun.spawn` was clean across 10/10 hammer runs.

**Deliberately left synchronous** (none on the daemon request path): CLI-side `daemon-control` `ps` probe, boot-time `install-symlink` `which`, one-time workspace migration 010, `cli db refresh`, and embed-worker lifecycle `ps` scans.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `eslint` + `prettier` clean over the diff
- [x] All touched suites pass individually: attachments-store (94), list-messages batch (144), disk/health batch (205), image batch (66), git-service (93), live-voice archive (17), skills/providers (82)
- [x] Image batch hammered 10x with `Bun.spawn` — no flakes
- [x] Known pre-existing cross-file `mock.module` pollution in hand-picked combined runs reproduces identically at the merge base (repo's sharded runner never co-schedules those files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8ycnppVJFcdS8Bn4x4GXx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->