### PR TITLE
chore(cli): delete resolveTunnelTargetPort, un-gate nginx-ingress up, update tunnel docs

### DIFF
--- a/cli/src/__tests__/nginx-ingress-command.test.ts
+++ b/cli/src/__tests__/nginx-ingress-command.test.ts
@@ -1,9 +1,37 @@
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { resolveNginxIngressTarget } from "../commands/nginx-ingress.js";
+import * as nginxIngressLib from "../lib/nginx-ingress.js";
+
+const realNginxIngressLib = { ...nginxIngressLib };
+
+const ensureTunnelEdgeMock = mock<typeof nginxIngressLib.ensureTunnelEdge>(
+  async () => ({ port: 7840, started: true, includesWebApp: true }),
+);
+
+mock.module("../lib/nginx-ingress.js", () => ({
+  ...nginxIngressLib,
+  ensureTunnelEdge: ensureTunnelEdgeMock,
+}));
+
+// Restore the real module once this file finishes so the mock does not leak
+// into sibling test files in the same `bun test` run.
+afterAll(() => {
+  mock.module("../lib/nginx-ingress.js", () => realNginxIngressLib);
+});
+
+import { resolveNginxIngressTarget, up } from "../commands/nginx-ingress.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-nginx-ingress-command-test-"));
@@ -29,25 +57,25 @@ function writeLockfile(
   );
 }
 
