### PR TITLE
feat(macos): derive desktop presence from powerMonitor idle and lock events

### DIFF
--- a/clients/macos/src/main/presence.test.ts
+++ b/clients/macos/src/main/presence.test.ts
@@ -78,10 +78,26 @@ afterEach(() => {
   globalThis.clearInterval = originalClearInterval;
 });
 
+// Install emits one report straight away; tests that assert on what follows
+// drop it so their expectations name only the transitions they exercise.
+const install = (): { reports: string[]; teardown: () => void } => {
+  const reports: string[] = [];
+  const teardown = installPresenceMonitor((state) => reports.push(state));
+  reports.length = 0;
+  return { reports, teardown };
+};
+
 describe("installPresenceMonitor", () => {
-  test("reports active when idle time is below the threshold", () => {
+  test("reports once at install, before the first poll tick", () => {
     const reports: string[] = [];
+    idleSeconds = 0;
     installPresenceMonitor((state) => reports.push(state));
+
+    expect(reports).toEqual(["active"]);
+  });
+
+  test("reports active when idle time is below the threshold", () => {
+    const { reports } = install();
 
     idleSeconds = IDLE_THRESHOLD_MS / 1000 - 1;
     intervalCallback?.();
@@ -90,8 +106,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("reports idle when idle time reaches the threshold", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleSeconds = IDLE_THRESHOLD_MS / 1000;
     intervalCallback?.();
@@ -100,8 +115,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("reports away immediately on lock-screen, ignoring the idle timer", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleSeconds = 0;
     fire("lock-screen");
@@ -110,8 +124,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("reports away immediately on suspend", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleSeconds = 0;
     fire("suspend");
@@ -120,8 +133,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("returns to active on unlock-screen", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleSeconds = 0;
     fire("lock-screen");
@@ -131,8 +143,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("stays away across poll ticks while locked", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     fire("lock-screen");
     intervalCallback?.();
@@ -140,9 +151,65 @@ describe("installPresenceMonitor", () => {
     expect(reports).toEqual(["away", "away"]);
   });
 
+  test("stays away when a locked machine suspends and resumes", () => {
+    const { reports } = install();
+
+    idleSeconds = 0;
+    fire("lock-screen");
+    fire("suspend");
+    fire("resume");
+    intervalCallback?.();
+
+    expect(reports).toEqual(["away", "away", "away", "away"]);
+  });
+
+  test("returns to active once the lock screen clears after a resume", () => {
+    const { reports } = install();
+
+    idleSeconds = 0;
+    fire("lock-screen");
+    fire("suspend");
+    fire("resume");
+    fire("unlock-screen");
+
+    expect(reports).toEqual(["away", "away", "away", "active"]);
+  });
+
+  test("stays away when a suspend arrives without a lock", () => {
+    const { reports } = install();
+
+    idleSeconds = 0;
+    fire("suspend");
+    intervalCallback?.();
+    fire("resume");
+
+    expect(reports).toEqual(["away", "away", "active"]);
+  });
+
+  test("reports away when the login session resigns", () => {
+    const { reports } = install();
+
+    idleSeconds = 0;
+    fire("user-did-resign-active");
+    intervalCallback?.();
+    fire("user-did-become-active");
+
+    expect(reports).toEqual(["away", "away", "active"]);
+  });
+
+  test("user-did-become-active does not clear the lock", () => {
+    const { reports } = install();
+
+    idleSeconds = 0;
+    fire("lock-screen");
+    fire("user-did-become-active");
+    intervalCallback?.();
+
+    expect(reports).toEqual(["away", "away", "away"]);
+  });
+
   test("reports on every poll tick even with no state change", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleSeconds = 0;
     intervalCallback?.();
@@ -154,8 +221,7 @@ describe("installPresenceMonitor", () => {
   });
 
   test("degrades to idle, never active, when the idle read throws", () => {
-    const reports: string[] = [];
-    installPresenceMonitor((state) => reports.push(state));
+    const { reports } = install();
 
     idleThrows = true;
     intervalCallback?.();
@@ -164,9 +230,8 @@ describe("installPresenceMonitor", () => {
   });
 
   test("teardown clears the interval and detaches every listener", () => {
-    const reports: string[] = [];
-    const teardown = installPresenceMonitor((state) => reports.push(state));
-    expect(listenerCount()).toBe(5);
+    const { reports, teardown } = install();
+    expect(listenerCount()).toBe(6);
 
     teardown();
 
@@ -174,6 +239,7 @@ describe("installPresenceMonitor", () => {
     expect(listenerCount()).toBe(0);
 
     fire("lock-screen");
+    fire("user-did-resign-active");
     expect(reports).toEqual([]);
   });
 });

--- a/clients/macos/src/main/presence.test.ts
+++ b/clients/macos/src/main/presence.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// `powerMonitor`'s subscriptions are captured by name so the test can fire
+// them at will, and `off` removes them so teardown is observable.
+type PowerListener = () => void;
+const powerListeners = new Map<string, Set<PowerListener>>();
+const powerOnMock = mock((event: string, listener: PowerListener) => {
+  const existing = powerListeners.get(event) ?? new Set<PowerListener>();
+  existing.add(listener);
+  powerListeners.set(event, existing);
+});
+const powerOffMock = mock((event: string, listener: PowerListener) => {
+  powerListeners.get(event)?.delete(listener);
+});
+
+let idleSeconds = 0;
+let idleThrows = false;
+const getSystemIdleTimeMock = mock(() => {
+  if (idleThrows) {
+    throw new Error("idle read failed");
+  }
+  return idleSeconds;
+});
+
+mock.module("electron", () => ({
+  powerMonitor: {
+    on: powerOnMock,
+    off: powerOffMock,
+    getSystemIdleTime: getSystemIdleTimeMock,
+  },
+}));
+
+const { IDLE_THRESHOLD_MS, POLL_INTERVAL_MS, installPresenceMonitor } =
+  await import("./presence");
+
+const fire = (event: string): void => {
+  for (const listener of powerListeners.get(event) ?? []) {
+    listener();
+  }
+};
+
+const listenerCount = (): number => {
+  let total = 0;
+  for (const listeners of powerListeners.values()) {
+    total += listeners.size;
+  }
+  return total;
+};
+
+// Fake timers so the poll loop is deterministic.
+let intervalCallback: (() => void) | null = null;
+let intervalDelay: number | null = null;
+const clearIntervalMock = mock((_id: unknown) => undefined);
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+
+beforeEach(() => {
+  powerListeners.clear();
+  powerOnMock.mockClear();
+  powerOffMock.mockClear();
+  getSystemIdleTimeMock.mockClear();
+  idleSeconds = 0;
+  idleThrows = false;
+  intervalCallback = null;
+  intervalDelay = null;
+  clearIntervalMock.mockClear();
+  globalThis.setInterval = ((cb: () => void, delay: number) => {
+    intervalCallback = cb;
+    intervalDelay = delay;
+    return 1 as unknown as ReturnType<typeof setInterval>;
+  }) as unknown as typeof setInterval;
+  globalThis.clearInterval =
+    clearIntervalMock as unknown as typeof clearInterval;
+});
+
+afterEach(() => {
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+});
+
+describe("installPresenceMonitor", () => {
+  test("reports active when idle time is below the threshold", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = IDLE_THRESHOLD_MS / 1000 - 1;
+    intervalCallback?.();
+
+    expect(reports).toEqual(["active"]);
+  });
+
+  test("reports idle when idle time reaches the threshold", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = IDLE_THRESHOLD_MS / 1000;
+    intervalCallback?.();
+
+    expect(reports).toEqual(["idle"]);
+  });
+
+  test("reports away immediately on lock-screen, ignoring the idle timer", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = 0;
+    fire("lock-screen");
+
+    expect(reports).toEqual(["away"]);
+  });
+
+  test("reports away immediately on suspend", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = 0;
+    fire("suspend");
+
+    expect(reports).toEqual(["away"]);
+  });
+
+  test("returns to active on unlock-screen", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = 0;
+    fire("lock-screen");
+    fire("unlock-screen");
+
+    expect(reports).toEqual(["away", "active"]);
+  });
+
+  test("stays away across poll ticks while locked", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    fire("lock-screen");
+    intervalCallback?.();
+
+    expect(reports).toEqual(["away", "away"]);
+  });
+
+  test("reports on every poll tick even with no state change", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleSeconds = 0;
+    intervalCallback?.();
+    intervalCallback?.();
+    intervalCallback?.();
+
+    expect(reports).toEqual(["active", "active", "active"]);
+    expect(intervalDelay).toBe(POLL_INTERVAL_MS);
+  });
+
+  test("degrades to idle, never active, when the idle read throws", () => {
+    const reports: string[] = [];
+    installPresenceMonitor((state) => reports.push(state));
+
+    idleThrows = true;
+    intervalCallback?.();
+
+    expect(reports).toEqual(["idle"]);
+  });
+
+  test("teardown clears the interval and detaches every listener", () => {
+    const reports: string[] = [];
+    const teardown = installPresenceMonitor((state) => reports.push(state));
+    expect(listenerCount()).toBe(5);
+
+    teardown();
+
+    expect(clearIntervalMock).toHaveBeenCalledTimes(1);
+    expect(listenerCount()).toBe(0);
+
+    fire("lock-screen");
+    expect(reports).toEqual([]);
+  });
+});

--- a/clients/macos/src/main/presence.ts
+++ b/clients/macos/src/main/presence.ts
@@ -2,7 +2,7 @@ import { powerMonitor } from "electron";
 
 /**
  * Desktop presence, derived from system-wide HID idle time plus screen
- * lock and suspend.
+ * lock, suspend, and login-session activation.
  *
  * Presence is deliberately NOT window focus. The question this answers is
  * whether a Mac notification banner will reach the user, so someone typing
@@ -29,10 +29,19 @@ export const POLL_INTERVAL_MS = 30_000;
 export const installPresenceMonitor = (
   onReport: (state: PresenceState) => void,
 ): (() => void) => {
+  // Three independently owned reasons the desktop is unreachable, each
+  // cleared only by its paired event. A locked machine that sleeps and wakes
+  // is still locked, and becoming the foreground login session says nothing
+  // about whether the lock screen is up.
   let locked = false;
+  let suspended = false;
+  // Assumed active until macOS reports another login session took over:
+  // getSystemIdleTime is system-wide, so that session's input would
+  // otherwise read as this user's.
+  let sessionActive = true;
 
   const evaluate = (): PresenceState => {
-    if (locked) {
+    if (locked || suspended || !sessionActive) {
       return "away";
     }
     try {
@@ -49,21 +58,46 @@ export const installPresenceMonitor = (
     onReport(evaluate());
   };
 
-  const onLocked = (): void => {
+  const onLockScreen = (): void => {
     locked = true;
     report();
   };
 
-  const onUnlocked = (): void => {
+  const onUnlockScreen = (): void => {
     locked = false;
     report();
   };
 
-  powerMonitor.on("lock-screen", onLocked);
-  powerMonitor.on("suspend", onLocked);
-  powerMonitor.on("unlock-screen", onUnlocked);
-  powerMonitor.on("resume", onUnlocked);
-  powerMonitor.on("user-did-become-active", onUnlocked);
+  const onSuspend = (): void => {
+    suspended = true;
+    report();
+  };
+
+  const onResume = (): void => {
+    suspended = false;
+    report();
+  };
+
+  const onSessionBecameActive = (): void => {
+    sessionActive = true;
+    report();
+  };
+
+  const onSessionResigned = (): void => {
+    sessionActive = false;
+    report();
+  };
+
+  powerMonitor.on("lock-screen", onLockScreen);
+  powerMonitor.on("unlock-screen", onUnlockScreen);
+  powerMonitor.on("suspend", onSuspend);
+  powerMonitor.on("resume", onResume);
+  powerMonitor.on("user-did-become-active", onSessionBecameActive);
+  powerMonitor.on("user-did-resign-active", onSessionResigned);
+
+  // Seeds the daemon before the first tick, so a message sent right after
+  // launch is judged against real presence rather than none.
+  report();
 
   // Reports on every tick, not only on transitions: the daemon expires
   // presence after a staleness bound, so a transition-only reporter would
@@ -73,10 +107,11 @@ export const installPresenceMonitor = (
 
   return (): void => {
     clearInterval(timer);
-    powerMonitor.off("lock-screen", onLocked);
-    powerMonitor.off("suspend", onLocked);
-    powerMonitor.off("unlock-screen", onUnlocked);
-    powerMonitor.off("resume", onUnlocked);
-    powerMonitor.off("user-did-become-active", onUnlocked);
+    powerMonitor.off("lock-screen", onLockScreen);
+    powerMonitor.off("unlock-screen", onUnlockScreen);
+    powerMonitor.off("suspend", onSuspend);
+    powerMonitor.off("resume", onResume);
+    powerMonitor.off("user-did-become-active", onSessionBecameActive);
+    powerMonitor.off("user-did-resign-active", onSessionResigned);
   };
 };

--- a/clients/macos/src/main/presence.ts
+++ b/clients/macos/src/main/presence.ts
@@ -1,0 +1,82 @@
+import { powerMonitor } from "electron";
+
+/**
+ * Desktop presence, derived from system-wide HID idle time plus screen
+ * lock and suspend.
+ *
+ * Presence is deliberately NOT window focus. The question this answers is
+ * whether a Mac notification banner will reach the user, so someone typing
+ * in another app at the same desk is attended and counts as `active`.
+ * System idle time also satisfies the rule that only outbound user input
+ * resets the timer: a notification appearing on screen is not input, so it
+ * leaves the idle clock running.
+ *
+ * Reference: https://www.electronjs.org/docs/latest/api/power-monitor
+ */
+
+export type PresenceState = "active" | "idle" | "away";
+
+/**
+ * Doubles as the effective handoff delay, since nothing schedules a
+ * deferred re-check. Ten minutes matches Slack's idle default: plain
+ * inactivity is a low-confidence signal, worth waiting out rather than
+ * buzzing a pocket while the user is still at the desk reading.
+ */
+export const IDLE_THRESHOLD_MS = 10 * 60_000;
+
+export const POLL_INTERVAL_MS = 30_000;
+
+export const installPresenceMonitor = (
+  onReport: (state: PresenceState) => void,
+): (() => void) => {
+  let locked = false;
+
+  const evaluate = (): PresenceState => {
+    if (locked) {
+      return "away";
+    }
+    try {
+      // getSystemIdleTime reports seconds.
+      const idleMs = powerMonitor.getSystemIdleTime() * 1000;
+      return idleMs < IDLE_THRESHOLD_MS ? "active" : "idle";
+    } catch {
+      // Fail open: a broken read must let the push through, never suppress it.
+      return "idle";
+    }
+  };
+
+  const report = (): void => {
+    onReport(evaluate());
+  };
+
+  const onLocked = (): void => {
+    locked = true;
+    report();
+  };
+
+  const onUnlocked = (): void => {
+    locked = false;
+    report();
+  };
+
+  powerMonitor.on("lock-screen", onLocked);
+  powerMonitor.on("suspend", onLocked);
+  powerMonitor.on("unlock-screen", onUnlocked);
+  powerMonitor.on("resume", onUnlocked);
+  powerMonitor.on("user-did-become-active", onUnlocked);
+
+  // Reports on every tick, not only on transitions: the daemon expires
+  // presence after a staleness bound, so a transition-only reporter would
+  // go stale while the user is still sitting there and pushes would
+  // silently resume.
+  const timer = setInterval(report, POLL_INTERVAL_MS);
+
+  return (): void => {
+    clearInterval(timer);
+    powerMonitor.off("lock-screen", onLocked);
+    powerMonitor.off("suspend", onLocked);
+    powerMonitor.off("unlock-screen", onUnlocked);
+    powerMonitor.off("resume", onUnlocked);
+    powerMonitor.off("user-did-become-active", onUnlocked);
+  };
+};


### PR DESCRIPTION
## Summary
- Adds `installPresenceMonitor`, deriving `active` / `idle` / `away` from system-wide HID idle time plus lock and suspend events
- Reports on every poll tick, not only transitions, so the daemon's staleness bound never expires while the user is still at the desk
- A thrown idle read degrades to `idle`, never `active`, so the feature fails open

Part of plan: presence-gated-reply-push.md (PR 5 of 7)