### PR TITLE
feat(web): unpair paired assistants from the chooser

### DIFF
--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -44,6 +44,7 @@ mock.module("@/lib/local-mode", () => ({
   }),
   isLocalAssistant: (a: { cloud?: string }) => a.cloud === "local",
   isLocalClient: () => isLocalClientValue,
+  isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
 }));
@@ -196,6 +197,29 @@ describe("retireAssistant", () => {
     expect(retireLocalAssistantMock).toHaveBeenCalledWith("l1");
     expect(retireAssistantByIdMock).not.toHaveBeenCalled();
     expect(outcome.ok).toBe(true);
+  });
+
+  test("a paired target is refused before any retire path runs", async () => {
+    // GIVEN a paired target in local mode
+    isLocalClientValue = true;
+    lockfileAssistants = [{ assistantId: "pr1", cloud: "paired" }];
+    storeAssistants = [{ id: "pr1" }];
+
+    // WHEN retiring it
+    const outcome = await retireAssistant("pr1");
+
+    // THEN the guard fails fast: neither retire path ran and nothing was
+    // cleaned up (the assistant still exists on its host machine).
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBe(
+        "This is a paired assistant. Remove it from this device instead of retiring it.",
+      );
+    }
+    expect(retireLocalAssistantMock).not.toHaveBeenCalled();
+    expect(retireAssistantByIdMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(clearResearchSnapshotMock).not.toHaveBeenCalled();
   });
 
   test("routes by the TARGET assistant, not local-mode alone", async () => {

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -3,6 +3,7 @@ import {
   getLockfile,
   isLocalAssistant,
   isLocalClient,
+  isPairedAssistant,
   retireLocalAssistant,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
@@ -64,6 +65,15 @@ export async function retireAssistant(
     const target = getLockfile().assistants.find(
       (a) => a.assistantId === assistantId,
     );
+    // A paired entry belongs to another machine; retiring can't touch it
+    // (the CLI refuses paired targets), so refuse with actionable copy.
+    if (target && isPairedAssistant(target)) {
+      return {
+        ok: false,
+        error:
+          "This is a paired assistant. Remove it from this device instead of retiring it.",
+      };
+    }
     const useLocal = isLocalClient() && !!target && isLocalAssistant(target);
 
     if (useLocal) {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -22,6 +22,10 @@ let searchParams = new URLSearchParams();
 let hasPlatformSessionValue = false;
 let assistantsValue: ResolvedAssistant[] = [];
 let localModeHostAvailableValue = false;
+let activeAssistantIdValue: string | null = null;
+const setActiveAssistantIdMock = mock((id: string | null) => {
+  activeAssistantIdValue = id;
+});
 
 const removePairedAssistantFromLockfileMock = mock(
   async (_id: string): Promise<{ ok: boolean; error?: string }> => ({
@@ -137,6 +141,10 @@ mock.module("@/stores/organization-store", () => ({
 mock.module("@/stores/resolved-assistants-store", () => ({
   useResolvedAssistantsStore: {
     use: { assistants: () => assistantsValue },
+    getState: () => ({
+      activeAssistantId: activeAssistantIdValue,
+      setActiveAssistantId: setActiveAssistantIdMock,
+    }),
   },
 }));
 
@@ -257,6 +265,8 @@ describe("SelectAssistantScreen paired assistants", () => {
       ok: true,
     }));
     removePlatformAssistantFromLockfileMock.mockClear();
+    activeAssistantIdValue = null;
+    setActiveAssistantIdMock.mockClear();
   });
 
   afterEach(cleanup);
@@ -422,6 +432,39 @@ describe("SelectAssistantScreen paired assistants", () => {
       ),
     );
     expect(removePlatformAssistantFromLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("removing the lifecycle-active paired entry clears the active id", async () => {
+    localModeHostAvailableValue = true;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    activeAssistantIdValue = PAIRED_ID;
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Remove from this device…"));
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(setActiveAssistantIdMock).toHaveBeenCalledWith(null),
+    );
+  });
+
+  test("removing a non-active paired entry leaves the active id alone", async () => {
+    localModeHostAvailableValue = true;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    activeAssistantIdValue = "some-other-assistant";
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Remove from this device…"));
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(removePairedAssistantFromLockfileMock).toHaveBeenCalled(),
+    );
+    expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
   });
 
   test("a paired removal failure surfaces the host error in the dialog", async () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -21,6 +21,18 @@ const navigateMock = mock((_to: string, _opts?: unknown) => {});
 let searchParams = new URLSearchParams();
 let hasPlatformSessionValue = false;
 let assistantsValue: ResolvedAssistant[] = [];
+let localModeHostAvailableValue = false;
+
+const removePairedAssistantFromLockfileMock = mock(
+  async (_id: string): Promise<{ ok: boolean; error?: string }> => ({
+    ok: true,
+  }),
+);
+const removePlatformAssistantFromLockfileMock = mock(
+  async (_id: string): Promise<{ ok: boolean; error?: string }> => ({
+    ok: true,
+  }),
+);
 
 const connectPairedAssistantMock = mock(async (_id: string) => {});
 const connectLocalAssistantMock = mock(async (_id: string) => {});
@@ -62,7 +74,8 @@ class MockUnresolvedLocalGatewayError extends Error {}
 
 mock.module("@/lib/local-mode", () => ({
   isCliWakeableAssistant: () => false,
-  removePlatformAssistantFromLockfile: async () => ({ ok: true as const }),
+  removePairedAssistantFromLockfile: removePairedAssistantFromLockfileMock,
+  removePlatformAssistantFromLockfile: removePlatformAssistantFromLockfileMock,
   UnresolvedLocalGatewayError: MockUnresolvedLocalGatewayError,
 }));
 
@@ -97,7 +110,7 @@ mock.module("@/runtime/is-electron", () => ({
 
 mock.module("@/runtime/local-mode-host", () => ({
   GuardianTokenError: MockGuardianTokenError,
-  isLocalModeHostAvailable: () => false,
+  isLocalModeHostAvailable: () => localModeHostAvailableValue,
   requiresGuardianReprovision: (error: unknown) =>
     error instanceof MockGuardianTokenError &&
     (error.status === 404 || error.status === 401),
@@ -154,8 +167,21 @@ mock.module("@vellumai/design-library/components/button", () => ({
 }));
 
 mock.module("@vellumai/design-library/components/confirm-dialog", () => ({
-  ConfirmDialog: ({ open, message }: { open: boolean; message: ReactNode }) =>
-    open ? <div>{message}</div> : null,
+  ConfirmDialog: ({
+    open,
+    message,
+    onConfirm,
+  }: {
+    open: boolean;
+    message: ReactNode;
+    onConfirm?: () => void;
+  }) =>
+    open ? (
+      <div>
+        {message}
+        <button onClick={onConfirm}>Confirm remove</button>
+      </div>
+    ) : null,
 }));
 
 mock.module("@vellumai/design-library/components/menu", () => ({
@@ -163,7 +189,13 @@ mock.module("@vellumai/design-library/components/menu", () => ({
     Root: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     Trigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Item: ({
+      children,
+      onSelect,
+    }: {
+      children: ReactNode;
+      onSelect?: () => void;
+    }) => <div onClick={onSelect}>{children}</div>,
   },
 }));
 
@@ -219,6 +251,12 @@ describe("SelectAssistantScreen paired assistants", () => {
     searchParams = new URLSearchParams();
     hasPlatformSessionValue = false;
     assistantsValue = [];
+    localModeHostAvailableValue = false;
+    removePairedAssistantFromLockfileMock.mockClear();
+    removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
+      ok: true,
+    }));
+    removePlatformAssistantFromLockfileMock.mockClear();
   });
 
   afterEach(cleanup);
@@ -339,5 +377,117 @@ describe("SelectAssistantScreen paired assistants", () => {
     );
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("a paired card offers the remove menu when the local-mode host is available", () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.getByLabelText("Actions for Office Mac")).toBeTruthy();
+  });
+
+  test("a paired card offers no remove menu without a local-mode host", () => {
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByLabelText("Actions for Office Mac")).toBeNull();
+  });
+
+  test("confirming a paired removal shows the pairing copy and calls removePairedAssistantFromLockfile", async () => {
+    // A pairing is device-local, so the affordance survives a platform
+    // session (which locks out the platform-card removal instead).
+    localModeHostAvailableValue = true;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Remove from this device…"));
+
+    expect(
+      screen.getByText(/It only forgets the pairing on this device/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Pair again anytime with vellum connect import/),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(removePairedAssistantFromLockfileMock).toHaveBeenCalledWith(
+        PAIRED_ID,
+      ),
+    );
+    expect(removePlatformAssistantFromLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("a paired removal failure surfaces the host error in the dialog", async () => {
+    localModeHostAvailableValue = true;
+    hasPlatformSessionValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
+      ok: false,
+      error: "Unpair is not supported by this app version",
+    }));
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Remove from this device…"));
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Unpair is not supported by this app version"),
+      ).toBeTruthy(),
+    );
+  });
+
+  test("clicking the remove menu does not select the card", () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [
+      makePairedAssistant(),
+      makePairedAssistant({ id: "paired-2", name: "Second Mac" }),
+    ];
+
+    render(<SelectAssistantScreen />);
+
+    // The first accessible card is auto-selected; poking the second card's
+    // menu trigger must not move the selection.
+    fireEvent.click(screen.getByLabelText("Actions for Second Mac"));
+
+    const radios = screen.getAllByRole("radio");
+    expect(
+      radios.find((r) => r.textContent?.includes("Office Mac"))
+        ?.getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      radios.find((r) => r.textContent?.includes("Second Mac"))
+        ?.getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  test("confirming a locked platform removal still calls removePlatformAssistantFromLockfile", async () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Remove from this device…"));
+
+    expect(
+      screen.getByText(/It only removes it from this device/),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Confirm remove"));
+
+    await waitFor(() =>
+      expect(removePlatformAssistantFromLockfileMock).toHaveBeenCalledWith(
+        PLATFORM_ID,
+      ),
+    );
+    expect(removePairedAssistantFromLockfileMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -276,6 +276,14 @@ export function SelectAssistantScreen() {
         ? await removePairedAssistantFromLockfile(removeTarget.id)
         : await removePlatformAssistantFromLockfile(removeTarget.id);
       if (result.ok) {
+        // The lockfile subscription reconciles the list and the selection,
+        // but not the lifecycle's active id: without this, navigating back
+        // to /assistant could admit the removed assistant with no
+        // connection behind it.
+        const resolvedStore = useResolvedAssistantsStore.getState();
+        if (resolvedStore.activeAssistantId === removeTarget.id) {
+          resolvedStore.setActiveAssistantId(null);
+        }
         removedThisVisitRef.current = true;
         setRemoveTarget(null);
       } else {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/auth/gateway-session";
 import {
   isCliWakeableAssistant,
+  removePairedAssistantFromLockfile,
   removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
@@ -101,6 +102,9 @@ export function SelectAssistantScreen() {
   // lockfile) only where a local-mode host can rewrite the lockfile.
   const canRemoveLockedAssistants =
     !hasPlatformSession && isLocalModeHostAvailable();
+  // A pairing is device-local regardless of platform session, so unpairing
+  // needs only the host, not a logged-out state.
+  const canRemovePairedAssistants = isLocalModeHostAvailable();
 
   const [selected, setSelected] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -268,7 +272,9 @@ export function SelectAssistantScreen() {
     setRemovePending(true);
     setRemoveError(null);
     try {
-      const result = await removePlatformAssistantFromLockfile(removeTarget.id);
+      const result = removeTarget.isPaired
+        ? await removePairedAssistantFromLockfile(removeTarget.id)
+        : await removePlatformAssistantFromLockfile(removeTarget.id);
       if (result.ok) {
         removedThisVisitRef.current = true;
         setRemoveTarget(null);
@@ -391,7 +397,8 @@ export function SelectAssistantScreen() {
                     : undefined
                 }
                 onRemove={
-                  assistant.isPlatformHosted && canRemoveLockedAssistants
+                  (assistant.isPlatformHosted && canRemoveLockedAssistants) ||
+                  (assistant.isPaired && canRemovePairedAssistants)
                     ? () => setRemoveTarget(assistant)
                     : undefined
                 }
@@ -474,10 +481,20 @@ export function SelectAssistantScreen() {
         title="Remove from this device?"
         message={
           <>
-            This won&rsquo;t delete{" "}
-            {removeTarget ? assistantLabel(removeTarget) : "the assistant"}.
-            It only removes it from this device. Logging in will make it
-            available again.
+            {removeTarget?.isPaired ? (
+              <>
+                This won&rsquo;t affect {assistantLabel(removeTarget)} on its
+                host machine. It only forgets the pairing on this device. Pair
+                again anytime with vellum connect import.
+              </>
+            ) : (
+              <>
+                This won&rsquo;t delete{" "}
+                {removeTarget ? assistantLabel(removeTarget) : "the assistant"}.
+                It only removes it from this device. Logging in will make it
+                available again.
+              </>
+            )}
             {removeError && (
               <span className="mt-2 block text-[var(--system-negative-strong)]">
                 {removeError}
@@ -525,6 +542,28 @@ function AssistantCard({
   // (12px padding, 12px radius, 12px icon→text gap, 11px secondary text) so
   // the picker reads at the same density as the native windows.
   const electron = isElectron();
+
+  const removeMenu = onRemove && (
+    <Menu.Root>
+      <Menu.Trigger asChild>
+        <Button
+          variant="ghost"
+          size="regular"
+          className="text-[var(--content-tertiary)]"
+          iconOnly={<EllipsisVertical />}
+          aria-label={`Actions for ${assistantLabel(assistant)}`}
+        />
+      </Menu.Trigger>
+      <Menu.Content align="end" sideOffset={4}>
+        <Menu.Item
+          onSelect={onRemove}
+          className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+        >
+          Remove from this device…
+        </Menu.Item>
+      </Menu.Content>
+    </Menu.Root>
+  );
 
   return (
     <div
@@ -599,43 +638,36 @@ function AssistantCard({
               {loginLabel}
             </Button>
           )}
-          {onRemove && (
-            <Menu.Root>
-              <Menu.Trigger asChild>
-                <Button
-                  variant="ghost"
-                  size="regular"
-                  className="text-[var(--content-tertiary)]"
-                  iconOnly={<EllipsisVertical />}
-                  aria-label={`Actions for ${assistantLabel(assistant)}`}
-                />
-              </Menu.Trigger>
-              <Menu.Content align="end" sideOffset={4}>
-                <Menu.Item
-                  onSelect={onRemove}
-                  className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
-                >
-                  Remove from this device…
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Root>
-          )}
+          {removeMenu}
         </div>
       ) : (
-        <div
-          className={[
-            "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
-            selected
-              ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
-              : "border-[var(--border-element)] group-hover:border-[var(--content-tertiary)]",
-          ].join(" ")}
-        >
-          {selected && (
-            <Check
-              className="h-3 w-3 text-[var(--surface-base)]"
-              strokeWidth={3}
-            />
+        <div className="flex shrink-0 items-center gap-2">
+          {removeMenu && (
+            /* The trigger sits inside the radio card: stop clicks and keys
+               from bubbling so opening the menu never selects the card and
+               the radio's Enter/Space handler never swallows the trigger. */
+            <div
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+            >
+              {removeMenu}
+            </div>
           )}
+          <div
+            className={[
+              "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200",
+              selected
+                ? "border-[var(--primary-base)] bg-[var(--primary-base)]"
+                : "border-[var(--border-element)] group-hover:border-[var(--content-tertiary)]",
+            ].join(" ")}
+          >
+            {selected && (
+              <Check
+                className="h-3 w-3 text-[var(--surface-base)]"
+                strokeWidth={3}
+              />
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -27,12 +27,20 @@ const saveLockfileAssistantHost = mock(
 
 const fetchGuardianTokenHost = mock(async (_id: string) => "guardian-tok");
 
+const unpairAssistantHost = mock(
+  async (_assistantId: string): Promise<localModeHost.LockfileWriteResult> => ({
+    ok: true as const,
+    lockfile: { assistants: [], activeAssistant: null },
+  }),
+);
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
   loadLockfileHost,
   saveLockfileAssistantHost,
   fetchGuardianTokenHost,
+  unpairAssistantHost,
 }));
 
 import {
@@ -56,6 +64,7 @@ import {
   primeLocalGatewayConnection,
   primeLocalGatewayConnectionWithStartupRetry,
   reconcileSelectedAssistant,
+  removePairedAssistantFromLockfile,
   removePlatformAssistantFromLockfile,
   saveManagedLockfileAssistant,
   syncPlatformAssistantsToLockfile,
@@ -65,6 +74,7 @@ import {
 import {
   clearGatewayToken,
   getGatewayToken,
+  seedGatewayToken,
 } from "@/lib/auth/gateway-session";
 import {
   getSelfHostedActorToken,
@@ -123,6 +133,7 @@ afterEach(() => {
   replacePlatformAssistantsHost.mockClear();
   saveLockfileAssistantHost.mockClear();
   fetchGuardianTokenHost.mockClear();
+  unpairAssistantHost.mockClear();
   clearGatewayToken();
   setSelfHostedConnection(null);
 });
@@ -308,6 +319,124 @@ describe("removePlatformAssistantFromLockfile", () => {
     await removePlatformAssistantFromLockfile("platform-a");
 
     expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("removePairedAssistantFromLockfile", () => {
+  function seedSessionResidue(): void {
+    seedGatewayToken({
+      token: "tok",
+      expiresAtEpochSeconds: Math.floor(Date.now() / 1000) + 3600,
+      source: "src",
+    });
+    setSelfHostedConnection({ url: "http://localhost/x", token: "tok" });
+  }
+
+  test("calls the host unpair and commits the returned lockfile", async () => {
+    setLockfile({
+      assistants: [localA, pairedEntry],
+      activeAssistant: "local-a",
+    });
+    const resulting = { assistants: [localA], activeAssistant: "local-a" };
+    unpairAssistantHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: resulting,
+    });
+
+    const result = await removePairedAssistantFromLockfile("paired-a");
+
+    expect(result).toEqual({ ok: true });
+    expect(unpairAssistantHost).toHaveBeenCalledWith("paired-a");
+    expect(useLockfileStore.getState().lockfile).toEqual(resulting);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("refuses non-paired entries without calling the host", async () => {
+    setLockfile({
+      assistants: [localA, platform],
+      activeAssistant: "local-a",
+    });
+
+    for (const id of ["local-a", "platform-a"]) {
+      const result = await removePairedAssistantFromLockfile(id);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeTruthy();
+    }
+    expect(unpairAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("refuses an unknown id without calling the host", async () => {
+    setLockfile({ assistants: [pairedEntry], activeAssistant: null });
+
+    const result = await removePairedAssistantFromLockfile("nope");
+
+    expect(result.ok).toBe(false);
+    expect(unpairAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("propagates a host failure without committing or clearing session state", async () => {
+    setLockfile({
+      assistants: [localA, pairedEntry],
+      activeAssistant: "local-a",
+    });
+    setSelected("paired-a");
+    unpairAssistantHost.mockResolvedValueOnce({
+      ok: false,
+      error: "Unpair is not supported by this app version",
+    });
+
+    const result = await removePairedAssistantFromLockfile("paired-a");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unpair is not supported by this app version",
+    });
+    expect(useLockfileStore.getState().committed).toBe(false);
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe(
+      "paired-a",
+    );
+  });
+
+  test("clears selection, gateway token, and self-hosted connection when removing the selected entry", async () => {
+    setLockfile({
+      assistants: [localA, pairedEntry],
+      activeAssistant: "local-a",
+    });
+    setSelected("paired-a");
+    seedSessionResidue();
+    unpairAssistantHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: { assistants: [localA], activeAssistant: "local-a" },
+    });
+
+    const result = await removePairedAssistantFromLockfile("paired-a");
+
+    expect(result.ok).toBe(true);
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
+    expect(getGatewayToken()).toBeNull();
+    expect(getSelfHostedIngressUrl()).toBeNull();
+  });
+
+  test("leaves session state alone when removing a non-selected entry", async () => {
+    setLockfile({
+      assistants: [localA, pairedEntry],
+      activeAssistant: "local-a",
+    });
+    setSelected("local-a");
+    seedSessionResidue();
+    unpairAssistantHost.mockResolvedValueOnce({
+      ok: true as const,
+      lockfile: { assistants: [localA], activeAssistant: "local-a" },
+    });
+
+    const result = await removePairedAssistantFromLockfile("paired-a");
+
+    expect(result.ok).toBe(true);
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe(
+      "local-a",
+    );
+    expect(getGatewayToken()).toBe("tok");
+    expect(getSelfHostedIngressUrl()).toBe("http://localhost/x");
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -22,6 +22,7 @@ import {
   replacePlatformAssistantsHost,
   retireLocalAssistantHost,
   saveLockfileAssistantHost,
+  unpairAssistantHost,
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
 import type {
@@ -372,6 +373,48 @@ export async function removePlatformAssistantFromLockfile(
   return { ok: true };
 }
 
+/**
+ * Drop the session state bound to the selected assistant: the raw selection
+ * key (no store import here, that would cycle; the reactive slice reconciles
+ * via `setFromLockfile` on the next lockfile commit/load), the gateway token,
+ * and the self-hosted connection.
+ */
+function clearSelectedAssistantSession(): void {
+  clearSelectedAssistantId();
+  clearGatewayToken();
+  setSelfHostedConnection(null);
+}
+
+/**
+ * Forget a paired assistant on this device: the host removes its lockfile
+ * entry and deletes its stored guardian token, never touching the remote
+ * assistant (pair again anytime with `vellum connect import`). When the
+ * removed entry is the effective selection, the session residue (selection
+ * key, gateway token, self-hosted connection) is cleared the same way a
+ * local retire clears it, so the next connect starts clean.
+ */
+export async function removePairedAssistantFromLockfile(
+  assistantId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry) {
+    return { ok: false, error: "This assistant isn't in the local list." };
+  }
+  if (!isPairedAssistant(entry)) {
+    return { ok: false, error: "This assistant isn't paired on this device." };
+  }
+  const wasSelected = getSelectedAssistant()?.assistantId === assistantId;
+  const result = await unpairAssistantHost(assistantId);
+  if (!result.ok) {
+    return { ok: false, error: result.error || "Failed to remove assistant." };
+  }
+  if (wasSelected) {
+    clearSelectedAssistantSession();
+  }
+  commitLockfile(result.lockfile);
+  return { ok: true };
+}
+
 // ---------------------------------------------------------------------------
 // Retire
 // ---------------------------------------------------------------------------
@@ -386,11 +429,7 @@ export async function retireLocalAssistant(
 ): Promise<LocalRetireResult> {
   const result = await retireLocalAssistantHost(assistantId);
   if (result.ok) {
-    // Clear the raw key directly (no store import here — that would cycle); the
-    // reactive slice reconciles via the `loadLockfile` below → `setFromLockfile`.
-    clearSelectedAssistantId();
-    clearGatewayToken();
-    setSelfHostedConnection(null);
+    clearSelectedAssistantSession();
     await loadLockfile();
   }
   return result;


### PR DESCRIPTION
## Summary
- removePairedAssistantFromLockfile rides the unpair host op and clears session residue for the selected entry
- Paired cards get the Remove from this device menu with pairing-specific confirm copy
- retire-service refuses paired targets with actionable copy

Part of plan: web-paired-entries.md (PR 7 of 8)