### PR TITLE
feat(web): use compact notification cards in the bell

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -1,13 +1,23 @@
 /**
  * Tests for `NotificationsBell`.
  *
- * Uses `renderToStaticMarkup` (SSR) like `preferences-menu.test.tsx`: only
- * the trigger is exercisable — Radix Popover/BottomSheet content is not
- * rendered when `open={false}`. The unread dot lives on the trigger, so
- * that's exactly the surface these tests pin down.
+ * The trigger tests use `renderToStaticMarkup` (SSR) like
+ * `preferences-menu.test.tsx`: the unread dot lives on the trigger, which is
+ * all Radix renders while the popover is closed. The panel tests render into
+ * happy-dom and click the trigger open, since the rows only mount with it.
+ *
+ * Assertions target text and test ids, never class strings: those drift with
+ * styling and turn behaviour tests into styling tests.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -82,9 +92,20 @@ function renderBell(): string {
   return renderToStaticMarkup(createElement(NotificationsBell));
 }
 
+async function openBell(): Promise<void> {
+  render(<NotificationsBell />);
+  fireEvent.click(screen.getByRole("button", { name: /^Notifications/ }));
+  // Radix measures and positions the panel after the click, off a promise.
+  await act(async () => {});
+}
+
 beforeEach(() => {
   isMobileRef.value = false;
   feedRef.items = [];
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 describe("NotificationsBell unread dot", () => {
@@ -130,5 +151,47 @@ describe("NotificationsBell unread dot", () => {
     const html = renderBell();
     expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
+  });
+});
+
+describe("NotificationsBell panel", () => {
+  test("renders each row as a card with category, title, and preview", async () => {
+    feedRef.items = [
+      feedItem({
+        category: "background",
+        title: "Watcher job failed",
+        summary: "The watcher job could not reach the upstream service.",
+      }),
+    ];
+
+    await openBell();
+
+    expect(screen.getByText("Background")).toBeTruthy();
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(
+      screen.getByText("The watcher job could not reach the upstream service."),
+    ).toBeTruthy();
+  });
+
+  test("keeps its own unread dot distinct from the rows'", async () => {
+    feedRef.items = [feedItem({ status: "new" })];
+
+    await openBell();
+
+    expect(screen.getByTestId("notifications-bell-unread-dot")).toBeTruthy();
+    expect(screen.getByTestId("home-recap-row-unread-dot")).toBeTruthy();
+  });
+
+  test("keeps the panel header and bulk actions", async () => {
+    feedRef.items = [feedItem({ status: "new" })];
+
+    await openBell();
+
+    expect(screen.getByRole("heading", { name: "Notifications" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "View all" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Mark all as read" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -32,9 +32,12 @@ export interface ActivityLocationState {
   feedItemId?: string;
 }
 
-// Caps the visible list at roughly five rows (48px rows + 4px gaps);
-// older notifications stay reachable by scrolling.
-const LIST_MAX_HEIGHT_CLASS = "max-h-[280px]";
+// Caps the visible list at five compact cards plus the four 8px gaps between
+// them. A compact card is 94.25px tall: 2px borders, 16px padding, a 32px meta
+// row (sized by the h-8 hover actions), two 2px gaps, a 19.25px title line, and
+// a 21px preview line. 5 * 94.25 + 4 * 8 = 503.25, rounded up here. Older
+// notifications stay reachable by scrolling.
+const LIST_MAX_HEIGHT_CLASS = "max-h-[504px]";
 
 /**
  * Notification bell for the top nav: a ghost icon button with an unread dot
@@ -138,7 +141,7 @@ export function NotificationsBell() {
       </Typography>
     ) : (
       <div
-        className={`flex flex-col gap-[var(--app-spacing-xs)] overflow-y-auto ${
+        className={`flex flex-col gap-[var(--app-spacing-sm)] overflow-y-auto ${
           isMobile ? "max-h-[60dvh]" : LIST_MAX_HEIGHT_CLASS
         }`}
       >
@@ -146,6 +149,7 @@ export function NotificationsBell() {
           <HomeRecapRow
             key={item.id}
             item={item}
+            density="compact"
             onSelect={handleSelectItem}
             onDismiss={(itemId) =>
               feedQuery.updateStatus.mutate({ itemId, status: "dismissed" })


### PR DESCRIPTION
## Summary
- Renders bell notifications as compact cards, matching the Activity page.
- Re-tunes the popover list height against the real compact card height, replacing arithmetic that described a row height no longer in use.

Part of plan: home-feed-notification-cards.md (PR 6 of 6)