### PR TITLE
feat(cli)!: vellum tunnel always fronts the nginx edge and fails hard when nginx is missing

### DIFF
--- a/cli/src/__tests__/tailscale-tunnel.test.ts
+++ b/cli/src/__tests__/tailscale-tunnel.test.ts
@@ -160,7 +160,6 @@ describe("startTailscaleServe", () => {
 
     expect(info.publicUrl).toBe("https://my-host.tail-scale.ts.net");
     expect(info.port).toBe(7840);
-    expect(info.viaIngress).toBe(false);
     expect(calls).toContainEqual(["serve", "--bg", "7840"]);
 
     const config = JSON.parse(

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -24,10 +24,14 @@ import { join } from "node:path";
 
 import * as cloudflareTunnel from "../lib/cloudflare-tunnel.js";
 import * as ngrok from "../lib/ngrok.js";
+import * as nginxIngress from "../lib/nginx-ingress.js";
+import * as tailscaleTunnel from "../lib/tailscale-tunnel.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 
 const realCloudflareTunnel = { ...cloudflareTunnel };
 const realNgrok = { ...ngrok };
+const realNginxIngress = { ...nginxIngress };
+const realTailscaleTunnel = { ...tailscaleTunnel };
 const realChildProcess = { ...childProcess };
 
 const runCloudflareTunnelMock = mock<
@@ -42,6 +46,24 @@ const runNgrokTunnelMock = mock<typeof ngrok.runNgrokTunnel>(async () => {});
 mock.module("../lib/ngrok", () => ({
   ...realNgrok,
   runNgrokTunnel: runNgrokTunnelMock,
+}));
+
+const runTailscaleTunnelMock = mock<typeof tailscaleTunnel.runTailscaleTunnel>(
+  async () => {},
+);
+mock.module("../lib/tailscale-tunnel.js", () => ({
+  ...realTailscaleTunnel,
+  runTailscaleTunnel: runTailscaleTunnelMock,
+}));
+
+const EDGE_PORT = 18080;
+
+const ensureTunnelEdgeMock = mock<typeof nginxIngress.ensureTunnelEdge>(
+  async () => ({ port: EDGE_PORT, started: true, includesWebApp: true }),
+);
+mock.module("../lib/nginx-ingress.js", () => ({
+  ...realNginxIngress,
+  ensureTunnelEdge: ensureTunnelEdgeMock,
 }));
 
 const { tunnel } = await import("../commands/tunnel.js");
@@ -115,20 +137,21 @@ async function runTunnelExpectingExit1(): Promise<{
   return { exited, errors: errors.join("\n") };
 }
 
-function mockEnabledFlagFetch() {
-  const fetchMock = mock(async (_input: string, _init?: RequestInit) => {
-    return new Response(
-      JSON.stringify({
-        flags: [{ key: "web-remote-ingress", enabled: true }],
-      }),
-      { status: 200, headers: { "Content-Type": "application/json" } },
-    );
+/** Run tunnel() capturing console.log output; returns the joined lines. */
+async function runTunnelCapturingLogs(): Promise<string> {
+  const logs: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
   });
-  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-  return fetchMock;
+  try {
+    await tunnel();
+  } finally {
+    logSpy.mockRestore();
+  }
+  return logs.join("\n");
 }
 
-describe("tunnel nginx ingress feature flag", () => {
+describe("tunnel edge targeting", () => {
   beforeEach(() => {
     process.argv = ["bun", "vellum", "tunnel"];
     writeLockfile(makeLocalEntry());
@@ -139,6 +162,14 @@ describe("tunnel nginx ingress feature flag", () => {
     runCloudflareTunnelMock.mockResolvedValue(undefined);
     runNgrokTunnelMock.mockReset();
     runNgrokTunnelMock.mockResolvedValue(undefined);
+    runTailscaleTunnelMock.mockReset();
+    runTailscaleTunnelMock.mockResolvedValue(undefined);
+    ensureTunnelEdgeMock.mockReset();
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: EDGE_PORT,
+      started: true,
+      includesWebApp: true,
+    });
   });
 
   afterEach(() => {
@@ -157,49 +188,117 @@ describe("tunnel nginx ingress feature flag", () => {
   afterAll(() => {
     mock.module("../lib/cloudflare-tunnel.js", () => realCloudflareTunnel);
     mock.module("../lib/ngrok", () => realNgrok);
+    mock.module("../lib/tailscale-tunnel.js", () => realTailscaleTunnel);
+    mock.module("../lib/nginx-ingress.js", () => realNginxIngress);
   });
 
-  test("does not start ngrok when the flag lookup fails", async () => {
+  test("does not start ngrok when the edge flag lookup fails", async () => {
     process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+    ensureTunnelEdgeMock.mockImplementation(realNginxIngress.ensureTunnelEdge);
 
-    await expect(tunnel()).rejects.toThrow(
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
       "Could not verify the `web-remote-ingress` feature flag",
     );
-
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });
 
-  test("checks the nginx flag through the local gateway for ngrok", async () => {
+  test("targets the edge port returned by ensureTunnelEdge for ngrok", async () => {
     const entry = makeLocalEntry();
     entry.runtimeUrl = "https://stale-tunnel.ngrok-free.dev";
     writeLockfile(entry);
     process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
-    const fetchMock = mockEnabledFlagFetch();
 
-    await tunnel();
+    const logs = await runTunnelCapturingLogs();
 
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe(
-      "http://127.0.0.1:7830/v1/assistants/assistant-1/feature-flags",
+    const workspaceDir = join(
+      entry.resources!.instanceDir,
+      ".vellum",
+      "workspace",
     );
-    expect(init?.method).toBe("GET");
-    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
-      port: 7830,
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
       assistantId: "assistant-1",
-      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
-      preferNginxIngress: true,
+      workspaceDir,
+      gatewayPort: 7830,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
     });
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+    expect(logs).toContain(`Started the nginx edge on 127.0.0.1:${EDGE_PORT}`);
+    expect(logs).toContain("serves remote web and webhooks");
   });
 
-  test("does not start cloudflared when the flag lookup fails", async () => {
+  test("targets the edge port for cloudflare", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
     process.argv = ["bun", "vellum", "tunnel", "--provider", "cloudflare"];
 
-    await expect(tunnel()).rejects.toThrow(
-      "Could not verify the `web-remote-ingress` feature flag",
+    await runTunnelCapturingLogs();
+
+    expect(runCloudflareTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
+    });
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("targets the edge port for tailscale and notes a reused webhooks-only edge", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "tailscale"];
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: EDGE_PORT,
+      started: false,
+      includesWebApp: false,
+    });
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(runTailscaleTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
+    });
+    expect(logs).toContain(`Reusing the nginx edge on 127.0.0.1:${EDGE_PORT}`);
+    expect(logs).toContain("serves webhooks only");
+  });
+
+  test("missing nginx aborts before any provider spawn", async () => {
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+    ensureTunnelEdgeMock.mockRejectedValue(
+      new Error(
+        "nginx is not installed, so the tunnel edge cannot start. " +
+          "Install it (macOS: `brew install nginx`, Linux: `sudo apt install nginx`) " +
+          "or point NGINX_BIN at an existing binary.",
+      ),
     );
 
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("brew install nginx");
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+    expect(runTailscaleTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("does not start cloudflared when the edge flag lookup fails", async () => {
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "cloudflare"];
+    ensureTunnelEdgeMock.mockImplementation(realNginxIngress.ensureTunnelEdge);
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Could not verify the `web-remote-ingress` feature flag",
+    );
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });
@@ -229,16 +328,14 @@ describe("tunnel nginx ingress feature flag", () => {
       "--domain",
       "foo.ngrok.app",
     ];
-    mockEnabledFlagFetch();
 
-    await tunnel();
+    await runTunnelCapturingLogs();
 
     expect(runNgrokTunnelMock).toHaveBeenCalledWith({
-      port: 7830,
+      port: EDGE_PORT,
       assistantId: "assistant-1",
       workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
       domain: "foo.ngrok.app",
-      preferNginxIngress: true,
     });
   });
 
@@ -295,6 +392,7 @@ describe("tunnel nginx ingress feature flag", () => {
     expect(err?.message).toContain("is not yet implemented");
     expect(err?.message).toContain("your CLI may be out of date");
     expect(err?.message).toContain("bun install -g vellum@latest");
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });
@@ -496,8 +594,9 @@ describe("ngrok --domain spawn args", () => {
     // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
     // listener is registered and the promise settles. Earlier tests leak
     // SIGINT handlers that call process.exit, so no-op it while pumping.
-    const exitSpy = spyOn(process, "exit").mockImplementation((() =>
-      undefined) as never);
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      (() => undefined) as never,
+    );
     const pump = setInterval(() => process.emit("SIGINT"), 10);
     try {
       await run;

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -3,10 +3,8 @@ import { join } from "path";
 import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
-import {
-  isAssistantFeatureFlagEnabled,
-  WEB_REMOTE_INGRESS_FLAG,
-} from "../lib/feature-flags.js";
+import { getDefaultWorkspaceDir } from "../lib/ingress-config.js";
+import { ensureTunnelEdge } from "../lib/nginx-ingress.js";
 import { runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
@@ -41,6 +39,13 @@ function parseArgs(): TunnelArgs {
       );
       console.log(
         "enabling webhook integrations (Telegram, Twilio, etc.) to reach the assistant.",
+      );
+      console.log("");
+      console.log(
+        "The tunnel always fronts the local nginx edge, which is started automatically.",
+      );
+      console.log(
+        "nginx must be installed (macOS: brew install nginx, Linux: sudo apt install nginx).",
       );
       console.log("");
       console.log("Arguments:");
@@ -159,25 +164,6 @@ function resolveEntryGatewayPort(entry: AssistantEntry): number {
   );
 }
 
-async function shouldPreferNginxIngress(
-  assistantId: string,
-  gatewayPort: number,
-): Promise<boolean> {
-  try {
-    return await isAssistantFeatureFlagEnabled(
-      assistantId,
-      WEB_REMOTE_INGRESS_FLAG,
-      { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
-    );
-  } catch (err) {
-    throw new Error(
-      `Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` feature flag before starting the tunnel. Is the assistant running? Try \`vellum wake\` and retry. ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-}
-
 export async function tunnel(): Promise<void> {
   const { assistantName, provider, domain } = parseArgs();
 
@@ -194,52 +180,58 @@ export async function tunnel(): Promise<void> {
     process.exit(1);
   }
 
+  if (
+    provider !== "ngrok" &&
+    provider !== "cloudflare" &&
+    provider !== "tailscale"
+  ) {
+    throw new Error(
+      `Tunnel provider '${provider}' is not yet implemented. ` +
+        `If this provider is documented, ${STALE_CLI_UPDATE_HINT}`,
+    );
+  }
+
   const resources = entry.resources;
   const gatewayPort = resolveEntryGatewayPort(entry);
+  const workspaceDir = resources
+    ? join(resources.instanceDir, ".vellum", "workspace")
+    : getDefaultWorkspaceDir();
+
+  let edge: Awaited<ReturnType<typeof ensureTunnelEdge>>;
+  try {
+    edge = await ensureTunnelEdge({
+      assistantId: entry.assistantId,
+      workspaceDir,
+      gatewayPort,
+    });
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `${edge.started ? "Started" : "Reusing"} the nginx edge on 127.0.0.1:${edge.port} ` +
+      `(${edge.includesWebApp ? "serves remote web and webhooks" : "serves webhooks only"}).`,
+  );
+
   const baseTunnelOpts = {
-    port: gatewayPort,
+    port: edge.port,
     assistantId: entry.assistantId,
-    ...(resources
-      ? { workspaceDir: join(resources.instanceDir, ".vellum", "workspace") }
-      : {}),
+    workspaceDir,
   };
 
   if (provider === "ngrok") {
     await runNgrokTunnel({
       ...baseTunnelOpts,
       ...(domain ? { domain } : {}),
-      preferNginxIngress: await shouldPreferNginxIngress(
-        entry.assistantId,
-        gatewayPort,
-      ),
     });
     return;
   }
 
   if (provider === "cloudflare") {
-    await runCloudflareTunnel({
-      ...baseTunnelOpts,
-      preferNginxIngress: await shouldPreferNginxIngress(
-        entry.assistantId,
-        gatewayPort,
-      ),
-    });
+    await runCloudflareTunnel(baseTunnelOpts);
     return;
   }
 
-  if (provider === "tailscale") {
-    await runTailscaleTunnel({
-      ...baseTunnelOpts,
-      preferNginxIngress: await shouldPreferNginxIngress(
-        entry.assistantId,
-        gatewayPort,
-      ),
-    });
-    return;
-  }
-
-  throw new Error(
-    `Tunnel provider '${provider}' is not yet implemented. ` +
-      `If this provider is documented, ${STALE_CLI_UPDATE_HINT}`,
-  );
+  await runTailscaleTunnel(baseTunnelOpts);
 }

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -6,7 +6,6 @@ import {
   getDefaultWorkspaceDir,
   saveIngressUrl,
 } from "./ingress-config.js";
-import { resolveTunnelTargetPort } from "./nginx-ingress.js";
 
 // ── Cloudflare Tunnel ─────────────────────────────────────────────────────────
 
@@ -116,7 +115,7 @@ export function waitForCloudflareTunnelUrl(
 /**
  * Run the cloudflared quick-tunnel workflow:
  * 1. Verify cloudflared is installed.
- * 2. Start a quick tunnel pointing at the gateway port.
+ * 2. Start a quick tunnel pointing at the local edge port.
  * 3. Parse the public URL from cloudflared output.
  * 4. Persist the URL to the workspace config as the ingress base URL.
  * 5. Block until the process exits or the user presses Ctrl+C.
@@ -125,12 +124,10 @@ export function waitForCloudflareTunnelUrl(
  * No Cloudflare account is required — quick tunnels are free and ephemeral.
  */
 export interface RunCloudflareTunnelOptions {
-  /** Gateway port to forward. Defaults to the global GATEWAY_PORT. */
+  /** Local edge port to forward. Defaults to the global GATEWAY_PORT. */
   port?: number;
   /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
   workspaceDir?: string;
-  /** Prefer nginx ingress over the gateway port when it is running. */
-  preferNginxIngress?: boolean;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
 }
@@ -156,17 +153,7 @@ export async function runCloudflareTunnel(
   console.log(`Using ${version}`);
 
   const workspaceDir = opts.workspaceDir ?? getDefaultWorkspaceDir();
-  const gatewayPort = opts.port ?? GATEWAY_PORT;
-  const { port, viaIngress } = resolveTunnelTargetPort(
-    workspaceDir,
-    gatewayPort,
-    { preferNginxIngress: opts.preferNginxIngress === true },
-  );
-  if (viaIngress) {
-    console.log(
-      `nginx ingress detected — tunneling to it on 127.0.0.1:${port}.`,
-    );
-  }
+  const port = opts.port ?? GATEWAY_PORT;
 
   console.log(`Starting cloudflared quick tunnel to localhost:${port}...`);
   console.log("No Cloudflare account required — quick tunnels are free.");

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -12,7 +12,6 @@ import {
   saveNgrokDomain,
 } from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
-import { resolveTunnelTargetPort } from "./nginx-ingress.js";
 
 const NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels";
 const NGROK_POLL_INTERVAL_MS = 500;
@@ -286,12 +285,10 @@ export async function maybeStartNgrokTunnel(
 }
 
 export interface RunNgrokTunnelOptions {
-  /** Gateway port to forward. Defaults to the global GATEWAY_PORT. */
+  /** Local edge port to forward. Defaults to the global GATEWAY_PORT. */
   port?: number;
   /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
   workspaceDir?: string;
-  /** Prefer nginx ingress over the gateway port when it is running. */
-  preferNginxIngress?: boolean;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
   /**
@@ -326,17 +323,7 @@ export async function runNgrokTunnel(
   console.log(`Using ${version}`);
 
   const workspaceDir = opts.workspaceDir ?? getDefaultWorkspaceDir();
-  const gatewayPort = opts.port ?? GATEWAY_PORT;
-  const { port, viaIngress } = resolveTunnelTargetPort(
-    workspaceDir,
-    gatewayPort,
-    { preferNginxIngress: opts.preferNginxIngress === true },
-  );
-  if (viaIngress) {
-    console.log(
-      `nginx ingress detected — tunneling to it on 127.0.0.1:${port}.`,
-    );
-  }
+  const port = opts.port ?? GATEWAY_PORT;
 
   // The saved domain is standing intent: a run without --domain reuses it,
   // and only an explicit --domain rewrites it.

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -6,7 +6,6 @@ import {
   getDefaultWorkspaceDir,
   saveIngressUrl,
 } from "./ingress-config.js";
-import { resolveTunnelTargetPort } from "./nginx-ingress.js";
 
 // ── Tailscale CLI discovery + invocation ────────────────────────────────────
 
@@ -161,12 +160,10 @@ export function shouldClearIngressUrl(
 // ── Tailscale serve lifecycle ───────────────────────────────────────────────
 
 export interface RunTailscaleTunnelOptions {
-  /** Gateway port to serve. Defaults to the global GATEWAY_PORT. */
+  /** Local edge port to serve. Defaults to the global GATEWAY_PORT. */
   port?: number;
   /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
   workspaceDir?: string;
-  /** Prefer nginx ingress over the gateway port when it is running. */
-  preferNginxIngress?: boolean;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
 }
@@ -174,7 +171,6 @@ export interface RunTailscaleTunnelOptions {
 export interface TailscaleServeInfo {
   publicUrl: string;
   port: number;
-  viaIngress: boolean;
   binary: string;
   workspaceDir: string;
 }
@@ -210,12 +206,7 @@ export async function startTailscaleServe(
   const publicUrl = `https://${hostname}`;
 
   const workspaceDir = opts.workspaceDir ?? getDefaultWorkspaceDir();
-  const gatewayPort = opts.port ?? GATEWAY_PORT;
-  const { port, viaIngress } = resolveTunnelTargetPort(
-    workspaceDir,
-    gatewayPort,
-    { preferNginxIngress: opts.preferNginxIngress === true },
-  );
+  const port = opts.port ?? GATEWAY_PORT;
 
   const serveResult = deps.run(binary, ["serve", "--bg", String(port)]);
   if (serveResult.status !== 0) {
@@ -224,7 +215,7 @@ export async function startTailscaleServe(
 
   saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
 
-  return { publicUrl, port, viaIngress, binary, workspaceDir };
+  return { publicUrl, port, binary, workspaceDir };
 }
 
 /**
@@ -252,12 +243,10 @@ export async function runTailscaleTunnel(
   const deps = realTailscaleDeps();
 
   console.log("Setting up tailscale serve...");
-  const { publicUrl, port, viaIngress, binary, workspaceDir } =
-    await startTailscaleServe(opts, deps);
-
-  if (viaIngress) {
-    console.log(`nginx ingress detected — serving it on 127.0.0.1:${port}.`);
-  }
+  const { publicUrl, port, binary, workspaceDir } = await startTailscaleServe(
+    opts,
+    deps,
+  );
 
   console.log("");
   console.log(`Tunnel established: ${publicUrl}`);


### PR DESCRIPTION
## Summary
- vellum tunnel calls ensureTunnelEdge before dispatching and hands every provider the edge port; missing nginx exits 1 with install instructions before any spawn
- preferNginxIngress and per-provider resolveTunnelTargetPort fallbacks removed from ngrok/cloudflare/tailscale runners
- web-remote-ingress now only selects SPA vs webhooks-only edge config, never the tunnel target

Part of plan: tunnel-edge-unify.md (PR 5 of 7)