### PR TITLE
fix(web): keep a pinned action's default caption on its shipped tier

### DIFF
--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -559,9 +559,10 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     // The persisted remap is visible on the tier row and as ghost provenance
     // on unpinned Speed-tier sites.
     expect(renderedText()).toContain("via Speed default");
-    // The pinned Filing Agent keeps its winner caption without an arrow:
-    // its pin outranks the remap.
-    expect(renderedText()).toContain("Default: My BYOK");
+    // The pinned Filing Agent's caption stays its shipped tier (what it
+    // falls back to when unpinned); it must not echo the pin.
+    expect(renderedText()).toContain("Default: Speed");
+    expect(renderedText()).not.toContain("Default: My BYOK");
 
     pickOption(tierTrigger("My BYOK"), "Speed (default)");
     fireEvent.click(getButton("Save"));
@@ -710,6 +711,30 @@ describe("OverridesDetailPanel - per-tier defaults (0.11.1+)", () => {
     const body = configPatchBodies[0] as { llm: Record<string, unknown> };
     expect("callSites" in body.llm).toBe(false);
     expect("defaultProfileOverrides" in body.llm).toBe(false);
+  });
+
+  test("pinning a row keeps its default caption on the shipped tier", async () => {
+    renderTierPanel();
+    await waitFor(() => {
+      expect(renderedText()).toContain("Default: Balanced");
+    });
+    const card = rowCard("Workflow Leaf");
+    const toggle = card.querySelector<HTMLElement>('[role="switch"]');
+    if (!toggle) {
+      throw new Error("expected the Workflow Leaf toggle");
+    }
+    fireEvent.click(toggle);
+    const dropdown = rowCard("Workflow Leaf").querySelector<HTMLElement>(
+      'button[role="combobox"]',
+    );
+    if (!dropdown) {
+      throw new Error("expected the pin dropdown");
+    }
+    pickOption(dropdown, "Quality");
+    // The caption names what the action falls back to when unpinned; it
+    // must not follow the pin.
+    expect(renderedText()).toContain("Default: Balanced");
+    expect(renderedText()).not.toContain("Default: Quality");
   });
 
   test("a remap the resolver skipped renders the shipped default, not the raw remap", async () => {

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -753,18 +753,20 @@ export function OverridesDetailPanel({
                       // caption. `displayedDefaultFor` trusts the resolver's
                       // winner for untouched tiers, so a remap resolution
                       // skipped never renders as if it applied. A pinned
-                      // site keeps the winner caption: the pin outranks the
-                      // remap, so tier provenance would claim an effect the
-                      // resolver doesn't apply.
+                      // site's caption stays the shipped tier: the default
+                      // is what the action falls back to when unpinned, and
+                      // must not follow the pin (`cs.defaultProfile` is the
+                      // effective winner, pins included, so it would just
+                      // echo the pin back).
                       const pinned = isDraftActive(drafts[cs.id] ?? null);
                       const shippedTier = cs.shippedDefaultProfile;
                       let defaultProfileLabel: string | null = null;
                       let ghost: { profile: string; caption: string } | null =
                         null;
-                      if (supportsTierOverrides && shippedTier && !pinned) {
+                      if (supportsTierOverrides && shippedTier) {
                         const displayed =
                           displayedDefaultFor(cs) ?? shippedTier;
-                        if (displayed !== shippedTier) {
+                        if (!pinned && displayed !== shippedTier) {
                           ghost = {
                             profile: displayed,
                             caption: `via ${profileLabelFor(shippedTier)} default`,


### PR DESCRIPTION
## Summary
- A pinned action row's "Default:" caption now stays on its shipped tier (what the action falls back to when unpinned) instead of echoing the pin back, since `cs.defaultProfile` is the effective winner with pins included.
- Applies to tier-overrides daemons only; the pre-0.11.1 path is unchanged. Covered by a test that pins a row in-session and asserts the caption holds.

## Original prompt
While testing the Action Overrides ghost-dropdown UX (#39999) on dev, Emmie pinned Subagent Spawn to Quality and its caption flipped from "Default: Balanced" to "Default: Quality". The default named in the caption should be unaffected by the specific per-action override, so pinned rows now derive the caption from the shipped tier rather than the resolved winner.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->