### PR TITLE
fix(cli): vellum tunnel resolves a local assistant instead of a default-workspace edge for cloud entries

### DIFF
--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -71,6 +71,7 @@ const { tunnel } = await import("../commands/tunnel.js");
 const originalArgv = [...process.argv];
 const originalFetch = globalThis.fetch;
 const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
 const tempDirs: string[] = [];
 
 function makeLocalEntry(assistantId = "assistant-1"): AssistantEntry {
@@ -96,6 +97,23 @@ function makeCloudEntry(assistantId = "cloud-1"): AssistantEntry {
     runtimeUrl: `https://runtime.example.com/${assistantId}`,
     cloud: "vellum",
   };
+}
+
+/** A `hatch --remote docker` entry: local container gateway, no `resources`. */
+function makeDockerEntry(assistantId = "docker-1"): AssistantEntry {
+  return {
+    assistantId,
+    runtimeUrl: "http://localhost:7930",
+    cloud: "docker",
+  };
+}
+
+/** Point the default workspace dir at a temp dir; returns that dir. */
+function useTempDefaultWorkspaceDir(): string {
+  const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-tunnel-ws-"));
+  tempDirs.push(workspaceDir);
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  return workspaceDir;
 }
 
 function writeLockfile(
@@ -194,6 +212,11 @@ describe("tunnel edge targeting", () => {
     } else {
       process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
     }
+    if (originalWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+    }
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -273,6 +296,72 @@ describe("tunnel edge targeting", () => {
     expect(runNgrokTunnelMock).toHaveBeenCalledWith({
       port: EDGE_PORT,
       assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("a positional docker assistant name tunnels via its runtimeUrl gateway port", async () => {
+    const workspaceDir = useTempDefaultWorkspaceDir();
+    const local = makeLocalEntry();
+    writeLockfile([local, makeDockerEntry()], local.assistantId);
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "docker-1",
+      "--provider",
+      "ngrok",
+    ];
+
+    await runTunnelCapturingLogs();
+
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "docker-1",
+      workspaceDir,
+      gatewayPort: 7930,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "docker-1",
+      workspaceDir,
+    });
+  });
+
+  test("an active docker assistant tunnels on a bare invocation", async () => {
+    const workspaceDir = useTempDefaultWorkspaceDir();
+    const docker = makeDockerEntry();
+    writeLockfile(docker, docker.assistantId);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    await runTunnelCapturingLogs();
+
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "docker-1",
+      workspaceDir,
+      gatewayPort: 7930,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "docker-1",
+      workspaceDir,
+    });
+  });
+
+  test("an active cloud assistant falls back to a sole docker entry with a note", async () => {
+    const workspaceDir = useTempDefaultWorkspaceDir();
+    const cloud = makeCloudEntry();
+    writeLockfile([cloud, makeDockerEntry()], cloud.assistantId);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(logs).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel. " +
+        "Tunneling the local assistant 'docker-1' instead.",
+    );
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "docker-1",
       workspaceDir,
     });
   });

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -73,11 +73,11 @@ const originalFetch = globalThis.fetch;
 const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
 const tempDirs: string[] = [];
 
