### PR TITLE
feat(web): resolve paired assistants in the lifecycle gateway-auth short-circuit

### DIFF
--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -112,10 +112,18 @@ const getSelectedAssistantMock = mock(
   (): { assistantId: string } | undefined => undefined,
 );
 const getLocalGatewayUrlMock = mock((): string | undefined => undefined);
+const getPairedGatewayUrlMock = mock((): string | undefined => undefined);
 mock.module("@/lib/local-mode", () => ({
   getActiveAssistant: () => undefined,
+  // Mirrors the real helper's composition so tests drive it through
+  // the two inner mocks.
+  getAuthGatewayIngressUrl: (): string | undefined => {
+    const base = getLocalGatewayUrlMock() ?? getPairedGatewayUrlMock();
+    return base ? `${window.location.origin}${base}` : undefined;
+  },
   getLocalAssistants: () => [],
   getLocalGatewayUrl: getLocalGatewayUrlMock,
+  getPairedGatewayUrl: getPairedGatewayUrlMock,
   getLockfile: () => ({ assistants: [], activeAssistant: null }),
   getPlatformAssistants: () => [],
   getPlatformRuntimeUrl: () => window.location.origin,
@@ -213,6 +221,7 @@ beforeEach(() => {
   isRemoteGatewayModeMock.mockImplementation(() => false);
   getSelectedAssistantMock.mockImplementation(() => undefined);
   getLocalGatewayUrlMock.mockImplementation(() => undefined);
+  getPairedGatewayUrlMock.mockImplementation(() => undefined);
   getAssistantMock.mockImplementation(async () => ({ ok: false, status: 404 }));
   getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
   getLocalAssistantStatusHostMock.mockClear();
@@ -463,6 +472,35 @@ describe("lifecycleService — bootstrap branches", () => {
     await waitFor(() => {
       const s = useAssistantLifecycleStore.getState().assistantState;
       return s.kind === "active" && s.health === "healthy";
+    });
+  });
+
+  test("gateway-auth short-circuit resolves a paired selection to the paired proxy URL", async () => {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+    getSelectedAssistantMock.mockImplementation(() => ({
+      assistantId: "asst-paired",
+    }));
+    getPairedGatewayUrlMock.mockImplementation(
+      () => "/assistant/__gateway-paired/asst-paired",
+    );
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledWith({
+      url: `${window.location.origin}/assistant/__gateway-paired/asst-paired`,
+      token: "token",
+    });
+    expect(useResolvedAssistantsStore.getState().activeAssistantId).toBe(
+      "asst-paired",
+    );
+    expect(useAssistantLifecycleStore.getState().assistantState).toMatchObject({
+      kind: "active",
+      isLocal: true,
     });
   });
 
@@ -1232,6 +1270,31 @@ describe("lifecycleService — selection subscription", () => {
       url: string;
     };
     expect(arg.url).toContain("/assistant/__gateway/2222");
+  });
+
+  test("switch from a local to a paired assistant republishes the paired proxy URL", async () => {
+    await driveGatewayActive("asst-local");
+    getLocalGatewayUrlMock.mockImplementation(() => undefined);
+    getPairedGatewayUrlMock.mockImplementation(
+      () => "/assistant/__gateway-paired/asst-paired",
+    );
+    getSelectedAssistantMock.mockImplementation(() => ({
+      assistantId: "asst-paired",
+    }));
+    setSelfHostedConnectionMock.mockClear();
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-paired");
+
+    expect(useResolvedAssistantsStore.getState().activeAssistantId).toBe(
+      "asst-paired",
+    );
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledTimes(1);
+    const arg = setSelfHostedConnectionMock.mock.calls[0]![0] as {
+      url: string;
+    };
+    expect(arg.url).toBe(
+      `${window.location.origin}/assistant/__gateway-paired/asst-paired`,
+    );
   });
 
   test("no republish while the lifecycle is still loading", () => {

--- a/clients/web/src/assistant/lifecycle-service.ts
+++ b/clients/web/src/assistant/lifecycle-service.ts
@@ -46,7 +46,7 @@ import type { AssistantState, LocalAssistantHealth } from "@/assistant/types";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getSelectedAssistant,
-  getLocalGatewayUrl,
+  getAuthGatewayIngressUrl,
   isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import { getLocalAssistantStatusHost } from "@/runtime/local-mode-host";
@@ -581,13 +581,15 @@ class AssistantLifecycleService {
   private applyGatewayAuthShortCircuit(): void {
     let ingressUrl = window.location.origin;
     let resolvedAssistantId = "self";
-    const localGateway = getLocalGatewayUrl();
     if (isRemoteGatewayMode()) {
       ingressUrl = getRemoteGatewayIngressUrl();
-    } else if (localGateway) {
+    } else {
       const assistant = getSelectedAssistant();
-      ingressUrl = `${window.location.origin}${localGateway}`;
-      resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;
+      const resolved = getAuthGatewayIngressUrl(assistant);
+      if (resolved) {
+        ingressUrl = resolved;
+        resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;
+      }
     }
     setSelfHostedConnection({ url: ingressUrl, token: getGatewayToken() });
     this.setOperationalStatusAssistantId(null);


### PR DESCRIPTION
## Summary
- applyGatewayAuthShortCircuit resolves ingress via getAuthGatewayIngressUrl, covering paired entries with the same-origin proxy URL and publishing the selected paired id as active

Part of plan: web-paired-entries.md (PR 3 of 8)