### PR TITLE
fix(daemon): make the startup BOOTSTRAP cleanup ignore background conversations

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1542,6 +1542,55 @@ describe("ensurePromptFiles", () => {
     expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
+  /** Project a conversation onto disk the way `initConversationDir` does. */
+  function writeConversationDir(id: string, type: string): void {
+    const dir = join(
+      TEST_DIR,
+      "conversations",
+      `2026-01-01T00-00-00.000Z_${id}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "meta.json"), JSON.stringify({ id, type }));
+  }
+
+  test("keeps BOOTSTRAP.md when the only conversations are background side threads", () => {
+    // Onboarding mints throwaway background threads (research, personality and
+    // identity rewrites) before the user's first visible chat, and each gets a
+    // disk-view directory.  A daemon restart in that window must not read them
+    // as evidence that onboarding ended.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeConversationDir("bg-002", "background");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("auto-deletes stale BOOTSTRAP.md when a standard conversation sits alongside background ones", () => {
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeConversationDir("std-001", "standard");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
+  });
+
+  test("seeds BOOTSTRAP.md on a fresh workspace whose only conversations are background", () => {
+    // Background side threads must not make a fresh workspace look like an
+    // upgraded one, or onboarding never gets its bootstrap file at all.
+    writeConversationDir("bg-001", "background");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
   test("keeps BOOTSTRAP.md when no conversations exist yet", () => {
     // Non-first-run but no conversations — user hasn't chatted yet
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -48,13 +48,52 @@ function hasPopulatedUsersDir(): boolean {
   }
 }
 
-function hasExistingConversations(): boolean {
+/**
+ * Conversation types that are internal side channels rather than threads the
+ * user opens: onboarding research, personality/identity rewrites, heartbeat
+ * and scheduled runs, plus legacy private rows.
+ */
+const HIDDEN_CONVERSATION_TYPES = new Set([
+  "background",
+  "scheduled",
+  "private",
+]);
+
+/**
+ * Whether the workspace carries at least one standard (user-visible)
+ * conversation.
+ *
+ * Classifies each disk-view directory by the `type` in its `meta.json` rather
+ * than counting raw directory entries, because hidden side threads get a
+ * disk-view directory too and must not be mistaken for the user's own history.
+ * The type read here is the same value `countConversations("standard")` filters
+ * on, but the answer comes off disk rather than out of the database:
+ * `ensurePromptFiles()` runs before `initializeDb()` settles in
+ * `daemon/lifecycle.ts`, so a query here would hit a partially-migrated schema.
+ *
+ * An entry whose `meta.json` is missing or unreadable counts as standard: a
+ * directory the daemon cannot classify is far more likely to be legacy history
+ * than a side thread, and over-counting only keeps onboarding from re-running.
+ */
+function hasStandardConversations(): boolean {
   try {
     const convDir = getConversationsDir();
     if (!existsSync(convDir)) {
       return false;
     }
-    return readdirSync(convDir).length > 0;
+    return readdirSync(convDir).some((entry) => {
+      try {
+        const meta = JSON.parse(
+          readFileSync(join(convDir, entry, "meta.json"), "utf-8"),
+        ) as { type?: unknown };
+        return (
+          typeof meta.type !== "string" ||
+          !HIDDEN_CONVERSATION_TYPES.has(meta.type)
+        );
+      } catch {
+        return true;
+      }
+    });
   } catch {
     return false;
   }
@@ -78,14 +117,14 @@ export function ensurePromptFiles(): void {
 
   // Track whether this is a fresh workspace.  A workspace counts as fresh
   // only when none of these signals are present: core prompt files, a
-  // populated `users/` directory, or existing conversations.  Upgraded
-  // workspaces that dropped USER.md but still carry personas or history
-  // would otherwise be mistaken for fresh installs and re-trigger
+  // populated `users/` directory, or existing standard conversations.
+  // Upgraded workspaces that dropped USER.md but still carry personas or
+  // history would otherwise be mistaken for fresh installs and re-trigger
   // onboarding.
   const isFirstRun =
     PROMPT_FILES.every((file) => !existsSync(getWorkspacePromptPath(file))) &&
     !hasPopulatedUsersDir() &&
-    !hasExistingConversations();
+    !hasStandardConversations();
 
   for (const file of PROMPT_FILES) {
     const dest = getWorkspacePromptPath(file);
@@ -152,18 +191,20 @@ export function ensurePromptFiles(): void {
   // Auto-delete stale BOOTSTRAP.md at startup.  The model is instructed to
   // delete it at the end of the first conversation, but if the user closes
   // the app or starts a new thread before the model gets another turn, it
-  // never gets the chance.  If BOOTSTRAP.md still exists but prior
-  // conversations are present, the onboarding window has passed — clean up.
+  // never gets the chance.  If BOOTSTRAP.md still exists but prior standard
+  // conversations are present, the onboarding window has passed, so clean up.
+  //
+  // Only standard conversations count, matching the in-process gate in
+  // `persistence/conversation-key-store.ts`.  Onboarding mints hidden side
+  // threads before the user's first visible chat, so counting those would
+  // delete BOOTSTRAP.md out from under that chat on the next daemon restart.
   const bootstrapCleanup = getWorkspacePromptPath("BOOTSTRAP.md");
-  if (!isFirstRun && existsSync(bootstrapCleanup)) {
-    const convDir = getConversationsDir();
-    try {
-      if (existsSync(convDir) && readdirSync(convDir).length > 0) {
-        cleanupBootstrapFiles("prior conversations exist");
-      }
-    } catch (err) {
-      log.warn({ err }, "Failed to auto-delete stale BOOTSTRAP.md");
-    }
+  if (
+    !isFirstRun &&
+    existsSync(bootstrapCleanup) &&
+    hasStandardConversations()
+  ) {
+    cleanupBootstrapFiles("prior conversations exist");
   }
 
   // Seed HEARTBEAT.md — always created if missing so the heartbeat service


### PR DESCRIPTION
## Summary
Fixes a gap found during plan self-review for bg-side-conversations.md.

**Gap:** the in-process first-conversation gate skips background creates, but the startup BOOTSTRAP.md cleanup keys on the conversations directory being non-empty, and background rows get a directory. A daemon restart between the onboarding side threads and the user's first chat deleted BOOTSTRAP.md anyway.
**Fix:** the startup check counts standard conversations only, so both paths agree.