### PR TITLE
fix(web): degrade voice cleanly for paired assistants

### DIFF
--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -190,6 +190,24 @@ describe("startDictationStream", () => {
     expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
   });
 
+  test("returns null for a paired-assistant ingress without dialling a socket", () => {
+    // The paired __gateway-paired proxy is HTTP-only, so streaming partials
+    // must skip deterministically; batch dictation is unaffected.
+    ingressUrl = "http://localhost:3000/assistant/__gateway-paired/asst-1";
+    let dialled = 0;
+    const handle = startDictationStream(
+      { onPartial: () => undefined },
+      {
+        webSocketFactory: () => {
+          dialled += 1;
+          throw new Error("unexpected socket dial for a paired ingress");
+        },
+      },
+    );
+    expect(handle).toBeNull();
+    expect(dialled).toBe(0);
+  });
+
   test("starts capture on open and composes partial/final transcripts", async () => {
     const partials: string[] = [];
     const { handle, ws, captureFake } = startWithFakes((t) => partials.push(t));

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -33,7 +33,10 @@ import {
   type LiveVoiceAudioCaptureOptions,
   type LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
-import { buildSelfHostedGatewayWsUrl } from "@/domains/chat/voice/live-voice/connection";
+import {
+  buildSelfHostedGatewayWsUrl,
+  isPairedGatewayIngress,
+} from "@/domains/chat/voice/live-voice/connection";
 import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/chat/voice/live-voice/protocol";
 import {
   getSelfHostedActorToken,
@@ -125,6 +128,14 @@ export function startDictationStream(
     // per session attempt so a missing-partials report is diagnosable.
     console.info(
       "dictation-stream: skipping (no self-hosted ingress/token or no AudioWorklet)",
+    );
+    return null;
+  }
+  if (isPairedGatewayIngress(ingressUrl)) {
+    // The paired gateway proxy is HTTP-only, so no STT stream WS exists;
+    // batch dictation over HTTP still works, only live partials are skipped.
+    console.info(
+      "dictation-stream: skipping (voice streaming isn't available for paired assistants yet)",
     );
     return null;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -21,8 +21,10 @@ import {
   buildLiveVoiceWsUrl,
   buildSelfHostedLiveVoiceWsUrl,
   getVelayWsScheme,
+  isPairedGatewayIngress,
   LiveVoiceTokenError,
   mintLiveVoiceToken,
+  PairedVoiceUnavailableError,
   resolveLiveVoiceWsUrl,
 } from "./connection";
 
@@ -252,6 +254,30 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
     expect(url.pathname).toBe("/v1/live-voice");
   });
 
+  test("paired __gateway-paired path throws PairedVoiceUnavailableError (browser origin)", () => {
+    // The paired proxy is HTTP-only and has no loopback port to bypass to, so
+    // no WS URL exists; the builder must fail typed instead of producing a
+    // ws://localhost URL no host upgrades.
+    expect(() =>
+      buildSelfHostedLiveVoiceWsUrl({
+        ingressUrl: "http://localhost:3000/assistant/__gateway-paired/asst-1",
+        token: "actor-tok",
+      }),
+    ).toThrow(PairedVoiceUnavailableError);
+  });
+
+  test("paired __gateway-paired path throws on an Electron app:// origin too", () => {
+    // The app:// protocol can't be rewritten to wss (the WHATWG setter no-ops
+    // on non-special to special), so this branch used to throw an opaque
+    // WebSocket construction error; now it fails typed before any dial.
+    expect(() =>
+      buildSelfHostedLiveVoiceWsUrl({
+        ingressUrl: "app://vellum/assistant/__gateway-paired/asst-1",
+        token: "actor-tok",
+      }),
+    ).toThrow(PairedVoiceUnavailableError);
+  });
+
   test("remote ingress (no __gateway path) keeps its host and appends the route", () => {
     // A real remote gateway ingress is dialled as-is — only the local proxy path
     // is rewritten to loopback.
@@ -322,5 +348,58 @@ describe("resolveLiveVoiceWsUrl", () => {
       resolveLiveVoiceWsUrl({ assistantId: "assistant-1" }),
     ).rejects.toBeInstanceOf(LiveVoiceTokenError);
     expect(captured).toBeNull();
+  });
+
+  test("paired ingress rejects with the voice-unavailable reason (and does not mint)", async () => {
+    // GIVEN the active selection is a paired assistant riding the HTTP-only
+    // same-origin proxy
+    setSelfHostedConnection({
+      url: "http://localhost:3000/assistant/__gateway-paired/asst-1",
+      token: "actor-tok",
+    });
+
+    // THEN the resolve fails typed with the user-facing reason live-voice
+    // surfaces via Error.message, and no velay token is minted
+    await expect(
+      resolveLiveVoiceWsUrl({ assistantId: "assistant-1" }),
+    ).rejects.toThrow("Voice isn't available for paired assistants yet.");
+    expect(captured).toBeNull();
+  });
+
+  test("paired ingress rejects even before the actor token is provisioned", async () => {
+    setSelfHostedConnection({
+      url: "app://vellum/assistant/__gateway-paired/asst-1",
+      token: null,
+    });
+
+    await expect(
+      resolveLiveVoiceWsUrl({ assistantId: "assistant-1" }),
+    ).rejects.toBeInstanceOf(PairedVoiceUnavailableError);
+    expect(captured).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPairedGatewayIngress
+// ---------------------------------------------------------------------------
+
+describe("isPairedGatewayIngress", () => {
+  test("matches the paired proxy path on browser and Electron origins", () => {
+    expect(
+      isPairedGatewayIngress(
+        "http://localhost:3000/assistant/__gateway-paired/asst-1",
+      ),
+    ).toBe(true);
+    expect(
+      isPairedGatewayIngress("app://vellum/assistant/__gateway-paired/asst-1"),
+    ).toBe(true);
+  });
+
+  test("does not match local proxy paths, remote ingresses, or junk", () => {
+    expect(
+      isPairedGatewayIngress("http://localhost:3000/assistant/__gateway/7821"),
+    ).toBe(false);
+    expect(isPairedGatewayIngress("https://x.ngrok-free.app")).toBe(false);
+    expect(isPairedGatewayIngress("not a url")).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -215,6 +215,40 @@ export interface BuildSelfHostedLiveVoiceWsUrlArgs {
  */
 const LOCAL_GATEWAY_PROXY_PATH = /^\/assistant\/__gateway\/(\d+)\/?$/;
 
+/**
+ * Paired gateway proxy path (`/assistant/__gateway-paired/<assistantId>`) as
+ * produced by `pairedGatewayProxyUrl` in local-mode. Like the local proxy, the
+ * hosts serving it forward HTTP only and drop WS upgrades; unlike the local
+ * proxy there is no loopback port to bypass to (the real gateway lives on
+ * another machine), so no WebSocket transport exists for a paired assistant.
+ */
+const PAIRED_GATEWAY_PROXY_PATH = /^\/assistant\/__gateway-paired\//;
+
+/**
+ * Whether a self-hosted ingress URL rides the paired gateway proxy, which
+ * cannot carry a WebSocket upgrade. Voice entry points use this to degrade
+ * cleanly instead of dialling an unusable socket.
+ */
+export function isPairedGatewayIngress(ingressUrl: string): boolean {
+  try {
+    return PAIRED_GATEWAY_PROXY_PATH.test(new URL(ingressUrl).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Thrown when a voice WebSocket URL is requested for a paired-assistant
+ * ingress. The message is user-facing: live-voice's connect failure path
+ * surfaces `Error.message` as the displayed reason.
+ */
+export class PairedVoiceUnavailableError extends Error {
+  constructor() {
+    super("Voice isn't available for paired assistants yet.");
+    this.name = "PairedVoiceUnavailableError";
+  }
+}
+
 export interface BuildSelfHostedGatewayWsUrlArgs {
   /**
    * The user's gateway ingress URL (e.g. `https://x.ngrok-free.app` or the local
@@ -242,6 +276,10 @@ export interface BuildSelfHostedGatewayWsUrlArgs {
  * - **Local `/assistant/__gateway/<port>` proxy path → direct loopback dial**
  *   (`ws://127.0.0.1:<port>{routePath}`), since that HTTP-only proxy can't carry
  *   the WS upgrade — see {@link LOCAL_GATEWAY_PROXY_PATH}.
+ * - **Paired `/assistant/__gateway-paired/<id>` proxy path → throws
+ *   {@link PairedVoiceUnavailableError}**: the proxy is HTTP-only and there is
+ *   no direct dial to fall back to, so no usable WS URL exists (see
+ *   {@link PAIRED_GATEWAY_PROXY_PATH}).
  * - **Remote ingress** (e.g. an ngrok `wss://` URL) keeps its host and path
  *   prefix, with `routePath` appended. Any query/hash on the ingress is dropped.
  */
@@ -252,6 +290,9 @@ export function buildSelfHostedGatewayWsUrl({
   params,
 }: BuildSelfHostedGatewayWsUrlArgs): string {
   const ingress = new URL(ingressUrl);
+  if (PAIRED_GATEWAY_PROXY_PATH.test(ingress.pathname)) {
+    throw new PairedVoiceUnavailableError();
+  }
   const localProxy = ingress.pathname.match(LOCAL_GATEWAY_PROXY_PATH);
 
   let target: URL;
@@ -306,7 +347,10 @@ export interface ResolveLiveVoiceWsUrlArgs {
  *   token-exchange happens. Throws {@link LiveVoiceTokenError} if the ingress is
  *   known but the actor token hasn't been provisioned yet (a brief post-hatch
  *   window), so the caller surfaces a connection failure rather than dialling an
- *   unauthenticated socket.
+ *   unauthenticated socket. A paired ingress throws
+ *   {@link PairedVoiceUnavailableError} first: the paired proxy is HTTP-only,
+ *   so no live-voice transport exists and the caller surfaces the
+ *   voice-unavailable reason.
  * - **Cloud** — mint a short-lived velay WS token and build the velay URL.
  */
 export async function resolveLiveVoiceWsUrl({
@@ -315,6 +359,9 @@ export async function resolveLiveVoiceWsUrl({
 }: ResolveLiveVoiceWsUrlArgs): Promise<string> {
   const ingressUrl = getSelfHostedIngressUrl();
   if (ingressUrl) {
+    if (isPairedGatewayIngress(ingressUrl)) {
+      throw new PairedVoiceUnavailableError();
+    }
     const token = getSelfHostedActorToken();
     if (!token) {
       throw new LiveVoiceTokenError(


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for web-paired-entries.md.

**Gap:** voice affordances for a paired selection built unusable WebSocket URLs (app:// protocol rewrite no-op / ws://localhost paired path) and failed obscurely.
**Fix:** the self-hosted WS URL builder recognizes the paired proxy prefix and reports voice as unavailable for paired assistants; callers degrade deterministically.