### PR TITLE
fix(macos,web): notification taps that never navigate — GC'd banners and cold-launch drops

### DIFF
--- a/clients/macos/src/main/notifications.test.ts
+++ b/clients/macos/src/main/notifications.test.ts
@@ -154,6 +154,8 @@ const {
   NOTIFICATION_CATEGORIES,
   __resetForTesting,
   __setDeliveryTimeoutForTesting,
+  __liveNotificationCountForTesting,
+  __pruneForTesting,
 } = await import("./notifications");
 
 // --- Helpers ---------------------------------------------------------------
@@ -416,6 +418,99 @@ describe("interaction broadcast", () => {
   });
 });
 
+// --- Notification liveness -------------------------------------------------
+//
+// `new Notification(...)` is function-local, so once the delivery promise
+// settles nothing references it and V8 may collect it — while the macOS
+// banner lives on in Notification Center for hours. A collected
+// notification still activates the app on click (macOS does that itself)
+// but fires no `click` in main, so the tap vanishes and the renderer lands
+// on its bootstrap default. These assert the object stays reachable for as
+// long as the banner is clickable, and is released once it isn't.
+
+describe("keeping shown notifications reachable", () => {
+  const payload = {
+    category: "notificationIntent",
+    title: "Review request",
+    body: "An item needs your attention",
+    deliveryId: "del-live",
+    conversationId: "conv-live",
+  };
+
+  test("a shown notification is retained", async () => {
+    await show(payload);
+    expect(__liveNotificationCountForTesting()).toBe(1);
+  });
+
+  // The regression itself: a click long after `show` must still deep-link.
+  test("a click well after delivery still broadcasts", async () => {
+    await show(payload);
+
+    at(6 * 60 * 60 * 1000); // six hours later
+    constructed[0]!.emit("click");
+
+    const actions = sentMessages.filter((m) => m.channel === ACTION_CHANNEL);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.payload).toMatchObject({
+      kind: "click",
+      conversationId: "conv-live",
+    });
+  });
+
+  test("a clicked notification is released", async () => {
+    await show(payload);
+    constructed[0]!.emit("click");
+    expect(__liveNotificationCountForTesting()).toBe(0);
+  });
+
+  test("a dismissed notification is released", async () => {
+    await show(payload);
+    constructed[0]!.emit("close");
+    expect(__liveNotificationCountForTesting()).toBe(0);
+  });
+
+  test("an action press releases the notification", async () => {
+    await show({ ...payload, category: "toolConfirmation" });
+    constructed[0]!.emit("action", {}, 0);
+    expect(__liveNotificationCountForTesting()).toBe(0);
+  });
+
+  test("a failed delivery is released", async () => {
+    deliveryOutcome = "failed";
+    await show(payload);
+    expect(__liveNotificationCountForTesting()).toBe(0);
+  });
+
+  // macOS does not guarantee `close` for a banner that ages out of
+  // Notification Center, so the TTL sweep is the backstop that keeps an
+  // always-on app from holding every notification it ever showed.
+  test("the prune sweep drops notifications past the TTL", async () => {
+    await show(payload);
+    expect(__liveNotificationCountForTesting()).toBe(1);
+
+    at(25 * 60 * 60 * 1000); // past the 24h TTL
+    __pruneForTesting();
+
+    expect(__liveNotificationCountForTesting()).toBe(0);
+  });
+
+  test("the sweep keeps notifications inside the TTL", async () => {
+    await show(payload);
+
+    at(60 * 60 * 1000); // one hour later
+    __pruneForTesting();
+
+    expect(__liveNotificationCountForTesting()).toBe(1);
+  });
+
+  test("a burst is capped so retention cannot grow without bound", async () => {
+    for (let i = 0; i < 300; i++) {
+      await show({ ...payload, deliveryId: `del-${i}`, body: `b-${i}` });
+    }
+    expect(__liveNotificationCountForTesting()).toBe(256);
+  });
+});
+
 // --- Tap buffering ---------------------------------------------------------
 //
 // Clicking a banner while the app is closed (or still booting) is exactly
