### PR TITLE
feat(web): deep-link anchor + local reset time for the daily credit limit

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -442,8 +442,8 @@ export function ChatMainPanel({
     void navigate(routes.settings.ai);
   }, [navigate]);
 
-  const pushToBillingSettings = useCallback(() => {
-    void navigate(routes.settings.usageBilling);
+  const pushToDailyLimitSettings = useCallback(() => {
+    void navigate(routes.settings.usageBillingDailyLimit);
   }, [navigate]);
 
   const checkAssistant = useCallback(
@@ -1235,7 +1235,7 @@ export function ChatMainPanel({
             onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
             billingBannerSlot={
               composerBillingBanner === "daily_limit" ? (
-                <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
+                <DailyLimitBanner onAdjustLimit={pushToDailyLimitSettings} />
               ) : composerBillingBanner === "provider_billing" ? (
                 <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
               ) : composerBillingBanner === "low_balance" ? (

--- a/clients/web/src/domains/chat/components/daily-limit-banner.tsx
+++ b/clients/web/src/domains/chat/components/daily-limit-banner.tsx
@@ -1,6 +1,7 @@
 import { CalendarClock } from "lucide-react";
 
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import { dailyResetTimePhrase } from "@/utils/daily-reset-time";
 
 interface DailyLimitBannerProps {
   onAdjustLimit: () => void;
@@ -17,7 +18,7 @@ export function DailyLimitBanner({ onAdjustLimit }: DailyLimitBannerProps) {
         />
       }
       title="Daily credit limit reached"
-      subtitle="This limit applies to Vellum credit spend and resets at midnight UTC."
+      subtitle={`This limit applies to Vellum credit spend and resets at ${dailyResetTimePhrase()}.`}
       action={{ label: "Adjust Limit", onClick: onAdjustLimit }}
     />
   );

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 
-import { useNavigate, useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -312,7 +312,9 @@ function UsagePanel() {
 
 export function BillingPage() {
   const billingGate = usePlatformGate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { hash } = useLocation();
   // Shown when signed in (`"full"`); for a signed-out-but-reachable viewer
   // (`"disabled"`) it stays reachable only when the URL carries billing intent
   // (a deeplink / upgrade CTA / Stripe return), so the BillingTab login notice
@@ -344,14 +346,17 @@ export function BillingPage() {
     if (searchParams.get("tab") !== activeTab) {
       const next = new URLSearchParams(searchParams);
       next.set("tab", activeTab);
-      setSearchParams(next, { replace: true });
+      // Not `setSearchParams` — that drops the URL hash, and anchor deep
+      // links (`#daily-credit-limit` from the daily-limit email) must survive
+      // this normalization however late the anchored card mounts.
+      void navigate({ search: `?${next}`, hash }, { replace: true });
     }
-  }, [isPlatformSessionSettled, searchParams, activeTab, setSearchParams]);
+  }, [isPlatformSessionSettled, searchParams, activeTab, navigate, hash]);
 
   const handleTabChange = (value: string) => {
     const next = new URLSearchParams(searchParams);
     next.set("tab", value);
-    setSearchParams(next, { replace: true });
+    void navigate({ search: `?${next}`, hash }, { replace: true });
   };
 
   return (

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -16,7 +16,10 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { StatSquare } from "@vellumai/design-library/components/stat-square";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { DailyCreditLimitCard } from "./daily-credit-limit-card";
+import {
+  DAILY_CREDIT_LIMIT_ANCHOR_ID,
+  DailyCreditLimitCard,
+} from "./daily-credit-limit-card";
 import { LowBalanceAlertCard } from "./low-balance-alert-card";
 import { ReferralModal } from "./referral-modal";
 
@@ -219,7 +222,10 @@ export function BillingPanel() {
         <div className="mt-6 border-t border-[var(--border-base)] pt-6">
           <AutoTopUpCard />
         </div>
-        <div className="mt-6 border-t border-[var(--border-base)] pt-6">
+        <div
+          id={DAILY_CREDIT_LIMIT_ANCHOR_ID}
+          className="mt-6 scroll-mt-4 border-t border-[var(--border-base)] pt-6"
+        >
           <DailyCreditLimitCard />
         </div>
       </Card>

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -39,7 +39,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
 import { organizationsBillingDailyCreditLimitRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { DailyCreditLimitResponse } from "@/generated/api/types.gen";
 
-const { DailyCreditLimitCard, validateDailyLimit } =
+import { routes } from "@/utils/routes";
+
+const { DAILY_CREDIT_LIMIT_ANCHOR_ID, DailyCreditLimitCard, validateDailyLimit } =
   await import("./daily-credit-limit-card");
 
 function makeClient(config: DailyCreditLimitResponse): QueryClient {
@@ -146,5 +148,11 @@ describe("DailyCreditLimitCard", () => {
 
     expect(container.textContent).toContain("Must be at least $1");
     expect(updateCalls.length).toBe(0);
+  });
+});
+
+describe("DAILY_CREDIT_LIMIT_ANCHOR_ID", () => {
+  test("matches the hash in the deep-link route constant", () => {
+    expect(routes.settings.usageBillingDailyLimit.endsWith(`#${DAILY_CREDIT_LIMIT_ANCHOR_ID}`)).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -9,10 +9,19 @@ import {
   organizationsBillingSummaryRetrieveOptions,
   organizationsBillingSummaryRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { useScrollToAnchor } from "@/hooks/use-scroll-to-anchor";
+import { dailyResetTimePhrase } from "@/utils/daily-reset-time";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
+
+/**
+ * In-page anchor for deep links straight to this card (chat banner "Adjust
+ * Limit", the platform's daily-limit email). Must match the hash in
+ * `routes.settings.usageBillingDailyLimit`.
+ */
+export const DAILY_CREDIT_LIMIT_ANCHOR_ID = "daily-credit-limit";
 
 /** Format a USD decimal string ("5.00") as "$5.00" for display copy. */
 function formatUsd(value: string): string {
@@ -65,6 +74,14 @@ export function DailyCreditLimitCard() {
     organizationsBillingDailyCreditLimitUpdateMutation(),
   );
 
+  // Deep links (`#daily-credit-limit`) land here once both queries have
+  // settled, so the content above the anchor has taken its final height
+  // before we scroll.
+  useScrollToAnchor(
+    DAILY_CREDIT_LIMIT_ANCHOR_ID,
+    !limitQuery.isLoading && !summaryQuery.isLoading,
+  );
+
   // `draft === null` means "not yet edited"; seed from the query below. Tracking
   // the edited value separately keeps the input controlled without an effect
   // that copies server state into local state.
@@ -103,6 +120,7 @@ export function DailyCreditLimitCard() {
   const summary = summaryQuery.data;
   const dailySpend = summary?.daily_spend_usd ?? config.current_day_spent_usd;
   const limitReached = summary?.daily_limit_reached === true;
+  const resetPhrase = dailyResetTimePhrase();
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDraft(e.target.value);
@@ -185,7 +203,7 @@ export function DailyCreditLimitCard() {
                   step="0.01"
                   min="1"
                   label="Stop spending Vellum credits after"
-                  helperText="Per UTC day. Resets at midnight UTC."
+                  helperText={`Resets daily at ${resetPhrase}.`}
                   placeholder="0.00"
                   value={value}
                   onChange={onChange}
@@ -224,7 +242,7 @@ export function DailyCreditLimitCard() {
             {limitReached && (
               <Notice tone="warning" data-testid="daily-credit-limit-reached">
                 Today&apos;s Vellum credit spend has reached this limit.
-                Generation resumes after midnight UTC or when you raise the
+                Generation resumes at {resetPhrase} or when you raise the
                 limit.
               </Notice>
             )}
@@ -234,7 +252,7 @@ export function DailyCreditLimitCard() {
 
       <p className="mt-3 text-body-small-default text-[var(--content-tertiary)]">
         Applies to Vellum credit spend only. Usage billed to your own provider
-        API keys isn&apos;t limited. Resets at midnight UTC.
+        API keys isn&apos;t limited. Resets daily at {resetPhrase}.
       </p>
 
       {showGenericError && (

--- a/clients/web/src/domains/settings/pages/billing-redirect-page.tsx
+++ b/clients/web/src/domains/settings/pages/billing-redirect-page.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useSearchParams } from "react-router";
+import { Navigate, useLocation, useSearchParams } from "react-router";
 
 import { routes } from "@/utils/routes";
 
@@ -7,20 +7,23 @@ import { routes } from "@/utils/routes";
  * `/assistant/settings/billing` route as a permanent redirect so existing
  * bookmarks — and the server-configured Stripe checkout/portal return URLs that
  * land here with `billing_status` / `session_id` / `adjust_plan` — continue to
- * work. All query params carry over verbatim. Billing is the destination
- * page's default tab when signed in, so these return flows reach the Billing
- * panel without an explicit `tab` (and a signed-out user, who can't reach these
- * flows anyway, falls back to Usage since the Billing tab is hidden for them).
+ * work. All query params and the hash carry over verbatim (platform emails
+ * deep-link to `#daily-credit-limit` through this route). Billing is the
+ * destination page's default tab when signed in, so these return flows reach
+ * the Billing panel without an explicit `tab` (and a signed-out user, who
+ * can't reach these flows anyway, falls back to Usage since the Billing tab is
+ * hidden for them).
  */
 export function BillingRedirectPage() {
   const [searchParams] = useSearchParams();
+  const { hash } = useLocation();
 
   const query = searchParams.toString();
 
   return (
     <Navigate
       replace
-      to={`${routes.settings.usage}${query ? `?${query}` : ""}`}
+      to={`${routes.settings.usage}${query ? `?${query}` : ""}${hash}`}
     />
   );
 }

--- a/clients/web/src/hooks/use-scroll-to-anchor.ts
+++ b/clients/web/src/hooks/use-scroll-to-anchor.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+/**
+ * One-shot scroll to an in-page anchor named by the URL hash.
+ *
+ * Captures `window.location.hash` when the calling component first renders,
+ * because later same-route navigations (e.g. tab rewrites via
+ * `setSearchParams`) drop the hash from the URL before async content settles.
+ * Scrolls once `ready` turns true and the element exists, then never again for
+ * the component's lifetime.
+ */
+export function useScrollToAnchor(anchorId: string, ready: boolean): void {
+  const [targetsAnchor] = useState(
+    () => window.location.hash === `#${anchorId}`,
+  );
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    if (!targetsAnchor || scrolled || !ready) {
+      return;
+    }
+    const element = document.getElementById(anchorId);
+    if (!element) {
+      return;
+    }
+    setScrolled(true);
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    element.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
+  }, [targetsAnchor, scrolled, ready, anchorId]);
+}

--- a/clients/web/src/utils/daily-reset-time.test.ts
+++ b/clients/web/src/utils/daily-reset-time.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { dailyResetTimePhrase } from "./daily-reset-time";
+
+describe("dailyResetTimePhrase", () => {
+  test("collapses to plain UTC copy when the clock aligns with UTC", () => {
+    expect(dailyResetTimePhrase("UTC", new Date("2026-07-15T10:00:00Z"))).toBe(
+      "midnight UTC",
+    );
+  });
+
+  test("renders the local reset hour for a DST-observing zone in summer", () => {
+    expect(
+      dailyResetTimePhrase("America/New_York", new Date("2026-07-15T10:00:00Z")),
+    ).toBe("8:00 PM your time (midnight UTC)");
+  });
+
+  test("renders the local reset hour for a DST-observing zone in winter", () => {
+    expect(
+      dailyResetTimePhrase("America/New_York", new Date("2026-01-15T10:00:00Z")),
+    ).toBe("7:00 PM your time (midnight UTC)");
+  });
+
+  test("handles half-hour offsets", () => {
+    expect(
+      dailyResetTimePhrase("Asia/Kolkata", new Date("2026-07-15T10:00:00Z")),
+    ).toBe("5:30 AM your time (midnight UTC)");
+  });
+});

--- a/clients/web/src/utils/daily-reset-time.test.ts
+++ b/clients/web/src/utils/daily-reset-time.test.ts
@@ -3,27 +3,27 @@ import { describe, expect, test } from "bun:test";
 import { dailyResetTimePhrase } from "./daily-reset-time";
 
 describe("dailyResetTimePhrase", () => {
-  test("collapses to plain UTC copy when the clock aligns with UTC", () => {
-    expect(dailyResetTimePhrase("UTC", new Date("2026-07-15T10:00:00Z"))).toBe(
-      "midnight UTC",
-    );
-  });
-
-  test("renders the local reset hour for a DST-observing zone in summer", () => {
+  test("uses the generic zone abbreviation, not the DST-specific one", () => {
     expect(
-      dailyResetTimePhrase("America/New_York", new Date("2026-07-15T10:00:00Z")),
-    ).toBe("8:00 PM your time (midnight UTC)");
+      dailyResetTimePhrase("America/Denver", new Date("2026-07-15T10:00:00Z")),
+    ).toBe("6:00 PM MT");
   });
 
-  test("renders the local reset hour for a DST-observing zone in winter", () => {
+  test("tracks DST: same zone shifts an hour in winter", () => {
     expect(
-      dailyResetTimePhrase("America/New_York", new Date("2026-01-15T10:00:00Z")),
-    ).toBe("7:00 PM your time (midnight UTC)");
+      dailyResetTimePhrase("America/Denver", new Date("2026-01-15T10:00:00Z")),
+    ).toBe("5:00 PM MT");
   });
 
-  test("handles half-hour offsets", () => {
+  test("handles half-hour offsets via the zone's fallback label", () => {
     expect(
       dailyResetTimePhrase("Asia/Kolkata", new Date("2026-07-15T10:00:00Z")),
-    ).toBe("5:30 AM your time (midnight UTC)");
+    ).toBe("5:30 AM India Time");
+  });
+
+  test("UTC-aligned viewers get a plain GMT label", () => {
+    expect(dailyResetTimePhrase("UTC", new Date("2026-07-15T10:00:00Z"))).toBe(
+      "12:00 AM GMT",
+    );
   });
 });

--- a/clients/web/src/utils/daily-reset-time.ts
+++ b/clients/web/src/utils/daily-reset-time.ts
@@ -1,0 +1,27 @@
+/**
+ * Human phrase for the moment the daily credit limit resets. The platform
+ * resets the spend counter at midnight UTC; this expresses that moment in the
+ * viewer's clock: "5:00 PM your time (midnight UTC)", or just "midnight UTC"
+ * when the viewer's clock aligns with UTC midnight.
+ *
+ * Computed from the actual next UTC midnight so DST transitions land on the
+ * right local hour. `timeZone` and `now` are injectable for tests; production
+ * callers pass neither.
+ */
+export function dailyResetTimePhrase(
+  timeZone?: string,
+  now: Date = new Date(),
+): string {
+  const nextUtcMidnight = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  );
+  const localTime = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    ...(timeZone ? { timeZone } : {}),
+  }).format(nextUtcMidnight);
+  if (localTime === "12:00 AM") {
+    return "midnight UTC";
+  }
+  return `${localTime} your time (midnight UTC)`;
+}

--- a/clients/web/src/utils/daily-reset-time.ts
+++ b/clients/web/src/utils/daily-reset-time.ts
@@ -1,8 +1,9 @@
 /**
  * Human phrase for the moment the daily credit limit resets. The platform
  * resets the spend counter at midnight UTC; this expresses that moment in the
- * viewer's clock: "5:00 PM your time (midnight UTC)", or just "midnight UTC"
- * when the viewer's clock aligns with UTC midnight.
+ * viewer's clock with a timezone label: "5:00 PM MT". The generic zone name
+ * avoids DST-specific abbreviations (MT, not MDT); zones without one fall
+ * back to a location or offset label ("India Time", "GMT+2").
  *
  * Computed from the actual next UTC midnight so DST transitions land on the
  * right local hour. `timeZone` and `now` are injectable for tests; production
@@ -15,17 +16,16 @@ export function dailyResetTimePhrase(
   const nextUtcMidnight = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
   );
-  const localTime = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    ...(timeZone ? { timeZone } : {}),
-  })
-    .format(nextUtcMidnight)
-    // Some ICU builds separate the time from AM/PM with a narrow no-break
-    // space; normalize so the comparison and the copy are runtime-independent.
-    .replace(/ /g, " ");
-  if (localTime === "12:00 AM") {
-    return "midnight UTC";
-  }
-  return `${localTime} your time (midnight UTC)`;
+  return (
+    new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "shortGeneric",
+      ...(timeZone ? { timeZone } : {}),
+    })
+      .format(nextUtcMidnight)
+      // Some ICU builds separate the time from AM/PM with a narrow no-break
+      // space; normalize so the copy is runtime-independent.
+      .replace(/ /g, " ")
+  );
 }

--- a/clients/web/src/utils/daily-reset-time.ts
+++ b/clients/web/src/utils/daily-reset-time.ts
@@ -19,7 +19,11 @@ export function dailyResetTimePhrase(
     hour: "numeric",
     minute: "2-digit",
     ...(timeZone ? { timeZone } : {}),
-  }).format(nextUtcMidnight);
+  })
+    .format(nextUtcMidnight)
+    // Some ICU builds separate the time from AM/PM with a narrow no-break
+    // space; normalize so the comparison and the copy are runtime-independent.
+    .replace(/ /g, " ");
   if (localTime === "12:00 AM") {
     return "midnight UTC";
   }

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -227,6 +227,11 @@ export const routes = {
     // Deep-link straight to the Billing sub-tab (only shown when signed in to
     // the Vellum platform).
     usageBilling: `${SETTINGS_USAGE_PATH}?tab=billing`,
+    // Lands on the daily credit limit card inside the Billing tab. The hash
+    // must match `DAILY_CREDIT_LIMIT_ANCHOR_ID` in `daily-credit-limit-card.tsx`
+    // (guarded by that card's test); the platform's daily-limit email links
+    // here via the `/assistant/settings/billing` redirect.
+    usageBillingDailyLimit: `${SETTINGS_USAGE_PATH}?tab=billing#daily-credit-limit`,
     usageBillingConfigureTopUps: `${SETTINGS_USAGE_PATH}?tab=billing&configure_top_up=1`,
     // Post-Stripe-Checkout return. The Billing tab opens the Pro onboarding
     // wizard while `session_id` is in the URL — the same param the platform's


### PR DESCRIPTION
## What

- Adds an in-page anchor (`#daily-credit-limit`) on the daily credit limit card in Settings → Billing, with a one-shot `useScrollToAnchor` hook that captures the URL hash at first render and scrolls once the card's queries settle. The hash is captured early because the billing page's tab-rewrite `setSearchParams` strips it from the URL right after load.
- The legacy `/assistant/settings/billing` redirect now carries the URL hash through (it previously only carried query params), so long-lived links like transactional emails can use the short path.
- The chat banner's **Adjust Limit** action now deep-links to the card via the new `routes.settings.usageBillingDailyLimit` constant instead of just the Billing tab.
- Daily-limit copy (banner subtitle, input helper, footer, limit-reached notice) now states the reset moment in the viewer's local clock via `dailyResetTimePhrase()`: "5:00 PM your time (midnight UTC)", collapsing to plain "midnight UTC" when the viewer's clock aligns with UTC. Computed from the actual next UTC midnight so DST lands on the right hour.

## Why

The platform is gaining a "daily credit limit reached" transactional email (companion PR in `vellum-assistant-platform`) that links users straight to this control; the anchor removes the scroll-hunt on arrival. The local reset time is the presentational half of making the limit timezone-aware, the enforcement day stays UTC.

## Tests

- `daily-reset-time.test.ts`: UTC collapse, DST summer/winter, half-hour offsets
- Anchor/route drift guard in `daily-credit-limit-card.test.tsx`
- Existing card + routes suites pass; `tsc --noEmit` and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->