### PR TITLE
feat(gateway): verify third-party plugin webhooks from a declared descriptor

### DIFF
--- a/gateway/src/channels/ingress-verification.test.ts
+++ b/gateway/src/channels/ingress-verification.test.ts
@@ -1,0 +1,401 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it } from "bun:test";
+
+import "../__tests__/test-preload.js";
+import {
+  canonicalVerification,
+  IngressVerificationSchema,
+  MAX_FRESHNESS_TOLERANCE_SECONDS,
+  verifyDeclaredSignature,
+  type IngressVerification,
+} from "./ingress-verification.js";
+
+const SECRET = "whsec_test";
+const NOW_MS = 1_700_000_000_000;
+
+const BODY_ONLY: IngressVerification = {
+  kind: "hmac",
+  algorithm: "sha256",
+  secret: { field: "comms_webhook_secret" },
+  signature: { header: "X-Osis-Signature", encoding: "hex", prefix: "sha256=" },
+  payload: ["body"],
+};
+
+const TIMESTAMPED: IngressVerification = {
+  kind: "hmac",
+  algorithm: "sha256",
+  secret: { field: "photon_webhook_secret" },
+  signature: {
+    header: "X-Spectrum-Signature",
+    encoding: "hex",
+    prefix: "v0=",
+  },
+  payload: [
+    { literal: "v0:" },
+    { header: "X-Spectrum-Timestamp" },
+    { literal: ":" },
+    "body",
+  ],
+  freshness: {
+    header: "X-Spectrum-Timestamp",
+    format: "unix-seconds",
+    toleranceSeconds: 300,
+  },
+};
+
+function bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function digest(
+  payload: string,
+  encoding: "hex" | "base64" = "hex",
+  secret = SECRET,
+): string {
+  return createHmac("sha256", secret).update(payload, "utf8").digest(encoding);
+}
+
+function verify(
+  verification: IngressVerification,
+  headers: Record<string, string>,
+  body: string,
+  opts: { secret?: string; nowMs?: number } = {},
+) {
+  return verifyDeclaredSignature({
+    verification,
+    headers: new Headers(headers),
+    body: bytes(body),
+    secret: opts.secret ?? SECRET,
+    nowMs: opts.nowMs ?? NOW_MS,
+  });
+}
+
+describe("the descriptor schema", () => {
+  it("accepts the shapes the shipped plugins declare", () => {
+    expect(IngressVerificationSchema.safeParse(BODY_ONLY).success).toBe(true);
+    expect(IngressVerificationSchema.safeParse(TIMESTAMPED).success).toBe(true);
+  });
+
+  it("rejects an unknown kind rather than falling back to a default", () => {
+    // A route the plugin believes is verified one way and the gateway
+    // verifies another is worse than no route.
+    const parsed = IngressVerificationSchema.safeParse({
+      ...BODY_ONLY,
+      kind: "jwt",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects an unknown algorithm or encoding", () => {
+    expect(
+      IngressVerificationSchema.safeParse({ ...BODY_ONLY, algorithm: "md5" })
+        .success,
+    ).toBe(false);
+    expect(
+      IngressVerificationSchema.safeParse({
+        ...BODY_ONLY,
+        signature: { ...BODY_ONLY.signature, encoding: "base64url" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unrecognized key", () => {
+    expect(
+      IngressVerificationSchema.safeParse({ ...BODY_ONLY, tolerate: true })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a credential field that could reach out of the plugin's service", () => {
+    for (const field of [
+      "../vellum/webhook_secret",
+      "vellum/webhook_secret",
+      "Webhook_Secret",
+      "",
+    ]) {
+      const parsed = IngressVerificationSchema.safeParse({
+        ...BODY_ONLY,
+        secret: { field },
+      });
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it("rejects a descriptor naming a service rather than a field", () => {
+    // The service half is composed gateway-side from the plugin's directory
+    // name, so a manifest may not supply one.
+    expect(
+      IngressVerificationSchema.safeParse({
+        ...BODY_ONLY,
+        secret: { service: "vellum", field: "webhook_secret" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty payload", () => {
+    expect(
+      IngressVerificationSchema.safeParse({ ...BODY_ONLY, payload: [] })
+        .success,
+    ).toBe(false);
+  });
+
+  it("bounds a declared replay window", () => {
+    const overWindow = {
+      ...TIMESTAMPED,
+      freshness: {
+        ...TIMESTAMPED.freshness,
+        toleranceSeconds: MAX_FRESHNESS_TOLERANCE_SECONDS + 1,
+      },
+    };
+    expect(IngressVerificationSchema.safeParse(overWindow).success).toBe(false);
+  });
+});
+
+describe("body-only verification", () => {
+  it("accepts a correct signature", () => {
+    const body = '{"event":"comms.message.received"}';
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": `sha256=${digest(body)}` },
+      body,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("covers the bytes as received, not a reserialization", () => {
+    const signed = '{"a":1}';
+    const delivered = '{ "a" : 1 }';
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": `sha256=${digest(signed)}` },
+      delivered,
+    );
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("reports a missing header separately from a wrong signature", () => {
+    expect(verify(BODY_ONLY, {}, "{}")).toEqual({
+      ok: false,
+      reason: "missing_signature",
+    });
+  });
+
+  it("rejects a signature missing its declared prefix", () => {
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": digest("{}") },
+      "{}",
+    );
+    expect(result).toEqual({ ok: false, reason: "malformed_signature" });
+  });
+
+  it("rejects a digest that is not the declared encoding", () => {
+    // `Buffer.from` drops characters it does not recognize, so a lenient
+    // decode could shorten an attacker's digest into a match.
+    for (const presented of ["sha256=zzzz", "sha256=abc", "sha256="]) {
+      const result = verify(BODY_ONLY, { "X-Osis-Signature": presented }, "{}");
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  it("rejects a truncated digest rather than comparing a prefix", () => {
+    const full = digest("{}");
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": `sha256=${full.slice(0, 16)}` },
+      "{}",
+    );
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a signature made with a different secret", () => {
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": `sha256=${digest("{}", "hex", "other")}` },
+      "{}",
+    );
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("treats an empty stored secret as unverifiable", () => {
+    const result = verify(
+      BODY_ONLY,
+      { "X-Osis-Signature": `sha256=${digest("{}")}` },
+      "{}",
+      { secret: "" },
+    );
+    expect(result).toEqual({ ok: false, reason: "missing_signature" });
+  });
+
+  it("accepts a base64 digest when that is what was declared", () => {
+    const base64Descriptor: IngressVerification = {
+      ...BODY_ONLY,
+      signature: { header: "X-Sig", encoding: "base64" },
+    };
+    const result = verify(
+      base64Descriptor,
+      { "X-Sig": digest("{}", "base64") },
+      "{}",
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("timestamped verification", () => {
+  const body = '{"event":"message.received"}';
+  const seconds = Math.floor(NOW_MS / 1000);
+
+  function signedAt(ts: number, payloadBody = body): Record<string, string> {
+    return {
+      "X-Spectrum-Timestamp": String(ts),
+      "X-Spectrum-Signature": `v0=${digest(`v0:${ts}:${payloadBody}`)}`,
+    };
+  }
+
+  it("accepts a delivery inside the window", () => {
+    expect(verify(TIMESTAMPED, signedAt(seconds), body)).toEqual({ ok: true });
+  });
+
+  it("accepts a clock a little ahead of ours", () => {
+    expect(verify(TIMESTAMPED, signedAt(seconds + 60), body)).toEqual({
+      ok: true,
+    });
+  });
+
+  it("rejects a replay past the window", () => {
+    expect(verify(TIMESTAMPED, signedAt(seconds - 3600), body)).toEqual({
+      ok: false,
+      reason: "stale_timestamp",
+    });
+  });
+
+  it("rejects a delivery with no timestamp", () => {
+    const result = verify(
+      TIMESTAMPED,
+      { "X-Spectrum-Signature": `v0=${digest(`v0::${body}`)}` },
+      body,
+    );
+    expect(result).toEqual({ ok: false, reason: "missing_timestamp" });
+  });
+
+  it("rejects an unparsable timestamp", () => {
+    const result = verify(
+      TIMESTAMPED,
+      {
+        "X-Spectrum-Timestamp": "not-a-number",
+        "X-Spectrum-Signature": `v0=${digest(`v0:not-a-number:${body}`)}`,
+      },
+      body,
+    );
+    expect(result).toEqual({ ok: false, reason: "missing_timestamp" });
+  });
+
+  it("binds the timestamp into the signature", () => {
+    // Restamping a captured delivery must not make it fresh again.
+    const headers = signedAt(seconds - 3600);
+    headers["X-Spectrum-Timestamp"] = String(seconds);
+    expect(verify(TIMESTAMPED, headers, body)).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
+  });
+
+  it("reports a payload header that is absent without a freshness rule", () => {
+    const noFreshness: IngressVerification = {
+      ...TIMESTAMPED,
+      freshness: undefined,
+    };
+    const result = verify(
+      noFreshness,
+      { "X-Spectrum-Signature": `v0=${digest(`v0::${body}`)}` },
+      body,
+    );
+    expect(result).toEqual({ ok: false, reason: "missing_payload_header" });
+  });
+
+  it("reads unix-millis and rfc3339 timestamps", () => {
+    const millis: IngressVerification = {
+      ...TIMESTAMPED,
+      payload: ["body"],
+      freshness: {
+        header: "X-Ts",
+        format: "unix-millis",
+        toleranceSeconds: 300,
+      },
+    };
+    expect(
+      verify(
+        millis,
+        {
+          "X-Ts": String(NOW_MS),
+          "X-Spectrum-Signature": `v0=${digest(body)}`,
+        },
+        body,
+      ),
+    ).toEqual({ ok: true });
+
+    const rfc: IngressVerification = {
+      ...millis,
+      freshness: { header: "X-Ts", format: "rfc3339", toleranceSeconds: 300 },
+    };
+    expect(
+      verify(
+        rfc,
+        {
+          "X-Ts": new Date(NOW_MS).toISOString(),
+          "X-Spectrum-Signature": `v0=${digest(body)}`,
+        },
+        body,
+      ),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("canonicalVerification", () => {
+  it("is stable under key reordering", () => {
+    const reordered = IngressVerificationSchema.parse({
+      payload: ["body"],
+      signature: {
+        prefix: "sha256=",
+        encoding: "hex",
+        header: "X-Osis-Signature",
+      },
+      secret: { field: "comms_webhook_secret" },
+      algorithm: "sha256",
+      kind: "hmac",
+    });
+    expect(canonicalVerification(reordered)).toBe(
+      canonicalVerification(BODY_ONLY),
+    );
+  });
+
+  it("changes when the secret field changes", () => {
+    expect(
+      canonicalVerification({
+        ...BODY_ONLY,
+        secret: { field: "other_secret" },
+      }),
+    ).not.toBe(canonicalVerification(BODY_ONLY));
+  });
+
+  it("changes when the covered bytes change", () => {
+    expect(
+      canonicalVerification({ ...BODY_ONLY, payload: [{ literal: "x" }] }),
+    ).not.toBe(canonicalVerification(BODY_ONLY));
+  });
+
+  it("keeps payload order, which is part of what is signed", () => {
+    const forward: IngressVerification = {
+      ...BODY_ONLY,
+      payload: [{ literal: "a" }, "body"],
+    };
+    const reversed: IngressVerification = {
+      ...BODY_ONLY,
+      payload: ["body", { literal: "a" }],
+    };
+    expect(canonicalVerification(forward)).not.toBe(
+      canonicalVerification(reversed),
+    );
+  });
+});

--- a/gateway/src/channels/ingress-verification.ts
+++ b/gateway/src/channels/ingress-verification.ts
@@ -1,0 +1,302 @@
+/**
+ * Declared signature verification for plugin ingress routes.
+ *
+ * A plugin route that receives third-party webhooks cannot use the platform
+ * scheme (`Vellum-Signature`, see `../http/vellum-signature.ts`): the caller is
+ * Comms, or Photon, or Stripe, and it signs the way it signs. Before this,
+ * such a route could be declared, approved, registered with the vendor, and
+ * then 403 every delivery — the only schemes the gateway knew were its own.
+ *
+ * So a route may declare *how* to verify it, as data. The gateway implements
+ * one HMAC engine and reads the vendor's specifics — algorithm, which header
+ * carries the digest, how it is encoded, and exactly which bytes it covers —
+ * out of the manifest. A third vendor is a manifest edit rather than gateway
+ * code, which is the whole point: the alternative is a growing switch of
+ * per-vendor verifiers that only the gateway team can extend.
+ *
+ * What stays gateway-side, and must:
+ *
+ * - **The credential's service.** A descriptor names a *field*; the service is
+ *   composed from the plugin's own directory name by the caller. A manifest
+ *   that could name the service could point a route at another plugin's secret,
+ *   or at the platform's.
+ * - **Fail-closed parsing.** Anything unrecognized — an unknown `kind`,
+ *   algorithm, encoding, or an extra key — fails the manifest rather than
+ *   falling back to the platform scheme. A route the plugin believes is
+ *   verified one way and the gateway verifies another is worse than no route.
+ * - **Raw bytes.** `body` is the bytes as received. Every vendor here signs
+ *   pre-parse, and a re-serialized JSON body does not match — a failure that
+ *   looks exactly like a wrong secret.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { z } from "zod";
+
+/** Hash functions a descriptor may name. */
+export const HmacAlgorithmSchema = z.enum(["sha1", "sha256", "sha512"]);
+
+/** How a digest is written in its header. */
+export const DigestEncodingSchema = z.enum(["hex", "base64"]);
+
+/**
+ * A credential field under the declaring plugin's own service.
+ *
+ * Constrained rather than free-form: the value is composed into a store key,
+ * and a field carrying `/` or `..` would let a manifest reach a service it does
+ * not own. The service half is never declarable at all — see the module note.
+ */
+export const CredentialFieldSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-z0-9][a-z0-9_]*$/,
+    "credential field must be lowercase alphanumeric with underscores",
+  );
+
+/**
+ * One piece of the byte string a signature covers, in order.
+ *
+ * `"body"` is the raw request body. `{ header }` is a request header's value —
+ * a header named here but absent from the request fails verification rather
+ * than contributing an empty string, or a caller could omit a timestamp to
+ * change what was signed. `{ literal }` is a fixed separator or version tag.
+ *
+ * Together these cover the shapes vendors actually use: `body` alone (Comms,
+ * GitHub), and `<tag>:<timestamp>:<body>` (Photon, Slack).
+ */
+export const PayloadPartSchema = z.union([
+  z.literal("body"),
+  z.object({ literal: z.string().min(1) }).strict(),
+  z.object({ header: z.string().min(1) }).strict(),
+]);
+export type PayloadPart = z.infer<typeof PayloadPartSchema>;
+
+export const TimestampFormatSchema = z.enum([
+  "unix-seconds",
+  "unix-millis",
+  "rfc3339",
+]);
+
+/** Ceiling on a declared replay window. A day is already generous. */
+export const MAX_FRESHNESS_TOLERANCE_SECONDS = 24 * 60 * 60;
+
+/**
+ * Replay guard.
+ *
+ * Optional because not every vendor offers one: a signature over the body
+ * alone stays valid for as long as the secret does, and a vendor that binds no
+ * timestamp cannot be given a window by us. Where one exists, declaring it is
+ * what makes a captured delivery stop working.
+ */
+export const FreshnessSchema = z
+  .object({
+    header: z.string().min(1),
+    format: TimestampFormatSchema,
+    toleranceSeconds: z
+      .number()
+      .int()
+      .positive()
+      .max(MAX_FRESHNESS_TOLERANCE_SECONDS),
+  })
+  .strict();
+
+export const HmacVerificationSchema = z
+  .object({
+    kind: z.literal("hmac"),
+    algorithm: HmacAlgorithmSchema,
+    secret: z.object({ field: CredentialFieldSchema }).strict(),
+    signature: z
+      .object({
+        header: z.string().min(1),
+        encoding: DigestEncodingSchema,
+        /** Stripped before comparison — `sha256=`, `v0=`. */
+        prefix: z.string().min(1).optional(),
+      })
+      .strict(),
+    payload: z.array(PayloadPartSchema).min(1),
+    freshness: FreshnessSchema.optional(),
+  })
+  .strict();
+
+/**
+ * How a route is verified.
+ *
+ * A discriminated union of one member today. It is a union rather than a bare
+ * object so a second scheme — a vendor that signs an asymmetric signature, say
+ * — is an added member with its own required fields, and every existing
+ * manifest keeps parsing.
+ */
+export const IngressVerificationSchema = z.discriminatedUnion("kind", [
+  HmacVerificationSchema,
+]);
+export type IngressVerification = z.infer<typeof IngressVerificationSchema>;
+
+/** Why a delivery was refused. For gateway logs; callers are told nothing. */
+export type VerificationRejection =
+  | "missing_signature"
+  | "malformed_signature"
+  | "missing_payload_header"
+  | "missing_timestamp"
+  | "stale_timestamp"
+  | "bad_signature";
+
+export type VerificationResult =
+  | { ok: true }
+  | { ok: false; reason: VerificationRejection };
+
+/** Assemble the exact bytes a signature covers, or the header that is missing. */
+function buildPayload(
+  parts: readonly PayloadPart[],
+  headers: Headers,
+  body: Uint8Array,
+): Buffer | { missingHeader: string } {
+  const chunks: Buffer[] = [];
+
+  for (const part of parts) {
+    if (part === "body") {
+      chunks.push(Buffer.from(body));
+      continue;
+    }
+    if ("literal" in part) {
+      chunks.push(Buffer.from(part.literal, "utf8"));
+      continue;
+    }
+    const value = headers.get(part.header);
+    if (value === null) {
+      return { missingHeader: part.header };
+    }
+    chunks.push(Buffer.from(value, "utf8"));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Decode a presented digest, or `null` when it is not that encoding.
+ *
+ * Validated before decoding because both decoders are lenient: `Buffer.from`
+ * drops characters it does not recognize, so an attacker-supplied digest could
+ * otherwise decode to a *shorter* buffer that happens to compare equal against
+ * a truncated expectation.
+ */
+function decodeDigest(
+  value: string,
+  encoding: "hex" | "base64",
+): Buffer | null {
+  if (encoding === "hex") {
+    if (!/^[0-9a-fA-F]+$/.test(value) || value.length % 2 !== 0) return null;
+    return Buffer.from(value, "hex");
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return null;
+  const decoded = Buffer.from(value, "base64");
+  // Round-trip guard: base64 has several spellings of the same bytes, and only
+  // the canonical one should be accepted.
+  return decoded.toString("base64").replace(/=+$/, "") ===
+    value.replace(/=+$/, "")
+    ? decoded
+    : null;
+}
+
+/** Unix milliseconds for a timestamp in the declared format, or `null`. */
+function timestampMs(value: string, format: string): number | null {
+  if (format === "rfc3339") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (!/^-?\d+$/.test(value)) return null;
+  const numeric = Number(value);
+  if (!Number.isSafeInteger(numeric)) return null;
+  return format === "unix-millis" ? numeric : numeric * 1000;
+}
+
+/**
+ * Verify a delivery against the route's declared scheme.
+ *
+ * Order matters: the freshness check runs before the HMAC because it is the
+ * cheap one and rejects a replay without touching the secret.
+ */
+export function verifyDeclaredSignature(opts: {
+  verification: IngressVerification;
+  headers: Headers;
+  body: Uint8Array;
+  secret: string;
+  nowMs?: number;
+}): VerificationResult {
+  const { verification, headers, body, secret } = opts;
+  const nowMs = opts.nowMs ?? Date.now();
+
+  const presented = headers.get(verification.signature.header);
+  if (!presented || !secret) {
+    return { ok: false, reason: "missing_signature" };
+  }
+
+  const { prefix } = verification.signature;
+  if (prefix && !presented.startsWith(prefix)) {
+    return { ok: false, reason: "malformed_signature" };
+  }
+  const digest = decodeDigest(
+    prefix ? presented.slice(prefix.length) : presented,
+    verification.signature.encoding,
+  );
+  if (!digest) {
+    return { ok: false, reason: "malformed_signature" };
+  }
+
+  const { freshness } = verification;
+  if (freshness) {
+    const stamped = headers.get(freshness.header);
+    if (stamped === null) {
+      return { ok: false, reason: "missing_timestamp" };
+    }
+    const ms = timestampMs(stamped, freshness.format);
+    if (ms === null) {
+      return { ok: false, reason: "missing_timestamp" };
+    }
+    if (Math.abs(nowMs - ms) > freshness.toleranceSeconds * 1000) {
+      return { ok: false, reason: "stale_timestamp" };
+    }
+  }
+
+  const payload = buildPayload(verification.payload, headers, body);
+  if ("missingHeader" in payload) {
+    return { ok: false, reason: "missing_payload_header" };
+  }
+
+  const expected = createHmac(verification.algorithm, secret)
+    .update(payload)
+    .digest();
+
+  // Length is compared first because timingSafeEqual throws on a mismatch, and
+  // digest length is a function of the declared algorithm — public either way.
+  if (digest.length !== expected.length) {
+    return { ok: false, reason: "bad_signature" };
+  }
+  return timingSafeEqual(digest, expected)
+    ? { ok: true }
+    : { ok: false, reason: "bad_signature" };
+}
+
+/**
+ * Stable string for a descriptor, for the approval digest.
+ *
+ * Keys are emitted in sorted order so a reformatted manifest that means the
+ * same thing does not drop a plugin back to `pending`, while any change to
+ * what is verified or which secret verifies it does.
+ */
+export function canonicalVerification(
+  verification: IngressVerification,
+): string {
+  return JSON.stringify(sortDeep(verification));
+}
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, nested]) => [key, sortDeep(nested)]),
+  );
+}

--- a/gateway/src/channels/plugin-ingress-approvals.test.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.test.ts
@@ -179,6 +179,71 @@ describe("ingressDeclarationDigest", () => {
     ).toBe("db809d978434fd3804c8faad82851069");
   });
 
+  it("keeps the digest a route had before verification existed", () => {
+    // Same golden guarantee as the handshake default: a route that declares
+    // no descriptor must digest exactly as it did before the field, or every
+    // approved plugin drops back to pending on upgrade.
+    expect(
+      ingressDeclarationDigest([
+        {
+          kind: "http",
+          signer: "plugin",
+          handshake: "signed-headers",
+          path: "hook",
+          verification: undefined,
+        },
+      ]),
+    ).toBe(
+      ingressDeclarationDigest([
+        {
+          kind: "http",
+          signer: "plugin",
+          handshake: "signed-headers",
+          path: "hook",
+        },
+      ]),
+    );
+  });
+
+  it("changes when a route gains a verification descriptor", () => {
+    // The descriptor decides which secret and which bytes make a delivery
+    // authentic. A guardian approved a route verified one way, not any way.
+    const base = {
+      kind: "http" as const,
+      signer: "plugin" as const,
+      handshake: "signed-headers" as const,
+      path: "events-comms",
+    };
+    const declared = {
+      ...base,
+      verification: {
+        kind: "hmac" as const,
+        algorithm: "sha256" as const,
+        secret: { field: "comms_webhook_secret" },
+        signature: {
+          header: "X-Osis-Signature",
+          encoding: "hex" as const,
+          prefix: "sha256=",
+        },
+        payload: ["body" as const],
+      },
+    };
+    expect(ingressDeclarationDigest([declared])).not.toBe(
+      ingressDeclarationDigest([base]),
+    );
+    expect(
+      ingressDeclarationDigest([
+        {
+          ...declared,
+          verification: {
+            ...declared.verification,
+            secret: { field: "other_secret" },
+          },
+        },
+      ]),
+    ).not.toBe(ingressDeclarationDigest([declared]));
+  });
+
   it("changes when the handshake scheme changes", () => {
     // signed-query makes the URL itself the credential. A guardian who
     // approved the header scheme has not approved that.

--- a/gateway/src/channels/plugin-ingress-approvals.ts
+++ b/gateway/src/channels/plugin-ingress-approvals.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 
 import { listPluginIngressApprovals } from "../db/plugin-ingress-approval-store.js";
 import { getLogger } from "../logger.js";
+import { canonicalVerification } from "./ingress-verification.js";
 import {
   discoverPluginIngress,
   PluginIngressCache,
@@ -20,32 +21,40 @@ const log = getLogger("plugin-ingress-approvals");
 /**
  * Digest of what a declaration asks for.
  *
- * Covers reach only — each route's transport, signer, handshake scheme, and
- * path, order-independent. A `description` reword leaves the digest alone, so
- * it does not revoke an approval, while adding a route, changing one's
- * transport, changing whose signature opens it, or moving it to a scheme that
- * exposes it differently all do.
+ * Covers reach only — each route's transport, signer, handshake scheme, path,
+ * and how it is verified, order-independent. A `description` reword leaves the
+ * digest alone, so it does not revoke an approval, while adding a route,
+ * changing one's transport, changing whose signature opens it, moving it to a
+ * scheme that exposes it differently, or changing which secret and which bytes
+ * decide a delivery is authentic all do.
  *
- * A route on the default `signed-headers` scheme is encoded without that
- * field, exactly as it was before the field existed. The alternative is that
- * introducing `handshake` silently re-digests every unchanged manifest, drops
- * each one back to `pending`, and 404s routes a guardian already approved
- * until someone approves them again. Omitting the default is unambiguous
- * because a path may not contain whitespace (see `IngressRouteSchema`), so a
- * three-token line can never be read as a four-token one.
+ * A route on the default `signed-headers` scheme, or with no declared
+ * verification, is encoded without that field, exactly as it was before the
+ * field existed. The alternative is that introducing a field silently
+ * re-digests every unchanged manifest, drops each one back to `pending`, and
+ * 404s routes a guardian already approved until someone approves them again.
+ * Omitting the defaults is unambiguous because a path may not contain
+ * whitespace (see `IngressRouteSchema`), so a three-token line can never be
+ * read as a four-token one, and a verification descriptor is appended behind a
+ * tab, which no path may carry and which `JSON.stringify` escapes rather than
+ * emits.
  */
 export function ingressDeclarationDigest(
   routes: readonly Pick<
     IngressRoute,
-    "kind" | "path" | "signer" | "handshake"
+    "kind" | "path" | "signer" | "handshake" | "verification"
   >[],
 ): string {
   const canonical = routes
-    .map((route) =>
-      route.handshake === "signed-headers"
-        ? `${route.kind} ${route.signer} ${route.path}`
-        : `${route.kind} ${route.signer} ${route.handshake} ${route.path}`,
-    )
+    .map((route) => {
+      const base =
+        route.handshake === "signed-headers"
+          ? `${route.kind} ${route.signer} ${route.path}`
+          : `${route.kind} ${route.signer} ${route.handshake} ${route.path}`;
+      return route.verification
+        ? `${base}\t${canonicalVerification(route.verification)}`
+        : base;
+    })
     .sort()
     .join("\n");
   return createHash("sha256").update(canonical).digest("hex").slice(0, 32);

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -138,6 +138,128 @@ describe("parsePluginIngressManifest", () => {
     ).toThrow(/only valid for websocket/);
   });
 
+  it("accepts a verification descriptor on an http route", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [
+        {
+          path: "events-comms",
+          kind: "http",
+          verification: {
+            kind: "hmac",
+            algorithm: "sha256",
+            secret: { field: "comms_webhook_secret" },
+            signature: {
+              header: "X-Osis-Signature",
+              encoding: "hex",
+              prefix: "sha256=",
+            },
+            payload: ["body"],
+          },
+          description: "inbound comms deliveries",
+        },
+      ],
+    });
+    expect(manifest.routes[0]!.verification?.secret.field).toBe(
+      "comms_webhook_secret",
+    );
+  });
+
+  it("leaves verification undeclared when the manifest omits it", () => {
+    // Absent means the platform scheme, exactly as before the field existed.
+    const manifest = parsePluginIngressManifest(JSON.parse(VALID));
+    expect(manifest.routes[0]!.verification).toBeUndefined();
+  });
+
+  it("rejects verification combined with signer vellum", () => {
+    // A `vellum` route is served without a guardian approval, so a descriptor
+    // there would let a plugin open an unreviewed route it verifies itself.
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "hook",
+            kind: "http",
+            signer: "vellum",
+            verification: {
+              kind: "hmac",
+              algorithm: "sha256",
+              secret: { field: "vendor_secret" },
+              signature: { header: "X-Sig", encoding: "hex" },
+              payload: ["body"],
+            },
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow(/cannot be combined with signer "vellum"/);
+  });
+
+  it("rejects verification on a websocket route", () => {
+    // A socket upgrade is bridged elsewhere and carries none of this.
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "realtime",
+            kind: "websocket",
+            verification: {
+              kind: "hmac",
+              algorithm: "sha256",
+              secret: { field: "vendor_secret" },
+              signature: { header: "X-Sig", encoding: "hex" },
+              payload: ["body"],
+            },
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow(/only valid for http routes/);
+  });
+
+  it("rejects a verification descriptor the gateway cannot run", () => {
+    // Fail the manifest rather than falling back to the platform scheme: a
+    // route verified differently than declared is worse than no route.
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "hook",
+            kind: "http",
+            verification: {
+              kind: "hmac",
+              algorithm: "md5",
+              secret: { field: "vendor_secret" },
+              signature: { header: "X-Sig", encoding: "hex" },
+              payload: ["body"],
+            },
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a descriptor reaching for another service's credential", () => {
+    expect(() =>
+      parsePluginIngressManifest({
+        routes: [
+          {
+            path: "hook",
+            kind: "http",
+            verification: {
+              kind: "hmac",
+              algorithm: "sha256",
+              secret: { field: "../vellum/webhook_secret" },
+              signature: { header: "X-Sig", encoding: "hex" },
+              payload: ["body"],
+            },
+            description: "d",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
   it("rejects an unknown handshake", () => {
     expect(() =>
       parsePluginIngressManifest({

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { getLogger } from "../logger.js";
 import { getWorkspaceDir } from "../paths.js";
+import { IngressVerificationSchema } from "./ingress-verification.js";
 
 const log = getLogger("plugin-ingress");
 
@@ -131,6 +132,33 @@ export const IngressRouteSchema = z.object({
    * approval a guardian granted for the other one.
    */
   handshake: IngressHandshakeSchema.default("signed-headers"),
+  /**
+   * How a third-party caller's signature is checked, when it is not ours.
+   *
+   * Absent (the default) means the platform scheme: `Vellum-Signature` over
+   * the body, keyed by whichever `webhook_secret` {@link signer} selects.
+   * That is right for a caller Vellum controls and wrong for every other one
+   * — Comms signs `X-Osis-Signature`, Photon signs `X-Spectrum-Signature` over
+   * a timestamped preamble, and neither can be asked to sign ours.
+   *
+   * Present, the route is verified by the descriptor instead: the gateway
+   * runs one HMAC engine and reads the vendor's specifics as data, so a new
+   * vendor is a manifest edit rather than gateway code. See
+   * `ingress-verification.ts` for the scheme and for what stays gateway-side.
+   *
+   * The descriptor supersedes {@link signer} — it names its own credential
+   * field, under this plugin's own service — so declaring it alongside
+   * `signer: "vellum"` is rejected: `vellum` routes are served without a
+   * guardian approval (see `findServableRoute`), and a route that both skips
+   * approval and verifies against a secret the plugin chose would be reach a
+   * plugin grants itself. HTTP only, for the same reason `signed-query` is
+   * WebSocket only: a socket upgrade is bridged elsewhere and carries none of
+   * this.
+   *
+   * Part of the digest, so what verifies a route cannot change under an
+   * approval granted for something else.
+   */
+  verification: IngressVerificationSchema.optional(),
   /** Human-readable purpose, surfaced in gateway logs and admin UI. */
   description: z.string().min(1),
 });
@@ -206,6 +234,18 @@ export function parsePluginIngressManifest(
       throw new Error(
         `route ${route.path}: signed-query handshakes are only valid for websocket routes`,
       );
+    }
+    if (route.verification) {
+      if (route.signer === "vellum") {
+        throw new Error(
+          `route ${route.path}: declared verification cannot be combined with signer "vellum"`,
+        );
+      }
+      if (route.kind !== "http") {
+        throw new Error(
+          `route ${route.path}: declared verification is only valid for http routes`,
+        );
+      }
     }
   }
   return manifest;

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 import "../../__tests__/test-preload.js";
 import { initSigningKey } from "../../auth/token-service.js";
 import type { PluginIngressResolution } from "../../channels/plugin-ingress-approvals.js";
+import type { IngressRoute } from "../../channels/plugin-ingress.js";
 import type { GatewayConfig } from "../../config.js";
 import { createPluginWebhookHandler } from "./plugin-webhook.js";
 
@@ -19,7 +20,7 @@ const CONFIG = {
   maxWebhookPayloadBytes: 1024,
 } as GatewayConfig;
 
-const ROUTE = {
+const ROUTE: IngressRoute = {
   path: "realtime",
   kind: "http" as const,
   signer: "plugin" as const,
@@ -29,6 +30,8 @@ const ROUTE = {
 
 const PLUGIN_SECRET = "plugin-webhook-secret";
 const VELLUM_SECRET = "platform-webhook-secret";
+/** Held under a field the manifest names, not under `webhook_secret`. */
+const VENDOR_SECRET = "whsec_vendor";
 
 /** Stands in for the credential cache, holding secrets by key. */
 function credentialsFor(entries: Record<string, string>) {
@@ -42,6 +45,7 @@ function credentialsFor(entries: Record<string, string>) {
 const CREDENTIALS = credentialsFor({
   "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
   "credential/vellum/webhook_secret": VELLUM_SECRET,
+  "credential/meeting-bot/vendor_webhook_secret": VENDOR_SECRET,
 });
 
 function sign(body: string, secret: string): string {
@@ -55,15 +59,7 @@ function resolution(
 }
 
 /** An approved declaration for `meeting-bot` carrying `routes`. */
-function approvedWith(
-  routes: {
-    path: string;
-    kind: "http" | "websocket";
-    signer: "plugin" | "vellum";
-    handshake: "signed-headers" | "signed-query";
-    description: string;
-  }[],
-): PluginIngressResolution {
+function approvedWith(routes: IngressRoute[]): PluginIngressResolution {
   return resolution({
     approved: [{ plugin: "meeting-bot", routes, digest: "d".repeat(32) }],
   });
@@ -494,6 +490,265 @@ describe("signature verification", () => {
       "meeting-bot",
       "realtime",
     );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("declared verification", () => {
+  /** A Comms-shaped descriptor: HMAC over the raw body, hex, prefixed. */
+  const BODY_ONLY: IngressRoute = {
+    ...ROUTE,
+    verification: {
+      kind: "hmac",
+      algorithm: "sha256",
+      secret: { field: "vendor_webhook_secret" },
+      signature: {
+        header: "X-Osis-Signature",
+        encoding: "hex",
+        prefix: "sha256=",
+      },
+      payload: ["body"],
+    },
+  };
+
+  /** A Photon-shaped descriptor: `v0:<timestamp>:<body>`, with a window. */
+  const TIMESTAMPED: IngressRoute = {
+    ...ROUTE,
+    verification: {
+      kind: "hmac",
+      algorithm: "sha256",
+      secret: { field: "vendor_webhook_secret" },
+      signature: {
+        header: "X-Spectrum-Signature",
+        encoding: "hex",
+        prefix: "v0=",
+      },
+      payload: [
+        { literal: "v0:" },
+        { header: "X-Spectrum-Timestamp" },
+        { literal: ":" },
+        "body",
+      ],
+      freshness: {
+        header: "X-Spectrum-Timestamp",
+        format: "unix-seconds",
+        toleranceSeconds: 300,
+      },
+    },
+  };
+
+  function hmac(payload: string, secret: string): string {
+    return createHmac("sha256", secret).update(payload, "utf8").digest("hex");
+  }
+
+  function vendorPost(body: string, headers: Record<string, string>): Request {
+    return new Request("http://gateway/webhooks/plugins/meeting-bot/realtime", {
+      method: "POST",
+      body,
+      headers,
+    });
+  }
+
+  it("accepts a delivery signed the vendor's way", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const body = '{"event":"comms.message.received"}';
+    const res = await handle(
+      vendorPost(body, {
+        "X-Osis-Signature": `sha256=${hmac(body, VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toBe(body);
+  });
+
+  it("reads the secret from the declared field, not webhook_secret", async () => {
+    // The plugin's own `webhook_secret` must not open a route the manifest
+    // said is verified by something else.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      vendorPost("{}", {
+        "X-Osis-Signature": `sha256=${hmac("{}", PLUGIN_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("stops accepting the platform scheme once a descriptor is declared", async () => {
+    // Otherwise a declared route would have two ways in, and the weaker one
+    // would decide.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      post("/webhooks/plugins/meeting-bot/realtime", "{}", VENDOR_SECRET),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("409s when the declared field holds nothing", async () => {
+    // Same fail-closed rule as a missing `webhook_secret`: the route is
+    // declared and approved, but nothing can authenticate a caller yet.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: credentialsFor({
+        "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
+      }),
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const res = await handle(
+      vendorPost("{}", {
+        "X-Osis-Signature": `sha256=${hmac("{}", VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(409);
+    expect(calls).toEqual([]);
+  });
+
+  it("signs over the bytes as received, not a reserialization", async () => {
+    // Every vendor here signs pre-parse, so whitespace inside the JSON is
+    // part of what was signed.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const body = '{ "event" :  "comms.message.received" }';
+    const res = await handle(
+      vendorPost(body, {
+        "X-Osis-Signature": `sha256=${hmac(body, VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls[0]!.body).toBe(body);
+  });
+
+  it("accepts a timestamped preamble inside the window", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([TIMESTAMPED]),
+      fetchImpl,
+    });
+
+    const body = '{"event":"message.received"}';
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await handle(
+      vendorPost(body, {
+        "X-Spectrum-Timestamp": ts,
+        "X-Spectrum-Signature": `v0=${hmac(`v0:${ts}:${body}`, VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("rejects a replay outside the declared window", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([TIMESTAMPED]),
+      fetchImpl,
+    });
+
+    const body = '{"event":"message.received"}';
+    const ts = String(Math.floor(Date.now() / 1000) - 3600);
+    const res = await handle(
+      vendorPost(body, {
+        "X-Spectrum-Timestamp": ts,
+        "X-Spectrum-Signature": `v0=${hmac(`v0:${ts}:${body}`, VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a delivery that omits a header the payload names", async () => {
+    // Dropping the timestamp must not silently change what was signed into
+    // something the caller can produce.
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([TIMESTAMPED]),
+      fetchImpl,
+    });
+
+    const body = '{"event":"message.received"}';
+    const res = await handle(
+      vendorPost(body, {
+        "X-Spectrum-Signature": `v0=${hmac(`v0::${body}`, VENDOR_SECRET)}`,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a delivery carrying no signature header at all", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: CREDENTIALS,
+      resolve: () => approvedWith([BODY_ONLY]),
+      fetchImpl,
+    });
+
+    const res = await handle(vendorPost("{}", {}), "meeting-bot", "realtime");
 
     expect(res.status).toBe(403);
     expect(calls).toEqual([]);

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -11,13 +11,19 @@
  * approval alone would only decide which paths exist, not who may call them.
  * Every request is therefore signature-checked before it is forwarded, and
  * a route whose secret is missing is refused rather than served unsigned.
- * The declaration picks whose secret that is — see `IngressRouteSchema.signer`.
+ * The declaration picks whose secret that is — see `IngressRouteSchema.signer`
+ * — and, for a route a third party calls, how the signature is formed at all
+ * (`IngressRouteSchema.verification`).
  */
 
 import {
   findServableRoute,
   type PluginIngressResolution,
 } from "../../channels/plugin-ingress-approvals.js";
+import {
+  verifyDeclaredSignature,
+  type VerificationRejection,
+} from "../../channels/ingress-verification.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -42,12 +48,23 @@ const log = getLogger("plugin-webhook");
  * from Vellum needs no secret of its own. Everything else verifies against
  * the plugin's, stored under its own service name.
  *
- * The field name is fixed for now; making it configurable per plugin is a
- * later step, along with what the HMAC covers.
+ * A route declaring `verification` names its own field instead, but only the
+ * field: the service half is composed here from the plugin's directory name,
+ * so no manifest can point a route at another plugin's secret or at the
+ * platform's.
  */
-function signingCredentialKey(plugin: string, signer: IngressSigner): string {
+function signingCredentialKey(
+  plugin: string,
+  route: {
+    signer: IngressSigner;
+    verification?: { secret: { field: string } };
+  },
+): string {
+  if (route.verification) {
+    return credentialKey(plugin, route.verification.secret.field);
+  }
   return credentialKey(
-    signer === "vellum" ? "vellum" : plugin,
+    route.signer === "vellum" ? "vellum" : plugin,
     "webhook_secret",
   );
 }
@@ -125,11 +142,12 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
     // Signature check before the forward, and fail-closed when no secret is
     // configured: serving a public route unsigned because its secret is
     // missing would turn a setup mistake into an open endpoint.
-    const secretKey = signingCredentialKey(plugin, route.signer);
+    const verification = route.verification;
+    const secretKey = signingCredentialKey(plugin, route);
     const secret = await resolveCredentialWithRefresh(credentials, secretKey);
     if (!secret) {
       log.warn(
-        { plugin, path, signer: route.signer },
+        { plugin, path, signer: route.signer, secretKey },
         "Plugin webhook secret is not configured — rejecting request",
       );
       return Response.json(
@@ -138,17 +156,38 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
       );
     }
 
+    // Kept for the log line only. The retry inside verifySecretWithRefresh can
+    // overwrite it, which is what we want: the reason reported is the one from
+    // the last secret tried, not the stale-cache attempt that preceded it.
+    let rejection: VerificationRejection | undefined;
     const signatureValid = await verifySecretWithRefresh({
       credentials,
       key: secretKey,
-      verify: (candidate) =>
-        verifyVellumSignature(req.headers, body.bytes, candidate),
+      verify: (candidate) => {
+        if (!verification) {
+          return verifyVellumSignature(req.headers, body.bytes, candidate);
+        }
+        const result = verifyDeclaredSignature({
+          verification,
+          headers: req.headers,
+          body: body.bytes,
+          secret: candidate,
+        });
+        rejection = result.ok ? undefined : result.reason;
+        return result.ok;
+      },
       log,
       label: "Plugin webhook signature",
     });
     if (!signatureValid) {
       log.warn(
-        { plugin, path, signer: route.signer },
+        {
+          plugin,
+          path,
+          signer: route.signer,
+          scheme: verification?.kind ?? "vellum",
+          rejection,
+        },
         "Plugin webhook signature verification failed",
       );
       return Response.json({ error: "Forbidden" }, { status: 403 });


### PR DESCRIPTION
## Prompt / plan

Follow-on to the `imessage` plugin's ingress manifest, which now declares two HTTP routes (`events-photon`, `events-comms`) whose deliveries come from Photon and Comms by Osis rather than from Vellum.

Today a plugin ingress route can be declared, approved, registered with the vendor, and then 403 every delivery: `plugin-webhook.ts` only knows `Vellum-Signature`, and no vendor can be asked to sign ours. The instruction that shaped the design was that solving this with per-vendor gateway code "kills the generic-webhooks end state we want to march towards" — so the vendor's specifics are declared as data in `channels/ingress.json`, and the gateway runs one engine over them.

**What a route may now declare.** An optional `verification` descriptor: HMAC algorithm, which credential field holds the secret, which header carries the digest and how it is encoded/prefixed, and exactly which bytes the signature covers — `["body"]` alone (Comms, GitHub) or `[{literal:"v0:"}, {header:"X-Spectrum-Timestamp"}, {literal:":"}, "body"]` (Photon, Slack) — plus an optional replay window. A third vendor is a manifest edit rather than a gateway PR.

**What deliberately stays gateway-side:**

- *The credential's service.* A descriptor names a **field**; the service half is composed from the plugin's own directory name in `signingCredentialKey`. A manifest that could name the service could point a route at another plugin's secret, or at the platform's. The field is constrained to `^[a-z0-9][a-z0-9_]*$` so it cannot carry `/` or `..` into the store key either.
- *Fail-closed parsing.* An unknown `kind`, algorithm, or encoding, or any extra key, fails the whole manifest rather than falling back to the platform scheme. A route the plugin believes is verified one way and the gateway verifies another is worse than no route.
- *Raw bytes.* Verification runs on the bytes as received — every vendor here signs pre-parse, and a re-serialized body fails in a way that looks exactly like a wrong secret.
- *Strict digest decoding.* `Buffer.from` silently drops characters it does not recognize, so a presented digest is validated against its declared encoding before decoding, and length is checked before the constant-time compare.

**Two manifest-level rejections carry the trust boundary.** `verification` may not be combined with `signer: "vellum"` — those routes are served *without* a guardian approval (`findServableRoute`), so a route that both skips approval and verifies against a secret the plugin chose would be reach a plugin grants itself. And it is HTTP-only, since a socket upgrade is bridged elsewhere and carries none of this.

**Approvals.** The descriptor is part of `ingressDeclarationDigest`, so changing which secret or which bytes decide authenticity drops the plugin back to `pending`. A route that declares no descriptor digests exactly as before, byte for byte, so no already-approved plugin 404s on upgrade — the same guarantee the `handshake` default carries, with golden values covering it.

## Test plan

- `bun run test` in `gateway/` — all 243 test files pass.
- `bunx tsc --noEmit` clean; `format:check` and `eslint` clean on the touched files (pre-commit hook ran both).
- New `gateway/src/channels/ingress-verification.test.ts`: schema acceptance/rejection (unknown kind/algorithm/encoding, extra keys, a `secret.service` a manifest must not be able to name, `../vellum/webhook_secret` as a field, empty payload, over-long replay window); body-only and timestamped verification including reserialized bodies, truncated and mis-encoded digests, a restamped replay, and canonical-digest stability.
- `plugin-ingress.test.ts`: the two new manifest rejections and a descriptor round-trip.
- `plugin-ingress-approvals.test.ts`: a route with no descriptor keeps its pre-existing digest; gaining one, or changing the secret field, changes it.
- `plugin-webhook.test.ts`: a Comms-shaped and a Photon-shaped delivery accepted end-to-end; the plugin's own `webhook_secret` rejected on a descriptor route; the platform scheme no longer accepted once a descriptor is declared; 409 when the declared field is empty; replay and missing-header rejections.
- Parsed the shipped `imessage` `channels/ingress.json` through `parsePluginIngressManifest` — both routes validate and produce a digest.

Existing `signer`/`handshake` behaviour is untouched; every prior test in these files passes unmodified.


---
_Generated by [Claude Code](https://claude.ai/code/session_013p1nTdvsuAtTJ7zyCSDLbx)_