### PR TITLE
feat(local-mode): forward the paired gateway data plane through the serving hosts

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -37,8 +37,11 @@ import {
   unpairAssistant,
   getGuardianAccessToken,
   parseGatewayUrl,
+  parsePairedGatewayUrl,
   resolveGatewayProxyTarget,
+  resolvePairedGatewayProxyTarget,
   readAllowedGatewayPorts,
+  readPairedGatewayTargets,
   isLoopbackAddr,
   headerHostIsLoopback,
   originIsAllowed,
@@ -505,7 +508,8 @@ async function handleLocalEndpoints(
     UNPAIR_PATTERN.test(pathname) ||
     GUARDIAN_TOKEN_PATTERN.test(pathname) ||
     PLATFORM_SESSION_PATTERN.test(pathname) ||
-    parseGatewayUrl(pathname).match;
+    parseGatewayUrl(pathname).match ||
+    parsePairedGatewayUrl(pathname).match;
 
   if (!isLocalRoute) return null;
 
@@ -765,28 +769,63 @@ async function handleLocalEndpoints(
     const targetUrl = `http://127.0.0.1:${gatewayTarget.port}${gatewayTarget.path}${url.search}`;
     const headers = new Headers(req.headers);
     headers.set("host", `127.0.0.1:${gatewayTarget.port}`);
+    return proxyGatewayFetch(req, targetUrl, headers, "Gateway proxy error");
+  }
 
-    try {
-      const hasBody = req.method !== "GET" && req.method !== "HEAD";
-      const proxyRes = await loopbackSafeFetch(targetUrl, {
-        method: req.method,
-        headers,
-        body: hasBody ? req.body : undefined,
-        redirect: "manual",
-      });
-      const resHeaders = new Headers(proxyRes.headers);
-      resHeaders.delete("transfer-encoding");
-      return new Response(proxyRes.body, {
-        status: proxyRes.status,
-        statusText: proxyRes.statusText,
-        headers: resHeaders,
-      });
-    } catch {
-      return new Response("Gateway proxy error", { status: 502 });
-    }
+  // Paired-gateway proxy: same shared decision as the web (Vite middleware)
+  // and Electron (`app://` handler) hosts, forwarding to the remote gateway an
+  // imported pairing recorded as its `runtimeUrl`. The lockfile's paired
+  // entries are the allowlist. Origin is dropped on the server-to-server hop;
+  // the guardian bearer passes through for the remote gateway to validate.
+  const pairedDecision = resolvePairedGatewayProxyTarget(pathname, () =>
+    readPairedGatewayTargets(lockfilePaths),
+  );
+  if (pairedDecision.kind === "unknown-assistant") {
+    return new Response("Assistant is not paired in lockfile", { status: 403 });
+  }
+  if (pairedDecision.kind === "forward") {
+    const targetUrl = `${pairedDecision.url}${url.search}`;
+    const headers = new Headers(req.headers);
+    headers.set("host", new URL(pairedDecision.url).host);
+    headers.delete("origin");
+    return proxyGatewayFetch(
+      req,
+      targetUrl,
+      headers,
+      "Paired gateway proxy error",
+    );
   }
 
   return null;
+}
+
+// One streamed hop for both gateway data-plane proxies. The upstream
+// `transfer-encoding` is dropped so re-serving the streamed body doesn't emit
+// a duplicate chunked header.
+async function proxyGatewayFetch(
+  req: Request,
+  targetUrl: string,
+  headers: Headers,
+  errorMessage: string,
+): Promise<Response> {
+  try {
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const proxyRes = await loopbackSafeFetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: hasBody ? req.body : undefined,
+      redirect: "manual",
+    });
+    const resHeaders = new Headers(proxyRes.headers);
+    resHeaders.delete("transfer-encoding");
+    return new Response(proxyRes.body, {
+      status: proxyRes.status,
+      statusText: proxyRes.statusText,
+      headers: resHeaders,
+    });
+  } catch {
+    return new Response(errorMessage, { status: 502 });
+  }
 }
 
 function getBaseDir(): string {

--- a/clients/macos/src/main/gateway-forward.test.ts
+++ b/clients/macos/src/main/gateway-forward.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { planGatewayForward } from "./gateway-forward";
+import {
+  planGatewayForward,
+  planPairedGatewayForward,
+} from "./gateway-forward";
 
 const allow =
   (...ports: number[]) =>
@@ -93,5 +96,81 @@ describe("planGatewayForward", () => {
     if (plan.kind !== "forward") throw new Error("expected forward");
     expect(plan.headers.get("authorization")).toBe("Bearer guardian-token");
     expect(plan.headers.get("content-type")).toBe("application/json");
+  });
+});
+
+const pair =
+  (entries: Record<string, string> = {}) =>
+  () =>
+    new Map<string, string>(Object.entries(entries));
+
+describe("planPairedGatewayForward", () => {
+  test("passes non-paired requests through to static serving", () => {
+    expect(
+      planPairedGatewayForward(
+        request("/assistant/assets/app.js"),
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "pass" });
+    // The loopback gateway path belongs to planGatewayForward, not this plan.
+    expect(
+      planPairedGatewayForward(request("/__gateway/8080/v1"), pair()),
+    ).toEqual({ kind: "pass" });
+  });
+
+  test("rejects an assistant absent from the lockfile pairings with 403", () => {
+    expect(
+      planPairedGatewayForward(
+        request("/__gateway-paired/unknown/v1"),
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    ).toEqual({
+      kind: "reject",
+      status: 403,
+      message: "Assistant is not paired in lockfile",
+    });
+  });
+
+  test("forwards a paired assistant to its runtimeUrl, preserving the query", () => {
+    const plan = planPairedGatewayForward(
+      request("/assistant/__gateway-paired/abc/v1/foo?x=1"),
+      pair({ abc: "https://gw.example.com" }),
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.url).toBe("https://gw.example.com/v1/foo?x=1");
+    expect(plan.method).toBe("GET");
+    expect(plan.hasBody).toBe(false);
+  });
+
+  test("removes the renderer's Origin entirely on the server-to-server hop", () => {
+    const plan = planPairedGatewayForward(
+      request("/__gateway-paired/abc/v1/events", {
+        method: "POST",
+        origin: "app://vellum.ai",
+      }),
+      pair({ abc: "https://gw.example.com" }),
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.has("origin")).toBe(false);
+    expect(plan.hasBody).toBe(true);
+  });
+
+  test("preserves non-Origin headers such as the guardian bearer", () => {
+    const req = {
+      url: "app://vellum.ai/assistant/__gateway-paired/abc/v1/foo",
+      method: "GET",
+      headers: new Headers({
+        origin: "app://vellum.ai",
+        authorization: "Bearer guardian-token",
+        accept: "text/event-stream",
+      }),
+    };
+    const plan = planPairedGatewayForward(
+      req,
+      pair({ abc: "https://gw.example.com" }),
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+    expect(plan.headers.get("authorization")).toBe("Bearer guardian-token");
+    expect(plan.headers.get("accept")).toBe("text/event-stream");
   });
 });

--- a/clients/macos/src/main/gateway-forward.ts
+++ b/clients/macos/src/main/gateway-forward.ts
@@ -1,7 +1,12 @@
-import { resolveGatewayProxyTarget } from "@vellumai/local-mode";
+import {
+  resolveGatewayProxyTarget,
+  resolvePairedGatewayProxyTarget,
+} from "@vellumai/local-mode";
 
 /**
- * Pure planning for the gateway data-plane proxy (`/assistant/__gateway/{port}/*`).
+ * Pure planning for the gateway data-plane proxies: the loopback
+ * `/assistant/__gateway/{port}/*` forward and the paired-remote
+ * `/assistant/__gateway-paired/{assistantId}/*` forward.
  *
  * Lives in its own file — like `app-protocol.ts` — so the URL/header logic is
  * testable without importing `src/main/index.ts` (which evaluates the full
@@ -73,6 +78,52 @@ export function planGatewayForward(
       return {
         kind: "forward",
         url: `http://127.0.0.1:${port}${targetPath}`,
+        method: request.method,
+        headers,
+        hasBody: request.method !== "GET" && request.method !== "HEAD",
+      };
+    }
+  }
+}
+
+/**
+ * Resolve a renderer request to a paired-gateway proxy plan
+ * (`/assistant/__gateway-paired/{assistantId}/*`), reusing the shared
+ * lockfile-pairing decision so the security boundary is defined once for every
+ * host: only assistants the user actually imported are reachable.
+ *
+ * On `forward`, the request's `Origin` is removed entirely. This is a
+ * server-to-server hop to a remote gateway, so the renderer's `app://` origin
+ * must not be sent, and unlike the loopback forward there is no
+ * loopback-origin gate to satisfy. The remaining headers (notably the
+ * guardian `Authorization` bearer) pass through unchanged; the remote gateway
+ * validates the bearer by signature and audience.
+ */
+export function planPairedGatewayForward(
+  request: GatewayForwardRequest,
+  getTargets: () => Map<string, string>,
+): GatewayForwardPlan {
+  const url = new URL(request.url);
+  const decision = resolvePairedGatewayProxyTarget(
+    url.pathname + url.search,
+    getTargets,
+  );
+
+  switch (decision.kind) {
+    case "pass":
+      return { kind: "pass" };
+    case "unknown-assistant":
+      return {
+        kind: "reject",
+        status: 403,
+        message: "Assistant is not paired in lockfile",
+      };
+    case "forward": {
+      const headers = new Headers(request.headers);
+      headers.delete("origin");
+      return {
+        kind: "forward",
+        url: decision.url,
         method: request.method,
         headers,
         hasBody: request.method !== "GET" && request.method !== "HEAD",

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
 import {
   readAllowedGatewayPorts,
+  readPairedGatewayTargets,
   resolveLocalConfigFromEnv,
   resolveLockfilePaths,
 } from "@vellumai/local-mode";
@@ -21,7 +22,11 @@ import { installCsp } from "./csp";
 import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
 import { registerVellumAppProtocol } from "./vellumapp-protocol";
-import { planGatewayForward } from "./gateway-forward";
+import {
+  planGatewayForward,
+  planPairedGatewayForward,
+  type GatewayForwardPlan,
+} from "./gateway-forward";
 import {
   fetchForwardPlanWithRetry,
   planPlatformForward,
@@ -228,6 +233,8 @@ const registerAppProtocol = (): void => {
   const lockfilePaths = resolveLockfilePaths(process.env);
   const getAllowedGatewayPorts = (): Set<number> =>
     readAllowedGatewayPorts(lockfilePaths);
+  const getPairedGatewayTargets = (): Map<string, string> =>
+    readPairedGatewayTargets(lockfilePaths);
   const { platformUrl } = resolveLocalConfigFromEnv(process.env);
 
   protocol.handle(APP_PROTOCOL, async (request) => {
@@ -238,6 +245,19 @@ const registerAppProtocol = (): void => {
     // Vite dev-server proxy (`clients/web/vite-plugin-local-mode.ts`).
     const proxied = await forwardGatewayRequest(request, getAllowedGatewayPorts);
     if (proxied) return proxied;
+
+    // Paired remote gateways ride the same-origin path too, via
+    // `/assistant/__gateway-paired/{assistantId}/*`: the packaged app's CSP
+    // pins `connect-src` to Vellum origins, so the renderer cannot reach a
+    // paired gateway directly. The lockfile's paired entries are the
+    // allowlist.
+    const pairedProxied = await forwardPairedGatewayRequest(
+      request,
+      getPairedGatewayTargets,
+    );
+    if (pairedProxied) {
+      return pairedProxied;
+    }
 
     // Platform API routes (`/v1/*`, `/_allauth/*`, `/accounts/*`) forward to
     // the cloud platform so managed mode works in packaged builds. Mirrors the
@@ -275,20 +295,16 @@ const fileExists = async (candidate: string): Promise<boolean> => {
 };
 
 /**
- * Forward a gateway data-plane request (`/assistant/__gateway/{port}/*`) to the
- * local gateway on loopback, or return `null` when the URL is not a gateway
- * request so the caller serves it as a static asset. `net.fetch` runs in the
- * main process, so the renderer only ever talks to its own secure `app://`
- * origin — main does the `http://127.0.0.1` hop. The streaming `Response` is
- * returned verbatim, preserving SSE and chunked transfers (Electron's
- * `stream: true` scheme privilege). `planGatewayForward` owns the allowlist and
- * header decisions; this wrapper is just the effect.
+ * Turn a gateway forward plan into its effect: `null` on `pass` so the caller
+ * serves the request as a static asset, otherwise the plan's rejection or a
+ * single `net.fetch` whose streaming `Response` is returned verbatim,
+ * preserving SSE and chunked transfers (Electron's `stream: true` scheme
+ * privilege). The plan owns the allowlist and header decisions.
  */
-const forwardGatewayRequest = async (
+const executeGatewayForwardPlan = (
+  plan: GatewayForwardPlan,
   request: GlobalRequest,
-  getAllowedPorts: () => Set<number>,
-): Promise<Response | null> => {
-  const plan = planGatewayForward(request, getAllowedPorts);
+): Promise<Response> | Response | null => {
   switch (plan.kind) {
     case "pass":
       return null;
@@ -306,6 +322,32 @@ const forwardGatewayRequest = async (
       });
   }
 };
+
+/**
+ * Forward a gateway data-plane request (`/assistant/__gateway/{port}/*`) to the
+ * local gateway on loopback, or return `null` when the URL is not a gateway
+ * request. `net.fetch` runs in the main process, so the renderer only ever
+ * talks to its own secure `app://` origin; main does the `http://127.0.0.1`
+ * hop.
+ */
+const forwardGatewayRequest = async (
+  request: GlobalRequest,
+  getAllowedPorts: () => Set<number>,
+): Promise<Response | null> =>
+  executeGatewayForwardPlan(planGatewayForward(request, getAllowedPorts), request);
+
+/**
+ * Forward a paired-gateway data-plane request
+ * (`/assistant/__gateway-paired/{assistantId}/*`) to the remote gateway an
+ * imported pairing recorded as its `runtimeUrl`, or return `null` when the URL
+ * is not a paired-gateway request. Main does the remote hop so the renderer
+ * stays same-origin.
+ */
+const forwardPairedGatewayRequest = async (
+  request: GlobalRequest,
+  getTargets: () => Map<string, string>,
+): Promise<Response | null> =>
+  executeGatewayForwardPlan(planPairedGatewayForward(request, getTargets), request);
 
 const resolvedConfig = resolveLocalConfigFromEnv(process.env);
 handleSync("vellum:config:get", () => ({

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import https from "node:https";
 import fs from "node:fs";
 import path from "node:path";
 import type { Plugin, Connect, ViteDevServer } from "vite";
@@ -22,7 +23,9 @@ import {
   unpairAssistant,
   getGuardianAccessToken,
   resolveGatewayProxyTarget,
+  resolvePairedGatewayProxyTarget,
   readAllowedGatewayPorts,
+  readPairedGatewayTargets,
   type CliInvocation,
 } from "@vellumai/local-mode";
 
@@ -105,6 +108,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
         guardianTokenMiddleware(config.configDir, baseDir, env),
       );
       server.middlewares.use(gatewayProxyMiddleware(config.lockfilePaths));
+      server.middlewares.use(pairedGatewayProxyMiddleware(config.lockfilePaths));
       server.middlewares.use(accountSpaFallback(server));
     },
   };
@@ -901,34 +905,95 @@ function gatewayProxyMiddleware(
     }
 
     const { target } = decision;
-    const proxyOptions: http.RequestOptions = {
-      hostname: "127.0.0.1",
-      port: target.port,
-      path: target.path,
-      method: req.method,
-      headers: { ...req.headers, host: `127.0.0.1:${target.port}` },
-    };
-
-    const proxyReq = http.request(proxyOptions, (proxyRes) => {
-      // Drop the upstream's `transfer-encoding` before re-emitting: Node's http
-      // server sets its own when we pipe the streamed body, so copying the
-      // gateway's `chunked` too yields a duplicate ("too many transfer
-      // encodings"). A strict downstream proxy (the `vel up` Caddy edge)
-      // rejects that with 502 — fatal for the SSE `/events` stream, whose
-      // failure drives a client reconnect + full-refetch loop.
-      const headers = { ...proxyRes.headers };
-      delete headers["transfer-encoding"];
-      res.writeHead(proxyRes.statusCode ?? 502, headers);
-      proxyRes.pipe(res);
-    });
-
-    proxyReq.on("error", () => {
-      if (!res.headersSent) {
-        res.statusCode = 502;
-        res.end("Gateway proxy error");
-      }
-    });
-
-    req.pipe(proxyReq);
+    pipeGatewayProxy(
+      req,
+      res,
+      http,
+      {
+        hostname: "127.0.0.1",
+        port: target.port,
+        path: target.path,
+        method: req.method,
+        headers: { ...req.headers, host: `127.0.0.1:${target.port}` },
+      },
+      "Gateway proxy error",
+    );
   };
+}
+
+// Paired-gateway data plane (`/__gateway-paired/{assistantId}/*`): same
+// posture as the loopback gateway proxy above, but the target is the remote
+// gateway an imported pairing recorded as its `runtimeUrl`. The lockfile's
+// paired entries are the allowlist. The `Origin` header is removed entirely on
+// this server-to-server hop; the guardian `Authorization` bearer passes
+// through untouched for the remote gateway to validate.
+function pairedGatewayProxyMiddleware(
+  lockfilePaths: string[],
+): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const decision = resolvePairedGatewayProxyTarget(req.url ?? "", () =>
+      readPairedGatewayTargets(lockfilePaths),
+    );
+    if (decision.kind === "pass") {
+      return next();
+    }
+
+    if (rejectUnlessLocalEndpointRequest(req, res)) {
+      return;
+    }
+
+    if (decision.kind === "unknown-assistant") {
+      res.statusCode = 403;
+      res.end("Assistant is not paired in lockfile");
+      return;
+    }
+
+    const target = new URL(decision.url);
+    const requestHeaders = { ...req.headers, host: target.host };
+    delete requestHeaders.origin;
+    pipeGatewayProxy(
+      req,
+      res,
+      target.protocol === "https:" ? https : http,
+      {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port || undefined,
+        path: target.pathname + target.search,
+        method: req.method,
+        headers: requestHeaders,
+      },
+      "Paired gateway proxy error",
+    );
+  };
+}
+
+// One streamed hop for both gateway data-plane proxies. Drops the upstream's
+// `transfer-encoding` before re-emitting: Node's http server sets its own when
+// we pipe the streamed body, so copying the gateway's `chunked` too yields a
+// duplicate ("too many transfer encodings"). A strict downstream proxy (the
+// `vel up` Caddy edge) rejects that with 502, fatal for the SSE `/events`
+// stream, whose failure drives a client reconnect + full-refetch loop.
+function pipeGatewayProxy(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  transport: Pick<typeof http, "request">,
+  options: http.RequestOptions,
+  errorMessage: string,
+): void {
+  const proxyReq = transport.request(options, (proxyRes) => {
+    const headers = { ...proxyRes.headers };
+    delete headers["transfer-encoding"];
+    res.writeHead(proxyRes.statusCode ?? 502, headers);
+    proxyRes.pipe(res);
+  });
+
+  proxyReq.on("error", () => {
+    if (!res.headersSent) {
+      res.statusCode = 502;
+      res.end(errorMessage);
+    }
+  });
+
+  req.pipe(proxyReq);
 }

--- a/packages/local-mode/src/__tests__/gateway-proxy.test.ts
+++ b/packages/local-mode/src/__tests__/gateway-proxy.test.ts
@@ -4,8 +4,11 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  parsePairedGatewayUrl,
   readAllowedGatewayPorts,
+  readPairedGatewayTargets,
   resolveGatewayProxyTarget,
+  resolvePairedGatewayProxyTarget,
 } from "../gateway-proxy";
 
 const allow =
@@ -116,5 +119,215 @@ describe("resolveGatewayProxyTarget", () => {
     expect(reads).toBe(0);
     resolveGatewayProxyTarget("/__gateway/8080/v1", counting);
     expect(reads).toBe(1);
+  });
+});
+
+const pair =
+  (entries: Record<string, string> = {}) =>
+  () =>
+    new Map<string, string>(Object.entries(entries));
+
+describe("parsePairedGatewayUrl", () => {
+  test("matches with and without the renderer's `/assistant` mount prefix", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc/v1/foo")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/v1/foo" },
+    });
+    expect(
+      parsePairedGatewayUrl("/assistant/__gateway-paired/abc/v1/foo"),
+    ).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/v1/foo" },
+    });
+  });
+
+  test("defaults a pathless tail to the gateway root", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/" },
+    });
+  });
+
+  test("percent-decodes the assistant id", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/a%20b/v1")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "a b", path: "/v1" },
+    });
+  });
+
+  test("treats malformed percent-encoding as invalid, not a crash", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/%zz/v1")).toEqual({
+      match: true,
+      valid: false,
+    });
+  });
+
+  test("does not match non-paired pathnames", () => {
+    expect(parsePairedGatewayUrl("/__gateway/8080/v1")).toEqual({
+      match: false,
+    });
+    expect(parsePairedGatewayUrl("/index.html")).toEqual({ match: false });
+  });
+});
+
+describe("resolvePairedGatewayProxyTarget", () => {
+  test("passes non-paired pathnames through untouched", () => {
+    expect(
+      resolvePairedGatewayProxyTarget("/index.html", pair({ abc: "https://gw.example.com" })),
+    ).toEqual({ kind: "pass" });
+    expect(
+      resolvePairedGatewayProxyTarget("/__gateway/8080/v1", pair()),
+    ).toEqual({ kind: "pass" });
+  });
+
+  test("forwards a paired id to its runtimeUrl, preserving the query", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/assistant/__gateway-paired/abc/v1/foo?x=1",
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "forward", url: "https://gw.example.com/v1/foo?x=1" });
+  });
+
+  test("strips the runtimeUrl's trailing slashes and keeps its path prefix", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/abc/v1/foo",
+        pair({ abc: "https://gw.example.com/" }),
+      ),
+    ).toEqual({ kind: "forward", url: "https://gw.example.com/v1/foo" });
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/abc/v1/foo",
+        pair({ abc: "https://gw.example.com/edge/" }),
+      ),
+    ).toEqual({ kind: "forward", url: "https://gw.example.com/edge/v1/foo" });
+  });
+
+  test("resolves a percent-encoded id against the decoded allowlist key", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/a%20b/v1",
+        pair({ "a b": "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "forward", url: "https://gw.example.com/v1" });
+  });
+
+  test("rejects an id that isn't paired in the lockfile", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/unknown/v1",
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "unknown-assistant" });
+  });
+
+  test("rejects a malformed percent-encoded id", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/%zz/v1",
+        pair({ "%zz": "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "unknown-assistant" });
+  });
+
+  test("never reads the allowlist for non-paired paths", () => {
+    let reads = 0;
+    const counting = () => {
+      reads += 1;
+      return new Map<string, string>([["abc", "https://gw.example.com"]]);
+    };
+    resolvePairedGatewayProxyTarget("/index.html", counting);
+    resolvePairedGatewayProxyTarget("/__gateway/8080/v1", counting);
+    expect(reads).toBe(0);
+    resolvePairedGatewayProxyTarget("/__gateway-paired/abc/v1", counting);
+    expect(reads).toBe(1);
+  });
+});
+
+describe("readPairedGatewayTargets", () => {
+  const withLockfile = (
+    contents: string,
+    run: (lockfilePath: string) => void,
+  ) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paired-gateway-test-"));
+    const lockfilePath = path.join(dir, "assistants.json");
+    try {
+      fs.writeFileSync(lockfilePath, contents);
+      run(lockfilePath);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  test("maps paired entries to their http(s) runtimeUrls, excluding everything else", () => {
+    withLockfile(
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "paired-a",
+            cloud: "paired",
+            runtimeUrl: "https://gw.example.com",
+          },
+          {
+            assistantId: "paired-b",
+            cloud: "paired",
+            runtimeUrl: "http://192.0.2.10:8443/edge",
+          },
+          // Non-paired entries never become forwardable, loopback or not.
+          { assistantId: "local-a", resources: { gatewayPort: 7830 } },
+          {
+            assistantId: "docker-a",
+            cloud: "docker",
+            runtimeUrl: "http://localhost:7930",
+          },
+          {
+            assistantId: "remote-a",
+            cloud: "gcp",
+            runtimeUrl: "https://assistant.example.com:8443",
+          },
+          // Paired entries without a usable absolute http(s) runtimeUrl are
+          // excluded rather than forwarded blind.
+          { assistantId: "paired-no-url", cloud: "paired" },
+          {
+            assistantId: "paired-bad-scheme",
+            cloud: "paired",
+            runtimeUrl: "ssh://gw.example.com",
+          },
+          {
+            assistantId: "paired-relative",
+            cloud: "paired",
+            runtimeUrl: "/not-absolute",
+          },
+          // Malformed entries are tolerated, not fatal.
+          null,
+          { cloud: "paired", runtimeUrl: "https://gw.example.com" },
+        ],
+      }),
+      (lockfilePath) => {
+        expect(readPairedGatewayTargets([lockfilePath])).toEqual(
+          new Map([
+            ["paired-a", "https://gw.example.com"],
+            ["paired-b", "http://192.0.2.10:8443/edge"],
+          ]),
+        );
+      },
+    );
+  });
+
+  test("returns an empty map for malformed JSON", () => {
+    withLockfile("not json", (lockfilePath) => {
+      expect(readPairedGatewayTargets([lockfilePath])).toEqual(new Map());
+    });
+  });
+
+  test("returns an empty map when no lockfile path exists", () => {
+    expect(
+      readPairedGatewayTargets(["/nonexistent/assistants.json"]),
+    ).toEqual(new Map());
   });
 });

