### PR TITLE
fix: harden and consolidate the paired gateway proxy

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -42,6 +42,7 @@ import {
   resolvePairedGatewayProxyTarget,
   readAllowedGatewayPorts,
   readPairedGatewayTargets,
+  sanitizePairedForwardHeaders,
   isLoopbackAddr,
   headerHostIsLoopback,
   originIsAllowed,
@@ -775,22 +776,25 @@ async function handleLocalEndpoints(
   // Paired-gateway proxy: same shared decision as the web (Vite middleware)
   // and Electron (`app://` handler) hosts, forwarding to the remote gateway an
   // imported pairing recorded as its `runtimeUrl`. The lockfile's paired
-  // entries are the allowlist. Origin is dropped on the server-to-server hop;
-  // the guardian bearer passes through for the remote gateway to validate.
-  const pairedDecision = resolvePairedGatewayProxyTarget(pathname, () =>
-    readPairedGatewayTargets(lockfilePaths),
+  // entries are the allowlist. Browser-ambient headers (Origin, Referer,
+  // Cookie, Sec-Fetch-*) are stripped on the server-to-server hop; the
+  // guardian bearer passes through for the remote gateway to validate.
+  const pairedDecision = resolvePairedGatewayProxyTarget(
+    pathname + url.search,
+    () => readPairedGatewayTargets(lockfilePaths),
   );
-  if (pairedDecision.kind === "unknown-assistant") {
-    return new Response("Assistant is not paired in lockfile", { status: 403 });
+  if (pairedDecision.kind === "reject") {
+    return new Response(pairedDecision.message, {
+      status: pairedDecision.status,
+    });
   }
   if (pairedDecision.kind === "forward") {
-    const targetUrl = `${pairedDecision.url}${url.search}`;
     const headers = new Headers(req.headers);
+    sanitizePairedForwardHeaders(headers);
     headers.set("host", new URL(pairedDecision.url).host);
-    headers.delete("origin");
     return proxyGatewayFetch(
       req,
-      targetUrl,
+      pairedDecision.url,
       headers,
       "Paired gateway proxy error",
     );

--- a/clients/macos/src/main/gateway-forward.test.ts
+++ b/clients/macos/src/main/gateway-forward.test.ts
@@ -142,20 +142,45 @@ describe("planPairedGatewayForward", () => {
     expect(plan.hasBody).toBe(false);
   });
 
-  test("removes the renderer's Origin entirely on the server-to-server hop", () => {
-    const plan = planPairedGatewayForward(
-      request("/__gateway-paired/abc/v1/events", {
-        method: "POST",
+  test("strips the browser-ambient headers on the server-to-server hop", () => {
+    const req = {
+      url: "app://vellum.ai/__gateway-paired/abc/v1/events",
+      method: "POST",
+      headers: new Headers({
         origin: "app://vellum.ai",
+        referer: "app://vellum.ai/assistant",
+        cookie: "sessionid=abc",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
       }),
+    };
+    const plan = planPairedGatewayForward(
+      req,
       pair({ abc: "https://gw.example.com" }),
     );
     if (plan.kind !== "forward") throw new Error("expected forward");
     expect(plan.headers.has("origin")).toBe(false);
+    expect(plan.headers.has("referer")).toBe(false);
+    expect(plan.headers.has("cookie")).toBe(false);
+    expect(plan.headers.has("sec-fetch-site")).toBe(false);
+    expect(plan.headers.has("sec-fetch-mode")).toBe(false);
     expect(plan.hasBody).toBe(true);
   });
 
-  test("preserves non-Origin headers such as the guardian bearer", () => {
+  test("rejects a dot-segment traversal tail with 403", () => {
+    expect(
+      planPairedGatewayForward(
+        request("/__gateway-paired/abc/%2e%2e/secrets"),
+        pair({ abc: "https://gw.example.com/edge" }),
+      ),
+    ).toEqual({
+      kind: "reject",
+      status: 403,
+      message: "Assistant is not paired in lockfile",
+    });
+  });
+
+  test("preserves non-ambient headers such as the guardian bearer", () => {
     const req = {
       url: "app://vellum.ai/assistant/__gateway-paired/abc/v1/foo",
       method: "GET",

--- a/clients/macos/src/main/gateway-forward.ts
+++ b/clients/macos/src/main/gateway-forward.ts
@@ -1,6 +1,7 @@
 import {
   resolveGatewayProxyTarget,
   resolvePairedGatewayProxyTarget,
+  sanitizePairedForwardHeaders,
 } from "@vellumai/local-mode";
 
 /**
@@ -92,12 +93,26 @@ export function planGatewayForward(
  * lockfile-pairing decision so the security boundary is defined once for every
  * host: only assistants the user actually imported are reachable.
  *
- * On `forward`, the request's `Origin` is removed entirely. This is a
- * server-to-server hop to a remote gateway, so the renderer's `app://` origin
- * must not be sent, and unlike the loopback forward there is no
- * loopback-origin gate to satisfy. The remaining headers (notably the
- * guardian `Authorization` bearer) pass through unchanged; the remote gateway
- * validates the bearer by signature and audience.
+ * On `forward`, the browser-ambient headers (`Origin`, `Referer`, `Cookie`,
+ * `Sec-Fetch-*`) are stripped via the shared `sanitizePairedForwardHeaders`:
+ * this is a server-to-server hop to a remote gateway, so nothing about the
+ * renderer's `app://` context may leak into it. The guardian `Authorization`
+ * bearer passes through unchanged; the remote gateway validates it by
+ * signature and audience.
+ *
+ * Unlike `planPlatformForward`, this plan deliberately carries no
+ * initiator-trust gate on unsafe methods. The platform hop attaches ambient
+ * credentials on the far side (session cookie / token headers), so a mutation
+ * must prove it came from the renderer, and the renderer's API interceptor
+ * stamps `X-Vellum-Electron-Renderer-Origin` on platform-bound mutations to
+ * make that provable. Paired-bound requests carry no such stamp (the
+ * interceptor rewrites them to the self-hosted ingress before the
+ * platform-header step), and after sanitization this hop carries no ambient
+ * credential at all: the lockfile allowlists the target, and the only
+ * credential is the explicit `Authorization` bearer, which a cross-site
+ * initiator cannot attach. An initiator gate here would add no protection
+ * while rejecting legitimate paired mutations, which present neither the
+ * stamp nor a usable `Origin` on the `app://` scheme.
  */
 export function planPairedGatewayForward(
   request: GatewayForwardRequest,
@@ -112,15 +127,11 @@ export function planPairedGatewayForward(
   switch (decision.kind) {
     case "pass":
       return { kind: "pass" };
-    case "unknown-assistant":
-      return {
-        kind: "reject",
-        status: 403,
-        message: "Assistant is not paired in lockfile",
-      };
+    case "reject":
+      return decision;
     case "forward": {
       const headers = new Headers(request.headers);
-      headers.delete("origin");
+      sanitizePairedForwardHeaders(headers);
       return {
         kind: "forward",
         url: decision.url,

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -748,10 +748,10 @@ describe("getAuthGatewayIngressUrl", () => {
     expect(getAuthGatewayIngressUrl(platform)).toBeUndefined();
   });
 
-  test("defaults to the selected assistant", () => {
+  test("resolves the selected assistant's ingress", () => {
     enableLocalMode();
     setLockfile({ assistants: [pairedEntry], activeAssistant: "paired-a" });
-    expect(getAuthGatewayIngressUrl()).toBe(
+    expect(getAuthGatewayIngressUrl(getSelectedAssistant())).toBe(
       `${window.location.origin}/assistant/__gateway-paired/paired-a`,
     );
   });

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -1,3 +1,5 @@
+import { isUsableRuntimeUrl } from "@vellumai/local-mode/contract";
+
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
   clearSelectedAssistantId,
@@ -669,24 +671,8 @@ function expectsPairedGateway(assistant: LockfileAssistant): boolean {
 }
 
 /** Same-origin proxy path for a paired assistant's remote gateway. */
-export function pairedGatewayProxyUrl(assistantId: string): string {
+function pairedGatewayProxyUrl(assistantId: string): string {
   return `/assistant/__gateway-paired/${encodeURIComponent(assistantId)}`;
-}
-
-/**
- * Whether a paired entry records a `runtimeUrl` the serving host can forward
- * to: an absolute http(s) URL.
- */
-function hasUsablePairedRuntimeUrl(assistant: LockfileAssistant): boolean {
-  if (!assistant.runtimeUrl) {
-    return false;
-  }
-  try {
-    const url = new URL(assistant.runtimeUrl);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -708,7 +694,7 @@ export function getPairedGatewayUrl(
   if (!assistant || !expectsPairedGateway(assistant)) {
     return undefined;
   }
-  if (!hasUsablePairedRuntimeUrl(assistant)) {
+  if (!isUsableRuntimeUrl(assistant.runtimeUrl)) {
     return undefined;
   }
   return pairedGatewayProxyUrl(assistant.assistantId);
@@ -720,7 +706,7 @@ export function getPairedGatewayUrl(
  * gateway proxy for paired entries, `undefined` otherwise.
  */
 export function getAuthGatewayIngressUrl(
-  assistant: LockfileAssistant | undefined = getSelectedAssistant(),
+  assistant: LockfileAssistant | undefined,
 ): string | undefined {
   const base = getLocalGatewayUrl(assistant) ?? getPairedGatewayUrl(assistant);
   if (!base) {

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -26,6 +26,7 @@ import {
   resolvePairedGatewayProxyTarget,
   readAllowedGatewayPorts,
   readPairedGatewayTargets,
+  sanitizePairedForwardHeaders,
   type CliInvocation,
 } from "@vellumai/local-mode";
 
@@ -112,6 +113,46 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(accountSpaFallback(server));
     },
   };
+}
+
+function respondJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Buffer and parse a JSON request body. An empty body resolves to `{}` (the
+ * per-field validation reports what's missing); malformed JSON resolves to
+ * `null`.
+ */
+function readJsonBody(
+  req: http.IncomingMessage,
+): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(
+          JSON.parse(Buffer.concat(chunks).toString()) as Record<
+            string,
+            unknown
+          >,
+        );
+      } catch {
+        resolve(null);
+      }
+    });
+  });
 }
 
 function rejectUnlessLocalEndpointRequest(
@@ -404,40 +445,23 @@ function retireMiddleware(
       return;
     }
 
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
-      let assistantId: string | undefined;
-      if (chunks.length > 0) {
-        try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            assistantId?: string;
-          };
-          assistantId = body.assistantId;
-        } catch {
-          res.statusCode = 400;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
-          return;
-        }
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
       }
 
-      if (!assistantId) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+      const assistantId = body.assistantId;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
         return;
       }
 
       if (!isActiveAssistant(lockfilePaths, assistantId)) {
-        res.statusCode = 403;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            ok: false,
-            error: "Can only retire the active local assistant",
-          }),
-        );
+        respondJson(res, 403, {
+          ok: false,
+          error: "Can only retire the active local assistant",
+        });
         return;
       }
 
@@ -445,26 +469,20 @@ function retireMiddleware(
       try {
         invocation = resolveDevCliInvocation(baseDir, import.meta.url);
       } catch (err) {
-        res.statusCode = 500;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        respondJson(res, 500, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         return;
       }
 
-      runRetire(invocation, assistantId, {
+      void runRetire(invocation, assistantId, {
         platformToken: getDevPlatformToken() ?? undefined,
       }).then((result) => {
-        res.statusCode = result.ok ? 200 : result.status;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify(
-            result.ok ? { ok: true } : { ok: false, error: result.error },
-          ),
+        respondJson(
+          res,
+          result.ok ? 200 : result.status,
+          result.ok ? { ok: true } : { ok: false, error: result.error },
         );
       });
     });
@@ -493,40 +511,25 @@ function unpairMiddleware(
       return;
     }
 
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
-      let assistantId: string | undefined;
-      if (chunks.length > 0) {
-        try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            assistantId?: string;
-          };
-          assistantId = body.assistantId;
-        } catch {
-          res.statusCode = 400;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
-          return;
-        }
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
       }
 
-      if (!assistantId) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+      const assistantId = body.assistantId;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
         return;
       }
 
       const result = unpairAssistant(lockfilePaths, configDir, assistantId);
-      res.statusCode = result.ok ? 200 : result.status;
-      res.setHeader("Content-Type", "application/json");
-      res.end(
-        JSON.stringify(
-          result.ok
-            ? { ok: true, lockfile: result.lockfile }
-            : { ok: false, error: result.error },
-        ),
+      respondJson(
+        res,
+        result.ok ? 200 : result.status,
+        result.ok
+          ? { ok: true, lockfile: result.lockfile }
+          : { ok: false, error: result.error },
       );
     });
   };
@@ -551,28 +554,15 @@ function sleepMiddleware(baseDir: string): Connect.NextHandleFunction {
       return;
     }
 
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
-      let assistantId: string | undefined;
-      if (chunks.length > 0) {
-        try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            assistantId?: string;
-          };
-          assistantId = body.assistantId;
-        } catch {
-          res.statusCode = 400;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
-          return;
-        }
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
       }
 
-      if (!assistantId) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+      const assistantId = body.assistantId;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
         return;
       }
 
@@ -580,24 +570,18 @@ function sleepMiddleware(baseDir: string): Connect.NextHandleFunction {
       try {
         invocation = resolveDevCliInvocation(baseDir, import.meta.url);
       } catch (err) {
-        res.statusCode = 500;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        respondJson(res, 500, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         return;
       }
 
-      runSleep(invocation, assistantId).then((result) => {
-        res.statusCode = result.ok ? 200 : result.status;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify(
-            result.ok ? { ok: true } : { ok: false, error: result.error },
-          ),
+      void runSleep(invocation, assistantId).then((result) => {
+        respondJson(
+          res,
+          result.ok ? 200 : result.status,
+          result.ok ? { ok: true } : { ok: false, error: result.error },
         );
       });
     });
@@ -620,31 +604,16 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
       return;
     }
 
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
-      let assistantId: string | undefined;
-      let repairGuardian = false;
-      if (chunks.length > 0) {
-        try {
-          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
-            assistantId?: string;
-            repairGuardian?: boolean;
-          };
-          assistantId = body.assistantId;
-          repairGuardian = body.repairGuardian === true;
-        } catch {
-          res.statusCode = 400;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ ok: false, error: "Invalid JSON body" }));
-          return;
-        }
+    void readJsonBody(req).then((body) => {
+      if (!body) {
+        respondJson(res, 400, { ok: false, error: "Invalid JSON body" });
+        return;
       }
 
-      if (!assistantId) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ ok: false, error: "Missing assistantId" }));
+      const assistantId = body.assistantId;
+      const repairGuardian = body.repairGuardian === true;
+      if (typeof assistantId !== "string" || !assistantId) {
+        respondJson(res, 400, { ok: false, error: "Missing assistantId" });
         return;
       }
 
@@ -652,26 +621,22 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
       try {
         invocation = resolveDevCliInvocation(baseDir, import.meta.url);
       } catch (err) {
-        res.statusCode = 500;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          }),
-        );
+        respondJson(res, 500, {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
         return;
       }
 
-      runWake(invocation, assistantId, { repairGuardian }).then((result) => {
-        res.statusCode = result.ok ? 200 : result.status;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify(
+      void runWake(invocation, assistantId, { repairGuardian }).then(
+        (result) => {
+          respondJson(
+            res,
+            result.ok ? 200 : result.status,
             result.ok ? { ok: true } : { ok: false, error: result.error },
-          ),
-        );
-      });
+          );
+        },
+      );
     });
   };
 }
@@ -924,8 +889,9 @@ function gatewayProxyMiddleware(
 // Paired-gateway data plane (`/__gateway-paired/{assistantId}/*`): same
 // posture as the loopback gateway proxy above, but the target is the remote
 // gateway an imported pairing recorded as its `runtimeUrl`. The lockfile's
-// paired entries are the allowlist. The `Origin` header is removed entirely on
-// this server-to-server hop; the guardian `Authorization` bearer passes
+// paired entries are the allowlist. Browser-ambient headers (`Origin`,
+// `Referer`, `Cookie`, `Sec-Fetch-*`) are stripped on this server-to-server
+// hop via the shared sanitizer; the guardian `Authorization` bearer passes
 // through untouched for the remote gateway to validate.
 function pairedGatewayProxyMiddleware(
   lockfilePaths: string[],
@@ -942,15 +908,28 @@ function pairedGatewayProxyMiddleware(
       return;
     }
 
-    if (decision.kind === "unknown-assistant") {
-      res.statusCode = 403;
-      res.end("Assistant is not paired in lockfile");
+    if (decision.kind === "reject") {
+      res.statusCode = decision.status;
+      res.end(decision.message);
       return;
     }
 
     const target = new URL(decision.url);
-    const requestHeaders = { ...req.headers, host: target.host };
-    delete requestHeaders.origin;
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (value === undefined) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          headers.append(name, item);
+        }
+      } else {
+        headers.set(name, value);
+      }
+    }
+    sanitizePairedForwardHeaders(headers);
+    headers.set("host", target.host);
     pipeGatewayProxy(
       req,
       res,
@@ -961,7 +940,7 @@ function pairedGatewayProxyMiddleware(
         port: target.port || undefined,
         path: target.pathname + target.search,
         method: req.method,
-        headers: requestHeaders,
+        headers: Object.fromEntries(headers.entries()),
       },
       "Paired gateway proxy error",
     );

--- a/packages/local-mode/src/__tests__/gateway-proxy.test.ts
+++ b/packages/local-mode/src/__tests__/gateway-proxy.test.ts
@@ -9,7 +9,14 @@ import {
   readPairedGatewayTargets,
   resolveGatewayProxyTarget,
   resolvePairedGatewayProxyTarget,
+  sanitizePairedForwardHeaders,
 } from "../gateway-proxy";
+
+const pairedRejection = {
+  kind: "reject",
+  status: 403,
+  message: "Assistant is not paired in lockfile",
+} as const;
 
 const allow =
   (...ports: number[]) =>
@@ -132,14 +139,14 @@ describe("parsePairedGatewayUrl", () => {
     expect(parsePairedGatewayUrl("/__gateway-paired/abc/v1/foo")).toEqual({
       match: true,
       valid: true,
-      target: { assistantId: "abc", path: "/v1/foo" },
+      target: { assistantId: "abc", path: "/v1/foo", search: "" },
     });
     expect(
       parsePairedGatewayUrl("/assistant/__gateway-paired/abc/v1/foo"),
     ).toEqual({
       match: true,
       valid: true,
-      target: { assistantId: "abc", path: "/v1/foo" },
+      target: { assistantId: "abc", path: "/v1/foo", search: "" },
     });
   });
 
@@ -147,7 +154,28 @@ describe("parsePairedGatewayUrl", () => {
     expect(parsePairedGatewayUrl("/__gateway-paired/abc")).toEqual({
       match: true,
       valid: true,
-      target: { assistantId: "abc", path: "/" },
+      target: { assistantId: "abc", path: "/", search: "" },
+    });
+  });
+
+  test("splits the query off the id instead of swallowing it", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc?x=1")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/", search: "?x=1" },
+    });
+  });
+
+  test("carries the query through on a pathful tail and drops a fragment", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc/v1/foo?x=1#frag")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/v1/foo", search: "?x=1" },
+    });
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc/v1#frag")).toEqual({
+      match: true,
+      valid: true,
+      target: { assistantId: "abc", path: "/v1", search: "" },
     });
   });
 
