### PR TITLE
feat(web): add duration and payload size to history_page_fetch diagnostics

### DIFF
--- a/clients/web/src/domains/chat/api/history.test.ts
+++ b/clients/web/src/domains/chat/api/history.test.ts
@@ -1,16 +1,27 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { ApiError } from "@/utils/api-errors";
-
-import {
-  fetchLatestHistoryPage,
-  fetchOlderHistoryPage,
-} from "@/domains/chat/api/history";
-
 import {
   messageText,
   textBody,
 } from "@/domains/chat/utils/message-test-helpers";
+
+const recordedDiagnostics: Array<{
+  kind: string;
+  details: Record<string, unknown>;
+}> = [];
+const actualDiagnostics = await import("@/lib/diagnostics");
+mock.module("@/lib/diagnostics", () => ({
+  ...actualDiagnostics,
+  recordDiagnostic: (kind: string, details: Record<string, unknown> = {}) => {
+    recordedDiagnostics.push({ kind, details });
+  },
+}));
+
+// Imported after the diagnostics mock so the fetchers bind to it.
+const { fetchLatestHistoryPage, fetchOlderHistoryPage } =
+  await import("@/domains/chat/api/history");
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -22,12 +33,17 @@ interface CapturedRequest {
 
 function makeJsonResponse(
   body: unknown,
-  init: { status?: number } = {},
+  init: { status?: number; contentLength?: number } = {},
 ): Response {
   const status = init.status ?? 200;
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.contentLength === undefined
+        ? {}
+        : { "Content-Length": String(init.contentLength) }),
+    },
   });
 }
 
@@ -39,6 +55,7 @@ beforeEach(() => {
   originalFetch = globalThis.fetch;
   captured = [];
   nextResponse = null;
+  recordedDiagnostics.length = 0;
   globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
     const url =
       typeof input === "string"
@@ -465,5 +482,88 @@ describe("error handling", () => {
     }
     expect(caught).toBeInstanceOf(ApiError);
     expect((caught as ApiError).status).toBe(502);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fetch diagnostics
+// ---------------------------------------------------------------------------
+
+function lastDiagnostic(kind: string): Record<string, unknown> {
+  const event = recordedDiagnostics.findLast((entry) => entry.kind === kind);
+  if (!event) {
+    throw new Error(`no ${kind} diagnostic was recorded`);
+  }
+  return event.details;
+}
+
+function expectDurationMs(details: Record<string, unknown>): void {
+  expect(Number.isInteger(details.durationMs)).toBe(true);
+  expect(details.durationMs as number).toBeGreaterThanOrEqual(0);
+}
+
+describe("fetch diagnostics", () => {
+  test("history_page_fetch carries the full payload plus durationMs and bytes", async () => {
+    nextResponse = makeJsonResponse(
+      {
+        messages: [],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 7,
+      },
+      { contentLength: 1234 },
+    );
+
+    await fetchLatestHistoryPage("asst-1", "K", 25);
+
+    const details = lastDiagnostic("history_page_fetch");
+    expect(details).toEqual({
+      assistantId: "asst-1",
+      query: { conversationId: "K", page: "latest", limit: 25 },
+      status: 200,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      seq: 7,
+      messages: {
+        count: 0,
+        roleCounts: {},
+        queuedCount: 0,
+        processingCount: 0,
+        first: null,
+        last: null,
+        tail: [],
+      },
+      durationMs: expect.any(Number),
+      bytes: 1234,
+    });
+    expectDurationMs(details);
+  });
+
+  test("bytes is null when the response omits content-length", async () => {
+    nextResponse = makeJsonResponse({ messages: [], hasMore: false });
+
+    await fetchOlderHistoryPage("asst-1", "K", 100);
+
+    const details = lastDiagnostic("history_page_fetch");
+    expect(details.bytes).toBeNull();
+    expectDurationMs(details);
+  });
+
+  test("history_page_fetch_error carries durationMs and bytes", async () => {
+    nextResponse = makeJsonResponse(
+      { detail: "boom" },
+      { status: 500, contentLength: 16 },
+    );
+
+    await expect(fetchLatestHistoryPage("asst-1", "K")).rejects.toBeInstanceOf(
+      ApiError,
+    );
+
+    const details = lastDiagnostic("history_page_fetch_error");
+    expect(details.status).toBe(500);
+    expect(details.bytes).toBe(16);
+    expectDurationMs(details);
   });
 });

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -99,6 +99,7 @@ async function fetchPaginatedHistory(
   // lets the snapshot-anchor frontier be tagged accordingly (see
   // `use-conversation-history`), so the stale-frontier guard can clear it.
   const seqGeneration = getSeqGeneration();
+  const startedAt = performance.now();
   const { data, error, response } = await messagesGet({
     path: { assistant_id: assistantId },
     query,
@@ -106,11 +107,16 @@ async function fetchPaginatedHistory(
   });
 
   assertHasResponse(response, error, "Failed to fetch history");
+  const durationMs = Math.round(performance.now() - startedAt);
+  const contentLength = response.headers.get("content-length");
+  const bytes = contentLength === null ? null : Number(contentLength);
   if (!response.ok) {
     recordDiagnostic("history_page_fetch_error", {
       assistantId,
       query,
       status: response.status,
+      durationMs,
+      bytes,
     });
     const message = extractErrorMessage(
       error,
@@ -133,6 +139,8 @@ async function fetchPaginatedHistory(
     oldestMessageId: result.oldestMessageId,
     seq: result.seq ?? null,
     messages: summarizeDisplayMessages(result.messages),
+    durationMs,
+    bytes,
   });
   return result;
 }


### PR DESCRIPTION
## Summary
- history_page_fetch and history_page_fetch_error diagnostics now carry durationMs and bytes (from content-length)
- Quantifies per-fetch latency and payload size in feedback bundles; no behavior change

Part of plan: measure-first-telemetry-followups.md (PR 2 of 7)