### PR TITLE
feat(cli): wake/upgrade restore one edge and point the webhook auto-tunnel at it

### DIFF
--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -135,10 +135,14 @@ mock.module("../lib/local", () => ({
 const maybeStartNgrokTunnelMock = mock<typeof ngrok.maybeStartNgrokTunnel>(
   async () => null,
 );
+const hasWebhookIntegrationsConfiguredMock = mock<
+  typeof ngrok.hasWebhookIntegrationsConfigured
+>(() => false);
 
 mock.module("../lib/ngrok", () => ({
   ...realNgrok,
   maybeStartNgrokTunnel: maybeStartNgrokTunnelMock,
+  hasWebhookIntegrationsConfigured: hasWebhookIntegrationsConfiguredMock,
 }));
 
 const realFeatureFlags = { ...featureFlags };
@@ -161,22 +165,13 @@ mock.module("../lib/ingress-config.js", () => ({
   loadRawConfig: loadRawConfigMock,
 }));
 
-const isIngressRunningMock = mock<typeof nginxIngress.isIngressRunning>(
-  () => false,
+const ensureTunnelEdgeMock = mock<typeof nginxIngress.ensureTunnelEdge>(
+  async () => ({ port: 7840, started: true, includesWebApp: true }),
 );
-const startRemoteWebIngressMock = mock<
-  typeof nginxIngress.startRemoteWebIngress
->(async () => ({
-  status: "started",
-  listenPort: 7840,
-  webDistDir: "/tmp/web/dist",
-  version: "nginx/1.25.3",
-}));
 
 mock.module("../lib/nginx-ingress.js", () => ({
   ...realNginxIngress,
-  isIngressRunning: isIngressRunningMock,
-  startRemoteWebIngress: startRemoteWebIngressMock,
+  ensureTunnelEdge: ensureTunnelEdgeMock,
 }));
 
 const { wake, WEB_INGRESS_FLAG_RETRY } = await import("../commands/wake.js");
@@ -256,18 +251,17 @@ beforeEach(() => {
   );
   maybeStartNgrokTunnelMock.mockReset();
   maybeStartNgrokTunnelMock.mockResolvedValue(null);
+  hasWebhookIntegrationsConfiguredMock.mockReset();
+  hasWebhookIntegrationsConfiguredMock.mockReturnValue(false);
   isAssistantFeatureFlagEnabledMock.mockReset();
   isAssistantFeatureFlagEnabledMock.mockResolvedValue(true);
   loadRawConfigMock.mockReset();
   loadRawConfigMock.mockReturnValue({});
-  isIngressRunningMock.mockReset();
-  isIngressRunningMock.mockReturnValue(false);
-  startRemoteWebIngressMock.mockReset();
-  startRemoteWebIngressMock.mockResolvedValue({
-    status: "started",
-    listenPort: 7840,
-    webDistDir: "/tmp/web/dist",
-    version: "nginx/1.25.3",
+  ensureTunnelEdgeMock.mockReset();
+  ensureTunnelEdgeMock.mockResolvedValue({
+    port: 7840,
+    started: true,
+    includesWebApp: true,
   });
 });
 
@@ -403,10 +397,11 @@ describe("vellum wake", () => {
   });
 });
 
-describe("vellum wake — web ingress restore", () => {
+describe("vellum wake — tunnel edge restore", () => {
   const enabledConfig = {
     ingress: { enabled: true, publicBaseUrl: "https://assistant.example.com" },
   };
+  const workspaceDirOf = (dir: string) => join(dir, ".vellum", "workspace");
 
   const originalRetry = { ...WEB_INGRESS_FLAG_RETRY };
 
@@ -422,103 +417,135 @@ describe("vellum wake — web ingress restore", () => {
     WEB_INGRESS_FLAG_RETRY.intervalMs = originalRetry.intervalMs;
   });
 
-  test("restores the edge when ingress is enabled, the flag is on, and it is not already running", async () => {
-    loadRawConfigMock.mockReturnValue(enabledConfig);
+  test("webhook-configured wake ensures the edge and tunnels the edge port", async () => {
+    hasWebhookIntegrationsConfiguredMock.mockReturnValue(true);
 
     await wake();
 
-    expect(isAssistantFeatureFlagEnabledMock).toHaveBeenCalledWith(
-      "local-assistant",
-      "web-remote-ingress",
-      { runtimeUrl: "http://127.0.0.1:7830" },
-    );
-    expect(startRemoteWebIngressMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceDir: join(tempDir, ".vellum", "workspace"),
-        gatewayPort: 7830,
-      }),
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "local-assistant",
+      workspaceDir: workspaceDirOf(tempDir),
+      gatewayPort: 7830,
+    });
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7840,
+      workspaceDirOf(tempDir),
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
 
-  test("does not attempt a restore when ingress is disabled", async () => {
+  test("ingress-enabled wake ensures the edge even without webhook integrations", async () => {
+    loadRawConfigMock.mockReturnValue(enabledConfig);
+
+    await wake();
+
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "local-assistant",
+      workspaceDir: workspaceDirOf(tempDir),
+      gatewayPort: 7830,
+    });
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7840,
+      workspaceDirOf(tempDir),
+    );
+    expect(logSpy).toHaveBeenCalledWith("Wake complete.");
+  });
+
+  test("skips the edge and tunnels the gateway port when nothing wants an edge", async () => {
+    await wake();
+
+    expect(isAssistantFeatureFlagEnabledMock).not.toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
+      workspaceDirOf(tempDir),
+    );
+  });
+
+  test("skips the edge when ingress is disabled and no webhooks are configured", async () => {
     loadRawConfigMock.mockReturnValue({ ingress: { enabled: false } });
 
     await wake();
 
-    expect(isAssistantFeatureFlagEnabledMock).not.toHaveBeenCalled();
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
+      workspaceDirOf(tempDir),
+    );
   });
 
-  test("does not attempt a restore when ingress config is absent", async () => {
-    loadRawConfigMock.mockReturnValue({});
-
-    await wake();
-
-    expect(isAssistantFeatureFlagEnabledMock).not.toHaveBeenCalled();
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
-  });
-
-  test("does not attempt a restore when enabled but the public URL is missing", async () => {
+  test("skips the edge when ingress is enabled but the public URL is missing", async () => {
     loadRawConfigMock.mockReturnValue({ ingress: { enabled: true } });
 
     await wake();
 
-    expect(isAssistantFeatureFlagEnabledMock).not.toHaveBeenCalled();
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
   });
 
-  test("does not start a second edge when one is already running", async () => {
-    loadRawConfigMock.mockReturnValue(enabledConfig);
-    isIngressRunningMock.mockReturnValue(true);
+  test("nginx-missing falls back to the gateway-port tunnel with a warning", async () => {
+    hasWebhookIntegrationsConfiguredMock.mockReturnValue(true);
+    ensureTunnelEdgeMock.mockRejectedValue(
+      new Error(
+        "nginx is not installed, so the tunnel edge cannot start. Install it (macOS: `brew install nginx`, Linux: `sudo apt install nginx`) or point NGINX_BIN at an existing binary.",
+      ),
+    );
 
     await wake();
 
-    // Already up — skip the flag probe and the start entirely.
-    expect(isAssistantFeatureFlagEnabledMock).not.toHaveBeenCalled();
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
-  });
-
-  test("skips the restore quietly with a hint when the flag is off", async () => {
-    loadRawConfigMock.mockReturnValue(enabledConfig);
-    isAssistantFeatureFlagEnabledMock.mockResolvedValue(false);
-
-    await wake();
-
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining("web-remote-ingress"),
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("brew install nginx"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("vellum nginx-ingress up"),
+    );
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
+      workspaceDirOf(tempDir),
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
 
-  test("a thrown restore failure warns but does not fail the wake", async () => {
-    loadRawConfigMock.mockReturnValue(enabledConfig);
-    startRemoteWebIngressMock.mockRejectedValue(new Error("nginx boom"));
-
-    await wake();
-
-    expect(startRemoteWebIngressMock).toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith("Wake complete.");
-  });
-
-  test("an unreachable edge warns but does not fail the wake", async () => {
-    loadRawConfigMock.mockReturnValue(enabledConfig);
-    startRemoteWebIngressMock.mockResolvedValue({
-      status: "unreachable",
-      listenPort: 7840,
-      logPath: "/tmp/nginx-ingress.log",
+  test("flag-off + webhooks-on produces a webhooks-only edge fronting the tunnel", async () => {
+    hasWebhookIntegrationsConfiguredMock.mockReturnValue(true);
+    isAssistantFeatureFlagEnabledMock.mockResolvedValue(false);
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: 7840,
+      started: true,
+      includesWebApp: false,
     });
 
     await wake();
 
-    expect(warnSpy).toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith("Wake complete.");
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantId: "local-assistant" }),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("webhooks only"),
+    );
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7840,
+      workspaceDirOf(tempDir),
+    );
   });
 
-  test("a failed flag probe warns and leaves the edge down without failing the wake", async () => {
+  test("a reused edge still points the tunnel at its listen port", async () => {
     loadRawConfigMock.mockReturnValue(enabledConfig);
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: 7841,
+      started: false,
+      includesWebApp: true,
+    });
+
+    await wake();
+
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7841,
+      workspaceDirOf(tempDir),
+    );
+  });
+
+  test("a failed flag probe warns and falls back to the gateway-port tunnel", async () => {
+    hasWebhookIntegrationsConfiguredMock.mockReturnValue(true);
     isAssistantFeatureFlagEnabledMock.mockRejectedValue(
       new Error("gateway unreachable"),
     );
@@ -527,8 +554,12 @@ describe("vellum wake — web ingress restore", () => {
 
     // The probe retries through the startup window before giving up.
     expect(isAssistantFeatureFlagEnabledMock.mock.calls.length).toBe(3);
-    expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
+      workspaceDirOf(tempDir),
+    );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
 
@@ -551,9 +582,9 @@ describe("vellum wake — web ingress restore", () => {
 
     expect(isAssistantFeatureFlagEnabledMock.mock.calls.length).toBe(3);
     expect(logSpy).toHaveBeenCalledWith(
-      "   Waiting for the gateway before restoring the web ingress edge...",
+      "   Waiting for the gateway before restoring the tunnel edge...",
     );
-    expect(startRemoteWebIngressMock).toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
 });

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -72,7 +72,7 @@ import {
   startLocalDaemon,
   stopLocalProcesses,
 } from "../lib/local.js";
-import { maybeStartNgrokTunnel } from "../lib/ngrok.js";
+import { restoreTunnelEdgeAndAutoTunnel } from "./wake.js";
 import {
   leaseGuardianToken,
   resetGuardianBootstrap,
@@ -1044,7 +1044,8 @@ async function upgradeLocal(
     ".vellum",
     "workspace",
   );
-  const ngrokChild = await maybeStartNgrokTunnel(
+  const ngrokChild = await restoreTunnelEdgeAndAutoTunnel(
+    entry.assistantId,
     entry.resources.gatewayPort,
     workspaceDir,
   );

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -29,16 +29,17 @@ import {
   startLocalDaemon,
   startGateway,
 } from "../lib/local";
-import { maybeStartNgrokTunnel } from "../lib/ngrok";
+import {
+  hasWebhookIntegrationsConfigured,
+  maybeStartNgrokTunnel,
+} from "../lib/ngrok";
 import {
   isAssistantFeatureFlagEnabled,
   WEB_REMOTE_INGRESS_FLAG,
 } from "../lib/feature-flags.js";
 import { loadRawConfig } from "../lib/ingress-config.js";
-import {
-  isIngressRunning,
-  startRemoteWebIngress,
-} from "../lib/nginx-ingress.js";
+import { ensureTunnelEdge } from "../lib/nginx-ingress.js";
+import type { ChildProcess } from "child_process";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
@@ -377,9 +378,11 @@ export async function wake(): Promise<void> {
     }
   }
 
-  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
+  // Restore the nginx edge and point the webhook auto-tunnel at it. Non-fatal:
+  // a down edge is a degraded remote-web/webhook path, not a broken assistant.
   const workspaceDir = join(resources.instanceDir, ".vellum", "workspace");
-  const ngrokChild = await maybeStartNgrokTunnel(
+  const ngrokChild = await restoreTunnelEdgeAndAutoTunnel(
+    entry.assistantId,
     resources.gatewayPort,
     workspaceDir,
   );
@@ -387,17 +390,6 @@ export async function wake(): Promise<void> {
     const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
     writeFileSync(ngrokPidFile, String(ngrokChild.pid));
   }
-
-  // Restore the nginx web ingress edge when the workspace config still wants
-  // it. A TLS-terminating front (tailscale serve / tunnel) persists across
-  // restarts and keeps proxying to the edge's loopback port, but the edge has
-  // a manual lifecycle — so a routine restart otherwise leaves the self-hosted
-  // remote-web path dead (502 / blank page) until someone runs it back up.
-  await restoreWebIngressIfEnabled(
-    entry.assistantId,
-    resources.gatewayPort,
-    workspaceDir,
-  );
 
   if (daemonMigrationsFailed) {
     console.log(
@@ -426,7 +418,7 @@ export async function wake(): Promise<void> {
 }
 
 /**
- * Retry policy for the flag probe that gates the web-ingress restore. The
+ * Retry policy for the flag probe that precedes the tunnel-edge restore. The
  * gateway has typically been up for milliseconds at this point and answers
  * `503 {"status":"starting"}` (or refuses connections) until its startup
  * completes, so a single probe races it. Mutable so tests can shrink the
@@ -438,27 +430,30 @@ export const WEB_INGRESS_FLAG_RETRY = {
 };
 
 /**
- * Probe the `web-remote-ingress` flag, riding out the gateway's startup
- * window: transient failures retry on an interval until the attempt budget is
- * spent, then the last error propagates to the caller's warn path.
+ * Wait for the gateway to answer the `web-remote-ingress` flag probe, riding
+ * out its startup window: transient failures retry on an interval until the
+ * attempt budget is spent, then the last error propagates to the caller's
+ * warn path. `ensureTunnelEdge` reads the flag itself to pick the edge mode;
+ * this probe only proves the gateway is ready to answer it.
  */
-async function verifyWebIngressFlagWithRetry(
+async function waitForFlagRouteReady(
   assistantId: string,
   gatewayPort: number,
-): Promise<boolean> {
+): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= WEB_INGRESS_FLAG_RETRY.attempts; attempt++) {
     try {
-      return await isAssistantFeatureFlagEnabled(
+      await isAssistantFeatureFlagEnabled(
         assistantId,
         WEB_REMOTE_INGRESS_FLAG,
         { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
       );
+      return;
     } catch (err) {
       lastError = err;
       if (attempt === 1) {
         console.log(
-          "   Waiting for the gateway before restoring the web ingress edge...",
+          "   Waiting for the gateway before restoring the tunnel edge...",
         );
       }
       if (attempt < WEB_INGRESS_FLAG_RETRY.attempts) {
@@ -472,95 +467,68 @@ async function verifyWebIngressFlagWithRetry(
 }
 
 /**
- * Bring the nginx web ingress edge back up after a wake when the workspace
- * config still wants it. Only restores when ingress is explicitly enabled with
- * a saved public URL and the `web-remote-ingress` flag is on — the edge is
- * pointless without the flag, so a disabled flag skips quietly with a hint.
- *
- * Reads the same workspace config the edge serves. Any failure to restore
- * warns with the manual `vellum nginx-ingress up` command and never fails the
- * wake — a down edge is a degraded remote-web path, not a broken assistant.
+ * Whether the workspace ingress config wants the remote-web edge: explicitly
+ * enabled with a saved public URL.
  */
-async function restoreWebIngressIfEnabled(
+function wantsWebIngress(workspaceDir: string): boolean {
+  try {
+    const config = loadRawConfig(workspaceDir);
+    const ingress = config.ingress as
+      | { enabled?: unknown; publicBaseUrl?: unknown }
+      | undefined;
+    return (
+      ingress?.enabled === true &&
+      typeof ingress.publicBaseUrl === "string" &&
+      ingress.publicBaseUrl.trim() !== ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Bring the nginx edge back up after a wake or local upgrade and point the
+ * webhook auto-tunnel at it. The edge is wanted when webhook integrations are
+ * configured or the workspace ingress config is enabled with a saved public
+ * URL; `ensureTunnelEdge` picks SPA vs webhooks-only mode off the
+ * `web-remote-ingress` flag. Edge failures warn (with the error's install or
+ * diagnostic text) and fall back to tunneling the gateway port directly, which
+ * `maybeStartNgrokTunnel` only does when webhook integrations are configured —
+ * so webhook channels on nginx-less machines keep working, and the caller
+ * never fails because of edge problems.
+ *
+ * Returns the spawned ngrok child (for PID tracking) or null.
+ */
+export async function restoreTunnelEdgeAndAutoTunnel(
   assistantId: string,
   gatewayPort: number,
   workspaceDir: string,
-): Promise<void> {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = config.ingress as
-    | { enabled?: unknown; publicBaseUrl?: unknown }
-    | undefined;
-  const enabled = ingress?.enabled === true;
-  const publicBaseUrl =
-    typeof ingress?.publicBaseUrl === "string"
-      ? ingress.publicBaseUrl.trim()
-      : "";
-  if (!enabled || !publicBaseUrl) {
-    return;
-  }
-
-  // The edge already survived (or was manually brought back) — nothing to do.
-  if (isIngressRunning(workspaceDir)) {
-    return;
-  }
-
-  let flagEnabled: boolean;
-  try {
-    flagEnabled = await verifyWebIngressFlagWithRetry(assistantId, gatewayPort);
-  } catch (err) {
-    console.warn(
-      `   Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` flag to restore the web ingress edge; leaving it down. Bring it up manually with \`vellum nginx-ingress up\`. ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-    return;
-  }
-  if (!flagEnabled) {
-    console.log(
-      `   Web ingress edge not restored: the \`${WEB_REMOTE_INGRESS_FLAG}\` flag is off. Enable it and run \`vellum nginx-ingress up\` to serve remote web access.`,
-    );
-    return;
-  }
-
-  try {
-    const result = await startRemoteWebIngress({
-      workspaceDir,
-      gatewayPort,
-      onStarting: ({ listenPort }) => {
-        console.log(
-          `Restoring web ingress edge on 127.0.0.1:${listenPort} (ingress.enabled)...`,
-        );
-      },
-    });
-    switch (result.status) {
-      case "started":
-        console.log(
-          `   Web ingress edge running: http://127.0.0.1:${result.listenPort}`,
-        );
-        break;
-      case "already-running":
-        break;
-      case "nginx-missing":
-        console.warn(
-          "   Could not restore the web ingress edge: nginx is not installed. Bring it up manually with `vellum nginx-ingress up`.",
-        );
-        break;
-      case "web-dist-missing":
-        console.warn(
-          "   Could not restore the web ingress edge: built web assets were not found. Bring it up manually with `vellum nginx-ingress up`.",
-        );
-        break;
-      case "unreachable":
-        console.warn(
-          `   Web ingress edge did not become reachable on 127.0.0.1:${result.listenPort}; check ${result.logPath}. Bring it up manually with \`vellum nginx-ingress up\`.`,
-        );
-        break;
+): Promise<ChildProcess | null> {
+  let tunnelTargetPort = gatewayPort;
+  if (
+    hasWebhookIntegrationsConfigured(workspaceDir) ||
+    wantsWebIngress(workspaceDir)
+  ) {
+    try {
+      await waitForFlagRouteReady(assistantId, gatewayPort);
+      const edge = await ensureTunnelEdge({
+        assistantId,
+        workspaceDir,
+        gatewayPort,
+      });
+      tunnelTargetPort = edge.port;
+      console.log(
+        `   Tunnel edge ${edge.started ? "started" : "already running"} on 127.0.0.1:${edge.port} (${
+          edge.includesWebApp ? "remote web + webhooks" : "webhooks only"
+        }).`,
+      );
+    } catch (err) {
+      console.warn(
+        `   Could not restore the tunnel edge: ${
+          err instanceof Error ? err.message : String(err)
+        } Bring it up manually with \`vellum nginx-ingress up\`.`,
+      );
     }
-  } catch (err) {
-    console.warn(
-      `   Failed to restore the web ingress edge: ${
-        err instanceof Error ? err.message : String(err)
-      }. Bring it up manually with \`vellum nginx-ingress up\`.`,
-    );
   }
+  return maybeStartNgrokTunnel(tunnelTargetPort, workspaceDir);
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -186,7 +186,9 @@ export async function waitForNgrokUrl(
  * Check whether any webhook-based integrations (e.g. Telegram, Twilio) are
  * configured that require a public ingress URL.
  */
-function hasWebhookIntegrationsConfigured(workspaceDir: string): boolean {
+export function hasWebhookIntegrationsConfigured(
+  workspaceDir: string,
+): boolean {
   try {
     const config = loadRawConfig(workspaceDir);
     const telegram = config.telegram as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary
- wake/upgrade now ensure the nginx edge first (SPA or webhooks-only per flag) and point the webhook auto-tunnel at the edge port
- nginx-missing or edge failure warns and falls back to the direct-gateway tunnel only when webhook integrations are configured; wake never fails because of edge problems
- restoreWebIngressIfEnabled and its flag-retry helper are folded into the shared ensureTunnelEdge path

Part of plan: tunnel-edge-unify.md (PR 6 of 7)