@@ -155,7 +183,7 @@ describe("parsePairedGatewayUrl", () => {
     expect(parsePairedGatewayUrl("/__gateway-paired/a%20b/v1")).toEqual({
       match: true,
       valid: true,
-      target: { assistantId: "a b", path: "/v1" },
+      target: { assistantId: "a b", path: "/v1", search: "" },
     });
   });
 
@@ -164,6 +192,33 @@ describe("parsePairedGatewayUrl", () => {
       match: true,
       valid: false,
     });
+  });
+
+  test("rejects dot segments in the tail, raw or percent-encoded", () => {
+    for (const url of [
+      "/__gateway-paired/abc/../secrets",
+      "/__gateway-paired/abc/v1/../../secrets",
+      "/__gateway-paired/abc/./v1",
+      "/__gateway-paired/abc/%2e%2e/secrets",
+      "/__gateway-paired/abc/%2E%2E/secrets",
+      "/__gateway-paired/abc/%2e/v1",
+      "/__gateway-paired/abc/v1/%zz",
+    ]) {
+      expect(parsePairedGatewayUrl(url)).toEqual({
+        match: true,
+        valid: false,
+      });
+    }
+  });
+
+  test("does not treat dot-containing filenames as traversal", () => {
+    expect(parsePairedGatewayUrl("/__gateway-paired/abc/v1/file.json")).toEqual(
+      {
+        match: true,
+        valid: true,
+        target: { assistantId: "abc", path: "/v1/file.json", search: "" },
+      },
+    );
   });
 
   test("does not match non-paired pathnames", () => {
@@ -191,6 +246,30 @@ describe("resolvePairedGatewayProxyTarget", () => {
         pair({ abc: "https://gw.example.com" }),
       ),
     ).toEqual({ kind: "forward", url: "https://gw.example.com/v1/foo?x=1" });
+  });
+
+  test("forwards a query on a pathless tail instead of treating it as part of the id", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/abc?x=1",
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    ).toEqual({ kind: "forward", url: "https://gw.example.com/?x=1" });
+  });
+
+  test("rejects a dot-segment traversal tail", () => {
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/abc/../../secrets",
+        pair({ abc: "https://gw.example.com/edge" }),
+      ),
+    ).toEqual(pairedRejection);
+    expect(
+      resolvePairedGatewayProxyTarget(
+        "/__gateway-paired/abc/%2e%2e/secrets",
+        pair({ abc: "https://gw.example.com/edge" }),
+      ),
+    ).toEqual(pairedRejection);
   });
 
   test("strips the runtimeUrl's trailing slashes and keeps its path prefix", () => {
@@ -223,7 +302,7 @@ describe("resolvePairedGatewayProxyTarget", () => {
         "/__gateway-paired/unknown/v1",
         pair({ abc: "https://gw.example.com" }),
       ),
-    ).toEqual({ kind: "unknown-assistant" });
+    ).toEqual(pairedRejection);
   });
 
   test("rejects a malformed percent-encoded id", () => {
@@ -232,7 +311,7 @@ describe("resolvePairedGatewayProxyTarget", () => {
         "/__gateway-paired/%zz/v1",
         pair({ "%zz": "https://gw.example.com" }),
       ),
-    ).toEqual({ kind: "unknown-assistant" });
+    ).toEqual(pairedRejection);
   });
 
   test("never reads the allowlist for non-paired paths", () => {
@@ -329,5 +408,63 @@ describe("readPairedGatewayTargets", () => {
     expect(
       readPairedGatewayTargets(["/nonexistent/assistants.json"]),
     ).toEqual(new Map());
+  });
+
+  test("stops at the first parseable lockfile even when it yields no targets", () => {
+    // The unpair write path targets the first lockfile path
+    // (writeRawLockfile), so the allowlist must not fall through to a stale
+    // legacy file just because the written file has no paired entries left.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paired-gateway-test-"));
+    const primary = path.join(dir, "assistants.json");
+    const legacy = path.join(dir, "legacy-assistants.json");
+    try {
+      fs.writeFileSync(primary, JSON.stringify({ assistants: [] }));
+      fs.writeFileSync(
+        legacy,
+        JSON.stringify({
+          assistants: [
+            {
+              assistantId: "paired-a",
+              cloud: "paired",
+              runtimeUrl: "https://gw.example.com",
+            },
+          ],
+        }),
+      );
+      expect(readPairedGatewayTargets([primary, legacy])).toEqual(new Map());
+      // A missing primary still falls through to the legacy file.
+      fs.rmSync(primary);
+      expect(readPairedGatewayTargets([primary, legacy])).toEqual(
+        new Map([["paired-a", "https://gw.example.com"]]),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("sanitizePairedForwardHeaders", () => {
+  test("strips Origin, Referer, Cookie, and Sec-Fetch-* but keeps the bearer", () => {
+    const headers = new Headers({
+      origin: "http://localhost:5173",
+      referer: "http://localhost:5173/assistant",
+      cookie: "sessionid=abc",
+      "sec-fetch-site": "same-origin",
+      "sec-fetch-mode": "cors",
+      "sec-fetch-dest": "empty",
+      authorization: "Bearer guardian-token",
+      accept: "text/event-stream",
+      "content-type": "application/json",
+    });
+    sanitizePairedForwardHeaders(headers);
+    expect(headers.has("origin")).toBe(false);
+    expect(headers.has("referer")).toBe(false);
+    expect(headers.has("cookie")).toBe(false);
+    expect(headers.has("sec-fetch-site")).toBe(false);
+    expect(headers.has("sec-fetch-mode")).toBe(false);
+    expect(headers.has("sec-fetch-dest")).toBe(false);
+    expect(headers.get("authorization")).toBe("Bearer guardian-token");
+    expect(headers.get("accept")).toBe("text/event-stream");
+    expect(headers.get("content-type")).toBe("application/json");
   });
 });

--- a/packages/local-mode/src/gateway-proxy.ts
+++ b/packages/local-mode/src/gateway-proxy.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 
-import { resolveCloud } from "./lockfile-contract";
+import { isUsableRuntimeUrl, resolveCloud } from "./lockfile-contract";
 
 const GATEWAY_PATTERN = /^(?:\/assistant)?\/__gateway\/(\d+)(\/.*)?$/;
 
 const PAIRED_GATEWAY_PATTERN =
-  /^(?:\/assistant)?\/__gateway-paired\/([^/]+)(\/.*)?$/;
+  /^(?:\/assistant)?\/__gateway-paired\/([^/?#]+)(\/.*)?$/;
 
 export interface GatewayTarget {
   port: number;
@@ -71,7 +71,10 @@ export function resolveGatewayProxyTarget(
 
 export interface PairedGatewayTarget {
   assistantId: string;
+  /** Pathname tail forwarded onto the runtimeUrl, without the query. */
   path: string;
+  /** Query string including the leading `?`, or empty. */
+  search: string;
 }
 
 export type PairedGatewayParseResult =
@@ -79,9 +82,38 @@ export type PairedGatewayParseResult =
   | { match: true; valid: false }
   | { match: false };
 
-export function parsePairedGatewayUrl(
-  pathname: string,
-): PairedGatewayParseResult {
+/**
+ * A tail containing a `.` or `..` path segment (raw or percent-encoded) could
+ * escape the runtimeUrl's recorded path prefix on hosts that forward the tail
+ * un-normalized, so it is an invalid parse. A segment whose percent-encoding
+ * doesn't decode is rejected for the same reason: it can't be verified.
+ */
+function hasDotSegment(path: string): boolean {
+  for (const segment of path.split("/")) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      return true;
+    }
+    if (decoded === "." || decoded === "..") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Parse a paired-gateway URL given as `pathname + search` (a `#fragment`
+ * suffix is tolerated and dropped), so every host hands over the same shape
+ * and the decision is host-independent.
+ */
+export function parsePairedGatewayUrl(url: string): PairedGatewayParseResult {
+  const delimiter = url.search(/[?#]/);
+  const pathname = delimiter === -1 ? url : url.slice(0, delimiter);
+  const suffix = delimiter === -1 ? "" : url.slice(delimiter);
+  const search = suffix.startsWith("?") ? (suffix.split("#")[0] ?? "") : "";
+
   const match = pathname.match(PAIRED_GATEWAY_PATTERN);
   if (!match) {
     return { match: false };
@@ -95,10 +127,15 @@ export function parsePairedGatewayUrl(
     return { match: true, valid: false };
   }
 
+  const path = match[2] || "/";
+  if (hasDotSegment(path)) {
+    return { match: true, valid: false };
+  }
+
   return {
     match: true,
     valid: true,
-    target: { assistantId, path: match[2] || "/" },
+    target: { assistantId, path, search },
   };
 }
 
@@ -108,46 +145,76 @@ export function parsePairedGatewayUrl(
  * decision a host can act on without re-deriving the rules.
  *
  *   - `pass`: not a paired-gateway URL; the host serves it normally.
- *   - `unknown-assistant`: a paired-gateway URL whose id is malformed or not
- *     paired in the lockfile (the security boundary: the proxy only reaches
- *     gateways of entries the user actually imported, never arbitrary URLs).
+ *   - `reject`: a paired-gateway URL whose id is malformed, whose tail is a
+ *     traversal attempt, or whose id is not paired in the lockfile (the
+ *     security boundary: the proxy only reaches gateways of entries the user
+ *     actually imported, never arbitrary URLs). Carries the status and
+ *     message the host answers with, so hosts don't restate them.
  *   - `forward`: forward to `url` (the entry's recorded runtimeUrl with the
- *     request path appended).
+ *     request path and query appended).
  */
 export type PairedGatewayProxyDecision =
   | { kind: "pass" }
-  | { kind: "unknown-assistant" }
+  | { kind: "reject"; status: number; message: string }
   | { kind: "forward"; url: string };
 
+const PAIRED_GATEWAY_REJECTION: PairedGatewayProxyDecision = {
+  kind: "reject",
+  status: 403,
+  message: "Assistant is not paired in lockfile",
+};
+
 /**
- * Resolve a request pathname (plus query, when the host includes it) to a
- * paired-gateway proxy verdict. Identical across every host that proxies the
- * data plane, mirroring {@link resolveGatewayProxyTarget}.
+ * Resolve a request URL, given as `pathname + search`, to a paired-gateway
+ * proxy verdict. Identical across every host that proxies the data plane,
+ * mirroring {@link resolveGatewayProxyTarget}.
  *
  * `getTargets` is a thunk (typically `() => readPairedGatewayTargets(...)`) so
  * the lockfile is read only once a paired-gateway URL is matched.
  */
 export function resolvePairedGatewayProxyTarget(
-  pathname: string,
+  url: string,
   getTargets: () => Map<string, string>,
 ): PairedGatewayProxyDecision {
-  const parsed = parsePairedGatewayUrl(pathname);
+  const parsed = parsePairedGatewayUrl(url);
   if (!parsed.match) {
     return { kind: "pass" };
   }
   if (!parsed.valid) {
-    return { kind: "unknown-assistant" };
+    return PAIRED_GATEWAY_REJECTION;
   }
   const runtimeUrl = getTargets().get(parsed.target.assistantId);
   if (!runtimeUrl) {
-    return { kind: "unknown-assistant" };
+    return PAIRED_GATEWAY_REJECTION;
   }
   // Preserve the runtimeUrl's own path prefix (minus trailing slashes), then
   // append the request path and query.
   return {
     kind: "forward",
-    url: `${runtimeUrl.replace(/\/+$/, "")}${parsed.target.path}`,
+    url: `${runtimeUrl.replace(/\/+$/, "")}${parsed.target.path}${parsed.target.search}`,
   };
+}
+
+/**
+ * Strip the browser-ambient headers from a paired forward before the remote
+ * hop: `Origin`, `Referer`, `Cookie`, and every `Sec-Fetch-*` header. This is
+ * the proxy family's only remote hop, so nothing about the renderer's browser
+ * context may leak to the paired gateway; the guardian `Authorization` bearer
+ * is the sole credential on the hop and passes through untouched.
+ */
+export function sanitizePairedForwardHeaders(headers: Headers): void {
+  const secFetchNames: string[] = [];
+  headers.forEach((_value, name) => {
+    if (name.toLowerCase().startsWith("sec-fetch-")) {
+      secFetchNames.push(name);
+    }
+  });
+  for (const name of secFetchNames) {
+    headers.delete(name);
+  }
+  headers.delete("origin");
+  headers.delete("referer");
+  headers.delete("cookie");
 }
 
 function addPortFromUrl(url: unknown, ports: Set<number>): void {
@@ -164,36 +231,71 @@ function addPortFromUrl(url: unknown, ports: Set<number>): void {
   }
 }
 
+type LockfileEntriesRead =
+  | { kind: "ok"; assistants: unknown[] }
+  | { kind: "missing" }
+  | { kind: "unreadable" };
+
+/**
+ * Read one lockfile candidate's raw `assistants` array. `missing` is an
+ * absent file; `unreadable` is any other read failure or malformed JSON. The
+ * one read-loop body both gateway-proxy readers share; how a caller walks the
+ * candidate list on `missing`/`unreadable` is its own posture.
+ */
+function readLockfileAssistantEntries(candidate: string): LockfileEntriesRead {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(candidate, "utf-8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kind: "missing" };
+    }
+    return { kind: "unreadable" };
+  }
+  try {
+    const data = JSON.parse(raw) as { assistants?: unknown };
+    return {
+      kind: "ok",
+      assistants: Array.isArray(data.assistants) ? data.assistants : [],
+    };
+  } catch {
+    return { kind: "unreadable" };
+  }
+}
+
 export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
   const ports = new Set<number>();
   for (const candidate of lockfilePaths) {
-    try {
-      const raw = fs.readFileSync(candidate, "utf-8");
-      const data = JSON.parse(raw) as {
-        assistants?: Array<{
-          gatewayUrl?: unknown;
-          localUrl?: unknown;
-          runtimeUrl?: unknown;
-          resources?: { gatewayPort?: unknown };
-        }>;
-      };
-      const assistants = Array.isArray(data.assistants) ? data.assistants : [];
-      for (const assistant of assistants) {
-        if (!assistant) continue;
-        addPortFromUrl(assistant.gatewayUrl, ports);
-        addPortFromUrl(assistant.localUrl, ports);
-        // Docker entries record their published gateway as a loopback
-        // `runtimeUrl` with no `resources` block; the loopback-hostname filter
-        // in addPortFromUrl keeps remote runtimeUrls out of the allowlist.
-        addPortFromUrl(assistant.runtimeUrl, ports);
-        const gp = assistant.resources?.gatewayPort;
-        if (typeof gp === "number" && Number.isInteger(gp) && gp >= 1024 && gp <= 65535) {
-          ports.add(gp);
-        }
+    const read = readLockfileAssistantEntries(candidate);
+    if (read.kind === "missing") {
+      continue;
+    }
+    if (read.kind === "unreadable") {
+      return new Set<number>();
+    }
+    for (const entry of read.assistants) {
+      if (!entry || typeof entry !== "object") {
+        continue;
       }
-      if (ports.size > 0) return ports;
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") return new Set<number>();
+      const assistant = entry as {
+        gatewayUrl?: unknown;
+        localUrl?: unknown;
+        runtimeUrl?: unknown;
+        resources?: { gatewayPort?: unknown };
+      };
+      addPortFromUrl(assistant.gatewayUrl, ports);
+      addPortFromUrl(assistant.localUrl, ports);
+      // Docker entries record their published gateway as a loopback
+      // `runtimeUrl` with no `resources` block; the loopback-hostname filter
+      // in addPortFromUrl keeps remote runtimeUrls out of the allowlist.
+      addPortFromUrl(assistant.runtimeUrl, ports);
+      const gp = assistant.resources?.gatewayPort;
+      if (typeof gp === "number" && Number.isInteger(gp) && gp >= 1024 && gp <= 65535) {
+        ports.add(gp);
+      }
+    }
+    if (ports.size > 0) {
+      return ports;
     }
   }
   return ports;
@@ -202,53 +304,39 @@ export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
 /**
  * Read the paired-gateway allowlist from the lockfile: assistantId to the
  * recorded remote `runtimeUrl`, for entries whose resolved cloud is "paired"
- * and whose runtimeUrl parses as an absolute http(s) URL. Same error posture
- * as {@link readAllowedGatewayPorts}: tolerant of malformed JSON and entries,
- * reading the first lockfile path that yields targets.
+ * and whose runtimeUrl is usable ({@link isUsableRuntimeUrl}). Tolerant of
+ * malformed entries. Path selection matches the unpair write path
+ * (`readRawLockfile` in lockfile.ts): the first readable, parseable lockfile
+ * is authoritative even when it yields no targets, so a pairing removed by an
+ * unpair write can never survive in a stale fallback file's allowlist.
  */
 export function readPairedGatewayTargets(
   lockfilePaths: string[],
 ): Map<string, string> {
   const targets = new Map<string, string>();
   for (const candidate of lockfilePaths) {
-    try {
-      const raw = fs.readFileSync(candidate, "utf-8");
-      const data = JSON.parse(raw) as {
-        assistants?: Array<Record<string, unknown> | null>;
-      };
-      const assistants = Array.isArray(data.assistants) ? data.assistants : [];
-      for (const assistant of assistants) {
-        if (!assistant || typeof assistant !== "object") {
-          continue;
-        }
-        if (resolveCloud(assistant) !== "paired") {
-          continue;
-        }
-        const { assistantId, runtimeUrl } = assistant;
-        if (typeof assistantId !== "string" || assistantId === "") {
-          continue;
-        }
-        if (typeof runtimeUrl !== "string") {
-          continue;
-        }
-        try {
-          const parsed = new URL(runtimeUrl);
-          if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-            continue;
-          }
-        } catch {
-          continue;
-        }
-        targets.set(assistantId, runtimeUrl);
-      }
-      if (targets.size > 0) {
-        return targets;
-      }
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        return new Map<string, string>();
-      }
+    const read = readLockfileAssistantEntries(candidate);
+    if (read.kind !== "ok") {
+      continue;
     }
+    for (const entry of read.assistants) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const assistant = entry as Record<string, unknown>;
+      if (resolveCloud(assistant) !== "paired") {
+        continue;
+      }
+      const { assistantId, runtimeUrl } = assistant;
+      if (typeof assistantId !== "string" || assistantId === "") {
+        continue;
+      }
+      if (typeof runtimeUrl !== "string" || !isUsableRuntimeUrl(runtimeUrl)) {
+        continue;
+      }
+      targets.set(assistantId, runtimeUrl);
+    }
+    return targets;
   }
   return targets;
 }

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -65,12 +65,10 @@ export {
   parsePairedGatewayUrl,
   readPairedGatewayTargets,
   resolvePairedGatewayProxyTarget,
+  sanitizePairedForwardHeaders,
 } from "./gateway-proxy";
 export type {
   GatewayTarget,
   GatewayParseResult,
   GatewayProxyDecision,
-  PairedGatewayTarget,
-  PairedGatewayParseResult,
-  PairedGatewayProxyDecision,
 } from "./gateway-proxy";

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -77,6 +77,23 @@ export function resolveCloud(raw: {
 }
 
 /**
+ * Whether an entry's `runtimeUrl` is one a serving host can forward to: an
+ * absolute http(s) URL. Shared by the renderer's paired-gateway URL derivation
+ * and the host-side paired allowlist reader so the two can't drift.
+ */
+export function isUsableRuntimeUrl(url: unknown): boolean {
+  if (typeof url !== "string" || url === "") {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Per-instance resources for a local assistant: the renderer-facing subset of
  * ports, the instance directory, and the local runtime install metadata.
  * Richer host-only fields (other ports, the signing key) live on the CLI's


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for web-paired-entries.md:
- Strip Cookie/Referer/sec-fetch-* (not just Origin) on the remote paired hop, via one shared helper
- Host-independent resolver contract: query-safe id pattern, standardized pathname+search input, dot-segment traversal rejected in the shared parser
- Paired allowlist reader now stops at the first readable lockfile, matching the unpair write path
- macOS paired forward initiator-trust parity (or documented rationale)
- Consolidation: shared isUsableRuntimeUrl, rejection carried in the proxy decision, deduped lockfile read-loop, JSON-body helpers, export trims

Note: `readAllowedGatewayPorts` has the same first-path-that-yields asymmetry (it returns early only when `ports.size > 0`); left unchanged as pre-existing behavior with a riskier blast radius for the local-port allowlist.

Gap E resolution: documented rationale instead of an initiator-trust gate. The renderer's API interceptor stamps `X-Vellum-Electron-Renderer-Origin` only on platform-bound mutations (paired-bound requests are rewritten to the self-hosted ingress before that step), so a faithful port of the platform gate would depend on Sec-Fetch-* delivery to the `app://` handler and could reject every legitimate paired mutation. After sanitization the paired hop carries no ambient credential (the bearer is explicit and un-forgeable cross-site), so the gate would add no protection; the JSDoc on `planPairedGatewayForward` now states this precisely.