### PR TITLE
fix: working tunnel guidance, recorded-state status output, already-running port contract

### DIFF
--- a/cli/src/__tests__/nginx-ingress-command.test.ts
+++ b/cli/src/__tests__/nginx-ingress-command.test.ts
@@ -19,10 +19,14 @@ const realNginxIngressLib = { ...nginxIngressLib };
 const ensureTunnelEdgeMock = mock<typeof nginxIngressLib.ensureTunnelEdge>(
   async () => ({ port: 7840, started: true, includesWebApp: true }),
 );
+const getIngressPidMock = mock<typeof nginxIngressLib.getIngressPid>(
+  () => null,
+);
 
 mock.module("../lib/nginx-ingress.js", () => ({
   ...nginxIngressLib,
   ensureTunnelEdge: ensureTunnelEdgeMock,
+  getIngressPid: getIngressPidMock,
 }));
 
 // Restore the real module once this file finishes so the mock does not leak
@@ -31,7 +35,11 @@ afterAll(() => {
   mock.module("../lib/nginx-ingress.js", () => realNginxIngressLib);
 });
 
-import { resolveNginxIngressTarget, up } from "../commands/nginx-ingress.js";
+import {
+  resolveNginxIngressTarget,
+  status,
+  up,
+} from "../commands/nginx-ingress.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-nginx-ingress-command-test-"));
@@ -134,7 +142,7 @@ describe("up", () => {
     const output = logs.join("\n");
     expect(output).toContain("http://127.0.0.1:7845 (webhooks only)");
     expect(output).toContain("web-remote-ingress");
-    expect(output).toContain("vellum tunnel");
+    expect(output).toContain("vellum tunnel --provider ngrok");
   });
 
   test("states the remote web mode when the flag is on", async () => {
@@ -153,5 +161,69 @@ describe("up", () => {
     const output = logs.join("\n");
     expect(output).toContain("http://127.0.0.1:7840 (remote web + webhooks)");
     expect(output).not.toContain("Enable the web-remote-ingress feature flag");
+  });
+});
+
+describe("status", () => {
+  const statusWorkspace = join(testDir, "status-workspace");
+  let logs: string[];
+  let logSpy: ReturnType<typeof spyOn<typeof console, "log">>;
+
+  beforeEach(() => {
+    getIngressPidMock.mockReset();
+    getIngressPidMock.mockReturnValue(4242);
+    logs = [];
+    logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(statusWorkspace, { recursive: true, force: true });
+  });
+
+  function writeIngressState(nginx: Record<string, unknown>): void {
+    mkdirSync(statusWorkspace, { recursive: true });
+    writeFileSync(
+      join(statusWorkspace, "config.json"),
+      JSON.stringify({ ingress: { nginx } }) + "\n",
+    );
+  }
+
+  test("prints the recorded gateway upstream, not the requested one", async () => {
+    writeIngressState({
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7900,
+    });
+
+    await status({ workspaceDir: statusWorkspace, gatewayPort: 7830 });
+
+    const output = logs.join("\n");
+    expect(output).toContain("nginx ingress: running");
+    expect(output).toContain("Listen:  http://127.0.0.1:7845");
+    expect(output).toContain("Gateway: http://127.0.0.1:7900");
+    expect(output).not.toContain("http://127.0.0.1:7830");
+    expect(output).not.toContain("(unverified)");
+    expect(output).toContain("Mode:    webhooks only");
+  });
+
+  test("marks the requested gateway port unverified when the record predates the field", async () => {
+    writeIngressState({ listenPort: 7845 });
+
+    await status({ workspaceDir: statusWorkspace, gatewayPort: 7830 });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Gateway: http://127.0.0.1:7830 (unverified)");
+    expect(output).toContain("Mode:    remote web + webhooks");
+  });
+
+  test("reports a stopped edge", async () => {
+    getIngressPidMock.mockReturnValue(null);
+
+    await status({ workspaceDir: statusWorkspace, gatewayPort: 7830 });
+
+    expect(logs.join("\n")).toContain("nginx ingress: not running");
   });
 });

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -686,12 +686,17 @@ describe("startRemoteWebIngress", () => {
       includeWebApp: false,
     });
 
