### PR TITLE
feat(web): home feed notification cards with title and message preview

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -57,10 +57,13 @@ mock.module("@/stores/resolved-assistants-store", () => {
 
 import { NotificationsBell } from "@/domains/home/components/notifications-bell";
 
-// The same amber dot HomeRecapRow puts on unread rows, top-right of the bell,
-// ringed in the top-bar surface color to separate it from the bell outline.
-const UNREAD_DOT_CLASS =
-  "-right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]";
+// The dot element itself, matched by a styling-independent test hook so the
+// assertions survive restyling. The accessible name is a separate concern, so
+// it is asserted alongside. The closing quote is load-bearing: it stops
+// READ_LABEL matching the unread label.
+const UNREAD_DOT = 'data-testid="notifications-bell-unread-dot"';
+const UNREAD_LABEL = 'aria-label="Notifications (unread)"';
+const READ_LABEL = 'aria-label="Notifications"';
 
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
   return {
@@ -88,8 +91,8 @@ describe("NotificationsBell unread dot", () => {
   test("shows the dot when an unread notification exists", () => {
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
-    expect(html).toContain(UNREAD_DOT_CLASS);
-    expect(html).toContain("Notifications (unread)");
+    expect(html).toContain(UNREAD_DOT);
+    expect(html).toContain(UNREAD_LABEL);
   });
 
   test("hides the dot when every notification has been read", () => {
@@ -98,14 +101,15 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "acted_on" }),
     ];
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
-    expect(html).toContain("Notifications");
-    expect(html).not.toContain("(unread)");
+    expect(html).not.toContain(UNREAD_DOT);
+    expect(html).toContain(READ_LABEL);
+    expect(html).not.toContain(UNREAD_LABEL);
   });
 
   test("hides the dot when the feed is empty", () => {
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
+    expect(html).not.toContain(UNREAD_DOT);
+    expect(html).toContain(READ_LABEL);
   });
 
   test("ignores unread items that the popover never shows", () => {
@@ -116,13 +120,15 @@ describe("NotificationsBell unread dot", () => {
       feedItem({ id: "b", status: "new", urgency: "high" }),
     ];
     const html = renderBell();
-    expect(html).not.toContain(UNREAD_DOT_CLASS);
+    expect(html).not.toContain(UNREAD_DOT);
+    expect(html).toContain(READ_LABEL);
   });
 
   test("mobile trigger carries the same dot", () => {
     isMobileRef.value = true;
     feedRef.items = [feedItem({ status: "new" })];
     const html = renderBell();
-    expect(html).toContain(UNREAD_DOT_CLASS);
+    expect(html).toContain(UNREAD_DOT);
+    expect(html).toContain(UNREAD_LABEL);
   });
 });

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -1,13 +1,23 @@
 /**
  * Tests for `NotificationsBell`.
  *
- * Uses `renderToStaticMarkup` (SSR) like `preferences-menu.test.tsx`: only
- * the trigger is exercisable — Radix Popover/BottomSheet content is not
- * rendered when `open={false}`. The unread dot lives on the trigger, so
- * that's exactly the surface these tests pin down.
+ * The trigger tests use `renderToStaticMarkup` (SSR) like
+ * `preferences-menu.test.tsx`: the unread dot lives on the trigger, which is
+ * all Radix renders while the popover is closed. The panel tests render into
+ * happy-dom and click the trigger open, since the rows only mount with it.
+ *
+ * Assertions target text and test ids, never class strings: those drift with
+ * styling and turn behaviour tests into styling tests.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -82,9 +92,20 @@ function renderBell(): string {
   return renderToStaticMarkup(createElement(NotificationsBell));
 }
 
+async function openBell(): Promise<void> {
+  render(<NotificationsBell />);
+  fireEvent.click(screen.getByRole("button", { name: /^Notifications/ }));
+  // Radix measures and positions the panel after the click, off a promise.
+  await act(async () => {});
+}
+
 beforeEach(() => {
   isMobileRef.value = false;
   feedRef.items = [];
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 describe("NotificationsBell unread dot", () => {
@@ -130,5 +151,47 @@ describe("NotificationsBell unread dot", () => {
     const html = renderBell();
     expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
+  });
+});
+
+describe("NotificationsBell panel", () => {
+  test("renders each row as a card with category, title, and preview", async () => {
+    feedRef.items = [
+      feedItem({
+        category: "background",
+        title: "Watcher job failed",
+        summary: "The watcher job could not reach the upstream service.",
+      }),
+    ];
+
+    await openBell();
+
+    expect(screen.getByText("Background")).toBeTruthy();
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(
+      screen.getByText("The watcher job could not reach the upstream service."),
+    ).toBeTruthy();
+  });
+
+  test("keeps its own unread dot distinct from the rows'", async () => {
+    feedRef.items = [feedItem({ status: "new" })];
+
+    await openBell();
+
+    expect(screen.getByTestId("notifications-bell-unread-dot")).toBeTruthy();
+    expect(screen.getByTestId("home-recap-row-unread-dot")).toBeTruthy();
+  });
+
+  test("keeps the panel header and bulk actions", async () => {
+    feedRef.items = [feedItem({ status: "new" })];
+
+    await openBell();
+
+    expect(screen.getByRole("heading", { name: "Notifications" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "View all" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Mark all as read" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -115,7 +115,10 @@ export function NotificationsBell() {
             // icon-only buttons grow on touch-mobile. The 2px ring eats into
             // the box (border-box), so size/offset grow by 2px each to keep
             // the 6px amber core in place.
-            <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]" />
+            <span
+              data-testid="notifications-bell-unread-dot"
+              className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+            />
           ) : null}
         </span>
       }

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -32,9 +32,12 @@ export interface ActivityLocationState {
   feedItemId?: string;
 }
 
-// Caps the visible list at roughly five rows (48px rows + 4px gaps);
-// older notifications stay reachable by scrolling.
-const LIST_MAX_HEIGHT_CLASS = "max-h-[280px]";
+// Caps the visible list at five compact cards plus the four 8px gaps between
+// them. A compact card is 94.25px tall: 2px borders, 16px padding, a 32px meta
+// row (sized by the h-8 hover actions), two 2px gaps, a 19.25px title line, and
+// a 21px preview line. 5 * 94.25 + 4 * 8 = 503.25, rounded up here. Older
+// notifications stay reachable by scrolling.
+const LIST_MAX_HEIGHT_CLASS = "max-h-[504px]";
 
 /**
  * Notification bell for the top nav: a ghost icon button with an unread dot
@@ -138,7 +141,7 @@ export function NotificationsBell() {
       </Typography>
     ) : (
       <div
-        className={`flex flex-col gap-[var(--app-spacing-xs)] overflow-y-auto ${
+        className={`flex flex-col gap-[var(--app-spacing-sm)] overflow-y-auto ${
           isMobile ? "max-h-[60dvh]" : LIST_MAX_HEIGHT_CLASS
         }`}
       >
@@ -146,6 +149,7 @@ export function NotificationsBell() {
           <HomeRecapRow
             key={item.id}
             item={item}
+            density="compact"
             onSelect={handleSelectItem}
             onDismiss={(itemId) =>
               feedQuery.updateStatus.mutate({ itemId, status: "dismissed" })

--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -9,22 +9,11 @@ import {
 } from "lucide-react";
 
 import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
-import type {
-  FeedItem,
-  FeedItemCategory,
-  FeedItemStatus,
-} from "@vellumai/assistant-api";
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Tag, Typography } from "@vellumai/design-library";
-import { CATEGORY_STYLES } from "../home-feed-filter-bar";
+import { resolveCategoryStyle } from "../home-feed-filter-bar";
 import { HomeGenericDetail } from "./home-generic-detail";
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
-
-function resolveCategoryStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES.system;
-}
 
 // The header shows the item's own title when it has one. Many feed items omit
 // a distinct title — for those, falling back to `summary` (which is also the

--- a/clients/web/src/domains/home/feed-category-chip.test.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for `FeedCategoryChip` and the shared `resolveCategoryStyle` it uses.
+ *
+ * Uses `renderToStaticMarkup` (SSR) like `notifications-bell.test.tsx`. The
+ * chip is a pure presentational component, so assertions cover rendered text
+ * and the absence of throwing. Class strings are deliberately not asserted.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FeedItemCategory } from "@vellumai/assistant-api";
+
+import { FeedCategoryChip } from "@/domains/home/feed-category-chip";
+import {
+  CATEGORY_STYLES,
+  resolveCategoryStyle,
+} from "@/domains/home/home-feed-filter-bar";
+
+const CATEGORY_LABELS = [
+  ["security", "Security"],
+  ["email", "Email"],
+  ["scheduling", "Scheduling"],
+  ["background", "Background"],
+  ["system", "System"],
+] as const satisfies readonly (readonly [FeedItemCategory, string])[];
+
+function stripTags(markup: string): string {
+  return markup.replace(/<[^>]*>/g, "");
+}
+
+describe("FeedCategoryChip", () => {
+  test.each(CATEGORY_LABELS)(
+    "renders %s in natural case",
+    (category, expected) => {
+      const markup = renderToStaticMarkup(
+        <FeedCategoryChip category={category} />,
+      );
+      expect(stripTags(markup)).toBe(expected);
+    },
+  );
+
+  test("falls back to the system label when no category is given", () => {
+    const markup = renderToStaticMarkup(<FeedCategoryChip />);
+    expect(stripTags(markup)).toBe("System");
+  });
+
+  test("does not throw for an unrecognized category", () => {
+    expect(() => {
+      renderToStaticMarkup(
+        <FeedCategoryChip category={"nonsense" as FeedItemCategory} />,
+      );
+    }).not.toThrow();
+  });
+
+  test("renders every category distinctly", () => {
+    const rendered = CATEGORY_LABELS.map(([category]) =>
+      renderToStaticMarkup(<FeedCategoryChip category={category} />),
+    );
+    expect(new Set(rendered).size).toBe(CATEGORY_LABELS.length);
+  });
+});
+
+describe("resolveCategoryStyle", () => {
+  test.each(CATEGORY_LABELS)("returns the %s style", (category) => {
+    expect(resolveCategoryStyle(category)).toBe(CATEGORY_STYLES[category]);
+  });
+
+  test("falls back to the system style when no category is given", () => {
+    expect(resolveCategoryStyle()).toBe(CATEGORY_STYLES.system);
+  });
+
+  test("falls back to the system style for an unrecognized category", () => {
+    expect(resolveCategoryStyle("nonsense" as FeedItemCategory)).toBe(
+      CATEGORY_STYLES.system,
+    );
+  });
+});

--- a/clients/web/src/domains/home/feed-category-chip.tsx
+++ b/clients/web/src/domains/home/feed-category-chip.tsx
@@ -1,0 +1,36 @@
+import { type CSSProperties } from "react";
+
+import type { FeedItemCategory } from "@vellumai/assistant-api";
+import { Tag } from "@vellumai/design-library";
+
+import { resolveCategoryStyle } from "./home-feed-filter-bar";
+
+const FALLBACK_CATEGORY: FeedItemCategory = "system";
+
+export interface FeedCategoryChipProps {
+  category?: FeedItemCategory;
+}
+
+/**
+ * Text-only chip naming a feed item's category, toned from `CATEGORY_STYLES`.
+ *
+ * The background alone carries the category hue: the `weak` token is a runtime
+ * value, so it goes in as a local custom property that a static Tailwind
+ * utility reads back, landing in the same `tailwind-merge` conflict group as
+ * `Tag`'s own `bg-[var(...)]` base class so it wins. The label deliberately
+ * keeps `Tag`'s `--content-default` text color, which clears WCAG AA against
+ * every category background at this 12px/600 size.
+ */
+export function FeedCategoryChip({ category }: FeedCategoryChipProps) {
+  const style = resolveCategoryStyle(category);
+  const label = category ?? FALLBACK_CATEGORY;
+
+  return (
+    <Tag
+      className="bg-[var(--feed-chip-weak)] uppercase tracking-wide leading-none"
+      style={{ "--feed-chip-weak": style.weak } as CSSProperties}
+    >
+      {label.charAt(0).toUpperCase() + label.slice(1)}
+    </Tag>
+  );
+}

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -13,6 +13,9 @@ const DERIVED_TITLE_MAX_LENGTH = 60;
 /** The module's `MAX_PREVIEW_LENGTH`, the cap it applies to flattened text. */
 const PREVIEW_MAX_LENGTH = 280;
 
+/** The module's `MAX_PARSE_LENGTH`, the bound it puts on the raw markdown. */
+const PARSE_MAX_LENGTH = 4096;
+
 /** A phrase whose repetition puts the cap in the middle of a word. */
 const CAP_STRADDLING_PHRASE = "lorem ipsum dolor sit amet consectetur ";
 
@@ -530,5 +533,59 @@ describe("flattenSummary", () => {
     const flattened = flattenSummary("x".repeat(PREVIEW_MAX_LENGTH + 40));
 
     expect(flattened).toBe("x".repeat(PREVIEW_MAX_LENGTH));
+  });
+});
+
+describe("summaries past the parse limit", () => {
+  /** A fenced block long enough that its closer sits past the parse limit. */
+  const LONG_CODE_BODY = "const secret = 1;\n".repeat(400);
+
+  test("caps prose the same way however far it runs past the limit", () => {
+    const summary = CAP_STRADDLING_PHRASE.repeat(400).trim();
+    expect(summary.length).toBeGreaterThan(PARSE_MAX_LENGTH);
+
+    const flattened = flattenSummary(summary);
+
+    expect(flattened).toBe(
+      flattenSummary(CAP_STRADDLING_PHRASE.repeat(20).trim()),
+    );
+    expect(flattened.length).toBeLessThanOrEqual(PREVIEW_MAX_LENGTH);
+    expect(summary.startsWith(flattened)).toBe(true);
+    expect(summary[flattened.length]).toBe(" ");
+  });
+
+  test("previews the prose a long summary opens with", () => {
+    const summary = `Deploy failed because the api worker never reported healthy. ${"Filler sentence. ".repeat(500)}`;
+    expect(summary.length).toBeGreaterThan(PARSE_MAX_LENGTH);
+
+    expect(resolvePreview("Deploy failed", summary)).toStartWith(
+      "because the api worker never reported healthy. Filler sentence.",
+    );
+  });
+
+  test("keeps the text ahead of a fence the limit cuts inside", () => {
+    const summary = `Compilation stopped early:\n\n\`\`\`ts\n${LONG_CODE_BODY}\`\`\`\n\nSee the job output.`;
+    expect(summary.indexOf("```")).toBeLessThan(PARSE_MAX_LENGTH);
+    expect(summary.lastIndexOf("```")).toBeGreaterThan(PARSE_MAX_LENGTH);
+
+    const preview = resolvePreview("Build log", summary);
+
+    expect(preview).toBe("Compilation stopped early:");
+    expect(preview).not.toContain("const secret");
+  });
+
+  test("reparses in full when a cut inside a fence empties the preview", () => {
+    const summary = `\`\`\`ts\n${LONG_CODE_BODY}\`\`\`\n\nSee the job output.`;
+    expect(summary.lastIndexOf("```")).toBeGreaterThan(PARSE_MAX_LENGTH);
+
+    expect(flattenSummary(summary)).toBe("See the job output.");
+  });
+
+  test("returns an empty string for a long summary of only code", () => {
+    expect(flattenSummary(`\`\`\`ts\n${LONG_CODE_BODY}\`\`\``)).toBe("");
+  });
+
+  test("returns an empty string for a long whitespace-only summary", () => {
+    expect(flattenSummary(" \n".repeat(PARSE_MAX_LENGTH))).toBe("");
   });
 });

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -1,11 +1,20 @@
-/** Tests for `resolvePreview`, the feed card's preview text resolver. */
+/**
+ * Tests for `feed-preview`, the feed card's preview text resolver and the
+ * flattener behind it.
+ */
 
 import { describe, expect, test } from "bun:test";
 
