### PR TITLE
fix(web): show placeholder rows while the sidebar conversation list loads

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -198,10 +198,12 @@ export function ChatLayout({
   // chat-layout child route (home, library, contacts, identity, chat)
   // inherits a populated sidebar on direct navigation — not just /assistant.
   // TanStack Query handles dedup with any other consumer using the same key.
-  const { conversations } = useConversationListQuery(
-    assistantId,
-    isAssistantActive,
-  );
+  // `isLoading` (first fetch actually in flight), not `isPending`: the query
+  // is gated on `isAssistantActive`, and a gated query is pending without
+  // fetching, which would leave the sidebar under placeholders for as long as
+  // the assistant took to come up (or forever, if it never did).
+  const { conversations, isLoading: isLoadingConversations } =
+    useConversationListQuery(assistantId, isAssistantActive);
   const { conversationGroups } = useConversationGroupsQuery(
     assistantId,
     isAssistantActive,
@@ -886,6 +888,7 @@ export function ChatLayout({
       width={args.width}
       onWidthChange={args.onWidthChange}
       conversations={conversations}
+      isLoadingConversations={isLoadingConversations}
       conversationGroups={conversationGroups}
       activeConversationId={sidebarActiveConversationId}
       processingConversationIds={processingConversationIds}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -193,3 +193,18 @@ export const GroupedView: Story = {
   beforeEach: () => seedViewMode("asst-grouped", "grouped"),
   args: { ...SHARED_ARGS, assistantId: "asst-grouped" },
 };
+
+/* What a cold load looks like before the conversation list resolves. The list
+   is one query that settles only once every page of it is in, so on a busy
+   assistant this is on screen for seconds, and it used to be indistinguishable
+   from having no conversations at all. */
+export const LoadingConversations: Story = {
+  name: "Loading conversations",
+  beforeEach: () => seedViewMode("asst-loading", "all"),
+  args: {
+    ...SHARED_ARGS,
+    assistantId: "asst-loading",
+    conversations: [],
+    isLoadingConversations: true,
+  },
+};

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -196,8 +196,8 @@ export const GroupedView: Story = {
 
 /* What a cold load looks like before the conversation list resolves. The list
    is one query that settles only once every page of it is in, so on a busy
-   assistant this is on screen for seconds, and it used to be indistinguishable
-   from having no conversations at all. */
+   assistant this state holds for seconds, and the placeholders are what keep
+   it distinguishable from an assistant with no conversations at all. */
 export const LoadingConversations: Story = {
   name: "Loading conversations",
   beforeEach: () => seedViewMode("asst-loading", "all"),

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1377,9 +1377,10 @@ describe("AssistantSideMenu · section reordering", () => {
 /**
  * The conversation list resolves only once every page of it has been fetched,
  * so "still loading" is a state the sidebar sits in for seconds on a cold
- * load. It used to render exactly like "this assistant has no conversations":
- * an empty scrollport. These assert the two stay distinguishable, and that a
- * refetch never blanks a sidebar that already has rows.
+ * load. Its natural rendering is an empty scrollport, which is also what "this
+ * assistant has no conversations" looks like. These assert the two stay
+ * distinguishable, and that a refetch never blanks a sidebar that already has
+ * rows.
  */
 describe("AssistantSideMenu · conversation list loading state", () => {
   const SKELETON = 'data-slot="sidebar-conversation-skeleton"';
@@ -1398,8 +1399,8 @@ describe("AssistantSideMenu · conversation list loading state", () => {
 
   test("draws no placeholders once an empty list has loaded", () => {
     // The sensitivity check on the test above: an assistant with genuinely no
-    // conversations must not sit under placeholders forever. Without this,
-    // unconditionally rendering the skeleton would still pass.
+    // conversations must not sit under placeholders forever. This is the
+    // assertion that fails if the skeleton renders unconditionally.
     const html = renderMenu({
       conversations: [],
       isLoadingConversations: false,

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -89,6 +89,7 @@ function renderMenu(props: {
   variant?: "rail" | "overlay";
   includeFooterAction?: boolean;
   includeTipCard?: boolean;
+  isLoadingConversations?: boolean;
 }): string {
   const includeFooterAction = props.includeFooterAction ?? true;
   const { container } = render(
@@ -97,6 +98,7 @@ function renderMenu(props: {
       collapsed: props.collapsed ?? false,
       variant: props.variant ?? "rail",
       conversations: props.conversations,
+      isLoadingConversations: props.isLoadingConversations,
       conversationGroups: props.conversationGroups,
       activeConversationId: props.activeConversationId,
       onSelectConversation: () => {},
@@ -1370,4 +1372,54 @@ describe("AssistantSideMenu · section reordering", () => {
       }
     },
   );
+});
+
+/**
+ * The conversation list resolves only once every page of it has been fetched,
+ * so "still loading" is a state the sidebar sits in for seconds on a cold
+ * load. It used to render exactly like "this assistant has no conversations":
+ * an empty scrollport. These assert the two stay distinguishable, and that a
+ * refetch never blanks a sidebar that already has rows.
+ */
+describe("AssistantSideMenu · conversation list loading state", () => {
+  const SKELETON = 'data-slot="sidebar-conversation-skeleton"';
+
+  test("draws placeholder rows while the first load is in flight", () => {
+    const html = renderMenu({
+      conversations: [],
+      isLoadingConversations: true,
+    });
+
+    expect(html).toContain(SKELETON);
+    // The section tree is what the placeholders stand in for, so it must not
+    // render alongside them.
+    expect(html).not.toContain(">Chats<");
+  });
+
+  test("draws no placeholders once an empty list has loaded", () => {
+    // The sensitivity check on the test above: an assistant with genuinely no
+    // conversations must not sit under placeholders forever. Without this,
+    // unconditionally rendering the skeleton would still pass.
+    const html = renderMenu({
+      conversations: [],
+      isLoadingConversations: false,
+    });
+
+    expect(html).not.toContain(SKELETON);
+  });
+
+  test("keeps live rows during a refetch instead of reverting to placeholders", () => {
+    // `isLoadingConversations` is true here, but the cache is already
+    // populated, so the rows win. Guards against a background refresh
+    // flashing the sidebar back to placeholders mid-session.
+    const html = renderMenu({
+      conversations: [
+        makeConversation({ conversationId: "r1", title: "Recent thread" }),
+      ],
+      isLoadingConversations: true,
+    });
+
+    expect(html).not.toContain(SKELETON);
+    expect(html).toContain(">Recent thread<");
+  });
 });

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -32,6 +32,7 @@ import { SideMenuBuiltInNav } from "@/domains/chat/components/side-menu-built-in
 import { SideMenuOverlayBottomColumn } from "@/domains/chat/components/side-menu-overlay-bottom-column";
 import { SidebarViewModeSelect } from "@/domains/chat/components/sidebar-view-mode-select";
 import { SidebarBackToTop } from "@/domains/chat/components/sidebar-back-to-top";
+import { SidebarConversationSkeleton } from "@/domains/chat/components/sidebar-conversation-skeleton";
 import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
 import { useSectionDragReorder } from "@/domains/chat/hooks/use-section-drag-reorder";
 import { useScrolledPast } from "@/domains/chat/hooks/use-scrolled-past";
@@ -47,6 +48,14 @@ import { Button, cn, SideMenu } from "@vellumai/design-library";
 
 export interface AssistantSideMenuProps extends UseSidebarStateParams {
   assistantName?: string | null;
+  /**
+   * The conversation list's first load is still in flight. Draws placeholder
+   * rows instead of the (still empty) section tree, so a cold load reads as
+   * loading rather than as an assistant with no conversations. Only consulted
+   * while `conversations` is empty, so a background refetch over an already
+   * populated sidebar never replaces live rows with placeholders.
+   */
+  isLoadingConversations?: boolean;
   collapsed: boolean;
   variant: "rail" | "overlay";
   width?: number;
@@ -180,6 +189,7 @@ function SearchButton() {
  * flow through {@link ConversationListProvider}.
  */
 export function AssistantSideMenu({
+  isLoadingConversations,
   assistantId,
   assistantName,
   collapsed,
@@ -228,6 +238,12 @@ export function AssistantSideMenu({
   });
 
   const isCollapsedRail = collapsed && variant === "rail";
+
+  /* Gated on an empty list, not on the loading flag alone: a refetch over a
+     populated sidebar keeps drawing the rows it already has rather than
+     blanking them back to placeholders. */
+  const showConversationSkeleton =
+    isLoadingConversations === true && conversations.length === 0;
 
   // --- Overlay bottom reserve ---
   // The overlay's floating bottom column (tip card + action pills) covers the
@@ -502,6 +518,8 @@ export function AssistantSideMenu({
               processingConversationIds={processingConversationIds}
               attentionConversationIds={attentionConversationIds}
             />
+          ) : showConversationSkeleton ? (
+            <SidebarConversationSkeleton />
           ) : (
             /* Right-clicking the list (including the empty space below the
                last section) creates a group, so the affordance covers the

--- a/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
@@ -1,0 +1,60 @@
+/**
+ * Placeholder rows shown while the sidebar's conversation list is still
+ * loading.
+ *
+ * The list arrives as one query that resolves only after every page of it has
+ * been fetched (see `fetchConversationList`), so on a cold load there is a
+ * stretch (proportional to how many conversations the assistant has) where
+ * the sidebar has no rows to draw. Without this the sidebar renders an empty
+ * scrollport, which reads as "you have no conversations" rather than "these
+ * are on their way": the two states looked identical, and the difference
+ * between them is the whole reason a user reaches for the menu.
+ *
+ * Deliberately fixed-width bars rather than randomized ones: the widths only
+ * have to break the grid enough to read as titles, and a stable set can't
+ * reflow between renders.
+ */
+
+import { SkeletonBar } from "@/domains/chat/components/chat-skeleton";
+
+/**
+ * Row widths, as Tailwind fraction utilities. Enough rows to fill the
+ * scrollport on a short viewport without implying a specific list length.
+ */
+const ROW_WIDTHS = [
+  "w-4/5",
+  "w-3/5",
+  "w-11/12",
+  "w-2/3",
+  "w-3/4",
+  "w-1/2",
+  "w-5/6",
+] as const;
+
+export function SidebarConversationSkeleton() {
+  return (
+    /* `gap-1` + the 30px row height restate the real list's row rhythm, so
+       rows don't shift vertically when the real ones replace these. */
+    /* `role="status"` rather than `aria-hidden`: telling loading apart from
+       "no conversations" is the whole point of this component, and a screen
+       reader given only decorative bars would be back to a silently empty
+       list. The bars themselves carry no text, so the label is the only thing
+       announced. */
+    <div
+      className="flex flex-col gap-1"
+      data-slot="sidebar-conversation-skeleton"
+      role="status"
+      aria-label="Loading conversations"
+    >
+      {ROW_WIDTHS.map((width, index) => (
+        <div
+          key={index}
+          className="flex h-[30px] items-center"
+          style={{ paddingInline: 6 }}
+        >
+          <SkeletonBar className={`h-3.5 ${width}`} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
@@ -5,10 +5,9 @@
  * The list arrives as one query that resolves only after every page of it has
  * been fetched (see `fetchConversationList`), so on a cold load there is a
  * stretch (proportional to how many conversations the assistant has) where
- * the sidebar has no rows to draw. Without this the sidebar renders an empty
- * scrollport, which reads as "you have no conversations" rather than "these
- * are on their way": the two states looked identical, and the difference
- * between them is the whole reason a user reaches for the menu.
+ * the sidebar has no rows to draw. These rows keep that stretch legible as
+ * loading rather than as an assistant with no conversations, which is the
+ * distinction a user opens the menu to see.
  *
  * Deliberately fixed-width bars rather than randomized ones: the widths only
  * have to break the grid enough to read as titles, and a stable set can't
@@ -36,10 +35,9 @@ export function SidebarConversationSkeleton() {
     /* `gap-1` + the 30px row height restate the real list's row rhythm, so
        rows don't shift vertically when the real ones replace these. */
     /* `role="status"` rather than `aria-hidden`: telling loading apart from
-       "no conversations" is the whole point of this component, and a screen
-       reader given only decorative bars would be back to a silently empty
-       list. The bars themselves carry no text, so the label is the only thing
-       announced. */
+       "no conversations" is the point of this component, and decorative-only
+       bars would leave a screen reader with a silently empty list. The bars
+       carry no text, so the label is the only thing announced. */
     <div
       className="flex flex-col gap-1"
       data-slot="sidebar-conversation-skeleton"


### PR DESCRIPTION
## TL;DR

The conversations menu renders an empty scrollport while it loads, which is indistinguishable from having no conversations. This draws placeholder rows for that window instead. Legibility only — it does not make the list load faster.

## Why

Reported from iOS production on v0.11.1: "conversations menu not loading" (Nick), "taking a few seconds for my list of convos to populate" (Noa).

The sidebar list is a single query that resolves only after **every** page of it has been fetched — `fetchConversationList` walks pages of 50 until `hasMore` is false, sequentially. Until the last page lands, consumers get an empty array, and no consumer read `isLoading`/`isPending`. So the menu drew nothing, with no spinner and no empty-state copy.

The seconds themselves are the serial page walk, which this PR does **not** change. That is tracked separately (see below). What this fixes is that the wait was unreadable as a wait.

## Before / after

| | Before | After |
|---|---|---|
| Cold load, list still fetching | Empty sidebar, no indication anything is happening | Placeholder rows |
| Assistant with genuinely no conversations | Empty sidebar | Empty sidebar (unchanged) |
| Background refetch over a loaded sidebar | Rows stay | Rows stay (placeholders never replace live rows) |
| Screen reader, cold load | Silence | "Loading conversations" |

## Why it's safe

- Additive: one optional prop, defaulted off. Every existing call site and story is unaffected.
- Gated on the list being **empty**, so a refetch can never blank a populated sidebar.
- Uses `isLoading` (first fetch in flight), not `isPending`. The query is gated on `isAssistantActive`, and a gated query is pending-but-not-fetching — `isPending` would have parked the sidebar under placeholders until the assistant came up, or forever if it never did.
- No change to fetching, caching, or the daemon.

## Testing

Three tests in `assistant-side-menu.test.tsx`, mutation-checked both ways:

- Forcing the skeleton to never render fails the loading test (and only that one).
- Forcing it to always render fails the two sensitivity tests, which is what keeps "genuinely empty" and "still loading" distinguishable.

Also verified visually in Storybook via a new `Loading conversations` story.

## Design system

`@vellumai/design-library` has no loading-placeholder primitive: `progress-bar` is determinate (it takes a value) and nothing else covers this case. Per `clients/web/AGENTS.md`, building a custom component is therefore in bounds, and this calls that choice out.

It is not hand-rolled from scratch. The bars reuse `SkeletonBar` / `.skeleton-shimmer`, the existing app idiom that already handles the `color-mix` fallback for WKWebView before iOS 16.2 and honors `prefers-reduced-motion`. No third animation is introduced.

The app does carry a competing, less-correct idiom (ad-hoc `animate-pulse`, no reduced-motion opt-out, surface token varying per call site) across ~10 files. That gap is filed as [LUM-3049](https://linear.app/vellum/issue/LUM-3049/design-library-add-a-skeleton-primitive-the-app-has-two-competing-hand) rather than widened here.

## Deferred

The actual load time is the serial page drain, unchanged here. Filed separately — it needs the sidebar's sections decoupled from the one full list before the list can safely paginate, which is why the earlier attempt at it was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
