### PR TITLE
fix(design-library): repair stale SegmentControl geometry tests and run bun unit tests in CI

### DIFF
--- a/.github/workflows/ci-main-design-library.yaml
+++ b/.github/workflows/ci-main-design-library.yaml
@@ -1,23 +1,29 @@
-name: PR Design Library Checks
+name: CI/CD Main Design Library
 
+# Typecheck and unit-test the design library off main. The PR workflow gates
+# merges; this catches breakage that lands without touching the package's PR
+# path filters (dependency bumps, direct pushes).
 on:
-  pull_request:
-    types: [synchronize, opened, reopened]
+  workflow_dispatch:
+  push:
+    branches: [main]
     paths:
       - 'package.json'
       - 'bun.lock'
       - 'patches/**'
       - 'packages/design-library/**'
-      - '.github/workflows/pr-design-library.yaml'
+      - '.github/workflows/ci-main-design-library.yaml'
 
 concurrency:
-  group: pr-design-library-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   checks:
-    name: Lint, Type Check & Test
+    name: Type Check & Unit Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: packages/design-library
@@ -34,16 +40,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --filter=@vellumai/design-library
 
-      - name: Install Playwright browsers
-        run: bunx playwright install chromium --with-deps
-
       - name: Type check
         run: bun run typecheck
 
-      # `bun run test` is vitest, whose config covers only the Storybook
-      # browser project; this step runs the package's bun:test unit files.
       - name: Unit tests
         run: bun run test:unit
-
-      - name: Test
-        run: bun run test

--- a/.github/workflows/pr-design-library.yaml
+++ b/.github/workflows/pr-design-library.yaml
@@ -40,5 +40,11 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+      # `bun run test` is vitest, whose config only defines the Storybook
+      # browser project, so the bun:test unit files never ran in CI and
+      # stale assertions went unnoticed. This step runs them.
+      - name: Unit tests
+        run: bun run test:unit
+
       - name: Test
         run: bun run test

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -23,6 +23,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest",
+    "test:unit": "bun test src",
     "typecheck": "bunx tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/design-library/src/components/segment-control.test.tsx
+++ b/packages/design-library/src/components/segment-control.test.tsx
@@ -4,7 +4,7 @@
  * No DOM environment — mirroring `button.test.tsx`, we verify behavior through
  * two angles:
  *   1. `renderToStaticMarkup` — asserts the HTML the component emits, including
- *      the icon-only geometry that PR 1 enlarges to match the iOS mock.
+ *      the normalized radii that #38603 made uniform across modes.
  *   2. The pure `resolveSegmentSelection` helper that each segment's onClick
  *      delegates to — asserts the click→onChange decision without a renderer.
  */
@@ -49,8 +49,14 @@ function containerClassName(html: string): string {
   return match?.match(/class="([^"]*)"/)?.[1] ?? "";
 }
 
