### PR TITLE
feat(web): ghost dropdown for remapped tier defaults in Action Overrides

### DIFF
--- a/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
@@ -72,8 +72,20 @@ describe("llm-call-sites-routes", () => {
     };
     for (const site of result.callSites) {
       expect(site.shippedDefaultProfile).toBe(
-        CALL_SITE_DEFAULTS[site.id as LLMCallSite]?.profile,
+        CALL_SITE_DEFAULTS[site.id as LLMCallSite]?.profile ?? "balanced",
       );
+    }
+  });
+
+  test("profileless call sites report the balanced anchor tier", async () => {
+    const result = (await route.handler({})) as {
+      callSites: Array<{ id: string; shippedDefaultProfile?: string }>;
+    };
+    // Both omit `profile` in CALL_SITE_DEFAULTS and ride the resolver's
+    // balanced anchor, so the catalog groups them under Balanced.
+    for (const id of ["workflowLeaf", "vision"]) {
+      const site = result.callSites.find((s) => s.id === id);
+      expect(site?.shippedDefaultProfile).toBe("balanced");
     }
   });
 

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -28,7 +28,9 @@ const callSiteEntrySchema = z.object({
    * The code-owned `CALL_SITE_DEFAULTS` tier key, independent of pins and
    * tier remaps. Clients group call sites by tier with this; grouping by
    * `defaultProfile` would scatter pinned or remapped sites across their
-   * winners.
+   * winners. Profileless call sites report `balanced`: the resolver's
+   * fallback anchor consults the balanced remap for them, so they follow
+   * the Balanced tier like any balanced-keyed site.
    */
   shippedDefaultProfile: z.string().optional(),
 });
