### PR TITLE
feat(web): connect and refresh sessions for paired assistants in the auth store

### DIFF
--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -52,7 +52,9 @@ import {
   isPlatformAssistant,
   isRemoteGatewayMode,
   loadLockfile,
+  LOCAL_GATEWAY_STARTUP_RETRY,
   primeLocalGatewayConnection,
+  primeLocalGatewayConnectionWithStartupRetry,
   reconcileSelectedAssistant,
   removePlatformAssistantFromLockfile,
   saveManagedLockfileAssistant,
@@ -757,6 +759,43 @@ describe("primeLocalGatewayConnection", () => {
 
     expect(getGatewayToken()).toBe(jwt);
     expect(localStorage.getItem("vellum:gw:expiresAt")).toBe("2000000000");
+  });
+});
+
+describe("primeLocalGatewayConnectionWithStartupRetry (paired target)", () => {
+  // The startup ride-out exists for the LOCAL gateway's reboot window and only
+  // retries GatewayTokenErrors, which the paired prime never throws. A paired
+  // failure (failed guardian lease, remote transport error) must fall through
+  // promptly to the chooser instead of stalling the 8x1s retry budget on a
+  // machine that waiting cannot fix.
+  test("a failing paired guardian lease is not ridden out: one attempt, prompt rejection", async () => {
+    enableLocalMode();
+    fetchGuardianTokenHost.mockImplementationOnce(async () => {
+      throw new localModeHost.GuardianTokenError(404, "guardian token missing");
+    });
+
+    const start = Date.now();
+    await expect(
+      primeLocalGatewayConnectionWithStartupRetry(pairedEntry),
+    ).rejects.toBeInstanceOf(localModeHost.GuardianTokenError);
+
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(1);
+    expect(Date.now() - start).toBeLessThan(
+      LOCAL_GATEWAY_STARTUP_RETRY.intervalMs,
+    );
+  });
+
+  test("a remote transport failure is not ridden out either", async () => {
+    enableLocalMode();
+    fetchGuardianTokenHost.mockImplementationOnce(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    await expect(
+      primeLocalGatewayConnectionWithStartupRetry(pairedEntry),
+    ).rejects.toThrow("Failed to fetch");
+
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -25,15 +25,19 @@ let mockIsLocalClient = false;
 let mockIsRemoteGatewayMode = false;
 // The assistant `getSelectedAssistant()` resolves; `undefined` means none selected.
 let mockSelectedAssistant: { assistantId: string; cloud: string } | undefined;
+// The entries `getLockfileAssistant(id)` resolves against.
+let mockLockfileAssistants: Array<{ assistantId: string; cloud: string }> = [];
 let mockPlatformAssistants: unknown[] = [];
 let mockPrimeError: Error | null = null;
 let mockGatewayToken: string | null = null;
 const setSelectedAssistantMock = mock(async (_id: string | null) => {});
-const primeLocalGatewayConnectionMock = mock(async () => {
-  if (mockPrimeError) {
-    throw mockPrimeError;
-  }
-});
+const primeLocalGatewayConnectionMock = mock(
+  async (_target?: { assistantId: string; cloud: string }) => {
+    if (mockPrimeError) {
+      throw mockPrimeError;
+    }
+  },
+);
 const primeLocalGatewayConnectionWithStartupRetryMock = mock(async () => {
   if (mockPrimeError) {
     throw mockPrimeError;
@@ -202,6 +206,8 @@ mock.module("@/lib/local-mode", () => ({
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],
   getSelectedAssistant: () => mockSelectedAssistant,
+  getLockfileAssistant: (id: string) =>
+    mockLockfileAssistants.find((a) => a.assistantId === id),
   primeLocalGatewayConnection: primeLocalGatewayConnectionMock,
   primeLocalGatewayConnectionWithStartupRetry:
     primeLocalGatewayConnectionWithStartupRetryMock,
@@ -385,6 +391,7 @@ beforeEach(() => {
   mockIsLocalClient = false;
   mockIsRemoteGatewayMode = false;
   mockSelectedAssistant = undefined;
+  mockLockfileAssistants = [];
   mockPlatformAssistants = [];
   mockIsNativePlatform = false;
   mockIsBiometricEnabled = false;
@@ -1827,6 +1834,184 @@ describe("connectLocalAssistant", () => {
     // A failed connect leaves the previous selection in place.
     expect(setSelectedAssistantMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
+  });
+});
+
+describe("connectPairedAssistant", () => {
+  const pairedEntry = { assistantId: "paired-a", cloud: "paired" };
+
+  test("primes via the host lease BEFORE selecting, then logs in and checks the assistant", async () => {
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [pairedEntry];
+    const order: string[] = [];
+    primeLocalGatewayConnectionMock.mockImplementationOnce(async () => {
+      order.push("prime");
+    });
+    setSelectedAssistantMock.mockImplementationOnce(async (id) => {
+      order.push(`select:${String(id)}`);
+    });
+
+    await useAuthStore.getState().connectPairedAssistant("paired-a");
+
+    expect(order).toEqual(["prime", "select:paired-a"]);
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local");
+    expect(lifecycleCheckAssistantMock).toHaveBeenCalledTimes(1);
+    // No platform assistants and no gateway auth in this arrangement, so the
+    // platform-session status settles directly to "absent".
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("uses the plain prime for the paired target: no wake-repair variant", async () => {
+    // Wake only runs inside primeLocalGatewayConnectionWithRepair, and it
+    // cannot start or repair an assistant on a remote machine, so a paired
+    // connect must stay on the plain prime.
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [pairedEntry];
+
+    await useAuthStore.getState().connectPairedAssistant("paired-a");
+
+    expect(primeLocalGatewayConnectionMock).toHaveBeenCalledTimes(1);
+    expect(primeLocalGatewayConnectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantId: "paired-a", cloud: "paired" }),
+    );
+    expect(primeLocalGatewayConnectionWithRepairMock).not.toHaveBeenCalled();
+    expect(
+      primeLocalGatewayConnectionWithStartupRetryMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("never bootstraps a platform identity, even with a live platform session", async () => {
+    // The bootstrap registers a LOCAL assistant with the platform; a paired
+    // entry is a client-side pairing record, not an assistant to register.
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [pairedEntry];
+    useAuthStore.setState({
+      platformSession: "present",
+      platformSessionRestoredOffline: false,
+    });
+
+    await useAuthStore.getState().connectPairedAssistant("paired-a");
+
+    expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-paired id without priming or selecting", async () => {
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [{ assistantId: "local-a", cloud: "local" }];
+
+    await expect(
+      useAuthStore.getState().connectPairedAssistant("local-a"),
+    ).rejects.toThrow("Not a paired assistant");
+
+    expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
+  });
+
+  test("rejects an unknown id", async () => {
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [pairedEntry];
+
+    await expect(
+      useAuthStore.getState().connectPairedAssistant("missing"),
+    ).rejects.toThrow("Not a paired assistant");
+
+    expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("rethrows the prime failure without selecting or marking the session logged in", async () => {
+    mockIsLocalClient = true;
+    mockLockfileAssistants = [pairedEntry];
+    mockPrimeError = new Error("Guardian token not found");
+
+    await expect(
+      useAuthStore.getState().connectPairedAssistant("paired-a"),
+    ).rejects.toThrow("Guardian token not found");
+
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
+  });
+});
+
+describe("paired selection in the gateway-auth session paths", () => {
+  const pairedSelection = { assistantId: "paired-a", cloud: "paired" };
+
+  test("refreshSession re-primes a paired selection and never fetches the SPA origin's /auth/token", async () => {
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = "seeded-guardian"; // isGatewayAuthMode() === true
+    mockSelectedAssistant = pairedSelection;
+    const fetchedUrls: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchedUrls.push(String(input));
+      throw new Error("unexpected fetch");
+    }) as unknown as typeof fetch;
+    try {
+      await expect(useAuthStore.getState().refreshSession()).resolves.toBe(
+        true,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(primeLocalGatewayConnectionMock).toHaveBeenCalledTimes(1);
+    expect(primeLocalGatewayConnectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantId: "paired-a", cloud: "paired" }),
+    );
+    // The undefined-token-URL fallback would mint at the SPA's own origin and
+    // clear the seeded paired token via the source-mismatch check.
+    expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+    expect(fetchedUrls).toEqual([]);
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("refreshSession ends the session when the paired re-lease fails", async () => {
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = "seeded-guardian";
+    mockSelectedAssistant = pairedSelection;
+    mockPrimeError = new Error("guardian lease failed");
+    useAuthStore.setState({ sessionStatus: "authenticated" });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshSession still mints through the local token URL for a local selection", async () => {
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
+    mockSelectedAssistant = { assistantId: "local-a", cloud: "local" };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(ensureGatewayTokenMock).toHaveBeenCalledTimes(1);
+    expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("boot with a paired selection whose guardian lease fails settles unauthenticated after one prime", async () => {
+    // The startup ride-out only retries GatewayTokenErrors, which the paired
+    // prime never throws; the budget pin for that lives in local-mode.test.ts
+    // ("a failing paired guardian lease is not ridden out"). Here: the boot
+    // path routes the paired selection through the generalized prime once and
+    // falls through promptly to the chooser.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockSelectedAssistant = pairedSelection;
+    mockPrimeError = new Error("guardian lease failed");
+
+    await useAuthStore.getState().initSession();
+
+    expect(
+      primeLocalGatewayConnectionWithStartupRetryMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
   });
 });
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -46,8 +46,12 @@ import { refreshRemoteGatewaySession } from "@/lib/auth/remote-gateway-session";
 import {
   isLocalClient,
   isRemoteGatewayMode,
+  getLockfileAssistant,
   getPlatformAssistants,
   getLocalAssistants,
+  getSelectedAssistant,
+  isPairedAssistant,
+  primeLocalGatewayConnection,
   primeLocalGatewayConnectionWithRepair,
   primeLocalGatewayConnectionWithStartupRetry,
   syncPlatformAssistantsToLockfile,
@@ -151,6 +155,7 @@ interface AuthState {
 interface AuthActions {
   initSession: () => Promise<void>;
   connectLocalAssistant: (assistantId: string) => Promise<void>;
+  connectPairedAssistant: (assistantId: string) => Promise<void>;
   connectPlatformAssistant: (assistantId: string) => Promise<void>;
   refreshSession: () => Promise<boolean>;
   logout: () => Promise<void>;
@@ -751,6 +756,21 @@ function probePlatformSessionIfReachable(
   }
 }
 
+/**
+ * Shared tail of the interactive connect actions, run after the target's
+ * gateway connection is primed: select the assistant, mark the session logged
+ * in, and drive `checkAssistant()` so the active id republishes even when the
+ * selection is unchanged (the selection subscription only fires on a change).
+ */
+async function establishLocalUserSession(
+  set: AuthSet,
+  assistantId: string,
+): Promise<void> {
+  await setSelectedAssistant(assistantId);
+  set(authenticatedLocalUser());
+  await lifecycleService.checkAssistant();
+}
+
 async function hasRemoteGatewaySessionAfterRefresh(): Promise<boolean> {
   try {
     if (await refreshRemoteGatewaySession()) {
@@ -943,9 +963,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       (a) => a.assistantId === assistantId,
     );
     await primeLocalGatewayConnectionWithRepair(target);
-    await setSelectedAssistant(assistantId);
-    set(authenticatedLocalUser());
-    await lifecycleService.checkAssistant();
+    await establishLocalUserSession(set, assistantId);
     if (
       isConfirmedPlatformSession(
         get().platformSession,
@@ -954,6 +972,28 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     ) {
       bootstrapLocalAssistantPlatformIdentity(assistantId);
     }
+    probePlatformSessionIfReachable(set);
+  },
+
+  /**
+   * Connect to a paired assistant: a remote machine's assistant imported via
+   * `vellum connect import`. Primes the connection (leasing the guardian
+   * bearer from the host), selects the assistant, and marks the session
+   * logged in, mirroring {@link AuthActions.connectLocalAssistant} with two
+   * deliberate differences: it primes through the plain
+   * `primeLocalGatewayConnection` because `wake` cannot start or repair an
+   * assistant on a remote machine, and it skips
+   * `bootstrapLocalAssistantPlatformIdentity` because that registers a LOCAL
+   * assistant with the platform while a paired entry is only a client-side
+   * pairing record.
+   */
+  connectPairedAssistant: async (assistantId: string) => {
+    const target = getLockfileAssistant(assistantId);
+    if (!target || !isPairedAssistant(target)) {
+      throw new Error("Not a paired assistant");
+    }
+    await primeLocalGatewayConnection(target);
+    await establishLocalUserSession(set, assistantId);
     probePlatformSessionIfReachable(set);
   },
 
@@ -982,7 +1022,19 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
 
     if (isGatewayAuthMode()) {
       try {
-        await ensureGatewayToken(getLocalTokenUrl());
+        const selected = getSelectedAssistant();
+        if (selected && isPairedAssistant(selected)) {
+          // A paired selection has no local `/auth/token` mint: the guardian
+          // access token leased from the host is the bearer itself, and
+          // `getLocalTokenUrl()` is undefined for it, so `ensureGatewayToken`
+          // would fall back to the SPA origin's own `/auth/token` (wrong
+          // host) and clear the seeded token via the source-mismatch check.
+          // Re-leasing is cheap: the host returns its cached access token
+          // unless a refresh is due.
+          await primeLocalGatewayConnection(selected);
+        } else {
+          await ensureGatewayToken(getLocalTokenUrl());
+        }
         set({ sessionStatus: "authenticated" });
       } catch {
         set(sessionEnded());


### PR DESCRIPTION
## Summary
- connectPairedAssistant: plain prime (no wake repair), select, authenticate, lifecycle check; no platform-identity bootstrap
- refreshSession re-primes paired selections instead of minting at the SPA origin's /auth/token

Part of plan: web-paired-entries.md (PR 4 of 8)