--- a/packages/local-mode/src/gateway-proxy.ts
+++ b/packages/local-mode/src/gateway-proxy.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 
+import { resolveCloud } from "./lockfile-contract";
+
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
+
+const PAIRED_GATEWAY_PATTERN =
+  /^(?:\/assistant)?\/__gateway-paired\/([^/]+)(\/.*)?$/;
 
 export interface GatewayTarget {
   port: number;
@@ -64,6 +69,87 @@ export function resolveGatewayProxyTarget(
   return { kind: "forward", target: parsed.target };
 }
 
+export interface PairedGatewayTarget {
+  assistantId: string;
+  path: string;
+}
+
+export type PairedGatewayParseResult =
+  | { match: true; valid: true; target: PairedGatewayTarget }
+  | { match: true; valid: false }
+  | { match: false };
+
+export function parsePairedGatewayUrl(
+  pathname: string,
+): PairedGatewayParseResult {
+  const match = pathname.match(PAIRED_GATEWAY_PATTERN);
+  if (!match) {
+    return { match: false };
+  }
+
+  let assistantId: string;
+  try {
+    assistantId = decodeURIComponent(match[1]!);
+  } catch {
+    // Malformed percent-encoding is an invalid parse, not a crash.
+    return { match: true, valid: false };
+  }
+
+  return {
+    match: true,
+    valid: true,
+    target: { assistantId, path: match[2] || "/" },
+  };
+}
+
+/**
+ * Verdict for a paired-gateway proxy URL (`/__gateway-paired/{assistantId}/*`),
+ * combining the URL parse with the lockfile pairing-allowlist check into one
+ * decision a host can act on without re-deriving the rules.
+ *
+ *   - `pass`: not a paired-gateway URL; the host serves it normally.
+ *   - `unknown-assistant`: a paired-gateway URL whose id is malformed or not
+ *     paired in the lockfile (the security boundary: the proxy only reaches
+ *     gateways of entries the user actually imported, never arbitrary URLs).
+ *   - `forward`: forward to `url` (the entry's recorded runtimeUrl with the
+ *     request path appended).
+ */
+export type PairedGatewayProxyDecision =
+  | { kind: "pass" }
+  | { kind: "unknown-assistant" }
+  | { kind: "forward"; url: string };
+
+/**
+ * Resolve a request pathname (plus query, when the host includes it) to a
+ * paired-gateway proxy verdict. Identical across every host that proxies the
+ * data plane, mirroring {@link resolveGatewayProxyTarget}.
+ *
+ * `getTargets` is a thunk (typically `() => readPairedGatewayTargets(...)`) so
+ * the lockfile is read only once a paired-gateway URL is matched.
+ */
+export function resolvePairedGatewayProxyTarget(
+  pathname: string,
+  getTargets: () => Map<string, string>,
+): PairedGatewayProxyDecision {
+  const parsed = parsePairedGatewayUrl(pathname);
+  if (!parsed.match) {
+    return { kind: "pass" };
+  }
+  if (!parsed.valid) {
+    return { kind: "unknown-assistant" };
+  }
+  const runtimeUrl = getTargets().get(parsed.target.assistantId);
+  if (!runtimeUrl) {
+    return { kind: "unknown-assistant" };
+  }
+  // Preserve the runtimeUrl's own path prefix (minus trailing slashes), then
+  // append the request path and query.
+  return {
+    kind: "forward",
+    url: `${runtimeUrl.replace(/\/+$/, "")}${parsed.target.path}`,
+  };
+}
+
 function addPortFromUrl(url: unknown, ports: Set<number>): void {
   if (typeof url !== "string") return;
   try {
@@ -111,4 +197,58 @@ export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
     }
   }
   return ports;
+}
+
+/**
+ * Read the paired-gateway allowlist from the lockfile: assistantId to the
+ * recorded remote `runtimeUrl`, for entries whose resolved cloud is "paired"
+ * and whose runtimeUrl parses as an absolute http(s) URL. Same error posture
+ * as {@link readAllowedGatewayPorts}: tolerant of malformed JSON and entries,
+ * reading the first lockfile path that yields targets.
+ */
+export function readPairedGatewayTargets(
+  lockfilePaths: string[],
+): Map<string, string> {
+  const targets = new Map<string, string>();
+  for (const candidate of lockfilePaths) {
+    try {
+      const raw = fs.readFileSync(candidate, "utf-8");
+      const data = JSON.parse(raw) as {
+        assistants?: Array<Record<string, unknown> | null>;
+      };
+      const assistants = Array.isArray(data.assistants) ? data.assistants : [];
+      for (const assistant of assistants) {
+        if (!assistant || typeof assistant !== "object") {
+          continue;
+        }
+        if (resolveCloud(assistant) !== "paired") {
+          continue;
+        }
+        const { assistantId, runtimeUrl } = assistant;
+        if (typeof assistantId !== "string" || assistantId === "") {
+          continue;
+        }
+        if (typeof runtimeUrl !== "string") {
+          continue;
+        }
+        try {
+          const parsed = new URL(runtimeUrl);
+          if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            continue;
+          }
+        } catch {
+          continue;
+        }
+        targets.set(assistantId, runtimeUrl);
+      }
+      if (targets.size > 0) {
+        return targets;
+      }
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        return new Map<string, string>();
+      }
+    }
+  }
+  return targets;
 }

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -62,9 +62,15 @@ export {
   parseGatewayUrl,
   readAllowedGatewayPorts,
   resolveGatewayProxyTarget,
+  parsePairedGatewayUrl,
+  readPairedGatewayTargets,
+  resolvePairedGatewayProxyTarget,
 } from "./gateway-proxy";
 export type {
   GatewayTarget,
   GatewayParseResult,
   GatewayProxyDecision,
+  PairedGatewayTarget,
+  PairedGatewayParseResult,
+  PairedGatewayProxyDecision,
 } from "./gateway-proxy";


### PR DESCRIPTION
## Summary
- Shared resolver: /assistant/__gateway-paired/<assistantId> forwards to the entry's recorded runtimeUrl (paired entries only; the lockfile is the allowlist)
- Wired into the Electron app:// handler, the Vite dev middleware, and the CLI web host, mirroring the loopback __gateway/{port} proxy
- Renderer bearer passes through untouched; Origin is dropped on the server-to-server hop

Companion to PR 2 (renderer side). Part of plan: web-paired-entries.md