### PR TITLE
fix(cli): verify edge port ownership via pid file instead of racing the child exit

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -1150,6 +1150,41 @@ describe("startRemoteWebIngress", () => {
 
     expect(result.status).toBe("port-conflict");
   });
+
+  test(
+    "a child still retrying its bind at the settle deadline is killed before rollback",
+    async () => {
+      const ws = makeWorkspace();
+      mockNginxInstalled();
+      mockWebDistMissing();
+      const kills: string[] = [];
+      // Alive for the whole settle window (nginx retrying its bind), never
+      // writes a pid file; an orphan left running could win the bind later.
+      spawnMock.mockImplementation((() => {
+        return {
+          unref: () => {},
+          exitCode: null,
+          pid: SPAWNED_NGINX_PID,
+          once: () => {},
+          kill: (signal: string) => {
+            kills.push(signal);
+            return true;
+          },
+        } as unknown as ChildProcess;
+      }) as unknown as typeof childProcess.spawn);
+
+      const result = await startRemoteWebIngress({
+        workspaceDir: ws,
+        gatewayPort: 7830,
+        listenPort: 7845,
+        includeWebApp: false,
+      });
+
+      expect(result.status).toBe("port-conflict");
+      expect(kills).toEqual(["SIGTERM"]);
+    },
+    10_000,
+  );
 });
 
 describe("ensureTunnelEdge", () => {

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -88,8 +88,30 @@ import {
 const originalKill = process.kill;
 const workspaces: string[] = [];
 
+/**
+ * Registry-backed process.kill mock: registered fake PIDs answer liveness
+ * probes and record kills, everything else forwards to the real kill. Lets
+ * helpers compose (old-edge PID and freshly-spawned master PID at once).
+ */
+const fakePids = new Map<number, { alive: boolean; unkillable?: boolean }>();
+
+function installKillMock(): void {
+  process.kill = mock((targetPid: number, signal?: string | number) => {
+    const entry = fakePids.get(targetPid);
+    if (!entry) return originalKill(targetPid, signal);
+    if (signal === 0) {
+      if (!entry.alive) throw new Error("dead");
+      return true;
+    }
+    if (entry.unkillable) throw new Error("operation not permitted");
+    entry.alive = false;
+    return true;
+  }) as unknown as typeof process.kill;
+}
+
 afterEach(() => {
   process.kill = originalKill;
+  fakePids.clear();
   execFileSyncMock.mockReset();
   spawnSyncMock.mockReset();
   spawnSyncMock.mockImplementation(realChildProcess.spawnSync);
@@ -465,13 +487,33 @@ function mockNginxMissing(): void {
   });
 }
 
+const SPAWNED_NGINX_PID = 4243;
+
+/**
+ * Spawned nginx that wins its bind: alive as the master, and it records its
+ * pid under the prefix dir like a real `daemon off` master, with a matching
+ * ps answer so getIngressPid confirms ownership.
+ */
 function mockNginxSpawn(): void {
-  spawnMock.mockReturnValue({
-    unref: () => {},
-    once: () => {},
-    exitCode: null,
-    pid: 4243,
-  } as unknown as ChildProcess);
+  spawnMock.mockImplementation(((_command: string, args: readonly string[]) => {
+    const dir = String(args[args.indexOf("-p") + 1]);
+    realFs.writeFileSync(join(dir, "nginx.pid"), `${SPAWNED_NGINX_PID}\n`);
+    fakePids.set(SPAWNED_NGINX_PID, { alive: true });
+    installKillMock();
+    execFileSyncMock.mockImplementation(((
+      _file: string,
+      psArgs?: readonly string[],
+    ) =>
+      psArgs?.includes(String(SPAWNED_NGINX_PID))
+        ? `nginx: master process nginx -p ${dir} -c ${join(dir, "nginx.conf")} -g daemon off;`
+        : "") as typeof childProcess.execFileSync);
+    return {
+      unref: () => {},
+      once: () => {},
+      exitCode: null,
+      pid: SPAWNED_NGINX_PID,
+    } as unknown as ChildProcess;
+  }) as unknown as typeof childProcess.spawn);
 }
 
 /** Spawned nginx that exits on startup, as when the listen port is already bound. */
@@ -482,8 +524,31 @@ function mockNginxSpawnExitsOnStartup(): void {
       if (event === "exit") listener();
     },
     exitCode: 1,
-    pid: 4243,
+    pid: SPAWNED_NGINX_PID,
   } as unknown as ChildProcess);
+}
+
+/**
+ * Spawned nginx that loses the bind race to a healthy squatter: still alive
+ * when the probe resolves, exits shortly after, never writes a pid file.
+ */
+function mockNginxSpawnExitsAfterProbe(): void {
+  spawnMock.mockImplementation((() => {
+    const child = {
+      unref: () => {},
+      exitCode: null as number | null,
+      pid: SPAWNED_NGINX_PID,
+      once: (event: string, listener: () => void) => {
+        if (event === "exit") {
+          setTimeout(() => {
+            child.exitCode = 1;
+            listener();
+          }, 150);
+        }
+      },
+    };
+    return child as unknown as ChildProcess;
+  }) as unknown as typeof childProcess.spawn);
 }
 
 /** Force findWebDistDir() to resolve nothing, regardless of checkout state. */