@@ -462,8 +557,8 @@ describe("tap buffering for taps that beat the renderer", () => {
 
   const clickPayload = {
     category: "notificationIntent",
-    title: "Zoom assets",
-    body: "Needs your review",
+    title: "Review request",
+    body: "An item needs your attention",
     deliveryId: "del-1",
     conversationId: "conv-1",
   };

--- a/clients/macos/src/main/notifications.test.ts
+++ b/clients/macos/src/main/notifications.test.ts
@@ -116,7 +116,22 @@ const handleMock = mock(
     handleRegistrations.push({ channel, schema, fn });
   },
 );
-mock.module("./ipc", () => ({ handle: handleMock }));
+type OnRegistration = {
+  channel: string;
+  schema: z.ZodType<unknown[]>;
+  fn: (args: unknown[], event: { sender: unknown }) => unknown;
+};
+const onRegistrations: OnRegistration[] = [];
+const onMock = mock(
+  (
+    channel: string,
+    schema: z.ZodType<unknown[]>,
+    fn: (args: unknown[], event: { sender: unknown }) => unknown,
+  ) => {
+    onRegistrations.push({ channel, schema, fn });
+  },
+);
+mock.module("./ipc", () => ({ handle: handleMock, on: onMock }));
 
 // --- Mock: ./main-window (ensureVisible spy) -------------------------------
 
@@ -171,7 +186,9 @@ beforeEach(() => {
   constructed.length = 0;
   sentMessages.length = 0;
   handleRegistrations.length = 0;
+  onRegistrations.length = 0;
   handleMock.mockClear();
+  onMock.mockClear();
   ensureVisibleMock.mockClear();
   at(0);
   installNotifications();
@@ -396,5 +413,142 @@ describe("interaction broadcast", () => {
       actionText: "Deny",
       deliveryId: "del-9",
     });
+  });
+});
+
+// --- Tap buffering ---------------------------------------------------------
+//
+// Clicking a banner while the app is closed (or still booting) is exactly
+// when the user most expects to land on the conversation, and exactly when
+// no renderer is subscribed to receive the broadcast. An un-listened
+// `webContents.send` is dropped, not queued, so main buffers the tap for
+// the drain the renderer performs on mount.
+
+describe("tap buffering for taps that beat the renderer", () => {
+  const DRAIN_CHANNEL = "vellum:notifications:drainActions";
+  const SUBSCRIBE_CHANNEL = "vellum:notifications:subscribeActions";
+  const UNSUBSCRIBE_CHANNEL = "vellum:notifications:unsubscribeActions";
+
+  const registrationFor = (channel: string): HandleRegistration => {
+    const reg = handleRegistrations.find((r) => r.channel === channel);
+    if (!reg) throw new Error(`no handler registered for ${channel}`);
+    return reg;
+  };
+  const listenerFor = (channel: string): OnRegistration => {
+    const reg = onRegistrations.find((r) => r.channel === channel);
+    if (!reg) throw new Error(`no listener registered for ${channel}`);
+    return reg;
+  };
+
+  const drain = () =>
+    registrationFor(DRAIN_CHANNEL).fn([]) as Array<{ kind: string }>;
+  const subscribe = (sender: unknown) =>
+    listenerFor(SUBSCRIBE_CHANNEL).fn([], { sender });
+  const unsubscribe = (sender: unknown) =>
+    listenerFor(UNSUBSCRIBE_CHANNEL).fn([], { sender });
+
+  /** A `WebContents` stand-in whose `once("destroyed", …)` main relies on. */
+  const makeSender = () => {
+    const destroyedHandlers: Array<() => void> = [];
+    return {
+      once: (event: string, cb: () => void) => {
+        if (event === "destroyed") destroyedHandlers.push(cb);
+      },
+      destroy: () => {
+        for (const cb of destroyedHandlers) cb();
+      },
+    };
+  };
+
+  const clickPayload = {
+    category: "notificationIntent",
+    title: "Zoom assets",
+    body: "Needs your review",
+    deliveryId: "del-1",
+    conversationId: "conv-1",
+  };
+
+  test("registers the drain, subscribe, and unsubscribe channels", () => {
+    expect(handleRegistrations.map((r) => r.channel)).toContain(DRAIN_CHANNEL);
+    expect(onRegistrations.map((r) => r.channel)).toEqual([
+      SUBSCRIBE_CHANNEL,
+      UNSUBSCRIBE_CHANNEL,
+    ]);
+  });
+
+  test("buffers a tap when no renderer is subscribed, and drain returns it", async () => {
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(drain()).toMatchObject([{ kind: "click", conversationId: "conv-1" }]);
+  });
+
+  test("drain clears the buffer so a tap is never replayed twice", async () => {
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(drain()).toHaveLength(1);
+    expect(drain()).toHaveLength(0);
+  });
+
+  test("does not buffer once a renderer is subscribed — it gets the live broadcast", async () => {
+    subscribe(makeSender());
+
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(
+      sentMessages.filter((m) => m.channel === ACTION_CHANNEL),
+    ).toHaveLength(1);
+    expect(drain()).toHaveLength(0);
+  });
+
+  test("buffers again after the last renderer unsubscribes", async () => {
+    const sender = makeSender();
+    subscribe(sender);
+    unsubscribe(sender);
+
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(drain()).toHaveLength(1);
+  });
+
+  // A window closed without running its React cleanup kills the JS context
+  // before the unsubscribe IPC is sent. Without the `destroyed` fallback the
+  // subscriber would leak and every later tap would be silently dropped.
+  test("a destroyed renderer stops counting as a subscriber", async () => {
+    const sender = makeSender();
+    subscribe(sender);
+    sender.destroy();
+
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(drain()).toHaveLength(1);
+  });
+
+  test("re-subscribing the same renderer does not double-register", async () => {
+    const sender = makeSender();
+    subscribe(sender);
+    subscribe(sender);
+    unsubscribe(sender);
+
+    await show(clickPayload);
+    constructed[0]!.emit("click");
+
+    expect(drain()).toHaveLength(1);
+  });
+
+  test("caps the buffer, keeping the most recent taps", async () => {
+    for (let i = 0; i < 20; i++) {
+      await show({ ...clickPayload, deliveryId: `del-${i}`, body: `b-${i}` });
+      constructed[i]!.emit("click");
+    }
+
+    const drained = drain();
+    expect(drained).toHaveLength(16);
+    expect(drained.at(-1)).toMatchObject({ deliveryId: "del-19" });
+    expect(drained[0]).toMatchObject({ deliveryId: "del-4" });
   });
 });

