### PR TITLE
feat(web): record first-frame time and keepalive cadence on SSE debug clients

### DIFF
--- a/clients/web/src/lib/streaming/stream-debug.test.ts
+++ b/clients/web/src/lib/streaming/stream-debug.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  afterEach,
+  describe,
+  expect,
+  test,
+  beforeEach,
+  setSystemTime,
+} from "bun:test";
 
 import {
   endSseClient,
@@ -18,6 +25,10 @@ import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 beforeEach(() => {
   resetSseDebugStateForTests();
+});
+
+afterEach(() => {
+  setSystemTime();
 });
 
 function makeTextDeltaEvent(text: string): AssistantEvent {
@@ -62,6 +73,8 @@ describe("registerSseClient", () => {
     expect(found!.lastDataAt).toBeNull();
     expect(found!.dataFrames).toBe(0);
     expect(found!.keepalives).toBe(0);
+    expect(found!.firstFrameAt).toBeNull();
+    expect(found!.interKeepaliveMs).toBeNull();
     // AND it starts out live (no end metadata yet)
     expect(found!.endedAt).toBeNull();
     expect(found!.endReason).toBeNull();
@@ -405,6 +418,126 @@ describe("recordSseTraffic", () => {
     // WHEN traffic is recorded against it
     // THEN it does not throw and records nothing
     expect(() => recordSseTraffic("sse-nonexistent", true)).not.toThrow();
+  });
+});
+
+describe("recordSseTraffic connect-latency and keepalive cadence", () => {
+  const START = 1_700_000_000_000;
+
+  /** Deliver keepalives at the given gaps, starting at START. */
+  function replayKeepalives(clientId: string, gaps: number[]): void {
+    let at = START;
+    setSystemTime(new Date(at));
+    recordSseTraffic(clientId, false);
+    for (const gap of gaps) {
+      at += gap;
+      setSystemTime(new Date(at));
+      recordSseTraffic(clientId, false);
+    }
+  }
+
+  function clientById(id: string) {
+    return getSseClients().find((c) => c.id === id)!;
+  }
+
+  test("stamps firstFrameAt on the first keepalive and never moves it", () => {
+    // GIVEN a live client whose first frame is a heartbeat comment
+    const id = registerSseClient(new AbortController().signal);
+    setSystemTime(new Date(START));
+    recordSseTraffic(id, false);
+
+    // WHEN later frames of either kind arrive
+    setSystemTime(new Date(START + 5_000));
+    recordSseTraffic(id, true);
+    setSystemTime(new Date(START + 9_000));
+    recordSseTraffic(id, false);
+
+    // THEN firstFrameAt still marks the connect moment, not the first data
+    const client = clientById(id);
+    expect(client.firstFrameAt).toBe(START);
+    expect(client.establishedAt).toBeNull();
+    expect(client.lastTrafficAt).toBe(START + 9_000);
+  });
+
+  test("stamps firstFrameAt on a first data frame too", () => {
+    const id = registerSseClient(new AbortController().signal);
+    setSystemTime(new Date(START));
+    recordSseTraffic(id, true);
+    expect(clientById(id).firstFrameAt).toBe(START);
+  });
+
+  test("reports the daemon heartbeat cadence for evenly spaced keepalives", () => {
+    // GIVEN ten keepalives 7s apart (a healthy end-to-end daemon heartbeat)
+    const id = registerSseClient(new AbortController().signal);
+    replayKeepalives(id, Array.from({ length: 9 }, () => 7_000));
+
+    // THEN the median gap reads back as the heartbeat interval
+    expect(clientById(id).interKeepaliveMs).toBe(7_000);
+    expect(clientById(id).keepalives).toBe(10);
+  });
+
+  test("reports the proxy injector cadence when the daemon heartbeat is lost", () => {
+    // GIVEN keepalives arriving only at the platform proxy's 10s injection
+    const id = registerSseClient(new AbortController().signal);
+    replayKeepalives(id, [10_000, 10_000, 10_000]);
+
+    expect(clientById(id).interKeepaliveMs).toBe(10_000);
+  });
+
+  test("takes the median, not the latest gap, of jittered arrivals", () => {
+    // GIVEN gaps alternating around 7s
+    const id = registerSseClient(new AbortController().signal);
+    replayKeepalives(id, [6_000, 8_000, 6_000, 8_000, 6_000, 8_000]);
+
+    // THEN a single jittered arrival cannot swing the reported cadence
+    expect(clientById(id).interKeepaliveMs).toBe(7_000);
+  });
+
+  test("stays null until two gaps are known", () => {
+    // GIVEN a single keepalive (no gap at all)
+    const id = registerSseClient(new AbortController().signal);
+    setSystemTime(new Date(START));
+    recordSseTraffic(id, false);
+    expect(clientById(id).interKeepaliveMs).toBeNull();
+
+    // AND a second keepalive (one gap is not yet a cadence)
+    setSystemTime(new Date(START + 7_000));
+    recordSseTraffic(id, false);
+    expect(clientById(id).interKeepaliveMs).toBeNull();
+
+    // THEN the third arrival is what establishes a median
+    setSystemTime(new Date(START + 14_000));
+    recordSseTraffic(id, false);
+    expect(clientById(id).interKeepaliveMs).toBe(7_000);
+  });
+
+  test("keeps only the most recent gaps so a cadence change is visible", () => {
+    // GIVEN a long run at 7s followed by more than the 20-gap window at 10s
+    const id = registerSseClient(new AbortController().signal);
+    replayKeepalives(id, [
+      ...Array.from({ length: 10 }, () => 7_000),
+      ...Array.from({ length: 21 }, () => 10_000),
+    ]);
+
+    // THEN the stale 7s run has aged out of the window
+    expect(clientById(id).interKeepaliveMs).toBe(10_000);
+  });
+
+  test("does not leak gap state from an ended client to its replacement", () => {
+    // GIVEN a client that ended with a settled 10s cadence
+    const first = registerSseClient(new AbortController().signal);
+    replayKeepalives(first, [10_000, 10_000, 10_000]);
+    endSseClient(first, "watchdog");
+
+    // WHEN a replacement connection starts and sees one keepalive
+    const second = registerSseClient(new AbortController().signal);
+    setSystemTime(new Date(START + 100_000));
+    recordSseTraffic(second, false);
+
+    // THEN the replacement reports no cadence yet, and the ended client
+    // keeps its final reading for post-hoc diagnosis
+    expect(clientById(second).interKeepaliveMs).toBeNull();
+    expect(clientById(first).interKeepaliveMs).toBe(10_000);
   });
 });
 

--- a/clients/web/src/lib/streaming/stream-debug.ts
+++ b/clients/web/src/lib/streaming/stream-debug.ts
@@ -58,6 +58,21 @@ export interface SseDebugClient {
   dataFrames: number;
   /** Count of heartbeat comment frames seen on this client. */
   keepalives: number;
+  /**
+   * Epoch ms of the FIRST frame of any kind, data or keepalive. Isolates
+   * connect latency from stream silence: a late `firstFrameAt` means the
+   * Django/vembda/pod connect was slow, not that the stream went quiet.
+   */
+  firstFrameAt: number | null;
+  /**
+   * Median gap in ms between the last up-to-20 keepalive comments. ~7000
+   * implicates nothing (the daemon heartbeat is healthy end to end); ~10000
+   * means the daemon heartbeat is lost and the platform proxy's injector is
+   * carrying the stream. The daemon heartbeat interval is 7s (see
+   * `assistant/src/runtime/routes/events-routes.ts`); the proxy injects
+   * keepalives at 10s.
+   */
+  interKeepaliveMs: number | null;
   /** Epoch ms when the connection ended (null while still live). */
   endedAt: number | null;
   /** Why the connection ended (null while still live). */
@@ -103,6 +118,18 @@ let nextClientId = 0;
 const clients = new Map<string, SseDebugClient>();
 const events: SseDebugEventEntry[] = [];
 
+/**
+ * Per-client keepalive gap history, kept off the client object so the
+ * feedback JSON stays flat scalars.
+ */
+const keepaliveGaps = new Map<
+  string,
+  { lastKeepaliveAt: number; gaps: number[] }
+>();
+
+/** How many recent keepalive gaps feed the median. */
+const MAX_KEEPALIVE_GAPS = 20;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -122,6 +149,8 @@ export function registerSseClient(abortSignal: AbortSignal): string {
     lastDataAt: null,
     dataFrames: 0,
     keepalives: 0,
+    firstFrameAt: null,
+    interKeepaliveMs: null,
     endedAt: null,
     endReason: null,
   };
@@ -171,12 +200,47 @@ export function recordSseTraffic(clientId: string, isData: boolean): void {
   }
   const now = Date.now();
   client.lastTrafficAt = now;
+  if (client.firstFrameAt === null) {
+    client.firstFrameAt = now;
+  }
   if (isData) {
     client.lastDataAt = now;
     client.dataFrames++;
   } else {
     client.keepalives++;
+    recordKeepaliveGap(client, now);
   }
+}
+
+/**
+ * Fold one keepalive arrival into the client's rolling gap history and
+ * refresh its median. A single keepalive yields no gap, and one gap is not
+ * yet a cadence, so `interKeepaliveMs` stays null until two are known.
+ */
+function recordKeepaliveGap(client: SseDebugClient, now: number): void {
+  const entry = keepaliveGaps.get(client.id);
+  if (!entry) {
+    keepaliveGaps.set(client.id, { lastKeepaliveAt: now, gaps: [] });
+    return;
+  }
+  entry.gaps.push(now - entry.lastKeepaliveAt);
+  entry.lastKeepaliveAt = now;
+  if (entry.gaps.length > MAX_KEEPALIVE_GAPS) {
+    entry.gaps.shift();
+  }
+  if (entry.gaps.length >= 2) {
+    client.interKeepaliveMs = Math.round(median(entry.gaps));
+  }
+}
+
+/** Median of a non-empty numeric list (mean of the middle pair when even). */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid]!;
+  }
+  return (sorted[mid - 1]! + sorted[mid]!) / 2;
 }
 
 /**
@@ -327,6 +391,7 @@ export function endSseClient(
   } else if (client.endReason === "aborted" && reason !== "aborted") {
     client.endReason = reason;
   }
+  keepaliveGaps.delete(clientId);
   evictEndedBeyondCap();
 }
 
@@ -352,6 +417,9 @@ function evictEndedBeyondCap(): void {
     }
     if (client.endedAt !== null) {
       clients.delete(id);
+      // A keepalive landing after endSseClient can re-seed the gap entry;
+      // dropping it here keeps its lifetime tied to the registry entry.
+      keepaliveGaps.delete(id);
       endedCount--;
     }
   }
@@ -364,5 +432,6 @@ function evictEndedBeyondCap(): void {
 export function resetSseDebugStateForTests(): void {
   nextClientId = 0;
   clients.clear();
+  keepaliveGaps.clear();
   events.length = 0;
 }


### PR DESCRIPTION
## Summary
- SseDebugClient gains firstFrameAt (connect latency) and interKeepaliveMs (median keepalive gap: ~7s = daemon heartbeat healthy, ~10s = proxy injector carrying a silent daemon)
- Lands in web-sse-liveness-triage.json automatically (the feedback modal spreads clients verbatim); no streaming behavior change

Part of plan: measure-first-telemetry-followups.md (PR 3 of 7)