### PR TITLE
feat(web): record conversation-list drain diagnostics in the feedback ring

### DIFF
--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Drain diagnostics for the conversation-list fetchers.
+ *
+ * The ring holds 200 entries, so a multi-page drain must contribute a bounded
+ * handful of them: the first page (the request that gates first paint), one
+ * summary, and one entry per failed page. These tests pin that budget.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { getDiagnosticsEvents, type DiagnosticsEvent } from "@/lib/diagnostics";
+import { ApiError } from "@/utils/api-errors";
+import { listConversations } from "@/utils/conversation-list-fetchers";
+import type { RawConversationSummary } from "@/utils/conversation-transforms";
+
+const ASSISTANT_ID = "assistant-1";
+
+function makeRaw(id: string): RawConversationSummary {
+  return {
+    id,
+    title: "",
+    createdAt: 0,
+    updatedAt: 0,
+    lastMessageAt: 0,
+    conversationType: "standard",
+    source: "vellum",
+    groupId: "",
+    isProcessing: false,
+  } as RawConversationSummary;
+}
+
+type PageFixture = {
+  ids: string[];
+  hasMore: boolean;
+  status?: number;
+  contentLength?: string;
+};
+
+/**
+ * Stub the daemon transport so each list GET resolves the next fixture in
+ * order. Returns the captured offsets so tests can assert the walk.
+ */
+function stubPages(fixtures: PageFixture[]): { offsets: number[] } {
+  const offsets: number[] = [];
+  daemonClient.get = mock(
+    async (options: { query?: Record<string, unknown> }) => {
+      const index = offsets.length;
+      offsets.push(Number(options.query?.offset ?? 0));
+      const fixture = fixtures[index];
+      if (!fixture) {
+        throw new Error(`test setup has no fixture for request ${index}`);
+      }
+      const status = fixture.status ?? 200;
+      const body = {
+        conversations: fixture.ids.map(makeRaw),
+        hasMore: fixture.hasMore,
+      };
+      return {
+        data: status === 200 ? body : null,
+        error: status === 200 ? null : { message: "boom" },
+        response: new Response(JSON.stringify(body), {
+          status,
+          headers: fixture.contentLength
+            ? { "content-length": fixture.contentLength }
+            : {},
+        }),
+      };
+    },
+  ) as typeof daemonClient.get;
+  return { offsets };
+}
+
+/**
+ * Run `run` and return its result alongside the diagnostics it recorded. The
+ * ring is process-wide and has no reset hook, so each case slices from the
+ * length it observed rather than clearing.
+ */
+async function diagnosticsDuring<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; events: DiagnosticsEvent[] }> {
+  const baseline = getDiagnosticsEvents().length;
+  const result = await run();
+  return { result, events: getDiagnosticsEvents().slice(baseline) };
+}
+
+const originalGet = daemonClient.get;
+
+afterEach(() => {
+  daemonClient.get = originalGet;
+});
+
+describe("conversation list drain diagnostics", () => {
+  test("a 3-page drain records the first page and one summary, not one per page", async () => {
+    const { offsets } = stubPages([
+      { ids: ["c-0", "c-1"], hasMore: true, contentLength: "100" },
+      { ids: ["c-2", "c-1"], hasMore: true, contentLength: "200" },
+      { ids: ["c-3"], hasMore: false, contentLength: "50" },
+    ]);
+
+    const { result: conversations, events } = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(offsets).toEqual([0, 50, 100]);
+    expect(conversations).toHaveLength(4);
+
+    expect(events.map((e) => e.kind)).toEqual([
+      "conversation_list_page_fetch",
+      "conversation_list_drain",
+    ]);
+
+    expect(events[0]?.details).toMatchObject({
+      assistantId: ASSISTANT_ID,
+      offset: 0,
+      status: 200,
+      count: 2,
+      hasMore: true,
+      bytes: 100,
+    });
+
+    expect(events[1]?.details).toMatchObject({
+      assistantId: ASSISTANT_ID,
+      outcome: "ok",
+      pages: 3,
+      // Deduped: "c-1" appears on both page 0 and page 1.
+      rows: 4,
+      totalBytes: 350,
+      conversationType: null,
+    });
+  });
+
+  test("a failing page records a page error plus an error summary and rethrows", async () => {
+    const { offsets } = stubPages([
+      { ids: ["c-0"], hasMore: true, contentLength: "100" },
+      { ids: [], hasMore: false, status: 500 },
+    ]);
+
+    let thrown: unknown;
+    const { events } = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID).catch((error: unknown) => {
+        thrown = error;
+      }),
+    );
+
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(500);
+    expect(offsets).toEqual([0, 50]);
+
+    expect(events.map((e) => e.kind)).toEqual([
+      "conversation_list_page_fetch",
+      "conversation_list_page_fetch_error",
+      "conversation_list_drain",
+    ]);
+
+    expect(events[1]?.details).toMatchObject({
+      assistantId: ASSISTANT_ID,
+      offset: 50,
+      status: 500,
+      conversationType: null,
+      archiveStatus: null,
+    });
+
+    expect(events[2]?.details).toMatchObject({
+      outcome: "error",
+      // Only the page that resolved counts toward the drain.
+      pages: 1,
+      rows: 1,
+      totalBytes: 100,
+    });
+  });
+
+  test("bytes is null when content-length is absent and numeric when present", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false }]);
+    const withoutHeader = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(withoutHeader.events[0]?.details.bytes).toBeNull();
+    expect(withoutHeader.events[1]?.details.totalBytes).toBeNull();
+
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "4096" }]);
+    const withHeader = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(withHeader.events[0]?.details.bytes).toBe(4096);
+    expect(withHeader.events[1]?.details.totalBytes).toBe(4096);
+  });
+
+  test("every recorded detail value is a scalar or null", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(events).toHaveLength(2);
+    for (const event of events) {
+      for (const value of Object.values(event.details)) {
+        if (value === null) {
+          continue;
+        }
+        expect(["string", "number", "boolean"]).toContain(typeof value);
+      }
+    }
+    expect(typeof events[0]?.details.durationMs).toBe("number");
+    expect(typeof events[1]?.details.maxPageMs).toBe("number");
+  });
+});

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -22,6 +22,7 @@ import {
   assertHasResponse,
   extractErrorMessage,
 } from "@/utils/api-errors";
