### PR TITLE
feat(web): add shared client perf-event emitter for watchdog telemetry

### DIFF
--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pins the shared `client_*` perf emitter's wire contract:
+ *   - One watchdog-shaped event carrying the page-load grouping key, surface,
+ *     os, and a rounded value, with caller detail merged last.
+ *   - Nothing is emitted without analytics consent.
+ *   - `boot_id` appears only once a boot id has been registered.
+ *   - A throwing transport never propagates to the caller.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let consent = true;
+const postTelemetryEventsMock = mock((_events: readonly object[]) => {});
+
+mock.module("@/lib/telemetry/consent", () => ({
+  readAnalyticsConsent: () => consent,
+}));
+mock.module("@/lib/telemetry/ingest", () => ({
+  postTelemetryEvents: postTelemetryEventsMock,
+}));
+
+const { __resetClientPerfForTests, emitClientPerfEvent, setClientPerfBootId } =
+  await import("./client-perf");
+
+function lastEvent(): Record<string, unknown> {
+  const call = postTelemetryEventsMock.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  const events = call![0];
+  expect(events).toHaveLength(1);
+  return events[0] as Record<string, unknown>;
+}
+
+function lastDetail(): Record<string, unknown> {
+  return lastEvent().detail as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  consent = true;
+  postTelemetryEventsMock.mockClear();
+  postTelemetryEventsMock.mockImplementation(() => {});
+  __resetClientPerfForTests();
+});
+
+describe("emitClientPerfEvent", () => {
+  test("emits one watchdog-shaped event with the perf detail bag", () => {
+    emitClientPerfEvent("client_switch.transcript_painted", 412.7);
+
+    const event = lastEvent();
+    expect(event.type).toBe("watchdog");
+    expect(event.check_name).toBe("client_switch.transcript_painted");
+    expect(event.value).toBe(413);
+    expect(typeof event.daemon_event_id).toBe("string");
+    expect(typeof event.recorded_at).toBe("number");
+
+    const detail = lastDetail();
+    expect(typeof detail.page_load_id).toBe("string");
+    expect(["ios_native", "android_native", "web"]).toContain(
+      String(detail.surface),
+    );
+    expect(typeof detail.os).toBe("string");
+  });
+
+  test("groups events from the same page load under one page_load_id", () => {
+    emitClientPerfEvent("client_list.drain", 1);
+    const first = lastDetail().page_load_id;
+    emitClientPerfEvent("client_list.drain", 2);
+    expect(lastDetail().page_load_id).toBe(first);
+  });
+
+  test("merges caller detail last so its keys win", () => {
+    emitClientPerfEvent("client_resume.request_count", 3, {
+      reason: "visibility",
+      surface: "caller_override",
+    });
+
+    const detail = lastDetail();
+    expect(detail.reason).toBe("visibility");
+    expect(detail.surface).toBe("caller_override");
+  });
+
+  test("emits nothing without analytics consent", () => {
+    consent = false;
+    emitClientPerfEvent("client_switch.stalled", 5000);
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+  });
+
+  test("omits boot_id until one is registered", () => {
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(lastDetail()).not.toHaveProperty("boot_id");
+
+    setClientPerfBootId("boot-123");
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(lastDetail().boot_id).toBe("boot-123");
+  });
+
+  test("swallows a throwing transport", () => {
+    postTelemetryEventsMock.mockImplementation(() => {
+      throw new Error("transport down");
+    });
+    expect(() => {
+      emitClientPerfEvent("client_switch.stalled", 1);
+    }).not.toThrow();
+  });
+});

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -1,0 +1,85 @@
+import { readAnalyticsConsent } from "@/lib/telemetry/consent";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+import { detectClientOs, isNativeMobile } from "@/runtime/platform-detection";
+
+/**
+ * Shared emitter for the `client_*` performance families.
+ *
+ * Rides the existing `watchdog` event shape: `check_name` is an open string,
+ * `value` a float magnitude, `detail` an open JSON bag. So a new family lands
+ * in the existing `stg_telemetry__watchdog` BigQuery model with no platform
+ * work. This is the same ride-an-existing-shape move `memory-telemetry.ts`
+ * makes on the `onboarding` event type, and boot-telemetry makes on
+ * `watchdog`.
+ *
+ * Metadata only: detail bags carry no conversation or assistant ids and no
+ * raw pathnames. Consent is read at emit time through the shared
+ * `readAnalyticsConsent()`, the same decision every other emitter gates on.
+ */
+
+/**
+ * Groups every perf event from a single page load. Same semantics as
+ * boot-telemetry's `boot_id`, minted independently so this module stands alone;
+ * the two converge once a caller registers the boot id via
+ * `setClientPerfBootId`.
+ */
+const pageLoadId = crypto.randomUUID();
+
+let bootId: string | null = null;
+
+/**
+ * Registers the boot-telemetry boot id so perf families become joinable with
+ * the boot series. Called by `startBootTelemetry` once that lands.
+ */
+export function setClientPerfBootId(id: string): void {
+  bootId = id;
+}
+
+type PerfSurface = "ios_native" | "android_native" | "web";
+
+/** Mirrors boot-telemetry's surface detection so the labels match its series. */
+function detectSurface(): PerfSurface {
+  const os = detectClientOs();
+  if (!isNativeMobile()) {
+    return "web";
+  }
+  return os === "android" ? "android_native" : "ios_native";
+}
+
+/**
+ * Fire-and-forget: never throws into the caller's path, so a perf probe can sit
+ * on a hot render or navigation path without adding a failure mode.
+ */
+export function emitClientPerfEvent(
+  checkName: string,
+  value: number,
+  detail?: Record<string, unknown>,
+): void {
+  try {
+    if (!readAnalyticsConsent()) {
+      return;
+    }
+    postTelemetryEvents([
+      {
+        type: "watchdog",
+        daemon_event_id: crypto.randomUUID(),
+        recorded_at: Date.now(),
+        check_name: checkName,
+        value: Math.round(value),
+        detail: {
+          page_load_id: pageLoadId,
+          surface: detectSurface(),
+          os: detectClientOs(),
+          ...(bootId === null ? {} : { boot_id: bootId }),
+          ...detail,
+        },
+      },
+    ]);
+  } catch {
+    // Telemetry is best-effort.
+  }
+}
+
+export function __resetClientPerfForTests(): void {
+  bootId = null;
+}


### PR DESCRIPTION
## Summary
- New lib/telemetry/client-perf.ts: emitClientPerfEvent rides the existing watchdog event shape into stg_telemetry__watchdog; consent-gated, fire-and-forget, never throws
- Mints a per-page-load page_load_id and exposes setClientPerfBootId as the convergence hook for boot-telemetry (PR #40029) once it merges
- Producer only: consumers (client_switch.*, client_resume.request_count, client_list.drain) land in the next wave

Part of plan: measure-first-telemetry-followups.md (PR 4 of 7)