### PR TITLE
feat(web): emit conversation-list drain timing to watchdog telemetry

### DIFF
--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -1,9 +1,10 @@
 /**
- * Drain diagnostics for the conversation-list fetchers.
+ * Drain diagnostics and telemetry for the conversation-list fetchers.
  *
  * The ring holds 200 entries, so a multi-page drain must contribute a bounded
  * handful of them: the first page (the request that gates first paint), one
- * summary, and one entry per failed page. These tests pin that budget.
+ * summary, and one entry per failed page. These tests pin that budget, plus
+ * the one aggregate watchdog event each drain puts on the telemetry rail.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -11,8 +12,18 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { getDiagnosticsEvents, type DiagnosticsEvent } from "@/lib/diagnostics";
 import { ApiError } from "@/utils/api-errors";
-import { listConversations } from "@/utils/conversation-list-fetchers";
 import type { RawConversationSummary } from "@/utils/conversation-transforms";
+
+const emitClientPerfEventMock = mock(
+  (_checkName: string, _value: number, _detail?: Record<string, unknown>) => {},
+);
+
+mock.module("@/lib/telemetry/client-perf", () => ({
+  emitClientPerfEvent: emitClientPerfEventMock,
+}));
+
+const { listBackgroundConversations, listConversations } =
+  await import("@/utils/conversation-list-fetchers");
 
 const ASSISTANT_ID = "assistant-1";
 
@@ -84,10 +95,21 @@ async function diagnosticsDuring<T>(
   return { result, events: getDiagnosticsEvents().slice(baseline) };
 }
 
+/** The `client_list.drain` emits recorded since the last reset. */
+function drainEmits(): Array<{
+  value: number;
+  detail: Record<string, unknown>;
+}> {
+  return emitClientPerfEventMock.mock.calls
+    .filter(([checkName]) => checkName === "client_list.drain")
+    .map(([, value, detail]) => ({ value, detail: detail ?? {} }));
+}
+
 const originalGet = daemonClient.get;
 
 afterEach(() => {
   daemonClient.get = originalGet;
+  emitClientPerfEventMock.mockClear();
 });
 
 describe("conversation list drain diagnostics", () => {
@@ -206,5 +228,81 @@ describe("conversation list drain diagnostics", () => {
     }
     expect(typeof events[0]?.details.durationMs).toBe("number");
     expect(typeof events[1]?.details.maxPageMs).toBe("number");
+  });
+});
+
+describe("conversation list drain telemetry", () => {
+  test("a 3-page drain emits one client_list.drain, not one per page", async () => {
+    stubPages([
+      { ids: ["c-0"], hasMore: true, contentLength: "100" },
+      { ids: ["c-1"], hasMore: true, contentLength: "200" },
+      { ids: ["c-2"], hasMore: false, contentLength: "50" },
+    ]);
+
+    await listConversations(ASSISTANT_ID);
+
+    expect(emitClientPerfEventMock.mock.calls).toHaveLength(1);
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    expect(typeof emits[0]?.value).toBe("number");
+    expect(emits[0]?.detail).toEqual({
+      outcome: "ok",
+      pages: "3",
+      rows: "3",
+      max_page_ms: expect.any(String),
+      total_bytes: "350",
+      list_kind: "foreground",
+    });
+  });
+
+  test("a background drain reports its own list_kind", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+
+    await listBackgroundConversations(ASSISTANT_ID);
+
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    expect(emits[0]?.detail).toMatchObject({
+      outcome: "ok",
+      pages: "1",
+      list_kind: "background",
+    });
+  });
+
+  test("the detail bag carries no assistant id, and unknown bytes when content-length is absent", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false }]);
+
+    await listConversations(ASSISTANT_ID);
+
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    const detail = emits[0]!.detail;
+    for (const key of Object.keys(detail)) {
+      expect(key.toLowerCase()).not.toContain("assistant");
+    }
+    expect(Object.values(detail)).not.toContain(ASSISTANT_ID);
+    expect(detail.total_bytes).toBe("unknown");
+  });
+
+  test("a failing drain emits outcome error and still rethrows", async () => {
+    stubPages([
+      { ids: ["c-0"], hasMore: true, contentLength: "100" },
+      { ids: [], hasMore: false, status: 500 },
+    ]);
+
+    let thrown: unknown;
+    await listConversations(ASSISTANT_ID).catch((error: unknown) => {
+      thrown = error;
+    });
+
+    expect(thrown).toBeInstanceOf(ApiError);
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    expect(emits[0]?.detail).toMatchObject({
+      outcome: "error",
+      pages: "1",
+      rows: "1",
+      list_kind: "foreground",
+    });
   });
 });

--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -22,8 +22,13 @@ mock.module("@/lib/telemetry/client-perf", () => ({
   emitClientPerfEvent: emitClientPerfEventMock,
 }));
 
