### PR TITLE
fix(daemon): tighten the create-conversation type contract and its comments

### DIFF
--- a/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
@@ -3,8 +3,8 @@
  * bookkeeper: the first standard conversation is the onboarding one (keep
  * BOOTSTRAP.md), and the second means onboarding is over (delete it).
  *
- * Onboarding also mints internal side threads — research, personality rewrite,
- * identity rewrite — as `conversationType: "background"` rows that the user
+ * Onboarding also mints internal side threads (research, personality rewrite,
+ * identity rewrite) as `conversationType: "background"` rows that the user
  * never opens. Those must be completely inert with respect to this bookkeeping:
  * if a hidden side thread consumed the first-conversation slot, the user's
  * FIRST visible chat would look like the second conversation and lose
@@ -14,6 +14,8 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
+
+import { assertNotLiveDb } from "./assert-not-live-db.js";
 
 const testDir = process.env.VELLUM_WORKSPACE_DIR!;
 const conversationsDir = join(testDir, "conversations");
@@ -45,6 +47,7 @@ beforeEach(() => {
   db.delete(conversationKeys).run();
   db.delete(conversations).run();
 
+  assertNotLiveDb(conversationsDir);
   rmSync(conversationsDir, { recursive: true, force: true });
   mkdirSync(conversationsDir, { recursive: true });
 

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -15,6 +15,7 @@ import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { getLogger } from "../util/logger.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
+import type { NonScheduledConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { conversationKeys, conversations } from "./schema/index.js";
 
@@ -22,7 +23,7 @@ const log = getLogger("conversation-key-store");
 
 /**
  * Set after the first *standard* conversation is created so BOOTSTRAP.md is
- * deleted on the second. Background/scheduled creates never touch it.
+ * deleted on the second. Background creates never touch it.
  */
 let firstConversationSeen = false;
 
@@ -153,7 +154,7 @@ export function resolveConversationId(idOrKey: string): string | null {
 export function getOrCreateConversation(
   conversationKey: string,
   opts?: {
-    conversationType?: "standard" | "background";
+    conversationType?: NonScheduledConversationType;
     /**
      * Caller-supplied title for the conversation, used only when this call
      * actually creates the row. Treated as a user-set title (`isAutoTitle = 0`)
@@ -220,20 +221,10 @@ export function getOrCreateConversation(
       };
     }
 
-    // Delete BOOTSTRAP.md when a non-first *standard* conversation is created.
-    // The first standard conversation is the onboarding one; keep BOOTSTRAP.md
-    // for its entire duration. Any subsequent standard conversation means
-    // onboarding is over.
-    //
-    // Background/scheduled rows are skipped entirely — they are internal side
-    // channels (onboarding research, personality/identity rewrites, heartbeat
-    // and scheduled runs) that the user never opens, so they are neither the
-    // onboarding conversation nor evidence that onboarding ended. Being inert
-    // here is what stops a hidden side thread minted before the user's first
-    // visible chat from consuming the first-conversation slot and deleting
-    // BOOTSTRAP.md out from under that chat's first turn. The type is read from
-    // the same `conversationType` the insert below persists, so the guard
-    // cannot drift from the stored row.
+    // The first standard conversation is the onboarding one, so BOOTSTRAP.md
+    // survives its whole duration and any later standard create means
+    // onboarding is over. Background rows stay inert: a hidden side thread
+    // minted before the user's first visible chat must not consume that slot.
     if (conversationType === "standard") {
       if (firstConversationSeen) {
         cleanupBootstrapFiles("new conversation created after onboarding");

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -25,6 +25,15 @@ export type ConversationCreateType = "standard" | "background" | "scheduled";
 export type ConversationType = ConversationCreateType;
 
 /**
+ * Conversation types minted outside the schedule pipeline. Scheduled rows are
+ * owned by it and created through `createConversation`.
+ */
+export type NonScheduledConversationType = Exclude<
+  ConversationCreateType,
+  "scheduled"
+>;
+
+/**
  * Conversation types created by background machinery (heartbeat runs,
  * scheduled runs, retrospective forks) rather than by a person. Exported as a
  * list so SQL filters (e.g. `notInArray`) share the same set as the predicate

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -224,6 +224,15 @@ describe("POST /v1/conversations (createConversation)", () => {
     expect(readConversation(result.id)?.conversationType).toBe("standard");
   });
 
+  test("explicit conversationType: null behaves exactly like an omitted one", async () => {
+    const result = (await createHandler({
+      body: { conversationType: null, title: "Visible thread" },
+    })) as { id: string; conversationType: string };
+
+    expect(result.conversationType).toBe("standard");
+    expect(readConversation(result.id)?.conversationType).toBe("standard");
+  });
+
   test.each(["scheduled", "nonsense"])(
     "conversationType: %p → BadRequestError, no row created",
     (conversationType) => {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -63,6 +63,7 @@ import {
   resolveConversationId,
   setConversationKeyIfAbsent,
 } from "../../persistence/conversation-key-store.js";
+import type { NonScheduledConversationType } from "../../persistence/conversation-types.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
@@ -100,11 +101,11 @@ const log = getLogger("conversation-management-routes");
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Conversation types this endpoint may mint. Deliberately narrower than
- * `ConversationType`: scheduled rows are owned by the schedule pipeline.
- */
-const createConversationTypeSchema = z.enum(["standard", "background"]);
+/** Conversation types this endpoint may mint. */
+const createConversationTypeSchema = z.enum([
+  "standard",
+  "background",
+] as const satisfies readonly NonScheduledConversationType[]);
 
 function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
@@ -135,8 +136,10 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   // Zod requestBody (it's codegen-only), so guard the types here: a malformed
   // `{ title: 123 }` would otherwise throw on `.trim()` and 500, and an
   // unsupported conversationType would reach the store unchecked.
+  // `.nullish()`: an explicit JSON `null` is how serializers spell an absent
+  // optional, so it means the same thing as omitting the key.
   const requestedType = createConversationTypeSchema
-    .optional()
+    .nullish()
     .safeParse(body.conversationType);
   if (!requestedType.success) {
     throw new BadRequestError(
@@ -167,11 +170,14 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
       headers?.["x-vellum-client-id"]?.trim() || undefined,
     );
   }
+  // On a conversationKey hit the row already exists, so the type it carries
+  // can differ from the requested one.
+  const storedType = normalizeConversationType(result.conversationType);
   log.info(
     {
       conversationId: result.conversationId,
       conversationKey,
-      conversationType,
+      conversationType: storedType,
       created: result.created,
     },
     "Created conversation via POST",
@@ -179,7 +185,7 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   return {
     id: result.conversationId,
     conversationKey,
-    conversationType: normalizeConversationType(result.conversationType),
+    conversationType: storedType,
     created: result.created,
   };
 }


### PR DESCRIPTION
## Summary
Fixes gaps found during plan self-review for bg-side-conversations.md.

- Treat an explicit `conversationType: null` as omitted rather than a 400.
- Log the stored conversation type, which differs from the requested one on a conversation-key hit.
- Add the required `assertNotLiveDb` guard before the destructive `rmSync` in the new test.
- Derive the accepted-type union from the canonical `ConversationCreateType`.
- Remove em dashes and trim a comment that documented a code path the signature makes impossible.