-describe("SegmentControl icon-only geometry", () => {
-  test("container uses the enlarged 10px radius", () => {
+// #38603 normalized the radii: the outer track is a strict 8px radius
+// (`rounded-md`: this repo's token scale maps md to 8px in tokens.css) and
+// the inner segments a strict 6px radius, identical in both modes. Icon-only
+// previously carried its own enlarged radii (`rounded-[10px]` track,
+// `rounded-lg` segments) from the iOS mock; these tests pin the
+// special-casing as gone, so a revert reintroducing it fails here.
+describe("SegmentControl geometry (normalized radii)", () => {
+  test("icon-only container uses the shared 8px track radius, not an enlarged one", () => {
     const html = renderToStaticMarkup(
       <SegmentControl
         items={iconItems}
@@ -60,10 +66,13 @@ describe("SegmentControl icon-only geometry", () => {
         ariaLabel="Theme"
       />,
     );
-    expect(containerClassName(html)).toContain("rounded-[10px]");
+    const container = containerClassName(html);
+    expect(container).toContain("rounded-md");
+    expect(container).not.toContain("rounded-[10px]");
+    expect(container).not.toContain("rounded-lg");
   });
 
-  test("each segment uses the enlarged radius (rounded-lg) and padding (px-2)", () => {
+  test("icon-only segments use the shared 6px radius and px-2 padding", () => {
     const html = renderToStaticMarkup(
       <SegmentControl
         items={iconItems}
@@ -76,14 +85,13 @@ describe("SegmentControl icon-only geometry", () => {
     const classes = radioClassNames(html);
     expect(classes).toHaveLength(iconItems.length);
     for (const cls of classes) {
-      expect(cls).toContain("rounded-lg");
+      expect(cls).toContain("rounded-[6px]");
+      expect(cls).not.toContain("rounded-lg");
       expect(cls).toContain("px-2");
     }
   });
-});
 
-describe("SegmentControl text-mode (non-icon-only) geometry is unchanged", () => {
-  test("container stays rounded-lg and does NOT gain the 10px radius", () => {
+  test("text-mode container shares the same radius and spans full width", () => {
     const html = renderToStaticMarkup(
       <SegmentControl
         items={textItems}
@@ -93,11 +101,13 @@ describe("SegmentControl text-mode (non-icon-only) geometry is unchanged", () =>
       />,
     );
     const container = containerClassName(html);
-    expect(container).toContain("rounded-lg");
+    expect(container).toContain("rounded-md");
+    expect(container).toContain("w-full");
     expect(container).not.toContain("rounded-[10px]");
+    expect(container).not.toContain("rounded-lg");
   });
 
-  test("each segment keeps flex-1, px-3 and py-1.5", () => {
+  test("text-mode segments keep flex-1 and px-3, sized by fixed height rather than py-1.5", () => {
     const html = renderToStaticMarkup(
       <SegmentControl
         items={textItems}
@@ -111,7 +121,10 @@ describe("SegmentControl text-mode (non-icon-only) geometry is unchanged", () =>
     for (const cls of classes) {
       expect(cls).toContain("flex-1");
       expect(cls).toContain("px-3");
-      expect(cls).toContain("py-1.5");
+      expect(cls).toContain("rounded-[6px]");
+      // Single-line segments are height-sized (see the size describe below);
+      // py-1.5 only returns when a sublabel switches the segment to h-auto.
+      expect(cls).not.toContain("py-1.5");
     }
   });
 });

--- a/packages/design-library/src/components/segment-control.test.tsx
+++ b/packages/design-library/src/components/segment-control.test.tsx
@@ -4,7 +4,7 @@
  * No DOM environment — mirroring `button.test.tsx`, we verify behavior through
  * two angles:
  *   1. `renderToStaticMarkup` — asserts the HTML the component emits, including
- *      the normalized radii that #38603 made uniform across modes.
+ *      the track/segment radii shared by both modes.
  *   2. The pure `resolveSegmentSelection` helper that each segment's onClick
  *      delegates to — asserts the click→onChange decision without a renderer.
  */
@@ -49,12 +49,10 @@ function containerClassName(html: string): string {
   return match?.match(/class="([^"]*)"/)?.[1] ?? "";
 }
 
-// #38603 normalized the radii: the outer track is a strict 8px radius
-// (`rounded-md`: this repo's token scale maps md to 8px in tokens.css) and
-// the inner segments a strict 6px radius, identical in both modes. Icon-only
-// previously carried its own enlarged radii (`rounded-[10px]` track,
-// `rounded-lg` segments) from the iOS mock; these tests pin the
-// special-casing as gone, so a revert reintroducing it fails here.
+// The outer track uses a strict 8px radius (`rounded-md`: this repo's token
+// scale maps md to 8px in tokens.css) and the inner segments a strict 6px
+// radius, identical in icon-only and text modes. These tests pin that shared
+// geometry, so any per-mode radius special-casing fails here.
 describe("SegmentControl geometry (normalized radii)", () => {
   test("icon-only container uses the shared 8px track radius, not an enlarged one", () => {
     const html = renderToStaticMarkup(
@@ -123,7 +121,7 @@ describe("SegmentControl geometry (normalized radii)", () => {
       expect(cls).toContain("px-3");
       expect(cls).toContain("rounded-[6px]");
       // Single-line segments are height-sized (see the size describe below);
-      // py-1.5 only returns when a sublabel switches the segment to h-auto.
+      // py-1.5 appears only when a sublabel switches the segment to h-auto.
       expect(cls).not.toContain("py-1.5");
     }
   });


### PR DESCRIPTION
## TL;DR

Four SegmentControl geometry tests have been failing on main since #38603 changed the control's radii without updating them, and nobody noticed because no CI workflow ever runs the design-library `bun:test` unit files. This PR fixes the stale tests (the component is correct) and adds the missing CI step.

## Which side was wrong

#38603 ("radius/sizing fixes") deliberately normalized SegmentControl to a strict 8px outer track / 6px inner segment radius in every mode, dropping the icon-only special casing (`rounded-[10px]` track, `rounded-lg` segments) left over from the iOS mock. `rounded-md` is 8px on this repo's token scale (`--radius-md: 8px` in `tokens.css`), so the rendered classes match that commit's stated intent exactly. The tests were asserting the pre-#38603 geometry and were never touched by that PR: they assert stale geometry, the component did not regress.

The rewritten tests pin the normalized geometry as the invariant (shared radii across modes, no enlarged icon-only special case, fixed-height text sizing instead of `py-1.5`). Sensitivity-checked: with the component reverted to its pre-#38603 state, all four new tests fail.

## Why this went unnoticed: the CI gap

`pr-design-library.yaml`'s test step runs `bun run test`, which is vitest, and `vitest.config.ts` defines only the Storybook browser project. None of the fifteen `bun:test` unit files in the package (button, markdown-message, virtual-list, segment-control, ...) run in any workflow, on PRs or on main. Only segment-control had rotted; the other fourteen files pass.

The fix adds a `test:unit` script (`bun test src`, path-scoped per the root AGENTS.md rule), a PR CI step between typecheck and the Storybook tests, and a `ci-main-design-library.yaml` workflow so typecheck and unit tests also run on pushes to main (catching breakage from dependency bumps or direct pushes that bypass the PR path filters). The whole unit suite runs in ~300ms.

The broader version of this gap (10 shared packages under `packages/` with typecheck/test scripts no workflow runs) is tracked in [LUM-3043](https://linear.app/vellum/issue/LUM-3043).

## Why this is safe

- No component/runtime code changes; only a test file, a package.json script, and a CI step.
- All 202 unit tests across the 15 files pass locally, and `bun run typecheck` is clean.
- The new CI step can only make PR checks stricter, and it is currently green.

## Before / after

| | Before | After |
|---|---|---|
| SegmentControl geometry tests | Assert pre-#38603 geometry; 4 fail on main | Assert the normalized #38603 geometry; all pass, and a revert of #38603 would fail them |
| design-library unit tests in CI | Never executed (vitest only runs Storybook browser tests) | `bun test src` runs on every design-library PR and on pushes to main |
| Rendered UI | unchanged | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
