### PR TITLE
docs(onboarding): describe the current side-thread visibility mechanism

### DIFF
--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -10,11 +10,11 @@
  * and settle logic, shared with the About Assistant personality page). The
  * user's profile (users/guardian.md) is left untouched.
  *
- * Like the research turn (`research-runner.ts`) and the check-in
- * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
- * conversation: we await hatch readiness, mint a conversation, post the prompt,
- * and let the rewrite turn settle. Talks to the daemon through the generated
- * SDK directly (`@/domains/chat/api/*` is import-banned from onboarding).
+ * Like the research turn (`research-runner.ts`), this runs on a dedicated
+ * throwaway side conversation: we await hatch readiness, mint a conversation,
+ * post the prompt, and let the rewrite turn settle. Talks to the daemon through
+ * the generated SDK directly (`@/domains/chat/api/*` is import-banned from
+ * onboarding).
  *
  * The thread is minted `conversationType: "background"`, which keeps it out of
  * the daemon's default `standard` conversation list: it never enters Recents

--- a/clients/web/src/domains/onboarding/established-assistant.ts
+++ b/clients/web/src/domains/onboarding/established-assistant.ts
@@ -4,11 +4,11 @@
  * can offer an explicit off-ramp instead of silently re-onboarding (and
  * rewriting the persona of) an assistant the user already customized.
  *
- * Conversation history is the establishment signal: a fresh hatch has none,
- * and the flow's own side conversations (research, personality) are archived
- * once they settle, so they don't count against a genuinely-new user who
- * abandoned a prior attempt. The identity name is fetched only for the guard
- * screen's copy and is best-effort.
+ * Conversation history is the establishment signal: a fresh hatch has none. The
+ * flow's own side conversations (research, personality) are minted `background`
+ * and `hasAnyActiveConversation` reads the foreground bucket, so they never
+ * count against a genuinely-new user who abandoned a prior attempt. The identity
+ * name is fetched only for the guard screen's copy and is best-effort.
  *
  * Fail-open: a genuine fetch failure treats the assistant as fresh — the
  * guard exists to stop silent persona rewrites of real assistants, not to


### PR DESCRIPTION
## Summary
Fixes a gap found during plan self-review for bg-side-conversations.md.

**Gap:** the comment sweep that was supposed to stop crediting the trailing archive with hiding the onboarding side threads only covered the files its PR touched. `established-assistant.ts` still documented the archive as the reason abandoned attempts do not trip the established-assistant guard, and `apply-personality.ts` still cited a sibling flow that no longer mints a conversation.
**Fix:** comments only, describing the present mechanism.