### PR TITLE
feat(macos): add postPresence to the host proxy poster

### DIFF
--- a/clients/macos/src/main/host-proxy-poster.test.ts
+++ b/clients/macos/src/main/host-proxy-poster.test.ts
@@ -297,6 +297,47 @@ describe("HostProxyPoster", () => {
     });
   });
 
+  describe("postPresence", () => {
+    test("sends correct URL, method, headers, and body", async () => {
+      const { fetchFn, captured } = createMockFetch();
+      const poster = makeLocalPoster(fetchFn);
+
+      const result = await poster.postPresence({ state: "active" });
+
+      expect(result).toBe(true);
+      expect(captured).toHaveLength(1);
+
+      const req = captured[0];
+      expect(req.url).toBe("http://127.0.0.1:9000/v1/clients/presence");
+      expect(req.method).toBe("POST");
+      expect(req.headers["Content-Type"]).toBe("application/json");
+      expect(req.headers["X-Vellum-Client-Id"]).toBe(FAKE_DEVICE_ID);
+
+      const body = JSON.parse(req.body!);
+      expect(body.state).toBe("active");
+    });
+
+    test("returns false without throwing when the daemon lacks the route", async () => {
+      const { fetchFn } = createMockFetch(404);
+      const poster = makeLocalPoster(fetchFn);
+
+      const result = await poster.postPresence({ state: "idle" });
+
+      expect(result).toBe(false);
+    });
+
+    test("returns false when fetch throws", async () => {
+      const throwingFetch = (async () => {
+        throw new Error("network failure");
+      }) as unknown as typeof globalThis.fetch;
+      const poster = makeLocalPoster(throwingFetch);
+
+      const result = await poster.postPresence({ state: "away" });
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe("pullTransferContent", () => {
     test("returns buffer on success", async () => {
       const payload = Buffer.from("file-bytes-here");

--- a/clients/macos/src/main/host-proxy-poster.ts
+++ b/clients/macos/src/main/host-proxy-poster.ts
@@ -85,6 +85,10 @@ export interface HostAppControlResultPayload {
   executionError?: string;
 }
 
+export interface PresencePayload {
+  state: "active" | "idle" | "away";
+}
+
 // ---------------------------------------------------------------------------
 // Fetch type — matches the subset of globalThis.fetch we use
 // ---------------------------------------------------------------------------
@@ -170,6 +174,10 @@ export class HostProxyPoster {
     result: HostUiSnapshotResultPayload,
   ): Promise<boolean> {
     return this.postJson("/host-ui-snapshot-result", result);
+  }
+
+  async postPresence(payload: PresencePayload): Promise<boolean> {
+    return this.postJson("/clients/presence", payload);
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `postPresence` posting to `/clients/presence` through the existing `postJson` helper
- Reuses `commonHeaders()`, so the report carries the same `X-Vellum-Client-Id` the SSE registration used
- A 404 from an older daemon returns `false` without throwing, so version skew fails open with no capability gate

Part of plan: presence-gated-reply-push.md (PR 6 of 7)