-const { listBackgroundConversations, listConversations } =
-  await import("@/utils/conversation-list-fetchers");
+const {
+  listArchivedConversations,
+  listBackgroundConversations,
+  listConversations,
+  listOriginChannelConversations,
+  listScheduledConversations,
+} = await import("@/utils/conversation-list-fetchers");
 
 const ASSISTANT_ID = "assistant-1";
 
@@ -267,6 +272,48 @@ describe("conversation list drain telemetry", () => {
       pages: "1",
       list_kind: "background",
     });
+  });
+
+  test("a scheduled drain reports its own list_kind", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+
+    await listScheduledConversations(ASSISTANT_ID);
+
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    expect(emits[0]?.detail).toMatchObject({ list_kind: "scheduled" });
+  });
+
+  test("an origin-channel drain is labeled origin_channel, not foreground", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+
+    await listOriginChannelConversations(ASSISTANT_ID, "slack");
+
+    const emits = drainEmits();
+    expect(emits).toHaveLength(1);
+    expect(emits[0]?.detail).toMatchObject({
+      outcome: "ok",
+      pages: "1",
+      list_kind: "origin_channel",
+    });
+  });
+
+  test("both archive-page drains are labeled archived, not foreground or background", async () => {
+    // The archive page drains the foreground and background buckets in
+    // parallel, so one call produces two emits.
+    stubPages([
+      { ids: ["c-0"], hasMore: false, contentLength: "10" },
+      { ids: ["c-1"], hasMore: false, contentLength: "20" },
+    ]);
+
+    await listArchivedConversations(ASSISTANT_ID);
+
+    const emits = drainEmits();
+    expect(emits).toHaveLength(2);
+    expect(emits.map((emit) => emit.detail.list_kind)).toEqual([
+      "archived",
+      "archived",
+    ]);
   });
 
   test("the detail bag carries no assistant id, and unknown bytes when content-length is absent", async () => {

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -125,6 +125,34 @@ type FetchConversationListOptions = {
   originChannel?: OriginChannel;
 };
 
+/**
+ * Closed set of `list_kind` labels for the `client_list.drain` watchdog event.
+ * One label per real caller, so the archive page and the channel sections stay
+ * distinguishable from the sidebar's foreground drain in the timing metric.
+ */
+type DrainListKind =
+  "foreground" | "background" | "scheduled" | "archived" | "origin_channel";
+
+/**
+ * Label a drain by the list it is fetching. Archive status is checked first
+ * because the archive page drains both the foreground and the background
+ * bucket, and both are archive-page cost rather than sidebar cost. Every
+ * channel collapses to one `"origin_channel"` label so the set stays bounded
+ * as channels are added.
+ */
+function drainListKind(options: FetchConversationListOptions): DrainListKind {
+  if (options.archiveStatus === "archived") {
+    return "archived";
+  }
+  if (options.conversationType !== undefined) {
+    return options.conversationType;
+  }
+  if (options.originChannel !== undefined) {
+    return "origin_channel";
+  }
+  return "foreground";
+}
+
 /** One page of a conversation list plus whether more pages exist. */
 export type ConversationListPage = {
   conversations: Conversation[];
@@ -229,7 +257,7 @@ async function fetchConversationList(
       rows: String(all.length),
       max_page_ms: String(maxPageMs),
       total_bytes: totalBytes === null ? "unknown" : String(totalBytes),
-      list_kind: options.conversationType ?? "foreground",
+      list_kind: drainListKind(options),
     });
   };
 

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -23,6 +23,7 @@ import {
   extractErrorMessage,
 } from "@/utils/api-errors";
 import { recordDiagnostic } from "@/lib/diagnostics";
+import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 import type { Conversation } from "@/types/conversation-types";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { toConversation } from "@/utils/conversation-transforms";
@@ -209,15 +210,26 @@ async function fetchConversationList(
   let totalBytes: number | null = null;
 
   const recordDrain = (outcome: "ok" | "error"): void => {
+    const totalMs = Math.round(performance.now() - drainStartedAt);
     recordDiagnostic("conversation_list_drain", {
       assistantId,
       outcome,
       pages,
       rows: all.length,
-      totalMs: Math.round(performance.now() - drainStartedAt),
+      totalMs,
       maxPageMs,
       totalBytes,
       conversationType: options.conversationType ?? null,
+    });
+    // The ring keeps `assistantId` for feedback bundles; the telemetry rail is
+    // metadata only.
+    emitClientPerfEvent("client_list.drain", totalMs, {
+      outcome,
+      pages: String(pages),
+      rows: String(all.length),
+      max_page_ms: String(maxPageMs),
+      total_bytes: totalBytes === null ? "unknown" : String(totalBytes),
+      list_kind: options.conversationType ?? "foreground",
     });
   };
 


### PR DESCRIPTION
## Summary
- One client_list.drain watchdog event per conversation-list drain: totalMs as the value, with outcome/pages/rows/max_page_ms/total_bytes/list_kind detail
- Rides the PR 1 ring summary's accumulators and the PR 4 emitter; no assistant ids on the telemetry rail; no fetching behavior change

Part of plan: measure-first-telemetry-followups.md (PR 7 of 7)