### PR TITLE
fix(daemon): skip non-conversation entries when classifying the conversations dir

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1518,10 +1518,7 @@ describe("ensurePromptFiles", () => {
     writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
     writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
 
-    // Create a conversations directory with at least one entry
-    const convDir = join(TEST_DIR, "conversations");
-    mkdirSync(convDir, { recursive: true });
-    writeFileSync(join(convDir, "conv-001.json"), "{}");
+    writeConversationDir("conv-001", "standard");
 
     ensurePromptFiles();
 
@@ -1533,9 +1530,7 @@ describe("ensurePromptFiles", () => {
     // will be re-seeded from templates) but still carries prior
     // conversations.  Existing conversation history signals a non-fresh
     // install, so onboarding must not re-trigger.
-    const convDir = join(TEST_DIR, "conversations");
-    mkdirSync(convDir, { recursive: true });
-    writeFileSync(join(convDir, "conv-001.json"), "{}");
+    writeConversationDir("conv-001", "standard");
 
     ensurePromptFiles();
 
@@ -1567,6 +1562,37 @@ describe("ensurePromptFiles", () => {
     ensurePromptFiles();
 
     expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("keeps BOOTSTRAP.md when a stray file sits beside background side threads", () => {
+    // The disk view is browsable, so a file explorer can drop `.DS_Store` into
+    // the conversations directory.  It is not a conversation and must not be
+    // classified as one.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeFileSync(join(TEST_DIR, "conversations", ".DS_Store"), "junk");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("auto-deletes stale BOOTSTRAP.md when a conversation directory has no meta.json", () => {
+    // A directory the daemon cannot classify counts as standard: it is far
+    // likelier to be legacy history than a side thread, and over-counting only
+    // suppresses an onboarding re-run.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
+    mkdirSync(join(TEST_DIR, "conversations", "2026-01-01T00-00-00.000Z_old"), {
+      recursive: true,
+    });
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
   test("auto-deletes stale BOOTSTRAP.md when a standard conversation sits alongside background ones", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -71,7 +71,13 @@ const HIDDEN_CONVERSATION_TYPES = new Set([
  * `ensurePromptFiles()` runs before `initializeDb()` settles in
  * `daemon/lifecycle.ts`, so a query here would hit a partially-migrated schema.
  *
- * An entry whose `meta.json` is missing or unreadable counts as standard: a
+ * Only directories are classified. The layout is browsable, so stray files such
+ * as `.DS_Store` sit beside the conversations, and a `meta.json` read under one
+ * fails indistinguishably from an unreadable conversation. Directory names are
+ * not filtered further, because both the canonical `<ISO>_<id>` layout and the
+ * legacy `<id>_<ISO>` one name real conversations.
+ *
+ * A directory whose `meta.json` is missing or unreadable counts as standard: a
  * directory the daemon cannot classify is far more likely to be legacy history
  * than a side thread, and over-counting only keeps onboarding from re-running.
  */
@@ -81,10 +87,13 @@ function hasStandardConversations(): boolean {
     if (!existsSync(convDir)) {
       return false;
     }
-    return readdirSync(convDir).some((entry) => {
+    return readdirSync(convDir, { withFileTypes: true }).some((entry) => {
+      if (!entry.isDirectory()) {
+        return false;
+      }
       try {
         const meta = JSON.parse(
-          readFileSync(join(convDir, entry, "meta.json"), "utf-8"),
+          readFileSync(join(convDir, entry.name, "meta.json"), "utf-8"),
         ) as { type?: unknown };
         return (
           typeof meta.type !== "string" ||
@@ -194,10 +203,15 @@ export function ensurePromptFiles(): void {
   // never gets the chance.  If BOOTSTRAP.md still exists but prior standard
   // conversations are present, the onboarding window has passed, so clean up.
   //
-  // Only standard conversations count, matching the in-process gate in
-  // `persistence/conversation-key-store.ts`.  Onboarding mints hidden side
-  // threads before the user's first visible chat, so counting those would
-  // delete BOOTSTRAP.md out from under that chat on the next daemon restart.
+  // Only standard conversations count.  Onboarding mints hidden side threads
+  // before the user's first visible chat, so counting those would delete
+  // BOOTSTRAP.md out from under that chat on the next daemon restart.
+  //
+  // This gate is one conversation stricter than the in-process gate in
+  // `persistence/conversation-key-store.ts`, which keeps BOOTSTRAP.md through
+  // the whole first standard conversation and deletes it when a second one is
+  // created.  A restart while the user is still inside that first conversation
+  // deletes BOOTSTRAP.md from under it.
   const bootstrapCleanup = getWorkspacePromptPath("BOOTSTRAP.md");
   if (
     !isFirstRun &&


### PR DESCRIPTION
## Summary
Fixes gaps found while re-reviewing the remediation round for bg-side-conversations.md.

- A stray non-directory entry under `conversations/` (`.DS_Store` being the realistic case) threw `ENOTDIR` into the classifier's catch and was counted as a standard conversation, so a background-only workspace lost BOOTSTRAP.md on the next restart.
- Correct a comment that claimed the startup gate matches the in-process gate. They differ by one: the in-process gate deletes on the second standard conversation, the startup gate on the first.