### PR TITLE
fix(macos,web): stop false "Trying to reach Vellum" banner for platform sessions

### DIFF
--- a/clients/macos/src/main/connectivity-probe.test.ts
+++ b/clients/macos/src/main/connectivity-probe.test.ts
@@ -121,6 +121,52 @@ describe("connectivity-probe", () => {
     expect(backendReachableCalls).toEqual([true]);
   });
 
+  test("sets backend reachable=true when a cloud assistant carries leftover local resources", async () => {
+    // Lockfile merges preserve `resources` across cloud transitions, so a
+    // platform entry can carry a stale gatewayPort. It must not be
+    // loopback-probed — that port belongs to a stopped local runtime.
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+            resources: { gatewayPort: 7830 },
+          },
+        ],
+        activeAssistant: "cloud-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual([]);
+    expect(backendReachableCalls).toEqual([true]);
+  });
+
+  test("probes docker assistants over their loopback gateway", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "docker-1",
+            cloud: "docker",
+            resources: { gatewayPort: 7840 },
+          },
+        ],
+        activeAssistant: "docker-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["http://127.0.0.1:7840/healthz"]);
+    expect(backendReachableCalls).toEqual([true]);
+  });
+
   test("does not change reachability when lockfile cannot be read", async () => {
     mockLockfileData = { ok: false };
 

--- a/clients/macos/src/main/connectivity-probe.test.ts
+++ b/clients/macos/src/main/connectivity-probe.test.ts
@@ -124,7 +124,7 @@ describe("connectivity-probe", () => {
   test("sets backend reachable=true when a cloud assistant carries leftover local resources", async () => {
     // Lockfile merges preserve `resources` across cloud transitions, so a
     // platform entry can carry a stale gatewayPort. It must not be
-    // loopback-probed — that port belongs to a stopped local runtime.
+    // loopback-probed: that port belongs to a stopped local runtime.
     mockLockfileData = {
       ok: true,
       data: {
@@ -165,6 +165,50 @@ describe("connectivity-probe", () => {
 
     expect(fetchCalls).toEqual(["http://127.0.0.1:7840/healthz"]);
     expect(backendReachableCalls).toEqual([true]);
+  });
+
+  test("recovers the docker probe port from a loopback runtimeUrl", async () => {
+    // Docker hatch records the published gateway as a loopback runtimeUrl
+    // with no `resources` block.
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "docker-1",
+            cloud: "docker",
+            runtimeUrl: "http://localhost:7841",
+          },
+        ],
+        activeAssistant: "docker-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["http://127.0.0.1:7841/healthz"]);
+    expect(backendReachableCalls).toEqual([true]);
+  });
+
+  test("does not probe a non-loopback runtimeUrl", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "docker-1",
+            cloud: "docker",
+            runtimeUrl: "http://192.0.2.10:7841",
+          },
+        ],
+        activeAssistant: "docker-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual([]);
+    expect(backendReachableCalls).toEqual([]);
   });
 
   test("does not change reachability when lockfile cannot be read", async () => {

--- a/clients/macos/src/main/connectivity-probe.test.ts
+++ b/clients/macos/src/main/connectivity-probe.test.ts
@@ -122,9 +122,7 @@ describe("connectivity-probe", () => {
   });
 
   test("sets backend reachable=true when a cloud assistant carries leftover local resources", async () => {
-    // Lockfile merges preserve `resources` across cloud transitions, so a
-    // platform entry can carry a stale gatewayPort. It must not be
-    // loopback-probed: that port belongs to a stopped local runtime.
+    // A stale gatewayPort merged onto a platform entry must not be probed.
     mockLockfileData = {
       ok: true,
       data: {

--- a/clients/macos/src/main/connectivity-probe.ts
+++ b/clients/macos/src/main/connectivity-probe.ts
@@ -42,9 +42,8 @@ function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   if (!activeAssistant) return { kind: "unknown" };
   const entry = assistants.find((a) => a.assistantId === activeAssistant);
   if (!entry) return { kind: "unknown" };
-  // Classify by cloud before resources: lockfile merges preserve stale
-  // `resources` across cloud transitions, so a non-local entry can carry a
-  // leftover gatewayPort that must not be loopback-probed.
+  // Cloud wins over resources: merges can leave a stale gatewayPort on a
+  // non-local entry, and it must not be loopback-probed.
   if (!isLoopbackGatewayCloud(entry.cloud)) {
     return { kind: "non-local" };
   }
@@ -55,7 +54,6 @@ function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
       url: `http://127.0.0.1:${port}/healthz`,
     };
   }
-  // Local runtime missing its port: can't prove reachability either way.
   return { kind: "unknown" };
 }
 

--- a/clients/macos/src/main/connectivity-probe.ts
+++ b/clients/macos/src/main/connectivity-probe.ts
@@ -13,23 +13,27 @@ let probing = false;
 /**
  * The outcome of trying to resolve a probe target from the lockfile.
  *
- * - `"local"` — the active assistant is local and has a gateway port; the
- *   caller should fetch the returned URL and set reachability from the
- *   response.
+ * - `"local"` — the active assistant runs its gateway on a loopback port
+ *   of this machine; the caller should fetch the returned URL and set
+ *   reachability from the response.
  * - `"non-local"` — the active assistant is cloud-hosted or self-hosted
  *   remote; there is no local gateway to probe, and any prior
  *   `backendReachable = false` from a stale local-assistant entry should
  *   be cleared. Non-local assistant health is tracked separately via the
  *   platform's operational-status polling.
  * - `"unknown"` — the lockfile could not be read, there is no active
- *   assistant, or the active entry exists but is local-shaped without a
- *   gateway port. The caller should not change the reachability state,
- *   because it cannot prove either direction.
+ *   assistant, or the active entry is a local runtime without a gateway
+ *   port. The caller should not change the reachability state, because
+ *   it cannot prove either direction.
  */
 type ProbeTarget =
   | { kind: "local"; url: string }
   | { kind: "non-local" }
   | { kind: "unknown" };
+
+// Clouds whose gateway listens on a loopback port of this machine. Everything
+// else is reached remotely and tracked via operational-status polling.
+const LOOPBACK_GATEWAY_CLOUDS = new Set(["local", "docker"]);
 
 function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   const result = getLockfileData(lockfilePaths);
@@ -38,18 +42,20 @@ function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   if (!activeAssistant) return { kind: "unknown" };
   const entry = assistants.find((a) => a.assistantId === activeAssistant);
   if (!entry) return { kind: "unknown" };
+  // Classify by cloud before resources: lockfile merges preserve stale
+  // `resources` across cloud transitions, so a non-local entry can carry a
+  // leftover gatewayPort that must not be loopback-probed.
+  if (!LOOPBACK_GATEWAY_CLOUDS.has(entry.cloud)) {
+    return { kind: "non-local" };
+  }
   if (entry.resources?.gatewayPort) {
     return {
       kind: "local",
       url: `http://127.0.0.1:${entry.resources.gatewayPort}/healthz`,
     };
   }
-  // No gateway port. If the entry is explicitly cloud/remote, there is
-  // no local gateway to probe — clear any stale unreachable state. If
-  // the entry is local but missing its port, we can't determine
-  // reachability either way, so leave the state unchanged.
-  if (entry.cloud === "local") return { kind: "unknown" };
-  return { kind: "non-local" };
+  // Local runtime missing its port: can't prove reachability either way.
+  return { kind: "unknown" };
 }
 
 async function runProbeOnce(lockfilePaths: string[]): Promise<void> {

--- a/clients/macos/src/main/connectivity-probe.ts
+++ b/clients/macos/src/main/connectivity-probe.ts
@@ -1,6 +1,10 @@
 import { app, BrowserWindow, net, powerMonitor } from "electron";
 
 import { getLockfileData } from "@vellumai/local-mode";
+import {
+  getLoopbackGatewayPort,
+  isLoopbackGatewayCloud,
+} from "@vellumai/local-mode/contract";
 
 import { setBackendReachable } from "./status";
 
@@ -13,15 +17,15 @@ let probing = false;
 /**
  * The outcome of trying to resolve a probe target from the lockfile.
  *
- * - `"local"` — the active assistant runs its gateway on a loopback port
+ * - `"local"`: the active assistant runs its gateway on a loopback port
  *   of this machine; the caller should fetch the returned URL and set
  *   reachability from the response.
- * - `"non-local"` — the active assistant is cloud-hosted or self-hosted
+ * - `"non-local"`: the active assistant is cloud-hosted or self-hosted
  *   remote; there is no local gateway to probe, and any prior
  *   `backendReachable = false` from a stale local-assistant entry should
  *   be cleared. Non-local assistant health is tracked separately via the
  *   platform's operational-status polling.
- * - `"unknown"` — the lockfile could not be read, there is no active
+ * - `"unknown"`: the lockfile could not be read, there is no active
  *   assistant, or the active entry is a local runtime without a gateway
  *   port. The caller should not change the reachability state, because
  *   it cannot prove either direction.
@@ -30,10 +34,6 @@ type ProbeTarget =
   | { kind: "local"; url: string }
   | { kind: "non-local" }
   | { kind: "unknown" };
-
-// Clouds whose gateway listens on a loopback port of this machine. Everything
-// else is reached remotely and tracked via operational-status polling.
-const LOOPBACK_GATEWAY_CLOUDS = new Set(["local", "docker"]);
 
 function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   const result = getLockfileData(lockfilePaths);
@@ -45,13 +45,14 @@ function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   // Classify by cloud before resources: lockfile merges preserve stale
   // `resources` across cloud transitions, so a non-local entry can carry a
   // leftover gatewayPort that must not be loopback-probed.
-  if (!LOOPBACK_GATEWAY_CLOUDS.has(entry.cloud)) {
+  if (!isLoopbackGatewayCloud(entry.cloud)) {
     return { kind: "non-local" };
   }
-  if (entry.resources?.gatewayPort) {
+  const port = getLoopbackGatewayPort(entry);
+  if (port) {
     return {
       kind: "local",
-      url: `http://127.0.0.1:${entry.resources.gatewayPort}/healthz`,
+      url: `http://127.0.0.1:${port}/healthz`,
     };
   }
   // Local runtime missing its port: can't prove reachability either way.

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -1064,8 +1064,6 @@ describe("StatusBanner", () => {
     });
 
     test("does not render backend-unreachable for a platform-hosted session", () => {
-      // The probe may be watching a stale local lockfile entry (e.g. a CLI
-      // experiment) while the platform assistant is fully reachable.
       isElectronMock = true;
       connectivityStateMock = "backend-unreachable";
       assistantStateMock = { kind: "active", isLocal: false };

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -1045,9 +1045,10 @@ describe("StatusBanner", () => {
       expect(html).not.toContain("Assistant fatal error");
     });
 
-    test("renders backend-unreachable banner before operational status", () => {
+    test("renders backend-unreachable banner before operational status for a local session", () => {
       isElectronMock = true;
       connectivityStateMock = "backend-unreachable";
+      assistantStateMock = { kind: "active", isLocal: true };
       operationalStatusQueryMock = {
         data: { state: "crash_loop" },
         isError: false,
@@ -1060,6 +1061,33 @@ describe("StatusBanner", () => {
       expect(html).toContain('data-tone="error"');
       expect(html).toContain("lucide-cloud-off");
       expect(html).not.toContain("Assistant fatal error");
+    });
+
+    test("does not render backend-unreachable for a platform-hosted session", () => {
+      // The probe may be watching a stale local lockfile entry (e.g. a CLI
+      // experiment) while the platform assistant is fully reachable.
+      isElectronMock = true;
+      connectivityStateMock = "backend-unreachable";
+      assistantStateMock = { kind: "active", isLocal: false };
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toBe("");
+    });
+
+    test("renders operational status instead of backend-unreachable for a platform-hosted session", () => {
+      isElectronMock = true;
+      connectivityStateMock = "backend-unreachable";
+      assistantStateMock = { kind: "active", isLocal: false };
+      operationalStatusQueryMock = {
+        data: { state: "crash_loop" },
+        isError: false,
+      };
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toContain("Assistant fatal error");
+      expect(html).not.toContain("Trying to reach Vellum");
     });
 
     test("does not render backend-unreachable connectivity state outside Electron", () => {

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -893,7 +893,17 @@ function useAssistantBannerConfig(): BannerConfig | null {
     return localHealthBanner;
   }
 
-  if (electron && connectivityState === "backend-unreachable") {
+  // The main-process probe only watches the lockfile-active local
+  // assistant's loopback gateway. A platform session must not surface it —
+  // the probe may be watching a stale/stopped local entry while the
+  // platform assistant is reachable (operational-status covers it below).
+  const localBackendSession =
+    assistantState.kind === "active" && assistantState.isLocal;
+  if (
+    electron &&
+    localBackendSession &&
+    connectivityState === "backend-unreachable"
+  ) {
     return {
       tone: "error",
       title: "Trying to reach Vellum…",

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -893,10 +893,8 @@ function useAssistantBannerConfig(): BannerConfig | null {
     return localHealthBanner;
   }
 
-  // The main-process probe only watches the lockfile-active local
-  // assistant's loopback gateway. A platform session must not surface it:
-  // the probe may be watching a stale/stopped local entry while the
-  // platform assistant is reachable (operational-status covers it below).
+  // The probe only watches the lockfile-active local assistant's loopback
+  // gateway; a platform session's reachability is operational-status below.
   const localBackendSession =
     assistantState.kind === "active" && assistantState.isLocal;
   if (

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -894,7 +894,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
   }
 
   // The main-process probe only watches the lockfile-active local
-  // assistant's loopback gateway. A platform session must not surface it —
+  // assistant's loopback gateway. A platform session must not surface it:
   // the probe may be watching a stale/stopped local entry while the
   // platform assistant is reachable (operational-status covers it below).
   const localBackendSession =

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -1,3 +1,8 @@
+import {
+  getLoopbackGatewayPort,
+  isLoopbackGatewayCloud,
+} from "@vellumai/local-mode/contract";
+
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
   clearSelectedAssistantId,
@@ -442,7 +447,7 @@ export function isLocalAssistant(a: LockfileAssistant): boolean {
  * clouds, and platform (`vellum`).
  */
 export function isLocalGatewayAssistant(a: LockfileAssistant): boolean {
-  return a.cloud === "local" || a.cloud === "docker";
+  return isLoopbackGatewayCloud(a.cloud);
 }
 
 export function isPlatformAssistant(a: LockfileAssistant): boolean {
@@ -558,35 +563,6 @@ function expectsLocalGateway(
 }
 
 /**
- * The loopback gateway port recorded for an assistant. Plain local entries
- * record it as `resources.gatewayPort`; Docker entries record the published
- * gateway address as a loopback `runtimeUrl` (`http://localhost:<port>`) with
- * no `resources` block, so the port is recovered from that URL. A non-loopback
- * `runtimeUrl` never yields a port — a remote address is not a local gateway.
- */
-function getRecordedGatewayPort(
-  assistant: LockfileAssistant,
-): number | undefined {
-  const recorded = assistant.resources?.gatewayPort;
-  if (recorded != null) {
-    return recorded;
-  }
-  if (!assistant.runtimeUrl) {
-    return undefined;
-  }
-  try {
-    const url = new URL(assistant.runtimeUrl);
-    if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
-      return undefined;
-    }
-    const port = Number(url.port);
-    return Number.isInteger(port) && port > 0 ? port : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
  * Return the local gateway proxy URL for the given assistant (default: the
  * selected one), or `undefined` when this runtime doesn't reach it over a local
  * gateway or the gateway port hasn't been recorded yet.
@@ -597,7 +573,7 @@ export function getLocalGatewayUrl(
   if (!expectsLocalGateway(assistant)) {
     return undefined;
   }
-  const gatewayPort = getRecordedGatewayPort(assistant);
+  const gatewayPort = getLoopbackGatewayPort(assistant);
   if (gatewayPort == null) {
     return undefined;
   }

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -77,6 +77,51 @@ export function resolveCloud(raw: {
 }
 
 /**
+ * Clouds whose gateway listens on a loopback port of this machine: the
+ * on-machine daemon ("local") and local Docker instances ("docker"). Excludes
+ * "apple-container" (macOS-app-managed, records no loopback gateway), the
+ * remote self-hosted clouds, and platform ("vellum"). The one definition of
+ * "locally reachable gateway" shared by the web client and the Electron main
+ * process.
+ */
+export const LOOPBACK_GATEWAY_CLOUDS: readonly Cloud[] = ["local", "docker"];
+
+export function isLoopbackGatewayCloud(cloud: Cloud): boolean {
+  return LOOPBACK_GATEWAY_CLOUDS.includes(cloud);
+}
+
+/**
+ * The loopback gateway port recorded for an assistant entry. Plain local
+ * entries record it as `resources.gatewayPort`; Docker entries record the
+ * published gateway address as a loopback `runtimeUrl`
+ * (`http://localhost:<port>`) with no `resources` block, so the port is
+ * recovered from that URL. A non-loopback `runtimeUrl` never yields a port: a
+ * remote address is not a local gateway.
+ */
+export function getLoopbackGatewayPort(entry: {
+  resources?: { gatewayPort?: number };
+  runtimeUrl?: string;
+}): number | undefined {
+  const recorded = entry.resources?.gatewayPort;
+  if (recorded != null) {
+    return recorded;
+  }
+  if (!entry.runtimeUrl) {
+    return undefined;
+  }
+  try {
+    const url = new URL(entry.runtimeUrl);
+    if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+      return undefined;
+    }
+    const port = Number(url.port);
+    return Number.isInteger(port) && port > 0 ? port : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Per-instance resources for a local assistant: the renderer-facing subset of
  * ports, the instance directory, and the local runtime install metadata.
  * Richer host-only fields (other ports, the signing key) live on the CLI's

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -78,11 +78,7 @@ export function resolveCloud(raw: {
 
 /**
  * Clouds whose gateway listens on a loopback port of this machine: the
- * on-machine daemon ("local") and local Docker instances ("docker"). Excludes
- * "apple-container" (macOS-app-managed, records no loopback gateway), the
- * remote self-hosted clouds, and platform ("vellum"). The one definition of
- * "locally reachable gateway" shared by the web client and the Electron main
- * process.
+ * on-machine daemon ("local") and local Docker instances ("docker").
  */
 export const LOOPBACK_GATEWAY_CLOUDS: readonly Cloud[] = ["local", "docker"];
 
@@ -91,12 +87,10 @@ export function isLoopbackGatewayCloud(cloud: Cloud): boolean {
 }
 
 /**
- * The loopback gateway port recorded for an assistant entry. Plain local
- * entries record it as `resources.gatewayPort`; Docker entries record the
- * published gateway address as a loopback `runtimeUrl`
- * (`http://localhost:<port>`) with no `resources` block, so the port is
- * recovered from that URL. A non-loopback `runtimeUrl` never yields a port: a
- * remote address is not a local gateway.
+ * The loopback gateway port recorded for an assistant entry:
+ * `resources.gatewayPort` when present, else the port of a loopback
+ * `runtimeUrl` (how docker hatch records its published gateway). A
+ * non-loopback `runtimeUrl` yields nothing.
  */
 export function getLoopbackGatewayPort(entry: {
   resources?: { gatewayPort?: number };


### PR DESCRIPTION
## Summary
- The macOS main-process connectivity probe targets the lockfile's `activeAssistant`. When that entry was a stopped local assistant with a recorded `resources.gatewayPort` (e.g. a one-off CLI hatch), the probe failed every cycle and the app showed **"Trying to reach Vellum…"** even though the platform assistant actually in use was fully reachable, and "Retry now" just re-probed the same dead port.
- `packages/local-mode/src/lockfile-contract.ts`: the loopback-gateway taxonomy (`local`, `docker`) and gateway-port recovery (`resources.gatewayPort`, falling back to a loopback `runtimeUrl` for docker entries) now live in the shared contract as `isLoopbackGatewayCloud` / `getLoopbackGatewayPort`, consumed by both the Electron probe and the web client.
- `clients/macos/src/main/connectivity-probe.ts`: classify the active entry by cloud **before** looking at `resources`. Only loopback-gateway clouds are probed; every other cloud resolves to `non-local`, clearing stale unreachable state. Lockfile upserts merge-preserve `resources` across cloud transitions, so a non-local entry can carry a leftover `gatewayPort` that must not be loopback-probed. Docker entries (loopback `runtimeUrl`, no `resources` block) are probed via the port recovered from that URL.
- `clients/web/src/components/status-banner.tsx`: only render the backend-unreachable banner when the session actually runs against a local assistant (`assistantState.kind === "active" && isLocal`). Platform sessions get their reachability signal from operational-status polling; the banner's original purpose (local gateway down before the first healthz heartbeat) is preserved.
- Tests: probe regressions (a `vellum` entry with a leftover `gatewayPort` is not probed and clears state; docker entries are probed via `resources` or loopback `runtimeUrl`; a non-loopback `runtimeUrl` is never probed) and banner coverage for platform-session suppression.

## Original prompt
A user reported that the "Trying to reach Vellum…" banner displays in the desktop app even though they can clearly reach their assistant. Find the root cause and fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)