-function makeLocalEntry(): AssistantEntry {
+function makeLocalEntry(assistantId = "assistant-1"): AssistantEntry {
   const instanceDir = mkdtempSync(join(tmpdir(), "vellum-tunnel-test-"));
   tempDirs.push(instanceDir);
   return {
-    assistantId: "assistant-1",
+    assistantId,
     runtimeUrl: "http://127.0.0.1:7830",
     cloud: "local",
     resources: {
@@ -90,7 +90,21 @@ function makeLocalEntry(): AssistantEntry {
   };
 }
 
-function writeLockfile(entry: AssistantEntry): void {
+function makeCloudEntry(assistantId = "cloud-1"): AssistantEntry {
+  return {
+    assistantId,
+    runtimeUrl: `https://runtime.example.com/${assistantId}`,
+    cloud: "vellum",
+  };
+}
+
+function writeLockfile(
+  entryOrEntries: AssistantEntry | AssistantEntry[],
+  activeAssistant?: string,
+): void {
+  const entries = Array.isArray(entryOrEntries)
+    ? entryOrEntries
+    : [entryOrEntries];
   const lockfileDir = mkdtempSync(join(tmpdir(), "vellum-tunnel-lockfile-"));
   tempDirs.push(lockfileDir);
   process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
@@ -99,8 +113,8 @@ function writeLockfile(entry: AssistantEntry): void {
     join(lockfileDir, ".vellum.lock.json"),
     JSON.stringify(
       {
-        activeAssistant: entry.assistantId,
-        assistants: [entry],
+        activeAssistant: activeAssistant ?? entries[0].assistantId,
+        assistants: entries,
       },
       null,
       2,
@@ -232,6 +246,96 @@ describe("tunnel edge targeting", () => {
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
     expect(logs).toContain(`Started the nginx edge on 127.0.0.1:${EDGE_PORT}`);
     expect(logs).toContain("serves remote web + webhooks");
+  });
+
+  test("an active cloud assistant falls back to the sole local entry with a note", async () => {
+    const cloud = makeCloudEntry();
+    const local = makeLocalEntry();
+    writeLockfile([cloud, local], cloud.assistantId);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    const logs = await runTunnelCapturingLogs();
+
+    const workspaceDir = join(
+      local.resources!.instanceDir,
+      ".vellum",
+      "workspace",
+    );
+    expect(logs).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel. " +
+        "Tunneling the local assistant 'assistant-1' instead.",
+    );
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "assistant-1",
+      workspaceDir,
+      gatewayPort: 7830,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("an active cloud assistant with no local entries exits with an error", async () => {
+    writeLockfile(makeCloudEntry());
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel.",
+    );
+    expect(errors).toContain("No local assistant found to tunnel");
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("an active cloud assistant with multiple local entries exits listing them", async () => {
+    const cloud = makeCloudEntry();
+    writeLockfile(
+      [cloud, makeLocalEntry("assistant-a"), makeLocalEntry("assistant-b")],
+      cloud.assistantId,
+    );
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel.",
+    );
+    expect(errors).toContain(
+      "Pass a local assistant as the name argument: assistant-a, assistant-b.",
+    );
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("a positional cloud assistant name errors without auto-fallback", async () => {
+    const local = makeLocalEntry();
+    writeLockfile([makeCloudEntry(), local], local.assistantId);
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "cloud-1",
+      "--provider",
+      "ngrok",
+    ];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel.",
+    );
+    expect(errors).toContain(
+      "Pass a local assistant as the name argument: assistant-1.",
+    );
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
   });
 
   test("targets the edge port for cloudflare", async () => {

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -338,6 +338,96 @@ describe("tunnel edge targeting", () => {
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
   });
 
+  test("a positional display name resolves the local assistant", async () => {
+    const local = makeLocalEntry();
+    local.name = "Ada";
+    writeLockfile([makeCloudEntry(), local], "cloud-1");
+    process.argv = ["bun", "vellum", "tunnel", "Ada", "--provider", "ngrok"];
+
+    await runTunnelCapturingLogs();
+
+    const workspaceDir = join(
+      local.resources!.instanceDir,
+      ".vellum",
+      "workspace",
+    );
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("an exact assistant ID wins over a colliding display name", async () => {
+    const decoy = makeLocalEntry("assistant-a");
+    decoy.name = "assistant-b";
+    const target = makeLocalEntry("assistant-b");
+    writeLockfile([decoy, target], "assistant-a");
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "assistant-b",
+      "--provider",
+      "ngrok",
+    ];
+
+    await runTunnelCapturingLogs();
+
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantId: "assistant-b" }),
+    );
+  });
+
+  test("a positional display name of a cloud assistant errors without auto-fallback", async () => {
+    const cloud = makeCloudEntry();
+    cloud.name = "Cloudy";
+    const local = makeLocalEntry();
+    writeLockfile([cloud, local], local.assistantId);
+    process.argv = ["bun", "vellum", "tunnel", "Cloudy", "--provider", "ngrok"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Assistant 'Cloudy (cloud-1)' runs on Vellum Cloud and needs no tunnel.",
+    );
+    expect(errors).toContain(
+      "Pass a local assistant as the name argument: assistant-1.",
+    );
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("an ambiguous positional display name errors listing the candidates", async () => {
+    const first = makeLocalEntry("assistant-a");
+    first.name = "Ada";
+    const second = makeLocalEntry("assistant-b");
+    second.name = "Ada";
+    writeLockfile([first, second], "assistant-a");
+    process.argv = ["bun", "vellum", "tunnel", "Ada", "--provider", "ngrok"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain(
+      "Multiple assistants match 'Ada': Ada (assistant-a), Ada (assistant-b).",
+    );
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("an unknown positional name errors", async () => {
+    process.argv = ["bun", "vellum", "tunnel", "nope", "--provider", "ngrok"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("No assistant found with name or ID 'nope'.");
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
   test("targets the edge port for cloudflare", async () => {
     const entry = makeLocalEntry();
     writeLockfile(entry);

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -108,6 +108,15 @@ function makeDockerEntry(assistantId = "docker-1"): AssistantEntry {
   };
 }
 
+/** A macOS-app-managed entry: local container gateway, no `resources`. */
+function makeAppleContainerEntry(assistantId = "apple-1"): AssistantEntry {
+  return {
+    assistantId,
+    runtimeUrl: "http://localhost:8030",
+    cloud: "apple-container",
+  };
+}
+
 /** Point the default workspace dir at a temp dir; returns that dir. */
 function useTempDefaultWorkspaceDir(): string {
   const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-tunnel-ws-"));
@@ -443,6 +452,85 @@ describe("tunnel edge targeting", () => {
     expect(runNgrokTunnelMock).toHaveBeenCalledWith({
       port: EDGE_PORT,
       assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("an unquoted multi-word display name resolves the local assistant", async () => {
+    const local = makeLocalEntry();
+    local.name = "Ada Lovelace";
+    writeLockfile([makeCloudEntry(), local], "cloud-1");
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "Ada",
+      "Lovelace",
+      "--provider",
+      "ngrok",
+    ];
+
+    await runTunnelCapturingLogs();
+
+    const workspaceDir = join(
+      local.resources!.instanceDir,
+      ".vellum",
+      "workspace",
+    );
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("a positional apple-container assistant name tunnels via its runtimeUrl gateway port", async () => {
+    const workspaceDir = useTempDefaultWorkspaceDir();
+    const local = makeLocalEntry();
+    writeLockfile([local, makeAppleContainerEntry()], local.assistantId);
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "apple-1",
+      "--provider",
+      "ngrok",
+    ];
+
+    await runTunnelCapturingLogs();
+
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "apple-1",
+      workspaceDir,
+      gatewayPort: 8030,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "apple-1",
+      workspaceDir,
+    });
+  });
+
+  test("an active cloud assistant falls back to a sole apple-container entry with a note", async () => {
+    const workspaceDir = useTempDefaultWorkspaceDir();
+    const cloud = makeCloudEntry();
+    writeLockfile([cloud, makeAppleContainerEntry()], cloud.assistantId);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(logs).toContain(
+      "Assistant 'cloud-1' runs on Vellum Cloud and needs no tunnel. " +
+        "Tunneling the local assistant 'apple-1' instead.",
+    );
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "apple-1",
+      workspaceDir,
+      gatewayPort: 8030,
+    });
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "apple-1",
       workspaceDir,
     });
   });

--- a/cli/src/commands/nginx-ingress.ts
+++ b/cli/src/commands/nginx-ingress.ts
@@ -90,12 +90,21 @@ function parsePortFromUrl(url: unknown): number | undefined {
   }
 }
 
-function resolveEntryGatewayPort(entry: AssistantEntry | undefined): number {
+/**
+ * Derive the gateway port from an entry's recorded URLs, preferring the
+ * loopback `localUrl` over `runtimeUrl`. Undefined when neither carries an
+ * explicit port (e.g. a platform-hosted https runtime URL).
+ */
+export function parseGatewayPortFromEntryUrls(
+  entry: AssistantEntry | undefined,
+): number | undefined {
   return (
-    parsePortFromUrl(entry?.localUrl) ??
-    parsePortFromUrl(entry?.runtimeUrl) ??
-    GATEWAY_PORT
+    parsePortFromUrl(entry?.localUrl) ?? parsePortFromUrl(entry?.runtimeUrl)
   );
+}
+
+function resolveEntryGatewayPort(entry: AssistantEntry | undefined): number {
+  return parseGatewayPortFromEntryUrls(entry) ?? GATEWAY_PORT;
 }
 
 /**

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -5,10 +5,12 @@ import {
   loadAllAssistants,
   resolveTargetAssistant,
   type AssistantEntry,
-  type LocalInstanceResources,
 } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
-import { saveNgrokDomain } from "../lib/ingress-config.js";
+import {
+  getDefaultWorkspaceDir,
+  saveNgrokDomain,
+} from "../lib/ingress-config.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
@@ -17,6 +19,7 @@ import {
 import { runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
+import { parseGatewayPortFromEntryUrls } from "./nginx-ingress.js";
 
 const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
 type TunnelProvider = (typeof VALID_PROVIDERS)[number];
@@ -176,12 +179,36 @@ function parseArgs(): TunnelArgs {
   return { assistantName, provider, domain, clearDomain };
 }
 
-type LocalAssistantEntry = AssistantEntry & {
-  resources: LocalInstanceResources;
-};
+/** A tunnelable assistant plus the gateway port and workspace the edge fronts. */
+interface LocalTunnelTarget {
+  entry: AssistantEntry;
+  gatewayPort: number;
+  workspaceDir: string;
+}
 
-function isLocalEntry(entry: AssistantEntry): entry is LocalAssistantEntry {
-  return entry.resources !== undefined;
+/**
+ * Map an entry to its local tunnel target, or null when it has no locally
+ * reachable gateway (e.g. platform-hosted). Entries with `resources` carry
+ * their own gateway port and instance workspace. Docker entries run locally
+ * without host resources: their gateway port comes from localUrl/runtimeUrl
+ * and their ingress state lives in the default workspace, matching the
+ * `vellum nginx-ingress` resolution for the same topology.
+ */
+function toLocalTunnelTarget(entry: AssistantEntry): LocalTunnelTarget | null {
+  if (entry.resources) {
+    return {
+      entry,
+      gatewayPort: entry.resources.gatewayPort,
+      workspaceDir: join(entry.resources.instanceDir, ".vellum", "workspace"),
+    };
+  }
+  if (entry.cloud === "docker") {
+    const gatewayPort = parseGatewayPortFromEntryUrls(entry);
+    if (gatewayPort !== undefined) {
+      return { entry, gatewayPort, workspaceDir: getDefaultWorkspaceDir() };
+    }
+  }
+  return null;
 }
 
 function describeUntunnelableEntry(entry: AssistantEntry): string {
@@ -193,38 +220,41 @@ function describeUntunnelableEntry(entry: AssistantEntry): string {
 
 /**
  * Resolve the assistant whose gateway and workspace the tunnel edge fronts.
- * Tunnels only make sense for assistants with local resources; when the
+ * Tunnels only make sense for assistants with a local gateway; when the
  * resolved entry has none (e.g. the active assistant is platform-hosted) and
- * no name was given, fall back to the sole local entry, otherwise exit with
+ * no name was given, fall back to the sole local target, otherwise exit with
  * an error naming the local assistants to pass explicitly.
  */
-function resolveLocalTunnelEntry(
+function resolveLocalTunnelTarget(
   assistantName: string | null,
-): LocalAssistantEntry {
+): LocalTunnelTarget {
   const entry = resolveTargetAssistant(assistantName ?? undefined);
 
-  if (isLocalEntry(entry)) {
-    return entry;
+  const target = toLocalTunnelTarget(entry);
+  if (target) {
+    return target;
   }
 
-  const localEntries = loadAllAssistants().filter(isLocalEntry);
+  const localTargets = loadAllAssistants()
+    .map(toLocalTunnelTarget)
+    .filter((local): local is LocalTunnelTarget => local !== null);
 
-  if (!assistantName && localEntries.length === 1) {
+  if (!assistantName && localTargets.length === 1) {
     console.log(
-      `${describeUntunnelableEntry(entry)} Tunneling the local assistant '${formatAssistantReference(localEntries[0])}' instead.`,
+      `${describeUntunnelableEntry(entry)} Tunneling the local assistant '${formatAssistantReference(localTargets[0].entry)}' instead.`,
     );
-    return localEntries[0];
+    return localTargets[0];
   }
 
   console.error(describeUntunnelableEntry(entry));
-  if (localEntries.length === 0) {
+  if (localTargets.length === 0) {
     console.error(
       "No local assistant found to tunnel. Run `vellum hatch` first.",
     );
   } else {
     console.error(
-      `Pass a local assistant as the name argument: ${localEntries
-        .map((local) => formatAssistantReference(local))
+      `Pass a local assistant as the name argument: ${localTargets
+        .map((local) => formatAssistantReference(local.entry))
         .join(", ")}.`,
     );
   }
@@ -241,9 +271,8 @@ export async function tunnel(): Promise<void> {
     );
   }
 
-  const entry = resolveLocalTunnelEntry(assistantName);
-  const { instanceDir, gatewayPort } = entry.resources;
-  const workspaceDir = join(instanceDir, ".vellum", "workspace");
+  const { entry, gatewayPort, workspaceDir } =
+    resolveLocalTunnelTarget(assistantName);
 
   if (clearDomain) {
     saveNgrokDomain(workspaceDir, null);

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,12 +1,14 @@
 import { join } from "path";
 
-import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
-import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
-import { GATEWAY_PORT } from "../lib/constants.js";
 import {
-  getDefaultWorkspaceDir,
-  saveNgrokDomain,
-} from "../lib/ingress-config.js";
+  formatAssistantReference,
+  loadAllAssistants,
+  resolveAssistant,
+  type AssistantEntry,
+  type LocalInstanceResources,
+} from "../lib/assistant-config";
+import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
+import { saveNgrokDomain } from "../lib/ingress-config.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
@@ -174,30 +176,31 @@ function parseArgs(): TunnelArgs {
   return { assistantName, provider, domain, clearDomain };
 }
 
-function parsePortFromUrl(url: unknown): number | undefined {
-  if (typeof url !== "string" || !url.trim()) return undefined;
-  try {
-    const port = Number(new URL(url).port);
-    return Number.isInteger(port) && port > 0 && port <= 65535
-      ? port
-      : undefined;
-  } catch {
-    return undefined;
-  }
+type LocalAssistantEntry = AssistantEntry & {
+  resources: LocalInstanceResources;
+};
+
+function isLocalEntry(entry: AssistantEntry): entry is LocalAssistantEntry {
+  return entry.resources !== undefined;
 }
 
-function resolveEntryGatewayPort(entry: AssistantEntry): number {
-  return (
-    entry.resources?.gatewayPort ??
-    parsePortFromUrl(entry.localUrl) ??
-    parsePortFromUrl(entry.runtimeUrl) ??
-    GATEWAY_PORT
-  );
+function describeUntunnelableEntry(entry: AssistantEntry): string {
+  const reference = formatAssistantReference(entry);
+  return entry.cloud === "vellum"
+    ? `Assistant '${reference}' runs on Vellum Cloud and needs no tunnel.`
+    : `Assistant '${reference}' has no locally managed runtime to tunnel.`;
 }
 
-export async function tunnel(): Promise<void> {
-  const { assistantName, provider, domain, clearDomain } = parseArgs();
-
+/**
+ * Resolve the assistant whose gateway and workspace the tunnel edge fronts.
+ * Tunnels only make sense for assistants with local resources; when the
+ * resolved entry has none (e.g. the active assistant is platform-hosted) and
+ * no name was given, fall back to the sole local entry, otherwise exit with
+ * an error naming the local assistants to pass explicitly.
+ */
+function resolveLocalTunnelEntry(
+  assistantName: string | null,
+): LocalAssistantEntry {
   const entry = resolveAssistant(assistantName ?? undefined);
 
   if (!entry) {
@@ -211,6 +214,37 @@ export async function tunnel(): Promise<void> {
     process.exit(1);
   }
 
+  if (isLocalEntry(entry)) {
+    return entry;
+  }
+
+  const localEntries = loadAllAssistants().filter(isLocalEntry);
+
+  if (!assistantName && localEntries.length === 1) {
+    console.log(
+      `${describeUntunnelableEntry(entry)} Tunneling the local assistant '${formatAssistantReference(localEntries[0])}' instead.`,
+    );
+    return localEntries[0];
+  }
+
+  console.error(describeUntunnelableEntry(entry));
+  if (localEntries.length === 0) {
+    console.error(
+      "No local assistant found to tunnel. Run `vellum hatch` first.",
+    );
+  } else {
+    console.error(
+      `Pass a local assistant as the name argument: ${localEntries
+        .map((local) => formatAssistantReference(local))
+        .join(", ")}.`,
+    );
+  }
+  process.exit(1);
+}
+
+export async function tunnel(): Promise<void> {
+  const { assistantName, provider, domain, clearDomain } = parseArgs();
+
   if (provider === "vellum") {
     throw new Error(
       `Tunnel provider '${provider}' is not yet implemented. ` +
@@ -218,11 +252,9 @@ export async function tunnel(): Promise<void> {
     );
   }
 
-  const resources = entry.resources;
-  const gatewayPort = resolveEntryGatewayPort(entry);
-  const workspaceDir = resources
-    ? join(resources.instanceDir, ".vellum", "workspace")
-    : getDefaultWorkspaceDir();
+  const entry = resolveLocalTunnelEntry(assistantName);
+  const { instanceDir, gatewayPort } = entry.resources;
+  const workspaceDir = join(instanceDir, ".vellum", "workspace");
 
   if (clearDomain) {
     saveNgrokDomain(workspaceDir, null);

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import {
   formatAssistantReference,
   loadAllAssistants,
-  resolveAssistant,
+  resolveTargetAssistant,
   type AssistantEntry,
   type LocalInstanceResources,
 } from "../lib/assistant-config";
@@ -201,18 +201,7 @@ function describeUntunnelableEntry(entry: AssistantEntry): string {
 function resolveLocalTunnelEntry(
   assistantName: string | null,
 ): LocalAssistantEntry {
-  const entry = resolveAssistant(assistantName ?? undefined);
-
-  if (!entry) {
-    if (assistantName) {
-      console.error(
-        `No assistant instance found with name '${assistantName}'.`,
-      );
-    } else {
-      console.error("No assistant instance found. Run `vellum hatch` first.");
-    }
-    process.exit(1);
-  }
+  const entry = resolveTargetAssistant(assistantName ?? undefined);
 
   if (isLocalEntry(entry)) {
     return entry;

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -6,6 +6,7 @@ import {
   resolveTargetAssistant,
   type AssistantEntry,
 } from "../lib/assistant-config";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import {
   getDefaultWorkspaceDir,
@@ -33,9 +34,10 @@ interface TunnelArgs {
   clearDomain: boolean;
 }
 
+const FLAGS_WITH_VALUES = ["--provider", "--domain"] as const;
+
 function parseArgs(): TunnelArgs {
   const args = process.argv.slice(3);
-  let assistantName: string | null = null;
   let provider: TunnelProvider = DEFAULT_PROVIDER;
   let domain: string | null = null;
   let clearDomain = false;
@@ -147,13 +149,13 @@ function parseArgs(): TunnelArgs {
     } else if (arg.startsWith("-")) {
       console.error(`Error: Unknown option '${arg}'.`);
       process.exit(1);
-    } else if (!assistantName) {
-      assistantName = arg;
-    } else {
-      console.error(`Error: Unexpected argument '${arg}'.`);
-      process.exit(1);
     }
   }
+
+  // Joins all positionals so unquoted multi-word display names resolve as one
+  // identifier (cli/AGENTS.md "Assistant targeting convention").
+  const assistantName =
+    parseAssistantTargetArg(args, FLAGS_WITH_VALUES) ?? null;
 
   if (domain && provider !== "ngrok") {
     console.error(
@@ -186,13 +188,19 @@ interface LocalTunnelTarget {
   workspaceDir: string;
 }
 
+/** Container topologies whose gateway runs on this machine without host `resources`. */
+function isLocalContainerEntry(entry: AssistantEntry): boolean {
+  return entry.cloud === "docker" || entry.cloud === "apple-container";
+}
+
 /**
  * Map an entry to its local tunnel target, or null when it has no locally
  * reachable gateway (e.g. platform-hosted). Entries with `resources` carry
- * their own gateway port and instance workspace. Docker entries run locally
- * without host resources: their gateway port comes from localUrl/runtimeUrl
- * and their ingress state lives in the default workspace, matching the
- * `vellum nginx-ingress` resolution for the same topology.
+ * their own gateway port and instance workspace. Local container entries
+ * (docker, apple-container) run locally without host resources: their gateway
+ * port comes from localUrl/runtimeUrl and their ingress state lives in the
+ * default workspace, matching the `vellum nginx-ingress` resolution for the
+ * same topology.
  */
 function toLocalTunnelTarget(entry: AssistantEntry): LocalTunnelTarget | null {
   if (entry.resources) {
@@ -202,7 +210,7 @@ function toLocalTunnelTarget(entry: AssistantEntry): LocalTunnelTarget | null {
       workspaceDir: join(entry.resources.instanceDir, ".vellum", "workspace"),
     };
   }
-  if (entry.cloud === "docker") {
+  if (isLocalContainerEntry(entry)) {
     const gatewayPort = parseGatewayPortFromEntryUrls(entry);
     if (gatewayPort !== undefined) {
       return { entry, gatewayPort, workspaceDir: getDefaultWorkspaceDir() };


### PR DESCRIPTION
## Summary
- A cloud-hosted active assistant no longer sends vellum tunnel to ~/.vellum/workspace with a default gateway port; the command tunnels the sole local assistant (with a note) or exits with a clear error
- Naming a cloud assistant positionally errors instead of forking ingress state into an unrelated directory

## Original prompt
Live testing of the tunnel-edge unification found that with a platform assistant active in the lockfile, bare vellum tunnel silently started an nginx edge under the default workspace dir and stamped ingress state there, fighting the real local assistant's config. Fix by resolving to a local assistant or failing clearly.