### PR TITLE
fix(android): guard push registration across rollout skew

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
@@ -9,8 +9,6 @@ import java.util.function.Consumer;
 
 @CapacitorPlugin(name = "AndroidPushRegistration")
 public class AndroidPushRegistrationPlugin extends Plugin {
-    private static final String FAILURE_CODE = "PUSH_REGISTRATION_FAILED";
-
     @PluginMethod
     public void register(PluginCall call) {
         invokeSafely(call, plugin -> plugin.register(call));
@@ -22,15 +20,13 @@ public class AndroidPushRegistrationPlugin extends Plugin {
     }
 
     private void invokeSafely(PluginCall call, Consumer<PushNotificationsPlugin> operation) {
-        try {
+        PushRegistrationGuard.run(call, () -> {
             PushNotificationsPlugin plugin = PushNotificationsPlugin.getPushNotificationsInstance();
             if (plugin == null) {
-                call.reject("Android push notifications are unavailable", FAILURE_CODE);
+                PushRegistrationGuard.reject(call);
                 return;
             }
             operation.accept(plugin);
-        } catch (RuntimeException exception) {
-            call.reject("Android push notifications are unavailable", FAILURE_CODE, exception);
-        }
+        });
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -9,13 +9,19 @@ import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
+import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
 import com.getcapacitor.CapConfig;
 import com.getcapacitor.Logger;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginLoadException;
+import com.getcapacitor.PluginManager;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.json.JSONException;
 
 public class MainActivity extends BridgeActivity {
@@ -46,12 +52,6 @@ public class MainActivity extends BridgeActivity {
         }
         configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
         pendingAppLink = consumeAppLinkIntent(getIntent());
-        registerPlugin(NativeAuthPlugin.class);
-        registerPlugin(NativeBiometricPlugin.class);
-        registerPlugin(AndroidNotificationSettingsPlugin.class);
-        registerPlugin(AndroidPushRegistrationPlugin.class);
-        registerPlugin(VoiceAudioSessionPlugin.class);
-        registerPlugin(VoiceLiveActivityPlugin.class);
         super.onCreate(savedInstanceState);
         deliverPendingVoiceLaunch();
         if (bridge != null) {
@@ -64,7 +64,21 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     protected void load() {
-        // Plugin discovery runs first, so this guard owns the bridge ID before the WebView starts.
+        List<Class<? extends Plugin>> plugins;
+        try {
+            plugins = new PluginManager(getAssets()).loadPluginClasses();
+            plugins.removeIf(PushNotificationsPlugin.class::equals);
+        } catch (PluginLoadException exception) {
+            Logger.error("Unable to load Capacitor plugins", exception);
+            plugins = new ArrayList<>();
+        }
+        bridgeBuilder.setPlugins(plugins);
+        registerPlugin(NativeAuthPlugin.class);
+        registerPlugin(NativeBiometricPlugin.class);
+        registerPlugin(AndroidNotificationSettingsPlugin.class);
+        registerPlugin(AndroidPushRegistrationPlugin.class);
+        registerPlugin(VoiceAudioSessionPlugin.class);
+        registerPlugin(VoiceLiveActivityPlugin.class);
         registerPlugin(SafePushNotificationsPlugin.class);
         super.load();
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -63,6 +63,13 @@ public class MainActivity extends BridgeActivity {
     }
 
     @Override
+    protected void load() {
+        // Plugin discovery runs first, so this guard owns the bridge ID before the WebView starts.
+        registerPlugin(SafePushNotificationsPlugin.class);
+        super.load();
+    }
+
+    @Override
     protected void onNewIntent(Intent intent) {
         URI appLink = consumeAppLinkIntent(intent);
         if (appLink != null) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/PushRegistrationGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/PushRegistrationGuard.java
@@ -1,0 +1,22 @@
+package ai.vellum.assistant;
+
+import com.getcapacitor.PluginCall;
+
+final class PushRegistrationGuard {
+    private static final String FAILURE_CODE = "PUSH_REGISTRATION_FAILED";
+    private static final String FAILURE_MESSAGE = "Android push notifications are unavailable";
+
+    private PushRegistrationGuard() {}
+
+    static void run(PluginCall call, Runnable operation) {
+        try {
+            operation.run();
+        } catch (RuntimeException exception) {
+            call.reject(FAILURE_MESSAGE, FAILURE_CODE, exception);
+        }
+    }
+
+    static void reject(PluginCall call) {
+        call.reject(FAILURE_MESSAGE, FAILURE_CODE);
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
@@ -12,25 +12,15 @@ import com.getcapacitor.annotation.Permission;
     permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = "receive")
 )
 public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
-    private static final String FAILURE_CODE = "PUSH_REGISTRATION_FAILED";
-
     @Override
     @PluginMethod
     public void register(PluginCall call) {
-        invokeSafely(call, () -> super.register(call));
+        PushRegistrationGuard.run(call, () -> super.register(call));
     }
 
     @Override
     @PluginMethod
     public void unregister(PluginCall call) {
-        invokeSafely(call, () -> super.unregister(call));
-    }
-
-    private void invokeSafely(PluginCall call, Runnable operation) {
-        try {
-            operation.run();
-        } catch (RuntimeException exception) {
-            call.reject("Android push notifications are unavailable", FAILURE_CODE, exception);
-        }
+        PushRegistrationGuard.run(call, () -> super.unregister(call));
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
@@ -1,0 +1,36 @@
+package ai.vellum.assistant;
+
+import android.Manifest;
+import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+
+@CapacitorPlugin(
+    name = "PushNotifications",
+    permissions = @Permission(strings = { Manifest.permission.POST_NOTIFICATIONS }, alias = "receive")
+)
+public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
+    private static final String FAILURE_CODE = "PUSH_REGISTRATION_FAILED";
+
+    @Override
+    @PluginMethod
+    public void register(PluginCall call) {
+        invokeSafely(call, () -> super.register(call));
+    }
+
+    @Override
+    @PluginMethod
+    public void unregister(PluginCall call) {
+        invokeSafely(call, () -> super.unregister(call));
+    }
+
+    private void invokeSafely(PluginCall call, Runnable operation) {
+        try {
+            operation.run();
+        } catch (RuntimeException exception) {
+            call.reject("Android push notifications are unavailable", FAILURE_CODE, exception);
+        }
+    }
+}

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -306,13 +306,13 @@ describe("registerForRemotePush", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  test("falls back to the upstream Android plugin on older shells", async () => {
+  test("skips registration on Android shells without the guarded plugin", async () => {
     platform = "android";
     androidPushRegistrationAvailable = false;
 
     await registerForRemotePush("assistant-1");
 
-    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).not.toHaveBeenCalled();
     expect(androidRegisterMock).not.toHaveBeenCalled();
   });
 
@@ -541,6 +541,16 @@ describe("unregisterFromRemotePush", () => {
     await unregisterFromRemotePush();
     expect(lastDeleteArg?.path.token).toBe("fcm-new");
     expect(androidUnregisterMock).toHaveBeenCalledTimes(1);
+    expect(unregisterMock).not.toHaveBeenCalled();
+  });
+
+  test("skips FCM unregister on Android shells without the guarded plugin", async () => {
+    platform = "android";
+    androidPushRegistrationAvailable = false;
+
+    await unregisterFromRemotePush();
+
+    expect(androidUnregisterMock).not.toHaveBeenCalled();
     expect(unregisterMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -312,6 +312,8 @@ describe("registerForRemotePush", () => {
 
     await registerForRemotePush("assistant-1");
 
+    expect(requestPermissionsMock).not.toHaveBeenCalled();
+    expect(ensureAndroidAlertsChannelMock).not.toHaveBeenCalled();
     expect(registerMock).not.toHaveBeenCalled();
     expect(androidRegisterMock).not.toHaveBeenCalled();
   });

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -306,12 +306,13 @@ describe("registerForRemotePush", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  test("skips registration on Android shells without the guarded plugin", async () => {
+  test("installs listeners but skips registration on Android shells without the guarded plugin", async () => {
     platform = "android";
     androidPushRegistrationAvailable = false;
 
     await registerForRemotePush("assistant-1");
 
+    expect(addListenerMock).toHaveBeenCalledTimes(4);
     expect(requestPermissionsMock).not.toHaveBeenCalled();
     expect(ensureAndroidAlertsChannelMock).not.toHaveBeenCalled();
     expect(registerMock).not.toHaveBeenCalled();

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -340,6 +340,13 @@ export async function registerForRemotePush(
   if (!isRemotePushSupported()) {
     return;
   }
+  const isAndroid = Capacitor.getPlatform() === "android";
+  if (
+    isAndroid &&
+    !Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
+  ) {
+    return;
+  }
   currentAssistantId = assistantId;
 
   // If iOS already handed us a token for this device under a different
@@ -358,10 +365,7 @@ export async function registerForRemotePush(
     if (permission.receive !== "granted") {
       return;
     }
-    if (Capacitor.getPlatform() === "android") {
-      if (!Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)) {
-        return;
-      }
+    if (isAndroid) {
       await AndroidPushRegistration.register();
     } else {
       await PushNotifications.register();

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -341,12 +341,6 @@ export async function registerForRemotePush(
     return;
   }
   const isAndroid = Capacitor.getPlatform() === "android";
-  if (
-    isAndroid &&
-    !Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
-  ) {
-    return;
-  }
   currentAssistantId = assistantId;
 
   // If iOS already handed us a token for this device under a different
@@ -360,6 +354,12 @@ export async function registerForRemotePush(
     // `@capacitor/push-notifications` is a plugin Proxy — destructure inline.
     const { PushNotifications } = await import("@capacitor/push-notifications");
     await ensureListeners();
+    if (
+      isAndroid &&
+      !Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
+    ) {
+      return;
+    }
     await ensureAndroidAlertsChannel();
     const permission = await PushNotifications.requestPermissions();
     if (permission.receive !== "granted") {

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -358,10 +358,10 @@ export async function registerForRemotePush(
     if (permission.receive !== "granted") {
       return;
     }
-    if (
-      Capacitor.getPlatform() === "android" &&
-      Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
-    ) {
+    if (Capacitor.getPlatform() === "android") {
+      if (!Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)) {
+        return;
+      }
       await AndroidPushRegistration.register();
     } else {
       await PushNotifications.register();
@@ -420,10 +420,6 @@ export async function unregisterFromRemotePush(): Promise<void> {
     try {
       if (Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)) {
         await AndroidPushRegistration.unregister();
-      } else {
-        const { PushNotifications } =
-          await import("@capacitor/push-notifications");
-        await PushNotifications.unregister();
       }
     } catch (err) {
       captureError(err, {


### PR DESCRIPTION
## Summary
- replace the Android PushNotifications bridge implementation with an app-owned guard that rejects missing Firebase failures instead of crashing the process
- skip remote push registration and unregister on older Android shells that do not expose the guarded bridge
- preserve the existing iOS PushNotifications path

## Original prompt
Fix the Android app crash caused by PushNotifications.register when Firebase is not configured, including when native and deployed web versions roll out at different times.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->