### PR TITLE
feat(assistant): add isDesktopAttended presence policy

### DIFF
--- a/assistant/src/runtime/__tests__/desktop-presence.test.ts
+++ b/assistant/src/runtime/__tests__/desktop-presence.test.ts
@@ -4,7 +4,8 @@
  * The invariant under test is fail-open: only a fresh `active` report from a
  * `macos` client answers `true`. Every other shape (stale, idle, away, no
  * presence, wrong interface, no clients, hub throw) answers `false` so the
- * push is sent.
+ * push is sent. Scoping the read to an actor principal narrows what counts as
+ * attendance, so it can only ever turn a `true` into a `false`.
  */
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
@@ -25,12 +26,14 @@ function registerClient(args: {
   clientId: string;
   interfaceId?: InterfaceId;
   presence?: DesktopPresenceState;
+  actorPrincipalId?: string;
 }): void {
   assistantEventHub.subscribe({
     type: "client",
     clientId: args.clientId,
     interfaceId: args.interfaceId ?? "macos",
     capabilities: [],
+    actorPrincipalId: args.actorPrincipalId,
     callback: () => {},
   });
   if (args.presence) {
@@ -63,7 +66,7 @@ describe("isDesktopAttended", () => {
 
   test("active report older than the staleness bound is not attended", () => {
     registerClient({ clientId: "mac-1", presence: "active" });
-    expect(isDesktopAttended(afterStaleness())).toBe(false);
+    expect(isDesktopAttended({ now: afterStaleness() })).toBe(false);
   });
 
   test("idle is not attended", () => {
@@ -112,5 +115,67 @@ describe("isDesktopAttended", () => {
     registerClient({ clientId: "mac-1", presence: "away" });
     registerClient({ clientId: "mac-2", presence: "active" });
     expect(isDesktopAttended()).toBe(true);
+  });
+});
+
+describe("isDesktopAttended scoped to an actor principal", () => {
+  test("matching actor principal is attended", () => {
+    registerClient({
+      clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    expect(isDesktopAttended({ actorPrincipalId: "actor-a" })).toBe(true);
+  });
+
+  test("another actor's attended mac does not count", () => {
+    registerClient({
+      clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    expect(isDesktopAttended({ actorPrincipalId: "actor-b" })).toBe(false);
+  });
+
+  test("client with no principal does not match a supplied principal", () => {
+    registerClient({ clientId: "mac-1", presence: "active" });
+    expect(isDesktopAttended({ actorPrincipalId: "actor-a" })).toBe(false);
+  });
+
+  test("omitting the principal counts any attended macos client", () => {
+    registerClient({
+      clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    expect(isDesktopAttended()).toBe(true);
+  });
+
+  test("target actor's stale report is not attended", () => {
+    registerClient({
+      clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    expect(
+      isDesktopAttended({
+        actorPrincipalId: "actor-a",
+        now: afterStaleness(),
+      }),
+    ).toBe(false);
+  });
+
+  test("only the non-target actor is active among several clients", () => {
+    registerClient({
+      clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    registerClient({
+      clientId: "mac-2",
+      presence: "away",
+      actorPrincipalId: "actor-b",
+    });
+    expect(isDesktopAttended({ actorPrincipalId: "actor-b" })).toBe(false);
   });
 });

--- a/assistant/src/runtime/__tests__/desktop-presence.test.ts
+++ b/assistant/src/runtime/__tests__/desktop-presence.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the desktop presence policy.
+ *
+ * The invariant under test is fail-open: only a fresh `active` report from a
+ * `macos` client answers `true`. Every other shape (stale, idle, away, no
+ * presence, wrong interface, no clients, hub throw) answers `false` so the
+ * push is sent.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import type { InterfaceId } from "../../channels/types.js";
+import {
+  assistantEventHub,
+  type DesktopPresenceState,
+} from "../assistant-event-hub.js";
+import {
+  isDesktopAttended,
+  PRESENCE_STALE_AFTER_MS,
+} from "../desktop-presence.js";
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function registerClient(args: {
+  clientId: string;
+  interfaceId?: InterfaceId;
+  presence?: DesktopPresenceState;
+}): void {
+  assistantEventHub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: args.interfaceId ?? "macos",
+    capabilities: [],
+    callback: () => {},
+  });
+  if (args.presence) {
+    assistantEventHub.setClientPresence(args.clientId, args.presence);
+  }
+}
+
+function clearHub(): void {
+  for (const client of assistantEventHub.listClients()) {
+    assistantEventHub.disposeClient(client.clientId);
+  }
+}
+
+/** A `now` far enough past every report to push all of them out of the window. */
+function afterStaleness(): Date {
+  return new Date(Date.now() + PRESENCE_STALE_AFTER_MS + 1_000);
+}
+
+afterEach(() => {
+  clearHub();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("isDesktopAttended", () => {
+  test("fresh active macos client is attended", () => {
+    registerClient({ clientId: "mac-1", presence: "active" });
+    expect(isDesktopAttended()).toBe(true);
+  });
+
+  test("active report older than the staleness bound is not attended", () => {
+    registerClient({ clientId: "mac-1", presence: "active" });
+    expect(isDesktopAttended(afterStaleness())).toBe(false);
+  });
+
+  test("idle is not attended", () => {
+    registerClient({ clientId: "mac-1", presence: "idle" });
+    expect(isDesktopAttended()).toBe(false);
+  });
+
+  test("away is not attended", () => {
+    registerClient({ clientId: "mac-1", presence: "away" });
+    expect(isDesktopAttended()).toBe(false);
+  });
+
+  test("client that never reported presence is not attended", () => {
+    registerClient({ clientId: "mac-1" });
+    expect(isDesktopAttended()).toBe(false);
+  });
+
+  test("active web client does not count as desktop presence", () => {
+    registerClient({
+      clientId: "web-1",
+      interfaceId: "web",
+      presence: "active",
+    });
+    expect(isDesktopAttended()).toBe(false);
+  });
+
+  test("no connected clients is not attended", () => {
+    expect(isDesktopAttended()).toBe(false);
+  });
+
+  test("a hub read that throws is not attended", () => {
+    const spy = spyOn(
+      assistantEventHub,
+      "listClientsByInterface",
+    ).mockImplementation(() => {
+      throw new Error("hub exploded");
+    });
+    try {
+      expect(isDesktopAttended()).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("one active macos client among several is enough", () => {
+    registerClient({ clientId: "mac-1", presence: "away" });
+    registerClient({ clientId: "mac-2", presence: "active" });
+    expect(isDesktopAttended()).toBe(true);
+  });
+});

--- a/assistant/src/runtime/desktop-presence.ts
+++ b/assistant/src/runtime/desktop-presence.ts
@@ -1,0 +1,45 @@
+/**
+ * Desktop presence policy.
+ *
+ * Answers exactly one question for notification producers: is the user
+ * demonstrably at their Mac right now? Producers use the answer to skip a
+ * push that the user would see on screen anyway.
+ *
+ * Fails open by design. Presence is in-memory, best-effort, and reported by
+ * a client that can drop off at any time, so anything short of a fresh
+ * `active` report from a `macos` client answers `false` and the push goes
+ * out. A missed notification is strictly worse than a redundant one.
+ *
+ * A future two-tier-delay design (hold the push briefly, then send it if the
+ * user never acknowledges) extends this module with delay tiers rather than
+ * replacing it: the attended/unattended read stays the same input.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { assistantEventHub } from "./assistant-event-hub.js";
+
+const log = getLogger("desktop-presence");
+
+/** Must exceed the client's report interval with margin, so a single dropped report does not read as absent. */
+export const PRESENCE_STALE_AFTER_MS = 3 * 60_000;
+
+/**
+ * Whether some macOS client has reported `active` recently enough to trust.
+ * Stale, absent, non-macOS, and error reads all answer `false`.
+ */
+export function isDesktopAttended(now: Date = new Date()): boolean {
+  try {
+    return assistantEventHub
+      .listClientsByInterface("macos")
+      .some(
+        (client) =>
+          client.presence?.state === "active" &&
+          now.getTime() - client.presence.reportedAt.getTime() <=
+            PRESENCE_STALE_AFTER_MS,
+      );
+  } catch (err) {
+    // Returning false sends the push, which is the safe direction.
+    log.warn({ err }, "desktop presence read failed; treating as unattended");
+    return false;
+  }
+}

--- a/assistant/src/runtime/desktop-presence.ts
+++ b/assistant/src/runtime/desktop-presence.ts
@@ -9,10 +9,6 @@
  * a client that can drop off at any time, so anything short of a fresh
  * `active` report from a `macos` client answers `false` and the push goes
  * out. A missed notification is strictly worse than a redundant one.
- *
- * A future two-tier-delay design (hold the push briefly, then send it if the
- * user never acknowledges) extends this module with delay tiers rather than
- * replacing it: the attended/unattended read stays the same input.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -23,20 +19,45 @@ const log = getLogger("desktop-presence");
 /** Must exceed the client's report interval with margin, so a single dropped report does not read as absent. */
 export const PRESENCE_STALE_AFTER_MS = 3 * 60_000;
 
+export interface DesktopAttendanceOptions {
+  /**
+   * Only count macOS clients whose verified actor principal matches this id.
+   * A client that connected without a principal (legacy or service token)
+   * never matches a supplied id.
+   */
+  actorPrincipalId?: string;
+  /** Clock used for the staleness comparison. */
+  now?: Date;
+}
+
 /**
  * Whether some macOS client has reported `active` recently enough to trust.
  * Stale, absent, non-macOS, and error reads all answer `false`.
+ *
+ * Callers whose notification targets one recipient (guardian-scoped or
+ * otherwise per-recipient pushes) must pass that recipient's
+ * `actorPrincipalId`, or another user's attended Mac suppresses the push.
+ * Omitting it treats any attended macOS client as attendance, which only
+ * suits notifications with no single recipient.
  */
-export function isDesktopAttended(now: Date = new Date()): boolean {
+export function isDesktopAttended(
+  options: DesktopAttendanceOptions = {},
+): boolean {
+  const { actorPrincipalId, now = new Date() } = options;
   try {
-    return assistantEventHub
-      .listClientsByInterface("macos")
-      .some(
-        (client) =>
-          client.presence?.state === "active" &&
-          now.getTime() - client.presence.reportedAt.getTime() <=
-            PRESENCE_STALE_AFTER_MS,
+    return assistantEventHub.listClientsByInterface("macos").some((client) => {
+      if (
+        actorPrincipalId !== undefined &&
+        client.actorPrincipalId !== actorPrincipalId
+      ) {
+        return false;
+      }
+      return (
+        client.presence?.state === "active" &&
+        now.getTime() - client.presence.reportedAt.getTime() <=
+          PRESENCE_STALE_AFTER_MS
       );
+    });
   } catch (err) {
     // Returning false sends the push, which is the safe direction.
     log.warn({ err }, "desktop presence read failed; treating as unattended");


### PR DESCRIPTION
## Summary
- Adds `isDesktopAttended()`, the single read-side question notification producers ask before suppressing a push
- Returns true only for a fresh, active, macos-interface client; stale, absent, wrong-interface, and thrown all return false
- Fails open by design: false sends the push, which is the safe direction

Part of plan: presence-gated-reply-push.md (PR 2 of 7)