### PR TITLE
test(onboarding): drop clock mutation and duplicate coverage from the side-thread tests

### DIFF
--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -25,7 +25,6 @@ import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { conversations } from "../../../persistence/schema/index.js";
-import { ROUTES as CONVERSATION_LIST_ROUTES } from "../conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "../inference-profile-session-routes.js";
 import type { RouteDefinition } from "../types.js";
@@ -61,10 +60,6 @@ function findHandler(routes: RouteDefinition[], operationId: string) {
 const createHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "createConversation",
-);
-const listHandlerForConversations = findHandler(
-  CONVERSATION_LIST_ROUTES,
-  "listConversations",
 );
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
@@ -121,15 +116,6 @@ describe("POST /v1/conversations (createConversation)", () => {
       .from(conversations)
       .where(eq(conversations.id, id))
       .get();
-  }
-
-  async function listConversationIds(
-    queryParams: Record<string, string>,
-  ): Promise<string[]> {
-    const result = (await listHandlerForConversations({ queryParams })) as {
-      conversations: Array<{ id: string }>;
-    };
-    return result.conversations.map((c) => c.id);
   }
 
   test("with a title → persists it as a user-set title (isAutoTitle = 0)", async () => {
@@ -191,28 +177,6 @@ describe("POST /v1/conversations (createConversation)", () => {
     // An explicit title stays user-set on a background row too.
     expect(row?.title).toBe("Updating personality");
     expect(row?.isAutoTitle).toBe(0);
-  });
-
-  test("a background row is absent from the foreground list and present under conversationType=background", async () => {
-    const background = (await createHandler({
-      body: { conversationType: "background", title: "Updating personality" },
-    })) as { id: string };
-    const foreground = (await createHandler({
-      body: { title: "Visible thread" },
-    })) as { id: string };
-
-    // This is the invariant the onboarding side-thread flows rest on: a
-    // background row can never be landed on or enter Recents, no matter how
-    // the retroactive archive races.
-    const foregroundIds = await listConversationIds({});
-    expect(foregroundIds).toContain(foreground.id);
-    expect(foregroundIds).not.toContain(background.id);
-
-    const backgroundIds = await listConversationIds({
-      conversationType: "background",
-    });
-    expect(backgroundIds).toContain(background.id);
-    expect(backgroundIds).not.toContain(foreground.id);
   });
 
   test("omitted conversationType still creates a standard row", async () => {

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -60,17 +60,16 @@ const { applyPersonality } = await import("./apply-personality");
 beforeEach(() => {
   conversationsPostMock.mockClear();
   messagesPostMock.mockClear();
+  archivePostMock.mockClear();
   saveSlidersMock.mockClear();
 });
 
-describe("applyPersonality side conversation", () => {
-  test("mints the throwaway thread as background even when the archive fails", async () => {
+describe("applyPersonality rewrite prompt", () => {
+  test("mints a background thread and posts the rewrite prompt as a hidden machine signal", async () => {
     // The thread's only renderable content is the assistant's first-person
     // self-description (the prompt posts hidden), so the `background` mint is
-    // what keeps it out of the user's view. Failing the archive here pins that
-    // the hiding comes from the mint alone.
-    archivePostMock.mockRejectedValueOnce(new Error("archive failed"));
-
+    // what keeps it out of the user's view. See
+    // `lib/side-conversation-message.ts` for why the prompt posts hidden.
     await applyPersonality({
       awaitAssistantId: async () => "ast-1",
       values: {},
@@ -80,17 +79,6 @@ describe("applyPersonality side conversation", () => {
       conversationType: "background",
       title: "Updating personality",
     });
-  });
-});
-
-describe("applyPersonality rewrite prompt", () => {
-  test("posts the rewrite prompt as a hidden machine signal", async () => {
-    // See `lib/side-conversation-message.ts` for why this posts hidden.
-    await applyPersonality({
-      awaitAssistantId: async () => "ast-1",
-      values: {},
-    });
-
     expect(messagesPostMock.mock.calls[0]?.[0].body.hidden).toBe(true);
   });
 });

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -3,7 +3,7 @@
  * `background` so it never enters the foreground list, the prompt is posted
  * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
  * only when the turn never started. It also covers the archive that cleans the
- * thread up on every exit path, including a poll-ceiling timeout.
+ * thread up on every exit path, including one that never reaches the poll loop.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -17,14 +17,7 @@ import { createElement, type ReactNode } from "react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  afterEach,
-  describe,
-  expect,
-  mock,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
@@ -48,16 +41,17 @@ let createCalls: CreateCall[] = [];
 let archiveCalls: ArchiveCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
-/**
- * When set, every `/messages` read jumps the clock past the runner's poll
- * ceiling, so the poll loop exits on its deadline check having parsed no
- * complete payload.
- */
-let expirePollCeiling = false;
-const PAST_POLL_CEILING_MS = 300_000;
+/** When set, the prompt POST fails, so the run gives up before the poll loop. */
+let failMessagePost = false;
 
 const ok = <T>(data: T) =>
   Promise.resolve({ data, error: undefined, response: { ok: true } });
+const notOk = () =>
+  Promise.resolve({
+    data: undefined,
+    error: undefined,
+    response: { ok: false },
+  });
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
@@ -74,14 +68,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
   messagesGet: () => {
     getCalls += 1;
-    if (expirePollCeiling) {
-      setSystemTime(new Date(Date.now() + PAST_POLL_CEILING_MS));
-    }
     return ok(listed);
   },
   messagesPost: (opts: PostCall) => {
     postCalls.push(opts);
-    return ok({});
+    return failMessagePost ? notOk() : ok({});
   },
 }));
 mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
@@ -111,8 +102,7 @@ afterEach(() => {
   archiveCalls = [];
   getCalls = 0;
   listed = { messages: [] };
-  expirePollCeiling = false;
-  setSystemTime();
+  failMessagePost = false;
 });
 
 /**
@@ -242,31 +232,27 @@ describe("research prompt send", () => {
 });
 
 describe("research conversation archive", () => {
-  test("archives the side conversation when the poll loop times out", async () => {
-    expirePollCeiling = true;
+  test("archives the side conversation when the prompt fails to post", async () => {
+    // A failed prompt POST abandons the run before the poll loop, with the
+    // conversation already minted. The archive is unconditional, so the
+    // throwaway thread is cleaned up on this exit path like any other.
+    failMessagePost = true;
     const { result } = renderRunner();
-    // A dedicated assistant id keeps this assertion clear of archives from
-    // the runs the tests above leave in flight.
-    const archived = () =>
-      archiveCalls.filter((c) => c.path.assistant_id === "ast-timeout");
 
     act(() => {
       result.current.start({
-        awaitAssistantId: async () => "ast-timeout",
+        awaitAssistantId: async () => "ast-1",
         subject,
       });
     });
 
-    await waitFor(
-      () => {
-        expect(archived()).toHaveLength(1);
-      },
-      { timeout: 8000 },
-    );
-    expect(archived()[0]?.path.id).toBe("conv-fresh");
+    await waitFor(() => {
+      expect(archiveCalls).toHaveLength(1);
+    });
+    expect(archiveCalls[0]?.path.id).toBe("conv-fresh");
 
     act(() => {
       result.current.reset();
     });
-  }, 10_000);
+  });
 });


### PR DESCRIPTION
## Summary
Fixes test-quality gaps found during plan self-review for bg-side-conversations.md.

- Prove the unconditional archive through a failed-post exit instead of mutating the process-global clock from inside a shared mock.
- Fold a redundant single-assertion describe block into the existing test and drop a decorative one-shot mock rejection that was never cleared.
- Drop daemon test coverage that re-asserted a neighboring route module's contract.