### PR TITLE
feat(web): count daemon API requests in the window after app resume

### DIFF
--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -27,6 +27,7 @@ import { useEffect } from "react";
 import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { setupQueryFocusManager } from "@/lib/query-focus-manager";
+import { subscribeResumeRequestCounter } from "@/lib/telemetry/resume-request-counter";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
 import { publishCapacitorDeepLinksSource } from "@/runtime/event-sources/capacitor-deep-links";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
@@ -66,6 +67,7 @@ export function useEventBusInit({
       publishElectronDeepLinksSource(),
       publishElectronConnectivitySource(),
       subscribeLifecycleDiagnostics(),
+      subscribeResumeRequestCounter(),
       setupQueryFocusManager(),
     ];
     return () => {

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -82,6 +82,17 @@ mock.module("@/lib/auth/hard-navigate", () => ({
   hardNavigate: hardNavigateMock,
 }));
 
+// Post-resume request counter, stubbed so a test can make it throw and prove
+// the interceptor still returns its request.
+let noteDaemonApiRequestImpl: (url: string) => void = () => {};
+const noteDaemonApiRequestMock = mock((url: string) => {
+  noteDaemonApiRequestImpl(url);
+});
+mock.module("@/lib/telemetry/resume-request-counter", () => ({
+  noteDaemonApiRequest: noteDaemonApiRequestMock,
+  subscribeResumeRequestCounter: () => () => {},
+}));
+
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { client as gatewayClient } from "@/generated/gateway/client.gen";
 import {
@@ -1666,5 +1677,47 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBe(
       String(PLATFORM_AUTH_MAX_REDIRECTS),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-resume request counting
+// ---------------------------------------------------------------------------
+
+describe("api-interceptors / post-resume request counting", () => {
+  beforeEach(() => {
+    noteDaemonApiRequestMock.mockClear();
+    noteDaemonApiRequestImpl = () => {};
+  });
+
+  afterEach(() => {
+    noteDaemonApiRequestImpl = () => {};
+    setSelfHostedConnection(null);
+  });
+
+  test("notes daemon requests", async () => {
+    const url = "https://platform.test/v1/assistants/a1/conversations";
+    await daemonRequestInterceptor(new Request(url));
+    expect(noteDaemonApiRequestMock).toHaveBeenCalledTimes(1);
+    expect(noteDaemonApiRequestMock.mock.calls.at(-1)?.[0]).toBe(url);
+  });
+
+  test("does not note platform requests", async () => {
+    await requestInterceptor(new Request("https://platform.test/v1/probe"));
+    expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("a throwing counter leaves the request path intact", async () => {
+    noteDaemonApiRequestImpl = () => {
+      throw new Error("counter down");
+    };
+    const input = new Request(
+      "https://platform.test/v1/assistants/a1/messages",
+    );
+
+    const output = await daemonRequestInterceptor(input);
+
+    expect(output.url).toBe(input.url);
+    expect(output.headers.get("X-Vellum-Client-Id")).toBe(getClientId());
   });
 });

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1707,6 +1707,34 @@ describe("api-interceptors / post-resume request counting", () => {
     expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
   });
 
+  test("notes daemon routes issued through the platform client", async () => {
+    // `subscribeEvents` opens the SSE stream through the platform client, so
+    // the reopen in a resume burst is only counted if the platform chain
+    // counts its daemon-bound paths.
+    const url = `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/events/`;
+    await requestInterceptor(new Request(url));
+    expect(noteDaemonApiRequestMock).toHaveBeenCalledTimes(1);
+    expect(noteDaemonApiRequestMock.mock.calls.at(-1)?.[0]).toBe(url);
+  });
+
+  test("notes a rewritten platform request exactly once", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const output = await requestInterceptor(
+      new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`),
+    );
+    expect(new URL(output.url).origin).toBe(INGRESS);
+    expect(noteDaemonApiRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not note platform-owned assistant routes", async () => {
+    await requestInterceptor(
+      new Request(
+        `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/maintenance-mode/`,
+      ),
+    );
+    expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
   test("a throwing counter leaves the request path intact", async () => {
     noteDaemonApiRequestImpl = () => {
       throw new Error("counter down");

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -46,6 +46,7 @@ import {
   getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
+import { noteDaemonApiRequest } from "@/lib/telemetry/resume-request-counter";
 import { getDeviceId } from "@/runtime/device-id";
 import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
@@ -304,12 +305,24 @@ export function authorizeRemoteGatewayRequest(
  *   clients (only allowlisted segments are forwarded; platform-owned
  *   routes like maintenance-mode, system-events, etc. fall through
  *   to Django).
+ * @param countResumeRequests `true` for the daemon + gateway clients, whose
+ *   traffic is what the post-resume request burst is measured on. Platform and
+ *   auth requests are deliberately left uncounted.
  */
 function createInterceptor({
   skipSegmentAllowlist = false,
   allowRemoteGatewayDirect = false,
+  countResumeRequests = false,
 } = {}) {
   return async (request: Request): Promise<Request> => {
+    if (countResumeRequests) {
+      try {
+        noteDaemonApiRequest(request.url);
+      } catch {
+        // Telemetry must never fail a request.
+      }
+    }
+
     const newRequest = new Request(request);
 
     // Per-tab client identity — sent on *every* request (GET included)
@@ -384,6 +397,7 @@ export const requestInterceptor = createInterceptor();
 export const daemonRequestInterceptor = createInterceptor({
   skipSegmentAllowlist: true,
   allowRemoteGatewayDirect: true,
+  countResumeRequests: true,
 });
 
 /**

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -137,6 +137,26 @@ const FLATTENED_FIRST_SEGMENTS = new Set<string>([
 ]);
 
 /**
+ * True when a path names daemon/gateway traffic, whichever client issues it.
+ * Mirrors the routing decision {@link rewriteForSelfHostedIngress} makes for
+ * the platform client, but is deliberately independent of whether an ingress
+ * is registered: the same path reaches the daemon through the platform's
+ * runtime proxy in cloud mode, so `client_resume.request_count` stays
+ * comparable across cloud and self-hosted.
+ */
+function isDaemonBoundPath(url: string): boolean {
+  const match = ASSISTANT_PATH_RE.exec(new URL(url).pathname);
+  if (!match) {
+    return false;
+  }
+  const firstSegment = match[2];
+  return (
+    RUNTIME_PROXIED_FIRST_SEGMENTS.has(firstSegment) ||
+    FLATTENED_FIRST_SEGMENTS.has(firstSegment)
+  );
+}
+
+/**
  * Rewrites a request bound for `/v1/assistants/{id}/{runtime-segment}/...`
  * to the registered self-hosted ingress, swapping platform session/CSRF
  * auth for `Authorization: Bearer <jwt>`.
@@ -305,22 +325,25 @@ export function authorizeRemoteGatewayRequest(
  *   clients (only allowlisted segments are forwarded; platform-owned
  *   routes like maintenance-mode, system-events, etc. fall through
  *   to Django).
- * @param countResumeRequests `true` for the daemon + gateway clients, whose
- *   traffic is what the post-resume request burst is measured on. Platform and
- *   auth requests are deliberately left uncounted.
+ * @param countEveryRequest `true` for the daemon + gateway clients, where every
+ *   request is daemon traffic by definition. The platform and auth clients
+ *   count only their daemon-bound paths ({@link isDaemonBoundPath}), the SSE
+ *   reopen among them, so the post-resume burst is measured whole while
+ *   platform-owned traffic stays out of it. One count per request: this is the
+ *   single choke point on each client's chain.
  */
 function createInterceptor({
   skipSegmentAllowlist = false,
   allowRemoteGatewayDirect = false,
-  countResumeRequests = false,
+  countEveryRequest = false,
 } = {}) {
   return async (request: Request): Promise<Request> => {
-    if (countResumeRequests) {
-      try {
+    try {
+      if (countEveryRequest || isDaemonBoundPath(request.url)) {
         noteDaemonApiRequest(request.url);
-      } catch {
-        // Telemetry must never fail a request.
       }
+    } catch {
+      // Telemetry must never fail a request.
     }
 
     const newRequest = new Request(request);
@@ -397,7 +420,7 @@ export const requestInterceptor = createInterceptor();
 export const daemonRequestInterceptor = createInterceptor({
   skipSegmentAllowlist: true,
   allowRemoteGatewayDirect: true,
-  countResumeRequests: true,
+  countEveryRequest: true,
 });
 
 /**

--- a/clients/web/src/lib/telemetry/resume-request-counter.test.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Pins the post-resume request counter's contract:
+ *   - one window per foreground, even when iOS publishes two resume signals;
+ *   - only requests inside the window are counted;
+ *   - endpoint labels come from the closed set, never a raw path;
+ *   - a zero-count window still emits, and unsubscribe cancels silently.
+ *
+ * bun:test has no fake-timer API, so `setTimeout` / `clearTimeout` are swapped
+ * for a capturing stub and fired by hand, the same idiom
+ * `use-feature-flag-bus-sync.test.tsx` uses.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const emitClientPerfEventMock = mock(
+  (_checkName: string, _value: number, _detail?: Record<string, unknown>) => {},
+);
+
+mock.module("@/lib/telemetry/client-perf", () => ({
+  emitClientPerfEvent: emitClientPerfEventMock,
+}));
+
+const { publish, __resetForTesting } = await import("@/lib/event-bus");
+const {
+  __resetResumeRequestCounterForTests,
+  noteDaemonApiRequest,
+  subscribeResumeRequestCounter,
+} = await import("./resume-request-counter");
+
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+let pendingTimers = new Map<number, () => void>();
+let nextTimerId = 1;
+let lastDelay: number | undefined;
+
+function fireTimers(): void {
+  const callbacks = Array.from(pendingTimers.values());
+  pendingTimers.clear();
+  for (const callback of callbacks) {
+    callback();
+  }
+}
+
+function lastEmit(): {
+  checkName: string;
+  value: number;
+  detail: Record<string, unknown>;
+} {
+  const call = emitClientPerfEventMock.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return {
+    checkName: call![0],
+    value: call![1],
+    detail: (call![2] ?? {}) as Record<string, unknown>,
+  };
+}
+
+function byGroup(): Record<string, number> {
+  return lastEmit().detail.by_group as Record<string, number>;
+}
+
+beforeEach(() => {
+  pendingTimers = new Map();
+  nextTimerId = 1;
+  lastDelay = undefined;
+  globalThis.setTimeout = ((callback: TimerHandler, delay?: number) => {
+    const id = nextTimerId++;
+    lastDelay = delay;
+    if (typeof callback === "function") {
+      pendingTimers.set(id, () => {
+        callback();
+      });
+    }
+    return id;
+  }) as unknown as typeof setTimeout;
+  globalThis.clearTimeout = ((id?: number) => {
+    if (id !== undefined) {
+      pendingTimers.delete(id);
+    }
+  }) as unknown as typeof clearTimeout;
+  emitClientPerfEventMock.mockClear();
+  __resetForTesting();
+  __resetResumeRequestCounterForTests();
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
+});
+
+describe("subscribeResumeRequestCounter", () => {
+  test("counts one window across the iOS double-publish", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    publish("app.resume", { signal: "app_state" });
+
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/messages");
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    const { checkName, value, detail } = lastEmit();
+    expect(checkName).toBe("client_resume.request_count");
+    expect(value).toBe(2);
+    expect(detail.window_ms).toBe(10_000);
+    expect(detail.signal).toBe("visibility");
+    expect(lastDelay).toBe(10_000);
+    unsubscribe();
+  });
+
+  test("ignores requests before the window opens and after it closes", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    fireTimers();
+
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    expect(lastEmit().value).toBe(1);
+    unsubscribe();
+  });
+
+  test("labels endpoints from the closed set and emits no path strings", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "app_state" });
+
+    noteDaemonApiRequest("/v1/assistants/x/conversations?limit=50");
+    noteDaemonApiRequest("https://api.test/v1/feature-flags");
+    noteDaemonApiRequest("https://api.test/v1/assistants/x/frobnicate");
+    fireTimers();
+
+    expect(byGroup()).toEqual({
+      conversations: 1,
+      "feature-flags": 1,
+      other: 1,
+    });
+    const serialized = JSON.stringify(lastEmit().detail);
+    expect(serialized).not.toContain("assistants");
+    expect(serialized).not.toContain("http");
+    expect(serialized).not.toContain("frobnicate");
+    unsubscribe();
+  });
+
+  test("emits a zero-count window", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "online" });
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    expect(lastEmit().value).toBe(0);
+    expect(byGroup()).toEqual({});
+    unsubscribe();
+  });
+
+  test("unsubscribe cancels an open window without emitting", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/messages");
+
+    unsubscribe();
+    fireTimers();
+
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+    expect(pendingTimers.size).toBe(0);
+  });
+
+  test("opens a fresh window on the next resume", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/events");
+    fireTimers();
+
+    publish("app.resume", { signal: "app_state" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/config");
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(2);
+    expect(lastEmit().value).toBe(1);
+    expect(byGroup()).toEqual({ config: 1 });
+    unsubscribe();
+  });
+});
+
+describe("noteDaemonApiRequest", () => {
+  test("never throws on a malformed url", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+
+    expect(() => {
+      noteDaemonApiRequest("http://[");
+    }).not.toThrow();
+    fireTimers();
+
+    expect(lastEmit().value).toBe(1);
+    expect(byGroup()).toEqual({ other: 1 });
+    unsubscribe();
+  });
+
+  test("is a no-op outside a window", () => {
+    expect(() => {
+      noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    }).not.toThrow();
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -9,10 +9,9 @@
  * Metadata only. Endpoint labels come from a closed set; raw pathnames and
  * URLs are never stored or emitted.
  *
- * The `client_resume.` check_name prefix is owned by the boot-telemetry PR
- * (#40029), which has not merged yet. Until it does, this module's detail bags
- * carry `page_load_id` where #40029's carry `boot_id`; downstream joins are
- * per check_name, so they are unaffected either way.
+ * Events in this family carry `page_load_id`, minted per page load by
+ * client-perf. Boot telemetry carries its own `boot_id`, and the two ids
+ * converge once a caller registers the boot id via `setClientPerfBootId`.
  */
 
 import { subscribe, type AppResumeSignal } from "@/lib/event-bus";

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -1,0 +1,133 @@
+/**
+ * Counts daemon API requests in the fixed window after an app resume.
+ *
+ * A real iOS feedback bundle showed a burst of daemon requests on every
+ * foreground. This counts that burst so the fix has a before/after number
+ * instead of an anecdote: one `client_resume.request_count` event per resume,
+ * carrying the total and a per-endpoint-group breakdown.
+ *
+ * Metadata only. Endpoint labels come from a closed set; raw pathnames and
+ * URLs are never stored or emitted.
+ *
+ * The `client_resume.` check_name prefix is owned by the boot-telemetry PR
+ * (#40029), which has not merged yet. Until it does, this module's detail bags
+ * carry `page_load_id` where #40029's carry `boot_id`; downstream joins are
+ * per check_name, so they are unaffected either way.
+ */
+
+import { subscribe, type AppResumeSignal } from "@/lib/event-bus";
+import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
+
+const WINDOW_MS = 10_000;
+
+const ENDPOINT_GROUPS = [
+  "conversations",
+  "messages",
+  "events",
+  "config",
+  "feature-flags",
+  "identity",
+  "schedules",
+  "apps",
+  "plugins",
+  "memory",
+  "other",
+] as const;
+
+type EndpointGroup = (typeof ENDPOINT_GROUPS)[number];
+
+const KNOWN_GROUPS = new Set<string>(ENDPOINT_GROUPS);
+
+/**
+ * Maps a request URL onto the closed label set. Anything unrecognized (and
+ * anything unparseable) lands on `"other"` so a new route can never leak a
+ * path into telemetry.
+ */
+function groupForUrl(url: string): EndpointGroup {
+  try {
+    const segments = new URL(url, "http://localhost").pathname
+      .split("/")
+      .filter(Boolean);
+    const v1 = segments.indexOf("v1");
+    if (v1 === -1) {
+      return "other";
+    }
+    // Daemon routes are either `/v1/<resource>` or the assistant-scoped
+    // `/v1/assistants/<id>/<resource>`.
+    const index = segments[v1 + 1] === "assistants" ? v1 + 3 : v1 + 1;
+    const segment = segments[index];
+    if (segment && KNOWN_GROUPS.has(segment)) {
+      return segment as EndpointGroup;
+    }
+    return "other";
+  } catch {
+    return "other";
+  }
+}
+
+let window_: {
+  timer: ReturnType<typeof setTimeout>;
+  total: number;
+  byGroup: Record<string, number>;
+  signal: AppResumeSignal;
+} | null = null;
+
+/** Drops any open window without emitting. */
+function cancelOpenWindow(): void {
+  if (!window_) {
+    return;
+  }
+  clearTimeout(window_.timer);
+  window_ = null;
+}
+
+/**
+ * Records one outgoing daemon request. No-op outside a resume window, so the
+ * steady-state cost is a single null check on the request path.
+ */
+export function noteDaemonApiRequest(url: string): void {
+  if (!window_) {
+    return;
+  }
+  const group = groupForUrl(url);
+  window_.total += 1;
+  window_.byGroup[group] = (window_.byGroup[group] ?? 0) + 1;
+}
+
+/**
+ * Opens a counting window on each `app.resume`. Returns an unsubscribe that
+ * also drops any window still open, without emitting.
+ */
+export function subscribeResumeRequestCounter(): () => void {
+  const unsubscribe = subscribe("app.resume", ({ signal }) => {
+    // iOS publishes both a visibility and an app_state resume for a single
+    // foreground; first edge wins so the burst is counted once.
+    if (window_) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      const closed = window_;
+      window_ = null;
+      if (!closed) {
+        return;
+      }
+      // A zero here is the signal we are looking for once the storm is fixed,
+      // so emit regardless of the count.
+      emitClientPerfEvent("client_resume.request_count", closed.total, {
+        by_group: closed.byGroup,
+        window_ms: WINDOW_MS,
+        signal: closed.signal,
+      });
+    }, WINDOW_MS);
+    window_ = { timer, total: 0, byGroup: {}, signal };
+  });
+
+  return () => {
+    unsubscribe();
+    cancelOpenWindow();
+  };
+}
+
+export function __resetResumeRequestCounterForTests(): void {
+  cancelOpenWindow();
+}


### PR DESCRIPTION
## Summary
- New client_resume.request_count telemetry: a 10s window opened on app.resume (first edge wins across the iOS double-publish) counts daemon/gateway API requests via the shared request interceptor
- Endpoint grouping uses a closed label set; raw URLs never stored or emitted; zero-count windows still emit as the success signal
- Interceptor hook is try/catch-guarded and inert on the request path

Part of plan: measure-first-telemetry-followups.md (PR 6 of 7)