-import { resolvePreview } from "./feed-preview";
+import { flattenSummary, resolvePreview } from "./feed-preview";
 
 /** The daemon's `NOTIFICATION_TITLE_MAX_LENGTH`, the clamp `deriveTitle` uses. */
 const DERIVED_TITLE_MAX_LENGTH = 60;
+
+/** The module's `MAX_PREVIEW_LENGTH`, the cap it applies to flattened text. */
+const PREVIEW_MAX_LENGTH = 280;
+
+/** A phrase whose repetition puts the cap in the middle of a word. */
+const CAP_STRADDLING_PHRASE = "lorem ipsum dolor sit amet consectetur ";
 
 /** Build a title the way the daemon's `deriveTitle` builds an over-long one. */
 function deriveTruncatedTitle(body: string, ellipsis: string): string {
@@ -438,5 +447,88 @@ describe("resolvePreview", () => {
     const preview = resolvePreview("Cafe", summary);
     expect(preview).toBe(summary);
     expect(preview?.startsWith(combiningAcute)).toBe(false);
+  });
+
+  test("returns null when a clamped title already carries the whole preview", () => {
+    // The producer strips the fence delimiters and keeps the code body, so its
+    // title runs past the paragraph this flattener stops at.
+    const summary =
+      "Build failed with this trace:\n```\nTypeError: undefined is not a function\n```";
+    const title = deriveTruncatedTitle(
+      "Build failed with this trace: TypeError: undefined is not a function",
+      "…",
+    );
+    expect(title).toBe(
+      "Build failed with this trace: TypeError: undefined is not a…",
+    );
+
+    expect(resolvePreview(title, summary)).toBeNull();
+  });
+
+  test("returns null when an unclamped title already carries the whole preview", () => {
+    expect(
+      resolvePreview(
+        "Build failed: TypeError raised",
+        "Build failed:\n```\nTypeError raised\n```",
+      ),
+    ).toBeNull();
+  });
+
+  test("keeps a preview the title only shares a word stem with", () => {
+    expect(resolvePreview("Deployment queue is backed up", "Deploy")).toBe(
+      "Deploy",
+    );
+  });
+
+  test("caps a long preview and cuts it on a word boundary", () => {
+    const summary = CAP_STRADDLING_PHRASE.repeat(20).trim();
+    expect(summary.length).toBeGreaterThan(PREVIEW_MAX_LENGTH);
+
+    const preview = resolvePreview("Long report", summary);
+
+    expect(preview).not.toBeNull();
+    expect(preview!.length).toBeLessThanOrEqual(PREVIEW_MAX_LENGTH);
+    expect(summary.startsWith(preview!)).toBe(true);
+    // The character the cut stopped before is a space, so no word was split.
+    expect(summary[preview!.length]).toBe(" ");
+    expect(preview).not.toContain("…");
+  });
+
+  test("caps the continuation left by a derived title", () => {
+    const summary = `Deploy failed. ${CAP_STRADDLING_PHRASE.repeat(20).trim()}`;
+
+    const preview = resolvePreview("Deploy failed", summary);
+
+    expect(preview).not.toBeNull();
+    expect(preview!.length).toBeLessThanOrEqual(PREVIEW_MAX_LENGTH);
+    expect(preview!.startsWith("lorem ipsum")).toBe(true);
+  });
+});
+
+describe("flattenSummary", () => {
+  test("returns markdown as plain text", () => {
+    expect(
+      flattenSummary("## Deploy failed\n\n**The api** never came up."),
+    ).toBe("Deploy failed The api never came up.");
+  });
+
+  test("returns an empty string for a summary with nothing renderable", () => {
+    expect(flattenSummary("```\nconst a = 1;\n```")).toBe("");
+  });
+
+  test("caps a long summary on a word boundary", () => {
+    const summary = CAP_STRADDLING_PHRASE.repeat(20).trim();
+
+    const flattened = flattenSummary(summary);
+
+    expect(flattened.length).toBeLessThanOrEqual(PREVIEW_MAX_LENGTH);
+    expect(summary.startsWith(flattened)).toBe(true);
+    expect(summary[flattened.length]).toBe(" ");
+  });
+
+  test("hard-clamps a single word longer than the cap", () => {
+    const flattened = flattenSummary("x".repeat(PREVIEW_MAX_LENGTH + 40));
+
+    expect(flattened).toBe("x".repeat(PREVIEW_MAX_LENGTH));
   });
 });

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -1,0 +1,442 @@
+/** Tests for `resolvePreview`, the feed card's preview text resolver. */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolvePreview } from "./feed-preview";
+
+/** The daemon's `NOTIFICATION_TITLE_MAX_LENGTH`, the clamp `deriveTitle` uses. */
+const DERIVED_TITLE_MAX_LENGTH = 60;
+
+/** Build a title the way the daemon's `deriveTitle` builds an over-long one. */
+function deriveTruncatedTitle(body: string, ellipsis: string): string {
+  return body.slice(0, DERIVED_TITLE_MAX_LENGTH).trim() + ellipsis;
+}
+
+describe("resolvePreview", () => {
+  test("unwraps inline emphasis in a flattened summary", () => {
+    expect(
+      resolvePreview(
+        "Watcher job failed",
+        "**Error:** message channel closed before a response was received.",
+      ),
+    ).toBe("Error: message channel closed before a response was received.");
+  });
+
+  test("passes a genuinely distinct summary through untouched", () => {
+    expect(
+      resolvePreview("Nightly backup", "All three volumes verified."),
+    ).toBe("All three volumes verified.");
+  });
+
+  test("returns null when the title and the summary are identical", () => {
+    const text = "Deploy finished without incident";
+    expect(resolvePreview(text, text)).toBeNull();
+  });
+
+  test("ignores emphasis and trailing punctuation when matching", () => {
+    expect(resolvePreview("Deploy failed", "**Deploy failed.**")).toBeNull();
+  });
+
+  test("returns the continuation when the title is a prefix of the summary", () => {
+    const preview = resolvePreview(
+      "Deploy failed",
+      "Deploy failed because the api worker never reported healthy.",
+    );
+    expect(preview).toBe("because the api worker never reported healthy.");
+  });
+
+  test("unwraps emphasis and code spans in the continuation", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "**Deploy failed** because the `api` worker never reported healthy.",
+      ),
+    ).toBe("because the api worker never reported healthy.");
+  });
+
+  test("drops a bold title's trailing period orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "**Deploy failed.** The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
+  test("drops an exclamation mark orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed!",
+        "Deploy failed! The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
+  test("drops a question mark orphaned by the slice", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed?",
+        "Deploy failed? The api worker never reported healthy.",
+      ),
+    ).toBe("The api worker never reported healthy.");
+  });
+
+  test("unwraps a code span that starts the continuation", () => {
+    expect(
+      resolvePreview("Deploy failed", "Deploy failed: `api` never came up."),
+    ).toBe("api never came up.");
+  });
+
+  test("returns null when the summary only links the title text", () => {
+    expect(
+      resolvePreview("Read docs", "Read [docs](https://example.com)"),
+    ).toBeNull();
+  });
+
+  test("returns the continuation after a linked title prefix", () => {
+    expect(
+      resolvePreview(
+        "Read the docs",
+        "Read the [docs](https://example.com) before rerunning the deploy.",
+      ),
+    ).toBe("before rerunning the deploy.");
+  });
+
+  test("keeps link text the title only partly covers", () => {
+    expect(
+      resolvePreview(
+        "Read docs",
+        "Read [docs and specs](https://example.com) before the next deploy.",
+      ),
+    ).toBe("and specs before the next deploy.");
+  });
+
+  test("unwraps a link the title does not cover", () => {
+    expect(
+      resolvePreview(
+        "Nightly backup",
+        "See [the report](https://example.com) for volume details.",
+      ),
+    ).toBe("See the report for volume details.");
+  });
+
+  test("unwraps a reference link to its text", () => {
+    expect(
+      resolvePreview(
+        "Nightly backup",
+        "See [the report][r] for volume details.\n\n[r]: https://example.com",
+      ),
+    ).toBe("See the report for volume details.");
+  });
+
+  test("does not strand a destination holding an escaped closing paren", () => {
+    const preview = resolvePreview(
+      "Read docs",
+      "Read [docs](a\\)) before rerunning the deploy.",
+    );
+    expect(preview).toBe("before rerunning the deploy.");
+    expect(preview?.startsWith(")")).toBe(false);
+  });
+
+  test("returns null when strikethrough wraps the whole title", () => {
+    expect(resolvePreview("Deploy failed", "~~Deploy failed~~")).toBeNull();
+  });
+
+  test("returns the continuation after a struck-through title prefix", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "~~Deploy failed~~ because the api worker never reported healthy.",
+      ),
+    ).toBe("because the api worker never reported healthy.");
+  });
+
+  test("handles single-tilde strikethrough in the prefix", () => {
+    expect(
+      resolvePreview(
+        "Deploy failed",
+        "~Deploy failed~ and the pods stayed down.",
+      ),
+    ).toBe("and the pods stayed down.");
+  });
+
+  test("returns null when the continuation is too short", () => {
+    expect(resolvePreview("Deploy failed", "Deploy failed on api.")).toBeNull();
+  });
+
+  test("strips headings and bullets and unwraps inline bold", () => {
+    expect(
+      resolvePreview(
+        "Deploy report",
+        "## Deploy failed\n\n- **api** timed out\n- worker OK",
+      ),
+    ).toBe("Deploy failed api timed out worker OK");
+  });
+
+  test("strips ordered list markers in both delimiter forms", () => {
+    expect(
+      resolvePreview("Steps", "1. Pull the image\n2) Restart the pod"),
+    ).toBe("Pull the image Restart the pod");
+  });
+
+  test("strips blockquote markers, including nested bullets", () => {
+    expect(
+      resolvePreview("Quoted", "> The check timed out\n> - retry scheduled"),
+    ).toBe("The check timed out retry scheduled");
+  });
+
+  test("drops fenced code block contents", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Compilation stopped early:\n\n```ts\nconst secret = 1;\n```\n\nSee the job output.",
+    );
+    expect(preview).toBe("Compilation stopped early: See the job output.");
+  });
+
+  test("drops tilde fenced code block contents", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Two files changed.\n~~~\ndiff --git a b\n~~~\nRerun when ready.",
+      ),
+    ).toBe("Two files changed. Rerun when ready.");
+  });
+
+  test("drops a fenced code block nested in a blockquote", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n\n> ```\n> secret payload\n> ```\n\nRerun the job.",
+      ),
+    ).toBe("Head of the log: Rerun the job.");
+  });
+
+  test("closes a blockquoted fence whose marker carries no space", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Head:\n> ```\n> payload\n>```\nAfter",
+    );
+    expect(preview).toBe("Head: After");
+    expect(preview).not.toContain("payload");
+  });
+
+  test("drops a fenced code block nested in a list item", () => {
+    expect(
+      resolvePreview(
+        "Runbook",
+        "Do this first:\n\n- ```\n  vellum run\n  ```\n\nThen check the log.",
+      ),
+    ).toBe("Do this first: Then check the log.");
+  });
+
+  test("does not close a top-level fence on a bulleted fence line of code", () => {
+    const preview = resolvePreview(
+      "Build log",
+      "Head:\n```text\n- ```\nsecret payload\n```",
+    );
+    expect(preview).toBe("Head:");
+    expect(preview).not.toContain("secret payload");
+  });
+
+  test("does not close a list-nested fence on a bulleted fence line of code", () => {
+    const preview = resolvePreview(
+      "Runbook",
+      "Do this first:\n\n- ```text\n  - ```\n  secret payload\n  ```\n\nThen check the log.",
+    );
+    expect(preview).toBe("Do this first: Then check the log.");
+    expect(preview).not.toContain("secret payload");
+  });
+
+  test("treats a backtick run with a backticked info string as an inline span", () => {
+    expect(
+      resolvePreview("Status check", "```code``` is the reported value"),
+    ).toBe("code is the reported value");
+  });
+
+  test("unwraps a code span whose content holds a backtick", () => {
+    const preview = resolvePreview(
+      "Shell tip",
+      "Use ``a ` b`` in the shell without escaping.",
+    );
+    expect(preview).toBe("Use a ` b in the shell without escaping.");
+  });
+
+  test("keeps escaped asterisks as literal text", () => {
+    expect(
+      resolvePreview(
+        "Export formatting",
+        "The label reads \\* literal stars \\* exactly as typed.",
+      ),
+    ).toBe("The label reads * literal stars * exactly as typed.");
+    expect(
+      resolvePreview(
+        "Export formatting",
+        "The label reads \\*literal stars\\* exactly as typed.",
+      ),
+    ).toBe("The label reads *literal stars* exactly as typed.");
+  });
+
+  test("returns a markdown-rich summary as plain text", () => {
+    const preview = resolvePreview(
+      "Release notes",
+      "## Rollout\n\n- **api** is `healthy` after the [runbook](https://example.com) steps\n- *worker* recovered",
+    );
+    expect(preview).toBe(
+      "Rollout api is healthy after the runbook steps worker recovered",
+    );
+    for (const character of ["*", "`", "#", "[", "]"]) {
+      expect(preview).not.toContain(character);
+    }
+  });
+
+  test("still opens a tilde fence whose info string holds a backtick", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Two files changed.\n~~~`js`\ndiff --git a b\n~~~\nRerun when ready.",
+      ),
+    ).toBe("Two files changed. Rerun when ready.");
+  });
+
+  test("keeps a fenced line with trailing text inside the block", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Compilation stopped early:\n```ts\n```not-a-close\nconst secret = 1;\n```\n\nSee the job output.",
+      ),
+    ).toBe("Compilation stopped early: See the job output.");
+  });
+
+  test("closes a fenced code block on a fence with trailing spaces", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n```\nstack trace\n```   \nRerun the job.",
+      ),
+    ).toBe("Head of the log: Rerun the job.");
+  });
+
+  test("drops an unterminated fenced code block", () => {
+    expect(
+      resolvePreview("Build log", "Head of the log:\n```\nstack trace here"),
+    ).toBe("Head of the log:");
+  });
+
+  test("drops an unterminated block holding a fence-like line", () => {
+    expect(
+      resolvePreview(
+        "Build log",
+        "Head of the log:\n```\n```not-a-close\nstack trace here",
+      ),
+    ).toBe("Head of the log:");
+  });
+
+  test("flattens a GFM table to its cell text", () => {
+    const preview = resolvePreview(
+      "Table",
+      "| Job | State |\n| --- | :---: |\n| api | failed |",
+    );
+    expect(preview).toBe("Job State api failed");
+    expect(preview).not.toContain("---");
+  });
+
+  test("drops thematic breaks written with asterisks", () => {
+    const preview = resolvePreview("Rollout notes", "Before\n\n***\n\nAfter");
+    expect(preview).toBe("Before After");
+    expect(preview).not.toContain("***");
+  });
+
+  test("drops thematic breaks written with underscores", () => {
+    const preview = resolvePreview("Rollout notes", "Before\n\n___\n\nAfter");
+    expect(preview).toBe("Before After");
+    expect(preview).not.toContain("___");
+  });
+
+  test("handles CRLF line endings", () => {
+    expect(
+      resolvePreview("Report", "## Deploy failed\r\n\r\n- api timed out"),
+    ).toBe("Deploy failed api timed out");
+  });
+
+  test("returns null for a whitespace-only summary", () => {
+    expect(resolvePreview("Anything", "   \n\t\r\n  ")).toBeNull();
+  });
+
+  test("returns null for an empty summary", () => {
+    expect(resolvePreview("Anything", "")).toBeNull();
+  });
+
+  test("returns null when the summary is only a fenced code block", () => {
+    expect(resolvePreview("Snippet", "```\nconst a = 1;\n```")).toBeNull();
+  });
+
+  test("does not treat a shared word prefix as a derived title", () => {
+    const preview = resolvePreview("Deploy", "Deployment queue is backed up");
+    expect(preview).toBe("Deployment queue is backed up");
+    expect(preview).not.toBe("ment queue is backed up");
+  });
+
+  test("matches a derived title clamped with a horizontal ellipsis", () => {
+    const summary =
+      "Deploy failed because the api worker never reported healthy after three restarts.";
+    const title = deriveTruncatedTitle(summary, "…");
+    // The first sentence runs past the clamp, which is what appends the ellipsis.
+    expect(summary.length).toBeGreaterThan(DERIVED_TITLE_MAX_LENGTH);
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("after three restarts.");
+    expect(preview).not.toContain("Deploy failed");
+    expect(preview).not.toContain("api worker");
+  });
+
+  test("matches a derived title clamped with three periods", () => {
+    const summary =
+      "Deploy failed because the api worker never reported healthy after three restarts.";
+    const title = deriveTruncatedTitle(summary, "...");
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("after three restarts.");
+    expect(preview).not.toContain("Deploy failed");
+  });
+
+  test("keeps the straddled word whole when the clamp cuts mid-word", () => {
+    const summary =
+      "Deploy failed because the api worker never reported unhealthy after restarts.";
+    const title = deriveTruncatedTitle(summary, "…");
+    // The clamp lands inside "unhealthy", which is what the marker signals.
+    expect(title).toBe(
+      "Deploy failed because the api worker never reported unhealth…",
+    );
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("unhealthy after restarts.");
+    expect(preview?.startsWith("y ")).toBe(false);
+  });
+
+  test("keeps the straddled word whole for a three-period clamp", () => {
+    const summary =
+      "Deploy failed because the api worker never reported unhealthy after restarts.";
+    const title = deriveTruncatedTitle(summary, "...");
+
+    const preview = resolvePreview(title, summary);
+    expect(preview).toBe("unhealthy after restarts.");
+    expect(preview?.startsWith("y ")).toBe(false);
+  });
+
+  test("keeps the whole preview when an ellipsized title is not a prefix", () => {
+    const summary =
+      "The api worker never reported healthy after three restarts.";
+    expect(resolvePreview("Waiting on the deploy…", summary)).toBe(summary);
+    expect(resolvePreview("Waiting on the deploy...", summary)).toBe(summary);
+  });
+
+  test("does not split a decomposed letter away from its combining mark", () => {
+    const combiningAcute = "\u0301";
+    const summary = `Cafe${combiningAcute} outage affected the api worker`;
+    expect(summary).toBe(summary.normalize("NFD"));
+
+    const preview = resolvePreview("Cafe", summary);
+    expect(preview).toBe(summary);
+    expect(preview?.startsWith(combiningAcute)).toBe(false);
+  });
+});

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -16,6 +16,9 @@ const PREVIEW_MAX_LENGTH = 280;
 /** The module's `MAX_PARSE_LENGTH`, the bound it puts on the raw markdown. */
 const PARSE_MAX_LENGTH = 4096;
 
