### PR TITLE
Clarify local dev instructions in the docs site README

### DIFF
--- a/clients/docs/README.md
+++ b/clients/docs/README.md
@@ -17,7 +17,7 @@ bun install                          # resolves to the workspace root
 bun run dev
 ```
 
-Then open <http://localhost:3005/docs> — everything lives under the `/docs`
+Then open <http://localhost:3005/docs>. Everything lives under the `/docs`
 prefix, so the bare root (`http://localhost:3005/`) is a 404. Before the dev
 server starts, `predev` regenerates the search index and markdown mirrors
 automatically; no manual generation step is needed.

--- a/clients/docs/README.md
+++ b/clients/docs/README.md
@@ -6,15 +6,25 @@ app, so every public URL and asset lives under the `/docs` prefix.
 
 ## Development
 
+The app is self-contained: no platform environment (`vel up`, Django) is
+required. The only network dependency is the releases page, which fetches
+published release notes from the public `www.vellum.ai` API at request time
+(override with `RELEASES_API_URL`) and renders an empty list if unreachable.
+
 ```bash
-export PATH="$HOME/.bun/bin:$PATH"
-bun install            # resolves to the workspace root
-bun run dev            # http://localhost:3005/docs
+export PATH="$HOME/.bun/bin:$PATH"   # if bun isn't already on your PATH
+bun install                          # resolves to the workspace root
+bun run dev
 ```
+
+Then open <http://localhost:3005/docs> — everything lives under the `/docs`
+prefix, so the bare root (`http://localhost:3005/`) is a 404. Before the dev
+server starts, `predev` regenerates the search index and markdown mirrors
+automatically; no manual generation step is needed.
 
 | Command | What it does |
 | --- | --- |
-| `bun run dev` | Dev server on port 3005 (predev regenerates the search index and markdown mirrors) |
+| `bun run dev` | Dev server on port 3005 |
 | `bun run build` | Production build (standalone output; prebuild runs both generators) |
 | `bun run start` | Serve the production build |
 | `bun run lint` / `bun run typecheck` / `bun run test` | The usual checks |


### PR DESCRIPTION
## Summary
- Document that `clients/docs` runs standalone: no platform environment (`vel up`, Django) is required, and the only network dependency is the releases page, which fetches the public `www.vellum.ai` API (overridable via `RELEASES_API_URL`) and falls back to an empty list.
- Make explicit that the dev server serves everything under the `/docs` prefix — open http://localhost:3005/docs; the bare root is a 404.
- Call out that `predev` regenerates the search index and markdown mirrors automatically before `bun run dev`, and drop the now-duplicated parenthetical from the command table.

## Original prompt
After the docs-site cutover to `clients/docs`, the user asked how to run the docs site locally and then asked to make sure the README captures those instructions end-to-end. The gaps were: the README implied but never stated that you must browse to `/docs` (the root 404s), never said the app needs no backend or platform environment, and buried the predev auto-generation behavior in a table parenthetical.