### PR TITLE
feat(web): prime the gateway connection for paired assistants via guardian bearer

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -187,6 +187,7 @@ mock.module("@/lib/local-mode", () => ({
   primeLocalGatewayConnection: async () => {},
   primeLocalGatewayConnectionWithRepair: async () => {},
   getLocalGatewayUrl: () => localGatewayUrlValue,
+  getPairedGatewayUrl: () => undefined,
   // Mirrors the real probe against the mocked gateway URL, so tests that stub
   // `globalThis.fetch` keep driving the readyz loop the same way.
   probeLocalGatewayReady: async () => {

--- a/clients/web/src/lib/auth/gateway-session.test.ts
+++ b/clients/web/src/lib/auth/gateway-session.test.ts
@@ -7,8 +7,11 @@ import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
   isRepairableGatewayTokenError,
+  seedGatewayToken,
   setRemoteGatewayToken,
 } from "@/lib/auth/gateway-session";
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
+import { useLockfileStore } from "@/stores/lockfile-store";
 
 const realFetch = globalThis.fetch;
 
@@ -22,6 +25,8 @@ afterEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
   globalThis.fetch = realFetch;
   clearGatewayToken();
+  useLockfileStore.setState({ lockfile: null, committed: false });
+  process.env.VITE_PLATFORM_MODE = "true";
 });
 
 describe("remote gateway mode", () => {
@@ -37,6 +42,57 @@ describe("remote gateway mode", () => {
     });
 
     expect(isGatewayAuthMode()).toBe(true);
+  });
+});
+
+describe("paired selection", () => {
+  function selectPaired(runtimeUrl?: string): void {
+    const paired = {
+      assistantId: "paired-a",
+      cloud: "paired",
+      ...(runtimeUrl != null && { runtimeUrl }),
+    } as LockfileAssistant;
+    useLockfileStore.setState({
+      lockfile: { assistants: [paired], activeAssistant: "paired-a" },
+    });
+  }
+
+  test("gateway auth is enabled for a paired selection with a usable runtimeUrl", () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    selectPaired("https://gw.example.com");
+
+    expect(isGatewayAuthEnabled()).toBe(true);
+  });
+
+  test("gateway auth stays disabled when the paired runtimeUrl is unusable", () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    selectPaired();
+
+    expect(isGatewayAuthEnabled()).toBe(false);
+  });
+
+  test("gateway auth stays disabled for a paired selection outside local mode", () => {
+    selectPaired("https://gw.example.com");
+
+    expect(isGatewayAuthEnabled()).toBe(false);
+  });
+
+  test("a seeded token turns gateway auth mode on without any fetch", () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    selectPaired("https://gw.example.com");
+    const fetchSpy = mock(async () => {
+      throw new Error("unexpected fetch");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    seedGatewayToken({
+      token: "guardian-tok",
+      expiresAtEpochSeconds: Math.floor(Date.now() / 1000) + 3600,
+      source: "https://gw.example.com/auth/token",
+    });
+
+    expect(isGatewayAuthMode()).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/lib/auth/gateway-session.ts
+++ b/clients/web/src/lib/auth/gateway-session.ts
@@ -1,6 +1,8 @@
 import {
   isLocalClient,
   getLocalGatewayUrl,
+  getPairedGatewayUrl,
+  getSelectedAssistant,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
@@ -60,7 +62,13 @@ export function isGatewayAuthEnabled(): boolean {
   if (isRemoteGatewayMode()) {
     return true;
   }
-  return isLocalClient() && getLocalGatewayUrl() != null;
+  if (!isLocalClient()) {
+    return false;
+  }
+  return (
+    getLocalGatewayUrl() != null ||
+    getPairedGatewayUrl(getSelectedAssistant()) != null
+  );
 }
 
 export function isGatewayAuthMode(): boolean {
@@ -122,6 +130,31 @@ export function getGatewayToken(): string | null {
   return null;
 }
 
+/**
+ * Install an externally-acquired bearer as the gateway token without any
+ * fetch, writing the same in-memory and localStorage slots the `/auth/token`
+ * mint fills. `getGatewayToken()`, `isGatewayAuthMode()`, and the
+ * source-mismatch clearing in `ensureGatewayToken` behave identically for a
+ * seeded token, and the session survives a reload. Used for paired
+ * assistants, whose guardian access token is the bearer itself.
+ */
+export function seedGatewayToken(params: {
+  token: string;
+  expiresAtEpochSeconds: number;
+  source: string;
+}): void {
+  try {
+    localStorage.setItem(LS_TOKEN_KEY, params.token);
+    localStorage.setItem(LS_EXPIRES_KEY, String(params.expiresAtEpochSeconds));
+    localStorage.setItem(LS_TOKEN_SOURCE_KEY, params.source);
+  } catch {
+    // localStorage unavailable
+  }
+  cachedToken = params.token;
+  cachedExpiresAt = params.expiresAtEpochSeconds;
+  cachedTokenSource = params.source;
+}
+
 async function acquireGatewayToken(
   tokenUrl?: string,
   guardianToken?: string,
@@ -142,16 +175,7 @@ async function acquireGatewayToken(
     token: string;
     expiresAt: number;
   };
-  try {
-    localStorage.setItem(LS_TOKEN_KEY, token);
-    localStorage.setItem(LS_EXPIRES_KEY, String(expiresAt));
-    localStorage.setItem(LS_TOKEN_SOURCE_KEY, url);
-  } catch {
-    // localStorage unavailable
-  }
-  cachedToken = token;
-  cachedExpiresAt = expiresAt;
-  cachedTokenSource = url;
+  seedGatewayToken({ token, expiresAtEpochSeconds: expiresAt, source: url });
   return token;
 }
 

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -142,6 +142,32 @@ describe("primeLocalGatewayConnectionWithRepair", () => {
     expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(1);
   });
 
+  test("a repairable failure for a paired target never wakes and rethrows", async () => {
+    // Wake is cloud:"local"-only (it refuses paired entries), so a paired
+    // connect failure must propagate immediately instead of spawning a wake
+    // that is guaranteed to refuse.
+    process.env.VITE_PLATFORM_MODE = "";
+    const paired: LockfileAssistant = {
+      assistantId: "paired-a",
+      cloud: "paired",
+      runtimeUrl: "https://gw.example.com",
+    } as LockfileAssistant;
+    useLockfileStore.setState({
+      lockfile: { assistants: [paired], activeAssistant: "paired-a" },
+    });
+    localStorage.setItem("vellum:local:selected-assistant", "paired-a");
+    fetchGuardianTokenHost = mock(async () => {
+      throw new GuardianTokenError(404, "token gone");
+    });
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+  });
+
   test("a non-repairable 403 surfaces immediately and never wakes", async () => {
     fetchGuardianTokenHost = mock(async () => {
       throw new GuardianTokenError(403, "forbidden");

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -528,29 +528,35 @@ describe("getLocalGatewayUrl", () => {
 });
 
 describe("getPairedGatewayUrl", () => {
-  test("resolves a paired entry's runtimeUrl in local mode", () => {
+  test("resolves the same-origin proxy path for a usable paired entry", () => {
     enableLocalMode();
-    expect(getPairedGatewayUrl(pairedEntry)).toBe("https://gw.example.com");
+    expect(getPairedGatewayUrl(pairedEntry)).toBe(
+      "/assistant/__gateway-paired/paired-a",
+    );
   });
 
-  test("strips trailing slashes", () => {
+  test("URL-encodes the assistant id in the proxy path", () => {
     enableLocalMode();
     const paired = {
       ...pairedEntry,
-      runtimeUrl: "https://gw.example.com///",
-    } as LockfileAssistant;
-    expect(getPairedGatewayUrl(paired)).toBe("https://gw.example.com");
-  });
-
-  test("preserves a path prefix, trailing slash stripped", () => {
-    enableLocalMode();
-    const paired = {
-      ...pairedEntry,
-      runtimeUrl: "https://gw.example.com/assistant/",
+      assistantId: "paired/one two",
     } as LockfileAssistant;
     expect(getPairedGatewayUrl(paired)).toBe(
-      "https://gw.example.com/assistant",
+      "/assistant/__gateway-paired/paired%2Fone%20two",
     );
+  });
+
+  test("accepts runtimeUrls with trailing slashes or path prefixes", () => {
+    enableLocalMode();
+    for (const runtimeUrl of [
+      "https://gw.example.com///",
+      "https://gw.example.com/assistant/",
+    ]) {
+      const paired = { ...pairedEntry, runtimeUrl } as LockfileAssistant;
+      expect(getPairedGatewayUrl(paired)).toBe(
+        "/assistant/__gateway-paired/paired-a",
+      );
+    }
   });
 
   test("is undefined for a non-http(s) runtimeUrl", () => {
@@ -599,10 +605,10 @@ describe("getAuthGatewayIngressUrl", () => {
     );
   });
 
-  test("returns the remote runtimeUrl for a paired entry", () => {
+  test("returns origin + paired gateway proxy for a paired entry", () => {
     enableLocalMode();
     expect(getAuthGatewayIngressUrl(pairedEntry)).toBe(
-      "https://gw.example.com",
+      `${window.location.origin}/assistant/__gateway-paired/paired-a`,
     );
   });
 
@@ -614,7 +620,9 @@ describe("getAuthGatewayIngressUrl", () => {
   test("defaults to the selected assistant", () => {
     enableLocalMode();
     setLockfile({ assistants: [pairedEntry], activeAssistant: "paired-a" });
-    expect(getAuthGatewayIngressUrl()).toBe("https://gw.example.com");
+    expect(getAuthGatewayIngressUrl()).toBe(
+      `${window.location.origin}/assistant/__gateway-paired/paired-a`,
+    );
   });
 });
 
@@ -727,12 +735,16 @@ describe("primeLocalGatewayConnection", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(fetchGuardianTokenHost).toHaveBeenCalledWith("paired-a");
     expect(getGatewayToken()).toBe("guardian-tok");
-    expect(getSelfHostedIngressUrl()).toBe("https://gw.example.com");
+    // The connection rides the same-origin host proxy, never the remote
+    // runtimeUrl directly (packaged-app CSP and browser CORS both block it).
+    expect(getSelfHostedIngressUrl()).toBe(
+      `${window.location.origin}/assistant/__gateway-paired/paired-a`,
+    );
     expect(getSelfHostedActorToken()).toBe("guardian-tok");
     // The seeded source mirrors local mode's `<base>/auth/token` shape so an
     // assistant switch trips the source-mismatch clear.
     expect(localStorage.getItem("vellum:gw:tokenSource")).toBe(
-      "https://gw.example.com/auth/token",
+      "/assistant/__gateway-paired/paired-a/auth/token",
     );
   });
 

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -25,18 +25,23 @@ const saveLockfileAssistantHost = mock(
   }),
 );
 
+const fetchGuardianTokenHost = mock(async (_id: string) => "guardian-tok");
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
   loadLockfileHost,
   saveLockfileAssistantHost,
+  fetchGuardianTokenHost,
 }));
 
 import {
   getActiveAssistant,
+  getAuthGatewayIngressUrl,
   getLocalGatewayUrl,
   getLocalAssistants,
   getLockfile,
+  getPairedGatewayUrl,
   getPlatformAssistants,
   getPlatformRuntimeUrl,
   getSelectedAssistant,
@@ -53,7 +58,17 @@ import {
   saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
   UnresolvedLocalGatewayError,
+  UnresolvedPairedGatewayError,
 } from "@/lib/local-mode";
+import {
+  clearGatewayToken,
+  getGatewayToken,
+} from "@/lib/auth/gateway-session";
+import {
+  getSelfHostedActorToken,
+  getSelfHostedIngressUrl,
+  setSelfHostedConnection,
+} from "@/lib/self-hosted/connection";
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 import { useLockfileStore } from "@/stores/lockfile-store";
@@ -81,6 +96,12 @@ const platform: LockfileAssistant = {
   cloud: "vellum",
 } as LockfileAssistant;
 
+const pairedEntry: LockfileAssistant = {
+  assistantId: "paired-a",
+  cloud: "paired",
+  runtimeUrl: "https://gw.example.com",
+} as LockfileAssistant;
+
 function setLockfile(lockfile: Lockfile): void {
   useLockfileStore.setState({ lockfile });
 }
@@ -99,6 +120,9 @@ afterEach(() => {
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
   saveLockfileAssistantHost.mockClear();
+  fetchGuardianTokenHost.mockClear();
+  clearGatewayToken();
+  setSelfHostedConnection(null);
 });
 
 describe("remote gateway mode", () => {
@@ -503,6 +527,97 @@ describe("getLocalGatewayUrl", () => {
   });
 });
 
+describe("getPairedGatewayUrl", () => {
+  test("resolves a paired entry's runtimeUrl in local mode", () => {
+    enableLocalMode();
+    expect(getPairedGatewayUrl(pairedEntry)).toBe("https://gw.example.com");
+  });
+
+  test("strips trailing slashes", () => {
+    enableLocalMode();
+    const paired = {
+      ...pairedEntry,
+      runtimeUrl: "https://gw.example.com///",
+    } as LockfileAssistant;
+    expect(getPairedGatewayUrl(paired)).toBe("https://gw.example.com");
+  });
+
+  test("preserves a path prefix, trailing slash stripped", () => {
+    enableLocalMode();
+    const paired = {
+      ...pairedEntry,
+      runtimeUrl: "https://gw.example.com/assistant/",
+    } as LockfileAssistant;
+    expect(getPairedGatewayUrl(paired)).toBe(
+      "https://gw.example.com/assistant",
+    );
+  });
+
+  test("is undefined for a non-http(s) runtimeUrl", () => {
+    enableLocalMode();
+    const paired = {
+      ...pairedEntry,
+      runtimeUrl: "ftp://x",
+    } as LockfileAssistant;
+    expect(getPairedGatewayUrl(paired)).toBeUndefined();
+  });
+
+  test("is undefined for a missing or malformed runtimeUrl", () => {
+    enableLocalMode();
+    const missing = { assistantId: "p", cloud: "paired" } as LockfileAssistant;
+    const malformed = {
+      ...pairedEntry,
+      runtimeUrl: "not a url",
+    } as LockfileAssistant;
+    expect(getPairedGatewayUrl(missing)).toBeUndefined();
+    expect(getPairedGatewayUrl(malformed)).toBeUndefined();
+  });
+
+  test("is undefined for non-paired entries", () => {
+    enableLocalMode();
+    expect(getPairedGatewayUrl(localA)).toBeUndefined();
+    expect(getPairedGatewayUrl(platform)).toBeUndefined();
+    expect(getPairedGatewayUrl(undefined)).toBeUndefined();
+  });
+
+  test("is undefined outside local mode", () => {
+    expect(getPairedGatewayUrl(pairedEntry)).toBeUndefined();
+  });
+
+  test("is undefined in remote-gateway mode", () => {
+    enableLocalMode();
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    expect(getPairedGatewayUrl(pairedEntry)).toBeUndefined();
+  });
+});
+
+describe("getAuthGatewayIngressUrl", () => {
+  test("returns origin + gateway proxy for a local entry", () => {
+    enableLocalMode();
+    expect(getAuthGatewayIngressUrl(localA)).toBe(
+      `${window.location.origin}/assistant/__gateway/7830`,
+    );
+  });
+
+  test("returns the remote runtimeUrl for a paired entry", () => {
+    enableLocalMode();
+    expect(getAuthGatewayIngressUrl(pairedEntry)).toBe(
+      "https://gw.example.com",
+    );
+  });
+
+  test("is undefined for a platform entry", () => {
+    enableLocalMode();
+    expect(getAuthGatewayIngressUrl(platform)).toBeUndefined();
+  });
+
+  test("defaults to the selected assistant", () => {
+    enableLocalMode();
+    setLockfile({ assistants: [pairedEntry], activeAssistant: "paired-a" });
+    expect(getAuthGatewayIngressUrl()).toBe("https://gw.example.com");
+  });
+});
+
 describe("isCliWakeableAssistant", () => {
   test("a cloud:local entry with no recorded port is wakeable (wake establishes it)", () => {
     setLockfile({
@@ -570,10 +685,66 @@ describe("primeLocalGatewayConnection", () => {
     ).resolves.toBeUndefined();
   });
 
-  test("is a no-op for a remote (paired) assistant — not a local gateway case", async () => {
+  test("is a no-op for a paired assistant outside local mode", async () => {
+    await expect(
+      primeLocalGatewayConnection(pairedEntry),
+    ).resolves.toBeUndefined();
+    expect(fetchGuardianTokenHost).not.toHaveBeenCalled();
+  });
+
+  test("throws UnresolvedPairedGatewayError for a paired assistant with no runtimeUrl", async () => {
     enableLocalMode();
     const paired = { assistantId: "p", cloud: "paired" } as LockfileAssistant;
-    await expect(primeLocalGatewayConnection(paired)).resolves.toBeUndefined();
+    await expect(primeLocalGatewayConnection(paired)).rejects.toBeInstanceOf(
+      UnresolvedPairedGatewayError,
+    );
+  });
+
+  test("throws UnresolvedPairedGatewayError for a paired assistant with a non-http runtimeUrl", async () => {
+    enableLocalMode();
+    const paired = {
+      ...pairedEntry,
+      runtimeUrl: "ftp://x",
+    } as LockfileAssistant;
+    await expect(primeLocalGatewayConnection(paired)).rejects.toBeInstanceOf(
+      UnresolvedPairedGatewayError,
+    );
+  });
+
+  test("paired prime seeds the guardian bearer without minting at /auth/token", async () => {
+    enableLocalMode();
+    const fetchSpy = mock(async () => {
+      throw new Error("unexpected fetch");
+    });
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      await primeLocalGatewayConnection(pairedEntry);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchGuardianTokenHost).toHaveBeenCalledWith("paired-a");
+    expect(getGatewayToken()).toBe("guardian-tok");
+    expect(getSelfHostedIngressUrl()).toBe("https://gw.example.com");
+    expect(getSelfHostedActorToken()).toBe("guardian-tok");
+    // The seeded source mirrors local mode's `<base>/auth/token` shape so an
+    // assistant switch trips the source-mismatch clear.
+    expect(localStorage.getItem("vellum:gw:tokenSource")).toBe(
+      "https://gw.example.com/auth/token",
+    );
+  });
+
+  test("paired prime reads the token's JWT exp for the seeded expiry", async () => {
+    enableLocalMode();
+    const jwt = `x.${btoa(JSON.stringify({ exp: 2_000_000_000 }))}.y`;
+    fetchGuardianTokenHost.mockResolvedValueOnce(jwt);
+
+    await primeLocalGatewayConnection(pairedEntry);
+
+    expect(getGatewayToken()).toBe(jwt);
+    expect(localStorage.getItem("vellum:gw:expiresAt")).toBe("2000000000");
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -9,6 +9,7 @@ import {
   GatewayTokenError,
   getGatewayToken,
   getLocalTokenUrl,
+  seedGatewayToken,
 } from "@/lib/auth/gateway-session";
 import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
@@ -616,6 +617,62 @@ export function getLocalGatewayUrl(
 }
 
 /**
+ * Whether this runtime should reach `assistant` at a remote paired gateway: a
+ * paired entry ({@link isPairedAssistant}), in local (non-remote-gateway) mode.
+ * Whether the entry records a usable `runtimeUrl` is a separate question
+ * answered by `getPairedGatewayUrl`. Deliberately not a type predicate: its
+ * false branch must not narrow `assistant` (a local entry also lands there).
+ */
+function expectsPairedGateway(assistant: LockfileAssistant): boolean {
+  return (
+    isLocalClient() && !isRemoteGatewayMode() && isPairedAssistant(assistant)
+  );
+}
+
+/**
+ * The remote gateway base URL for a paired assistant, or `undefined` when the
+ * entry isn't paired, isn't usable in this runtime (non-local client or
+ * remote-gateway mode), or records no absolute http(s) `runtimeUrl`. A path
+ * prefix in the recorded URL is preserved (a paired gateway may be served
+ * under a subpath, like remote-gateway mode's prefix-served assistants);
+ * trailing slashes are stripped.
+ */
+export function getPairedGatewayUrl(
+  assistant: LockfileAssistant | undefined,
+): string | undefined {
+  if (!assistant || !expectsPairedGateway(assistant)) {
+    return undefined;
+  }
+  if (!assistant.runtimeUrl) {
+    return undefined;
+  }
+  try {
+    const url = new URL(assistant.runtimeUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return undefined;
+    }
+    return `${url.origin}${url.pathname}`.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Absolute base URL this runtime reaches the given assistant's gateway at:
+ * origin + local gateway proxy for local/docker entries, the remote
+ * `runtimeUrl` for paired entries, `undefined` otherwise.
+ */
+export function getAuthGatewayIngressUrl(
+  assistant: LockfileAssistant | undefined = getSelectedAssistant(),
+): string | undefined {
+  const local = getLocalGatewayUrl(assistant);
+  if (local) {
+    return `${window.location.origin}${local}`;
+  }
+  return getPairedGatewayUrl(assistant);
+}
+
+/**
  * One-shot probe of the local gateway's `/readyz` (which reports gateway AND
  * upstream daemon readiness). True only when the gateway answers
  * `{ status: "ok" }`; false when the gateway URL is unresolvable, the request
@@ -661,6 +718,46 @@ export class UnresolvedLocalGatewayError extends Error {
 }
 
 /**
+ * A paired assistant records no usable `runtimeUrl`, so there is no remote
+ * gateway to reach. Deliberately not {@link UnresolvedLocalGatewayError}: that
+ * one routes to the wake-recovery dialog in the chooser, and `wake` refuses
+ * paired entries (re-pairing from the source machine is the fix).
+ */
+export class UnresolvedPairedGatewayError extends Error {
+  constructor(assistantId: string) {
+    super(`Paired assistant ${assistantId} has no usable runtimeUrl`);
+    this.name = "UnresolvedPairedGatewayError";
+  }
+}
+
+/**
+ * The numeric `exp` claim of a JWT, in epoch seconds, or `undefined` when the
+ * token isn't a decodable JWT or carries no numeric `exp`. Never throws.
+ */
+function decodeJwtExpSeconds(token: string): number | undefined {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) {
+      return undefined;
+    }
+    const decoded: unknown = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    if (
+      decoded !== null &&
+      typeof decoded === "object" &&
+      "exp" in decoded &&
+      typeof decoded.exp === "number"
+    ) {
+      return decoded.exp;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Acquire a gateway token and prime the self-hosted connection for the given
  * local assistant (default: the selected one). The guardian token and gateway
  * exchange both ride the host's local-mode transport, so this stays
@@ -673,6 +770,30 @@ export async function primeLocalGatewayConnection(
   target?: LockfileAssistant,
 ): Promise<void> {
   const assistant = target ?? getSelectedAssistant();
+  if (assistant && expectsPairedGateway(assistant)) {
+    const pairedUrl = getPairedGatewayUrl(assistant);
+    if (!pairedUrl) {
+      throw new UnresolvedPairedGatewayError(assistant.assistantId);
+    }
+    // The remote gateway's `/auth/token` mint is loopback- and Origin-gated to
+    // localhost, so a cross-machine mint is impossible: the guardian access
+    // token itself is the bearer, exactly like the CLI's `vellum client`
+    // paired path. The seeded source uses the same `<base>/auth/token` shape
+    // as local mode's token URL so an assistant switch trips
+    // `ensureGatewayToken`'s source-mismatch clear naturally. The 1-hour
+    // fallback expiry forces a cheap periodic re-lease when the token carries
+    // no readable `exp`.
+    const guardianToken = await fetchGuardianTokenHost(assistant.assistantId);
+    seedGatewayToken({
+      token: guardianToken,
+      expiresAtEpochSeconds:
+        decodeJwtExpSeconds(guardianToken) ??
+        Math.floor(Date.now() / 1000) + 3600,
+      source: `${pairedUrl}/auth/token`,
+    });
+    setSelfHostedConnection({ url: pairedUrl, token: guardianToken });
+    return;
+  }
   const tokenUrl = getLocalTokenUrl(assistant);
   if (!tokenUrl) {
     // A local assistant we recognize but can't resolve a gateway for (no port)
@@ -687,12 +808,12 @@ export async function primeLocalGatewayConnection(
     ? await fetchGuardianTokenHost(assistant.assistantId)
     : undefined;
   await ensureGatewayToken(tokenUrl, guardianToken);
-  const localGateway = getLocalGatewayUrl(assistant);
-  if (!localGateway) {
+  const ingressUrl = getAuthGatewayIngressUrl(assistant);
+  if (!ingressUrl) {
     return;
   }
   setSelfHostedConnection({
-    url: `${window.location.origin}${localGateway}`,
+    url: ingressUrl,
     token: getGatewayToken(),
   });
 }
@@ -825,17 +946,22 @@ export async function primeLocalGatewayConnectionWithStartupRetry(
 export async function primeLocalGatewayConnectionWithRepair(
   target?: LockfileAssistant,
 ): Promise<void> {
+  const assistant = target ?? getSelectedAssistant();
   try {
-    await primeLocalGatewayConnection(target);
+    await primeLocalGatewayConnection(assistant);
     return;
   } catch (error) {
+    // Wake operates only on plain local assistants (see
+    // `isCliWakeableAssistant`): spawning it for a paired or otherwise
+    // non-local target would burn time on a refusal, so their failures
+    // propagate untouched.
+    if (!assistant || !isLocalAssistant(assistant)) {
+      throw error;
+    }
     if (!isRepairableConnectError(error)) {
       throw error;
     }
-    const assistantId = (target ?? getSelectedAssistant())?.assistantId;
-    if (!assistantId) {
-      throw error;
-    }
+    const assistantId = assistant.assistantId;
     const repair = await wakeLocalAssistantHost(assistantId);
     if (!repair.ok) {
       throw error;
@@ -851,7 +977,7 @@ export async function primeLocalGatewayConnectionWithRepair(
     // connect dead-ends to the recovery controls. Ride out that restart window
     // instead, so a persisted local assistant reconnects on its own.
     await primeLocalGatewayWithStartupRideout(
-      refreshed ?? target,
+      refreshed ?? assistant,
       isGatewayRestartTransient,
     );
   }

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -629,13 +629,39 @@ function expectsPairedGateway(assistant: LockfileAssistant): boolean {
   );
 }
 
+/** Same-origin proxy path for a paired assistant's remote gateway. */
+export function pairedGatewayProxyUrl(assistantId: string): string {
+  return `/assistant/__gateway-paired/${encodeURIComponent(assistantId)}`;
+}
+
 /**
- * The remote gateway base URL for a paired assistant, or `undefined` when the
- * entry isn't paired, isn't usable in this runtime (non-local client or
- * remote-gateway mode), or records no absolute http(s) `runtimeUrl`. A path
- * prefix in the recorded URL is preserved (a paired gateway may be served
- * under a subpath, like remote-gateway mode's prefix-served assistants);
- * trailing slashes are stripped.
+ * Whether a paired entry records a `runtimeUrl` the serving host can forward
+ * to: an absolute http(s) URL.
+ */
+function hasUsablePairedRuntimeUrl(assistant: LockfileAssistant): boolean {
+  if (!assistant.runtimeUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(assistant.runtimeUrl);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The same-origin proxy path this runtime reaches a paired assistant's remote
+ * gateway through, or `undefined` when the entry isn't paired, isn't usable in
+ * this runtime (non-local client or remote-gateway mode), or records no
+ * absolute http(s) `runtimeUrl` for the host to forward to.
+ *
+ * The renderer never fetches the remote origin directly: the packaged app's
+ * CSP pins `connect-src` to Vellum origins, and a browser-served SPA would be
+ * stopped by the remote gateway's CORS. Instead the serving host (the Electron
+ * `app://` handler, the Vite dev middleware, the CLI web server) resolves the
+ * entry's recorded `runtimeUrl` and forwards, exactly like the loopback
+ * `__gateway/{port}` data-plane proxy.
  */
 export function getPairedGatewayUrl(
   assistant: LockfileAssistant | undefined,
@@ -643,33 +669,25 @@ export function getPairedGatewayUrl(
   if (!assistant || !expectsPairedGateway(assistant)) {
     return undefined;
   }
-  if (!assistant.runtimeUrl) {
+  if (!hasUsablePairedRuntimeUrl(assistant)) {
     return undefined;
   }
-  try {
-    const url = new URL(assistant.runtimeUrl);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      return undefined;
-    }
-    return `${url.origin}${url.pathname}`.replace(/\/+$/, "");
-  } catch {
-    return undefined;
-  }
+  return pairedGatewayProxyUrl(assistant.assistantId);
 }
 
 /**
  * Absolute base URL this runtime reaches the given assistant's gateway at:
- * origin + local gateway proxy for local/docker entries, the remote
- * `runtimeUrl` for paired entries, `undefined` otherwise.
+ * origin + local gateway proxy for local/docker entries, origin + paired
+ * gateway proxy for paired entries, `undefined` otherwise.
  */
 export function getAuthGatewayIngressUrl(
   assistant: LockfileAssistant | undefined = getSelectedAssistant(),
 ): string | undefined {
-  const local = getLocalGatewayUrl(assistant);
-  if (local) {
-    return `${window.location.origin}${local}`;
+  const base = getLocalGatewayUrl(assistant) ?? getPairedGatewayUrl(assistant);
+  if (!base) {
+    return undefined;
   }
-  return getPairedGatewayUrl(assistant);
+  return `${window.location.origin}${base}`;
 }
 
 /**
@@ -778,11 +796,12 @@ export async function primeLocalGatewayConnection(
     // The remote gateway's `/auth/token` mint is loopback- and Origin-gated to
     // localhost, so a cross-machine mint is impossible: the guardian access
     // token itself is the bearer, exactly like the CLI's `vellum client`
-    // paired path. The seeded source uses the same `<base>/auth/token` shape
-    // as local mode's token URL so an assistant switch trips
-    // `ensureGatewayToken`'s source-mismatch clear naturally. The 1-hour
-    // fallback expiry forces a cheap periodic re-lease when the token carries
-    // no readable `exp`.
+    // paired path. Traffic rides the same-origin `__gateway-paired` host proxy
+    // (see getPairedGatewayUrl). The seeded source uses the same
+    // `<base>/auth/token` shape as local mode's token URL so an assistant
+    // switch trips `ensureGatewayToken`'s source-mismatch clear naturally. The
+    // 1-hour fallback expiry forces a cheap periodic re-lease when the token
+    // carries no readable `exp`.
     const guardianToken = await fetchGuardianTokenHost(assistant.assistantId);
     seedGatewayToken({
       token: guardianToken,
@@ -791,7 +810,10 @@ export async function primeLocalGatewayConnection(
         Math.floor(Date.now() / 1000) + 3600,
       source: `${pairedUrl}/auth/token`,
     });
-    setSelfHostedConnection({ url: pairedUrl, token: guardianToken });
+    setSelfHostedConnection({
+      url: `${window.location.origin}${pairedUrl}`,
+      token: guardianToken,
+    });
     return;
   }
   const tokenUrl = getLocalTokenUrl(assistant);


### PR DESCRIPTION
## Summary
- getPairedGatewayUrl + getAuthGatewayIngressUrl resolve a paired entry's remote gateway base
- primeLocalGatewayConnection seeds the guardian access token as the gateway bearer (no /auth/token mint; the remote mint is loopback-gated) and points the self-hosted slot at the runtimeUrl
- isGatewayAuthEnabled covers paired selections; wake repair is scoped to cloud=local targets

Part of plan: web-paired-entries.md (PR 2 of 7)