### PR TITLE
feat(assistant): store per-client desktop presence on the event hub

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -435,6 +435,81 @@ describe("AssistantEventHub — actorPrincipalId on ClientEntry", () => {
   });
 });
 
+// ── ClientEntry desktop presence ─────────────────────────────────────────────
+
+describe("AssistantEventHub client presence", () => {
+  function subscribeClient(hub: AssistantEventHub, clientId: string): void {
+    hub.subscribe({
+      type: "client",
+      clientId,
+      interfaceId: "macos",
+      capabilities: [],
+      callback: () => {},
+    });
+  }
+
+  test("records presence on a matching client", () => {
+    const hub = new AssistantEventHub();
+    subscribeClient(hub, "mac-1");
+
+    expect(hub.setClientPresence("mac-1", "active")).toBe(true);
+
+    const presence = hub.getClientById("mac-1")!.presence!;
+    expect(presence.state).toBe("active");
+    expect(presence.since.getTime()).toBe(presence.reportedAt.getTime());
+  });
+
+  test("preserves since when the same state is re-reported", async () => {
+    const hub = new AssistantEventHub();
+    subscribeClient(hub, "mac-1");
+
+    hub.setClientPresence("mac-1", "idle");
+    const first = hub.getClientById("mac-1")!.presence!;
+
+    await Bun.sleep(5);
+    hub.setClientPresence("mac-1", "idle");
+    const second = hub.getClientById("mac-1")!.presence!;
+
+    expect(second.since.getTime()).toBe(first.since.getTime());
+    expect(second.reportedAt.getTime()).toBeGreaterThan(
+      first.reportedAt.getTime(),
+    );
+  });
+
+  test("advances since on a state transition", async () => {
+    const hub = new AssistantEventHub();
+    subscribeClient(hub, "mac-1");
+
+    hub.setClientPresence("mac-1", "active");
+    const first = hub.getClientById("mac-1")!.presence!;
+
+    await Bun.sleep(5);
+    hub.setClientPresence("mac-1", "away");
+    const second = hub.getClientById("mac-1")!.presence!;
+
+    expect(second.state).toBe("away");
+    expect(second.since.getTime()).toBeGreaterThan(first.since.getTime());
+    expect(second.since.getTime()).toBe(second.reportedAt.getTime());
+  });
+
+  test("returns false for an unknown clientId", () => {
+    const hub = new AssistantEventHub();
+    subscribeClient(hub, "mac-1");
+
+    expect(hub.setClientPresence("does-not-exist", "active")).toBe(false);
+    expect(hub.getClientById("mac-1")?.presence).toBeUndefined();
+  });
+
+  test("a disposed client no longer accepts presence", () => {
+    const hub = new AssistantEventHub();
+    subscribeClient(hub, "mac-1");
+
+    expect(hub.disposeClient("mac-1")).toBe(1);
+    expect(hub.setClientPresence("mac-1", "active")).toBe(false);
+    expect(hub.getClientById("mac-1")).toBeUndefined();
+  });
+});
+
 // ── capabilityForMessageType — host-prefix routing ───────────────────────────
 
 describe("capabilityForMessageType — host-prefix routing", () => {

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -95,6 +95,16 @@ interface BaseSubscriberEntry {
   connectionId: string;
 }
 
+export type DesktopPresenceState = "active" | "idle" | "away";
+
+export interface ClientPresence {
+  state: DesktopPresenceState;
+  /** When the client entered this state. Preserved across re-reports. */
+  since: Date;
+  /** When the daemon last heard from the client. Drives staleness. */
+  reportedAt: Date;
+}
+
 interface ClientEntry extends BaseSubscriberEntry {
   type: "client";
   clientId: string;
@@ -111,6 +121,11 @@ interface ClientEntry extends BaseSubscriberEntry {
    * service-token connections that have no principal.
    */
   actorPrincipalId?: string;
+  /**
+   * Last desktop presence reported by this client, for clients that report it.
+   * In-memory only, so consumers must fail open when it is absent.
+   */
+  presence?: ClientPresence;
 }
 
 interface ProcessEntry extends BaseSubscriberEntry {
@@ -521,6 +536,32 @@ export class AssistantEventHub {
         entry.lastActiveAt = now;
       }
     }
+  }
+
+  /**
+   * Record the desktop presence state reported by a client. `since` is kept
+   * when the state is unchanged, so consumers can tell how long the client has
+   * held it; `reportedAt` always advances. Returns true when at least one
+   * active client entry matched.
+   */
+  setClientPresence(clientId: string, state: DesktopPresenceState): boolean {
+    const now = new Date();
+    let matched = false;
+    for (const entry of this.subscribers) {
+      if (
+        entry.active &&
+        entry.type === "client" &&
+        entry.clientId === clientId
+      ) {
+        entry.presence = {
+          state,
+          since: entry.presence?.state === state ? entry.presence.since : now,
+          reportedAt: now,
+        };
+        matched = true;
+      }
+    }
+    return matched;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds an optional `presence` field to the event hub's `ClientEntry` plus a `setClientPresence` method
- Presence is in-memory only by design: it is meaningless after a daemon restart, and losing it must fail open
- Storage only; the policy module, HTTP route, and producer gate land in later PRs

Part of plan: presence-gated-reply-push.md (PR 1 of 7)