### PR TITLE
refactor(onboarding): archive side threads unconditionally

### DIFF
--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -78,9 +78,9 @@ export async function runIdentityRewrite({
       return false;
     }
 
-    // Let the rewrite turn run before hiding the thread — archiving mid-turn
-    // could drop the identity edits. Settle on the daemon's turn-completion
-    // flag (see `shouldSettlePersonalityPoll`).
+    // Let the rewrite turn run before the archive: archiving mid-turn could
+    // drop the identity edits. Settle on the daemon's turn-completion flag
+    // (see `shouldSettlePersonalityPoll`).
     const deadline = Date.now() + MAX_POLL_MS;
     let lastText = "";
     let stableReads = 0;
@@ -115,7 +115,7 @@ export async function runIdentityRewrite({
   } catch (err) {
     captureError(err, { context });
   } finally {
-    // Archive the throwaway thread so it never appears in the sidebar.
+    // Best-effort cleanup of the throwaway thread.
     if (conversationId) {
       try {
         await conversationsByIdArchivePost({

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -115,8 +115,8 @@ export async function applyPersonality({
     // rewrite alone would lose them. Best-effort, like the rest of the flow.
     await savePersonalitySliders(assistantId, completeSliderValues(values));
 
-    // Let the rewrite turn run before hiding the thread — archiving mid-turn
-    // could drop the identity edits, and the chat handoff awaits this promise
+    // Let the rewrite turn run before the archive: archiving mid-turn could
+    // drop the identity edits, and the chat handoff awaits this promise
     // so the first greeting must not start until the identity files are
     // written. Settle on the daemon's turn-completion flag (see
     // `shouldSettlePersonalityPoll`).

--- a/clients/web/src/domains/onboarding/archive-research-conversation.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.ts
@@ -4,23 +4,21 @@
  *
  * That conversation is a throwaway side channel: it exists only to drive the
  * research prompt whose claims/suggestions the in-flow result steps render. It
- * must never surface in the user's chat sidebar when they land in their
- * workspace, so once the research response has settled we archive it — the
- * sidebar's `group-conversations.ts` drops `archivedAt != null` rows, so an
- * archived conversation simply disappears from the list.
+ * is minted `background`, which the daemon keeps out of the default `standard`
+ * conversation list, so the sidebar never shows it. Archiving is cleanup on top
+ * of that: it also drops the row from the lazily-loaded Background section.
  *
- * Best-effort: this runs after the response is delivered, so a failure here
- * must never block or surface in the flow. Every error is swallowed (reported
- * to Sentry) and never rethrown, mirroring `checkin-scheduler.ts`.
+ * Best-effort: a failure here must never block or surface in the flow. Every
+ * error is swallowed (reported to Sentry) and never rethrown, mirroring
+ * `checkin-scheduler.ts`.
  */
 
 import { conversationsByIdArchivePost } from "@/generated/daemon/sdk.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 
 /**
- * Archive the research-onboarding side conversation so it never appears in the
- * chat sidebar. Best-effort and fire-and-forget: resolves regardless of outcome
- * and never throws.
+ * Archive the research-onboarding side conversation. Best-effort and
+ * fire-and-forget: resolves regardless of outcome and never throws.
  */
 export async function archiveResearchConversation(
   assistantId: string,

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -2,7 +2,8 @@
  * Tests for how the research runner opens its side conversation: it is minted
  * `background` so it never enters the foreground list, the prompt is posted
  * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
- * only when the turn never started.
+ * only when the turn never started. It also covers the archive that cleans the
+ * thread up on every exit path, including a poll-ceiling timeout.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -16,7 +17,14 @@ import { createElement, type ReactNode } from "react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
@@ -31,10 +39,22 @@ interface CreateCall {
   body: { conversationType?: string; title?: string };
 }
 
+interface ArchiveCall {
+  path: { assistant_id: string; id: string };
+}
+
 let postCalls: PostCall[] = [];
 let createCalls: CreateCall[] = [];
+let archiveCalls: ArchiveCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
+/**
+ * When set, every `/messages` read jumps the clock past the runner's poll
+ * ceiling, so the poll loop exits on its deadline check having parsed no
+ * complete payload.
+ */
+let expirePollCeiling = false;
+const PAST_POLL_CEILING_MS = 300_000;
 
 const ok = <T>(data: T) =>
   Promise.resolve({ data, error: undefined, response: { ok: true } });
@@ -48,9 +68,15 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     createCalls.push(opts);
     return ok({ id: "conv-fresh" });
   },
-  conversationsByIdArchivePost: () => ok({}),
+  conversationsByIdArchivePost: (opts: ArchiveCall) => {
+    archiveCalls.push(opts);
+    return ok({});
+  },
   messagesGet: () => {
     getCalls += 1;
+    if (expirePollCeiling) {
+      setSystemTime(new Date(Date.now() + PAST_POLL_CEILING_MS));
+    }
     return ok(listed);
   },
   messagesPost: (opts: PostCall) => {
@@ -82,8 +108,11 @@ function renderRunner() {
 afterEach(() => {
   postCalls = [];
   createCalls = [];
+  archiveCalls = [];
   getCalls = 0;
   listed = { messages: [] };
+  expirePollCeiling = false;
+  setSystemTime();
 });
 
 /**
@@ -210,4 +239,34 @@ describe("research prompt send", () => {
       result.current.reset();
     });
   });
+});
+
+describe("research conversation archive", () => {
+  test("archives the side conversation when the poll loop times out", async () => {
+    expirePollCeiling = true;
+    const { result } = renderRunner();
+    // A dedicated assistant id keeps this assertion clear of archives from
+    // the runs the tests above leave in flight.
+    const archived = () =>
+      archiveCalls.filter((c) => c.path.assistant_id === "ast-timeout");
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-timeout",
+        subject,
+      });
+    });
+
+    await waitFor(
+      () => {
+        expect(archived()).toHaveLength(1);
+      },
+      { timeout: 8000 },
+    );
+    expect(archived()[0]?.path.id).toBe("conv-fresh");
+
+    act(() => {
+      result.current.reset();
+    });
+  }, 10_000);
 });

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -18,7 +18,6 @@ import {
   resolveResearchCompletionStatus,
   resolveOnboardingPluginInstalls,
   selectRecommendableCapabilities,
-  shouldArchiveCompletedResearchConversation,
   shouldSettleResearchPoll,
   useResearchRunner,
 } from "@/domains/onboarding/research-runner";
@@ -325,23 +324,5 @@ describe("useResearchRunner reinstallPlugins", () => {
     expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
       "settled",
     );
-  });
-});
-
-describe("shouldArchiveCompletedResearchConversation", () => {
-  test("archives when a complete payload was observed", () => {
-    expect(
-      shouldArchiveCompletedResearchConversation({
-        sawCompletePayload: true,
-      }),
-    ).toBe(true);
-  });
-
-  test("does not archive partial or timed-out research turns", () => {
-    expect(
-      shouldArchiveCompletedResearchConversation({
-        sawCompletePayload: false,
-      }),
-    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -78,13 +78,6 @@ export function resolveResearchCompletionStatus({
   return sawCompletePayload ? "done" : "error";
 }
 
-export function shouldArchiveCompletedResearchConversation({
-  sawCompletePayload,
-}: {
-  sawCompletePayload: boolean;
-}): boolean {
-  return sawCompletePayload;
-}
 /**
  * Org that owns first-party, reviewed Vellum plugins. Onboarding only ever
  * surfaces and installs plugins from this owner — never third-party/external
@@ -632,8 +625,8 @@ export function useResearchRunner(): UseResearchRunner {
               },
               throwOnError: false,
             });
-            // Capture before the stale check so the finally block can archive it
-            // once a complete payload settles.
+            // Capture before the stale check so the finally block can archive
+            // it on every exit path.
             createdConversationId = conversation.data?.id;
             const id = conversation.data?.id;
             if (!conversation.response?.ok || !id) {
@@ -851,16 +844,9 @@ export function useResearchRunner(): UseResearchRunner {
           // a stale bail-out, or a reply that never emitted a `plugins` array) so
           // `awaitPluginInstalls` can never hang.
           resolvePluginsReady();
-          // Archive only after the full research payload is available. If the poll
-          // ceiling fired before that, the assistant turn may still be running and
-          // the conversation remains available for reconciliation/debugging.
-          if (
-            shouldArchiveCompletedResearchConversation({
-              sawCompletePayload,
-            }) &&
-            resolvedAssistantId &&
-            createdConversationId
-          ) {
+          // Unconditional cleanup: a timed-out or superseded run must not leave
+          // the throwaway side conversation behind.
+          if (resolvedAssistantId && createdConversationId) {
             await archiveResearchConversation(
               resolvedAssistantId,
               createdConversationId,

--- a/clients/web/src/domains/onboarding/send-research-correction.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.ts
@@ -21,9 +21,8 @@
  * (`@/domains/chat/api/*` is import-banned from onboarding), mirroring the
  * research runner that minted this conversation.
  *
- * The conversation was archived once research settled; posting a message can
- * resurface it in the sidebar, so we re-archive afterwards (idempotent,
- * best-effort) to keep the throwaway side channel hidden.
+ * Re-archives the conversation after the post as idempotent, best-effort
+ * cleanup of the throwaway side channel.
  */
 
 import { messagesPost } from "@/generated/daemon/sdk.gen";
@@ -108,7 +107,7 @@ export async function sendResearchCorrection({
   } catch (err) {
     captureError(err, { context: "research_onboarding_correction" });
   }
-  // Keep the throwaway side conversation out of the sidebar even if posting
-  // resurfaced it. Best-effort and already-swallowed by the helper.
+  // Idempotent cleanup of the throwaway side conversation. Best-effort and
+  // already-swallowed by the helper.
   await archiveResearchConversation(assistantId, conversationId);
 }


### PR DESCRIPTION
## Summary
- Archive the research side conversation on every exit path, including a poll-ceiling timeout, which previously left the row un-archived indefinitely.
- Refresh the side-thread comments so none of them credit the archive with hiding the thread; the `background` conversation type does that.

Part of plan: bg-side-conversations.md (PR 5 of 5)