+import { recordDiagnostic } from "@/lib/diagnostics";
 import type { Conversation } from "@/types/conversation-types";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { toConversation } from "@/utils/conversation-transforms";
@@ -129,12 +130,32 @@ export type ConversationListPage = {
   hasMore: boolean;
 };
 
+/**
+ * A page plus what it cost to fetch. The timings stay internal to this module
+ * so the public {@link ConversationListPage} contract is unchanged.
+ */
+type TimedConversationListPage = ConversationListPage & {
+  durationMs: number;
+  /** `content-length` in bytes, or null when the server omits the header. */
+  bytes: number | null;
+};
+
+function readContentLength(response: Response): number | null {
+  const header = response.headers.get("content-length");
+  if (header === null) {
+    return null;
+  }
+  const bytes = Number(header);
+  return Number.isFinite(bytes) ? bytes : null;
+}
+
 async function fetchConversationListPage(
   assistantId: string,
   offset: number,
   options: FetchConversationListOptions = {},
-): Promise<ConversationListPage> {
+): Promise<TimedConversationListPage> {
   const { conversationType, archiveStatus, originChannel } = options;
+  const startedAt = performance.now();
   const { data, error, response } = await conversationsGet({
     path: { assistant_id: assistantId },
     query: {
@@ -147,7 +168,16 @@ async function fetchConversationListPage(
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to list conversations.");
+  const durationMs = Math.round(performance.now() - startedAt);
   if (!response.ok) {
+    recordDiagnostic("conversation_list_page_fetch_error", {
+      assistantId,
+      offset,
+      status: response.status,
+      durationMs,
+      conversationType: conversationType ?? null,
+      archiveStatus: archiveStatus ?? null,
+    });
     const msg = extractErrorMessage(
       error,
       response,
@@ -159,6 +189,8 @@ async function fetchConversationListPage(
   return {
     conversations: (data?.conversations ?? []).map(toConversation),
     hasMore: data?.hasMore ?? false,
+    durationMs,
+    bytes: readContentLength(response),
   };
 }
 
@@ -169,29 +201,68 @@ async function fetchConversationList(
   const all: Conversation[] = [];
   const seen = new Set<string>();
 
-  for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
-    const offset = page * CONVERSATION_LIST_PAGE_SIZE;
-    const { conversations, hasMore } = await fetchConversationListPage(
+  // A full drain can be dozens of pages, so only the first page (the one that
+  // gates first paint) and a single summary reach the 200-entry ring.
+  const drainStartedAt = performance.now();
+  let pages = 0;
+  let maxPageMs = 0;
+  let totalBytes: number | null = null;
+
+  const recordDrain = (outcome: "ok" | "error"): void => {
+    recordDiagnostic("conversation_list_drain", {
       assistantId,
-      offset,
-      options,
-    );
-    for (const conversation of conversations) {
-      if (!seen.has(conversation.conversationId)) {
-        seen.add(conversation.conversationId);
-        all.push(conversation);
+      outcome,
+      pages,
+      rows: all.length,
+      totalMs: Math.round(performance.now() - drainStartedAt),
+      maxPageMs,
+      totalBytes,
+      conversationType: options.conversationType ?? null,
+    });
+  };
+
+  try {
+    for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
+      const offset = page * CONVERSATION_LIST_PAGE_SIZE;
+      const { conversations, hasMore, durationMs, bytes } =
+        await fetchConversationListPage(assistantId, offset, options);
+      pages++;
+      maxPageMs = Math.max(maxPageMs, durationMs);
+      if (bytes !== null) {
+        totalBytes = (totalBytes ?? 0) + bytes;
+      }
+      if (page === 0) {
+        recordDiagnostic("conversation_list_page_fetch", {
+          assistantId,
+          offset: 0,
+          status: 200,
+          count: conversations.length,
+          hasMore,
+          durationMs,
+          bytes,
+        });
+      }
+      for (const conversation of conversations) {
+        if (!seen.has(conversation.conversationId)) {
+          seen.add(conversation.conversationId);
+          all.push(conversation);
+        }
+      }
+
+      if (!hasMore) {
+        break;
+      }
+
+      if (conversations.length === 0) {
+        break;
       }
     }
-
-    if (!hasMore) {
-      break;
-    }
-
-    if (conversations.length === 0) {
-      break;
-    }
+  } catch (error) {
+    recordDrain("error");
+    throw error;
   }
 
+  recordDrain("ok");
   return all;
 }
 


### PR DESCRIPTION
## Summary
- Records conversation_list_page_fetch (first page), per-page errors, and a conversation_list_drain summary (pages/rows/totalMs/maxPageMs/totalBytes) in the diagnostics ring so feedback bundles finally show why the sidebar list is slow or blank
- Adds payload-size capture via content-length; ring-pressure-safe (max 3 entries per drain)
- Observation only: no change to fetching behavior, page size, or callers

Part of plan: measure-first-telemetry-followups.md (PR 1 of 7)