@@ -45,7 +47,8 @@ async function handleGetCallSites() {
     callSites: CALL_SITE_CATALOG.map((entry) => ({
       ...entry,
       defaultProfile: resolveDefaultProfileKey(entry.id as LLMCallSite, llm),
-      shippedDefaultProfile: CALL_SITE_DEFAULTS[entry.id]?.profile,
+      shippedDefaultProfile:
+        CALL_SITE_DEFAULTS[entry.id]?.profile ?? "balanced",
     })),
   };
 }

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -138,6 +138,10 @@ export function CallSiteOverrideRow({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {/* Ghost pinning depends on `Dropdown` firing onChange when the
+              already-selected option is re-picked (how a user pins the shown
+              value). `Select`, its planned replacement, is silent on
+              re-selection — a migration must keep that path working. */}
           {(overrideOn || shownGhost) && (
             <Dropdown
               value={shownGhost ? shownGhost.profile : profileVal}

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -141,7 +141,7 @@ export function CallSiteOverrideRow({
           {/* Ghost pinning depends on `Dropdown` firing onChange when the
               already-selected option is re-picked (how a user pins the shown
               value). `Select`, its planned replacement, is silent on
-              re-selection — a migration must keep that path working. */}
+              re-selection, so a migration must keep that path working. */}
           {(overrideOn || shownGhost) && (
             <Dropdown
               value={shownGhost ? shownGhost.profile : profileVal}

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -29,6 +29,13 @@ export interface CallSiteOverrideRowProps {
   displayName: string;
   description?: string;
   defaultProfileLabel: string | null;
+  /**
+   * Effective profile for an unpinned row whose tier default is remapped:
+   * renders a muted dropdown showing `profile` with `caption` as provenance.
+   * Picking from it creates a real pin via the normal draft path; the toggle
+   * stays off until then because it strictly means "explicitly pinned".
+   */
+  ghost?: { profile: string; caption: string } | null;
   draft: CallSiteOverrideDraft | null;
   profileOptions: ProfileOption[];
   onDraftChange: (id: string, draft: CallSiteOverrideDraft | null) => void;
@@ -44,12 +51,14 @@ export function CallSiteOverrideRow({
   displayName,
   description,
   defaultProfileLabel,
+  ghost,
   draft,
   profileOptions,
   onDraftChange,
   onToggle,
 }: CallSiteOverrideRowProps) {
   const overrideOn = isDraftActive(draft);
+  const shownGhost = overrideOn ? null : (ghost ?? null);
 
   const profileVal = (() => {
     if (!draft || !overrideOn) {
@@ -117,21 +126,24 @@ export function CallSiteOverrideRow({
           {description && (
             <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
               {description}
-              {defaultProfileLabel && (
+              {(shownGhost || defaultProfileLabel) && (
                 <span className="ml-1.5 text-body-small-default text-[var(--content-tertiary)] opacity-60">
-                  &middot; Default: {defaultProfileLabel}
+                  &middot;{" "}
+                  {shownGhost
+                    ? shownGhost.caption
+                    : `Default: ${defaultProfileLabel}`}
                 </span>
               )}
             </p>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {overrideOn && (
+          {(overrideOn || shownGhost) && (
             <Dropdown
-              value={profileVal}
+              value={shownGhost ? shownGhost.profile : profileVal}
               onChange={handleProfilePickerChange}
               options={profileOptions}
-              className="w-44"
+              className={shownGhost ? "w-44 opacity-60" : "w-44"}
               menuMinWidth={280}
               menuAlign="end"
             />

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -515,8 +515,9 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     });
 
     pickOption(tierTrigger("Balanced (default)"), "My BYOK");
-    // The per-action caption reflects the pending remap.
-    expect(renderedText()).toContain("Balanced → My BYOK");
+    // The unpinned Balanced-tier row reflects the pending remap as a ghost
+    // dropdown with tier provenance.
+    expect(renderedText()).toContain("via Balanced default");
 
     fireEvent.click(getButton("Save"));
     await waitFor(() => {
@@ -538,9 +539,9 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     await waitFor(() => {
       expect(renderedText()).toContain("Defaults");
     });
-    // The persisted remap is visible on the tier row and in the caption of
-    // unpinned Speed-tier sites.
-    expect(renderedText()).toContain("Speed → My BYOK");
+    // The persisted remap is visible on the tier row and as ghost provenance
+    // on unpinned Speed-tier sites.
+    expect(renderedText()).toContain("via Speed default");
     // The pinned Filing Agent keeps its winner caption without an arrow:
     // its pin outranks the remap.
     expect(renderedText()).toContain("Default: My BYOK");
@@ -554,6 +555,104 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     expect(body.llm.defaultProfileOverrides).toEqual({
       "cost-optimized": null,
     });
+  });
+
+  // The card containing `rowText`, for scoping queries to one call-site row.
+  function rowCard(rowText: string): HTMLElement {
+    const match = Array.from(
+      document.querySelectorAll<HTMLElement>("div.rounded-lg"),
+    ).find((d) => d.textContent?.includes(rowText));
+    if (!match) {
+      throw new Error(`expected a row card containing "${rowText}"`);
+    }
+    return match;
+  }
+
+  test("a remapped unpinned row shows a ghost dropdown, toggle stays off", async () => {
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { balanced: "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("via Balanced default");
+    });
+    const card = rowCard("Workflow Leaf");
+    const dropdown = card.querySelector<HTMLElement>('button[role="combobox"]');
+    expect(dropdown?.textContent).toContain("My BYOK");
+    const toggle = card.querySelector<HTMLElement>('[role="switch"]');
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("picking from the ghost dropdown creates a real pin", async () => {
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { balanced: "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("via Balanced default");
+    });
+    const dropdown = rowCard("Workflow Leaf").querySelector<HTMLElement>(
+      'button[role="combobox"]',
+    );
+    if (!dropdown) {
+      throw new Error("expected the ghost dropdown");
+    }
+    pickOption(dropdown, "Quality");
+    // The pin flips the toggle on and drops the tier provenance.
+    const toggle = rowCard("Workflow Leaf").querySelector<HTMLElement>(
+      '[role="switch"]',
+    );
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+    expect(renderedText()).not.toContain("via Balanced default");
+
+    fireEvent.click(getButton("Save"));
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as {
+      llm: { callSites: Record<string, unknown> };
+    };
+    expect(body.llm.callSites.workflowLeaf).toEqual({
+      profile: "quality",
+      provider: null,
+      model: null,
+    });
+    // The other ghost-eligible rows stay out of the patch.
+    expect("heartbeatAgent" in body.llm.callSites).toBe(false);
+  });
+
+  test("untouched ghost rows serialize no per-action pins", async () => {
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { balanced: "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("via Balanced default");
+    });
+    // Save something unrelated (the advisor) so the patch fires.
+    const advisorTrigger = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    ).find((t) => t.textContent?.includes("Quality"));
+    if (!advisorTrigger) {
+      throw new Error("expected the advisor dropdown trigger");
+    }
+    pickOption(advisorTrigger, "My BYOK");
+    fireEvent.click(getButton("Save"));
+
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    // The remap must stay a tier-level fact: no ghost row materializes
+    // into `llm.callSites`, else later tier changes stop moving them.
+    const body = configPatchBodies[0] as { llm: Record<string, unknown> };
+    expect("callSites" in body.llm).toBe(false);
+    expect("defaultProfileOverrides" in body.llm).toBe(false);
   });
 
   test("Reset clears per-action pins but keeps the tier remaps", async () => {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -625,6 +625,37 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     expect("heartbeatAgent" in body.llm.callSites).toBe(false);
   });
 
+  test("toggling on a ghost row pins the displayed profile, not the persisted winner", async () => {
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+    // Remap Balanced without saving, then flip the Workflow Leaf toggle on:
+    // the pin must seed from the remap target the ghost dropdown shows, not
+    // from the catalog's persisted `defaultProfile` ("balanced").
+    pickOption(tierTrigger("Balanced (default)"), "My BYOK");
+    const toggle = rowCard("Workflow Leaf").querySelector<HTMLElement>(
+      '[role="switch"]',
+    );
+    if (!toggle) {
+      throw new Error("expected the Workflow Leaf toggle");
+    }
+    fireEvent.click(toggle);
+    fireEvent.click(getButton("Save"));
+
+    await waitFor(() => {
+      expect(configPatchBodies.length).toBe(1);
+    });
+    const body = configPatchBodies[0] as {
+      llm: { callSites: Record<string, unknown> };
+    };
+    expect(body.llm.callSites.workflowLeaf).toEqual({
+      profile: "my-byok",
+      provider: null,
+      model: null,
+    });
+  });
+
   test("untouched ghost rows serialize no per-action pins", async () => {
     renderTierPanel({
       llm: {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -457,13 +457,27 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     },
   };
 
-  function renderTierPanel(config: unknown = TIER_CONFIG) {
-    servedCatalog = TIER_CATALOG;
+  // Fixture catalog with `id`'s resolved winner replaced, mirroring what
+  // the daemon reports when a persisted remap (or fallback) won resolution.
+  function withWinner(id: string, winner: string) {
+    return {
+      ...TIER_CATALOG,
+      callSites: TIER_CATALOG.callSites.map((cs) =>
+        cs.id === id ? { ...cs, defaultProfile: winner } : cs,
+      ),
+    };
+  }
+
+  function renderTierPanel(
+    config: unknown = TIER_CONFIG,
+    catalog: unknown = TIER_CATALOG,
+  ) {
+    servedCatalog = catalog;
     servedConfig = config;
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: 0 } },
     });
-    client.setQueryData([{ _id: "configLlmCallsitesGet" }], TIER_CATALOG);
+    client.setQueryData([{ _id: "configLlmCallsitesGet" }], catalog);
     client.setQueryData([{ _id: "configGet" }], config);
     return render(
       createElement(
@@ -530,12 +544,15 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
   });
 
   test("clearing a persisted remap sends null for that tier", async () => {
-    renderTierPanel({
-      llm: {
-        ...TIER_CONFIG.llm,
-        defaultProfileOverrides: { "cost-optimized": "my-byok" },
+    renderTierPanel(
+      {
+        llm: {
+          ...TIER_CONFIG.llm,
+          defaultProfileOverrides: { "cost-optimized": "my-byok" },
+        },
       },
-    });
+      withWinner("heartbeatAgent", "my-byok"),
+    );
     await waitFor(() => {
       expect(renderedText()).toContain("Defaults");
     });
@@ -569,12 +586,15 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
   }
 
   test("a remapped unpinned row shows a ghost dropdown, toggle stays off", async () => {
-    renderTierPanel({
-      llm: {
-        ...TIER_CONFIG.llm,
-        defaultProfileOverrides: { balanced: "my-byok" },
+    renderTierPanel(
+      {
+        llm: {
+          ...TIER_CONFIG.llm,
+          defaultProfileOverrides: { balanced: "my-byok" },
+        },
       },
-    });
+      withWinner("workflowLeaf", "my-byok"),
+    );
     await waitFor(() => {
       expect(renderedText()).toContain("via Balanced default");
     });
@@ -586,12 +606,15 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
   });
 
   test("picking from the ghost dropdown creates a real pin", async () => {
-    renderTierPanel({
-      llm: {
-        ...TIER_CONFIG.llm,
-        defaultProfileOverrides: { balanced: "my-byok" },
+    renderTierPanel(
+      {
+        llm: {
+          ...TIER_CONFIG.llm,
+          defaultProfileOverrides: { balanced: "my-byok" },
+        },
       },
-    });
+      withWinner("workflowLeaf", "my-byok"),
+    );
     await waitFor(() => {
       expect(renderedText()).toContain("via Balanced default");
     });
@@ -657,12 +680,15 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
   });
 
   test("untouched ghost rows serialize no per-action pins", async () => {
-    renderTierPanel({
-      llm: {
-        ...TIER_CONFIG.llm,
-        defaultProfileOverrides: { balanced: "my-byok" },
+    renderTierPanel(
+      {
+        llm: {
+          ...TIER_CONFIG.llm,
+          defaultProfileOverrides: { balanced: "my-byok" },
+        },
       },
-    });
+      withWinner("workflowLeaf", "my-byok"),
+    );
     await waitFor(() => {
       expect(renderedText()).toContain("via Balanced default");
     });
@@ -684,6 +710,24 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     const body = configPatchBodies[0] as { llm: Record<string, unknown> };
     expect("callSites" in body.llm).toBe(false);
     expect("defaultProfileOverrides" in body.llm).toBe(false);
+  });
+
+  test("a remap the resolver skipped renders the shipped default, not the raw remap", async () => {
+    // The persisted remap targets a profile resolution skipped (disabled or
+    // incomplete), so the catalog's winner stays the shipped tier. The row
+    // must render the plain default caption, not a ghost dropdown claiming
+    // the remap applied.
+    renderTierPanel({
+      llm: {
+        ...TIER_CONFIG.llm,
+        defaultProfileOverrides: { "cost-optimized": "my-byok" },
+      },
+    });
+    await waitFor(() => {
+      expect(renderedText()).toContain("Defaults");
+    });
+    expect(renderedText()).not.toContain("via Speed default");
+    expect(renderedText()).toContain("Default: Speed");
   });
 
   test("Reset clears per-action pins but keeps the tier remaps", async () => {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -226,6 +226,22 @@ export function OverridesDetailPanel({
     [tierEdits, persistedTierOverrides],
   );
 
+  // The default an unpinned row displays and toggle-on seeds from. A tier
+  // touched this session shows its pending edit optimistically; an
+  // untouched tier trusts the catalog's resolved winner (`defaultProfile`)
+  // rather than the raw persisted remap, which resolution may have skipped
+  // (disabled or incomplete target).
+  const displayedDefaultFor = useCallback(
+    (cs: CallSiteEntry): string | undefined => {
+      const shippedTier = cs.shippedDefaultProfile;
+      if (supportsTierOverrides && shippedTier && shippedTier in tierEdits) {
+        return tierEdits[shippedTier] ?? shippedTier;
+      }
+      return cs.defaultProfile;
+    },
+    [supportsTierOverrides, tierEdits],
+  );
+
   const tierOverridesDirty = useMemo(
     () =>
       Object.entries(tierEdits).some(
@@ -389,19 +405,11 @@ export function OverridesDetailPanel({
         return;
       }
       const cs = gatedCallSites.find((c) => c.id === id);
-      // Seed from the effective default the row is displaying, not the
-      // catalog's persisted winner: with an unsaved tier remap pending the
-      // ghost dropdown shows the remap target, and pinning must match what
-      // the user sees (`cs.defaultProfile` is computed daemon-side from the
-      // persisted config only).
-      const shippedTier = cs?.shippedDefaultProfile;
-      const displayedDefault =
-        (supportsTierOverrides && shippedTier
-          ? effectiveTierRemap(shippedTier)
-          : null) ?? cs?.defaultProfile;
+      // Seed from the same default the row is displaying so the pin
+      // matches what the user sees.
       const seedProfile = selectSeedProfileForOverride(
         orderedProfiles,
-        displayedDefault,
+        cs ? displayedDefaultFor(cs) : undefined,
       );
       if (seedProfile) {
         setDraftEdits((prev) => ({ ...prev, [id]: { profile: seedProfile } }));
@@ -419,8 +427,7 @@ export function OverridesDetailPanel({
       gatedCallSites,
       orderedProfiles,
       selectableInferenceProviders,
-      supportsTierOverrides,
-      effectiveTierRemap,
+      displayedDefaultFor,
     ],
   );
 
@@ -739,13 +746,13 @@ export function OverridesDetailPanel({
                         }
                         return d.profile ?? "";
                       })();
-                      // Provenance for an unpinned site on a tier-overrides
-                      // daemon builds from the shipped tier plus its remap;
-                      // `defaultProfile` (the effective winner) already IS
-                      // the remapped profile there, so deriving from it
-                      // would lose the tier. A remapped site renders the
-                      // effective profile in a ghost dropdown (picking from
-                      // it creates a pin) instead of caption text. A pinned
+                      // An unpinned site on a tier-overrides daemon whose
+                      // displayed default diverges from its shipped tier
+                      // renders that default in a ghost dropdown (picking
+                      // from it creates a pin) with tier provenance as the
+                      // caption. `displayedDefaultFor` trusts the resolver's
+                      // winner for untouched tiers, so a remap resolution
+                      // skipped never renders as if it applied. A pinned
                       // site keeps the winner caption: the pin outranks the
                       // remap, so tier provenance would claim an effect the
                       // resolver doesn't apply.
@@ -755,10 +762,11 @@ export function OverridesDetailPanel({
                       let ghost: { profile: string; caption: string } | null =
                         null;
                       if (supportsTierOverrides && shippedTier && !pinned) {
-                        const tierRemap = effectiveTierRemap(shippedTier);
-                        if (tierRemap) {
+                        const displayed =
+                          displayedDefaultFor(cs) ?? shippedTier;
+                        if (displayed !== shippedTier) {
                           ghost = {
-                            profile: tierRemap,
+                            profile: displayed,
                             caption: `via ${profileLabelFor(shippedTier)} default`,
                           };
                         } else {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -723,22 +723,31 @@ export function OverridesDetailPanel({
                         }
                         return d.profile ?? "";
                       })();
-                      // Caption provenance for an unpinned site on a
-                      // tier-overrides daemon builds from the shipped tier
-                      // plus its remap; `defaultProfile` (the effective
-                      // winner) already IS the remapped profile there, so
-                      // deriving from it would lose the tier. A pinned
-                      // site keeps the winner caption: the pin outranks
-                      // the remap, so an arrow would claim an effect the
+                      // Provenance for an unpinned site on a tier-overrides
+                      // daemon builds from the shipped tier plus its remap;
+                      // `defaultProfile` (the effective winner) already IS
+                      // the remapped profile there, so deriving from it
+                      // would lose the tier. A remapped site renders the
+                      // effective profile in a ghost dropdown (picking from
+                      // it creates a pin) instead of caption text. A pinned
+                      // site keeps the winner caption: the pin outranks the
+                      // remap, so tier provenance would claim an effect the
                       // resolver doesn't apply.
                       const pinned = isDraftActive(drafts[cs.id] ?? null);
                       const shippedTier = cs.shippedDefaultProfile;
                       let defaultProfileLabel: string | null = null;
+                      let ghost: { profile: string; caption: string } | null =
+                        null;
                       if (supportsTierOverrides && shippedTier && !pinned) {
                         const tierRemap = effectiveTierRemap(shippedTier);
-                        defaultProfileLabel =
-                          profileLabelFor(shippedTier) +
-                          (tierRemap ? ` → ${profileLabelFor(tierRemap)}` : "");
+                        if (tierRemap) {
+                          ghost = {
+                            profile: tierRemap,
+                            caption: `via ${profileLabelFor(shippedTier)} default`,
+                          };
+                        } else {
+                          defaultProfileLabel = profileLabelFor(shippedTier);
+                        }
                       } else if (cs.defaultProfile) {
                         defaultProfileLabel = profileLabelFor(
                           cs.defaultProfile,
@@ -752,10 +761,11 @@ export function OverridesDetailPanel({
                           displayName={cs.displayName}
                           description={cs.description}
                           defaultProfileLabel={defaultProfileLabel}
+                          ghost={ghost}
                           draft={drafts[cs.id] ?? null}
                           profileOptions={buildProfileOptionsForRow(
                             profileVal === "" || profileVal === CUSTOM_SENTINEL
-                              ? null
+                              ? (ghost?.profile ?? null)
                               : profileVal,
                           )}
                           onDraftChange={handleDraftChange}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -389,9 +389,19 @@ export function OverridesDetailPanel({
         return;
       }
       const cs = gatedCallSites.find((c) => c.id === id);
+      // Seed from the effective default the row is displaying, not the
+      // catalog's persisted winner: with an unsaved tier remap pending the
+      // ghost dropdown shows the remap target, and pinning must match what
+      // the user sees (`cs.defaultProfile` is computed daemon-side from the
+      // persisted config only).
+      const shippedTier = cs?.shippedDefaultProfile;
+      const displayedDefault =
+        (supportsTierOverrides && shippedTier
+          ? effectiveTierRemap(shippedTier)
+          : null) ?? cs?.defaultProfile;
       const seedProfile = selectSeedProfileForOverride(
         orderedProfiles,
-        cs?.defaultProfile,
+        displayedDefault,
       );
       if (seedProfile) {
         setDraftEdits((prev) => ({ ...prev, [id]: { profile: seedProfile } }));
@@ -405,7 +415,13 @@ export function OverridesDetailPanel({
         }));
       }
     },
-    [gatedCallSites, orderedProfiles, selectableInferenceProviders],
+    [
+      gatedCallSites,
+      orderedProfiles,
+      selectableInferenceProviders,
+      supportsTierOverrides,
+      effectiveTierRemap,
+    ],
   );
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Unpinned actions whose tier default is remapped now render the effective profile in a muted (ghost) dropdown with a "via <Tier> default" caption, instead of the "Default: Balanced → Quality" arrow text the reader had to resolve in their head.
- The toggle keeps its single meaning (explicit per-action pin): it stays off for ghost rows, and picking from the ghost dropdown flips it on by creating a real pin through the normal draft path.
- Untouched ghost rows serialize nothing on Save — tier remaps never materialize into per-action pins, so later tier changes keep moving those actions (covered by a new test).

## Original prompt
While validating the per-tier default-profile override UX (#39907/#39957) on dev, Emmie found the "Default: Balanced → Quality" caption on remapped rows hard to parse and asked whether the row should just show the overriding profile. We agreed the toggle must keep meaning "explicitly pinned" (rendering remapped rows as toggle-on would either invent a per-action remap opt-out or silently convert remaps into pins on save), and landed on this middle ground: always surface the effective profile in a ghost dropdown on remapped unpinned rows, where interacting with it creates a real pin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->