### PR TITLE
fix(computer-use): re-check host-proxy attachment at tool-call time

### DIFF
--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -70,8 +70,12 @@ function buildMockContext(
   hostCuProxy?: InstanceType<typeof HostCuProxy>,
   trustGuardianPrincipalId: string | null = DEFAULT_PRINCIPAL,
   actorPrincipalId: string | null = trustGuardianPrincipalId,
+  // Mirrors `Conversation.ensureHostProxiesForTurn`: attaches a CU proxy when
+  // the gate passes. Left undefined to model a conversation that cannot
+  // attach one (the gate denies, or the context predates the hook).
+  ensureHostProxiesForTurn?: () => void,
 ): SurfaceConversationContext {
-  return {
+  const ctx: SurfaceConversationContext = {
     conversationId: "test-session",
     trustContext:
       trustGuardianPrincipalId != null
@@ -100,12 +104,15 @@ function buildMockContext(
     surfaceActionRequestIds: new Set(),
     currentTurnSurfaces: [],
     hostCuProxy,
+    transportInterface: "web",
+    ensureHostProxiesForTurn,
     isProcessing: () => false,
     enqueueMessage: () => ({ queued: false, requestId: "r1" }),
     getQueueDepth: () => 0,
     processMessage: async () => "",
     withSurface: async (_id, fn) => fn(),
   };
+  return ctx;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,21 +144,63 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   // No desktop client connected
   // -------------------------------------------------------------------------
 
-  describe("no desktop client connected", () => {
-    test("returns error when hostCuProxy is undefined", async () => {
-      const ctx = buildMockContext(/* no proxy */);
-      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+  describe("attaching the proxy at tool-call time", () => {
+    test("attaches a proxy when the conversation has none and dispatches", async () => {
+      // The reported bug: `assistant clients list` showed the desktop
+      // connected and usable, while every computer_use_* call answered "no
+      // desktop client connected" — because attachment was decided at turn
+      // start, before the desktop was reachable, and never revisited.
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "mock-client-1",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+      ];
+
+      let attachCalls = 0;
+      const ctx: SurfaceConversationContext = buildMockContext(
+        /* no proxy */ undefined,
+        DEFAULT_PRINCIPAL,
+        DEFAULT_PRINCIPAL,
+        () => {
+          attachCalls++;
+          proxy = new HostCuProxy();
+          (ctx as { hostCuProxy?: unknown }).hostCuProxy = proxy;
+        },
+      );
+
+      const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
         element_id: 42,
         reasoning: "click the button",
       });
 
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain("not available");
-      expect(result.content).toContain("no desktop client");
+      expect(attachCalls).toBe(1);
+      expect(ctx.hostCuProxy).toBeDefined();
+      // Dispatched for real: the request reached the wire, not an error result.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as { type?: string; requestId?: string };
+      expect(sent.type).toBe("host_cu_request");
+
+      proxy.processObservation(sent.requestId!, { axTree: "window Safari" });
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
     });
 
-    test("returns error for screenshot tool when no proxy", async () => {
-      const ctx = buildMockContext();
+    test("reports the interface, not a missing desktop, when the gate still denies", async () => {
+      // The gate ran and refused (e.g. a chrome-extension source, or a
+      // desktop signed in as someone else). Saying "no desktop client
+      // connected" here contradicts a listing that plainly shows one.
+      mockCuClients = [
+        {
+          clientId: "mock-client-other",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "someone-else",
+        },
+      ];
+      const ctx = buildMockContext(/* no proxy, no attach hook */);
       const result = await surfaceProxyResolver(
         ctx,
         "computer_use_screenshot",
@@ -159,11 +208,26 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("not available");
+      expect(result.content).toContain("not available for this conversation");
+      expect(result.content).not.toContain("no desktop client connected");
+    });
+
+    test("reports no connected client when the hub has none", async () => {
+      mockCuClients = [];
+      const ctx = buildMockContext(/* no proxy */);
+      const result = await surfaceProxyResolver(
+        ctx,
+        "computer_use_screenshot",
+        {},
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("no desktop client connected");
     });
 
     test("returns error when proxy exists but client not connected", async () => {
       mockHasClient = false;
+      mockCuClients = [];
       const proxyObj = new HostCuProxy();
       const ctx = buildMockContext(proxyObj);
       const result = await surfaceProxyResolver(ctx, "computer_use_click", {
@@ -171,7 +235,7 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("not available");
+      expect(result.content).toContain("no desktop client connected");
       proxyObj.dispose();
     });
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -27,6 +27,7 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
+import type { InterfaceId } from "../channels/types.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -1038,6 +1039,21 @@ export interface SurfaceConversationContext {
   hostCuProxy?: HostCuProxy;
   /** Optional proxy for delegating per-app app-control actions to a connected desktop client. */
   hostAppControlProxy?: HostAppControlProxy;
+  /**
+   * The interface ID of the connected client driving the current turn (e.g.
+   * "macos", "chrome-extension"). Propagated into ToolContext for browser
+   * backend selection, and read by the CU dispatch path to re-run the
+   * host-proxy attachment gate at tool-call time.
+   */
+  readonly transportInterface?: InterfaceId;
+  /**
+   * Re-run the host-proxy attachment gate and instantiate any proxy that now
+   * passes it. `Conversation` implements this; the resolver calls it when a
+   * `computer_use_*` call arrives on a conversation with no CU proxy, so a
+   * desktop that became reachable after the turn started can still service
+   * the call.
+   */
+  ensureHostProxiesForTurn?(sourceInterface: InterfaceId | undefined): void;
   /**
    * Setter that lets the resolver detach the conversation's app-control proxy
    * after `app_control_stop`. Disposes the existing proxy when transitioning
@@ -2938,6 +2954,54 @@ export function buildAppOpenPreview(
 }
 
 /**
+ * Explain why a `computer_use_*` call cannot be dispatched, after
+ * {@link ensureHostCuProxy} has already failed to attach one.
+ *
+ * "No desktop client connected" is only one of the reasons, and stating it
+ * unconditionally contradicts `assistant clients list` whenever a desktop is
+ * plainly connected. Only counts are reported — never client ids or actor
+ * principals — since this string reaches the model and the transcript.
+ */
+function describeComputerUseUnavailable(
+  ctx: SurfaceConversationContext,
+): string {
+  const capable = assistantEventHub.listClientsByCapability("host_cu");
+  if (capable.length === 0) {
+    return "Computer use is not available — no desktop client connected. Open the Vellum desktop app on the machine you want to control, then retry.";
+  }
+  return `Computer use is not available for this conversation — ${capable.length} desktop client(s) advertise host_cu, but none of them can be driven from this conversation's interface (${ctx.transportInterface ?? "unknown"}) as its current user.`;
+}
+
+/**
+ * Return the conversation's CU proxy, attaching one first when the
+ * conversation has none.
+ *
+ * Host-proxy attachment is decided at turn boundaries — message create and
+ * queue drain — and a `computer_use_*` call can arrive well after that
+ * decision was made. A conversation whose gate failed at turn start (the
+ * desktop had not connected yet, or the actor principal was not yet
+ * resolvable) therefore stayed permanently without a CU proxy for the rest
+ * of the turn, and every computer-use call reported "no desktop client
+ * connected" while `assistant clients list` showed the desktop connected and
+ * usable.
+ *
+ * Re-running the same gate here — `Conversation.ensureHostProxiesForTurn`,
+ * the very function both turn-boundary paths call — makes the decision track
+ * the live state instead of a stale snapshot. It grants nothing on its own:
+ * the gate is unchanged, and every dispatch below still binds to the calling
+ * actor through the same-actor checks.
+ */
+function ensureHostCuProxy(
+  ctx: SurfaceConversationContext,
+): HostCuProxy | undefined {
+  if (ctx.hostCuProxy) {
+    return ctx.hostCuProxy;
+  }
+  ctx.ensureHostProxiesForTurn?.(ctx.transportInterface);
+  return ctx.hostCuProxy;
+}
+
+/**
  * Resolve a proxy tool call that targets a UI surface.
  * Handles ui_show, ui_update, ui_dismiss, computer_use_* proxy tools, and app_open.
  */
@@ -2950,9 +3014,10 @@ export async function surfaceProxyResolver(
 ): Promise<ToolExecutionResult> {
   // Route CU proxy tools (all computer_use_* action tools)
   if (toolName.startsWith("computer_use_")) {
-    if (!ctx.hostCuProxy || !ctx.hostCuProxy.isAvailable()) {
+    const hostCuProxy = ensureHostCuProxy(ctx);
+    if (!hostCuProxy || !hostCuProxy.isAvailable()) {
       return {
-        content: "Computer use is not available — no desktop client connected.",
+        content: describeComputerUseUnavailable(ctx),
         isError: true,
       };
     }
@@ -2968,7 +3033,7 @@ export async function surfaceProxyResolver(
           : typeof input.answer === "string"
             ? input.answer
             : "Task complete";
-      ctx.hostCuProxy.reset();
+      hostCuProxy.reset();
       return { content: summary, isError: false };
     }
 
@@ -3041,12 +3106,12 @@ export async function surfaceProxyResolver(
       }
     }
 
-    ctx.hostCuProxy.recordAction(toolName, input, reasoning);
-    return ctx.hostCuProxy.request(
+    hostCuProxy.recordAction(toolName, input, reasoning);
+    return hostCuProxy.request(
       toolName,
       input,
       ctx.conversationId,
-      ctx.hostCuProxy.stepCount,
+      hostCuProxy.stepCount,
       reasoning,
       signal,
       targetClientId,

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -115,8 +115,6 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   currentTurnTrustContext?: TrustContext;
   /** Voice/call session ID, if the conversation originates from a call. Propagated into ToolContext for scoped grant consumption. */
   callSessionId?: string;
-  /** The interface ID of the connected client driving the current turn (e.g. "macos", "chrome-extension"). Propagated into ToolContext for browser backend selection. */
-  readonly transportInterface?: InterfaceId;
   /**
    * Per-turn snapshot of the channel's UI capabilities, captured at turn start
    * (mirrors {@link Conversation.currentTurnChannelCapabilities}). Read per tool


### PR DESCRIPTION
## Prompt / plan

Blocker 1 of 3 from a computer-use session on dev: `assistant clients list --capability host_cu` listed a connected macOS desktop, and `computer_use_observe` against that exact client id answered **"Computer use is not available — no desktop client connected."**

```
CLIENT ID                             INTERFACE  CAPABILITIES                   LABEL  CONNECTED
c7a2116f-25cc-4705-b15c-25cfdacf9df1  macos      host_bash, …, host_cu, …       Mac    7m ago
```

The listing was right. The bug is in computer use.

### What is actually broken

Host-proxy attachment is decided **only at turn boundaries** — message create in `conversation-routes.ts` and queue drain in `conversation-process.ts` — and a `computer_use_*` call arrives well after that decision was taken. A conversation whose gate failed at turn start (the desktop had not connected yet, or the actor principal was not yet resolvable) then carries no `hostCuProxy` for the rest of the turn, and `surfaceProxyResolver` reads that stale absence as "no desktop client connected". Worse, the create path *clears* an existing proxy when its gate fails, so a transient miss can un-arm a conversation that was working a moment earlier.

Nothing re-examines the decision, no matter how long the turn runs or what connects during it.

### The fix

The dispatch path re-runs the same gate when it finds no proxy, by calling the very function both turn-boundary paths already call — `Conversation.ensureHostProxiesForTurn` — with the turn's live interface and actor:

```ts
const hostCuProxy = ensureHostCuProxy(ctx);
if (!hostCuProxy || !hostCuProxy.isAvailable()) { … }
```

This grants nothing on its own. The gate is unchanged (same interface support rules, same chrome-extension denial, same same-actor client filter), and every dispatch below still binds to the calling actor through the existing `enforceSameActorOrErrorResult` / `pickSameUserAutoResolve` checks. All it changes is *when* the question is asked — against live state rather than a snapshot taken before the tool call existed.

When the gate genuinely refuses, the message no longer claims nothing is connected: it reports how many desktop clients advertise `host_cu` and that none can be driven from this conversation, so the failure stops contradicting the listing. Counts only — no client ids, no actor principals — since the string reaches the model and the transcript.

`transportInterface` and `ensureHostProxiesForTurn` move onto `SurfaceConversationContext` so the resolver can reach them; `transportInterface`'s duplicate declaration on `ToolSetupContext` (which extends it) is dropped.

## Test plan

- `bun test src/__tests__/cu-unified-flow.test.ts` — 33 pass. The old "returns error when hostCuProxy is undefined" case is replaced by the regression itself: a conversation with no proxy and a connected same-user desktop now attaches one and dispatches a real `host_cu_request` through to a resolved observation. Two further cases pin the failure wording — "no desktop client connected" only when the hub genuinely has none, and the interface-scoped message when the gate refuses.
- `bun test` over `host-cu-proxy`, `host-cu-routes-targeted`, `computer-use-tools`, `conversation-surfaces-standalone{,-payloads}`, `conversation-surfaces-app-control`, `computer-use-skill-manifest-regression` — 211 pass.
- `conversation-routes-disk-view`, `host-proxy-preactivation`, `app-control-flow`, `conversation-tool-setup` pass individually; the seven failures they show when run in one batch reproduce identically on a clean `main` checkout (cross-file test pollution).
- `bunx tsc --noEmit`, eslint, prettier — clean.

## CLI verb checklist

No new routes.