--- a/clients/macos/src/main/notifications.ts
+++ b/clients/macos/src/main/notifications.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Notification } from "electron";
+import { BrowserWindow, Notification, type WebContents } from "electron";
 import { z } from "zod";
 
 import {
@@ -9,7 +9,7 @@ import {
   showNotificationPayloadSchema,
 } from "@vellumai/ipc-contract";
 
-import { handle } from "./ipc";
+import { handle, on } from "./ipc";
 import { ensureVisible } from "./main-window";
 import log from "./logger";
 
@@ -175,7 +175,40 @@ let deliveryTimeoutMs = DELIVERY_TIMEOUT_MS;
 // Show notification
 // ---------------------------------------------------------------------------
 
+/**
+ * Taps arriving before a renderer is listening, queued for the drain the
+ * renderer performs on mount.
+ *
+ * A tap is the one notification event with nowhere else to go: clicking a
+ * banner while the app is closed (or still booting) is precisely when the
+ * user most expects to land on the conversation, and it is also when no
+ * renderer exists to receive the broadcast. `ensureVisible()` opens the
+ * window, but `webContents.send` on the next line reaches a renderer that
+ * has not yet subscribed -- and an un-listened `send` is dropped, not
+ * queued. Buffering here is the same shape `deep-links.ts` uses for
+ * `vellum://thread/...`, which has the identical cold-launch problem.
+ *
+ * Bounded because a buffered tap is only worth replaying while it still
+ * describes what the user just clicked; past the cap the oldest go.
+ */
+const MAX_PENDING_ACTIONS = 16;
+const pendingActions: NotificationActionEvent[] = [];
+
+/**
+ * Renderers listening for taps, tracked by `WebContents` rather than a
+ * count so a window torn down without running its React cleanup cannot
+ * leak a subscriber and silently flip buffering off for every later tap.
+ * Mirrors the subscriber model in `deep-links.ts`.
+ */
+const actionSubscribers = new Set<WebContents>();
+
 const broadcastAction = (event: NotificationActionEvent): void => {
+  if (actionSubscribers.size === 0) {
+    pendingActions.push(event);
+    if (pendingActions.length > MAX_PENDING_ACTIONS) {
+      pendingActions.shift();
+    }
+  }
   for (const win of BrowserWindow.getAllWindows()) {
     if (win.isDestroyed()) {
       continue;
@@ -292,12 +325,38 @@ export const installNotifications = (): void => {
     ([payload]) => showNotification(payload),
   );
 
+  // Renderer drains on mount; returns AND clears the buffer. Whether a
+  // later tap is buffered is governed by `actionSubscribers`, not by
+  // whether drain has run.
+  handle("vellum:notifications:drainActions", z.tuple([]), () =>
+    pendingActions.splice(0, pendingActions.length),
+  );
+
+  // Subscriber accounting. The preload sends these around its
+  // `ipcRenderer.on` registration; the `destroyed` listener covers the
+  // window-close path, where the JS context dies before React effect
+  // cleanup can run.
+  on("vellum:notifications:subscribeActions", z.tuple([]), (_args, event) => {
+    if (actionSubscribers.has(event.sender)) {
+      return;
+    }
+    actionSubscribers.add(event.sender);
+    event.sender.once("destroyed", () => {
+      actionSubscribers.delete(event.sender);
+    });
+  });
+  on("vellum:notifications:unsubscribeActions", z.tuple([]), (_args, event) => {
+    actionSubscribers.delete(event.sender);
+  });
+
   pruneTimer = setInterval(pruneStaleEntries, PRUNE_INTERVAL_MS);
 };
 
 // Test seam
 export const __resetForTesting = (): void => {
   recentNotifications.clear();
+  actionSubscribers.clear();
+  pendingActions.length = 0;
   deliveryTimeoutMs = DELIVERY_TIMEOUT_MS;
   if (pruneTimer) {
     clearInterval(pruneTimer);

--- a/clients/macos/src/main/notifications.ts
+++ b/clients/macos/src/main/notifications.ts
@@ -142,6 +142,77 @@ const pruneStaleEntries = (): void => {
       recentNotifications.delete(key);
     }
   }
+  pruneStaleLiveNotifications();
+};
+
+// ---------------------------------------------------------------------------
+// Liveness — keeping `Notification` objects reachable
+// ---------------------------------------------------------------------------
+
+/**
+ * Notifications still on screen, held so their `click` handler survives.
+ *
+ * `new Notification(...)` is function-local: once the delivery promise
+ * settles (on `show`, milliseconds later) nothing in the process references
+ * it, and V8 is free to collect it. The macOS banner long outlives that --
+ * it sits in Notification Center for hours. Clicking a collected one still
+ * activates the app, because macOS does that itself, but fires no `click`
+ * in the main process: no `broadcastAction`, no deep link, and the renderer
+ * lands on its bootstrap default -- the user's most recent conversation.
+ * The tap is gone with no error anywhere.
+ *
+ * That is the shape of the bug this map exists to prevent: not a crash, a
+ * notification that quietly stops being clickable some seconds after it
+ * appears. Keeping a reference until the OS is done with the banner is the
+ * documented requirement for `electron.Notification`, the same one `Tray`
+ * carries.
+ *
+ * Entries are released on `click` / `close` / `failed`, and swept by TTL as
+ * a backstop -- macOS does not guarantee `close` for a banner that ages out
+ * of Notification Center, so without the sweep a long-running app would
+ * accumulate them.
+ */
+interface LiveNotification {
+  notif: Electron.Notification;
+  shownAt: number;
+}
+const liveNotifications = new Map<number, LiveNotification>();
+let liveNotificationSeq = 0;
+
+/**
+ * How long a banner stays clickable. Generous because that is the whole
+ * point -- a notification the user gets to after lunch must still deep-link
+ * -- but bounded so an always-on desktop app does not hold every
+ * notification it has ever shown.
+ */
+const LIVE_NOTIFICATION_TTL_MS = 24 * 60 * 60 * 1000;
+/** Hard ceiling, in case a burst outpaces the TTL sweep. */
+const MAX_LIVE_NOTIFICATIONS = 256;
+
+const retainNotification = (notif: Electron.Notification): number => {
+  const id = ++liveNotificationSeq;
+  liveNotifications.set(id, { notif, shownAt: Date.now() });
+  while (liveNotifications.size > MAX_LIVE_NOTIFICATIONS) {
+    const oldest = liveNotifications.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    liveNotifications.delete(oldest);
+  }
+  return id;
+};
+
+const releaseNotification = (id: number): void => {
+  liveNotifications.delete(id);
+};
+
+const pruneStaleLiveNotifications = (): void => {
+  const cutoff = Date.now() - LIVE_NOTIFICATION_TTL_MS;
+  for (const [id, entry] of liveNotifications) {
+    if (entry.shownAt < cutoff) {
+      liveNotifications.delete(id);
+    }
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -203,6 +274,16 @@ const pendingActions: NotificationActionEvent[] = [];
 const actionSubscribers = new Set<WebContents>();
 
 const broadcastAction = (event: NotificationActionEvent): void => {
+  // Logged unconditionally: every previous way a tap could go missing did so
+  // in silence, which is why diagnosing one needed the source rather than a
+  // feedback bundle. A tap reaching main is now always on the record.
+  log.info("[notifications] tap received", {
+    kind: event.kind,
+    category: event.category,
+    hasConversationId: event.conversationId != null,
+    subscribers: actionSubscribers.size,
+    buffered: actionSubscribers.size === 0,
+  });
   if (actionSubscribers.size === 0) {
     pendingActions.push(event);
     if (pendingActions.length > MAX_PENDING_ACTIONS) {
@@ -256,12 +337,19 @@ const showNotification = (payload: ShowNotificationPayload): Promise<ShowResult>
     deepLinkMetadata: payload.deepLinkMetadata,
   };
 
+  // Hold the object reachable for as long as the banner is clickable.
+  // Registered before the handlers so nothing can observe an unretained
+  // notification. See `liveNotifications` for why this is load-bearing.
+  const liveId = retainNotification(notif);
+
   notif.on("click", () => {
+    releaseNotification(liveId);
     void ensureVisible();
     broadcastAction({ kind: "click", ...baseMeta });
   });
 
   notif.on("action", (_event: Electron.Event, index: number) => {
+    releaseNotification(liveId);
     void ensureVisible();
     const actionDef = actions[index];
     broadcastAction({
@@ -270,6 +358,11 @@ const showNotification = (payload: ShowNotificationPayload): Promise<ShowResult>
       actionText: actionDef?.text,
       ...baseMeta,
     });
+  });
+
+  // The user dismissed the banner (or the OS retired it) without acting.
+  notif.on("close", () => {
+    releaseNotification(liveId);
   });
 
   // Resolve the IPC result from the real delivery outcome so the renderer
@@ -303,6 +396,7 @@ const showNotification = (payload: ShowNotificationPayload): Promise<ShowResult>
     });
 
     notif.on("failed", (_event, error) => {
+      releaseNotification(liveId);
       // Electron delivers the `failed` error as a string description.
       log.warn("[notifications] Notification failed:", error);
       settle({ success: false, errorMessage: error });
@@ -355,6 +449,8 @@ export const installNotifications = (): void => {
 // Test seam
 export const __resetForTesting = (): void => {
   recentNotifications.clear();
+  liveNotifications.clear();
+  liveNotificationSeq = 0;
   actionSubscribers.clear();
   pendingActions.length = 0;
   deliveryTimeoutMs = DELIVERY_TIMEOUT_MS;
@@ -368,4 +464,12 @@ export const __resetForTesting = (): void => {
 // can be exercised without waiting the full production duration.
 export const __setDeliveryTimeoutForTesting = (ms: number): void => {
   deliveryTimeoutMs = ms;
+};
+
+// Test seams — assert that shown notifications stay reachable (and are
+// released) without reaching into module internals from the test.
+export const __liveNotificationCountForTesting = (): number =>
+  liveNotifications.size;
+export const __pruneForTesting = (): void => {
+  pruneStaleEntries();
 };

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -472,6 +472,10 @@ const bridge: VellumBridge = {
         "vellum:notifications:show",
         payload,
       ) as Promise<{ success: boolean; errorMessage?: string }>,
+    drainActions: (): Promise<NotificationActionEvent[]> =>
+      ipcRenderer.invoke("vellum:notifications:drainActions") as Promise<
+        NotificationActionEvent[]
+      >,
     onAction: (callback) => {
       const handler = (
         _event: IpcRendererEvent,
@@ -480,8 +484,13 @@ const bridge: VellumBridge = {
         callback(event);
       };
       ipcRenderer.on("vellum:notifications:action", handler);
+      // Tell main a renderer is listening so it stops buffering taps.
+      // Without this every live tap would also enter the buffer and be
+      // replayed on a later drain (renderer reload, logout-relogin).
+      ipcRenderer.send("vellum:notifications:subscribeActions");
       return () => {
         ipcRenderer.off("vellum:notifications:action", handler);
+        ipcRenderer.send("vellum:notifications:unsubscribeActions");
       };
     },
   },

--- a/clients/web/src/hooks/use-notification-tap-navigation.ts
+++ b/clients/web/src/hooks/use-notification-tap-navigation.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import * as Sentry from "@sentry/react";
 
+import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
 import { publish } from "@/lib/event-bus";
 import { setNotificationTapHandler } from "@/runtime/notifications";
 
@@ -26,6 +27,16 @@ export function useNotificationTapNavigation(): void {
       return;
     }
     setNotificationTapHandler((payload) => {
+      // Recorded on the lifecycle ring, not only as a Sentry breadcrumb: a
+      // breadcrumb surfaces only when some later event is captured, so it
+      // cannot answer "did my tap navigate?" from a feedback bundle. The
+      // whole class of tap bugs here was invisible for exactly that reason.
+      recordLifecycleDiagnostic("notification_tap", {
+        sourceEventName: payload.sourceEventName,
+        deliveryId: payload.deliveryId,
+        conversationId: payload.conversationId,
+        navigated: payload.conversationId != null,
+      });
       if (payload.conversationId) {
         publish("deeplink.openThread", { threadId: payload.conversationId });
         return;

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -278,6 +278,12 @@ declare global {
         onAction(
           callback: (event: NotificationActionEvent) => void,
         ): () => void;
+        /**
+         * Return AND clear the taps main buffered while no renderer was
+         * listening — a click that launched the app, or landed while it
+         * was still booting.
+         */
+        drainActions(): Promise<NotificationActionEvent[]>;
       };
       popout?: {
         open(conversationId: string): Promise<void>;

--- a/clients/web/src/runtime/notification-tap-buffering.test.ts
+++ b/clients/web/src/runtime/notification-tap-buffering.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Notification taps that arrive before the renderer is listening.
+ *
+ * Clicking a banner while the app is closed is exactly when the user most
+ * expects to land on the conversation, and exactly when no renderer is
+ * subscribed: `tapHandler` is registered from a React effect at
+ * `RootLayout`, long after the main process fires the click. Main buffers
+ * those taps; this covers the renderer half — subscribe, drain, replay —
+ * plus the local guard that keeps any path from dropping a tap silently.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { NotificationTapPayload } from "@/runtime/notifications";
+
+// ── host platform guards ────────────────────────────────────────────────────
+//
+// Force the Electron branch: it is the one with a main-process buffer to
+// drain, and the branch the desktop app actually takes.
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => true,
+}));
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+}));
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeAndroid: () => false,
+}));
+
+const captureErrorMock = mock((_error: unknown, _context: unknown) => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+// ── the Electron bridge ─────────────────────────────────────────────────────
+
+interface ActionEvent {
+  kind: string;
+  category: string;
+  conversationId?: string;
+  deliveryId?: string;
+}
+
+let actionCallback: ((event: ActionEvent) => void) | null = null;
+let bufferedActions: ActionEvent[] = [];
+let drainRejects = false;
+let drainResolvers: Array<() => void> = [];
+/** When true, `drainActions` waits for `releaseDrain()` before resolving. */
+let drainDeferred = false;
+
+const onActionMock = mock((cb: (event: ActionEvent) => void) => {
+  actionCallback = cb;
+  return () => {
+    actionCallback = null;
+  };
+});
+const drainActionsMock = mock(async (): Promise<ActionEvent[]> => {
+  if (drainRejects) {
+    throw new Error("drain failed");
+  }
+  if (drainDeferred) {
+    await new Promise<void>((resolve) => drainResolvers.push(resolve));
+  }
+  return bufferedActions;
+});
+
+const releaseDrain = () => {
+  for (const resolve of drainResolvers) {
+    resolve();
+  }
+  drainResolvers = [];
+};
+
+Object.defineProperty(window, "vellum", {
+  configurable: true,
+  writable: true,
+  value: {
+    notifications: { onAction: onActionMock, drainActions: drainActionsMock },
+  },
+});
+
+const { setNotificationTapHandler, __resetNotificationsStateForTests } =
+  await import("@/runtime/notifications");
+
+/** Let the drain promise chain settle. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const taps: NotificationTapPayload[] = [];
+const record = (payload: NotificationTapPayload) => {
+  taps.push(payload);
+};
+
+beforeEach(() => {
+  taps.length = 0;
+  bufferedActions = [];
+  drainRejects = false;
+  drainDeferred = false;
+  drainResolvers = [];
+  actionCallback = null;
+  onActionMock.mockClear();
+  drainActionsMock.mockClear();
+  captureErrorMock.mockClear();
+  __resetNotificationsStateForTests();
+});
+
+describe("draining taps buffered while the app was closed", () => {
+  test("replays a buffered tap to the handler registered on mount", async () => {
+    bufferedActions = [
+      {
+        kind: "click",
+        category: "notificationIntent",
+        conversationId: "conv-cold",
+        deliveryId: "del-cold",
+      },
+    ];
+
+    setNotificationTapHandler(record);
+    await flush();
+
+    expect(taps).toEqual([
+      {
+        conversationId: "conv-cold",
+        sourceEventName: "electron:notificationIntent:click",
+        deliveryId: "del-cold",
+      },
+    ]);
+  });
+
+  test("subscribes before draining so a tap landing between the two is not lost", async () => {
+    // The live listener must already be attached when drain is issued.
+    drainDeferred = true;
+    setNotificationTapHandler(record);
+
+    expect(onActionMock).toHaveBeenCalledTimes(1);
+    expect(actionCallback).not.toBeNull();
+
+    actionCallback!({
+      kind: "click",
+      category: "notificationIntent",
+      conversationId: "conv-live",
+    });
+    releaseDrain();
+    await flush();
+
+    expect(taps.map((t) => t.conversationId)).toEqual(["conv-live"]);
+  });
+
+  test("replays every buffered tap in order", async () => {
+    bufferedActions = [
+      { kind: "click", category: "notificationIntent", conversationId: "c1" },
+      { kind: "action", category: "toolConfirmation", conversationId: "c2" },
+    ];
+
+    setNotificationTapHandler(record);
+    await flush();
+
+    expect(taps.map((t) => t.conversationId)).toEqual(["c1", "c2"]);
+    expect(taps.map((t) => t.sourceEventName)).toEqual([
+      "electron:notificationIntent:click",
+      "electron:toolConfirmation:action",
+    ]);
+  });
+
+  test("an empty buffer dispatches nothing", async () => {
+    setNotificationTapHandler(record);
+    await flush();
+
+    expect(taps).toHaveLength(0);
+  });
+
+  // A failed drain costs the launching tap; it must not take the live
+  // listener down with it.
+  test("a failed drain is reported and leaves live taps working", async () => {
+    drainRejects = true;
+
+    setNotificationTapHandler(record);
+    await flush();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock.mock.calls[0]![1]).toMatchObject({
+      context: "notifications.drainActions",
+    });
+
+    actionCallback!({
+      kind: "click",
+      category: "notificationIntent",
+      conversationId: "conv-after-failure",
+    });
+    expect(taps.map((t) => t.conversationId)).toEqual(["conv-after-failure"]);
+  });
+
+  test("drains once, not on every handler re-registration", async () => {
+    setNotificationTapHandler(record);
+    await flush();
+    setNotificationTapHandler(record);
+    await flush();
+
+    expect(drainActionsMock).toHaveBeenCalledTimes(1);
+    expect(onActionMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("taps arriving with no handler registered", () => {
+  test("a tap dispatched before registration is replayed, not dropped", async () => {
+    // Register once to attach the platform listener, then simulate a tap
+    // reaching the renderer while no handler is installed.
+    setNotificationTapHandler(record);
+    await flush();
+    const liveCallback = actionCallback!;
+
+    __resetNotificationsStateForTests();
+    Object.defineProperty(window, "vellum", {
+      configurable: true,
+      writable: true,
+      value: {
+        notifications: {
+          onAction: onActionMock,
+          drainActions: drainActionsMock,
+        },
+      },
+    });
+
+    liveCallback({
+      kind: "click",
+      category: "notificationIntent",
+      conversationId: "conv-orphan",
+    });
+    expect(taps).toHaveLength(0);
+
+    setNotificationTapHandler(record);
+    expect(taps.map((t) => t.conversationId)).toEqual(["conv-orphan"]);
+  });
+
+  test("a replayed tap is not delivered twice on a later registration", async () => {
+    setNotificationTapHandler(record);
+    await flush();
+    const liveCallback = actionCallback!;
+
+    __resetNotificationsStateForTests();
+    liveCallback({
+      kind: "click",
+      category: "notificationIntent",
+      conversationId: "conv-once",
+    });
+
+    setNotificationTapHandler(record);
+    setNotificationTapHandler(record);
+
+    expect(taps).toHaveLength(1);
+  });
+});

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -35,7 +35,11 @@ import {
   ANDROID_ALERTS_CHANNEL_ID,
   ensureAndroidAlertsChannel,
 } from "@/runtime/android-notification-channels";
-import { isElectron } from "@/runtime/is-electron";
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+  isElectron,
+  type ElectronNotificationActionEvent,
+} from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
 import { isNativeAndroid } from "@/runtime/platform-detection";
 import {
@@ -61,6 +65,35 @@ let cachedPermission: PermissionState | null = null;
 let permissionPromptIssued = false;
 let tapListenersRegistered = false;
 let tapHandler: ((payload: NotificationTapPayload) => void) | null = null;
+
+/**
+ * A tap that arrived with no handler registered, replayed the moment one
+ * is. Defensive rather than load-bearing: today every platform listener is
+ * registered *from* `setNotificationTapHandler`, which assigns `tapHandler`
+ * first, so a tap can only outrun the handler if that ordering changes.
+ * The cold-launch drop this guards against is fixed in the main process,
+ * which buffers taps until a renderer subscribes.
+ *
+ * It exists because the failure is silent and expensive: the previous
+ * `if (!tapHandler) return` in each path discarded the tap with no log, no
+ * telemetry, and no user-visible signal beyond the app opening to the
+ * wrong place. One slot is enough — taps are user clicks, and the newest
+ * is the one whose destination they are waiting on.
+ */
+let pendingTap: NotificationTapPayload | null = null;
+
+/**
+ * Route a tap to the handler, or hold it until one registers.
+ * Every platform tap path funnels through here so none of them can
+ * reintroduce a silent drop.
+ */
+function dispatchTap(payload: NotificationTapPayload): void {
+  if (!tapHandler) {
+    pendingTap = payload;
+    return;
+  }
+  tapHandler(payload);
+}
 const recentNativeDeliveryIds = new Set<string>();
 const nativeDeliveryPromises = new Map<string, Promise<void>>();
 const MAX_RECENT_DELIVERY_IDS = 128;
@@ -193,16 +226,33 @@ async function registerTapListeners(): Promise<void> {
   // `NotificationTapPayload` so the same `tapHandler` is invoked
   // regardless of platform. The listener is permanent (app lifetime).
   if (isElectron() && window.vellum?.notifications) {
-    window.vellum.notifications.onAction((event) => {
-      if (!tapHandler) {
-        return;
-      }
-      tapHandler({
-        conversationId: event.conversationId,
-        sourceEventName: `electron:${event.category}:${event.kind}`,
-        deliveryId: event.deliveryId,
-      });
+    const toPayload = (
+      event: ElectronNotificationActionEvent,
+    ): NotificationTapPayload => ({
+      conversationId: event.conversationId,
+      sourceEventName: `electron:${event.category}:${event.kind}`,
+      deliveryId: event.deliveryId,
     });
+    window.vellum.notifications.onAction((event) => {
+      dispatchTap(toPayload(event));
+    });
+    // Subscribe first (above), then drain: a tap landing between the two
+    // is broadcast to the live listener rather than lost, and main stops
+    // buffering as soon as the subscribe IPC lands. Best-effort — a
+    // failed drain costs the launching tap, not the live ones.
+    void window.vellum.notifications
+      .drainActions()
+      .then((buffered) => {
+        for (const event of buffered) {
+          dispatchTap(toPayload(event));
+        }
+      })
+      .catch((error: unknown) => {
+        captureError(error, {
+          context: "notifications.drainActions",
+          bestEffort: true,
+        });
+      });
     return;
   }
 
@@ -215,8 +265,8 @@ async function registerTapListeners(): Promise<void> {
       (action) => {
         const extra = action.notification.extra as
           NotificationTapPayload | undefined;
-        if (extra && tapHandler) {
-          tapHandler(extra);
+        if (extra) {
+          dispatchTap(extra);
         }
       },
     );
@@ -238,6 +288,13 @@ export function setNotificationTapHandler(
 ): void {
   tapHandler = handler;
   void registerTapListeners();
+  // Replay a tap that beat this registration. Cleared before dispatch so a
+  // handler that re-registers during the call cannot replay it twice.
+  if (pendingTap) {
+    const replayed = pendingTap;
+    pendingTap = null;
+    handler(replayed);
+  }
 }
 
 /**
@@ -519,9 +576,7 @@ export async function postLocalNotification(
       });
       n.onclick = () => {
         window.focus();
-        if (tapHandler) {
-          tapHandler(tapPayload);
-        }
+        dispatchTap(tapPayload);
         n.close();
       };
     } catch (err) {
@@ -575,6 +630,7 @@ export function __resetNotificationsStateForTests(): void {
   permissionPromptIssued = false;
   tapListenersRegistered = false;
   tapHandler = null;
+  pendingTap = null;
   recentNativeDeliveryIds.clear();
   nativeDeliveryPromises.clear();
 }

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -236,6 +236,13 @@ export interface VellumBridge {
       payload: ShowNotificationPayload,
     ): Promise<{ success: boolean; errorMessage?: string }>;
     onAction(callback: (event: NotificationActionEvent) => void): () => void;
+    /**
+     * Return AND clear the taps main buffered while no renderer was
+     * listening — a click that launched the app, or landed while it was
+     * still booting. Subscribe first, then drain, so a tap arriving
+     * between the two is broadcast rather than lost.
+     */
+    drainActions(): Promise<NotificationActionEvent[]>;
   };
   bundleConfirm: {
     getData(): Promise<BundleScanData | null>;


### PR DESCRIPTION
## Prompt / plan

From a support report on the desktop app: a recurring alert emitted by a scheduled poller, where clicking the notification opened the app but never landed on the notification's thread. The reporter added that it always opened their **most recent conversation** instead, and that it never once reached the target.

That detail is the whole diagnosis. **"Most recent conversation" is not a wrong destination — it's the absence of one.** `use-conversation-loader.ts:349-353` computes the bootstrap landing as `latestForeground`, the newest non-background conversation. That's what renders when no deep-link navigation happens at all. So the deep link wasn't pointing somewhere wrong; it never fired.

Two ways a tap goes missing, both silent.

### 1. The `Notification` object is garbage collected (`d6f3033`) — primary

`showNotification` does `const notif = new Notification({...})` — a function-local. Once the delivery promise settles (on `show`, milliseconds later) nothing in the process references it, and V8 is free to collect it. `recentNotifications` holds only `dedupKey → timestamp`, not the object.

The macOS banner far outlives the JS object — it sits in Notification Center for hours. Clicking a collected one:
- still activates the app, because macOS does that itself → the app opens
- fires no `click` in main → no `broadcastAction`, no `deeplink.openThread`, no navigation
- → renderer lands on its bootstrap default → the most recent conversation

That accounts for the report including its "never": a banner clicked within seconds still works, which is exactly why deliberate repro attempts kept succeeding and the bug looked unreproducible.

Fix: retain each notification until the OS is done with it — the documented requirement for `electron.Notification`, the same one `Tray` carries. Released on click / action / close / failed, with a 24h TTL sweep as the backstop (macOS doesn't guarantee `close` for a banner that ages out of Notification Center) and a hard cap so a burst can't outpace the sweep.

### 2. Cold-launch taps are dropped (`fa904d8`) — real, but not this report's cause

Independent of GC: clicking while the app is closed drops the tap at two points. `notifications.ts` fires `broadcastAction` immediately after `void ensureVisible()`, discarding the window-readiness promise `ensureVisible` returns for exactly this purpose — and `webContents.send` to an unsubscribed renderer is dropped, not queued (on a cold click `getAllWindows()` is empty). Separately, the renderer only attaches its listener from inside `setNotificationTapHandler`, which runs in a React effect at `RootLayout`, so anything arriving before React mounts hit `if (!tapHandler) return`.

`deep-links.ts` already solves this for `vellum://thread/...`, which has the identical cold-launch problem. This adopts that pattern rather than inventing a second one: main buffers taps while no renderer is subscribed, tracks subscribers by `WebContents` (so a window closed without running its React cleanup can't leak a subscriber and mute every later tap), and the renderer subscribes-then-drains on mount — subscribe first, so a tap landing between the two is broadcast rather than lost.

### Diagnosability

Both commits add instrumentation, because the real story here is that **every way a tap could go missing was silent** — no log, no telemetry, nothing in a feedback bundle. Competing explanations had to be argued from source rather than evidence. Main now logs every tap it receives (with subscriber count and whether it buffered), and the renderer records a `notification_tap` lifecycle diagnostic — the ring the support export actually captures — so the next report answers *"did my tap navigate?"* directly. The existing Sentry breadcrumb stays, but it only surfaces attached to some later captured event, so it could never answer this alone.

### Dropped from an earlier revision of this PR

A commit that surfaced background/scheduled deep-link targets into Recents. The finding behind it is real and still open — deep links can point at conversations excluded from both the sidebar listing and search, since `standardListingVisibilitySql` gates both while the single-row `GET` gates neither. But promoting the target is the wrong remedy: for the two producers that actually hit this it would push a poller run transcript, or the conversation where a schedule was created, into Recents. Noted as follow-up rather than shipped here.

## Not addressed (follow-ups)

- **The deep link points into the notification's past, not its future.** Three producers, three wrong-ish destinations: notify-mode schedules deep-link to `job.createdFromConversationId` (`scheduler.ts:543`) — the conversation where the schedule was *created*; talk-mode runs point at that run's `scheduled` conversation; CLI `notifications send` points wherever it was invoked. The chain `pairing ?? sourceContextId ?? contextPayload.deepLinkConversationId` answers "where did this come from?" rather than "where do I act on this?"
- **There is no conversation for a passive notification at all.** `conversation-pairing.ts:130` deliberately returns `conversationId: null` for the vellum channel unless the producer sets `requiresConversation` — only five call sites do, all guardian requests. A notification whose copy asks the user to reply therefore has no thread to reply in, which is also why the poller in this report kept re-prompting.

## Test plan

- **20 new tests.** Retention (`notifications.test.ts`): a shown notification is retained; **a click six hours after delivery still broadcasts** (the regression itself); released on click / action / close / failed; the TTL sweep drops stale entries and keeps fresh ones; a 300-notification burst caps at 256. Cold-launch buffering: buffers when unsubscribed and drain returns the tap; drain clears so nothing replays twice; no buffering once subscribed; buffers again after unsubscribe; a destroyed renderer stops counting as a subscriber; re-subscribe doesn't double-register; the buffer caps keeping the newest. Renderer (`notification-tap-buffering.test.ts`): buffered taps replay on mount, in order; subscribe precedes drain so an interleaved tap survives; a failed drain reports and leaves live taps working; drain runs once, not per re-registration; an orphaned tap replays and never delivers twice.
- **Full client suites green under the real CI runners** (`scripts/run-tests.ts`, which isolates each file in its own subprocess because `mock.module` leaks process-globally): web **841/841**, macOS **66/66**. Plain `bun test <dir>` numbers are noise from that leak.
- `tsc --noEmit` clean on `clients/web`, `clients/macos`, `packages/ipc-contract`. `eslint` clean on all changed files.
- **Not verified end-to-end** — no macOS host available here, and the GC path needs a real banner aged past a collection cycle. To confirm: with the app open the entire time, trigger a notification, wait 2+ minutes, then click it. GC predicts it fails on `main` and works on this branch; the cold-launch race predicts it works either way, since the app never closed. That single test separates them.

## CLI verb checklist

No new routes under `assistant/src/runtime/routes/` — this PR touches no assistant code. The new IPC channels (`vellum:notifications:drainActions`, `…:subscribeActions`, `…:unsubscribeActions`) are Electron main↔renderer only, mirroring the existing `vellum:deepLinks:*` trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vd7sVkfuA9wvcWhquUyR2