### PR TITLE
feat(web): render home feed items as cards with a message preview

### DIFF
--- a/clients/web/src/domains/home/home-feed-list.tsx
+++ b/clients/web/src/domains/home/home-feed-list.tsx
@@ -153,7 +153,7 @@ export function HomeFeedList({
               {TIME_GROUP_LABELS[group]}
             </Typography>
 
-            <div className="flex flex-col gap-[var(--app-spacing-xs)]">
+            <div className="flex flex-col gap-[var(--app-spacing-sm)]">
               {groupItems.map((item) => (
                 <HomeRecapRow
                   key={item.id}
@@ -188,7 +188,7 @@ export function HomeFeedList({
               <span>Earlier ({archivedRead.length})</span>
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+              <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">
                 {archivedRead.map((item) => (
                   <HomeRecapRow
                     key={item.id}
@@ -224,7 +224,7 @@ export function HomeFeedList({
               <span>Dismissed ({dismissed.length})</span>
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+              <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">
                 {dismissed.map((item) => (
                   <HomeRecapRow
                     key={item.id}

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -2,9 +2,9 @@
  * Tests for `HomeRecapRow`.
  *
  * Rendered into happy-dom via `@testing-library/react` so clicks can be
- * dispatched. Assertions target text, roles, `aria-label`s, and DOM structure,
- * never class strings: those drift with styling and turn behaviour tests into
- * styling tests.
+ * dispatched. Assertions target text, roles, `aria-label`s, test ids, and DOM
+ * structure, never class strings: those drift with styling and turn behaviour
+ * tests into styling tests.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -40,7 +40,7 @@ function renderRow(props: Partial<HomeRecapRowProps> = {}) {
   const threads: string[] = [];
   const item = props.item ?? makeItem();
 
-  render(
+  const { container } = render(
     <HomeRecapRow
       item={item}
       onSelect={(selectedItem) => selected.push(selectedItem)}
@@ -51,7 +51,7 @@ function renderRow(props: Partial<HomeRecapRowProps> = {}) {
     />,
   );
 
-  return { item, selected, dismissed, readToggles, threads };
+  return { container, item, selected, dismissed, readToggles, threads };
 }
 
 afterEach(() => {
@@ -166,5 +166,71 @@ describe("HomeRecapRow", () => {
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
 
     expect(dismissed).toEqual(["feed-1"]);
+  });
+});
+
+describe("HomeRecapRow card content", () => {
+  test("renders the category, the title, and a preview of the summary", () => {
+    renderRow();
+
+    expect(screen.getByText("Background")).toBeTruthy();
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(
+      screen.getByText("The watcher job could not reach the upstream service."),
+    ).toBeTruthy();
+  });
+
+  test("renders no preview when the summary only restates the title", () => {
+    renderRow({
+      item: makeItem({
+        title: "Watcher job failed",
+        summary: "Watcher job failed",
+      }),
+    });
+
+    expect(screen.getAllByText("Watcher job failed").length).toBe(1);
+  });
+
+  test("an untitled item shows its summary once and no preview", () => {
+    const summary = "The watcher job could not reach the upstream service.";
+    renderRow({ item: makeItem({ title: undefined }) });
+
+    expect(screen.getAllByText(summary).length).toBe(1);
+  });
+
+  test("renders an informative source label", () => {
+    renderRow({ item: makeItem({ sourceLabel: "Heartbeat" }) });
+
+    expect(screen.getByText("Heartbeat")).toBeTruthy();
+  });
+
+  test.each(["Conversation", "Other"])(
+    "omits the generic %s source label",
+    (sourceLabel) => {
+      renderRow({ item: makeItem({ sourceLabel }) });
+
+      expect(screen.queryByText(sourceLabel)).toBeNull();
+    },
+  );
+
+  test("marks an unread item with a dot", () => {
+    renderRow();
+
+    expect(screen.getByTestId("home-recap-row-unread-dot")).toBeTruthy();
+  });
+
+  test("omits the dot for an already-read item", () => {
+    renderRow({ item: makeItem({ status: "seen" }) });
+
+    expect(screen.queryByTestId("home-recap-row-unread-dot")).toBeNull();
+  });
+
+  test("compact density renders and differs from the comfortable default", () => {
+    const comfortable = renderRow().container.innerHTML;
+    cleanup();
+    const { container } = renderRow({ density: "compact" });
+
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(container.innerHTML).not.toBe(comfortable);
   });
 });

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -1,14 +1,17 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { formatRelativeDate } from "@/utils/format-date";
-import type {
-  FeedItem,
-  FeedItemCategory,
-  FeedItemStatus,
-} from "@vellumai/assistant-api";
-import { cn, Tooltip } from "@vellumai/design-library";
-import { CATEGORY_STYLES } from "./home-feed-filter-bar";
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
+import {
+  cn,
+  Tooltip,
+  Typography,
+  type TypographyVariant,
+} from "@vellumai/design-library";
+
+import { FeedCategoryChip } from "./feed-category-chip";
+import { resolvePreview } from "./feed-preview";
 
 function HoverIconButton({
   label,
@@ -43,12 +46,30 @@ function HoverIconButton({
   );
 }
 
-function resolveStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES.system;
+/** Source labels that carry nothing the category chip does not already say. */
+const GENERIC_SOURCE_LABELS = new Set(["Conversation", "Other"]);
+
+export type HomeRecapRowDensity = "comfortable" | "compact";
+
+interface DensityStyle {
+  /** Card padding and the gap between the meta row, title, and preview. */
+  card: string;
+  titleVariant: TypographyVariant;
+  clamp: string;
 }
+
+const DENSITY_STYLES: Record<HomeRecapRowDensity, DensityStyle> = {
+  comfortable: {
+    card: "gap-[var(--app-spacing-xs)] p-[var(--app-spacing-md)]",
+    titleVariant: "title-small",
+    clamp: "line-clamp-2",
+  },
+  compact: {
+    card: "gap-[var(--app-spacing-xxs)] p-[var(--app-spacing-sm)]",
+    titleVariant: "body-medium-default",
+    clamp: "line-clamp-1",
+  },
+};
 
 export type HomeRecapRowTrailingAction = "dismiss" | "restore";
 
@@ -61,6 +82,7 @@ export interface HomeRecapRowProps {
   onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
   onGoToThread?: (conversationId: string) => void;
   trailingAction?: HomeRecapRowTrailingAction;
+  density?: HomeRecapRowDensity;
 }
 
 export function HomeRecapRow({
@@ -72,136 +94,169 @@ export function HomeRecapRow({
   onToggleRead,
   onGoToThread,
   trailingAction = "dismiss",
+  density = "comfortable",
 }: HomeRecapRowProps) {
-  const style = resolveStyle(item.category);
-  const Icon = style.icon;
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
-  const label = item.title ?? item.summary;
+  const title = item.title ?? item.summary;
+  const densityStyle = DENSITY_STYLES[density];
+
+  const sourceLabel =
+    item.sourceLabel && !GENERIC_SOURCE_LABELS.has(item.sourceLabel)
+      ? item.sourceLabel
+      : null;
+
+  // Memoized: resolving a preview parses the summary as markdown, and the feed
+  // re-renders every card whenever its filter changes.
+  const preview = useMemo(
+    () => resolvePreview(title, item.summary),
+    [title, item.summary],
+  );
 
   return (
     <div
       className={cn(
-        "group relative flex min-h-[48px] w-full items-center gap-[var(--app-spacing-sm)]",
-        "rounded-[var(--radius-md)] px-[var(--app-spacing-md)] py-[var(--app-spacing-sm)]",
+        "group relative flex w-full flex-col",
+        "rounded-[var(--radius-lg)] border border-[var(--border-base)]",
         "transition-[background-color,opacity] duration-150",
+        densityStyle.card,
         isActive
           ? "bg-[var(--surface-active)]"
           : "bg-[var(--surface-overlay)] hover:bg-[var(--surface-hover)]",
         !isUnread && !isActive && "opacity-70",
       )}
     >
-      {/* Stretched link: the row's single click target. Everything else stacks
+      {/* Stretched link: the card's single click target. Everything else stacks
           above it and so must stay `pointer-events-none` unless it is itself
-          interactive, or clicks meant for the row get swallowed. */}
+          interactive, or clicks meant for the card get swallowed. */}
       <button
         type="button"
-        aria-label={label}
+        aria-label={title}
         onClick={() => onSelect(item)}
-        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-md)]"
+        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-lg)]"
       />
 
-      <span
-        className="pointer-events-none relative shrink-0"
-        aria-hidden="true"
-      >
-        <span
-          className="flex items-center justify-center rounded-full"
-          style={{
-            width: 26,
-            height: 26,
-            backgroundColor: style.weak,
-          }}
-        >
-          <Icon width={12} height={12} style={{ color: style.strong }} />
-        </span>
-        {isUnread && (
-          <span className="absolute -left-0.5 -top-0.5 h-2 w-2 rounded-full bg-[var(--system-mid-strong)]" />
+      <div className="pointer-events-none relative flex items-center gap-[var(--app-spacing-sm)]">
+        <FeedCategoryChip category={item.category} />
+
+        {sourceLabel !== null && (
+          <Typography
+            variant="body-small-default"
+            className="min-w-0 truncate text-[var(--content-tertiary)]"
+          >
+            {sourceLabel}
+          </Typography>
         )}
-      </span>
 
-      <span
-        className={cn(
-          "text-body-medium-default pointer-events-none relative min-w-0 flex-1 truncate text-left",
-          "text-[var(--content-secondary)]",
-        )}
-      >
-        {label}
-      </span>
-
-      {/* Timestamp and actions share one grid cell so the row keeps a stable
-          width as they cross-fade. */}
-      <span className="pointer-events-none relative grid shrink-0 items-center justify-items-end">
-        <span
-          className={cn(
-            "col-start-1 row-start-1",
-            "text-body-small-default text-[var(--content-tertiary)]",
-            "transition-opacity duration-150",
-            "group-hover:opacity-0 group-focus-within:opacity-0",
-          )}
-        >
-          {formatRelativeDate(item.timestamp)}
-        </span>
-
-        <span
-          className={cn(
-            "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
-            "pointer-events-none opacity-0 transition-opacity duration-150",
-            "group-hover:pointer-events-auto group-hover:opacity-100",
-            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-          )}
-        >
-          {isRestore ? (
-            <HoverIconButton
-              label="Restore"
-              onClick={() => onDismiss(item.id)}
-              className="w-auto gap-[var(--app-spacing-xs)] px-2"
+        {/* Timestamp and actions share one grid cell so the card keeps a stable
+            width as they cross-fade. */}
+        <span className="ml-auto grid shrink-0 items-center justify-items-end">
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-xs)]",
+              "transition-opacity duration-150",
+              "group-hover:opacity-0 group-focus-within:opacity-0",
+            )}
+          >
+            <Typography
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
             >
-              <RotateCcw width={16} height={16} aria-hidden="true" />
-              <span className="text-body-small-default">Restore</span>
-            </HoverIconButton>
-          ) : (
-            <>
-              {onToggleRead && (
-                <HoverIconButton
-                  label={isUnread ? "Mark as read" : "Mark as unread"}
-                  onClick={() =>
-                    onToggleRead(item.id, isUnread ? "seen" : "new")
-                  }
-                >
-                  {isUnread ? (
-                    <MailOpen width={16} height={16} />
-                  ) : (
-                    <Mail width={16} height={16} />
-                  )}
-                </HoverIconButton>
-              )}
-              {onGoToThread &&
-                item.conversationId &&
-                (!validConversationIds ||
-                  validConversationIds.has(item.conversationId)) && (
+              {formatRelativeDate(item.timestamp)}
+            </Typography>
+            {isUnread && (
+              <span
+                data-testid="home-recap-row-unread-dot"
+                aria-hidden="true"
+                className="h-2 w-2 shrink-0 rounded-full bg-[var(--system-mid-strong)]"
+              />
+            )}
+          </span>
+
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
+              "pointer-events-none opacity-0 transition-opacity duration-150",
+              "group-hover:pointer-events-auto group-hover:opacity-100",
+              "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+            )}
+          >
+            {isRestore ? (
+              <HoverIconButton
+                label="Restore"
+                onClick={() => onDismiss(item.id)}
+                className="w-auto gap-[var(--app-spacing-xs)] px-2"
+              >
+                <RotateCcw width={16} height={16} aria-hidden="true" />
+                <span className="text-body-small-default">Restore</span>
+              </HoverIconButton>
+            ) : (
+              <>
+                {onToggleRead && (
                   <HoverIconButton
-                    label="Go to thread"
-                    onClick={() => {
-                      if (isUnread && onToggleRead) {
-                        onToggleRead(item.id, "seen");
-                      }
-                      onGoToThread(item.conversationId!);
-                    }}
+                    label={isUnread ? "Mark as read" : "Mark as unread"}
+                    onClick={() =>
+                      onToggleRead(item.id, isUnread ? "seen" : "new")
+                    }
                   >
-                    <MessageSquare width={16} height={16} />
+                    {isUnread ? (
+                      <MailOpen width={16} height={16} />
+                    ) : (
+                      <Mail width={16} height={16} />
+                    )}
                   </HoverIconButton>
                 )}
-              <HoverIconButton
-                label="Dismiss"
-                onClick={() => onDismiss(item.id)}
-              >
-                <Trash2 width={16} height={16} />
-              </HoverIconButton>
-            </>
-          )}
+                {onGoToThread &&
+                  item.conversationId &&
+                  (!validConversationIds ||
+                    validConversationIds.has(item.conversationId)) && (
+                    <HoverIconButton
+                      label="Go to thread"
+                      onClick={() => {
+                        if (isUnread && onToggleRead) {
+                          onToggleRead(item.id, "seen");
+                        }
+                        onGoToThread(item.conversationId!);
+                      }}
+                    >
+                      <MessageSquare width={16} height={16} />
+                    </HoverIconButton>
+                  )}
+                <HoverIconButton
+                  label="Dismiss"
+                  onClick={() => onDismiss(item.id)}
+                >
+                  <Trash2 width={16} height={16} />
+                </HoverIconButton>
+              </>
+            )}
+          </span>
         </span>
-      </span>
+      </div>
+
+      {/* leading-snug: the title-small token is line-height:1, and line-clamp's
+          overflow clipping would cut descenders without real line height. */}
+      <Typography
+        variant={densityStyle.titleVariant}
+        className={cn(
+          "pointer-events-none relative leading-snug text-[var(--content-default)]",
+          densityStyle.clamp,
+        )}
+      >
+        {title}
+      </Typography>
+
+      {preview !== null && (
+        <Typography
+          variant="body-medium-lighter"
+          className={cn(
+            "pointer-events-none relative leading-normal text-[var(--content-secondary)]",
+            densityStyle.clamp,
+          )}
+        >
+          {preview}
+        </Typography>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Rebuilds the home feed row as a card: category chip, optional source label, timestamp and unread dot on the meta row, then the title, then a plain-text message preview.
- Adds a `density` prop so the notifications bell can render the same card compactly.
- Drops the category icon circle; the chip now carries category identity.

Part of plan: home-feed-notification-cards.md (PR 6 of 6)