### PR TITLE
Mint onboarding side conversations as background (LUM-3011)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6796,9 +6796,15 @@ paths:
                     `id`.
                   type: string
                 conversationType:
-                  description: Only standard conversations are created by this endpoint
+                  description:
+                    Conversation type for the new row. "background" keeps it out of the foreground list and the sidebar's
+                    Recents grouping, used by internal side-channel flows (onboarding research, persona/identity
+                    rewrites) that mint a throwaway thread the user should never see. "scheduled" is not accepted here;
+                    scheduled rows are owned by the schedule pipeline.
                   type: string
-                  const: standard
+                  enum:
+                    - standard
+                    - background
                 title:
                   description:
                     Explicit title for the conversation. When provided on creation, it is persisted as a user-set title (never

--- a/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
@@ -3,8 +3,8 @@
  * bookkeeper: the first standard conversation is the onboarding one (keep
  * BOOTSTRAP.md), and the second means onboarding is over (delete it).
  *
- * Onboarding also mints internal side threads — research, personality rewrite,
- * identity rewrite — as `conversationType: "background"` rows that the user
+ * Onboarding also mints internal side threads (research, personality rewrite,
+ * identity rewrite) as `conversationType: "background"` rows that the user
  * never opens. Those must be completely inert with respect to this bookkeeping:
  * if a hidden side thread consumed the first-conversation slot, the user's
  * FIRST visible chat would look like the second conversation and lose
@@ -14,6 +14,8 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
+
+import { assertNotLiveDb } from "./assert-not-live-db.js";
 
 const testDir = process.env.VELLUM_WORKSPACE_DIR!;
 const conversationsDir = join(testDir, "conversations");
@@ -45,6 +47,7 @@ beforeEach(() => {
   db.delete(conversationKeys).run();
   db.delete(conversations).run();
 
+  assertNotLiveDb(conversationsDir);
   rmSync(conversationsDir, { recursive: true, force: true });
   mkdirSync(conversationsDir, { recursive: true });
 

--- a/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-bootstrap-cleanup.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `getOrCreateConversation` doubles as the first-conversation bootstrap
+ * bookkeeper: the first standard conversation is the onboarding one (keep
+ * BOOTSTRAP.md), and the second means onboarding is over (delete it).
+ *
+ * Onboarding also mints internal side threads — research, personality rewrite,
+ * identity rewrite — as `conversationType: "background"` rows that the user
+ * never opens. Those must be completely inert with respect to this bookkeeping:
+ * if a hidden side thread consumed the first-conversation slot, the user's
+ * FIRST visible chat would look like the second conversation and lose
+ * BOOTSTRAP.md before its opening turn.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const testDir = process.env.VELLUM_WORKSPACE_DIR!;
+const conversationsDir = join(testDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+import {
+  _resetFirstConversationSeenForTesting,
+  getOrCreateConversation,
+} from "../persistence/conversation-key-store.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  conversationKeys,
+  conversations,
+} from "../persistence/schema/index.js";
+
+await initializeDb();
+
+const bootstrapPath = join(testDir, "BOOTSTRAP.md");
+const bootstrapReferencePath = join(testDir, "BOOTSTRAP-REFERENCE.md");
+
+function seedBootstrapFiles(): void {
+  writeFileSync(bootstrapPath, "# First run\n", "utf-8");
+  writeFileSync(bootstrapReferencePath, "# Reference\n", "utf-8");
+}
+
+beforeEach(() => {
+  const db = getDb();
+  db.delete(conversationKeys).run();
+  db.delete(conversations).run();
+
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+
+  // `firstConversationSeen` is module-level (process-global) state, so each
+  // test has to replay the fresh-install sequence from a known-clean flag.
+  _resetFirstConversationSeenForTesting();
+  seedBootstrapFiles();
+});
+
+describe("getOrCreateConversation bootstrap bookkeeping", () => {
+  test("background side threads do not consume the first-conversation slot", () => {
+    // The exact onboarding sequence: three hidden side threads, then the
+    // user's first real chat.
+    for (const key of ["onboarding-research", "personality", "identity"]) {
+      const created = getOrCreateConversation(key, {
+        conversationType: "background",
+      });
+      expect(created.created).toBe(true);
+      expect(created.conversationType).toBe("background");
+      expect(existsSync(bootstrapPath)).toBe(true);
+    }
+
+    const firstVisible = getOrCreateConversation("user-first-chat");
+    expect(firstVisible.created).toBe(true);
+    expect(firstVisible.conversationType).toBe("standard");
+
+    // The user's first visible chat is still the FIRST conversation as far as
+    // onboarding is concerned, so its first-run context survives.
+    expect(existsSync(bootstrapPath)).toBe(true);
+    expect(existsSync(bootstrapReferencePath)).toBe(true);
+  });
+
+  test("a background create after the first standard one is still inert", () => {
+    getOrCreateConversation("user-first-chat");
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    getOrCreateConversation("side-thread", { conversationType: "background" });
+    expect(existsSync(bootstrapPath)).toBe(true);
+    expect(existsSync(bootstrapReferencePath)).toBe(true);
+  });
+
+  test("the second standard conversation still deletes the bootstrap files", () => {
+    getOrCreateConversation("first-chat");
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    getOrCreateConversation("second-chat");
+    expect(existsSync(bootstrapPath)).toBe(false);
+    expect(existsSync(bootstrapReferencePath)).toBe(false);
+  });
+
+  test("background creates interleaved with standard ones do not shift the slot", () => {
+    getOrCreateConversation("bg-a", { conversationType: "background" });
+    getOrCreateConversation("first-chat");
+    getOrCreateConversation("bg-b", { conversationType: "background" });
+    expect(existsSync(bootstrapPath)).toBe(true);
+
+    // Only the second STANDARD conversation ends onboarding.
+    getOrCreateConversation("second-chat");
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
+  test("resolving an existing key never re-runs the bookkeeping", () => {
+    const first = getOrCreateConversation("first-chat");
+    const again = getOrCreateConversation("first-chat");
+    expect(again.created).toBe(false);
+    expect(again.conversationId).toBe(first.conversationId);
+    expect(existsSync(bootstrapPath)).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1542,6 +1542,55 @@ describe("ensurePromptFiles", () => {
     expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
+  /** Project a conversation onto disk the way `initConversationDir` does. */
+  function writeConversationDir(id: string, type: string): void {
+    const dir = join(
+      TEST_DIR,
+      "conversations",
+      `2026-01-01T00-00-00.000Z_${id}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "meta.json"), JSON.stringify({ id, type }));
+  }
+
+  test("keeps BOOTSTRAP.md when the only conversations are background side threads", () => {
+    // Onboarding mints throwaway background threads (research, personality and
+    // identity rewrites) before the user's first visible chat, and each gets a
+    // disk-view directory.  A daemon restart in that window must not read them
+    // as evidence that onboarding ended.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeConversationDir("bg-002", "background");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("auto-deletes stale BOOTSTRAP.md when a standard conversation sits alongside background ones", () => {
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeConversationDir("std-001", "standard");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
+  });
+
+  test("seeds BOOTSTRAP.md on a fresh workspace whose only conversations are background", () => {
+    // Background side threads must not make a fresh workspace look like an
+    // upgraded one, or onboarding never gets its bootstrap file at all.
+    writeConversationDir("bg-001", "background");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
   test("keeps BOOTSTRAP.md when no conversations exist yet", () => {
     // Non-first-run but no conversations — user hasn't chatted yet
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -1518,10 +1518,7 @@ describe("ensurePromptFiles", () => {
     writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
     writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
 
-    // Create a conversations directory with at least one entry
-    const convDir = join(TEST_DIR, "conversations");
-    mkdirSync(convDir, { recursive: true });
-    writeFileSync(join(convDir, "conv-001.json"), "{}");
+    writeConversationDir("conv-001", "standard");
 
     ensurePromptFiles();
 
@@ -1533,9 +1530,7 @@ describe("ensurePromptFiles", () => {
     // will be re-seeded from templates) but still carries prior
     // conversations.  Existing conversation history signals a non-fresh
     // install, so onboarding must not re-trigger.
-    const convDir = join(TEST_DIR, "conversations");
-    mkdirSync(convDir, { recursive: true });
-    writeFileSync(join(convDir, "conv-001.json"), "{}");
+    writeConversationDir("conv-001", "standard");
 
     ensurePromptFiles();
 
@@ -1567,6 +1562,37 @@ describe("ensurePromptFiles", () => {
     ensurePromptFiles();
 
     expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("keeps BOOTSTRAP.md when a stray file sits beside background side threads", () => {
+    // The disk view is browsable, so a file explorer can drop `.DS_Store` into
+    // the conversations directory.  It is not a conversation and must not be
+    // classified as one.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Bootstrap");
+    writeConversationDir("bg-001", "background");
+    writeFileSync(join(TEST_DIR, "conversations", ".DS_Store"), "junk");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("auto-deletes stale BOOTSTRAP.md when a conversation directory has no meta.json", () => {
+    // A directory the daemon cannot classify counts as standard: it is far
+    // likelier to be legacy history than a side thread, and over-counting only
+    // suppresses an onboarding re-run.
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
+    mkdirSync(join(TEST_DIR, "conversations", "2026-01-01T00-00-00.000Z_old"), {
+      recursive: true,
+    });
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
   });
 
   test("auto-deletes stale BOOTSTRAP.md when a standard conversation sits alongside background ones", () => {

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -20,8 +20,19 @@ import { conversationKeys, conversations } from "./schema/index.js";
 
 const log = getLogger("conversation-key-store");
 
-/** Set after the first conversation is created so BOOTSTRAP.md is deleted on the second. */
+/**
+ * Set after the first *standard* conversation is created so BOOTSTRAP.md is
+ * deleted on the second. Background/scheduled creates never touch it.
+ */
 let firstConversationSeen = false;
+
+/**
+ * Test-only reset of the process-global first-conversation flag, so a test file
+ * can replay the "fresh install" sequence more than once.
+ */
+export function _resetFirstConversationSeenForTesting(): void {
+  firstConversationSeen = false;
+}
 
 export interface ConversationKeyMapping {
   id: string;
@@ -142,7 +153,7 @@ export function resolveConversationId(idOrKey: string): string | null {
 export function getOrCreateConversation(
   conversationKey: string,
   opts?: {
-    conversationType?: "standard";
+    conversationType?: "standard" | "background";
     /**
      * Caller-supplied title for the conversation, used only when this call
      * actually creates the row. Treated as a user-set title (`isAutoTitle = 0`)
@@ -209,14 +220,26 @@ export function getOrCreateConversation(
       };
     }
 
-    // Delete BOOTSTRAP.md when a non-first conversation is created.
-    // The first conversation is the onboarding one; keep BOOTSTRAP.md
-    // for its entire duration. Any subsequent conversation means
+    // Delete BOOTSTRAP.md when a non-first *standard* conversation is created.
+    // The first standard conversation is the onboarding one; keep BOOTSTRAP.md
+    // for its entire duration. Any subsequent standard conversation means
     // onboarding is over.
-    if (firstConversationSeen) {
-      cleanupBootstrapFiles("new conversation created after onboarding");
+    //
+    // Background/scheduled rows are skipped entirely — they are internal side
+    // channels (onboarding research, personality/identity rewrites, heartbeat
+    // and scheduled runs) that the user never opens, so they are neither the
+    // onboarding conversation nor evidence that onboarding ended. Being inert
+    // here is what stops a hidden side thread minted before the user's first
+    // visible chat from consuming the first-conversation slot and deleting
+    // BOOTSTRAP.md out from under that chat's first turn. The type is read from
+    // the same `conversationType` the insert below persists, so the guard
+    // cannot drift from the stored row.
+    if (conversationType === "standard") {
+      if (firstConversationSeen) {
+        cleanupBootstrapFiles("new conversation created after onboarding");
+      }
+      firstConversationSeen = true;
     }
-    firstConversationSeen = true;
 
     const now = Date.now();
     const conversationId = uuid();

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -15,6 +15,7 @@ import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { getLogger } from "../util/logger.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
+import type { NonScheduledConversationType } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { conversationKeys, conversations } from "./schema/index.js";
 
@@ -22,7 +23,7 @@ const log = getLogger("conversation-key-store");
 
 /**
  * Set after the first *standard* conversation is created so BOOTSTRAP.md is
- * deleted on the second. Background/scheduled creates never touch it.
+ * deleted on the second. Background creates never touch it.
  */
 let firstConversationSeen = false;
 
@@ -153,7 +154,7 @@ export function resolveConversationId(idOrKey: string): string | null {
 export function getOrCreateConversation(
   conversationKey: string,
   opts?: {
-    conversationType?: "standard" | "background";
+    conversationType?: NonScheduledConversationType;
     /**
      * Caller-supplied title for the conversation, used only when this call
      * actually creates the row. Treated as a user-set title (`isAutoTitle = 0`)
@@ -220,20 +221,10 @@ export function getOrCreateConversation(
       };
     }
 
-    // Delete BOOTSTRAP.md when a non-first *standard* conversation is created.
-    // The first standard conversation is the onboarding one; keep BOOTSTRAP.md
-    // for its entire duration. Any subsequent standard conversation means
-    // onboarding is over.
-    //
-    // Background/scheduled rows are skipped entirely — they are internal side
-    // channels (onboarding research, personality/identity rewrites, heartbeat
-    // and scheduled runs) that the user never opens, so they are neither the
-    // onboarding conversation nor evidence that onboarding ended. Being inert
-    // here is what stops a hidden side thread minted before the user's first
-    // visible chat from consuming the first-conversation slot and deleting
-    // BOOTSTRAP.md out from under that chat's first turn. The type is read from
-    // the same `conversationType` the insert below persists, so the guard
-    // cannot drift from the stored row.
+    // The first standard conversation is the onboarding one, so BOOTSTRAP.md
+    // survives its whole duration and any later standard create means
+    // onboarding is over. Background rows stay inert: a hidden side thread
+    // minted before the user's first visible chat must not consume that slot.
     if (conversationType === "standard") {
       if (firstConversationSeen) {
         cleanupBootstrapFiles("new conversation created after onboarding");

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -25,6 +25,15 @@ export type ConversationCreateType = "standard" | "background" | "scheduled";
 export type ConversationType = ConversationCreateType;
 
 /**
+ * Conversation types minted outside the schedule pipeline. Scheduled rows are
+ * owned by it and created through `createConversation`.
+ */
+export type NonScheduledConversationType = Exclude<
+  ConversationCreateType,
+  "scheduled"
+>;
+
+/**
  * Conversation types created by background machinery (heartbeat runs,
  * scheduled runs, retrospective forks) rather than by a person. Exported as a
  * list so SQL filters (e.g. `notInArray`) share the same set as the predicate

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -48,13 +48,52 @@ function hasPopulatedUsersDir(): boolean {
   }
 }
 
-function hasExistingConversations(): boolean {
+/**
+ * Conversation types that are internal side channels rather than threads the
+ * user opens: onboarding research, personality/identity rewrites, heartbeat
+ * and scheduled runs, plus legacy private rows.
+ */
+const HIDDEN_CONVERSATION_TYPES = new Set([
+  "background",
+  "scheduled",
+  "private",
+]);
+
+/**
+ * Whether the workspace carries at least one standard (user-visible)
+ * conversation.
+ *
+ * Classifies each disk-view directory by the `type` in its `meta.json` rather
+ * than counting raw directory entries, because hidden side threads get a
+ * disk-view directory too and must not be mistaken for the user's own history.
+ * The type read here is the same value `countConversations("standard")` filters
+ * on, but the answer comes off disk rather than out of the database:
+ * `ensurePromptFiles()` runs before `initializeDb()` settles in
+ * `daemon/lifecycle.ts`, so a query here would hit a partially-migrated schema.
+ *
+ * An entry whose `meta.json` is missing or unreadable counts as standard: a
+ * directory the daemon cannot classify is far more likely to be legacy history
+ * than a side thread, and over-counting only keeps onboarding from re-running.
+ */
+function hasStandardConversations(): boolean {
   try {
     const convDir = getConversationsDir();
     if (!existsSync(convDir)) {
       return false;
     }
-    return readdirSync(convDir).length > 0;
+    return readdirSync(convDir).some((entry) => {
+      try {
+        const meta = JSON.parse(
+          readFileSync(join(convDir, entry, "meta.json"), "utf-8"),
+        ) as { type?: unknown };
+        return (
+          typeof meta.type !== "string" ||
+          !HIDDEN_CONVERSATION_TYPES.has(meta.type)
+        );
+      } catch {
+        return true;
+      }
+    });
   } catch {
     return false;
   }
@@ -78,14 +117,14 @@ export function ensurePromptFiles(): void {
 
   // Track whether this is a fresh workspace.  A workspace counts as fresh
   // only when none of these signals are present: core prompt files, a
-  // populated `users/` directory, or existing conversations.  Upgraded
-  // workspaces that dropped USER.md but still carry personas or history
-  // would otherwise be mistaken for fresh installs and re-trigger
+  // populated `users/` directory, or existing standard conversations.
+  // Upgraded workspaces that dropped USER.md but still carry personas or
+  // history would otherwise be mistaken for fresh installs and re-trigger
   // onboarding.
   const isFirstRun =
     PROMPT_FILES.every((file) => !existsSync(getWorkspacePromptPath(file))) &&
     !hasPopulatedUsersDir() &&
-    !hasExistingConversations();
+    !hasStandardConversations();
 
   for (const file of PROMPT_FILES) {
     const dest = getWorkspacePromptPath(file);
@@ -152,18 +191,20 @@ export function ensurePromptFiles(): void {
   // Auto-delete stale BOOTSTRAP.md at startup.  The model is instructed to
   // delete it at the end of the first conversation, but if the user closes
   // the app or starts a new thread before the model gets another turn, it
-  // never gets the chance.  If BOOTSTRAP.md still exists but prior
-  // conversations are present, the onboarding window has passed — clean up.
+  // never gets the chance.  If BOOTSTRAP.md still exists but prior standard
+  // conversations are present, the onboarding window has passed, so clean up.
+  //
+  // Only standard conversations count, matching the in-process gate in
+  // `persistence/conversation-key-store.ts`.  Onboarding mints hidden side
+  // threads before the user's first visible chat, so counting those would
+  // delete BOOTSTRAP.md out from under that chat on the next daemon restart.
   const bootstrapCleanup = getWorkspacePromptPath("BOOTSTRAP.md");
-  if (!isFirstRun && existsSync(bootstrapCleanup)) {
-    const convDir = getConversationsDir();
-    try {
-      if (existsSync(convDir) && readdirSync(convDir).length > 0) {
-        cleanupBootstrapFiles("prior conversations exist");
-      }
-    } catch (err) {
-      log.warn({ err }, "Failed to auto-delete stale BOOTSTRAP.md");
-    }
+  if (
+    !isFirstRun &&
+    existsSync(bootstrapCleanup) &&
+    hasStandardConversations()
+  ) {
+    cleanupBootstrapFiles("prior conversations exist");
   }
 
   // Seed HEARTBEAT.md — always created if missing so the heartbeat service

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -71,7 +71,13 @@ const HIDDEN_CONVERSATION_TYPES = new Set([
  * `ensurePromptFiles()` runs before `initializeDb()` settles in
  * `daemon/lifecycle.ts`, so a query here would hit a partially-migrated schema.
  *
- * An entry whose `meta.json` is missing or unreadable counts as standard: a
+ * Only directories are classified. The layout is browsable, so stray files such
+ * as `.DS_Store` sit beside the conversations, and a `meta.json` read under one
+ * fails indistinguishably from an unreadable conversation. Directory names are
+ * not filtered further, because both the canonical `<ISO>_<id>` layout and the
+ * legacy `<id>_<ISO>` one name real conversations.
+ *
+ * A directory whose `meta.json` is missing or unreadable counts as standard: a
  * directory the daemon cannot classify is far more likely to be legacy history
  * than a side thread, and over-counting only keeps onboarding from re-running.
  */
@@ -81,10 +87,13 @@ function hasStandardConversations(): boolean {
     if (!existsSync(convDir)) {
       return false;
     }
-    return readdirSync(convDir).some((entry) => {
+    return readdirSync(convDir, { withFileTypes: true }).some((entry) => {
+      if (!entry.isDirectory()) {
+        return false;
+      }
       try {
         const meta = JSON.parse(
-          readFileSync(join(convDir, entry, "meta.json"), "utf-8"),
+          readFileSync(join(convDir, entry.name, "meta.json"), "utf-8"),
         ) as { type?: unknown };
         return (
           typeof meta.type !== "string" ||
@@ -194,10 +203,15 @@ export function ensurePromptFiles(): void {
   // never gets the chance.  If BOOTSTRAP.md still exists but prior standard
   // conversations are present, the onboarding window has passed, so clean up.
   //
-  // Only standard conversations count, matching the in-process gate in
-  // `persistence/conversation-key-store.ts`.  Onboarding mints hidden side
-  // threads before the user's first visible chat, so counting those would
-  // delete BOOTSTRAP.md out from under that chat on the next daemon restart.
+  // Only standard conversations count.  Onboarding mints hidden side threads
+  // before the user's first visible chat, so counting those would delete
+  // BOOTSTRAP.md out from under that chat on the next daemon restart.
+  //
+  // This gate is one conversation stricter than the in-process gate in
+  // `persistence/conversation-key-store.ts`, which keeps BOOTSTRAP.md through
+  // the whole first standard conversation and deletes it when a second one is
+  // created.  A restart while the user is still inside that first conversation
+  // deletes BOOTSTRAP.md from under it.
   const bootstrapCleanup = getWorkspacePromptPath("BOOTSTRAP.md");
   if (
     !isFirstRun &&

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -25,7 +25,6 @@ import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { conversations } from "../../../persistence/schema/index.js";
-import { ROUTES as CONVERSATION_LIST_ROUTES } from "../conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "../inference-profile-session-routes.js";
 import type { RouteDefinition } from "../types.js";
@@ -61,10 +60,6 @@ function findHandler(routes: RouteDefinition[], operationId: string) {
 const createHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "createConversation",
-);
-const listHandlerForConversations = findHandler(
-  CONVERSATION_LIST_ROUTES,
-  "listConversations",
 );
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
@@ -121,15 +116,6 @@ describe("POST /v1/conversations (createConversation)", () => {
       .from(conversations)
       .where(eq(conversations.id, id))
       .get();
-  }
-
-  async function listConversationIds(
-    queryParams: Record<string, string>,
-  ): Promise<string[]> {
-    const result = (await listHandlerForConversations({ queryParams })) as {
-      conversations: Array<{ id: string }>;
-    };
-    return result.conversations.map((c) => c.id);
   }
 
   test("with a title → persists it as a user-set title (isAutoTitle = 0)", async () => {
@@ -191,28 +177,6 @@ describe("POST /v1/conversations (createConversation)", () => {
     // An explicit title stays user-set on a background row too.
     expect(row?.title).toBe("Updating personality");
     expect(row?.isAutoTitle).toBe(0);
-  });
-
-  test("a background row is absent from the foreground list and present under conversationType=background", async () => {
-    const background = (await createHandler({
-      body: { conversationType: "background", title: "Updating personality" },
-    })) as { id: string };
-    const foreground = (await createHandler({
-      body: { title: "Visible thread" },
-    })) as { id: string };
-
-    // This is the invariant the onboarding side-thread flows rest on: a
-    // background row can never be landed on or enter Recents, no matter how
-    // the retroactive archive races.
-    const foregroundIds = await listConversationIds({});
-    expect(foregroundIds).toContain(foreground.id);
-    expect(foregroundIds).not.toContain(background.id);
-
-    const backgroundIds = await listConversationIds({
-      conversationType: "background",
-    });
-    expect(backgroundIds).toContain(background.id);
-    expect(backgroundIds).not.toContain(foreground.id);
   });
 
   test("omitted conversationType still creates a standard row", async () => {

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -224,6 +224,15 @@ describe("POST /v1/conversations (createConversation)", () => {
     expect(readConversation(result.id)?.conversationType).toBe("standard");
   });
 
+  test("explicit conversationType: null behaves exactly like an omitted one", async () => {
+    const result = (await createHandler({
+      body: { conversationType: null, title: "Visible thread" },
+    })) as { id: string; conversationType: string };
+
+    expect(result.conversationType).toBe("standard");
+    expect(readConversation(result.id)?.conversationType).toBe("standard");
+  });
+
   test.each(["scheduled", "nonsense"])(
     "conversationType: %p → BadRequestError, no row created",
     (conversationType) => {

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -25,6 +25,7 @@ import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { conversations } from "../../../persistence/schema/index.js";
+import { ROUTES as CONVERSATION_LIST_ROUTES } from "../conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../conversation-management-routes.js";
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "../inference-profile-session-routes.js";
 import type { RouteDefinition } from "../types.js";
@@ -60,6 +61,10 @@ function findHandler(routes: RouteDefinition[], operationId: string) {
 const createHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "createConversation",
+);
+const listHandlerForConversations = findHandler(
+  CONVERSATION_LIST_ROUTES,
+  "listConversations",
 );
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
@@ -111,10 +116,20 @@ describe("POST /v1/conversations (createConversation)", () => {
       .select({
         title: conversations.title,
         isAutoTitle: conversations.isAutoTitle,
+        conversationType: conversations.conversationType,
       })
       .from(conversations)
       .where(eq(conversations.id, id))
       .get();
+  }
+
+  async function listConversationIds(
+    queryParams: Record<string, string>,
+  ): Promise<string[]> {
+    const result = (await listHandlerForConversations({ queryParams })) as {
+      conversations: Array<{ id: string }>;
+    };
+    return result.conversations.map((c) => c.id);
   }
 
   test("with a title → persists it as a user-set title (isAutoTitle = 0)", async () => {
@@ -160,6 +175,64 @@ describe("POST /v1/conversations (createConversation)", () => {
     ).toThrow(/title must be a string/);
     expect(getDb().select().from(conversations).all()).toHaveLength(0);
   });
+
+  test("conversationType: background → persists a background row and echoes it back", async () => {
+    const result = (await createHandler({
+      body: {
+        conversationType: "background",
+        title: "Updating personality",
+      },
+    })) as { id: string; conversationType: string; created: boolean };
+
+    expect(result.created).toBe(true);
+    expect(result.conversationType).toBe("background");
+    const row = readConversation(result.id);
+    expect(row?.conversationType).toBe("background");
+    // An explicit title stays user-set on a background row too.
+    expect(row?.title).toBe("Updating personality");
+    expect(row?.isAutoTitle).toBe(0);
+  });
+
+  test("a background row is absent from the foreground list and present under conversationType=background", async () => {
+    const background = (await createHandler({
+      body: { conversationType: "background", title: "Updating personality" },
+    })) as { id: string };
+    const foreground = (await createHandler({
+      body: { title: "Visible thread" },
+    })) as { id: string };
+
+    // This is the invariant the onboarding side-thread flows rest on: a
+    // background row can never be landed on or enter Recents, no matter how
+    // the retroactive archive races.
+    const foregroundIds = await listConversationIds({});
+    expect(foregroundIds).toContain(foreground.id);
+    expect(foregroundIds).not.toContain(background.id);
+
+    const backgroundIds = await listConversationIds({
+      conversationType: "background",
+    });
+    expect(backgroundIds).toContain(background.id);
+    expect(backgroundIds).not.toContain(foreground.id);
+  });
+
+  test("omitted conversationType still creates a standard row", async () => {
+    const result = (await createHandler({
+      body: { title: "Visible thread" },
+    })) as { id: string; conversationType: string };
+
+    expect(result.conversationType).toBe("standard");
+    expect(readConversation(result.id)?.conversationType).toBe("standard");
+  });
+
+  test.each(["scheduled", "nonsense"])(
+    "conversationType: %p → BadRequestError, no row created",
+    (conversationType) => {
+      expect(() => createHandler({ body: { conversationType } })).toThrow(
+        /conversationType must be one of standard, background/,
+      );
+      expect(getDb().select().from(conversations).all()).toHaveLength(0);
+    },
+  );
 });
 
 describe("PUT /v1/conversations/:id/inference-profile", () => {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -63,6 +63,7 @@ import {
   resolveConversationId,
   setConversationKeyIfAbsent,
 } from "../../persistence/conversation-key-store.js";
+import type { NonScheduledConversationType } from "../../persistence/conversation-types.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
@@ -100,11 +101,11 @@ const log = getLogger("conversation-management-routes");
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Conversation types this endpoint may mint. Deliberately narrower than
- * `ConversationType`: scheduled rows are owned by the schedule pipeline.
- */
-const createConversationTypeSchema = z.enum(["standard", "background"]);
+/** Conversation types this endpoint may mint. */
+const createConversationTypeSchema = z.enum([
+  "standard",
+  "background",
+] as const satisfies readonly NonScheduledConversationType[]);
 
 function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
@@ -135,8 +136,10 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   // Zod requestBody (it's codegen-only), so guard the types here: a malformed
   // `{ title: 123 }` would otherwise throw on `.trim()` and 500, and an
   // unsupported conversationType would reach the store unchecked.
+  // `.nullish()`: an explicit JSON `null` is how serializers spell an absent
+  // optional, so it means the same thing as omitting the key.
   const requestedType = createConversationTypeSchema
-    .optional()
+    .nullish()
     .safeParse(body.conversationType);
   if (!requestedType.success) {
     throw new BadRequestError(
@@ -167,11 +170,14 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
       headers?.["x-vellum-client-id"]?.trim() || undefined,
     );
   }
+  // On a conversationKey hit the row already exists, so the type it carries
+  // can differ from the requested one.
+  const storedType = normalizeConversationType(result.conversationType);
   log.info(
     {
       conversationId: result.conversationId,
       conversationKey,
-      conversationType,
+      conversationType: storedType,
       created: result.created,
     },
     "Created conversation via POST",
@@ -179,7 +185,7 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   return {
     id: result.conversationId,
     conversationKey,
-    conversationType: normalizeConversationType(result.conversationType),
+    conversationType: storedType,
     created: result.created,
   };
 }

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -100,6 +100,12 @@ const log = getLogger("conversation-management-routes");
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Conversation types this endpoint may mint. Deliberately narrower than
+ * `ConversationType`: scheduled rows are owned by the schedule pipeline.
+ */
+const createConversationTypeSchema = z.enum(["standard", "background"]);
+
 function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
   if (!id) {
@@ -126,14 +132,24 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   const conversationKey =
     (body.conversationKey as string | undefined) ?? crypto.randomUUID();
   // The shared route adapter does not runtime-validate the body against the
-  // Zod requestBody (it's codegen-only), so guard the type before trimming —
-  // a malformed `{ title: 123 }` would otherwise throw on `.trim()` and 500.
+  // Zod requestBody (it's codegen-only), so guard the types here: a malformed
+  // `{ title: 123 }` would otherwise throw on `.trim()` and 500, and an
+  // unsupported conversationType would reach the store unchecked.
+  const requestedType = createConversationTypeSchema
+    .optional()
+    .safeParse(body.conversationType);
+  if (!requestedType.success) {
+    throw new BadRequestError(
+      `conversationType must be one of ${createConversationTypeSchema.options.join(", ")}`,
+    );
+  }
   if (body.title !== undefined && typeof body.title !== "string") {
     throw new BadRequestError("title must be a string");
   }
   const customTitle = body.title?.trim() || undefined;
+  const conversationType = requestedType.data ?? "standard";
   const result = getOrCreateConversation(conversationKey, {
-    conversationType: "standard",
+    conversationType,
   });
   if (result.created) {
     // A caller-supplied title is user-set: persist it with isAutoTitle = 0 so
@@ -155,6 +171,7 @@ function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
     {
       conversationId: result.conversationId,
       conversationKey,
+      conversationType,
       created: result.created,
     },
     "Created conversation via POST",
@@ -863,10 +880,11 @@ export const ROUTES: RouteDefinition[] = [
         .describe(
           "Optional external key. Echoed back in the response. Non-vellum channels (Telegram, WhatsApp) use this to scope to a logical channel thread; vellum-web clients can omit it and rely on the assistant-minted `id`.",
         ),
-      conversationType: z
-        .literal("standard")
+      conversationType: createConversationTypeSchema
         .optional()
-        .describe("Only standard conversations are created by this endpoint"),
+        .describe(
+          'Conversation type for the new row. "background" keeps it out of the foreground list and the sidebar\'s Recents grouping, used by internal side-channel flows (onboarding research, persona/identity rewrites) that mint a throwaway thread the user should never see. "scheduled" is not accepted here; scheduled rows are owned by the schedule pipeline.',
+        ),
       title: z
         .string()
         .optional()

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -1,6 +1,7 @@
 /**
- * Pins the shape of the identity-rewrite send: it goes out hidden (see
- * `lib/side-conversation-message.ts`) and the side conversation is archived.
+ * Pins the shape of the identity-rewrite send: the side conversation is minted
+ * `background`, the prompt goes out hidden (see
+ * `lib/side-conversation-message.ts`), and the thread is archived.
  *
  * NOTE: `bun mock.module` can leak across files. Run this file singly:
  *   bun test src/domains/intelligence/identity-actions/run-identity-rewrite.test.ts
@@ -15,6 +16,12 @@ interface PostCall {
   body: { conversationId: string; content: string; hidden?: boolean };
 }
 
+interface CreateCall {
+  path: { assistant_id: string };
+  body: { conversationType?: string; title?: string };
+}
+
+let createCalls: CreateCall[] = [];
 let postCalls: PostCall[] = [];
 let archiveCalls: Array<{ path: { assistant_id: string; id: string } }> = [];
 
@@ -23,7 +30,10 @@ const ok = <T>(data: T) =>
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
-  conversationsPost: () => ok({ id: "conv-1" }),
+  conversationsPost: (opts: CreateCall) => {
+    createCalls.push(opts);
+    return ok({ id: "conv-1" });
+  },
   messagesPost: (opts: PostCall) => {
     postCalls.push(opts);
     return ok({});
@@ -47,17 +57,25 @@ mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
 const { runIdentityRewrite } = await import("./run-identity-rewrite");
 
 afterEach(() => {
+  createCalls = [];
   postCalls = [];
   archiveCalls = [];
 });
 
 describe("runIdentityRewrite", () => {
-  test("posts the rewrite prompt hidden and archives the side conversation", async () => {
+  test("mints a background thread, posts the prompt hidden, and archives it", async () => {
     await runIdentityRewrite({
       assistantId: "ast-1",
       content: "<system-message>rewrite</system-message>",
       title: "Updating personality",
       context: "test",
+    });
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]?.path).toEqual({ assistant_id: "ast-1" });
+    expect(createCalls[0]?.body).toEqual({
+      conversationType: "background",
+      title: "Updating personality",
     });
 
     expect(postCalls).toHaveLength(1);

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -78,9 +78,9 @@ export async function runIdentityRewrite({
       return false;
     }
 
-    // Let the rewrite turn run before hiding the thread — archiving mid-turn
-    // could drop the identity edits. Settle on the daemon's turn-completion
-    // flag (see `shouldSettlePersonalityPoll`).
+    // Let the rewrite turn run before the archive: archiving mid-turn could
+    // drop the identity edits. Settle on the daemon's turn-completion flag
+    // (see `shouldSettlePersonalityPoll`).
     const deadline = Date.now() + MAX_POLL_MS;
     let lastText = "";
     let stableReads = 0;
@@ -115,7 +115,7 @@ export async function runIdentityRewrite({
   } catch (err) {
     captureError(err, { context });
   } finally {
-    // Archive the throwaway thread so it never appears in the sidebar.
+    // Best-effort cleanup of the throwaway thread.
     if (conversationId) {
       try {
         await conversationsByIdArchivePost({

--- a/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/run-identity-rewrite.ts
@@ -3,10 +3,13 @@
  *
  * The About Assistant surfaces reshape the assistant's persona the same way
  * research onboarding does: post a system-message that asks the assistant to
- * rewrite its own identity files (IDENTITY.md / SOUL.md), wait for the turn
- * to settle, then archive the conversation so it never shows in the user's
- * sidebar. The identity files feed every future conversation's system
+ * rewrite its own identity files (IDENTITY.md / SOUL.md) and wait for the
+ * turn to settle. The identity files feed every future conversation's system
  * prompt, which is what makes this durable.
+ *
+ * The thread is minted `background`, a type the daemon keeps out of its
+ * default `standard` conversation list, so it never appears in Recents and is
+ * never selectable as the landing conversation.
  *
  * Unlike onboarding's fire-and-forget `applyPersonality`, callers here drive
  * visible UI (a saving state and a success/failure toast), so this resolves
@@ -36,7 +39,7 @@ export interface RunIdentityRewriteOptions {
   assistantId: string;
   /** The full `<system-message>…</system-message>` content to post. */
   content: string;
-  /** Sidebar-invisible conversation title (useful in logs/inspector). */
+  /** Conversation title, surfaced only in logs/inspector. */
   title: string;
   /** Sentry context tag for failures. */
   context: string;
@@ -53,7 +56,7 @@ export async function runIdentityRewrite({
   try {
     const conversation = await conversationsPost({
       path: { assistant_id: assistantId },
-      body: { conversationType: "standard", title },
+      body: { conversationType: "background", title },
       throwOnError: false,
     });
     conversationId = conversation.data?.id;

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -7,15 +7,18 @@
  * message-builder tests stay free of module mocks.
  *
  * Also pins that the rewrite send goes out hidden (see
- * `lib/side-conversation-message.ts`).
+ * `lib/side-conversation-message.ts`) and that the throwaway thread is minted
+ * `background`, which is what keeps it out of the conversation list.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const conversationsPostMock = mock(async () => ({
-  data: { id: "conv-1" },
-  response: { ok: true },
-}));
+const conversationsPostMock = mock(
+  async (_opts: { body: { conversationType?: string } }) => ({
+    data: { id: "conv-1" },
+    response: { ok: true },
+  }),
+);
 const messagesPostMock = mock(
   async (_opts: { body: { hidden?: boolean } }) => ({
     response: { ok: true },
@@ -58,6 +61,26 @@ beforeEach(() => {
   conversationsPostMock.mockClear();
   messagesPostMock.mockClear();
   saveSlidersMock.mockClear();
+});
+
+describe("applyPersonality side conversation", () => {
+  test("mints the throwaway thread as background even when the archive fails", async () => {
+    // The thread's only renderable content is the assistant's first-person
+    // self-description (the prompt posts hidden), so the `background` mint is
+    // what keeps it out of the user's view. Failing the archive here pins that
+    // the hiding comes from the mint alone.
+    archivePostMock.mockRejectedValueOnce(new Error("archive failed"));
+
+    await applyPersonality({
+      awaitAssistantId: async () => "ast-1",
+      values: {},
+    });
+
+    expect(conversationsPostMock.mock.calls[0]?.[0].body).toMatchObject({
+      conversationType: "background",
+      title: "Updating personality",
+    });
+  });
 });
 
 describe("applyPersonality rewrite prompt", () => {

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -60,17 +60,16 @@ const { applyPersonality } = await import("./apply-personality");
 beforeEach(() => {
   conversationsPostMock.mockClear();
   messagesPostMock.mockClear();
+  archivePostMock.mockClear();
   saveSlidersMock.mockClear();
 });
 
-describe("applyPersonality side conversation", () => {
-  test("mints the throwaway thread as background even when the archive fails", async () => {
+describe("applyPersonality rewrite prompt", () => {
+  test("mints a background thread and posts the rewrite prompt as a hidden machine signal", async () => {
     // The thread's only renderable content is the assistant's first-person
     // self-description (the prompt posts hidden), so the `background` mint is
-    // what keeps it out of the user's view. Failing the archive here pins that
-    // the hiding comes from the mint alone.
-    archivePostMock.mockRejectedValueOnce(new Error("archive failed"));
-
+    // what keeps it out of the user's view. See
+    // `lib/side-conversation-message.ts` for why the prompt posts hidden.
     await applyPersonality({
       awaitAssistantId: async () => "ast-1",
       values: {},
@@ -80,17 +79,6 @@ describe("applyPersonality side conversation", () => {
       conversationType: "background",
       title: "Updating personality",
     });
-  });
-});
-
-describe("applyPersonality rewrite prompt", () => {
-  test("posts the rewrite prompt as a hidden machine signal", async () => {
-    // See `lib/side-conversation-message.ts` for why this posts hidden.
-    await applyPersonality({
-      awaitAssistantId: async () => "ast-1",
-      values: {},
-    });
-
     expect(messagesPostMock.mock.calls[0]?.[0].body.hidden).toBe(true);
   });
 });

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -13,9 +13,14 @@
  * Like the research turn (`research-runner.ts`) and the check-in
  * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
  * conversation: we await hatch readiness, mint a conversation, post the prompt,
- * let the rewrite turn settle, then archive it so it never shows in the user's
- * sidebar. Talks to the daemon through the generated SDK directly
- * (`@/domains/chat/api/*` is import-banned from onboarding).
+ * and let the rewrite turn settle. Talks to the daemon through the generated
+ * SDK directly (`@/domains/chat/api/*` is import-banned from onboarding).
+ *
+ * The thread is minted `conversationType: "background"`, which keeps it out of
+ * the daemon's default `standard` conversation list: it never enters Recents
+ * and is never selectable as the landing conversation. The prompt posts hidden,
+ * so the thread's only renderable content is the assistant's reply. The archive
+ * below is best-effort cleanup.
  *
  * Best-effort and fire-and-forget: a failure here must never block or surface
  * in the onboarding flow. Every error is swallowed (reported to Sentry).
@@ -83,7 +88,7 @@ export async function applyPersonality({
 
     const conversation = await conversationsPost({
       path: { assistant_id: assistantId },
-      body: { conversationType: "standard", title: "Updating personality" },
+      body: { conversationType: "background", title: "Updating personality" },
       throwOnError: false,
     });
     conversationId = conversation.data?.id;
@@ -148,7 +153,8 @@ export async function applyPersonality({
   } catch (err) {
     captureError(err, { context: "research_onboarding_personality" });
   } finally {
-    // Archive the throwaway thread so it never appears in the sidebar.
+    // Best-effort cleanup of the throwaway thread. The `background` mint (see
+    // the module header) is what keeps it hidden, not this call.
     if (assistantId && conversationId) {
       try {
         await conversationsByIdArchivePost({

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -115,8 +115,8 @@ export async function applyPersonality({
     // rewrite alone would lose them. Best-effort, like the rest of the flow.
     await savePersonalitySliders(assistantId, completeSliderValues(values));
 
-    // Let the rewrite turn run before hiding the thread — archiving mid-turn
-    // could drop the identity edits, and the chat handoff awaits this promise
+    // Let the rewrite turn run before the archive: archiving mid-turn could
+    // drop the identity edits, and the chat handoff awaits this promise
     // so the first greeting must not start until the identity files are
     // written. Settle on the daemon's turn-completion flag (see
     // `shouldSettlePersonalityPoll`).

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -10,11 +10,11 @@
  * and settle logic, shared with the About Assistant personality page). The
  * user's profile (users/guardian.md) is left untouched.
  *
- * Like the research turn (`research-runner.ts`) and the check-in
- * (`checkin-scheduler.ts`), this runs on a dedicated throwaway side
- * conversation: we await hatch readiness, mint a conversation, post the prompt,
- * and let the rewrite turn settle. Talks to the daemon through the generated
- * SDK directly (`@/domains/chat/api/*` is import-banned from onboarding).
+ * Like the research turn (`research-runner.ts`), this runs on a dedicated
+ * throwaway side conversation: we await hatch readiness, mint a conversation,
+ * post the prompt, and let the rewrite turn settle. Talks to the daemon through
+ * the generated SDK directly (`@/domains/chat/api/*` is import-banned from
+ * onboarding).
  *
  * The thread is minted `conversationType: "background"`, which keeps it out of
  * the daemon's default `standard` conversation list: it never enters Recents

--- a/clients/web/src/domains/onboarding/archive-research-conversation.ts
+++ b/clients/web/src/domains/onboarding/archive-research-conversation.ts
@@ -4,23 +4,21 @@
  *
  * That conversation is a throwaway side channel: it exists only to drive the
  * research prompt whose claims/suggestions the in-flow result steps render. It
- * must never surface in the user's chat sidebar when they land in their
- * workspace, so once the research response has settled we archive it — the
- * sidebar's `group-conversations.ts` drops `archivedAt != null` rows, so an
- * archived conversation simply disappears from the list.
+ * is minted `background`, which the daemon keeps out of the default `standard`
+ * conversation list, so the sidebar never shows it. Archiving is cleanup on top
+ * of that: it also drops the row from the lazily-loaded Background section.
  *
- * Best-effort: this runs after the response is delivered, so a failure here
- * must never block or surface in the flow. Every error is swallowed (reported
- * to Sentry) and never rethrown, mirroring `checkin-scheduler.ts`.
+ * Best-effort: a failure here must never block or surface in the flow. Every
+ * error is swallowed (reported to Sentry) and never rethrown, mirroring
+ * `checkin-scheduler.ts`.
  */
 
 import { conversationsByIdArchivePost } from "@/generated/daemon/sdk.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 
 /**
- * Archive the research-onboarding side conversation so it never appears in the
- * chat sidebar. Best-effort and fire-and-forget: resolves regardless of outcome
- * and never throws.
+ * Archive the research-onboarding side conversation. Best-effort and
+ * fire-and-forget: resolves regardless of outcome and never throws.
  */
 export async function archiveResearchConversation(
   assistantId: string,

--- a/clients/web/src/domains/onboarding/established-assistant.ts
+++ b/clients/web/src/domains/onboarding/established-assistant.ts
@@ -4,11 +4,11 @@
  * can offer an explicit off-ramp instead of silently re-onboarding (and
  * rewriting the persona of) an assistant the user already customized.
  *
- * Conversation history is the establishment signal: a fresh hatch has none,
- * and the flow's own side conversations (research, personality) are archived
- * once they settle, so they don't count against a genuinely-new user who
- * abandoned a prior attempt. The identity name is fetched only for the guard
- * screen's copy and is best-effort.
+ * Conversation history is the establishment signal: a fresh hatch has none. The
+ * flow's own side conversations (research, personality) are minted `background`
+ * and `hasAnyActiveConversation` reads the foreground bucket, so they never
+ * count against a genuinely-new user who abandoned a prior attempt. The identity
+ * name is fetched only for the guard screen's copy and is best-effort.
  *
  * Fail-open: a genuine fetch failure treats the assistant as fresh — the
  * guard exists to stop silent persona rewrites of real assistants, not to

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -3,7 +3,7 @@
  * `background` so it never enters the foreground list, the prompt is posted
  * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
  * only when the turn never started. It also covers the archive that cleans the
- * thread up on every exit path, including a poll-ceiling timeout.
+ * thread up on every exit path, including one that never reaches the poll loop.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -17,14 +17,7 @@ import { createElement, type ReactNode } from "react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  afterEach,
-  describe,
-  expect,
-  mock,
-  setSystemTime,
-  test,
-} from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
@@ -48,16 +41,17 @@ let createCalls: CreateCall[] = [];
 let archiveCalls: ArchiveCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
-/**
- * When set, every `/messages` read jumps the clock past the runner's poll
- * ceiling, so the poll loop exits on its deadline check having parsed no
- * complete payload.
- */
-let expirePollCeiling = false;
-const PAST_POLL_CEILING_MS = 300_000;
+/** When set, the prompt POST fails, so the run gives up before the poll loop. */
+let failMessagePost = false;
 
 const ok = <T>(data: T) =>
   Promise.resolve({ data, error: undefined, response: { ok: true } });
+const notOk = () =>
+  Promise.resolve({
+    data: undefined,
+    error: undefined,
+    response: { ok: false },
+  });
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
@@ -74,14 +68,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
   messagesGet: () => {
     getCalls += 1;
-    if (expirePollCeiling) {
-      setSystemTime(new Date(Date.now() + PAST_POLL_CEILING_MS));
-    }
     return ok(listed);
   },
   messagesPost: (opts: PostCall) => {
     postCalls.push(opts);
-    return ok({});
+    return failMessagePost ? notOk() : ok({});
   },
 }));
 mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
@@ -111,8 +102,7 @@ afterEach(() => {
   archiveCalls = [];
   getCalls = 0;
   listed = { messages: [] };
-  expirePollCeiling = false;
-  setSystemTime();
+  failMessagePost = false;
 });
 
 /**
@@ -242,31 +232,27 @@ describe("research prompt send", () => {
 });
 
 describe("research conversation archive", () => {
-  test("archives the side conversation when the poll loop times out", async () => {
-    expirePollCeiling = true;
+  test("archives the side conversation when the prompt fails to post", async () => {
+    // A failed prompt POST abandons the run before the poll loop, with the
+    // conversation already minted. The archive is unconditional, so the
+    // throwaway thread is cleaned up on this exit path like any other.
+    failMessagePost = true;
     const { result } = renderRunner();
-    // A dedicated assistant id keeps this assertion clear of archives from
-    // the runs the tests above leave in flight.
-    const archived = () =>
-      archiveCalls.filter((c) => c.path.assistant_id === "ast-timeout");
 
     act(() => {
       result.current.start({
-        awaitAssistantId: async () => "ast-timeout",
+        awaitAssistantId: async () => "ast-1",
         subject,
       });
     });
 
-    await waitFor(
-      () => {
-        expect(archived()).toHaveLength(1);
-      },
-      { timeout: 8000 },
-    );
-    expect(archived()[0]?.path.id).toBe("conv-fresh");
+    await waitFor(() => {
+      expect(archiveCalls).toHaveLength(1);
+    });
+    expect(archiveCalls[0]?.path.id).toBe("conv-fresh");
 
     act(() => {
       result.current.reset();
     });
-  }, 10_000);
+  });
 });

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -2,7 +2,8 @@
  * Tests for how the research runner opens its side conversation: it is minted
  * `background` so it never enters the foreground list, the prompt is posted
  * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
- * only when the turn never started.
+ * only when the turn never started. It also covers the archive that cleans the
+ * thread up on every exit path, including a poll-ceiling timeout.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -16,7 +17,14 @@ import { createElement, type ReactNode } from "react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
@@ -31,10 +39,22 @@ interface CreateCall {
   body: { conversationType?: string; title?: string };
 }
 
+interface ArchiveCall {
+  path: { assistant_id: string; id: string };
+}
+
 let postCalls: PostCall[] = [];
 let createCalls: CreateCall[] = [];
+let archiveCalls: ArchiveCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
+/**
+ * When set, every `/messages` read jumps the clock past the runner's poll
+ * ceiling, so the poll loop exits on its deadline check having parsed no
+ * complete payload.
+ */
+let expirePollCeiling = false;
+const PAST_POLL_CEILING_MS = 300_000;
 
 const ok = <T>(data: T) =>
   Promise.resolve({ data, error: undefined, response: { ok: true } });
@@ -48,9 +68,15 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     createCalls.push(opts);
     return ok({ id: "conv-fresh" });
   },
-  conversationsByIdArchivePost: () => ok({}),
+  conversationsByIdArchivePost: (opts: ArchiveCall) => {
+    archiveCalls.push(opts);
+    return ok({});
+  },
   messagesGet: () => {
     getCalls += 1;
+    if (expirePollCeiling) {
+      setSystemTime(new Date(Date.now() + PAST_POLL_CEILING_MS));
+    }
     return ok(listed);
   },
   messagesPost: (opts: PostCall) => {
@@ -82,8 +108,11 @@ function renderRunner() {
 afterEach(() => {
   postCalls = [];
   createCalls = [];
+  archiveCalls = [];
   getCalls = 0;
   listed = { messages: [] };
+  expirePollCeiling = false;
+  setSystemTime();
 });
 
 /**
@@ -210,4 +239,34 @@ describe("research prompt send", () => {
       result.current.reset();
     });
   });
+});
+
+describe("research conversation archive", () => {
+  test("archives the side conversation when the poll loop times out", async () => {
+    expirePollCeiling = true;
+    const { result } = renderRunner();
+    // A dedicated assistant id keeps this assertion clear of archives from
+    // the runs the tests above leave in flight.
+    const archived = () =>
+      archiveCalls.filter((c) => c.path.assistant_id === "ast-timeout");
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-timeout",
+        subject,
+      });
+    });
+
+    await waitFor(
+      () => {
+        expect(archived()).toHaveLength(1);
+      },
+      { timeout: 8000 },
+    );
+    expect(archived()[0]?.path.id).toBe("conv-fresh");
+
+    act(() => {
+      result.current.reset();
+    });
+  }, 10_000);
 });

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for how the research runner opens its side conversation: the prompt is
- * posted hidden (see `lib/side-conversation-message.ts`), and a resumed run
- * re-posts only when the turn never started.
+ * Tests for how the research runner opens its side conversation: it is minted
+ * `background` so it never enters the foreground list, the prompt is posted
+ * hidden (see `lib/side-conversation-message.ts`), and a resumed run re-posts
+ * only when the turn never started.
  *
  * Hidden rows are filtered out of `/messages`, so "did the prompt land?" reads
  * the turn's own state (still processing, or rows already produced) instead of
@@ -25,7 +26,13 @@ interface PostCall {
   body: { conversationId: string; hidden?: boolean };
 }
 
+interface CreateCall {
+  path: { assistant_id: string };
+  body: { conversationType?: string; title?: string };
+}
+
 let postCalls: PostCall[] = [];
+let createCalls: CreateCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
 
@@ -37,7 +44,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   pluginsSearchGet: () => ok({ matches: [] }),
   pluginsInstallPost: () => ok({}),
   telemetryIngestPost: () => ok({}),
-  conversationsPost: () => ok({ id: "conv-fresh" }),
+  conversationsPost: (opts: CreateCall) => {
+    createCalls.push(opts);
+    return ok({ id: "conv-fresh" });
+  },
   conversationsByIdArchivePost: () => ok({}),
   messagesGet: () => {
     getCalls += 1;
@@ -71,6 +81,7 @@ function renderRunner() {
 
 afterEach(() => {
   postCalls = [];
+  createCalls = [];
   getCalls = 0;
   listed = { messages: [] };
 });
@@ -87,6 +98,31 @@ async function whenResumeDecided(): Promise<void> {
 }
 
 describe("research prompt send", () => {
+  test("mints the side conversation as background", async () => {
+    // The regression this guards: a `standard` row is visible until the
+    // end-of-run archive wins the race, so the user can land on a thread whose
+    // only rendered content is an assistant intro.
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        conversationTitle: "Getting to know Alice",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createCalls).toHaveLength(1);
+    });
+    expect(createCalls[0]?.body.conversationType).toBe("background");
+    expect(createCalls[0]?.body.title).toBe("Getting to know Alice");
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
   test("posts the prompt as a hidden machine signal", async () => {
     const { result } = renderRunner();
 

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -18,7 +18,6 @@ import {
   resolveResearchCompletionStatus,
   resolveOnboardingPluginInstalls,
   selectRecommendableCapabilities,
-  shouldArchiveCompletedResearchConversation,
   shouldSettleResearchPoll,
   useResearchRunner,
 } from "@/domains/onboarding/research-runner";
@@ -325,23 +324,5 @@ describe("useResearchRunner reinstallPlugins", () => {
     expect(await raceInstallGate(result.current.awaitPluginInstalls())).toBe(
       "settled",
     );
-  });
-});
-
-describe("shouldArchiveCompletedResearchConversation", () => {
-  test("archives when a complete payload was observed", () => {
-    expect(
-      shouldArchiveCompletedResearchConversation({
-        sawCompletePayload: true,
-      }),
-    ).toBe(true);
-  });
-
-  test("does not archive partial or timed-out research turns", () => {
-    expect(
-      shouldArchiveCompletedResearchConversation({
-        sawCompletePayload: false,
-      }),
-    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -621,10 +621,13 @@ export function useResearchRunner(): UseResearchRunner {
           const startFreshConversation = async (): Promise<
             string | undefined
           > => {
+            // `background` creates the row outside the daemon's default
+            // `standard` list, so it never appears in Recents and can never be
+            // selected as the landing conversation.
             const conversation = await conversationsPost({
               path: { assistant_id: assistantId },
               body: {
-                conversationType: "standard",
+                conversationType: "background",
                 ...(conversationTitle ? { title: conversationTitle } : {}),
               },
               throwOnError: false,

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -78,13 +78,6 @@ export function resolveResearchCompletionStatus({
   return sawCompletePayload ? "done" : "error";
 }
 
-export function shouldArchiveCompletedResearchConversation({
-  sawCompletePayload,
-}: {
-  sawCompletePayload: boolean;
-}): boolean {
-  return sawCompletePayload;
-}
 /**
  * Org that owns first-party, reviewed Vellum plugins. Onboarding only ever
  * surfaces and installs plugins from this owner — never third-party/external
@@ -632,8 +625,8 @@ export function useResearchRunner(): UseResearchRunner {
               },
               throwOnError: false,
             });
-            // Capture before the stale check so the finally block can archive it
-            // once a complete payload settles.
+            // Capture before the stale check so the finally block can archive
+            // it on every exit path.
             createdConversationId = conversation.data?.id;
             const id = conversation.data?.id;
             if (!conversation.response?.ok || !id) {
@@ -851,16 +844,9 @@ export function useResearchRunner(): UseResearchRunner {
           // a stale bail-out, or a reply that never emitted a `plugins` array) so
           // `awaitPluginInstalls` can never hang.
           resolvePluginsReady();
-          // Archive only after the full research payload is available. If the poll
-          // ceiling fired before that, the assistant turn may still be running and
-          // the conversation remains available for reconciliation/debugging.
-          if (
-            shouldArchiveCompletedResearchConversation({
-              sawCompletePayload,
-            }) &&
-            resolvedAssistantId &&
-            createdConversationId
-          ) {
+          // Unconditional cleanup: a timed-out or superseded run must not leave
+          // the throwaway side conversation behind.
+          if (resolvedAssistantId && createdConversationId) {
             await archiveResearchConversation(
               resolvedAssistantId,
               createdConversationId,

--- a/clients/web/src/domains/onboarding/send-research-correction.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.ts
@@ -21,9 +21,8 @@
  * (`@/domains/chat/api/*` is import-banned from onboarding), mirroring the
  * research runner that minted this conversation.
  *
- * The conversation was archived once research settled; posting a message can
- * resurface it in the sidebar, so we re-archive afterwards (idempotent,
- * best-effort) to keep the throwaway side channel hidden.
+ * Re-archives the conversation after the post as idempotent, best-effort
+ * cleanup of the throwaway side channel.
  */
 
 import { messagesPost } from "@/generated/daemon/sdk.gen";
@@ -108,7 +107,7 @@ export async function sendResearchCorrection({
   } catch (err) {
     captureError(err, { context: "research_onboarding_correction" });
   }
-  // Keep the throwaway side conversation out of the sidebar even if posting
-  // resurfaced it. Best-effort and already-swallowed by the helper.
+  // Idempotent cleanup of the throwaway side conversation. Best-effort and
+  // already-swallowed by the helper.
   await archiveResearchConversation(assistantId, conversationId);
 }


### PR DESCRIPTION
## Summary

Onboarding mints three throwaway side conversations (research, personality rewrite, identity rewrite) as `conversationType: "standard"` — ordinary foreground threads — and relies on a retroactive `POST /conversations/:id/archive` to hide them. That archive races the chat handoff, and when it loses, the user lands on or sees a thread whose only visible content is an assistant-authored intro/setup message (the prompt posts `hidden: true`, so no user bubble renders above it). That is LUM-3011.

This makes those threads **born invisible** instead: the daemon's create route learns to accept `conversationType: "background"`, and the three call sites switch over. Background rows are excluded from the daemon's default conversation list server-side, so they can never be `defaultConversationId`, never enter Recents, and no longer depend on archive timing.

## Race windows this closes

1. The research thread was archived only when `sawCompletePayload` was true, so a poll-ceiling timeout left it un-archived indefinitely.
2. The handoff (`finishAndEnterChat`) waits on the plugin decision, not the research poll loop, so the archive could land after the chat had already loaded.
3. The personality and correction archives never invalidated the conversation-list cache, so even a successful archive could be invisible to the already-mounted chat page.
4. `defaultConversationId` is the newest non-archived, non-background conversation, so an un-archived side thread was the landing conversation on any load that fell through to the default.

## Bonus fix

Codex caught that `getOrCreateConversation` flips `firstConversationSeen` and deletes `BOOTSTRAP.md` on the *second* created conversation regardless of type. Today's `standard` side threads therefore already delete `BOOTSTRAP.md` before the user's first real chat ever opens. Background creates are now inert for that bookkeeping, and the startup cleanup path was made type-aware to match, so the first-run prompt survives to the turn it was written for.

## PRs merged into this branch

| PR | |
| --- | --- |
| #39982 | daemon: accept `conversationType: "background"` on `POST /v1/conversations` |
| #39987 | onboarding: mint the research side conversation as background |
| #39989 | onboarding: mint the personality-rewrite thread as background |
| #39988 | intelligence: mint the identity-rewrite thread as background |
| #39997 | onboarding: archive side threads unconditionally |

### Self-review fix PRs

| PR | |
| --- | --- |
| #40005 | docs: describe the current side-thread visibility mechanism |
| #40006 | daemon: tighten the create-conversation type contract and its comments |
| #40007 | daemon: make the startup BOOTSTRAP cleanup ignore background conversations |
| #40008 | test: drop clock mutation and duplicate coverage from the side-thread tests |
| #40011 | daemon: skip non-conversation entries when classifying the conversations dir |

## Self-review result

Four fresh-eyes passes, then a re-review of the remediation round. Two rounds of fixes, ten gaps closed. One finding was investigated and **refuted**: a claim that the `background` mint opens the `background-turn` prompt injector (because two flows post `transport: "vellum"` and `INTERACTIVE_INTERFACES` omits `vellum`) is wrong — `LEGACY_INTERFACE_ALIASES` maps `vellum` to `web` inside `parseInterfaceId`, so those turns are interactive and the injector's gate stays closed. Verified independently twice.

## Known trade-offs, deliberately deferred

- **Disk pressure**: `disk-pressure-policy.ts` blocks background turns before reaching the local-owner arm, so on a disk-locked daemon these onboarding turns now silently produce nothing where they previously ran in cleanup mode. A disk-locked daemon is already a broken-workspace state, and speculative onboarding research is the right work to shed first. The failure is silent rather than surfaced; the cheap improvement is client-side.
- **Startup vs in-process gate off-by-one**: the in-process gate deletes `BOOTSTRAP.md` on the *second* standard conversation, the startup gate on the *first*, so a restart mid-first-chat still deletes it. Pre-existing, out of scope, and now documented in the code rather than papered over.

Fixes LUM-3011.