### PR TITLE
feat(web): measure conversation-switch to first transcript paint

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
@@ -13,6 +13,20 @@ import type { AssistantEvent } from "@/types/event-types";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 const CONV = "conv-A";
+
+// Records which conversations opened a switch-telemetry window, so the gate in
+// `switchToConversation` can be asserted without reaching the ingest layer.
+// The module's other exports are stubbed too: a module mock is process-wide, so
+// a sibling file sharing this Bun process must still find them.
+const switchStartedConversationIds: string[] = [];
+mock.module("@/lib/telemetry/switch-telemetry", () => ({
+  noteConversationSwitchStarted: (conversationId: string) => {
+    switchStartedConversationIds.push(conversationId);
+  },
+  noteSwitchTranscriptPainted: () => {},
+  abandonSwitchMeasurement: () => {},
+  subscribeSwitchTelemetry: () => () => {},
+}));
 
 function snapshot(
   messages: DisplayMessage[],
@@ -353,5 +367,78 @@ describe("chat-session-store — snapshot + optimistic", () => {
       afterReseed.find((m) => m.id === "msg-server-1")?.attachments?.[0]
         ?.previewUrl,
     ).toBe("data:image/png;base64,x");
+  });
+});
+
+describe("chat-session-store: switch telemetry gate", () => {
+  beforeEach(() => {
+    switchStartedConversationIds.length = 0;
+    useChatSessionStore.setState({
+      previousConversationId: null,
+      previousAssistantId: null,
+      draftConversationIdResolution: false,
+    });
+  });
+
+  test("a cold mount with no prior conversation opens no window", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+
+    expect(switchStartedConversationIds).toEqual([]);
+  });
+
+  test("a move between two conversations of one assistant opens a window", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-B",
+    });
+
+    expect(switchStartedConversationIds).toEqual(["conv-B"]);
+  });
+
+  test("an assistant change opens no window", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    store().switchToConversation({
+      assistantId: "asst-2",
+      activeConversationId: "conv-B",
+    });
+
+    expect(switchStartedConversationIds).toEqual([]);
+  });
+
+  test("re-entering the same conversation opens no window", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+
+    expect(switchStartedConversationIds).toEqual([]);
+  });
+
+  test("a draft-key resolution is not a switch", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    store().markDraftResolution();
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-server-1",
+    });
+
+    expect(switchStartedConversationIds).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -49,6 +49,7 @@ import {
 } from "@/domains/chat/transcript/rolling-snapshot";
 import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
 import { getSseEnvelopesSince } from "@/lib/streaming/stream-debug";
+import { noteConversationSwitchStarted } from "@/lib/telemetry/switch-telemetry";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
@@ -515,6 +516,9 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
     const usageByConversation = needsHydration
       ? loadContextWindowUsageMap(assistantId)
       : state.contextWindowUsageByConversation;