-    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
     expect(edge.killed()).toBe(false);
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  test("short-circuits when the recorded gateway port matches the request", async () => {
+  test("already-running carries the recorded listen port over the requested one", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
@@ -705,12 +710,45 @@ describe("startRemoteWebIngress", () => {
     const result = await startRemoteWebIngress({
       workspaceDir: ws,
       gatewayPort: 7830,
+      listenPort: 7999,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
+    expect(edge.killed()).toBe(false);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("a failed restart reports the recorded mode and gateway port", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+    const pid = mockRunningEdge(ws, {
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7900,
+    });
+    mockUnkillableNginx(pid);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
       listenPort: 7845,
       includeWebApp: false,
     });
 
-    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
-    expect(edge.killed()).toBe(false);
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7900,
+    });
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -799,7 +837,12 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
     });
 
-    expect(result).toEqual({ status: "already-running", listenPort: 7845 });
+    expect(result).toEqual({
+      status: "already-running",
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+    });
     expect(edge.killed()).toBe(false);
     expect(spawnMock).not.toHaveBeenCalled();
   });

--- a/cli/src/commands/nginx-ingress.ts
+++ b/cli/src/commands/nginx-ingress.ts
@@ -20,6 +20,7 @@ import {
   isIngressRunning,
   readIngressState,
   stopIngressNginx,
+  type TunnelEdge,
 } from "../lib/nginx-ingress.js";
 
 function printHelp(): void {
@@ -138,7 +139,7 @@ export function resolveNginxIngressTarget(
 export async function up(target: NginxIngressTarget): Promise<void> {
   const { workspaceDir, gatewayPort } = target;
 
-  let edge: Awaited<ReturnType<typeof ensureTunnelEdge>>;
+  let edge: TunnelEdge;
   try {
     edge = await ensureTunnelEdge({
       assistantId: target.assistantId,
@@ -175,7 +176,10 @@ export async function up(target: NginxIngressTarget): Promise<void> {
   console.log("");
   console.log("Next steps:");
   console.log(
-    "  vellum tunnel                    # put an HTTPS front on this edge",
+    "  vellum tunnel --provider ngrok   # put an HTTPS front on this edge",
+  );
+  console.log(
+    "                                   # (cloudflare and tailscale work too)",
   );
   console.log("  vellum nginx-ingress down        # stop the edge");
 }
@@ -191,7 +195,7 @@ async function down(target: NginxIngressTarget): Promise<void> {
   );
 }
 
-async function status(target: NginxIngressTarget): Promise<void> {
+export async function status(target: NginxIngressTarget): Promise<void> {
   const { workspaceDir, gatewayPort } = target;
   const { confPath, logPath } = getIngressPaths(workspaceDir);
   const pid = getIngressPid(workspaceDir);
@@ -201,12 +205,18 @@ async function status(target: NginxIngressTarget): Promise<void> {
   }
   const state = readIngressState(workspaceDir);
   const listenPort = state?.listenPort ?? getNginxIngressPort();
-  const mode = formatEdgeMode(state?.includeWebApp !== false);
+  const mode = formatEdgeMode(state?.includeWebApp ?? true);
+  // The recorded gateway port is what the running edge proxies; a record
+  // predating the field cannot be verified.
+  const gatewayLine =
+    state?.gatewayPort !== undefined
+      ? `http://127.0.0.1:${state.gatewayPort}`
+      : `http://127.0.0.1:${gatewayPort} (unverified)`;
   console.log("nginx ingress: running");
   console.log(`  PID:     ${pid}`);
   console.log(`  Mode:    ${mode}`);
   console.log(`  Listen:  http://127.0.0.1:${listenPort}`);
-  console.log(`  Gateway: http://127.0.0.1:${gatewayPort}`);
+  console.log(`  Gateway: ${gatewayLine}`);
   console.log(`  Config:  ${confPath}`);
   console.log(`  Log:     ${logPath}`);
 }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -4,7 +4,11 @@ import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
 import { getDefaultWorkspaceDir } from "../lib/ingress-config.js";
-import { ensureTunnelEdge, formatEdgeMode } from "../lib/nginx-ingress.js";
+import {
+  ensureTunnelEdge,
+  formatEdgeMode,
+  type TunnelEdge,
+} from "../lib/nginx-ingress.js";
 import { runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
@@ -180,11 +184,7 @@ export async function tunnel(): Promise<void> {
     process.exit(1);
   }
 
-  if (
-    provider !== "ngrok" &&
-    provider !== "cloudflare" &&
-    provider !== "tailscale"
-  ) {
+  if (provider === "vellum") {
     throw new Error(
       `Tunnel provider '${provider}' is not yet implemented. ` +
         `If this provider is documented, ${STALE_CLI_UPDATE_HINT}`,
@@ -197,7 +197,7 @@ export async function tunnel(): Promise<void> {
     ? join(resources.instanceDir, ".vellum", "workspace")
     : getDefaultWorkspaceDir();
 
-  let edge: Awaited<ReturnType<typeof ensureTunnelEdge>>;
+  let edge: TunnelEdge;
   try {
     edge = await ensureTunnelEdge({
       assistantId: entry.assistantId,

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -124,8 +124,7 @@ function gatewayProxyBlock(gatewayPort: number): string {
  * Sensitive local-only routes the edge must never expose to the internet,
  * regardless of whether the SPA is being served.
  */
-function denylistLocations(): string {
-  return `    location = /auth/token { return 404; }
+const DENYLIST_LOCATIONS = `    location = /auth/token { return 404; }
     location = /auth/token/ { return 404; }
     location = /v1/pair { return 404; }
     location = /v1/pair/ { return 404; }
@@ -143,7 +142,6 @@ function denylistLocations(): string {
     location = /v1/remote-web/pairing-verification/ { return 404; }
     location ^~ /assistant/__local/ { return 404; }
     location ^~ /assistant/__gateway/ { return 404; }`;
-}
 
 export interface RemoteWebIngressOptions {
   webDistDir: string;
@@ -197,7 +195,7 @@ export function buildIngressNginxConfig(opts: {
         indexHtmlPath: remoteWebIngress.indexHtmlPath,
         config: remoteWebIngressConfig(remoteWebIngress.config),
       })
-    : `${denylistLocations()}
+    : `${DENYLIST_LOCATIONS}
 
     location / {
 ${proxyBlock}
@@ -266,7 +264,7 @@ function buildRemoteWebIngressLocations(opts: {
     opts.indexHtmlPath ?? join(opts.webDistDir, "index.html");
   const configJson = JSON.stringify(opts.config);
 
-  return `${denylistLocations()}
+  return `${DENYLIST_LOCATIONS}
 
     location = /healthz {
 ${proxyBlock}
@@ -414,7 +412,10 @@ export function isIngressRunning(workspaceDir: string): boolean {
 
 export interface IngressState {
   listenPort: number;
-  /** Edge mode: SPA + proxy (true) or webhooks-only proxy (false). */
+  /**
+   * Edge mode: SPA + proxy (true) or webhooks-only proxy (false). A persisted
+   * record without this field represents an SPA edge.
+   */
   includeWebApp: boolean;
   /**
    * Gateway port the edge's proxy_pass targets. Undefined in state records
@@ -432,7 +433,6 @@ export function readIngressState(workspaceDir: string): IngressState | null {
   const listenPort = nginx?.listenPort;
   if (typeof listenPort !== "number") return null;
   const gatewayPort = nginx?.gatewayPort;
-  // A state record without includeWebApp represents an SPA edge.
   return {
     listenPort,
     includeWebApp: nginx?.includeWebApp !== false,
@@ -601,7 +601,15 @@ export type StartRemoteWebIngressResult =
       webDistDir: string | null;
       version: string;
     }
-  | { status: "already-running"; listenPort: number }
+  | {
+      status: "already-running";
+      /** Recorded listen port of the running edge (requested port when no state is recorded). */
+      listenPort: number;
+      /** Recorded edge mode; a running edge without a state record reports the SPA default. */
+      includeWebApp: boolean;
+      /** Recorded gateway upstream; undefined when the record predates the field. */
+      gatewayPort?: number;
+    }
   | { status: "nginx-missing" }
   | { status: "web-dist-missing" }
   | { status: "unreachable"; listenPort: number; logPath: string };
@@ -654,16 +662,23 @@ export async function startRemoteWebIngress(opts: {
   }
 
   const running = isIngressRunning(opts.workspaceDir);
-  if (running) {
-    const state = readIngressState(opts.workspaceDir);
-    const recordedMode = state?.includeWebApp ?? true;
-    // An unknown recorded gateway port is unverified (see IngressState).
-    if (
-      recordedMode === includeWebApp &&
-      state?.gatewayPort === opts.gatewayPort
-    ) {
-      return { status: "already-running", listenPort };
-    }
+  const recorded = running ? readIngressState(opts.workspaceDir) : null;
+  const recordedMode = recorded?.includeWebApp ?? true;
+  const alreadyRunning = (): StartRemoteWebIngressResult => ({
+    status: "already-running",
+    listenPort: recorded?.listenPort ?? listenPort,
+    includeWebApp: recordedMode,
+    ...(recorded?.gatewayPort !== undefined
+      ? { gatewayPort: recorded.gatewayPort }
+      : {}),
+  });
+  // An unknown recorded gateway port is unverified (see IngressState).
+  if (
+    running &&
+    recordedMode === includeWebApp &&
+    recorded?.gatewayPort === opts.gatewayPort
+  ) {
+    return alreadyRunning();
   }
 
   let webDistDir: string | null = null;
@@ -683,7 +698,7 @@ export async function startRemoteWebIngress(opts: {
     !(await stopIngressNginx(opts.workspaceDir)) &&
     isIngressRunning(opts.workspaceDir)
   ) {
-    return { status: "already-running", listenPort };
+    return alreadyRunning();
   }
 
   opts.onStarting?.({ version, webDistDir, listenPort });
@@ -728,7 +743,7 @@ async function resolveEdgeIncludesWebApp(
     );
   } catch (err) {
     throw new Error(
-      `Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` feature flag before starting the tunnel. Is the assistant running? Try \`vellum wake\` and retry. ${
+      `Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` feature flag before starting the edge. Is the assistant running? Try \`vellum wake\` and retry. ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
@@ -738,6 +753,15 @@ async function resolveEdgeIncludesWebApp(
 /** User-facing label for the edge mode, shared by every edge status line. */
 export function formatEdgeMode(includesWebApp: boolean): string {
   return includesWebApp ? "remote web + webhooks" : "webhooks only";
+}
+
+/** Resolved edge a tunnel (or bring-your-own HTTPS front) should target. */
+export interface TunnelEdge {
+  /** Loopback listen port the HTTPS front should forward to. */
+  port: number;
+  /** True when this call started the edge, false when a running one was reused. */
+  started: boolean;
+  includesWebApp: boolean;
 }
 
 /**
@@ -765,7 +789,7 @@ export async function ensureTunnelEdge(opts: {
     webDistDir: string | null;
     listenPort: number;
   }) => void;
-}): Promise<{ port: number; started: boolean; includesWebApp: boolean }> {
+}): Promise<TunnelEdge> {
   const includeWebApp = opts.assistantId
     ? await resolveEdgeIncludesWebApp(opts.assistantId, opts.gatewayPort)
     : false;
@@ -786,23 +810,19 @@ export async function ensureTunnelEdge(opts: {
       };
     case "already-running": {
       // `already-running` also covers a drifted edge whose restart failed, so
-      // trust the recorded state over the requested config. A state record
-      // without includeWebApp represents an SPA edge; one without a gateway
-      // port is unverified (see IngressState).
-      const state = readIngressState(opts.workspaceDir);
-      const recordedIncludesWebApp = state?.includeWebApp ?? true;
-      if (recordedIncludesWebApp !== includeWebApp) {
+      // trust the recorded state it carries over the requested config.
+      if (result.includeWebApp !== includeWebApp) {
         const describe = (spa: boolean) => (spa ? "web app" : "webhooks-only");
         throw new Error(
-          `The nginx edge is still running in ${describe(recordedIncludesWebApp)} mode ` +
+          `The nginx edge is still running in ${describe(result.includeWebApp)} mode ` +
             `and could not be restarted in ${describe(includeWebApp)} mode. ` +
             "Run `vellum nginx-ingress down` and retry.",
         );
       }
-      if (state?.gatewayPort !== opts.gatewayPort) {
+      if (result.gatewayPort !== opts.gatewayPort) {
         const upstream =
-          state?.gatewayPort !== undefined
-            ? `still proxying gateway port ${state.gatewayPort}`
+          result.gatewayPort !== undefined
+            ? `still proxying gateway port ${result.gatewayPort}`
             : "proxying an unknown gateway port";
         throw new Error(
           `The nginx edge is ${upstream} ` +
@@ -810,12 +830,10 @@ export async function ensureTunnelEdge(opts: {
             "Run `vellum nginx-ingress down` and retry.",
         );
       }
-      // The reused edge's recorded listen port is the target; the result's
-      // listenPort is only the port this call would have requested.
       return {
-        port: state?.listenPort ?? result.listenPort,
+        port: result.listenPort,
         started: false,
-        includesWebApp: recordedIncludesWebApp,
+        includesWebApp: result.includeWebApp,
       };
     }
     case "nginx-missing":

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -202,8 +202,8 @@ vellum tunnel --provider ngrok --domain my-assistant.ngrok.app
 
 The domain is saved to the workspace config. `vellum wake` restores the
 tunnel automatically only when a messaging channel like Telegram or Twilio is
-configured; otherwise rerun `vellum tunnel` after a restart and the saved
-domain is reused.
+configured; otherwise rerun `vellum tunnel --provider ngrok` after a restart
+and the saved domain is reused.
 
 **Privacy trade-off:** these publish a public-internet URL, so anyone who
 learns the URL can reach your assistant's sign-in and pairing page (pairing


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tunnel-edge-unify.md.

**Gap:** guidance copy recommended bare vellum tunnel (always errors); status printed the requested rather than recorded gateway upstream; already-running leaked the requested listen port forcing a compensating state re-read; assorted slop nits.
**Fix:** copy names --provider ngrok; status reads recorded state with an unverified fallback; already-running carries recorded port+mode; nits cleaned.