### PR TITLE
feat(web): catalog every upsell wall and its CTA in Storybook

### DIFF
--- a/clients/web/src/components/disk-pressure-banner.stories.tsx
+++ b/clients/web/src/components/disk-pressure-banner.stories.tsx
@@ -1,0 +1,161 @@
+/**
+ * The storage wall. Three escalating modes, and (the part worth cataloging)
+ * an **Upgrade** CTA that appears only when the assistant actually has an
+ * upgrade path.
+ *
+ * Both mount points gate that CTA themselves and pass `onUpgradeStorage: null`
+ * when there is nowhere to upgrade to:
+ *
+ *   - chat: `assistantStateKind === "active" && !isNativeAndroid`
+ *     (`disk-pressure-banner-slot.tsx:125`)
+ *   - settings: `infraGate === "full" && !isNativeAndroid`
+ *     (`general-page.tsx:149`)
+ *
+ * The settings mount also omits `onDismissWarning`, so it has no dismiss X and
+ * no "Don't show again" checkbox. Both variants are storied below.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+
+import { DiskPressureBanner } from "@/components/disk-pressure-banner";
+
+function makeStatus(
+  overrides: Partial<DiskPressureStatus> = {},
+): DiskPressureStatus {
+  return {
+    enabled: true,
+    state: "warning",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: 86,
+    thresholdPercent: 85,
+    path: "/workspace",
+    lastCheckedAt: "2026-08-04T12:00:00Z",
+    blockedCapabilities: [],
+    error: null,
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof DiskPressureBanner> = {
+  title: "Upsell Walls/Storage Wall",
+  component: DiskPressureBanner,
+  parameters: { layout: "padded" },
+  argTypes: {
+    mode: {
+      control: "select",
+      options: ["warning", "cleanup", "acknowledgement-required"],
+    },
+  },
+  args: {
+    status: makeStatus(),
+    mode: "warning",
+    onAcknowledge: () => {},
+    onDismissWarning: () => {},
+    onReviewWorkspaceData: () => {},
+    onUpgradeStorage: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[720px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DiskPressureBanner>;
+
+/**
+ * The chat mount on a platform-hosted assistant: **Manage Storage** to free
+ * space, **Upgrade** to buy more, plus the dismiss affordances.
+ */
+export const WarningWithUpgrade: Story = {
+  name: "Warning · Manage Storage + Upgrade",
+};
+
+/**
+ * Self-hosted, or native Android (consumption-only). With
+ * `onUpgradeStorage: null` the Upgrade button disappears **and the body copy
+ * drops "or add more storage"**. The wall stops advertising a purchase it
+ * cannot complete.
+ */
+export const WarningWithoutUpgrade: Story = {
+  name: "Warning · no upgrade path (self-hosted / Android)",
+  args: { onUpgradeStorage: null },
+};
+
+/**
+ * The settings mount (`general-page.tsx`) passes no `onDismissWarning`, so the
+ * banner is not dismissible and the "Don't show again" checkbox is gone.
+ */
+export const WarningNotDismissible: Story = {
+  name: "Warning · settings mount (not dismissible)",
+  args: { onDismissWarning: undefined },
+};
+
+/** Usage is unknown when the daemon reports a null percentage. */
+export const WarningUnknownUsage: Story = {
+  name: "Warning · unknown usage",
+  args: { status: makeStatus({ usagePercent: null }) },
+};
+
+/**
+ * Cleanup mode: the assistant is actively freeing space. Same two CTAs, but no
+ * dismiss and no checkbox: the user cannot opt out of this one.
+ */
+export const Cleanup: Story = {
+  args: {
+    mode: "cleanup",
+    status: makeStatus({ state: "warning", usagePercent: 94 }),
+  },
+};
+
+/**
+ * Critical: the banner turns `tone="error"` and collapses to a single
+ * **Review** button. There is deliberately no inline Upgrade here, because the
+ * upgrade path lives inside the acknowledgement modal.
+ */
+export const CriticalAcknowledgementRequired: Story = {
+  name: "Critical · Review (opens modal)",
+  args: {
+    mode: "acknowledgement-required",
+    status: makeStatus({ state: "critical", usagePercent: 99 }),
+  },
+};
+
+/**
+ * Critical with a failed acknowledgement. The error renders inline above the
+ * Review button as an alert.
+ */
+export const CriticalWithAcknowledgeError: Story = {
+  name: "Critical · acknowledge failed",
+  args: {
+    mode: "acknowledgement-required",
+    status: makeStatus({ state: "critical", usagePercent: 99 }),
+    acknowledgeError: "Could not acknowledge. Please try again.",
+  },
+};
+
+/**
+ * The acknowledgement modal is where the critical-state **Upgrade** CTA
+ * actually lives, beside **Acknowledge**. Opened here so the catalog shows the
+ * CTA without a click.
+ */
+export const CriticalModalUpgradeCta: Story = {
+  name: "Critical · modal holds the Upgrade CTA",
+  args: {
+    mode: "acknowledgement-required",
+    status: makeStatus({ state: "critical", usagePercent: 99 }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Review" }));
+  },
+};

--- a/clients/web/src/components/disk-pressure-banner.stories.tsx
+++ b/clients/web/src/components/disk-pressure-banner.stories.tsx
@@ -100,7 +100,7 @@ export const WarningNotDismissible: Story = {
   args: { onDismissWarning: undefined },
 };
 
-/** Usage is unknown when the daemon reports a null percentage. */
+/** Usage is unknown when the assistant reports a null percentage. */
 export const WarningUnknownUsage: Story = {
   name: "Warning · unknown usage",
   args: { status: makeStatus({ usagePercent: null }) },
@@ -145,8 +145,9 @@ export const CriticalWithAcknowledgeError: Story = {
 
 /**
  * The acknowledgement modal is where the critical-state **Upgrade** CTA
- * actually lives, beside **Acknowledge**. Opened here so the catalog shows the
- * CTA without a click.
+ * actually lives, beside **Acknowledge**. The interaction below opens it on
+ * the canvas; on this docs page play functions do not run, so open the canvas
+ * (or click **Review**) to see it.
  */
 export const CriticalModalUpgradeCta: Story = {
   name: "Critical · modal holds the Upgrade CTA",

--- a/clients/web/src/components/upsell-walls-overview.stories.tsx
+++ b/clients/web/src/components/upsell-walls-overview.stories.tsx
@@ -1,0 +1,345 @@
+/**
+ * **Every wall a user can hit, and the CTA we show them, on one page.**
+ *
+ * This is the index for the rest of the `Upsell Walls/` section: each case
+ * below states what triggers the wall, what the button says, and where it goes,
+ * above the real component rendering it. Individual story files drill into the
+ * per-wall variants (dismissible/not, Android, pending, error).
+ *
+ * It lives outside `src/domains/` deliberately: the walls span chat, settings
+ * and billing, and `local/no-cross-domain-imports` only constrains files that
+ * sit inside a domain.
+ *
+ * Two things worth knowing before reading it:
+ *
+ *   - **Add credits vs Upgrade is one branch, not a redesign.** Every credit
+ *     wall says "Add credits" unless the `experiment-billing-cta-2026-07-23`
+ *     flag is on the `upgrade-cta` arm *and* the org is on the free (`base`)
+ *     plan. Paid orgs keep "Add credits" in both arms.
+ *   - **Every non-credit upsell in the app routes to `routes.plans`**, the
+ *     plans takeover. There is no second upsell destination.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CalendarClock, KeyRound } from "lucide-react";
+
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+import { Button, Notice } from "@vellumai/design-library";
+
+import { DiskPressureBanner } from "@/components/disk-pressure-banner";
+import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import {
+  ADD_CREDITS_COPY,
+  UPGRADE_COPY,
+} from "@/domains/chat/components/credits-upsell-card";
+import { PlanPromoCard } from "@/domains/settings/billing/plan-promo-card";
+import { packageSpecs } from "@/domains/settings/billing/plan-spec";
+import { makeSuperPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+
+const DISK_STATUS: DiskPressureStatus = {
+  enabled: true,
+  state: "warning",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: 86,
+  thresholdPercent: 85,
+  path: "/workspace",
+  lastCheckedAt: "2026-08-04T12:00:00Z",
+  blockedCapabilities: [],
+  error: null,
+};
+
+interface WallCaseProps {
+  wall: string;
+  trigger: string;
+  cta: string;
+  destination: string;
+  children: React.ReactNode;
+}
+
+/** Story chrome: the metadata row above each live wall. */
+function WallCase({
+  wall,
+  trigger,
+  cta,
+  destination,
+  children,
+}: WallCaseProps) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h3
+        className="text-body-medium-default m-0"
+        style={{ color: "var(--content-default)" }}
+      >
+        {wall}
+      </h3>
+      <dl
+        className="text-label-small-default m-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        <dt>Triggered when</dt>
+        <dd className="m-0">{trigger}</dd>
+        <dt>CTA</dt>
+        <dd className="m-0" style={{ color: "var(--content-default)" }}>
+          {cta}
+        </dd>
+        <dt>Goes to</dt>
+        <dd className="m-0">{destination}</dd>
+      </dl>
+      <div className="mt-1">{children}</div>
+    </section>
+  );
+}
+
+function Group({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-6">
+      <h2
+        className="text-body-large-default m-0 border-b pb-2"
+        style={{
+          color: "var(--content-default)",
+          borderColor: "var(--border-default)",
+        }}
+      >
+        {heading}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+const meta: Meta = {
+  title: "Upsell Walls/Overview",
+  parameters: { layout: "padded", controls: { disable: true } },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** Credit walls: the only place the CTA label forks. */
+export const CreditWalls: Story = {
+  render: () => (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-10 py-4">
+      <Group heading="Credit walls">
+        <WallCase
+          wall="Out of credits (default)"
+          trigger="Balance ≤ 0. Control arm, or any paid plan (an unresolved plan counts as paid)."
+          cta={ADD_CREDITS_COPY.ctaLabel}
+          destination="Add Credits modal → Stripe checkout"
+        >
+          <BillingErrorBanner
+            ariaLabel={`${ADD_CREDITS_COPY.title}. ${ADD_CREDITS_COPY.subtitle}`}
+            icon={<span className="text-lg opacity-80">💰</span>}
+            title={ADD_CREDITS_COPY.title}
+            subtitle={ADD_CREDITS_COPY.subtitle}
+            action={{ label: ADD_CREDITS_COPY.ctaLabel, onClick: () => {} }}
+            detached
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Out of credits (free plan, upgrade arm)"
+          trigger="Balance ≤ 0, experiment-billing-cta-2026-07-23 = upgrade-cta, AND plan_id = base."
+          cta={UPGRADE_COPY.ctaLabel}
+          destination="/assistant/plans (plans takeover)"
+        >
+          <BillingErrorBanner
+            ariaLabel={`${UPGRADE_COPY.title}. ${UPGRADE_COPY.subtitle}`}
+            icon={<span className="text-lg opacity-80">💰</span>}
+            title={UPGRADE_COPY.title}
+            subtitle={UPGRADE_COPY.subtitle}
+            action={{ label: UPGRADE_COPY.ctaLabel, onClick: () => {} }}
+            detached
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Low balance"
+          trigger="Server sets low_balance_warning, balance still > 0, banner not dismissed."
+          cta="Add credits"
+          destination="Add Credits modal → Stripe checkout"
+        >
+          <BillingErrorBanner
+            ariaLabel="Your credits are running low. Add credits to avoid an interruption."
+            title="Your credits are running low"
+            subtitle="Add credits to avoid an interruption."
+            action={{ label: "Add credits", onClick: () => {} }}
+            onDismiss={() => {}}
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Daily credit limit reached"
+          trigger="User's own daily spend cap hit. Not a plan wall."
+          cta="Adjust Limit"
+          destination="/assistant/settings/usage?tab=billing"
+        >
+          <BillingErrorBanner
+            ariaLabel="Daily credit limit reached"
+            icon={
+              <CalendarClock
+                className="size-5"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            }
+            title="Daily credit limit reached"
+            subtitle="This limit applies to Vellum credit spend and resets at midnight UTC."
+            action={{ label: "Adjust Limit", onClick: () => {} }}
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Provider billing (bring-your-own key)"
+          trigger="The user's own model provider is out of funds."
+          cta="Open Settings"
+          destination="/assistant/settings/ai (no Vellum upsell)"
+        >
+          <BillingErrorBanner
+            ariaLabel="Your API key needs credits"
+            icon={
+              <KeyRound
+                className="size-5"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            }
+            title="Your API key needs credits"
+            subtitle="Add funds with your provider or lower the model token limit."
+            action={{ label: "Open Settings", onClick: () => {} }}
+          />
+        </WallCase>
+      </Group>
+    </div>
+  ),
+};
+
+/** Storage, entitlement and plan walls, all of which route to the takeover. */
+export const ResourceAndEntitlementWalls: Story = {
+  render: () => (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-10 py-4">
+      <Group heading="Storage wall">
+        <WallCase
+          wall="Storage almost full"
+          trigger="Disk usage crosses the warn threshold on a platform-hosted assistant."
+          cta="Manage Storage + Upgrade"
+          destination="/workspace?sort=size · /assistant/plans"
+        >
+          <DiskPressureBanner
+            status={DISK_STATUS}
+            mode="warning"
+            onAcknowledge={() => {}}
+            onDismissWarning={() => {}}
+            onReviewWorkspaceData={() => {}}
+            onUpgradeStorage={() => {}}
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Storage almost full (no upgrade path)"
+          trigger="Same, but self-hosted or native Android. The Upgrade CTA is dropped and the copy stops offering more storage."
+          cta="Manage Storage"
+          destination="/workspace?sort=size"
+        >
+          <DiskPressureBanner
+            status={DISK_STATUS}
+            mode="warning"
+            onAcknowledge={() => {}}
+            onDismissWarning={() => {}}
+            onReviewWorkspaceData={() => {}}
+            onUpgradeStorage={null}
+          />
+        </WallCase>
+
+        <WallCase
+          wall="Storage critically low"
+          trigger="Disk usage crosses the critical threshold; the assistant will lock if it runs out."
+          cta="Review (the Upgrade CTA lives in the modal it opens)"
+          destination="/assistant/plans"
+        >
+          <DiskPressureBanner
+            status={{ ...DISK_STATUS, state: "critical", usagePercent: 99 }}
+            mode="acknowledgement-required"
+            onAcknowledge={() => {}}
+            onUpgradeStorage={() => {}}
+          />
+        </WallCase>
+      </Group>
+
+      <Group heading="Entitlement wall">
+        <WallCase
+          wall="Managed email not included"
+          trigger="entitlements.managed_email is false on the subscription. Read off the entitlement, not the plan. An admin override can grant it to a Base org."
+          cta="Upgrade"
+          destination="/assistant/plans"
+        >
+          <Notice
+            tone="info"
+            title="Give your assistant its own email address"
+            actions={<Button size="compact">Upgrade</Button>}
+          >
+            Upgrade to a plan that includes an email address for your assistant.
+            No provider setup required.
+          </Notice>
+        </WallCase>
+      </Group>
+
+      <Group heading="Plan management upsell">
+        <WallCase
+          wall="Recommended package"
+          trigger="A higher package exists in the catalog and the relation is not a lateral switch."
+          cta="Upgrade"
+          destination="Stripe checkout (base) or package-switch confirm (pro)"
+        >
+          <div className="w-[360px]">
+            <PlanPromoCard
+              title="Upgrade to Super"
+              specs={packageSpecs(makeSuperPackage())}
+              ctaLabel="Upgrade"
+              onCtaClick={() => {}}
+            />
+          </div>
+        </WallCase>
+
+        <WallCase
+          wall="Top of catalog"
+          trigger="A Pro user already at the top of the catalog, or whose tiers match no package."
+          cta="Customize"
+          destination="Custom plan modal (in-place tier change)"
+        >
+          <div className="w-[360px]">
+            <PlanPromoCard
+              title="Create a custom plan"
+              ctaLabel="Customize"
+              onCtaClick={() => {}}
+            />
+          </div>
+        </WallCase>
+      </Group>
+
+      <Group heading="Native Android (consumption only)">
+        <WallCase
+          wall="Any purchase wall on native Android"
+          trigger="useIsNativeAndroid(). Every purchase entry point app-wide is suppressed and the copy points at the website."
+          cta="none"
+          destination="n/a"
+        >
+          <BillingErrorBanner
+            ariaLabel={`${ADD_CREDITS_COPY.title}. ${ANDROID_BILLING_MESSAGE}`}
+            icon={<span className="text-lg opacity-80">💰</span>}
+            title={ADD_CREDITS_COPY.title}
+            subtitle={ANDROID_BILLING_MESSAGE}
+            detached
+          />
+        </WallCase>
+      </Group>
+    </div>
+  ),
+};

--- a/clients/web/src/components/upsell-walls-overview.stories.tsx
+++ b/clients/web/src/components/upsell-walls-overview.stories.tsx
@@ -19,11 +19,11 @@
  *   - **Every non-credit upsell in the app routes to `routes.plans`**, the
  *     plans takeover. There is no second upsell destination.
  */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CalendarClock, KeyRound } from "lucide-react";
 
 import type { DiskPressureStatus } from "@vellumai/assistant-api";
-import { Button, Notice } from "@vellumai/design-library";
 
 import { DiskPressureBanner } from "@/components/disk-pressure-banner";
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
@@ -31,10 +31,38 @@ import {
   ADD_CREDITS_COPY,
   UPGRADE_COPY,
 } from "@/domains/chat/components/credits-upsell-card";
+import { EmailManagedContent } from "@/domains/settings/ai/email-managed-content";
 import { PlanPromoCard } from "@/domains/settings/billing/plan-promo-card";
 import { packageSpecs } from "@/domains/settings/billing/plan-spec";
 import { makeSuperPackage } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
 import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+
+/**
+ * The entitlement wall is the real `EmailManagedContent`, not a rebuild of it,
+ * so the catalog cannot drift from the icon, copy and Android CTA suppression
+ * the production component owns. Only the subscription read is faked; one
+ * instance mounts here, and the component writes no global store, so unlike the
+ * credit wall it is safe to co-mount with the rest of the page.
+ */
+const NOT_ENTITLED: SubscriptionResponse = {
+  plan_id: "base",
+  status: "active",
+  renewal_date: null,
+  current_period_end: null,
+  cancel_at_period_end: false,
+  cancel_at: null,
+  entitlements: { managed_email: false, phone_number: false },
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+queryClient.setQueryData(
+  organizationsBillingSubscriptionRetrieveOptions().queryKey,
+  NOT_ENTITLED,
+);
 
 const DISK_STATUS: DiskPressureStatus = {
   enabled: true,
@@ -224,122 +252,123 @@ export const CreditWalls: Story = {
 /** Storage, entitlement and plan walls, all of which route to the takeover. */
 export const ResourceAndEntitlementWalls: Story = {
   render: () => (
-    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-10 py-4">
-      <Group heading="Storage wall">
-        <WallCase
-          wall="Storage almost full"
-          trigger="Disk usage crosses the warn threshold on a platform-hosted assistant."
-          cta="Manage Storage + Upgrade"
-          destination="/workspace?sort=size · /assistant/plans"
-        >
-          <DiskPressureBanner
-            status={DISK_STATUS}
-            mode="warning"
-            onAcknowledge={() => {}}
-            onDismissWarning={() => {}}
-            onReviewWorkspaceData={() => {}}
-            onUpgradeStorage={() => {}}
-          />
-        </WallCase>
-
-        <WallCase
-          wall="Storage almost full (no upgrade path)"
-          trigger="Same, but self-hosted or native Android. The Upgrade CTA is dropped and the copy stops offering more storage."
-          cta="Manage Storage"
-          destination="/workspace?sort=size"
-        >
-          <DiskPressureBanner
-            status={DISK_STATUS}
-            mode="warning"
-            onAcknowledge={() => {}}
-            onDismissWarning={() => {}}
-            onReviewWorkspaceData={() => {}}
-            onUpgradeStorage={null}
-          />
-        </WallCase>
-
-        <WallCase
-          wall="Storage critically low"
-          trigger="Disk usage crosses the critical threshold; the assistant will lock if it runs out."
-          cta="Review (the Upgrade CTA lives in the modal it opens)"
-          destination="/assistant/plans"
-        >
-          <DiskPressureBanner
-            status={{ ...DISK_STATUS, state: "critical", usagePercent: 99 }}
-            mode="acknowledgement-required"
-            onAcknowledge={() => {}}
-            onUpgradeStorage={() => {}}
-          />
-        </WallCase>
-      </Group>
-
-      <Group heading="Entitlement wall">
-        <WallCase
-          wall="Managed email not included"
-          trigger="entitlements.managed_email is false on the subscription. Read off the entitlement, not the plan. An admin override can grant it to a Base org."
-          cta="Upgrade"
-          destination="/assistant/plans"
-        >
-          <Notice
-            tone="info"
-            title="Give your assistant its own email address"
-            actions={<Button size="compact">Upgrade</Button>}
+    // The seeded client is only for the entitlement wall's subscription read;
+    // every other case on this page is pure props.
+    <QueryClientProvider client={queryClient}>
+      <div className="mx-auto flex w-full max-w-[760px] flex-col gap-10 py-4">
+        <Group heading="Storage wall">
+          <WallCase
+            wall="Storage almost full"
+            trigger="Disk usage crosses the warn threshold on a platform-hosted assistant."
+            cta="Manage Storage + Upgrade"
+            destination="/workspace?sort=size · /assistant/plans"
           >
-            Upgrade to a plan that includes an email address for your assistant.
-            No provider setup required.
-          </Notice>
-        </WallCase>
-      </Group>
-
-      <Group heading="Plan management upsell">
-        <WallCase
-          wall="Recommended package"
-          trigger="A higher package exists in the catalog and the relation is not a lateral switch."
-          cta="Upgrade"
-          destination="Stripe checkout (base) or package-switch confirm (pro)"
-        >
-          <div className="w-[360px]">
-            <PlanPromoCard
-              title="Upgrade to Super"
-              specs={packageSpecs(makeSuperPackage())}
-              ctaLabel="Upgrade"
-              onCtaClick={() => {}}
+            <DiskPressureBanner
+              status={DISK_STATUS}
+              mode="warning"
+              onAcknowledge={() => {}}
+              onDismissWarning={() => {}}
+              onReviewWorkspaceData={() => {}}
+              onUpgradeStorage={() => {}}
             />
-          </div>
-        </WallCase>
+          </WallCase>
 
-        <WallCase
-          wall="Top of catalog"
-          trigger="A Pro user already at the top of the catalog, or whose tiers match no package."
-          cta="Customize"
-          destination="Custom plan modal (in-place tier change)"
-        >
-          <div className="w-[360px]">
-            <PlanPromoCard
-              title="Create a custom plan"
-              ctaLabel="Customize"
-              onCtaClick={() => {}}
+          <WallCase
+            wall="Storage almost full (no upgrade path)"
+            trigger="Same, but self-hosted or native Android. The Upgrade CTA is dropped and the copy stops offering more storage."
+            cta="Manage Storage"
+            destination="/workspace?sort=size"
+          >
+            <DiskPressureBanner
+              status={DISK_STATUS}
+              mode="warning"
+              onAcknowledge={() => {}}
+              onDismissWarning={() => {}}
+              onReviewWorkspaceData={() => {}}
+              onUpgradeStorage={null}
             />
-          </div>
-        </WallCase>
-      </Group>
+          </WallCase>
 
-      <Group heading="Native Android (consumption only)">
-        <WallCase
-          wall="Any purchase wall on native Android"
-          trigger="useIsNativeAndroid(). Every purchase entry point app-wide is suppressed and the copy points at the website."
-          cta="none"
-          destination="n/a"
-        >
-          <BillingErrorBanner
-            ariaLabel={`${ADD_CREDITS_COPY.title}. ${ANDROID_BILLING_MESSAGE}`}
-            icon={<span className="text-lg opacity-80">💰</span>}
-            title={ADD_CREDITS_COPY.title}
-            subtitle={ANDROID_BILLING_MESSAGE}
-            detached
-          />
-        </WallCase>
-      </Group>
-    </div>
+          <WallCase
+            wall="Storage critically low"
+            trigger="Disk usage crosses the critical threshold; the assistant will lock if it runs out."
+            cta="Review (the Upgrade CTA lives in the modal it opens)"
+            destination="/assistant/plans"
+          >
+            <DiskPressureBanner
+              status={{ ...DISK_STATUS, state: "critical", usagePercent: 99 }}
+              mode="acknowledgement-required"
+              onAcknowledge={() => {}}
+              onUpgradeStorage={() => {}}
+            />
+          </WallCase>
+        </Group>
+
+        <Group heading="Entitlement wall">
+          <WallCase
+            wall="Managed email not included"
+            trigger="entitlements.managed_email is false on the subscription. Read off the entitlement, not the plan. An admin override can grant it to a Base org."
+            cta="Upgrade"
+            destination="/assistant/plans"
+          >
+            <EmailManagedContent
+              assistantId="story-assistant"
+              assistantHandle="ada"
+              emailRootDomain="vellum.ai"
+            />
+          </WallCase>
+        </Group>
+
+        <Group heading="Plan management upsell">
+          <WallCase
+            wall="Recommended package"
+            trigger="A higher package exists in the catalog and the relation is not a lateral switch."
+            cta="Upgrade"
+            destination="Stripe checkout (base) or package-switch confirm (pro)"
+          >
+            <div className="w-[360px]">
+              <PlanPromoCard
+                title="Upgrade to Super"
+                specs={packageSpecs(makeSuperPackage())}
+                ctaLabel="Upgrade"
+                onCtaClick={() => {}}
+              />
+            </div>
+          </WallCase>
+
+          <WallCase
+            wall="Top of catalog"
+            trigger="A Pro user already at the top of the catalog, or whose tiers match no package."
+            cta="Customize"
+            destination="Custom plan modal (in-place tier change)"
+          >
+            <div className="w-[360px]">
+              <PlanPromoCard
+                title="Create a custom plan"
+                ctaLabel="Customize"
+                onCtaClick={() => {}}
+              />
+            </div>
+          </WallCase>
+        </Group>
+
+        <Group heading="Native Android (consumption only)">
+          <WallCase
+            wall="Any purchase wall on native Android"
+            trigger="useIsNativeAndroid(). Every purchase entry point app-wide is suppressed and the copy points at the website."
+            cta="none"
+            destination="n/a"
+          >
+            <BillingErrorBanner
+              ariaLabel={`${ADD_CREDITS_COPY.title}. ${ANDROID_BILLING_MESSAGE}`}
+              icon={<span className="text-lg opacity-80">💰</span>}
+              title={ADD_CREDITS_COPY.title}
+              subtitle={ANDROID_BILLING_MESSAGE}
+              detached
+            />
+          </WallCase>
+        </Group>
+      </div>
+    </QueryClientProvider>
   ),
 };

--- a/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
@@ -3,7 +3,8 @@
  * {@link BillingErrorBanner}. This file catalogs both layers:
  *
  *   1. the primitive's own variant matrix (icon / action / dismiss / detached),
- *   2. the four real walls built on it, each with its production copy and CTA.
+ *   2. the three composer walls built on it, each with its production copy and
+ *      CTA.
  *
  * Which of the composer banners is shown is decided by the pure resolver
  * `resolveComposerBillingBanner` (`utils/error-classification.ts:111`), whose
@@ -11,9 +12,15 @@
  * (which renders nothing here, since the transcript's credit wall owns it) >
  * low_balance. The credit wall itself lives in its own story file, since its
  * CTA is the one that forks between Add credits and View plans.
+ *
+ * Android consumption-only suppression applies to **purchase** surfaces only.
+ * Among these three that is just `LowBalanceBanner`; `DailyLimitBanner` (a
+ * settings deep-link) and `ProviderBillingBanner` (the user's own provider is
+ * out of funds, so there is nothing for Vellum to sell) keep their copy and CTA
+ * on every platform.
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { CalendarClock, KeyRound } from "lucide-react";
+import { CalendarClock } from "lucide-react";
 
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 import { DailyLimitBanner } from "@/domains/chat/components/daily-limit-banner";
@@ -65,15 +72,27 @@ export const WithDismiss: Story = {
 };
 
 /**
- * No CTA and no dismiss collapses the whole right-hand column. This is what
- * every purchase wall degrades to on native Android, which is
- * consumption-only.
+ * No CTA and no dismiss collapses the whole right-hand column. The credit wall
+ * on native Android is the surface that reaches this shape (see
+ * `Upsell Walls/Credit Wall`); it renders `detached` on top of it.
  */
 export const NoActionNoDismiss: Story = {
-  name: "No CTA (native Android)",
+  name: "No CTA and no dismiss",
+  args: { action: undefined, onDismiss: undefined },
+};
+
+/**
+ * The low-balance wall on native Android: the purchase CTA is suppressed and
+ * the subtitle points at the website, but the dismiss stays, because
+ * `LowBalanceBanner` passes `onDismiss` unconditionally. The other two composer
+ * walls are not purchase surfaces and are unaffected on Android.
+ */
+export const AndroidLowBalance: Story = {
+  name: "Low balance on native Android",
   args: {
+    ariaLabel: `Your credits are running low. ${ANDROID_BILLING_MESSAGE}`,
     action: undefined,
-    onDismiss: undefined,
+    onDismiss: () => {},
     subtitle: ANDROID_BILLING_MESSAGE,
   },
 };
@@ -118,7 +137,11 @@ export const RealLowBalanceBanner: Story = {
   render: () => <LowBalanceBanner />,
 };
 
-/** The three composer walls together, in resolver precedence order. */
+/**
+ * The three composer walls together, in resolver precedence order. Only one is
+ * ever mounted at a time in the app; they are stacked here to compare their
+ * CTAs.
+ */
 export const AllComposerWalls: Story = {
   name: "All composer walls",
   parameters: { controls: { disable: true } },
@@ -127,17 +150,6 @@ export const AllComposerWalls: Story = {
       <DailyLimitBanner onAdjustLimit={() => {}} />
       <ProviderBillingBanner onOpenSettings={() => {}} />
       <LowBalanceBanner />
-      <BillingErrorBanner
-        ariaLabel="Your API key needs credits"
-        icon={
-          <KeyRound
-            className="size-5"
-            style={{ color: "var(--content-tertiary)" }}
-          />
-        }
-        title="Your API key needs credits"
-        subtitle={ANDROID_BILLING_MESSAGE}
-      />
     </div>
   ),
 };

--- a/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
@@ -1,0 +1,143 @@
+/**
+ * Every billing wall that appears in chat renders through one primitive,
+ * {@link BillingErrorBanner}. This file catalogs both layers:
+ *
+ *   1. the primitive's own variant matrix (icon / action / dismiss / detached),
+ *   2. the four real walls built on it, each with its production copy and CTA.
+ *
+ * Which of the composer banners is shown is decided by the pure resolver
+ * `resolveComposerBillingBanner` (`utils/error-classification.ts:111`), whose
+ * precedence is strict: daily_limit > provider_billing > managed_credits
+ * (which renders nothing here, since the transcript's credit wall owns it) >
+ * low_balance. The credit wall itself lives in its own story file, since its
+ * CTA is the one that forks between Add credits and View plans.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CalendarClock, KeyRound } from "lucide-react";
+
+import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import { DailyLimitBanner } from "@/domains/chat/components/daily-limit-banner";
+import { LowBalanceBanner } from "@/domains/chat/components/low-balance-banner";
+import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
+import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
+
+const meta: Meta<typeof BillingErrorBanner> = {
+  title: "Upsell Walls/Composer Banners",
+  component: BillingErrorBanner,
+  parameters: { layout: "padded" },
+  args: {
+    ariaLabel: "Billing notice",
+    title: "Your credits are running low",
+    subtitle: "Add credits to avoid an interruption.",
+    action: { label: "Add credits", onClick: () => {} },
+    detached: false,
+  },
+  decorators: [
+    (Story) => (
+      // The banner sizes itself against the composer, which is width-capped.
+      <div className="mx-auto w-full max-w-[720px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BillingErrorBanner>;
+
+/**
+ * Flush-mounted above the composer: square bottom corners so it reads as one
+ * surface with the input below it.
+ */
+export const Attached: Story = {};
+
+/**
+ * `detached`: a standalone rounded card, inset 24px. Used by the credit wall,
+ * which renders inside the transcript rather than above the composer.
+ */
+export const Detached: Story = {
+  args: { detached: true },
+};
+
+/** With a dismiss X after the CTA. The low-balance wall is dismissible. */
+export const WithDismiss: Story = {
+  args: { onDismiss: () => {} },
+};
+
+/**
+ * No CTA and no dismiss collapses the whole right-hand column. This is what
+ * every purchase wall degrades to on native Android, which is
+ * consumption-only.
+ */
+export const NoActionNoDismiss: Story = {
+  name: "No CTA (native Android)",
+  args: {
+    action: undefined,
+    onDismiss: undefined,
+    subtitle: ANDROID_BILLING_MESSAGE,
+  },
+};
+
+/** An icon slot sits before the copy; the daily-limit wall uses one. */
+export const WithIcon: Story = {
+  args: {
+    icon: (
+      <CalendarClock
+        className="size-5"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    ),
+  },
+};
+
+/**
+ * **Daily credit limit reached.** A self-imposed spend cap, not a plan wall,
+ * so the CTA deep-links into billing settings rather than upselling.
+ */
+export const RealDailyLimitBanner: Story = {
+  name: "Real · Daily limit → Adjust Limit",
+  render: () => <DailyLimitBanner onAdjustLimit={() => {}} />,
+};
+
+/**
+ * **Bring-your-own-key billing.** The user's own provider is out of funds, so
+ * there is nothing for Vellum to sell. The CTA opens AI settings.
+ */
+export const RealProviderBillingBanner: Story = {
+  name: "Real · Provider billing → Open Settings",
+  render: () => <ProviderBillingBanner onOpenSettings={() => {}} />,
+};
+
+/**
+ * **Low balance.** The proactive warn-band wall: still usable, so it is
+ * dismissible, and its CTA opens the Add Credits modal rather than the plans
+ * takeover.
+ */
+export const RealLowBalanceBanner: Story = {
+  name: "Real · Low balance → Add credits",
+  render: () => <LowBalanceBanner />,
+};
+
+/** The three composer walls together, in resolver precedence order. */
+export const AllComposerWalls: Story = {
+  name: "All composer walls",
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <DailyLimitBanner onAdjustLimit={() => {}} />
+      <ProviderBillingBanner onOpenSettings={() => {}} />
+      <LowBalanceBanner />
+      <BillingErrorBanner
+        ariaLabel="Your API key needs credits"
+        icon={
+          <KeyRound
+            className="size-5"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+        }
+        title="Your API key needs credits"
+        subtitle={ANDROID_BILLING_MESSAGE}
+      />
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/components/credits-upsell-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.stories.tsx
@@ -1,0 +1,188 @@
+/**
+ * The credit wall: the surface that answers "when do we show **Add credits**
+ * and when do we show **Upgrade**?".
+ *
+ * These stories drive the real {@link CreditsUpsellCard}, not a lookalike, so
+ * the branch under test is the production one at `credits-upsell-card.tsx:51`:
+ *
+ *   isUpgrade = isBillingCtaUpgradeArm(arm) && isFreePlan === true
+ *
+ * Both inputs are seeded through their real read seams: the
+ * `experiment-billing-cta-2026-07-23` arm via the client feature-flag store,
+ * and `plan_id` via the subscription query cache. If either seam moves,
+ * these stories move with it instead of silently drifting.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLayoutEffect } from "react";
+
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
+import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  PlanIdEnum,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+import { useAuthStore } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/** The `experiment-billing-cta-2026-07-23` arm, keyed as the store holds it. */
+const ARM_FLAG_KEY = "experimentBillingCta20260723";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+
+function makeSubscription(planId: PlanIdEnum): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+interface CreditWallStoryArgs {
+  /** `experiment-billing-cta-2026-07-23` arm. */
+  arm: "control" | "upgrade-cta";
+  /** `plan_id` on the billing subscription. `base` is the free plan. */
+  planId: "base" | "pro";
+  /** Whether a platform session exists; `absent` drives the login treatment. */
+  platformSession: "present" | "absent";
+  /** A self-hosted active assistant gates the card away entirely. */
+  selfHosted: boolean;
+}
+
+/**
+ * Seeds the four real read seams the card seldom sees in one place, then hands
+ * every one of them back on unmount so a story cannot leak its billing state
+ * into the next one. Written in an effect rather than during render because
+ * these stores are subscribed by the tree being rendered.
+ */
+function SeededStores({
+  args,
+  children,
+}: {
+  args: CreditWallStoryArgs;
+  children: React.ReactNode;
+}) {
+  const { arm, planId, platformSession, selfHosted } = args;
+
+  useLayoutEffect(() => {
+    const previousAuth = useAuthStore.getState().platformSession;
+    const previousLifecycle =
+      useAssistantLifecycleStore.getState().assistantState;
+
+    useAuthStore.setState({ platformSession });
+    useAssistantLifecycleStore.setState({
+      assistantState: selfHosted
+        ? { kind: "self_hosted" }
+        : { kind: "active", isLocal: false, health: "healthy" },
+    });
+    // `setStringFlag` is the store's own override seam (the same one the
+    // localStorage dev override uses), so the arm is set exactly the way a
+    // real client sets it rather than by reaching past the store's types.
+    useClientFeatureFlagStore.getState().setStringFlag(ARM_FLAG_KEY, arm);
+    // `useIsFreePlan` reads the subscription through TanStack Query, which
+    // serves cached data even while `enabled` is false, so seeding the cache
+    // is enough and no org-store hydration is needed.
+    queryClient.setQueryData(
+      organizationsBillingSubscriptionRetrieveOptions().queryKey,
+      makeSubscription(planId),
+    );
+
+    return () => {
+      useAuthStore.setState({ platformSession: previousAuth });
+      useAssistantLifecycleStore.setState({
+        assistantState: previousLifecycle,
+      });
+      useClientFeatureFlagStore.getState().clearStringOverride(ARM_FLAG_KEY);
+      queryClient.removeQueries({
+        queryKey: organizationsBillingSubscriptionRetrieveOptions().queryKey,
+      });
+    };
+  }, [arm, planId, platformSession, selfHosted]);
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const meta: Meta<CreditWallStoryArgs> = {
+  title: "Upsell Walls/Credit Wall",
+  parameters: { layout: "padded" },
+  argTypes: {
+    arm: { control: "radio", options: ["control", "upgrade-cta"] },
+    planId: { control: "radio", options: ["base", "pro"] },
+    platformSession: { control: "radio", options: ["present", "absent"] },
+    selfHosted: { control: "boolean" },
+  },
+  args: {
+    arm: "control",
+    planId: "base",
+    platformSession: "present",
+    selfHosted: false,
+  },
+  render: (args) => (
+    <SeededStores args={args}>
+      {/* The card is detached and sizes itself against the composer width. */}
+      <div className="mx-auto w-full max-w-[720px]">
+        <CreditsUpsellCard />
+      </div>
+    </SeededStores>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<CreditWallStoryArgs>;
+
+/**
+ * **Add credits**: the default everyone gets. The control arm never shows an
+ * upgrade CTA, so a free-plan org still lands here.
+ */
+export const AddCredits_ControlArm: Story = {
+  name: "Add credits · control arm (default)",
+  args: { arm: "control", planId: "base" },
+};
+
+/**
+ * **Upgrade**: the only combination that swaps the CTA. It needs the `upgrade-cta` arm
+ * *and* a free (`base`) plan. Note the title also changes to "out of **Free**
+ * credits". The CTA routes to the plans takeover rather than opening the Add
+ * Credits modal.
+ */
+export const Upgrade_FreePlanInUpgradeArm: Story = {
+  name: "View plans · upgrade arm + free plan",
+  args: { arm: "upgrade-cta", planId: "base" },
+};
+
+/**
+ * A paying org in the upgrade arm keeps **Add credits**, because the experiment only
+ * ever re-points free users. This is the story that proves the swap is not
+ * simply "the flag is on".
+ */
+export const AddCredits_PaidPlanInUpgradeArm: Story = {
+  name: "Add credits · upgrade arm + paid plan",
+  args: { arm: "upgrade-cta", planId: "pro" },
+};
+
+/**
+ * Platform reachable but no session: every billing CTA would dead-end, so the
+ * card swaps itself for the shared login affordance.
+ */
+export const NoPlatformSession: Story = {
+  name: "Log in · no platform session",
+  args: { platformSession: "absent" },
+};
+
+/**
+ * A self-hosted active assistant gates the card away entirely. It renders
+ * `null`, which is why this story is deliberately empty.
+ */
+export const SelfHostedRendersNothing: Story = {
+  name: "Gated · self-hosted (renders nothing)",
+  args: { selfHosted: true },
+};

--- a/clients/web/src/domains/chat/components/credits-upsell-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.stories.tsx
@@ -113,6 +113,17 @@ function SeededStores({
 
 const meta: Meta<CreditWallStoryArgs> = {
   title: "Upsell Walls/Credit Wall",
+  // Opted out of the global `autodocs` tag. The card resolves its CTA from
+  // module-singleton Zustand stores, so N variants cannot co-exist: the docs
+  // page mounts every story at once and whichever effect ran last decides the
+  // arm, plan and gate for all of them. In practice the last story here is the
+  // self-hosted one, which gated every card to `null` and rendered the page as
+  // five empty boxes. Isolating the seed per instance is not possible while the
+  // source of truth is a module singleton, so the variants are canvas-only,
+  // where exactly one is mounted at a time. `Upsell Walls/Overview` carries the
+  // side-by-side comparison instead, built on the presentational primitive fed
+  // with this card's real exported copy.
+  tags: ["!autodocs"],
   parameters: { layout: "padded" },
   argTypes: {
     arm: { control: "radio", options: ["control", "upgrade-cta"] },

--- a/clients/web/src/domains/chat/components/credits-upsell-card.tsx
+++ b/clients/web/src/domains/chat/components/credits-upsell-card.tsx
@@ -13,13 +13,15 @@ import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { useAddCreditsModalStore } from "@/stores/add-credits-modal-store";
 import { routes } from "@/utils/routes";
 
-const UPGRADE_COPY = {
+/** Free-plan copy in the `upgrade-cta` experiment arm. */
+export const UPGRADE_COPY = {
   title: "You’re out of Free credits",
   subtitle: "Upgrade your plan to keep the conversation going.",
   ctaLabel: "View plans",
 };
 
-const ADD_CREDITS_COPY = {
+/** The default credit-wall copy: control arm, or any paid plan. */
+export const ADD_CREDITS_COPY = {
   title: "You’re out of credits",
   subtitle: "Add credits to pick up where you left off.",
   ctaLabel: "Add credits",

--- a/clients/web/src/domains/settings/ai/email-managed-content.stories.tsx
+++ b/clients/web/src/domains/settings/ai/email-managed-content.stories.tsx
@@ -1,0 +1,79 @@
+/**
+ * The managed-email entitlement wall: the only true *entitlement* gate in the
+ * web client. Everything else that upsells is a resource wall (credits,
+ * storage) or plan management.
+ *
+ * The gate reads `entitlements.managed_email` off the billing subscription
+ * rather than the plan id (`email-managed-content.tsx:86-91`), because an admin
+ * override can grant a Base org the entitlement. It is deliberately tri-state:
+ * entitled / explicitly-not-entitled / unknown, and only the middle one shows
+ * the wall. An unknown subscription fails open to the form.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLayoutEffect } from "react";
+
+import { EmailManagedContent } from "@/domains/settings/ai/email-managed-content";
+import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+
+const NOT_ENTITLED: SubscriptionResponse = {
+  plan_id: "base",
+  status: "active",
+  renewal_date: null,
+  current_period_end: null,
+  cancel_at_period_end: false,
+  cancel_at: null,
+  entitlements: { managed_email: false, phone_number: false },
+};
+
+const meta: Meta<typeof EmailManagedContent> = {
+  title: "Upsell Walls/Managed Email Entitlement",
+  component: EmailManagedContent,
+  parameters: { layout: "padded" },
+  args: {
+    assistantId: "story-assistant",
+    assistantHandle: "ada",
+    emailRootDomain: "vellum.ai",
+  },
+  decorators: [
+    (Story) => {
+      useLayoutEffect(() => {
+        queryClient.setQueryData(
+          organizationsBillingSubscriptionRetrieveOptions().queryKey,
+          NOT_ENTITLED,
+        );
+        return () => {
+          queryClient.removeQueries({
+            queryKey:
+              organizationsBillingSubscriptionRetrieveOptions().queryKey,
+          });
+        };
+      }, []);
+      return (
+        <QueryClientProvider client={queryClient}>
+          <div className="mx-auto w-full max-w-[720px]">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EmailManagedContent>;
+
+/**
+ * The wall: an info-tone notice with a single **Upgrade** CTA into the plans
+ * takeover. The form behind it is never rendered, because the downstream domain
+ * queries are gated off the same entitlement, so a non-entitled org never
+ * fires a request that would 403.
+ */
+export const NotEntitled: Story = {
+  name: "Not entitled · Upgrade",
+};

--- a/clients/web/src/domains/settings/billing/plan-promo-card.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.stories.tsx
@@ -1,0 +1,101 @@
+/**
+ * The billing "Plan" section's promo card: the settings-side upsell. Which of
+ * its two variants renders is decided in `plan-card.tsx:198-210`:
+ *
+ *   - **Upgrade to {name}** when a higher package is recommended and the
+ *     relation is not a lateral `switch`.
+ *   - **Create a custom plan** for a Pro user at the top of the catalog, or one
+ *     whose tiers match no package.
+ *   - neither → the card does not render at all.
+ *
+ * Specs come from the production `packageSpecs()` builder fed by the shared
+ * package fixtures, so the chips read exactly as they do in the app.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PlanPromoCard } from "@/domains/settings/billing/plan-promo-card";
+import { packageSpecs } from "@/domains/settings/billing/plan-spec";
+import {
+  makeSuperPackage,
+  makeUltraPackage,
+} from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+
+const meta: Meta<typeof PlanPromoCard> = {
+  title: "Upsell Walls/Plan Promo Card",
+  component: PlanPromoCard,
+  parameters: { layout: "centered" },
+  args: {
+    onCtaClick: () => {},
+    pending: false,
+    disabled: false,
+  },
+  decorators: [
+    (Story) => (
+      // The card lives in a flex row in the billing panel and is narrow enough
+      // that its chip row wraps; pin that width so the story matches.
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PlanPromoCard>;
+
+/** The upgrade variant, with the target package's spec chips. */
+export const UpgradeToPackage: Story = {
+  name: "Upgrade to {package}",
+  args: {
+    title: "Upgrade to Super",
+    specs: packageSpecs(makeSuperPackage()),
+    ctaLabel: "Upgrade",
+    ctaTestId: "recommended-upgrade-button",
+  },
+};
+
+/** A larger package wraps its chip row rather than truncating. */
+export const UpgradeToTopPackage: Story = {
+  name: "Upgrade to {package} · wide specs",
+  args: {
+    title: "Upgrade to Ultra",
+    specs: packageSpecs(makeUltraPackage()),
+    ctaLabel: "Upgrade",
+    ctaTestId: "recommended-upgrade-button",
+  },
+};
+
+/**
+ * The customize variant deliberately carries no spec chips, because there is no target
+ * package yet, so there is nothing concrete to advertise.
+ */
+export const CreateCustomPlan: Story = {
+  name: "Create a custom plan",
+  args: {
+    title: "Create a custom plan",
+    ctaLabel: "Customize",
+    ctaTestId: "recommended-customize-button",
+  },
+};
+
+/** Checkout in flight: spinner on the CTA, button disabled. */
+export const Pending: Story = {
+  args: {
+    title: "Upgrade to Super",
+    specs: packageSpecs(makeSuperPackage()),
+    ctaLabel: "Upgrade",
+    pending: true,
+  },
+};
+
+/**
+ * Disabled without a spinner. The customize CTA holds here while the current
+ * tier reads settle.
+ */
+export const Disabled: Story = {
+  args: {
+    title: "Create a custom plan",
+    ctaLabel: "Customize",
+    disabled: true,
+  },
+};


### PR DESCRIPTION
## Why

We could not answer "what CTA does a user see when they hit a wall?" without reading branch logic across chat, settings and billing. This adds an `Upsell Walls` Storybook section that answers it by looking.

The headline question was **when we show "Add credits" vs "Upgrade"**. It turns out to be one branch (`credits-upsell-card.tsx:51`):

```ts
isUpgrade = isBillingCtaUpgradeArm(arm) && isFreePlan === true
```

| `experiment-billing-cta-2026-07-23` | Plan | CTA | Destination |
| --- | --- | --- | --- |
| `control` (default) | any | **Add credits** | Add Credits modal, then Stripe |
| `upgrade-cta` | free (`base`) | **View plans** | `/assistant/plans` takeover |
| `upgrade-cta` | **paid** | **Add credits** | Add Credits modal, then Stripe |

Paid orgs keep "Add credits" in both arms, and an unresolved plan counts as paid. The title also changes ("out of **Free** credits" vs "out of credits"). All three rows are stories, so the distinction is visible rather than inferred.

## What is in it

| Story | Covers |
| --- | --- |
| `Upsell Walls/Overview` | Every wall on one page with its trigger, CTA and destination above the live component |
| `Upsell Walls/Credit Wall` | The 3 CTA combinations, plus no-platform-session (Log In) and self-hosted (renders nothing) |
| `Upsell Walls/Composer Banners` | The shared `BillingErrorBanner` matrix plus the real low-balance, daily-limit and provider-billing walls |
| `Upsell Walls/Storage Wall` | warning / cleanup / critical, with and without an upgrade path, and the modal that holds the critical Upgrade CTA |
| `Upsell Walls/Managed Email Entitlement` | The only true entitlement gate in the web client |
| `Upsell Walls/Plan Promo Card` | Upgrade vs Customize, pending, disabled |

The Credit Wall and Managed Email stories drive the **real** components through their **real** read seams (the feature-flag store's `setStringFlag`, and the subscription query cache) rather than a story-local lookalike, so they move with the code instead of silently drifting.

## Findings worth recording

- Every non-credit upsell in the app routes to `routes.plans`. There is no second upsell destination.
- The only true *entitlement* gate is `entitlements.managed_email`. Plugin "Upgrade" and `MemoryUpgradePrompt` are version upgrades, not plan upsells.
- There are no seat, message-cap, or rate-limit walls in the web client.

## Notes for review

- **One production change**: the two credit-wall copy tables are now exported so the overview renders the real strings instead of duplicates of them. No behavior change.
- The overview lives outside `src/domains/` because it spans chat, settings and billing; `no-cross-domain-imports` only constrains files inside a domain (`eslint-rules/no-cross-domain-imports.mjs:70`).
- **Deliberately not storied**: `PlanCard`, `BillingPanel` and `ResizeCard`. Each needs 4 to 7 mocked query/mutation hooks and this repo has no story mocking infrastructure (no msw, no module mocks). Their CTAs are documented in the Overview instead. Extracting their presentational shells would be a good follow-up.
- The Android consumption-only variant is storied at the presentational primitive, because `useIsNativeAndroid` reads a module function through `useSyncExternalStore` and is not seedable.

## Verification

- `bunx tsc --noEmit`: 0 errors
- `bun run lint` on all changed files: clean
- `bun test src/domains/chat/components/credits-upsell-card.test.tsx`: 7 pass, 0 fail
- Every story rendered in the browser at `bun run storybook`, in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)