@@ -540,29 +605,15 @@ function mockRunningEdge(
 
 /** SIGTERM to the given PID marks it dead; signal 0 reflects liveness. */
 function mockKillableNginx(pid: number): { killed: () => boolean } {
-  let alive = true;
-  process.kill = mock((targetPid: number, signal?: string | number) => {
-    if (targetPid !== pid) return originalKill(targetPid, signal);
-    if (signal === 0) {
-      if (!alive) throw new Error("dead");
-      return true;
-    }
-    if (signal === "SIGTERM") {
-      alive = false;
-      return true;
-    }
-    return true;
-  }) as unknown as typeof process.kill;
-  return { killed: () => !alive };
+  fakePids.set(pid, { alive: true });
+  installKillMock();
+  return { killed: () => fakePids.get(pid)?.alive === false };
 }
 
 /** The given PID stays alive: liveness probes succeed, kill signals fail. */
 function mockUnkillableNginx(pid: number): void {
-  process.kill = mock((targetPid: number, signal?: string | number) => {
-    if (targetPid !== pid) return originalKill(targetPid, signal);
-    if (signal === 0) return true;
-    throw new Error("operation not permitted");
-  }) as unknown as typeof process.kill;
+  fakePids.set(pid, { alive: true, unkillable: true });
+  installKillMock();
 }
 
 describe("startRemoteWebIngress", () => {
@@ -1014,6 +1065,67 @@ describe("startRemoteWebIngress", () => {
       | Record<string, unknown>
       | undefined;
     expect(ingress?.nginx).toBeUndefined();
+  });
+
+  test("a child that outlives the probe but never owns the port is a port conflict", async () => {
+    // The healthy-squatter race: another workspace's edge answers the probe in
+    // milliseconds, while our master is still failing its bind. The child being
+    // alive right after the probe must not count as started.
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawnExitsAfterProbe();
+    mockWebDistMissing();
+    waitForDaemonReadyMock.mockImplementation(async () => true);
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "port-conflict",
+      listenPort: 7845,
+      logPath: join(ws, "data", "logs", "nginx-ingress.log"),
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const ingress = readConfig(ws).ingress as
+      | Record<string, unknown>
+      | undefined;
+    expect(ingress?.nginx).toBeUndefined();
+  });
+
+  test("started requires the pid file to name the live spawned master", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistMissing();
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
+
+    expect(result).toEqual({
+      status: "started",
+      listenPort: 7845,
+      webDistDir: null,
+      version: NGINX_VERSION,
+    });
+    expect(
+      realFs
+        .readFileSync(join(ws, "data", "ingress", "nginx.pid"), "utf-8")
+        .trim(),
+    ).toBe(String(SPAWNED_NGINX_PID));
+    // Ownership confirmed on the first settle iteration: exactly one ps
+    // lookup, for the spawned master's pid, with no polling delay.
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock.mock.calls[0]?.[1]).toContain(
+      String(SPAWNED_NGINX_PID),
+    );
   });
 
   test("a spawn that exits with a failed probe is also a port conflict", async () => {

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -98,12 +98,18 @@ const fakePids = new Map<number, { alive: boolean; unkillable?: boolean }>();
 function installKillMock(): void {
   process.kill = mock((targetPid: number, signal?: string | number) => {
     const entry = fakePids.get(targetPid);
-    if (!entry) return originalKill(targetPid, signal);
+    if (!entry) {
+      return originalKill(targetPid, signal);
+    }
     if (signal === 0) {
-      if (!entry.alive) throw new Error("dead");
+      if (!entry.alive) {
+        throw new Error("dead");
+      }
       return true;
     }
-    if (entry.unkillable) throw new Error("operation not permitted");
+    if (entry.unkillable) {
+      throw new Error("operation not permitted");
+    }
     entry.alive = false;
     return true;
   }) as unknown as typeof process.kill;

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -1068,8 +1068,7 @@ describe("startRemoteWebIngress", () => {
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const ingress = readConfig(ws).ingress as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     expect(ingress?.nginx).toBeUndefined();
   });
 
@@ -1097,8 +1096,7 @@ describe("startRemoteWebIngress", () => {
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const ingress = readConfig(ws).ingress as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     expect(ingress?.nginx).toBeUndefined();
   });
 
@@ -1151,40 +1149,36 @@ describe("startRemoteWebIngress", () => {
     expect(result.status).toBe("port-conflict");
   });
 
-  test(
-    "a child still retrying its bind at the settle deadline is killed before rollback",
-    async () => {
-      const ws = makeWorkspace();
-      mockNginxInstalled();
-      mockWebDistMissing();
-      const kills: string[] = [];
-      // Alive for the whole settle window (nginx retrying its bind), never
-      // writes a pid file; an orphan left running could win the bind later.
-      spawnMock.mockImplementation((() => {
-        return {
-          unref: () => {},
-          exitCode: null,
-          pid: SPAWNED_NGINX_PID,
-          once: () => {},
-          kill: (signal: string) => {
-            kills.push(signal);
-            return true;
-          },
-        } as unknown as ChildProcess;
-      }) as unknown as typeof childProcess.spawn);
+  test("a child still retrying its bind at the settle deadline is killed before rollback", async () => {
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockWebDistMissing();
+    const kills: string[] = [];
+    // Alive for the whole settle window (nginx retrying its bind), never
+    // writes a pid file; an orphan left running could win the bind later.
+    spawnMock.mockImplementation((() => {
+      return {
+        unref: () => {},
+        exitCode: null,
+        pid: SPAWNED_NGINX_PID,
+        once: () => {},
+        kill: (signal: string) => {
+          kills.push(signal);
+          return true;
+        },
+      } as unknown as ChildProcess;
+    }) as unknown as typeof childProcess.spawn);
 
-      const result = await startRemoteWebIngress({
-        workspaceDir: ws,
-        gatewayPort: 7830,
-        listenPort: 7845,
-        includeWebApp: false,
-      });
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+      includeWebApp: false,
+    });
 
-      expect(result.status).toBe("port-conflict");
-      expect(kills).toEqual(["SIGTERM"]);
-    },
-    10_000,
-  );
+    expect(result.status).toBe("port-conflict");
+    expect(kills).toEqual(["SIGTERM"]);
+  }, 10_000);
 });
 
 describe("ensureTunnelEdge", () => {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -587,6 +587,14 @@ export async function stopIngressNginx(workspaceDir: string): Promise<boolean> {
 export const INGRESS_READY_TIMEOUT_MS = 5_000;
 
 /**
+ * Settle budget for the spawned nginx to prove port ownership: a healthy
+ * master records its pid under our prefix within milliseconds, while one that
+ * lost the bind exits. Bounds the wait for whichever happens first.
+ */
+const OWNERSHIP_SETTLE_TIMEOUT_MS = 2_000;
+const OWNERSHIP_SETTLE_INTERVAL_MS = 100;
+
+/**
  * Outcome of an attempt to bring up the nginx ingress edge. Callers render
  * their own messaging per variant: `ensureTunnelEdge` maps failure variants to
  * thrown errors with actionable text, which `vellum tunnel` and
@@ -616,10 +624,11 @@ export type StartRemoteWebIngressResult =
   | { status: "port-conflict"; listenPort: number; logPath: string };
 
 /**
- * Generate the nginx config and start the remote-web ingress edge, then probe
- * /healthz through it to prove the ingress → gateway path is live. A spawned
- * but unreachable nginx is rolled back so a failed attempt leaves no half-up
- * edge behind.
+ * Generate the nginx config and start the remote-web ingress edge, probe
+ * /healthz through it to prove the ingress → gateway path is live, and confirm
+ * via the recorded pid file that the spawned nginx owns the listen port. A
+ * spawned but unreachable or unowned nginx is rolled back so a failed attempt
+ * leaves no half-up edge behind.
  *
  * An edge already running in the requested mode against the requested gateway
  * port short-circuits as `already-running`; one running in the other mode
@@ -722,23 +731,39 @@ export async function startRemoteWebIngress(opts: {
     listenPort,
     opts.readyTimeoutMs ?? INGRESS_READY_TIMEOUT_MS,
   );
+  const rollback = async (
+    status: "port-conflict" | "unreachable",
+  ): Promise<StartRemoteWebIngressResult> => {
+    const { logPath } = getIngressPaths(opts.workspaceDir);
+    await stopIngressNginx(opts.workspaceDir);
+    return { status, listenPort, logPath };
+  };
+  const childExited = (): boolean => exited || child.exitCode !== null;
   // nginx runs `daemon off`, so the spawned process is the master and stays
-  // alive while the edge serves. An early exit means startup failed, and a
-  // probe that still succeeded reached some other process bound to the port
-  // (e.g. another assistant's edge), not this one. Checked before readiness
-  // so a dead spawn is reported as a port conflict, not as this edge.
-  if (exited || child.exitCode !== null) {
-    const { logPath } = getIngressPaths(opts.workspaceDir);
-    await stopIngressNginx(opts.workspaceDir);
-    return { status: "port-conflict", listenPort, logPath };
-  }
+  // alive while the edge serves. An early exit means startup failed: a dead
+  // spawn is reported as a port conflict even when the probe succeeded, since
+  // that probe reached some other process bound to the port (e.g. another
+  // assistant's edge), not this one.
   if (!ready) {
-    const { logPath } = getIngressPaths(opts.workspaceDir);
-    await stopIngressNginx(opts.workspaceDir);
-    return { status: "unreachable", listenPort, logPath };
+    return rollback(childExited() ? "port-conflict" : "unreachable");
   }
-
-  return { status: "started", listenPort, webDistDir, version };
+  // A successful probe alone does not prove ownership either: a healthy edge
+  // from another workspace answers /healthz before our master finishes failing
+  // its bind. A master that won the bind records its pid under our prefix, so
+  // settle-poll until the spawn either exits (lost the bind) or that pid file
+  // names a live ingress nginx of ours (owns the port).
+  const deadline = Date.now() + OWNERSHIP_SETTLE_TIMEOUT_MS;
+  for (;;) {
+    if (childExited()) break;
+    if (getIngressPid(opts.workspaceDir) !== null) {
+      return { status: "started", listenPort, webDistDir, version };
+    }
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) =>
+      setTimeout(resolve, OWNERSHIP_SETTLE_INTERVAL_MS),
+    );
+  }
+  return rollback("port-conflict");
 }
 
 /** Retry policy for the `web-remote-ingress` flag lookup. */

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -591,7 +591,10 @@ export const INGRESS_READY_TIMEOUT_MS = 5_000;
  * master records its pid under our prefix within milliseconds, while one that
  * lost the bind exits. Bounds the wait for whichever happens first.
  */
-const OWNERSHIP_SETTLE_TIMEOUT_MS = 2_000;
+// The settle window must outlast nginx's internal bind-retry loop (5 attempts
+// with 500ms sleeps) so a contested bind resolves to a child exit rather than
+// a timeout while the child is still retrying.
+const OWNERSHIP_SETTLE_TIMEOUT_MS = 4_000;
 const OWNERSHIP_SETTLE_INTERVAL_MS = 100;
 
 /**
@@ -761,6 +764,14 @@ export async function startRemoteWebIngress(opts: {
       return { status: "started", listenPort, webDistDir, version };
     }
     if (Date.now() >= deadline) {
+      // The child is alive but never proved ownership. Kill it before rolling
+      // back: it may still be inside nginx's bind-retry loop, and an orphan
+      // that later wins the bind would serve with no recorded state.
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Already gone; the rollback below clears any remaining state.
+      }
       break;
     }
     await new Promise((resolve) =>

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -754,11 +754,15 @@ export async function startRemoteWebIngress(opts: {
   // names a live ingress nginx of ours (owns the port).
   const deadline = Date.now() + OWNERSHIP_SETTLE_TIMEOUT_MS;
   for (;;) {
-    if (childExited()) break;
+    if (childExited()) {
+      break;
+    }
     if (getIngressPid(opts.workspaceDir) !== null) {
       return { status: "started", listenPort, webDistDir, version };
     }
-    if (Date.now() >= deadline) break;
+    if (Date.now() >= deadline) {
+      break;
+    }
     await new Promise((resolve) =>
       setTimeout(resolve, OWNERSHIP_SETTLE_INTERVAL_MS),
     );


### PR DESCRIPTION
## Summary
- startRemoteWebIngress no longer trusts a ready probe plus a not-yet-exited child; it settle-polls until the spawned nginx either exits (port-conflict) or provably owns the port via our prefix's pid file (getIngressPid)
- Closes the race where a healthy edge from another workspace answered the probe before our nginx finished failing its bind, producing a false Started and state for an unowned edge

## Original prompt
Live testing of the tunnel-edge unification reproduced the cross-assistant collision Codex flagged: with another workspace's edge on 7840, the CLI reported Started while no new nginx master existed. Replace the exit-timing check with positive pid-file ownership.