+afterAll(() => {
+  if (originalLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+  }
+  if (originalWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+  rmSync(testDir, { recursive: true, force: true });
+});
+
 describe("resolveNginxIngressTarget", () => {
   beforeEach(() => {
     process.env.VELLUM_LOCKFILE_DIR = testDir;
     process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
     rmSync(join(testDir, ".vellum.lock.json"), { force: true });
-  });
-
-  afterAll(() => {
-    if (originalLockfileDir === undefined) {
-      delete process.env.VELLUM_LOCKFILE_DIR;
-    } else {
-      process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
-    }
-    if (originalWorkspaceDir === undefined) {
-      delete process.env.VELLUM_WORKSPACE_DIR;
-    } else {
-      process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
-    }
-    rmSync(testDir, { recursive: true, force: true });
   });
 
   test("derives the gateway port from runtimeUrl when resources are absent", () => {
@@ -65,5 +93,65 @@ describe("resolveNginxIngressTarget", () => {
       workspaceDir,
       gatewayPort: 9123,
     });
+  });
+});
+
+describe("up", () => {
+  let logs: string[];
+  let logSpy: ReturnType<typeof spyOn<typeof console, "log">>;
+
+  beforeEach(() => {
+    ensureTunnelEdgeMock.mockClear();
+    logs = [];
+    logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  test("starts the webhooks-only edge when the flag is off and states the mode", async () => {
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: 7845,
+      started: true,
+      includesWebApp: false,
+    });
+
+    await up({
+      assistantId: "assistant-1",
+      workspaceDir,
+      gatewayPort: 7830,
+    });
+
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledTimes(1);
+    expect(ensureTunnelEdgeMock.mock.calls[0]?.[0]).toMatchObject({
+      assistantId: "assistant-1",
+      workspaceDir,
+      gatewayPort: 7830,
+    });
+    const output = logs.join("\n");
+    expect(output).toContain("http://127.0.0.1:7845 (webhooks only)");
+    expect(output).toContain("web-remote-ingress");
+    expect(output).toContain("vellum tunnel");
+  });
+
+  test("states the remote web mode when the flag is on", async () => {
+    ensureTunnelEdgeMock.mockResolvedValue({
+      port: 7840,
+      started: true,
+      includesWebApp: true,
+    });
+
+    await up({
+      assistantId: "assistant-1",
+      workspaceDir,
+      gatewayPort: 7830,
+    });
+
+    const output = logs.join("\n");
+    expect(output).toContain("http://127.0.0.1:7840 (remote web + webhooks)");
+    expect(output).not.toContain("Enable the web-remote-ingress feature flag");
   });
 });

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -81,7 +81,6 @@ import {
   buildIngressNginxConfig,
   buildRemoteWebIndexHtml,
   ensureTunnelEdge,
-  resolveTunnelTargetPort,
   startRemoteWebIngress,
   stopIngressNginx,
 } from "../lib/nginx-ingress.js";
@@ -341,79 +340,6 @@ describe("nginx ingress process state", () => {
     const dir = join(workspaceDir, "data", "ingress");
     return `nginx: master process nginx -p ${dir} -c ${join(dir, "nginx.conf")} -g daemon off;`;
   }
-
-  /** A PID guaranteed dead: a short-lived child that has already exited. */
-  function deadPid(): number {
-    const result = childProcess.spawnSync("sh", ["-c", "exit 0"]);
-    if (!result.pid) throw new Error("failed to spawn probe process");
-    return result.pid;
-  }
-
-  test("falls back to the gateway port when no ingress state exists", () => {
-    const ws = makeWorkspace();
-    expect(resolveTunnelTargetPort(ws, 7830)).toEqual({
-      port: 7830,
-      viaIngress: false,
-    });
-  });
-
-  test("falls back when ingress state exists but the process is dead", () => {
-    const ws = makeWorkspace();
-    writeIngressState(ws, 7841);
-    writePidFile(ws, deadPid());
-    expect(resolveTunnelTargetPort(ws, 7830)).toEqual({
-      port: 7830,
-      viaIngress: false,
-    });
-  });
-
-  test("falls back when the recorded PID belongs to a non-nginx process", () => {
-    const ws = makeWorkspace();
-    writeIngressState(ws, 7841);
-    writePidFile(ws, process.pid);
-    execFileSyncMock.mockReturnValue("bun test");
-    expect(resolveTunnelTargetPort(ws, 7830)).toEqual({
-      port: 7830,
-      viaIngress: false,
-    });
-  });
-
-  test("falls back when the recorded PID belongs to another nginx instance", () => {
-    const ws = makeWorkspace();
-    writeIngressState(ws, 7841);
-    writePidFile(ws, process.pid);
-    execFileSyncMock.mockReturnValue(
-      "nginx: master process nginx -p /tmp/other-ingress -c /tmp/other-ingress/nginx.conf",
-    );
-    expect(resolveTunnelTargetPort(ws, 7830)).toEqual({
-      port: 7830,
-      viaIngress: false,
-    });
-  });
-
-  test("targets the ingress when state exists and the PID is this nginx", () => {
-    const ws = makeWorkspace();
-    writeIngressState(ws, 7841);
-    writePidFile(ws, process.pid);
-    execFileSyncMock.mockReturnValue(nginxCommand(ws));
-    expect(resolveTunnelTargetPort(ws, 7830)).toEqual({
-      port: 7841,
-      viaIngress: true,
-    });
-  });
-
-  test("falls back when nginx ingress is not preferred", () => {
-    const ws = makeWorkspace();
-    writeIngressState(ws, 7841);
-    writePidFile(ws, process.pid);
-    execFileSyncMock.mockReturnValue(nginxCommand(ws));
-    expect(
-      resolveTunnelTargetPort(ws, 7830, { preferNginxIngress: false }),
-    ).toEqual({
-      port: 7830,
-      viaIngress: false,
-    });
-  });
 
   test("clears ingress state after nginx is confirmed stopped", async () => {
     const ws = makeWorkspace();
@@ -1245,6 +1171,34 @@ describe("ensureTunnelEdge", () => {
       listenPort: REQUESTED_PORT,
       includeWebApp: false,
       gatewayPort: 7830,
+    });
+  });
+
+  test("forwards onStarting so callers can print progress", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    isFeatureFlagEnabledMock.mockImplementation(async () => false);
+    const onStarting = mock(
+      (_info: {
+        version: string;
+        webDistDir: string | null;
+        listenPort: number;
+      }) => {},
+    );
+
+    await ensureTunnelEdge({
+      assistantId: ASSISTANT_ID,
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      onStarting,
+    });
+
+    expect(onStarting).toHaveBeenCalledWith({
+      version: NGINX_VERSION,
+      webDistDir: null,
+      listenPort: REQUESTED_PORT,
     });
   });
 

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -231,7 +231,7 @@ describe("tunnel edge targeting", () => {
     });
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
     expect(logs).toContain(`Started the nginx edge on 127.0.0.1:${EDGE_PORT}`);
-    expect(logs).toContain("serves remote web and webhooks");
+    expect(logs).toContain("serves remote web + webhooks");
   });
 
   test("targets the edge port for cloudflare", async () => {

--- a/cli/src/commands/nginx-ingress.ts
+++ b/cli/src/commands/nginx-ingress.ts
@@ -9,36 +9,38 @@ import {
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
-import {
-  formatFeatureFlagGateMessage,
-  isAssistantFeatureFlagEnabled,
-  WEB_REMOTE_INGRESS_FLAG,
-} from "../lib/feature-flags.js";
+import { WEB_REMOTE_INGRESS_FLAG } from "../lib/feature-flags.js";
 import {
   DEFAULT_NGINX_INGRESS_PORT,
+  ensureTunnelEdge,
+  formatEdgeMode,
   getIngressPaths,
   getIngressPid,
+  getNginxIngressPort,
   isIngressRunning,
-  resolveTunnelTargetPort,
-  startRemoteWebIngress,
+  readIngressState,
   stopIngressNginx,
 } from "../lib/nginx-ingress.js";
 
 function printHelp(): void {
   console.log("Usage: vellum nginx-ingress <subcommand> [<name>] [options]");
   console.log("");
+  console.log("Manage the nginx edge that fronts the gateway for tunnel");
+  console.log("traffic: browser/webhooks → tunnel (TLS) → nginx@127.0.0.1.");
   console.log(
-    "Manage the nginx web edge that serves the SPA and fronts the gateway",
+    "`vellum tunnel` starts or reuses this edge automatically; use this",
   );
   console.log(
-    "for remote web access: browser → tunnel (TLS) → nginx@127.0.0.1.",
+    "command as plumbing: check status, stop the edge, or start it for a",
   );
-  console.log("While nginx ingress is running, `vellum tunnel` targets it.");
+  console.log("bring-your-own HTTPS front (e.g. `tailscale serve`).");
   console.log("");
   console.log("Subcommands:");
-  console.log("  up       Generate the nginx config and start the proxy");
-  console.log("  down     Stop the proxy");
-  console.log("  status   Show whether the proxy is running and where");
+  console.log("  up       Generate the nginx config and start the edge");
+  console.log("  down     Stop the edge");
+  console.log(
+    "  status   Show whether the edge is running, its mode, and where",
+  );
   console.log("");
   console.log("Arguments:");
   console.log(
@@ -50,19 +52,23 @@ function printHelp(): void {
   console.log("");
   console.log("Environment:");
   console.log(
-    `  VELLUM_NGINX_INGRESS_PORT   nginx ingress loopback listen port (default ${DEFAULT_NGINX_INGRESS_PORT})`,
+    `  VELLUM_NGINX_INGRESS_PORT   nginx edge loopback listen port (default ${DEFAULT_NGINX_INGRESS_PORT})`,
   );
   console.log("  NGINX_BIN             Path to the nginx binary");
   console.log("");
   console.log("Examples:");
-  console.log("  $ vellum nginx-ingress up");
   console.log("  $ vellum nginx-ingress status");
+  console.log("  $ vellum nginx-ingress up");
   console.log("  $ vellum nginx-ingress down my-assistant");
   console.log("");
   console.log("Feature flags:");
   console.log(
-    `  ${WEB_REMOTE_INGRESS_FLAG} must be enabled to start nginx ingress`,
+    `  ${WEB_REMOTE_INGRESS_FLAG} selects the edge mode: enabled serves the`,
   );
+  console.log(
+    "  remote web app alongside webhooks; disabled starts a webhooks-only",
+  );
+  console.log("  proxy.");
 }
 
 interface NginxIngressTarget {
@@ -129,101 +135,49 @@ export function resolveNginxIngressTarget(
   };
 }
 
-async function assertWebRemoteIngressEnabled(
-  target: NginxIngressTarget,
-): Promise<void> {
-  if (!target.assistantId) {
-    throw new Error(formatFeatureFlagGateMessage(WEB_REMOTE_INGRESS_FLAG));
-  }
-
-  let enabled: boolean;
-  try {
-    enabled = await isAssistantFeatureFlagEnabled(
-      target.assistantId,
-      WEB_REMOTE_INGRESS_FLAG,
-      { runtimeUrl: `http://127.0.0.1:${target.gatewayPort}` },
-    );
-  } catch (err) {
-    throw new Error(
-      `Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` feature flag. Is the assistant running? Try \`vellum wake\` and retry. ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-
-  if (!enabled) {
-    throw new Error(formatFeatureFlagGateMessage(WEB_REMOTE_INGRESS_FLAG));
-  }
-}
-
-async function up(target: NginxIngressTarget): Promise<void> {
+export async function up(target: NginxIngressTarget): Promise<void> {
   const { workspaceDir, gatewayPort } = target;
 
-  await assertWebRemoteIngressEnabled(target);
-
-  const result = await startRemoteWebIngress({
-    workspaceDir,
-    gatewayPort,
-    onStarting: ({ version, webDistDir, listenPort }) => {
-      console.log(`Using ${version}`);
-      const webSegment = webDistDir ? `web ${webDistDir} + ` : "";
-      console.log(
-        `Starting nginx ingress on 127.0.0.1:${listenPort} → ${webSegment}gateway 127.0.0.1:${gatewayPort}...`,
-      );
-    },
-  });
-
-  switch (result.status) {
-    case "already-running":
-      console.log("nginx ingress is already running.");
-      await status(target);
-      return;
-    case "started":
-      console.log("");
-      console.log(
-        `nginx ingress running: http://127.0.0.1:${result.listenPort}`,
-      );
-      console.log("");
-      console.log("Next steps:");
-      console.log(
-        "  vellum tunnel --provider ngrok   # tunnel now targets nginx ingress",
-      );
-      console.log("  vellum nginx-ingress down        # stop the proxy");
-      return;
-    case "nginx-missing":
-      console.error("Error: nginx is not installed.");
-      console.error("");
-      console.error("Install nginx:");
-      console.error("  macOS:  brew install nginx");
-      console.error("  Linux:  sudo apt install nginx");
-      console.error("");
-      console.error(
-        "Or point NGINX_BIN at an existing binary: NGINX_BIN=/path/to/nginx",
-      );
-      break;
-    case "web-dist-missing":
-      console.error(
-        "Error: unable to locate built web assets for remote web ingress.",
-      );
-      console.error("");
-      console.error("Build the SPA first:");
-      console.error(
-        "  cd clients/web && VITE_PLATFORM_MODE=false bun run build",
-      );
-      console.error("");
-      console.error(
-        "Or install @vellumai/web so its packaged dist directory is available.",
-      );
-      break;
-    case "unreachable":
-      console.error(
-        `Error: nginx ingress did not become reachable on 127.0.0.1:${result.listenPort}.`,
-      );
-      console.error(`Check the nginx log: ${result.logPath}`);
-      break;
+  let edge: Awaited<ReturnType<typeof ensureTunnelEdge>>;
+  try {
+    edge = await ensureTunnelEdge({
+      assistantId: target.assistantId,
+      workspaceDir,
+      gatewayPort,
+      onStarting: ({ version, webDistDir, listenPort }) => {
+        console.log(`Using ${version}`);
+        const webSegment = webDistDir ? `web ${webDistDir} + ` : "";
+        console.log(
+          `Starting nginx ingress on 127.0.0.1:${listenPort} → ${webSegment}gateway 127.0.0.1:${gatewayPort}...`,
+        );
+      },
+    });
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
   }
 
-  process.exit(1);
+  const mode = formatEdgeMode(edge.includesWebApp);
+
+  if (!edge.started) {
+    console.log(`nginx ingress is already running (${mode}).`);
+    await status(target);
+    return;
+  }
+
+  console.log("");
+  console.log(`nginx ingress running: http://127.0.0.1:${edge.port} (${mode})`);
+  if (!edge.includesWebApp) {
+    console.log(
+      `Enable the ${WEB_REMOTE_INGRESS_FLAG} feature flag to also serve the web app remotely.`,
+    );
+  }
+  console.log("");
+  console.log("Next steps:");
+  console.log(
+    "  vellum tunnel                    # put an HTTPS front on this edge",
+  );
+  console.log("  vellum nginx-ingress down        # stop the edge");
 }
 
 async function down(target: NginxIngressTarget): Promise<void> {
@@ -245,10 +199,13 @@ async function status(target: NginxIngressTarget): Promise<void> {
     console.log("nginx ingress: not running");
     return;
   }
-  const { port } = resolveTunnelTargetPort(workspaceDir, gatewayPort);
+  const state = readIngressState(workspaceDir);
+  const listenPort = state?.listenPort ?? getNginxIngressPort();
+  const mode = formatEdgeMode(state?.includeWebApp !== false);
   console.log("nginx ingress: running");
   console.log(`  PID:     ${pid}`);
-  console.log(`  Listen:  http://127.0.0.1:${port}`);
+  console.log(`  Mode:    ${mode}`);
+  console.log(`  Listen:  http://127.0.0.1:${listenPort}`);
   console.log(`  Gateway: http://127.0.0.1:${gatewayPort}`);
   console.log(`  Config:  ${confPath}`);
   console.log(`  Log:     ${logPath}`);

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -4,7 +4,7 @@ import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
 import { getDefaultWorkspaceDir } from "../lib/ingress-config.js";
-import { ensureTunnelEdge } from "../lib/nginx-ingress.js";
+import { ensureTunnelEdge, formatEdgeMode } from "../lib/nginx-ingress.js";
 import { runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
@@ -211,7 +211,7 @@ export async function tunnel(): Promise<void> {
 
   console.log(
     `${edge.started ? "Started" : "Reusing"} the nginx edge on 127.0.0.1:${edge.port} ` +
-      `(${edge.includesWebApp ? "serves remote web and webhooks" : "serves webhooks only"}).`,
+      `(serves ${formatEdgeMode(edge.includesWebApp)}).`,
   );
 
   const baseTunnelOpts = {

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -38,7 +38,7 @@ import {
   WEB_REMOTE_INGRESS_FLAG,
 } from "../lib/feature-flags.js";
 import { loadRawConfig } from "../lib/ingress-config.js";
-import { ensureTunnelEdge } from "../lib/nginx-ingress.js";
+import { ensureTunnelEdge, formatEdgeMode } from "../lib/nginx-ingress.js";
 import type { ChildProcess } from "child_process";
 
 export async function wake(): Promise<void> {
@@ -518,9 +518,9 @@ export async function restoreTunnelEdgeAndAutoTunnel(
       });
       tunnelTargetPort = edge.port;
       console.log(
-        `   Tunnel edge ${edge.started ? "started" : "already running"} on 127.0.0.1:${edge.port} (${
-          edge.includesWebApp ? "remote web + webhooks" : "webhooks only"
-        }).`,
+        `   Tunnel edge ${edge.started ? "started" : "already running"} on 127.0.0.1:${edge.port} (${formatEdgeMode(
+          edge.includesWebApp,
+        )}).`,
       );
     } catch (err) {
       console.warn(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -106,7 +106,7 @@ function printHelp(): void {
   console.log("  gateway  Gateway management commands");
   console.log("  hatch    Create a new assistant instance");
   console.log(
-    "  nginx-ingress  Manage the nginx proxy fronting the gateway for web access [beta]",
+    "  nginx-ingress  Manage the nginx edge that `vellum tunnel` fronts [beta]",
   );
   console.log("  logs     View logs from an assistant instance");
   console.log("  login    Log in to the Vellum platform");

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -16,7 +16,6 @@ import {
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
-import { GATEWAY_PORT } from "./constants.js";
 import {
   isAssistantFeatureFlagEnabled,
   WEB_REMOTE_INGRESS_FLAG,
@@ -25,11 +24,11 @@ import { waitForDaemonReady } from "./http-client.js";
 import { loadRawConfig, saveRawConfig } from "./ingress-config.js";
 
 /**
- * CLI-managed nginx reverse proxy that fronts the gateway for remote web
- * ingress: browser → tunnel (TLS) → nginx@127.0.0.1 → gateway@127.0.0.1.
+ * CLI-managed nginx reverse proxy that fronts the gateway as the canonical
+ * tunnel target: browser → tunnel (TLS) → nginx@127.0.0.1 → gateway@127.0.0.1.
  *
- * While this proxy is running, `vellum tunnel` targets nginx's loopback listen
- * port instead of the gateway port.
+ * `vellum tunnel` (and the wake restore path) bring this edge up via
+ * `ensureTunnelEdge` and always front its loopback listen port.
  */
 
 export const DEFAULT_NGINX_INGRESS_PORT = 7840;
@@ -413,7 +412,7 @@ export function isIngressRunning(workspaceDir: string): boolean {
   return getIngressPid(workspaceDir) !== null;
 }
 
-interface IngressState {
+export interface IngressState {
   listenPort: number;
   /** Edge mode: SPA + proxy (true) or webhooks-only proxy (false). */
   includeWebApp: boolean;
@@ -426,7 +425,7 @@ interface IngressState {
   gatewayPort?: number;
 }
 
-function readIngressState(workspaceDir: string): IngressState | null {
+export function readIngressState(workspaceDir: string): IngressState | null {
   const config = loadRawConfig(workspaceDir);
   const ingress = config.ingress as Record<string, unknown> | undefined;
   const nginx = ingress?.nginx as Record<string, unknown> | undefined;
@@ -588,10 +587,11 @@ export async function stopIngressNginx(workspaceDir: string): Promise<boolean> {
 export const INGRESS_READY_TIMEOUT_MS = 5_000;
 
 /**
- * Outcome of an attempt to bring up the remote-web nginx ingress edge. Callers
- * render their own messaging per variant: `nginx-ingress up` prints
- * install/build guidance and exits non-zero, while the wake restore path warns
- * and continues.
+ * Outcome of an attempt to bring up the nginx ingress edge. Callers render
+ * their own messaging per variant: `ensureTunnelEdge` maps failure variants to
+ * thrown errors with actionable text, which `vellum tunnel` and
+ * `nginx-ingress up` print before exiting non-zero while the wake restore path
+ * warns and continues.
  */
 export type StartRemoteWebIngressResult =
   | {
@@ -618,8 +618,8 @@ export type StartRemoteWebIngressResult =
  * restarted with the requested config.
  *
  * Pure mechanism: it performs no console output and never exits the process, so
- * both the `nginx-ingress up` command and the wake restore path can share one
- * implementation and map the returned result to their own UX.
+ * every edge caller (`vellum tunnel`, `nginx-ingress up`, the wake restore
+ * path) can share one implementation and map the returned result to its own UX.
  */
 export async function startRemoteWebIngress(opts: {
   workspaceDir: string;
@@ -735,6 +735,11 @@ async function resolveEdgeIncludesWebApp(
   }
 }
 
+/** User-facing label for the edge mode, shared by every edge status line. */
+export function formatEdgeMode(includesWebApp: boolean): string {
+  return includesWebApp ? "remote web + webhooks" : "webhooks only";
+}
+
 /**
  * Bring up the nginx edge as the canonical tunnel target and return the listen
  * port a tunnel should front.
@@ -754,6 +759,12 @@ export async function ensureTunnelEdge(opts: {
   assistantId: string | undefined;
   workspaceDir: string;
   gatewayPort: number;
+  /** Forwarded to `startRemoteWebIngress` for caller progress output. */
+  onStarting?: (info: {
+    version: string;
+    webDistDir: string | null;
+    listenPort: number;
+  }) => void;
 }): Promise<{ port: number; started: boolean; includesWebApp: boolean }> {
   const includeWebApp = opts.assistantId
     ? await resolveEdgeIncludesWebApp(opts.assistantId, opts.gatewayPort)
@@ -763,6 +774,7 @@ export async function ensureTunnelEdge(opts: {
     workspaceDir: opts.workspaceDir,
     gatewayPort: opts.gatewayPort,
     includeWebApp,
+    ...(opts.onStarting ? { onStarting: opts.onStarting } : {}),
   });
 
   switch (result.status) {
@@ -824,25 +836,4 @@ export async function ensureTunnelEdge(opts: {
           `Check the nginx log: ${result.logPath}`,
       );
   }
-}
-
-/**
- * Resolve the local port a tunnel should target: the nginx ingress when it is
- * recorded AND its process is alive, otherwise the gateway port directly
- * (unchanged behavior when the proxy is not running).
- */
-export function resolveTunnelTargetPort(
-  workspaceDir: string,
-  gatewayPort: number = GATEWAY_PORT,
-  opts: { preferNginxIngress?: boolean } = {},
-): { port: number; viaIngress: boolean } {
-  if (opts.preferNginxIngress === false) {
-    return { port: gatewayPort, viaIngress: false };
-  }
-
-  const state = readIngressState(workspaceDir);
-  if (state && isIngressRunning(workspaceDir)) {
-    return { port: state.listenPort, viaIngress: true };
-  }
-  return { port: gatewayPort, viaIngress: false };
 }

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -200,8 +200,10 @@ one with `--domain`:
 vellum tunnel --provider ngrok --domain my-assistant.ngrok.app
 ```
 
-The domain is saved to the workspace config; the tunnel that `vellum wake`
-restores binds it again.
+The domain is saved to the workspace config. `vellum wake` restores the
+tunnel automatically only when a messaging channel like Telegram or Twilio is
+configured; otherwise rerun `vellum tunnel` after a restart and the saved
+domain is reused.
 
 **Privacy trade-off:** these publish a public-internet URL, so anyone who
 learns the URL can reach your assistant's sign-in and pairing page (pairing
@@ -280,7 +282,7 @@ connects changes.
 > produces a build that carries it today.
 
 **Recommended: scan the Step 4 QR, then tap "Open in the Vellum app."** You
-don't need a different command — the QR from `vellum pair --qr` (Step 4)
+don't need a different command: the QR from `vellum pair --qr` (Step 4)
 already works for the app:
 
 1. Point the phone's **system camera** at the QR and open the pairing page in
@@ -360,7 +362,8 @@ URL — you reach your own assistant, not Vellum Cloud.
   in the foreground, but no push notifications. For proactive pings, connect a
   channel like Telegram, which delivers notifications independently.
 - **Tailnet-private by default.** `tailscale serve` exposes the edge only to
-  your own devices, not the public internet. Use a public tunnel (Step 4) only
-  if you accept the privacy trade-off.
+  your own devices, not the public internet. Use a public tunnel
+  ([Step 3](#3-put-an-https-address-in-front)) only if you accept
+  the privacy trade-off.
 - **Pairing codes are single-use and expire in 10 minutes.** Re-run
   `vellum pair --qr` whenever you need a fresh one.

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -8,7 +8,7 @@ single scan.
 
 Connect from any browser (on phones and tablets, add it to your home screen
 for a full-screen PWA) or from the native **Vellum iOS app** pointed at your
-own server (see [Using the Vellum iOS app](#6-using-the-vellum-ios-app)). All
+own server (see [Using the Vellum iOS app](#5-using-the-vellum-ios-app)). All
 paths reach the same assistant.
 
 This is a CLI-driven flow for people who already run their assistant locally
@@ -17,14 +17,14 @@ this; sign in and your devices are already connected.
 
 > **Check your version first.** This flow uses recent additions to the `vellum`
 > CLI and the assistant it runs: remote web ingress (Step 1), `vellum tunnel`
-> providers (Step 4), `vellum pair --qr` (Step 5), and the iOS app's connect
-> handler (Step 6). They ship in the next release; until then they're available
+> providers (Step 3), `vellum pair --qr` (Step 4), and the iOS app's connect
+> handler (Step 5). They ship in the next release; until then they're available
 > on builds from source. Check what you have with `vellum --version` (it prints
 > `@vellumai/cli v<version>`). If `vellum tunnel --provider tailscale` reports
 > `not yet implemented` or `vellum pair --qr` isn't recognized, your CLI
 > predates this flow — update it once the release lands, or build from source
 > (the web app in [Step 2](#2-the-web-app-ships-with-the-cli) and the iOS shell
-> in [Step 7](#7-native-ios-shell-optional-for-developers) both note how).
+> in [Step 6](#6-native-ios-shell-optional-for-developers) both note how).
 
 ## How it works
 
@@ -36,13 +36,14 @@ Tailscale front  (https://your-assistant.ts.net)
    │
    ▼
 nginx edge  (127.0.0.1:7840)  ──►  serves the web app
-   │                               proxies /v1 to the gateway
+   │                               proxies /v1 and /webhooks to the gateway
    ▼
 gateway ──► assistant
 ```
 
 The nginx edge is the single public surface: it serves the web app and
-forwards API traffic to the gateway. An HTTPS front (Tailscale by default)
+forwards API and webhook traffic to the gateway. `vellum tunnel` starts and
+manages the edge automatically. An HTTPS front (Tailscale by default)
 terminates TLS and makes the edge reachable from your devices.
 
 ## Before you start
@@ -54,7 +55,7 @@ terminates TLS and makes the edge reachable from your devices.
   - Linux: `sudo apt install nginx`
 - **Tailscale** installed on the host machine and on every device you'll
   connect, all signed into the same tailnet. (Only needed for the default
-  private path; see [Step 4](#4-put-an-https-address-in-front) for public
+  private path; see [Step 3](#3-put-an-https-address-in-front) for public
   alternatives.)
 - If you run more than one local assistant, decide which one your devices
   connect to: every step below applies to a single assistant (see
@@ -82,7 +83,8 @@ vellum flags set web-remote-ingress true
 
 The `vellum` CLI includes a prebuilt bundle of the web app, compiled for
 self-hosting (pointed at your own gateway, not Vellum Cloud). The nginx edge
-in the next step finds it automatically; there is nothing to build.
+that `vellum tunnel` manages in the next step finds it automatically; there
+is nothing to build.
 
 To open the web UI on the host machine itself, serve the same bundle locally:
 
@@ -107,43 +109,35 @@ cd clients/web && VITE_PLATFORM_MODE=false bun run build
 your assistant on the host. Press Ctrl+C to stop it — your other devices
 don't use this local server.
 
-## 3. Start the nginx edge
+## 3. Put an HTTPS address in front
 
-```bash
-vellum nginx-ingress up
-```
-
-This serves the web app on `http://127.0.0.1:7840` and proxies `/v1` to the
-gateway. Related commands:
-
-```bash
-vellum nginx-ingress status   # is it running, and where
-vellum nginx-ingress down     # stop the edge
-```
-
-The listen port defaults to `7840`; override it with the
-`VELLUM_NGINX_INGRESS_PORT` environment variable if it clashes with
-something else.
-
-**Verify:** `vellum nginx-ingress status` reports `running` with a
-`Listen:  http://127.0.0.1:7840` line.
-
-## 4. Put an HTTPS address in front
-
-Your devices need an HTTPS URL that reaches the nginx edge. **Tailscale is
+Your devices need an HTTPS URL that reaches your assistant. **Tailscale is
 the recommended front**: the assistant stays private to your own devices and
 the address is permanent, so each device pairs once and stays connected. The
-public alternatives below are instant but internet-exposed — and a Cloudflare
+public alternatives below are instant but internet-exposed, and a Cloudflare
 quick tunnel's URL is temporary on top (details in its section below).
 
 ```bash
 vellum tunnel --provider tailscale
 ```
 
-While the nginx edge is running, the tunnel automatically targets it and
-records the public URL in your workspace config (`ingress.publicBaseUrl`), so
-channel integrations (Telegram, Twilio, …) can reach the assistant too. It
-prints the address it established:
+`vellum tunnel` manages the nginx edge for you: it starts the edge on
+`http://127.0.0.1:7840` (or reuses one already running) and fronts it, so a
+single address serves the web app and forwards API and webhook traffic to
+the gateway. nginx must be installed (see
+[Before you start](#before-you-start)); without it the command fails with
+install instructions. The edge listen port defaults to `7840`; override it
+with the `VELLUM_NGINX_INGRESS_PORT` environment variable if it clashes with
+something else. To inspect or stop the edge later:
+
+```bash
+vellum nginx-ingress status   # is the edge running, in which mode, and where
+vellum nginx-ingress down     # stop the edge
+```
+
+The tunnel records the public URL in your workspace config
+(`ingress.publicBaseUrl`), so channel integrations (Telegram, Twilio, …) can
+reach the assistant too. It prints the address it established:
 
 ```
 Tunnel established: https://your-machine.your-tailnet.ts.net
@@ -162,18 +156,20 @@ pairing — a broken HTTPS front is the most common reason later steps fail.
 <details>
 <summary>Manual Tailscale fallback (no <code>vellum tunnel</code> needed)</summary>
 
-Tailscale can serve the edge directly. This works on any recent Tailscale
-install:
+Tailscale can serve the edge directly. Start the edge yourself, then serve
+it (this works on any recent Tailscale install):
 
 ```bash
+vellum nginx-ingress up
 tailscale serve --bg 7840
 tailscale serve status   # prints your https://<host>.<tailnet>.ts.net URL
 ```
 
 That URL fronts the nginx edge over your tailnet with automatic HTTPS. Use it
-as the `--url` value in [Step 5](#5-pair-your-devices). To let channel
+as the `--url` value in [Step 4](#4-pair-your-devices). To let channel
 integrations use it as well, run `vellum tunnel --provider tailscale` instead,
-which also writes it to `ingress.publicBaseUrl`.
+which manages the edge itself and also writes the URL to
+`ingress.publicBaseUrl`.
 
 </details>
 
@@ -196,8 +192,16 @@ URL.
 `trycloudflare.com` URL changes every time the tunnel restarts, and paired
 devices point at the old address — you re-pair each device after every
 restart. Good for trying the flow; switch to Tailscale for a permanent
-setup. ngrok URLs follow your ngrok account instead: with a static ngrok
-domain the address survives restarts, so paired devices keep working.
+setup. ngrok URLs follow your ngrok account instead: with a reserved ngrok
+domain the address survives restarts, so paired devices keep working. Bind
+one with `--domain`:
+
+```bash
+vellum tunnel --provider ngrok --domain my-assistant.ngrok.app
+```
+
+The domain is saved to the workspace config; the tunnel that `vellum wake`
+restores binds it again.
 
 **Privacy trade-off:** these publish a public-internet URL, so anyone who
 learns the URL can reach your assistant's sign-in and pairing page (pairing
@@ -206,7 +210,7 @@ keeps the edge visible only to devices on your own tailnet.
 
 </details>
 
-## 5. Pair your devices
+## 4. Pair your devices
 
 On the host, generate a single-scan pairing QR:
 
@@ -214,7 +218,7 @@ On the host, generate a single-scan pairing QR:
 vellum pair --qr
 ```
 
-If you put the HTTPS front in place with `vellum tunnel` (Step 4),
+If you put the HTTPS front in place with `vellum tunnel` (Step 3),
 `vellum pair --qr` reuses that saved address automatically and prints
 `Using saved ingress URL … (from vellum tunnel; override with --url)` — so you
 don't need to know or retype your URL. Pass `--url` to advertise a different
@@ -244,7 +248,7 @@ On the device you're pairing:
    **Open in the Vellum app** or **Continue in this browser**; tap
    **Open in the Vellum app** to finish pairing in the native app, or
    **Continue in this browser** to pair here. See
-   [Using the Vellum iOS app](#6-using-the-vellum-ios-app) for iOS details.
+   [Using the Vellum iOS app](#5-using-the-vellum-ios-app) for iOS details.
 3. On phones and tablets, use the browser **Share → Add to Home Screen** to
    install the assistant as an app icon.
 
@@ -261,22 +265,22 @@ card: **Settings → General → Pair a device**. It prefills the address
 isn't one), rejects lookalike tunnel-provider website URLs, and names the
 assistant it pairs — generate the QR there and scan it the same way.
 
-## 6. Using the Vellum iOS app
+## 5. Using the Vellum iOS app
 
 The native **Vellum iOS app** can point at your self-hosted assistant instead
 of Vellum Cloud, giving you the full app shell against your own server rather
-than a home-screen web page. Steps 1–5 are identical; only the way the phone
+than a home-screen web page. Steps 1–4 are identical; only the way the phone
 connects changes.
 
 > **Build requirement.** The app's connect handler ships in the next app
 > release (TestFlight, then the App Store) — see the version note at the top of
 > this guide. On an older build, use the browser / Add to Home Screen path in
-> [Step 5](#5-pair-your-devices), which keeps working unchanged. Building the
-> shell from source ([Step 7](#7-native-ios-shell-optional-for-developers))
+> [Step 4](#4-pair-your-devices), which keeps working unchanged. Building the
+> shell from source ([Step 6](#6-native-ios-shell-optional-for-developers))
 > produces a build that carries it today.
 
-**Recommended: scan the Step 5 QR, then tap "Open in the Vellum app."** You
-don't need a different command — the QR from `vellum pair --qr` (Step 5)
+**Recommended: scan the Step 4 QR, then tap "Open in the Vellum app."** You
+don't need a different command — the QR from `vellum pair --qr` (Step 4)
 already works for the app:
 
 1. Point the phone's **system camera** at the QR and open the pairing page in
@@ -287,7 +291,7 @@ already works for the app:
    works if the app isn't installed.
 
 The saved server and the pairing belong to the assistant you targeted in
-Steps 1–5. With several local assistants, keep them all pointed at the same
+Steps 1–4. With several local assistants, keep them all pointed at the same
 one (`vellum ps` shows the active one).
 
 **Verify:** the app opens to your own assistant, not Vellum Cloud.
@@ -329,9 +333,9 @@ field yourself) returns the app to Vellum Cloud.
 The [Good to know](#good-to-know) notes below apply to the app just as they do
 to the browser path.
 
-## 7. Native iOS shell (optional, for developers)
+## 6. Native iOS shell (optional, for developers)
 
-The browser (Step 5) and released-app (Step 6) paths above cover most people.
+The browser (Step 4) and released-app (Step 5) paths above cover most people.
 If you want to build the native Capacitor iOS shell yourself — for example to
 get the app features before they reach TestFlight — point it at your host's
 HTTPS URL:


### PR DESCRIPTION
## Summary
- resolveTunnelTargetPort deleted (no callers remain after PRs 5 and 6)
- vellum nginx-ingress up starts in SPA or webhooks-only mode per the web-remote-ingress flag instead of hard-requiring it; copy repositions the command as plumbing behind vellum tunnel
- docs/self-hosted-phone.md describes the one-command flow (vellum tunnel manages the edge, needs nginx, --domain for reserved ngrok domains)

Part of plan: tunnel-edge-unify.md (PR 7 of 7)