+
+    // Start the paint measurement at the same instant the transcript blanks.
+    noteConversationSwitchStarted(activeConversationId);
 
     set({
       snapshot: null,

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -517,8 +517,14 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
       ? loadContextWindowUsageMap(assistantId)
       : state.contextWindowUsageByConversation;
 
-    // Start the paint measurement at the same instant the transcript blanks.
-    noteConversationSwitchStarted(activeConversationId);
+    // Start the paint measurement at the same instant the transcript blanks,
+    // but only for a real conversation-to-conversation move within the same
+    // assistant. A cold mount, a last-viewed bootstrap, or an assistant change
+    // is boot latency, which the boot family already owns; folding it in here
+    // would mix first-fetch time into the switch distribution.
+    if (isConversationSwitch && !isAssistantSwitch) {
+      noteConversationSwitchStarted(activeConversationId);
+    }
 
     set({
       snapshot: null,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -56,7 +56,10 @@ import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachmen
 import { useSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import { recordCommit } from "@/lib/commit-pressure";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
-import { noteSwitchTranscriptPainted } from "@/lib/telemetry/switch-telemetry";
+import {
+  abandonSwitchMeasurement,
+  noteSwitchTranscriptPainted,
+} from "@/lib/telemetry/switch-telemetry";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
@@ -515,14 +518,36 @@ export function ChatMainPanel({
   // conversation's first paint. It runs from an ancestor effect
   // (`ActiveChatView`), which React commits after this one, so the render that
   // first carries the new id finds no pending window and measures nothing.
-  const switchTranscriptPainted = !(isLoadingHistory && messages.length === 0);
+  // A failed initial `/messages` fetch clears `isLoadingHistory` with no
+  // messages, which reads exactly like an instant empty conversation, so the
+  // query's own error state has to veto the paint. An older-page failure keeps
+  // `isSuccess`, and the transcript it already painted still counts.
+  const historyLoadFailed =
+    historyPagination.isError && !historyPagination.isSuccess;
+  const switchTranscriptPainted =
+    !historyLoadFailed && !(isLoadingHistory && messages.length === 0);
   useEffect(() => {
-    if (switchTranscriptPainted && activeConversationId) {
+    if (!activeConversationId) {
+      return;
+    }
+    if (historyLoadFailed) {
+      // A failed load is neither a paint nor a stall. The failure is already
+      // visible as `history_page_fetch_error`, and leaving the window open
+      // would let the 15s TTL bill a fast-failing fetch as a slow switch.
+      abandonSwitchMeasurement();
+      return;
+    }
+    if (switchTranscriptPainted) {
       noteSwitchTranscriptPainted(activeConversationId, {
         hadHistory: messages.length > 0,
       });
     }
-  }, [switchTranscriptPainted, activeConversationId, messages.length]);
+  }, [
+    switchTranscriptPainted,
+    historyLoadFailed,
+    activeConversationId,
+    messages.length,
+  ]);
 
   // Clear staged quotes and dismiss the reply bubble when the active
   // conversation changes to prevent quotes from one conversation leaking

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -56,6 +56,7 @@ import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachmen
 import { useSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import { recordCommit } from "@/lib/commit-pressure";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { noteSwitchTranscriptPainted } from "@/lib/telemetry/switch-telemetry";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
@@ -507,6 +508,21 @@ export function ChatMainPanel({
   useEffect(() => {
     recordCommit();
   });
+
+  // Closes the switch measurement `switchToConversation` opened. That action
+  // blanks the snapshot and sets `isLoadingHistory` in one commit, so the first
+  // render that is not an empty loading transcript is the incoming
+  // conversation's first paint. It runs from an ancestor effect
+  // (`ActiveChatView`), which React commits after this one, so the render that
+  // first carries the new id finds no pending window and measures nothing.
+  const switchTranscriptPainted = !(isLoadingHistory && messages.length === 0);
+  useEffect(() => {
+    if (switchTranscriptPainted && activeConversationId) {
+      noteSwitchTranscriptPainted(activeConversationId, {
+        hadHistory: messages.length > 0,
+      });
+    }
+  }, [switchTranscriptPainted, activeConversationId, messages.length]);
 
   // Clear staged quotes and dismiss the reply bubble when the active
   // conversation changes to prevent quotes from one conversation leaking

--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -27,6 +27,7 @@ import { useEffect } from "react";
 import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { setupQueryFocusManager } from "@/lib/query-focus-manager";
+import { subscribeSwitchTelemetry } from "@/lib/telemetry/switch-telemetry";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
 import { publishCapacitorDeepLinksSource } from "@/runtime/event-sources/capacitor-deep-links";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
@@ -66,6 +67,7 @@ export function useEventBusInit({
       publishElectronDeepLinksSource(),
       publishElectronConnectivitySource(),
       subscribeLifecycleDiagnostics(),
+      subscribeSwitchTelemetry(),
       setupQueryFocusManager(),
     ];
     return () => {

--- a/clients/web/src/lib/telemetry/switch-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.test.ts
@@ -4,6 +4,7 @@
  *   - a paint for a different conversation leaves the window open
  *   - a re-switch supersedes the pending sample silently
  *   - `app.hidden` abandons it so backgrounded switches never land
+ *   - a failed history load abandons it: neither a paint nor a stall
  *   - nothing is emitted without analytics consent
  *   - no emitted detail carries a conversation id
  */
@@ -22,6 +23,7 @@ mock.module("@/lib/telemetry/ingest", () => ({
 const { publish, __resetForTesting } = await import("@/lib/event-bus");
 const {
   __resetSwitchTelemetryForTests,
+  abandonSwitchMeasurement,
   noteConversationSwitchStarted,
   noteSwitchTranscriptPainted,
   subscribeSwitchTelemetry,
@@ -168,6 +170,28 @@ describe("switch telemetry", () => {
     expect(postTelemetryEventsMock).not.toHaveBeenCalled();
 
     unsubscribe();
+  });
+
+  test("a failed history load abandons the window without a sample", () => {
+    // The panel calls this on the error path instead of reporting a paint.
+    noteConversationSwitchStarted("conv-1");
+    clock += 300;
+    abandonSwitchMeasurement();
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    // The stall timer went with it, so the failure never lands as a slow switch.
+    runScheduledTimers();
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: false });
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+  });
+
+  test("abandoning with no pending window is a no-op", () => {
+    abandonSwitchMeasurement();
+    noteConversationSwitchStarted("conv-1");
+    clock += 40;
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+
+    expect(onlyEvent().value).toBe(40);
   });
 
   test("emits nothing without analytics consent", () => {

--- a/clients/web/src/lib/telemetry/switch-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Pins the conversation-switch paint measurement:
+ *   - one sample per switch, painted or stalled, never both
+ *   - a paint for a different conversation leaves the window open
+ *   - a re-switch supersedes the pending sample silently
+ *   - `app.hidden` abandons it so backgrounded switches never land
+ *   - nothing is emitted without analytics consent
+ *   - no emitted detail carries a conversation id
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let consent = true;
+const postTelemetryEventsMock = mock((_events: readonly object[]) => {});
+
+mock.module("@/lib/telemetry/consent", () => ({
+  readAnalyticsConsent: () => consent,
+}));
+mock.module("@/lib/telemetry/ingest", () => ({
+  postTelemetryEvents: postTelemetryEventsMock,
+}));
+
+const { publish, __resetForTesting } = await import("@/lib/event-bus");
+const {
+  __resetSwitchTelemetryForTests,
+  noteConversationSwitchStarted,
+  noteSwitchTranscriptPainted,
+  subscribeSwitchTelemetry,
+} = await import("./switch-telemetry");
+
+// The module reads `performance.now()` for elapsed time and schedules the TTL
+// on `setTimeout`; both are driven from the test so the 15s window is
+// exercised without real waiting.
+let clock = 0;
+let realNow: () => number;
+let realSetTimeout: typeof globalThis.setTimeout;
+let realClearTimeout: typeof globalThis.clearTimeout;
+let timers = new Map<number, () => void>();
+let nextTimerId = 1;
+
+function runScheduledTimers(): void {
+  const due = [...timers.values()];
+  timers.clear();
+  for (const fn of due) {
+    fn();
+  }
+}
+
+function emittedEvents(): Record<string, unknown>[] {
+  return postTelemetryEventsMock.mock.calls.flatMap(
+    (call) => call[0] as Record<string, unknown>[],
+  );
+}
+
+function onlyEvent(): Record<string, unknown> {
+  const events = emittedEvents();
+  expect(events).toHaveLength(1);
+  return events[0]!;
+}
+
+beforeEach(() => {
+  consent = true;
+  clock = 1_000;
+  timers = new Map();
+  nextTimerId = 1;
+  realNow = performance.now.bind(performance);
+  realSetTimeout = globalThis.setTimeout;
+  realClearTimeout = globalThis.clearTimeout;
+  performance.now = () => clock;
+  globalThis.setTimeout = ((fn: () => void) => {
+    const id = nextTimerId++;
+    timers.set(id, fn);
+    return id;
+  }) as unknown as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((id?: number) => {
+    if (id !== undefined) {
+      timers.delete(id);
+    }
+  }) as unknown as typeof globalThis.clearTimeout;
+  postTelemetryEventsMock.mockClear();
+  __resetForTesting();
+  __resetSwitchTelemetryForTests();
+});
+
+afterEach(() => {
+  performance.now = realNow;
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.clearTimeout = realClearTimeout;
+  __resetForTesting();
+  __resetSwitchTelemetryForTests();
+});
+
+describe("switch telemetry", () => {
+  test("emits the elapsed paint time for the switched-to conversation", () => {
+    noteConversationSwitchStarted("conv-1");
+    clock += 412;
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+
+    const event = onlyEvent();
+    expect(event.check_name).toBe("client_switch.transcript_painted");
+    expect(event.value).toBe(412);
+    expect((event.detail as Record<string, unknown>).had_history).toBe("true");
+  });
+
+  test("labels an empty incoming conversation with had_history false", () => {
+    noteConversationSwitchStarted("conv-1");
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: false });
+
+    expect((onlyEvent().detail as Record<string, unknown>).had_history).toBe(
+      "false",
+    );
+  });
+
+  test("ignores a paint for a different conversation and keeps the window", () => {
+    noteConversationSwitchStarted("conv-1");
+    noteSwitchTranscriptPainted("conv-2", { hadHistory: true });
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    clock += 50;
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(onlyEvent().value).toBe(50);
+  });
+
+  test("a re-switch supersedes the pending sample without emitting", () => {
+    noteConversationSwitchStarted("conv-1");
+    clock += 90;
+    noteConversationSwitchStarted("conv-2");
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    clock += 10;
+    noteSwitchTranscriptPainted("conv-2", { hadHistory: true });
+    expect(onlyEvent().value).toBe(10);
+  });
+
+  test("emits one stall sample when the window outlives its TTL", () => {
+    noteConversationSwitchStarted("conv-1");
+    runScheduledTimers();
+
+    const event = onlyEvent();
+    expect(event.check_name).toBe("client_switch.stalled");
+    expect(event.value).toBe(15_000);
+    expect((event.detail as Record<string, unknown>).reason).toBe("timeout");
+
+    // The stall closed the window: a late paint is not a second sample.
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(emittedEvents()).toHaveLength(1);
+  });
+
+  test("a paint cancels the stall so a switch never reports both", () => {
+    noteConversationSwitchStarted("conv-1");
+    clock += 200;
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    runScheduledTimers();
+
+    expect(onlyEvent().check_name).toBe("client_switch.transcript_painted");
+  });
+
+  test("app.hidden abandons the pending sample silently", () => {
+    const unsubscribe = subscribeSwitchTelemetry();
+    noteConversationSwitchStarted("conv-1");
+    publish("app.hidden", { signal: "visibility" });
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    runScheduledTimers();
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  test("emits nothing without analytics consent", () => {
+    consent = false;
+    noteConversationSwitchStarted("conv-1");
+    clock += 100;
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    runScheduledTimers();
+
+    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+  });
+
+  test("never puts a conversation id in an emitted detail bag", () => {
+    noteConversationSwitchStarted("conv-secret-1");
+    clock += 5;
+    noteSwitchTranscriptPainted("conv-secret-1", { hadHistory: true });
+    noteConversationSwitchStarted("conv-secret-2");
+    runScheduledTimers();
+
+    const events = emittedEvents();
+    expect(events).toHaveLength(2);
+    for (const event of events) {
+      const serialized = JSON.stringify(event.detail);
+      expect(serialized).not.toContain("conv-secret-1");
+      expect(serialized).not.toContain("conv-secret-2");
+      for (const key of Object.keys(event.detail as Record<string, unknown>)) {
+        expect(key).not.toContain("conversation");
+        expect(key).not.toContain("assistant");
+      }
+    }
+  });
+});

--- a/clients/web/src/lib/telemetry/switch-telemetry.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.ts
@@ -2,10 +2,12 @@
  * Measures conversation switch to first transcript paint.
  *
  * `switchToConversation` opens a pending window at the instant the transcript
- * is blanked; the chat panel closes it on the first render that is no longer
- * an empty loading transcript. One `client_switch.transcript_painted` sample
- * per switch, or one `client_switch.stalled` if the window outlives its TTL.
- * Never both: whichever lands first clears the pending window.
+ * is blanked, and only for a real move between two conversations of the same
+ * assistant; the chat panel closes it on the first render that is no longer an
+ * empty loading transcript. One `client_switch.transcript_painted` sample per
+ * switch, or one `client_switch.stalled` if the window outlives its TTL. Never
+ * both: whichever lands first clears the pending window. A window whose history
+ * fetch failed is abandoned without a sample.
  *
  * The TTL is 15s rather than the resume family's 10s because a cold history
  * fetch through the proxy chain can legitimately take that long on LTE. The
@@ -69,6 +71,14 @@ export function noteSwitchTranscriptPainted(
   emitClientPerfEvent("client_switch.transcript_painted", elapsedMs, {
     had_history: String(extra.hadHistory),
   });
+}
+
+/**
+ * Drops the pending window without emitting anything. Used when the switch
+ * neither painted nor stalled, so there is no sample to attribute to it.
+ */
+export function abandonSwitchMeasurement(): void {
+  abandonPending();
 }
 
 /**

--- a/clients/web/src/lib/telemetry/switch-telemetry.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.ts
@@ -1,0 +1,84 @@
+/**
+ * Measures conversation switch to first transcript paint.
+ *
+ * `switchToConversation` opens a pending window at the instant the transcript
+ * is blanked; the chat panel closes it on the first render that is no longer
+ * an empty loading transcript. One `client_switch.transcript_painted` sample
+ * per switch, or one `client_switch.stalled` if the window outlives its TTL.
+ * Never both: whichever lands first clears the pending window.
+ *
+ * The TTL is 15s rather than the resume family's 10s because a cold history
+ * fetch through the proxy chain can legitimately take that long on LTE. The
+ * stall series is the denominator for "how often does a switch never paint",
+ * not an error report.
+ *
+ * Metadata only: the conversation id is used to match a paint to its pending
+ * window and never reaches an emitted detail bag.
+ */
+
+import { subscribe } from "@/lib/event-bus";
+import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
+
+const STALL_TTL_MS = 15_000;
+
+let pending: {
+  conversationId: string;
+  at: number;
+  timer: ReturnType<typeof setTimeout>;
+} | null = null;
+
+function abandonPending(): void {
+  if (pending === null) {
+    return;
+  }
+  clearTimeout(pending.timer);
+  pending = null;
+}
+
+/**
+ * Opens the pending window. An impatient re-switch supersedes the previous
+ * sample silently: counting superseded switches is deliberately out of scope.
+ */
+export function noteConversationSwitchStarted(conversationId: string): void {
+  abandonPending();
+  pending = {
+    conversationId,
+    at: performance.now(),
+    timer: setTimeout(() => {
+      pending = null;
+      emitClientPerfEvent("client_switch.stalled", STALL_TTL_MS, {
+        reason: "timeout",
+      });
+    }, STALL_TTL_MS),
+  };
+}
+
+/**
+ * Closes the pending window when the transcript for `conversationId` paints.
+ * A paint for any other conversation is ignored and leaves the window open.
+ */
+export function noteSwitchTranscriptPainted(
+  conversationId: string,
+  extra: { hadHistory: boolean },
+): void {
+  if (pending === null || pending.conversationId !== conversationId) {
+    return;
+  }
+  const elapsedMs = performance.now() - pending.at;
+  abandonPending();
+  emitClientPerfEvent("client_switch.transcript_painted", elapsedMs, {
+    had_history: String(extra.hadHistory),
+  });
+}
+
+/**
+ * Abandons any pending window when the app is backgrounded, so a switch the
+ * user walked away from never contaminates the p95. Returns an unsubscribe.
+ */
+export function subscribeSwitchTelemetry(): () => void {
+  return subscribe("app.hidden", abandonPending);
+}
+
+export function __resetSwitchTelemetryForTests(): void {
+  abandonPending();
+}


### PR DESCRIPTION
## Summary
- New client_switch telemetry family: switchToConversation to first non-empty transcript paint (client_switch.transcript_painted), with a 15s client_switch.stalled denominator
- Re-switch supersedes the pending sample; app.hidden abandons it so backgrounded switches never contaminate the p95; had_history label separates cold fetches from instant empty conversations
- No conversation or assistant ids in emitted detail; consent-gated via emitClientPerfEvent

Part of plan: measure-first-telemetry-followups.md (PR 5 of 7)