### PR TITLE
fix: diagnose stale ngrok tunnels on other ports and add --clear-domain

### DIFF
--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -360,6 +360,82 @@ describe("tunnel edge targeting", () => {
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });
 
+  test("--clear-domain drops the saved domain and runs domainless", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    const workspaceDir = join(
+      entry.resources!.instanceDir,
+      ".vellum",
+      "workspace",
+    );
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({ ingress: { ngrok: { domain: "dead.ngrok.app" } } }),
+    );
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--clear-domain",
+    ];
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(logs).toContain("Cleared the saved ngrok domain");
+    const config = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    ) as { ingress?: { ngrok?: { domain?: string } } };
+    expect(config.ingress?.ngrok).toBeUndefined();
+    // The run proceeds domainless: no `domain` key reaches runNgrokTunnel.
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("rejects --clear-domain combined with --domain", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--domain",
+      "foo.ngrok.app",
+      "--clear-domain",
+    ];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("--clear-domain cannot be combined with --domain");
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects --clear-domain with a non-ngrok provider", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "cloudflare",
+      "--clear-domain",
+    ];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "--clear-domain is only supported with --provider ngrok",
+    );
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
   test("errors when --domain is missing its value", async () => {
     process.argv = [
       "bun",
@@ -479,10 +555,11 @@ describe("ngrok --domain spawn args", () => {
 
   test("runNgrokTunnel spawns ngrok with --domain and persists the domain", async () => {
     const ws = makeWorkspace({});
-    // The unrelated-port tunnel is listed first both before and after the
-    // spawn; only the tunnel matching the target port and domain may be saved.
+    // The pre-spawn listing is empty (any running tunnel would abort the run);
+    // post-spawn, only the tunnel matching the target port and domain may be
+    // saved even with an unrelated-port tunnel listed first.
     mockNgrokApiFetch([
-      { tunnels: [unrelatedPortTunnel] },
+      { tunnels: [] },
       {
         tunnels: [
           unrelatedPortTunnel,
@@ -652,6 +729,84 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.publicBaseUrl).toBeUndefined();
     // …and the reserved domain stays saved as standing intent.
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+
+  test("maybeStartNgrokTunnel skips when an existing agent tunnels a different port", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+    });
+    // A stale pre-upgrade agent still tunnels the raw gateway port; the edge
+    // port (18080) has no tunnel.
+    mockTunnelListFetch("https://stale.ngrok-free.app", "localhost:7830");
+
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
+      (...a: unknown[]) => {
+        warnings.push(a.join(" "));
+      },
+    );
+
+    let child: unknown;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(child).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+    const combined = warnings.join("\n");
+    expect(combined).toContain("different local port");
+    expect(combined).toContain(
+      "https://stale.ngrok-free.app -> localhost:7830",
+    );
+    expect(combined).toContain("not 18080");
+    expect(combined).toContain("vellum tunnel --provider ngrok");
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress?: { publicBaseUrl?: string } };
+    expect(config.ingress?.publicBaseUrl).toBeUndefined();
+  });
+
+  test("runNgrokTunnel fails loudly when an existing agent tunnels a different port", async () => {
+    const ws = makeWorkspace({});
+    mockTunnelListFetch("https://stale.ngrok-free.app", "localhost:7830");
+
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    try {
+      await expect(
+        realNgrok.runNgrokTunnel({ port: 18080, workspaceDir: ws }),
+      ).rejects.toThrow("exit:1");
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    const combined = errors.join("\n");
+    expect(combined).toContain("different local port");
+    expect(combined).toContain(
+      "https://stale.ngrok-free.app -> localhost:7830",
+    );
+    expect(combined).toContain("not 18080");
+    expect(combined).toContain("Stop the existing ngrok agent");
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress?: { publicBaseUrl?: string } };
+    expect(config.ingress?.publicBaseUrl).toBeUndefined();
   });
 
   test("maybeStartNgrokTunnel passes the saved domain to the spawn args", async () => {

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -3,7 +3,10 @@ import { join } from "path";
 import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
-import { getDefaultWorkspaceDir } from "../lib/ingress-config.js";
+import {
+  getDefaultWorkspaceDir,
+  saveNgrokDomain,
+} from "../lib/ingress-config.js";
 import { ensureTunnelEdge, formatEdgeMode } from "../lib/nginx-ingress.js";
 import { runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
@@ -18,6 +21,7 @@ interface TunnelArgs {
   assistantName: string | null;
   provider: TunnelProvider;
   domain: string | null;
+  clearDomain: boolean;
 }
 
 function parseArgs(): TunnelArgs {
@@ -25,6 +29,7 @@ function parseArgs(): TunnelArgs {
   let assistantName: string | null = null;
   let provider: TunnelProvider = DEFAULT_PROVIDER;
   let domain: string | null = null;
+  let clearDomain = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -63,6 +68,12 @@ function parseArgs(): TunnelArgs {
       console.log(
         "                                Saved to the workspace config so `vellum wake` restores reuse it.",
       );
+      console.log(
+        "  --clear-domain                Clear the saved ngrok domain (ngrok provider only) and tunnel",
+      );
+      console.log(
+        "                                without one. Cannot be combined with --domain.",
+      );
       console.log("");
       console.log("Providers:");
       console.log(
@@ -90,6 +101,7 @@ function parseArgs(): TunnelArgs {
       console.log(
         "  $ vellum tunnel --provider ngrok --domain my-assistant.ngrok.app",
       );
+      console.log("  $ vellum tunnel --provider ngrok --clear-domain");
       console.log("  $ vellum tunnel --provider cloudflare");
       console.log("  $ vellum tunnel my-assistant --provider tailscale");
       process.exit(0);
@@ -122,6 +134,8 @@ function parseArgs(): TunnelArgs {
       }
       domain = next;
       i++;
+    } else if (arg === "--clear-domain") {
+      clearDomain = true;
     } else if (arg.startsWith("-")) {
       console.error(`Error: Unknown option '${arg}'.`);
       process.exit(1);
@@ -140,7 +154,21 @@ function parseArgs(): TunnelArgs {
     process.exit(1);
   }
 
-  return { assistantName, provider, domain };
+  if (clearDomain && provider !== "ngrok") {
+    console.error(
+      `Error: --clear-domain is only supported with --provider ngrok (got '${provider}').`,
+    );
+    process.exit(1);
+  }
+
+  if (clearDomain && domain) {
+    console.error(
+      "Error: --clear-domain cannot be combined with --domain. Pass --domain alone to replace the saved domain.",
+    );
+    process.exit(1);
+  }
+
+  return { assistantName, provider, domain, clearDomain };
 }
 
 function parsePortFromUrl(url: unknown): number | undefined {
@@ -165,7 +193,7 @@ function resolveEntryGatewayPort(entry: AssistantEntry): number {
 }
 
 export async function tunnel(): Promise<void> {
-  const { assistantName, provider, domain } = parseArgs();
+  const { assistantName, provider, domain, clearDomain } = parseArgs();
 
   const entry = resolveAssistant(assistantName ?? undefined);
 
@@ -196,6 +224,11 @@ export async function tunnel(): Promise<void> {
   const workspaceDir = resources
     ? join(resources.instanceDir, ".vellum", "workspace")
     : getDefaultWorkspaceDir();
+
+  if (clearDomain) {
+    saveNgrokDomain(workspaceDir, null);
+    console.log("Cleared the saved ngrok domain from the workspace config.");
+  }
 
   let edge: Awaited<ReturnType<typeof ensureTunnelEdge>>;
   try {

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -87,16 +87,16 @@ function pickMatchingTunnel(
   return matches.find((t) => t.public_url)?.public_url ?? null;
 }
 
-/**
- * Find an existing ngrok tunnel that targets the given local address.
- * Returns the HTTPS public URL if found, null otherwise.
- */
-export async function findExistingTunnel(
-  targetPort: number,
-): Promise<string | null> {
-  const tunnels = await queryNgrokTunnels();
-  if (!tunnels || tunnels.length === 0) return null;
-  return pickMatchingTunnel(tunnels, targetPort);
+/** Render listed tunnels as `url -> addr` pairs for mismatch diagnostics. */
+function describeTunnels(tunnels: NgrokTunnel[]): string {
+  return tunnels
+    .map((t) => `${t.public_url} -> ${t.config?.addr ?? "unknown target"}`)
+    .join(", ");
+}
+
+/** Recovery copy for a saved domain whose reservation may have lapsed. */
+function savedDomainRecoveryHint(domain: string): string {
+  return `The saved ngrok domain '${domain}' (ingress.ngrok.domain in the workspace config) may no longer be reserved. Run \`vellum tunnel --provider ngrok --clear-domain\` to drop it and tunnel without one.`;
 }
 
 /** Whether a tunnel public URL's host equals the given reserved domain. */
@@ -243,7 +243,8 @@ export async function maybeStartNgrokTunnel(
   const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
 
   // Reuse an existing tunnel if one is already running
-  const existingUrl = await findExistingTunnel(targetPort);
+  const runningTunnels = (await queryNgrokTunnels()) ?? [];
+  const existingUrl = pickMatchingTunnel(runningTunnels, targetPort);
   if (existingUrl) {
     if (savedDomain && !urlMatchesDomain(existingUrl, savedDomain)) {
       // Spawning a second agent would collide (ERR_NGROK_334), and saving the
@@ -256,6 +257,15 @@ export async function maybeStartNgrokTunnel(
     }
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl);
+    return null;
+  }
+  if (runningTunnels.length > 0) {
+    // An agent is up but tunnels some other local port (likely started before
+    // the edge unification, or by an external process). Spawning a second
+    // agent would collide (ERR_NGROK_334) on single-agent plans, so skip.
+    console.warn(
+      `   ⚠ An ngrok agent is already running but tunnels a different local port (${describeTunnels(runningTunnels)}), not ${targetPort}. It was likely started before the tunnel edge unification or by an external process. Stop that ngrok agent, then run \`vellum tunnel --provider ngrok\` to tunnel the local edge.`,
+    );
     return null;
   }
 
@@ -281,6 +291,9 @@ export async function maybeStartNgrokTunnel(
     console.warn(
       `   ⚠ Could not start ngrok tunnel. Webhook integrations may not work until you run \`vellum tunnel\`.`,
     );
+    if (savedDomain) {
+      console.warn(`   ⚠ ${savedDomainRecoveryHint(savedDomain)}`);
+    }
     if (!ngrokProcess.killed) ngrokProcess.kill("SIGTERM");
     return null;
   }
@@ -334,8 +347,20 @@ export async function runNgrokTunnel(
     console.log(`Using saved ngrok domain: ${domain}`);
   }
 
-  // Check for an existing ngrok tunnel pointing at the gateway
-  const existingUrl = await findExistingTunnel(port);
+  // Check for an existing ngrok tunnel pointing at the local edge
+  const runningTunnels = (await queryNgrokTunnels()) ?? [];
+  const existingUrl = pickMatchingTunnel(runningTunnels, port);
+  if (!existingUrl && runningTunnels.length > 0) {
+    // Spawning a second agent would collide (ERR_NGROK_334) on single-agent
+    // plans; fail loudly instead, matching the domain-mismatch path.
+    console.error(
+      `Error: an ngrok agent is already running but tunnels a different local port (${describeTunnels(runningTunnels)}), not ${port}. It was likely started before the tunnel edge unification or by an external process.`,
+    );
+    console.error(
+      "Stop the existing ngrok agent first, then re-run this command to tunnel the local edge.",
+    );
+    process.exit(1);
+  }
   if (existingUrl) {
     if (domain && !urlMatchesDomain(existingUrl, domain)) {
       console.error(
@@ -419,6 +444,9 @@ export async function runNgrokTunnel(
     publicUrl = await waitForNgrokUrl(port, domain);
   } catch (err) {
     cleanup();
+    if (domain && !opts.domain) {
+      console.error(savedDomainRecoveryHint(domain));
+    }
     throw err;
   }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tunnel-edge-unify.md.

**Gap:** stale pre-upgrade ngrok agents targeting the gateway port caused silent spawn collisions and left the direct-gateway URL published; saved reserved domains had no clearing path.
**Fix:** port-mismatched existing tunnels now warn and skip (wake) or fail loudly (tunnel) instead of colliding; vellum tunnel --clear-domain drops the saved domain and failure copy names the recovery.