+/** The module's `MAX_FALLBACK_PARSE_LENGTH`, the bound on its recovery parse. */
+const FALLBACK_PARSE_MAX_LENGTH = PARSE_MAX_LENGTH * 4;
+
 /** A phrase whose repetition puts the cap in the middle of a word. */
 const CAP_STRADDLING_PHRASE = "lorem ipsum dolor sit amet consectetur ";
 
@@ -540,6 +543,9 @@ describe("summaries past the parse limit", () => {
   /** A fenced block long enough that its closer sits past the parse limit. */
   const LONG_CODE_BODY = "const secret = 1;\n".repeat(400);
 
+  /** A fenced block long enough that its closer sits past the fallback limit. */
+  const OVERSIZED_CODE_BODY = "const secret = 1;\n".repeat(1200);
+
   test("caps prose the same way however far it runs past the limit", () => {
     const summary = CAP_STRADDLING_PHRASE.repeat(400).trim();
     expect(summary.length).toBeGreaterThan(PARSE_MAX_LENGTH);
@@ -574,11 +580,22 @@ describe("summaries past the parse limit", () => {
     expect(preview).not.toContain("const secret");
   });
 
-  test("reparses in full when a cut inside a fence empties the preview", () => {
+  test("reparses a wider window when a cut inside a fence empties the preview", () => {
     const summary = `\`\`\`ts\n${LONG_CODE_BODY}\`\`\`\n\nSee the job output.`;
     expect(summary.lastIndexOf("```")).toBeGreaterThan(PARSE_MAX_LENGTH);
+    expect(summary.lastIndexOf("```")).toBeLessThan(FALLBACK_PARSE_MAX_LENGTH);
 
     expect(flattenSummary(summary)).toBe("See the job output.");
+  });
+
+  test("accepts an empty preview when a fence closes past the fallback window", () => {
+    const summary = `\`\`\`ts\n${OVERSIZED_CODE_BODY}\`\`\`\n\nSee the job output.`;
+    expect(summary.lastIndexOf("```")).toBeGreaterThan(
+      FALLBACK_PARSE_MAX_LENGTH,
+    );
+
+    expect(flattenSummary(summary)).toBe("");
+    expect(resolvePreview("Build log", summary)).toBeNull();
   });
 
   test("returns an empty string for a long summary of only code", () => {

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -2,8 +2,8 @@
  * Preview text resolution for home feed cards. A feed item's `summary` is
  * markdown, so it has to be flattened to a single line of plain text before it
  * can sit under the title, and suppressed entirely when it would only restate
- * that title. The returned string carries no markdown syntax and is meant to be
- * rendered directly.
+ * that title. The strings both exports return carry no markdown syntax and are
+ * meant to be rendered directly.
  */
 
 import remarkGfm from "remark-gfm";
@@ -12,6 +12,14 @@ import { unified } from "unified";
 
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
+
+/**
+ * Longest flattened summary worth putting in the DOM. A summary is unbounded
+ * and every card in the feed and the bell carries one, while two lines of a
+ * card hold roughly a hundred characters, so this is generous headroom for a
+ * wide card and still keeps a card's share of the document bounded.
+ */
+const MAX_PREVIEW_LENGTH = 280;
 
 /**
  * Sentence punctuation, ignored at the end of a comparison form and left
@@ -268,12 +276,50 @@ function startOfWordAt(value: string, index: number): number {
 }
 
 /**
+ * Clamp `value` to `MAX_PREVIEW_LENGTH`, pulling the cut back to the last whole
+ * word so the text never ends on a fragment. A word longer than the cap on its
+ * own leaves nothing behind, and a hard clamp says more there than an empty
+ * string.
+ *
+ * No marker is appended: the card line-clamps this text, so CSS already draws
+ * an ellipsis, and a second one in the string would render beside it.
+ */
+function capPreviewLength(value: string): string {
+  if (value.length <= MAX_PREVIEW_LENGTH) {
+    return value;
+  }
+  const clamped = value.slice(0, MAX_PREVIEW_LENGTH);
+  const cut = isWordCharacter(value[MAX_PREVIEW_LENGTH])
+    ? startOfWordAt(clamped, clamped.length)
+    : clamped.length;
+  const capped = clamped.slice(0, cut).trimEnd();
+  return capped.length === 0 ? clamped : capped;
+}
+
+/**
+ * A feed item's markdown summary as one bounded line of plain text.
+ *
+ * Read this anywhere a summary lands in a slot that renders text rather than
+ * markdown, such as the title slot of a card whose item carries no title of its
+ * own, where the raw string would otherwise show its own syntax and be read out
+ * as markup by a screen reader.
+ */
+export function flattenSummary(summary: string): string {
+  return capPreviewLength(flattenMarkdownBlocks(summary));
+}
+
+/**
  * The preview line for a feed card, or `null` when there is nothing worth
  * showing beneath the title.
  *
  * Returns `null` when the flattened summary is empty, when it matches the
- * title, and when the title is a prefix of it (a title derived from the
- * summary) with too short a continuation left over.
+ * title, when the title is a prefix of it (a title derived from the summary)
+ * with too short a continuation left over, and when the preview is a prefix of
+ * the title, where the whole preview is already visible in the line above it.
+ *
+ * That last shape comes from the producer reading text this flattener drops:
+ * its title keeps a code block's body while the preview stops at the paragraph
+ * introducing it, leaving the preview a fragment of the title.
  *
  * A title carrying a trailing truncation marker is exempt from the word
  * boundary check, because a clamp at a fixed offset lands mid-word often and
@@ -285,7 +331,7 @@ function startOfWordAt(value: string, index: number): number {
  * discards it along with the rest of the trailing sentence punctuation.
  */
 export function resolvePreview(title: string, summary: string): string | null {
-  const preview = flattenMarkdownBlocks(summary);
+  const preview = flattenSummary(summary);
   if (preview.length === 0) {
     return null;
   }
@@ -301,7 +347,10 @@ export function resolvePreview(title: string, summary: string): string | null {
     ? normalizedPreview.startsWith(normalizedTitle)
     : startsWithWholeWords(normalizedPreview, normalizedTitle);
   if (!isDerived) {
-    return preview;
+    const titleCoversPreview = isTruncated
+      ? normalizedTitle.startsWith(normalizedPreview)
+      : startsWithWholeWords(normalizedTitle, normalizedPreview);
+    return titleCoversPreview ? null : preview;
   }
 
   const cut =

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -1,0 +1,314 @@
+/**
+ * Preview text resolution for home feed cards. A feed item's `summary` is
+ * markdown, so it has to be flattened to a single line of plain text before it
+ * can sit under the title, and suppressed entirely when it would only restate
+ * that title. The returned string carries no markdown syntax and is meant to be
+ * rendered directly.
+ */
+
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+/** Shortest continuation worth showing after the title's prefix is removed. */
+const MIN_PREVIEW_LENGTH = 12;
+
+/**
+ * Sentence punctuation, ignored at the end of a comparison form and left
+ * dangling once a title prefix is sliced away. Both sites read this one set,
+ * so the slice can never strand a character the comparison already discounted.
+ *
+ * The horizontal ellipsis is in here so a title the producer truncated compares
+ * as its unellipsized text and is still recognized as derived from the summary.
+ * The three-period form falls out of `.` already being a member, since the
+ * trailing trim runs over the whole punctuation run.
+ */
+const SENTENCE_PUNCTUATION = ".,;:!?-…";
+
+/**
+ * A trailing truncation marker: a horizontal ellipsis or a run of three or more
+ * ASCII periods. The producer appends one when it clamps a title at a fixed
+ * character offset, which makes the marker its explicit signal that the title
+ * was cut in the middle of the text it came from.
+ */
+const TRUNCATION_MARKER = /(?:…|\.{3,})$/;
+
+/**
+ * The parts of a markdown node the flattener reads. Structural rather than
+ * imported so the walk stays tolerant of node types remark adds.
+ */
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  alt?: string | null;
+  children?: MarkdownNode[];
+}
+
+/**
+ * Node types that carry inline content. Inline siblings run together with no
+ * separator; every other node is a block and is spaced away from its
+ * neighbours.
+ */
+const INLINE_NODE_TYPES = new Set([
+  "break",
+  "delete",
+  "emphasis",
+  "footnoteReference",
+  "image",
+  "imageReference",
+  "inlineCode",
+  "link",
+  "linkReference",
+  "strong",
+  "text",
+]);
+
+const markdownParser = unified().use(remarkParse).use(remarkGfm);
+
+function isSentencePunctuation(char: string): boolean {
+  return SENTENCE_PUNCTUATION.includes(char);
+}
+
+function trimTrailingSentencePunctuation(value: string): string {
+  let end = value.length;
+  while (end > 0 && isSentencePunctuation(value[end - 1])) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+/**
+ * Turn multi-line markdown into a single line of plain text, dropping block
+ * structure and code blocks and unwrapping every inline marker. A link
+ * contributes its text and drops its destination.
+ */
+function flattenMarkdownBlocks(summary: string): string {
+  const tree = markdownParser.parse(summary) as MarkdownNode;
+  return flattenNode(tree).replace(/\s+/g, " ").trim();
+}
+
+/** The single-line text a node contributes to the preview. */
+function flattenNode(node: MarkdownNode): string {
+  switch (node.type) {
+    case "code":
+    case "html":
+    case "thematicBreak":
+    case "yaml": {
+      return "";
+    }
+    case "inlineCode":
+    case "text": {
+      return node.value ?? "";
+    }
+    case "break": {
+      return " ";
+    }
+    case "delete":
+    case "emphasis":
+    case "link":
+    case "linkReference":
+    case "strong": {
+      return flattenChildren(node);
+    }
+    case "image":
+    case "imageReference": {
+      const alt = node.alt ?? "";
+      return alt.trim().length === 0 ? "" : alt;
+    }
+    default: {
+      if (node.children !== undefined) {
+        return flattenChildren(node);
+      }
+      return node.value ?? "";
+    }
+  }
+}
+
+/**
+ * Concatenate what a node's children contribute, separating each block from
+ * the one before it with a single space. Children that contribute nothing,
+ * such as a dropped code block, never introduce a separator of their own.
+ */
+function flattenChildren(node: MarkdownNode): string {
+  let result = "";
+  for (const child of node.children ?? []) {
+    const text = flattenNode(child);
+    if (text.length === 0) {
+      continue;
+    }
+    if (result.length > 0 && !INLINE_NODE_TYPES.has(child.type)) {
+      result += " ";
+    }
+    result += text;
+  }
+  return result;
+}
+
+/** One character of the comparison form and where it ends in the source. */
+interface NormalizedCharacter {
+  char: string;
+  /** Offset in the source string just past the text this character came from. */
+  end: number;
+}
+
+/**
+ * Emit the comparison form of `value` one character at a time, recording where
+ * each character ends in the source. Whitespace runs collapse to a single
+ * space, leading whitespace is skipped, and letters are lowercased.
+ *
+ * Comparison and slicing both read this one walk, so the offset a slice cuts
+ * at can never drift from what the comparison collapsed.
+ */
+function normalizedCharacters(value: string): NormalizedCharacter[] {
+  const characters: NormalizedCharacter[] = [];
+  let previousWasSpace = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const end = index + 1;
+    if (/\s/.test(char)) {
+      if (previousWasSpace || characters.length === 0) {
+        continue;
+      }
+      previousWasSpace = true;
+      characters.push({ char: " ", end });
+      continue;
+    }
+    previousWasSpace = false;
+    // A case fold that changes length would break the one-to-one mapping.
+    const lowered = char.toLowerCase();
+    characters.push({ char: lowered.length === 1 ? lowered : char, end });
+  }
+
+  return characters;
+}
+
+/**
+ * Reduce a string to the form used for title-versus-preview comparison, so
+ * that case, spacing, and trailing sentence punctuation never make two
+ * equivalent strings look different.
+ */
+function normalizeForCompare(value: string): string {
+  const flattened = normalizedCharacters(value)
+    .map((entry) => entry.char)
+    .join("")
+    .trimEnd();
+  return trimTrailingSentencePunctuation(flattened).trimEnd();
+}
+
+/**
+ * Drop the first `normalizedLength` comparison characters from `original` and
+ * return what is left of the untouched string.
+ *
+ * Normalization changes length, so the offset cannot be reused directly. The
+ * walk that produced those characters recorded where each one ends, and the
+ * cut is taken from that record.
+ */
+function sliceAfterNormalizedPrefix(
+  original: string,
+  normalizedLength: number,
+): string {
+  if (normalizedLength <= 0) {
+    return original;
+  }
+  const characters = normalizedCharacters(original);
+  if (normalizedLength > characters.length) {
+    return "";
+  }
+  return original.slice(characters[normalizedLength - 1].end);
+}
+
+/**
+ * Clean up the join between a sliced-off title and the text that follows it,
+ * dropping the leading whitespace and sentence punctuation the cut leaves
+ * behind.
+ */
+function stripSliceDebris(value: string): string {
+  let index = 0;
+  while (index < value.length) {
+    const char = value[index];
+    if (!/\s/.test(char) && !isSentencePunctuation(char)) {
+      break;
+    }
+    index += 1;
+  }
+  return value.slice(index);
+}
+
+/**
+ * Whether a character belongs to a word. Combining marks count, so a
+ * decomposed letter is never split away from its accent.
+ */
+function isWordCharacter(char: string | undefined): boolean {
+  return char !== undefined && /[\p{L}\p{M}\p{N}]/u.test(char);
+}
+
+/**
+ * True when `value` opens with `prefix` and that prefix ends on a word
+ * boundary, so a title of "Deploy" is not read as a prefix of "Deployment
+ * queue is backed up".
+ */
+function startsWithWholeWords(value: string, prefix: string): boolean {
+  if (!value.startsWith(prefix)) {
+    return false;
+  }
+  return !isWordCharacter(value[prefix.length]);
+}
+
+/**
+ * Walk `index` back to where its word starts in `value`, so a cut taken there
+ * opens on a whole word rather than on the tail of one.
+ */
+function startOfWordAt(value: string, index: number): number {
+  let start = index;
+  while (start > 0 && isWordCharacter(value[start - 1])) {
+    start -= 1;
+  }
+  return start;
+}
+
+/**
+ * The preview line for a feed card, or `null` when there is nothing worth
+ * showing beneath the title.
+ *
+ * Returns `null` when the flattened summary is empty, when it matches the
+ * title, and when the title is a prefix of it (a title derived from the
+ * summary) with too short a continuation left over.
+ *
+ * A title carrying a trailing truncation marker is exempt from the word
+ * boundary check, because a clamp at a fixed offset lands mid-word often and
+ * the marker is the producer saying so. Its cut then moves back to the start of
+ * the straddled word, which repeats one visibly truncated word rather than
+ * dropping the rest of it.
+ *
+ * The marker has to be read off the untouched title, since normalization
+ * discards it along with the rest of the trailing sentence punctuation.
+ */
+export function resolvePreview(title: string, summary: string): string | null {
+  const preview = flattenMarkdownBlocks(summary);
+  if (preview.length === 0) {
+    return null;
+  }
+
+  const normalizedPreview = normalizeForCompare(preview);
+  const normalizedTitle = normalizeForCompare(title);
+  if (normalizedPreview === normalizedTitle) {
+    return null;
+  }
+
+  const isTruncated = TRUNCATION_MARKER.test(title.trimEnd());
+  const isDerived = isTruncated
+    ? normalizedPreview.startsWith(normalizedTitle)
+    : startsWithWholeWords(normalizedPreview, normalizedTitle);
+  if (!isDerived) {
+    return preview;
+  }
+
+  const cut =
+    isTruncated && isWordCharacter(normalizedPreview[normalizedTitle.length])
+      ? startOfWordAt(normalizedPreview, normalizedTitle.length)
+      : normalizedTitle.length;
+
+  const remainder = stripSliceDebris(sliceAfterNormalizedPrefix(preview, cut));
+  return remainder.length < MIN_PREVIEW_LENGTH ? null : remainder;
+}

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -22,6 +22,17 @@ const MIN_PREVIEW_LENGTH = 12;
 const MAX_PREVIEW_LENGTH = 280;
 
 /**
+ * Longest stretch of raw markdown worth parsing. A parse costs time linear in
+ * its input, so an unbounded summary makes every card in the feed and the bell
+ * pay to build a tree whose text the cap throws away.
+ *
+ * Roughly fourteen times the output cap, which leaves room for the syntax and
+ * the dropped blocks (fences, link destinations, front matter) that a summary
+ * can lead with and that contribute no preview text at all.
+ */
+const MAX_PARSE_LENGTH = 4096;
+
+/**
  * Sentence punctuation, ignored at the end of a comparison form and left
  * dangling once a title prefix is sliced away. Both sites read this one set,
  * so the slice can never strand a character the comparison already discounted.
@@ -89,8 +100,27 @@ function trimTrailingSentencePunctuation(value: string): string {
  * Turn multi-line markdown into a single line of plain text, dropping block
  * structure and code blocks and unwrapping every inline marker. A link
  * contributes its text and drops its destination.
+ *
+ * Only the first `MAX_PARSE_LENGTH` characters are parsed, since the result is
+ * capped far below that. A cut lands mid-construct often, and the one shape
+ * that loses text is a fenced block whose opener sits ahead of it: the fence
+ * reads as unterminated, so remark drops everything from the opener on. When
+ * that leaves nothing at all, the whole summary is parsed instead, which
+ * recovers the text past the block. Only that shape pays for a second parse.
  */
 function flattenMarkdownBlocks(summary: string): string {
+  if (summary.length <= MAX_PARSE_LENGTH) {
+    return parseToSingleLine(summary);
+  }
+  const flattened = parseToSingleLine(summary.slice(0, MAX_PARSE_LENGTH));
+  if (flattened.length > 0 || summary.trim().length === 0) {
+    return flattened;
+  }
+  return parseToSingleLine(summary);
+}
+
+/** Parse markdown and collapse the tree's text down to one line. */
+function parseToSingleLine(summary: string): string {
   const tree = markdownParser.parse(summary) as MarkdownNode;
   return flattenNode(tree).replace(/\s+/g, " ").trim();
 }

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -33,6 +33,16 @@ const MAX_PREVIEW_LENGTH = 280;
 const MAX_PARSE_LENGTH = 4096;
 
 /**
+ * Longest stretch worth re-parsing once the bounded parse comes back empty.
+ * Four times the parse bound, which is wide enough to clear the fenced log or
+ * stack trace a summary realistically leads with, and narrow enough that the
+ * recovery stays a fixed multiple of an already bounded parse rather than
+ * scaling with the summary. A block running past even this leaves the preview
+ * empty, which is the same result the card shows for a summary of only code.
+ */
+const MAX_FALLBACK_PARSE_LENGTH = MAX_PARSE_LENGTH * 4;
+
+/**
  * Sentence punctuation, ignored at the end of a comparison form and left
  * dangling once a title prefix is sliced away. Both sites read this one set,
  * so the slice can never strand a character the comparison already discounted.
@@ -105,8 +115,10 @@ function trimTrailingSentencePunctuation(value: string): string {
  * capped far below that. A cut lands mid-construct often, and the one shape
  * that loses text is a fenced block whose opener sits ahead of it: the fence
  * reads as unterminated, so remark drops everything from the opener on. When
- * that leaves nothing at all, the whole summary is parsed instead, which
- * recovers the text past the block. Only that shape pays for a second parse.
+ * that leaves nothing at all, `MAX_FALLBACK_PARSE_LENGTH` characters are parsed
+ * instead, which recovers the text past a block that closes inside that wider
+ * window. Only that shape pays for a second parse, and both parses read a fixed
+ * length, so no summary is ever parsed whole once it runs past the bound.
  */
 function flattenMarkdownBlocks(summary: string): string {
   if (summary.length <= MAX_PARSE_LENGTH) {
@@ -116,7 +128,7 @@ function flattenMarkdownBlocks(summary: string): string {
   if (flattened.length > 0 || summary.trim().length === 0) {
     return flattened;
   }
-  return parseToSingleLine(summary);
+  return parseToSingleLine(summary.slice(0, MAX_FALLBACK_PARSE_LENGTH));
 }
 
 /** Parse markdown and collapse the tree's text down to one line. */

--- a/clients/web/src/domains/home/home-feed-filter-bar.tsx
+++ b/clients/web/src/domains/home/home-feed-filter-bar.tsx
@@ -43,6 +43,16 @@ export const CATEGORY_STYLES: Record<FeedItemCategory, CategoryStyle> = {
   },
 };
 
+/** Resolves a category to its style, falling back to `system`. */
+export function resolveCategoryStyle(
+  category?: FeedItemCategory,
+): CategoryStyle {
+  if (category && CATEGORY_STYLES[category]) {
+    return CATEGORY_STYLES[category];
+  }
+  return CATEGORY_STYLES.system;
+}
+
 export const CATEGORY_ORDER: FeedItemCategory[] = [
   "security",
   "email",

--- a/clients/web/src/domains/home/home-feed-list.tsx
+++ b/clients/web/src/domains/home/home-feed-list.tsx
@@ -153,7 +153,7 @@ export function HomeFeedList({
               {TIME_GROUP_LABELS[group]}
             </Typography>
 
-            <div className="flex flex-col gap-[var(--app-spacing-xs)]">
+            <div className="flex flex-col gap-[var(--app-spacing-sm)]">
               {groupItems.map((item) => (
                 <HomeRecapRow
                   key={item.id}
@@ -188,7 +188,7 @@ export function HomeFeedList({
               <span>Earlier ({archivedRead.length})</span>
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+              <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">
                 {archivedRead.map((item) => (
                   <HomeRecapRow
                     key={item.id}
@@ -224,7 +224,7 @@ export function HomeFeedList({
               <span>Dismissed ({dismissed.length})</span>
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+              <div className="flex flex-col gap-[var(--app-spacing-sm)] pt-[var(--app-spacing-sm)]">
                 {dismissed.map((item) => (
                   <HomeRecapRow
                     key={item.id}

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -198,6 +198,29 @@ describe("HomeRecapRow card content", () => {
     expect(screen.getAllByText(summary).length).toBe(1);
   });
 
+  test("an untitled item renders its markdown summary as plain text once", () => {
+    const { container } = renderRow({
+      item: makeItem({
+        title: undefined,
+        summary: "## Deploy failed\n\n**The api** never came up.",
+      }),
+    });
+    const flattened = "Deploy failed The api never came up.";
+
+    expect(screen.getAllByText(flattened).length).toBe(1);
+    expect(screen.getByRole("button", { name: flattened })).toBeTruthy();
+    expect(container.textContent).not.toContain("*");
+    expect(container.textContent).not.toContain("#");
+  });
+
+  test("an untitled item with no renderable summary still names its click target", () => {
+    renderRow({
+      item: makeItem({ title: undefined, summary: "```\nconst a = 1;\n```" }),
+    });
+
+    expect(screen.getByRole("button", { name: "Notification" })).toBeTruthy();
+  });
+
   test("renders an informative source label", () => {
     renderRow({ item: makeItem({ sourceLabel: "Heartbeat" }) });
 

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for `HomeRecapRow`.
+ *
+ * Rendered into happy-dom via `@testing-library/react` so clicks can be
+ * dispatched. Assertions target text, roles, `aria-label`s, and DOM structure,
+ * never class strings: those drift with styling and turn behaviour tests into
+ * styling tests.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
+
+import { HomeRecapRow, type HomeRecapRowProps } from "./home-recap-row";
+
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+
+function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  const timestamp = new Date(Date.now() - THREE_DAYS_MS).toISOString();
+  return {
+    id: "feed-1",
+    type: "notification",
+    priority: 50,
+    category: "background",
+    status: "new",
+    title: "Watcher job failed",
+    summary: "The watcher job could not reach the upstream service.",
+    timestamp,
+    createdAt: timestamp,
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function renderRow(props: Partial<HomeRecapRowProps> = {}) {
+  const selected: FeedItem[] = [];
+  const dismissed: string[] = [];
+  const readToggles: Array<[string, FeedItemStatus]> = [];
+  const threads: string[] = [];
+  const item = props.item ?? makeItem();
+
+  render(
+    <HomeRecapRow
+      item={item}
+      onSelect={(selectedItem) => selected.push(selectedItem)}
+      onDismiss={(itemId) => dismissed.push(itemId)}
+      onToggleRead={(itemId, status) => readToggles.push([itemId, status])}
+      onGoToThread={(conversationId) => threads.push(conversationId)}
+      {...props}
+    />,
+  );
+
+  return { item, selected, dismissed, readToggles, threads };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HomeRecapRow", () => {
+  test("renders no button inside another button", () => {
+    renderRow();
+
+    expect(document.querySelectorAll("button button").length).toBe(0);
+  });
+
+  test("exposes one click target named after the title", () => {
+    const { item, selected } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Watcher job failed" }));
+
+    expect(selected).toEqual([item]);
+  });
+
+  test("falls back to the summary for the click target's name", () => {
+    renderRow({ item: makeItem({ title: undefined }) });
+
+    expect(
+      screen.getByRole("button", {
+        name: "The watcher job could not reach the upstream service.",
+      }),
+    ).toBeTruthy();
+  });
+
+  test("renders the actions without any hover simulation", () => {
+    renderRow();
+
+    expect(screen.getByRole("button", { name: "Mark as read" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Go to thread" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  test("renders the timestamp alongside the actions", () => {
+    renderRow();
+
+    expect(screen.getByText("3d ago")).toBeTruthy();
+  });
+
+  test("labels the read toggle for an already-read item", () => {
+    renderRow({ item: makeItem({ status: "seen" }) });
+
+    expect(screen.getByRole("button", { name: "Mark as unread" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+  });
+
+  test("dismiss fires its callback without selecting the row", () => {
+    const { selected, dismissed } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(dismissed).toEqual(["feed-1"]);
+    expect(selected).toEqual([]);
+  });
+
+  test("mark as read fires its callback without selecting the row", () => {
+    const { selected, readToggles } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark as read" }));
+
+    expect(readToggles).toEqual([["feed-1", "seen"]]);
+    expect(selected).toEqual([]);
+  });
+
+  test("go to thread marks an unread item read and navigates", () => {
+    const { selected, readToggles, threads } = renderRow();
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to thread" }));
+
+    expect(readToggles).toEqual([["feed-1", "seen"]]);
+    expect(threads).toEqual(["conversation-1"]);
+    expect(selected).toEqual([]);
+  });
+
+  test("hides go to thread when the conversation is not listed as valid", () => {
+    renderRow({ validConversationIds: new Set(["other-conversation"]) });
+
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+  });
+
+  test("hides go to thread when the item has no conversation", () => {
+    renderRow({ item: makeItem({ conversationId: undefined }) });
+
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+  });
+
+  test("omits the read toggle when no handler is supplied", () => {
+    render(
+      <HomeRecapRow
+        item={makeItem()}
+        onSelect={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+  });
+
+  test("the restore variant renders only the restore control", () => {
+    const { dismissed } = renderRow({ trailingAction: "restore" });
+
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go to thread" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    expect(dismissed).toEqual(["feed-1"]);
+  });
+});

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -2,9 +2,9 @@
  * Tests for `HomeRecapRow`.
  *
  * Rendered into happy-dom via `@testing-library/react` so clicks can be
- * dispatched. Assertions target text, roles, `aria-label`s, and DOM structure,
- * never class strings: those drift with styling and turn behaviour tests into
- * styling tests.
+ * dispatched. Assertions target text, roles, `aria-label`s, test ids, and DOM
+ * structure, never class strings: those drift with styling and turn behaviour
+ * tests into styling tests.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -40,7 +40,7 @@ function renderRow(props: Partial<HomeRecapRowProps> = {}) {
   const threads: string[] = [];
   const item = props.item ?? makeItem();
 
-  render(
+  const { container } = render(
     <HomeRecapRow
       item={item}
       onSelect={(selectedItem) => selected.push(selectedItem)}
@@ -51,7 +51,7 @@ function renderRow(props: Partial<HomeRecapRowProps> = {}) {
     />,
   );
 
-  return { item, selected, dismissed, readToggles, threads };
+  return { container, item, selected, dismissed, readToggles, threads };
 }
 
 afterEach(() => {
@@ -166,5 +166,71 @@ describe("HomeRecapRow", () => {
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
 
     expect(dismissed).toEqual(["feed-1"]);
+  });
+});
+
+describe("HomeRecapRow card content", () => {
+  test("renders the category, the title, and a preview of the summary", () => {
+    renderRow();
+
+    expect(screen.getByText("Background")).toBeTruthy();
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(
+      screen.getByText("The watcher job could not reach the upstream service."),
+    ).toBeTruthy();
+  });
+
+  test("renders no preview when the summary only restates the title", () => {
+    renderRow({
+      item: makeItem({
+        title: "Watcher job failed",
+        summary: "Watcher job failed",
+      }),
+    });
+
+    expect(screen.getAllByText("Watcher job failed").length).toBe(1);
+  });
+
+  test("an untitled item shows its summary once and no preview", () => {
+    const summary = "The watcher job could not reach the upstream service.";
+    renderRow({ item: makeItem({ title: undefined }) });
+
+    expect(screen.getAllByText(summary).length).toBe(1);
+  });
+
+  test("renders an informative source label", () => {
+    renderRow({ item: makeItem({ sourceLabel: "Heartbeat" }) });
+
+    expect(screen.getByText("Heartbeat")).toBeTruthy();
+  });
+
+  test.each(["Conversation", "Other"])(
+    "omits the generic %s source label",
+    (sourceLabel) => {
+      renderRow({ item: makeItem({ sourceLabel }) });
+
+      expect(screen.queryByText(sourceLabel)).toBeNull();
+    },
+  );
+
+  test("marks an unread item with a dot", () => {
+    renderRow();
+
+    expect(screen.getByTestId("home-recap-row-unread-dot")).toBeTruthy();
+  });
+
+  test("omits the dot for an already-read item", () => {
+    renderRow({ item: makeItem({ status: "seen" }) });
+
+    expect(screen.queryByTestId("home-recap-row-unread-dot")).toBeNull();
+  });
+
+  test("compact density renders and differs from the comfortable default", () => {
+    const comfortable = renderRow().container.innerHTML;
+    cleanup();
+    const { container } = renderRow({ density: "compact" });
+
+    expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(container.innerHTML).not.toBe(comfortable);
   });
 });

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -1,14 +1,17 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { formatRelativeDate } from "@/utils/format-date";
-import type {
-  FeedItem,
-  FeedItemCategory,
-  FeedItemStatus,
-} from "@vellumai/assistant-api";
-import { cn, Tooltip } from "@vellumai/design-library";
-import { CATEGORY_STYLES } from "./home-feed-filter-bar";
+import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
+import {
+  cn,
+  Tooltip,
+  Typography,
+  type TypographyVariant,
+} from "@vellumai/design-library";
+
+import { FeedCategoryChip } from "./feed-category-chip";
+import { resolvePreview } from "./feed-preview";
 
 function HoverIconButton({
   label,
@@ -43,12 +46,30 @@ function HoverIconButton({
   );
 }
 
-function resolveStyle(category?: FeedItemCategory) {
-  if (category && CATEGORY_STYLES[category]) {
-    return CATEGORY_STYLES[category];
-  }
-  return CATEGORY_STYLES.system;
+/** Source labels that carry nothing the category chip does not already say. */
+const GENERIC_SOURCE_LABELS = new Set(["Conversation", "Other"]);
+
+export type HomeRecapRowDensity = "comfortable" | "compact";
+
+interface DensityStyle {
+  /** Card padding and the gap between the meta row, title, and preview. */
+  card: string;
+  titleVariant: TypographyVariant;
+  clamp: string;
 }
+
+const DENSITY_STYLES: Record<HomeRecapRowDensity, DensityStyle> = {
+  comfortable: {
+    card: "gap-[var(--app-spacing-xs)] p-[var(--app-spacing-md)]",
+    titleVariant: "title-small",
+    clamp: "line-clamp-2",
+  },
+  compact: {
+    card: "gap-[var(--app-spacing-xxs)] p-[var(--app-spacing-sm)]",
+    titleVariant: "body-medium-default",
+    clamp: "line-clamp-1",
+  },
+};
 
 export type HomeRecapRowTrailingAction = "dismiss" | "restore";
 
@@ -61,6 +82,7 @@ export interface HomeRecapRowProps {
   onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
   onGoToThread?: (conversationId: string) => void;
   trailingAction?: HomeRecapRowTrailingAction;
+  density?: HomeRecapRowDensity;
 }
 
 export function HomeRecapRow({
@@ -72,136 +94,169 @@ export function HomeRecapRow({
   onToggleRead,
   onGoToThread,
   trailingAction = "dismiss",
+  density = "comfortable",
 }: HomeRecapRowProps) {
-  const style = resolveStyle(item.category);
-  const Icon = style.icon;
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
-  const label = item.title ?? item.summary;
+  const title = item.title ?? item.summary;
+  const densityStyle = DENSITY_STYLES[density];
+
+  const sourceLabel =
+    item.sourceLabel && !GENERIC_SOURCE_LABELS.has(item.sourceLabel)
+      ? item.sourceLabel
+      : null;
+
+  // Memoized: resolving a preview parses the summary as markdown, and the feed
+  // re-renders every card whenever its filter changes.
+  const preview = useMemo(
+    () => resolvePreview(title, item.summary),
+    [title, item.summary],
+  );
 
   return (
     <div
       className={cn(
-        "group relative flex min-h-[48px] w-full items-center gap-[var(--app-spacing-sm)]",
-        "rounded-[var(--radius-md)] px-[var(--app-spacing-md)] py-[var(--app-spacing-sm)]",
+        "group relative flex w-full flex-col",
+        "rounded-[var(--radius-lg)] border border-[var(--border-base)]",
         "transition-[background-color,opacity] duration-150",
+        densityStyle.card,
         isActive
           ? "bg-[var(--surface-active)]"
           : "bg-[var(--surface-overlay)] hover:bg-[var(--surface-hover)]",
         !isUnread && !isActive && "opacity-70",
       )}
     >
-      {/* Stretched link: the row's single click target. Everything else stacks
+      {/* Stretched link: the card's single click target. Everything else stacks
           above it and so must stay `pointer-events-none` unless it is itself
-          interactive, or clicks meant for the row get swallowed. */}
+          interactive, or clicks meant for the card get swallowed. */}
       <button
         type="button"
-        aria-label={label}
+        aria-label={title}
         onClick={() => onSelect(item)}
-        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-md)]"
+        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-lg)]"
       />
 
-      <span
-        className="pointer-events-none relative shrink-0"
-        aria-hidden="true"
-      >
-        <span
-          className="flex items-center justify-center rounded-full"
-          style={{
-            width: 26,
-            height: 26,
-            backgroundColor: style.weak,
-          }}
-        >
-          <Icon width={12} height={12} style={{ color: style.strong }} />
-        </span>
-        {isUnread && (
-          <span className="absolute -left-0.5 -top-0.5 h-2 w-2 rounded-full bg-[var(--system-mid-strong)]" />
+      <div className="pointer-events-none relative flex items-center gap-[var(--app-spacing-sm)]">
+        <FeedCategoryChip category={item.category} />
+
+        {sourceLabel !== null && (
+          <Typography
+            variant="body-small-default"
+            className="min-w-0 truncate text-[var(--content-tertiary)]"
+          >
+            {sourceLabel}
+          </Typography>
         )}
-      </span>
 
-      <span
-        className={cn(
-          "text-body-medium-default pointer-events-none relative min-w-0 flex-1 truncate text-left",
-          "text-[var(--content-secondary)]",
-        )}
-      >
-        {label}
-      </span>
-
-      {/* Timestamp and actions share one grid cell so the row keeps a stable
-          width as they cross-fade. */}
-      <span className="pointer-events-none relative grid shrink-0 items-center justify-items-end">
-        <span
-          className={cn(
-            "col-start-1 row-start-1",
-            "text-body-small-default text-[var(--content-tertiary)]",
-            "transition-opacity duration-150",
-            "group-hover:opacity-0 group-focus-within:opacity-0",
-          )}
-        >
-          {formatRelativeDate(item.timestamp)}
-        </span>
-
-        <span
-          className={cn(
-            "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
-            "pointer-events-none opacity-0 transition-opacity duration-150",
-            "group-hover:pointer-events-auto group-hover:opacity-100",
-            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-          )}
-        >
-          {isRestore ? (
-            <HoverIconButton
-              label="Restore"
-              onClick={() => onDismiss(item.id)}
-              className="w-auto gap-[var(--app-spacing-xs)] px-2"
+        {/* Timestamp and actions share one grid cell so the card keeps a stable
+            width as they cross-fade. */}
+        <span className="ml-auto grid shrink-0 items-center justify-items-end">
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-xs)]",
+              "transition-opacity duration-150",
+              "group-hover:opacity-0 group-focus-within:opacity-0",
+            )}
+          >
+            <Typography
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
             >
-              <RotateCcw width={16} height={16} aria-hidden="true" />
-              <span className="text-body-small-default">Restore</span>
-            </HoverIconButton>
-          ) : (
-            <>
-              {onToggleRead && (
-                <HoverIconButton
-                  label={isUnread ? "Mark as read" : "Mark as unread"}
-                  onClick={() =>
-                    onToggleRead(item.id, isUnread ? "seen" : "new")
-                  }
-                >
-                  {isUnread ? (
-                    <MailOpen width={16} height={16} />
-                  ) : (
-                    <Mail width={16} height={16} />
-                  )}
-                </HoverIconButton>
-              )}
-              {onGoToThread &&
-                item.conversationId &&
-                (!validConversationIds ||
-                  validConversationIds.has(item.conversationId)) && (
+              {formatRelativeDate(item.timestamp)}
+            </Typography>
+            {isUnread && (
+              <span
+                data-testid="home-recap-row-unread-dot"
+                aria-hidden="true"
+                className="h-2 w-2 shrink-0 rounded-full bg-[var(--system-mid-strong)]"
+              />
+            )}
+          </span>
+
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
+              "pointer-events-none opacity-0 transition-opacity duration-150",
+              "group-hover:pointer-events-auto group-hover:opacity-100",
+              "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+            )}
+          >
+            {isRestore ? (
+              <HoverIconButton
+                label="Restore"
+                onClick={() => onDismiss(item.id)}
+                className="w-auto gap-[var(--app-spacing-xs)] px-2"
+              >
+                <RotateCcw width={16} height={16} aria-hidden="true" />
+                <span className="text-body-small-default">Restore</span>
+              </HoverIconButton>
+            ) : (
+              <>
+                {onToggleRead && (
                   <HoverIconButton
-                    label="Go to thread"
-                    onClick={() => {
-                      if (isUnread && onToggleRead) {
-                        onToggleRead(item.id, "seen");
-                      }
-                      onGoToThread(item.conversationId!);
-                    }}
+                    label={isUnread ? "Mark as read" : "Mark as unread"}
+                    onClick={() =>
+                      onToggleRead(item.id, isUnread ? "seen" : "new")
+                    }
                   >
-                    <MessageSquare width={16} height={16} />
+                    {isUnread ? (
+                      <MailOpen width={16} height={16} />
+                    ) : (
+                      <Mail width={16} height={16} />
+                    )}
                   </HoverIconButton>
                 )}
-              <HoverIconButton
-                label="Dismiss"
-                onClick={() => onDismiss(item.id)}
-              >
-                <Trash2 width={16} height={16} />
-              </HoverIconButton>
-            </>
-          )}
+                {onGoToThread &&
+                  item.conversationId &&
+                  (!validConversationIds ||
+                    validConversationIds.has(item.conversationId)) && (
+                    <HoverIconButton
+                      label="Go to thread"
+                      onClick={() => {
+                        if (isUnread && onToggleRead) {
+                          onToggleRead(item.id, "seen");
+                        }
+                        onGoToThread(item.conversationId!);
+                      }}
+                    >
+                      <MessageSquare width={16} height={16} />
+                    </HoverIconButton>
+                  )}
+                <HoverIconButton
+                  label="Dismiss"
+                  onClick={() => onDismiss(item.id)}
+                >
+                  <Trash2 width={16} height={16} />
+                </HoverIconButton>
+              </>
+            )}
+          </span>
         </span>
-      </span>
+      </div>
+
+      {/* leading-snug: the title-small token is line-height:1, and line-clamp's
+          overflow clipping would cut descenders without real line height. */}
+      <Typography
+        variant={densityStyle.titleVariant}
+        className={cn(
+          "pointer-events-none relative leading-snug text-[var(--content-default)]",
+          densityStyle.clamp,
+        )}
+      >
+        {title}
+      </Typography>
+
+      {preview !== null && (
+        <Typography
+          variant="body-medium-lighter"
+          className={cn(
+            "pointer-events-none relative leading-normal text-[var(--content-secondary)]",
+            densityStyle.clamp,
+          )}
+        >
+          {preview}
+        </Typography>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -11,7 +11,7 @@ import {
 } from "@vellumai/design-library";
 
 import { FeedCategoryChip } from "./feed-category-chip";
-import { resolvePreview } from "./feed-preview";
+import { flattenSummary, resolvePreview } from "./feed-preview";
 
 function HoverIconButton({
   label,
@@ -48,6 +48,14 @@ function HoverIconButton({
 
 /** Source labels that carry nothing the category chip does not already say. */
 const GENERIC_SOURCE_LABELS = new Set(["Conversation", "Other"]);
+
+/**
+ * Name for an item with neither a title nor a summary that renders as text, so
+ * the card's click target always has an accessible name. The category is not
+ * used here: its chip is already on the card, and repeating it would read the
+ * same word twice.
+ */
+const UNNAMED_ITEM_TITLE = "Notification";
 
 export type HomeRecapRowDensity = "comfortable" | "compact";
 
@@ -98,7 +106,6 @@ export function HomeRecapRow({
 }: HomeRecapRowProps) {
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
-  const title = item.title ?? item.summary;
   const densityStyle = DENSITY_STYLES[density];
 
   const sourceLabel =
@@ -106,8 +113,17 @@ export function HomeRecapRow({
       ? item.sourceLabel
       : null;
 
-  // Memoized: resolving a preview parses the summary as markdown, and the feed
-  // re-renders every card whenever its filter changes.
+  // An item without its own title falls back to the summary, which is markdown:
+  // it goes through the flattener so the title line and the click target's name
+  // carry text rather than syntax.
+  //
+  // Both memoized: each parses the summary as markdown, and the feed re-renders
+  // every card whenever its filter changes.
+  const title = useMemo(() => {
+    const resolved = item.title ?? flattenSummary(item.summary);
+    return resolved.length > 0 ? resolved : UNNAMED_ITEM_TITLE;
+  }, [item.title, item.summary]);
+
   const preview = useMemo(
     () => resolvePreview(title, item.summary),
     [title, item.summary],

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -1,5 +1,5 @@
 import { Mail, MailOpen, MessageSquare, RotateCcw, Trash2 } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
 
 import { formatRelativeDate } from "@/utils/format-date";
 import type {
@@ -73,31 +73,38 @@ export function HomeRecapRow({
   onGoToThread,
   trailingAction = "dismiss",
 }: HomeRecapRowProps) {
-  const [isHovering, setIsHovering] = useState(false);
   const style = resolveStyle(item.category);
   const Icon = style.icon;
   const isUnread = item.status === "new";
   const isRestore = trailingAction === "restore";
+  const label = item.title ?? item.summary;
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(item)}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
+    <div
       className={cn(
-        "flex min-h-[48px] w-full cursor-pointer items-center gap-[var(--app-spacing-sm)]",
+        "group relative flex min-h-[48px] w-full items-center gap-[var(--app-spacing-sm)]",
         "rounded-[var(--radius-md)] px-[var(--app-spacing-md)] py-[var(--app-spacing-sm)]",
         "transition-[background-color,opacity] duration-150",
         isActive
           ? "bg-[var(--surface-active)]"
-          : isHovering
-            ? "bg-[var(--surface-hover)]"
-            : "bg-[var(--surface-overlay)]",
+          : "bg-[var(--surface-overlay)] hover:bg-[var(--surface-hover)]",
         !isUnread && !isActive && "opacity-70",
       )}
     >
-      <span className="relative shrink-0" aria-hidden="true">
+      {/* Stretched link: the row's single click target. Everything else stacks
+          above it and so must stay `pointer-events-none` unless it is itself
+          interactive, or clicks meant for the row get swallowed. */}
+      <button
+        type="button"
+        aria-label={label}
+        onClick={() => onSelect(item)}
+        className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-md)]"
+      />
+
+      <span
+        className="pointer-events-none relative shrink-0"
+        aria-hidden="true"
+      >
         <span
           className="flex items-center justify-center rounded-full"
           style={{
@@ -115,61 +122,86 @@ export function HomeRecapRow({
 
       <span
         className={cn(
-          "text-body-medium-default min-w-0 flex-1 truncate text-left",
+          "text-body-medium-default pointer-events-none relative min-w-0 flex-1 truncate text-left",
           "text-[var(--content-secondary)]",
         )}
       >
-        {item.title ?? item.summary}
+        {label}
       </span>
 
-      {isHovering && !isRestore ? (
-        <span className="flex shrink-0 items-center gap-[var(--app-spacing-sm)]">
-          {onToggleRead && (
-            <HoverIconButton
-              label={isUnread ? "Mark as read" : "Mark as unread"}
-              onClick={() => onToggleRead(item.id, isUnread ? "seen" : "new")}
-            >
-              {isUnread ? (
-                <MailOpen width={16} height={16} />
-              ) : (
-                <Mail width={16} height={16} />
-              )}
-            </HoverIconButton>
+      {/* Timestamp and actions share one grid cell so the row keeps a stable
+          width as they cross-fade. */}
+      <span className="pointer-events-none relative grid shrink-0 items-center justify-items-end">
+        <span
+          className={cn(
+            "col-start-1 row-start-1",
+            "text-body-small-default text-[var(--content-tertiary)]",
+            "transition-opacity duration-150",
+            "group-hover:opacity-0 group-focus-within:opacity-0",
           )}
-          {onGoToThread &&
-            item.conversationId &&
-            (!validConversationIds ||
-              validConversationIds.has(item.conversationId)) && (
-              <HoverIconButton
-                label="Go to thread"
-                onClick={() => {
-                  if (isUnread && onToggleRead) {
-                    onToggleRead(item.id, "seen");
-                  }
-                  onGoToThread(item.conversationId!);
-                }}
-              >
-                <MessageSquare width={16} height={16} />
-              </HoverIconButton>
-            )}
-          <HoverIconButton label="Dismiss" onClick={() => onDismiss(item.id)}>
-            <Trash2 width={16} height={16} />
-          </HoverIconButton>
-        </span>
-      ) : isHovering && isRestore ? (
-        <HoverIconButton
-          label="Restore"
-          onClick={() => onDismiss(item.id)}
-          className="w-auto gap-[var(--app-spacing-xs)] px-2"
         >
-          <RotateCcw width={16} height={16} aria-hidden="true" />
-          <span className="text-body-small-default">Restore</span>
-        </HoverIconButton>
-      ) : (
-        <span className="shrink-0 text-body-small-default text-[var(--content-tertiary)]">
           {formatRelativeDate(item.timestamp)}
         </span>
-      )}
-    </button>
+
+        <span
+          className={cn(
+            "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
+            "pointer-events-none opacity-0 transition-opacity duration-150",
+            "group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+          )}
+        >
+          {isRestore ? (
+            <HoverIconButton
+              label="Restore"
+              onClick={() => onDismiss(item.id)}
+              className="w-auto gap-[var(--app-spacing-xs)] px-2"
+            >
+              <RotateCcw width={16} height={16} aria-hidden="true" />
+              <span className="text-body-small-default">Restore</span>
+            </HoverIconButton>
+          ) : (
+            <>
+              {onToggleRead && (
+                <HoverIconButton
+                  label={isUnread ? "Mark as read" : "Mark as unread"}
+                  onClick={() =>
+                    onToggleRead(item.id, isUnread ? "seen" : "new")
+                  }
+                >
+                  {isUnread ? (
+                    <MailOpen width={16} height={16} />
+                  ) : (
+                    <Mail width={16} height={16} />
+                  )}
+                </HoverIconButton>
+              )}
+              {onGoToThread &&
+                item.conversationId &&
+                (!validConversationIds ||
+                  validConversationIds.has(item.conversationId)) && (
+                  <HoverIconButton
+                    label="Go to thread"
+                    onClick={() => {
+                      if (isUnread && onToggleRead) {
+                        onToggleRead(item.id, "seen");
+                      }
+                      onGoToThread(item.conversationId!);
+                    }}
+                  >
+                    <MessageSquare width={16} height={16} />
+                  </HoverIconButton>
+                )}
+              <HoverIconButton
+                label="Dismiss"
+                onClick={() => onDismiss(item.id)}
+              >
+                <Trash2 width={16} height={16} />
+              </HoverIconButton>
+            </>
+          )}
+        </span>
+      </span>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the single-line home feed row with a card showing a category chip, an optional source label, a relative timestamp and unread dot, the item title, and a message preview drawn from `item.summary`. One component serves both the Activity page (comfortable) and the notifications bell (compact).

Closes the "message preview" half of LUM-3004. The "clear title" half ships separately on `Jasonnnz/home-feed-required-titles`.

**Web only.** No daemon, schema, or OpenAPI changes: `summary`, `category`, and `sourceLabel` were already on `FeedItem`.

## PRs merged into this branch

- #39973 add home feed preview text resolution
- #39969 add the home feed category chip
- #39972 make home feed row actions valid and keyboard reachable
- #39971 assert bell unread state semantically instead of by class string
- #40032 render home feed items as cards with a message preview
- #40037 use compact notification cards in the bell

## Two deliberate deviations from the design mock

1. **Category chips use a tinted background with the design-library default text color, not colored text.** Colored text on those tints measured 1.33:1 to 2.99:1 against WCAG AA's 4.5:1 (the chip is 12px/600, so the large-text exemption does not apply); seven of eight category/theme combinations failed. The current pairing measures 9.4:1 to 11.9:1. The category hue is still carried by the background.
2. **Previews are plain text, so bolded fragments render at normal weight.** The preview flattener originally parsed markdown and re-emitted a markdown string for an inline renderer. That round trip loses escapes (`\*literal stars\*` became real emphasis) and cannot reproduce code-span delimiter runs. Emitting plain text removes the defect class rather than guarding each instance, and removed a planned PR.

## Two bugs fixed on the way

- Action buttons were rendered **inside** the row's outer `<button>`, which is invalid HTML.
- Those actions were gated on React hover state, so mark-read, go-to-thread, and dismiss were **unreachable by keyboard**. They are now cross-faded via CSS and reachable through normal tab order.

## Notable implementation choices

- Preview flattening walks the markdown AST (`unified` + `remark-parse` + `remark-gfm`, all already direct dependencies). **No dependency added.**
- `resolvePreview` is memoized at the call site; it parses markdown per call at ~0.5ms.
- The bell's list height was hand-derived from a 48px row that no longer exists and was showing ~2.5 cards. Recomputed against a measured 94.25px compact card to `max-h-[504px]`.

## Known limitations

Both stem from the client inferring where the daemon truncated a derived title rather than being told:

1. An authored title that is a bare possessive or version stem of its own summary slices at the punctuation (`Worker` / `Worker's queue is backed up.` yields `'s queue is backed up.`). Cosmetic.
2. `deriveTitle` runs on the daemon's own flattened text while this runs on the markdown AST, so a derived title is not always an exact prefix. When the prefix test fails the full preview is returned, which is the safe direction.

The upstream fix for both is for the daemon to ship derivation metadata alongside the title. Cross-repo, and a natural follow-up to #39863.

Part of plan: home-feed-notification-cards.md