### PR TITLE
feat(assistant): add clients/presence route for desktop presence reports

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4615,6 +4615,43 @@ paths:
                 required:
                   - disconnected
                 additionalProperties: false
+  /v1/clients/presence:
+    post:
+      operationId: clients_presence_post
+      summary: Report desktop presence
+      description: Record the desktop presence state reported by the client identified by the X-Vellum-Client-Id header.
+      tags:
+        - clients
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                state:
+                  type: string
+                  enum:
+                    - active
+                    - idle
+                    - away
+                  description: Reported desktop presence state.
+              required:
+                - state
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  recorded:
+                    type: boolean
+                    description: Whether a connected client matched the reporting clientId.
+                required:
+                  - recorded
+                additionalProperties: false
   /v1/config:
     get:
       operationId: config_get

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -95,7 +95,13 @@ interface BaseSubscriberEntry {
   connectionId: string;
 }
 
-export type DesktopPresenceState = "active" | "idle" | "away";
+/**
+ * The presence states a desktop client may report. Single runtime source: the
+ * stored type and the route's wire enum both derive from this tuple.
+ */
+export const DESKTOP_PRESENCE_STATES = ["active", "idle", "away"] as const;
+
+export type DesktopPresenceState = (typeof DESKTOP_PRESENCE_STATES)[number];
 
 export interface ClientPresence {
   state: DesktopPresenceState;

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -7,7 +7,8 @@
  * - Dev-bypass mode (`isHttpAuthDisabled()`) returns all clients.
  *
  * POST /v1/clients/presence (report_client_presence) records presence keyed
- * off the `x-vellum-client-id` header.
+ * off the `x-vellum-client-id` header, and applies the same ownership posture:
+ * only the actor that owns the target client may report its presence.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -177,7 +178,10 @@ describe("report_client_presence route", () => {
 
     const handler = findHandler("report_client_presence");
     const result = handler({
-      headers: { "x-vellum-client-id": "client-A1" },
+      headers: {
+        "x-vellum-client-id": "client-A1",
+        "x-vellum-actor-principal-id": "user-A",
+      },
       body: { state: "active" },
     }) as { recorded: boolean };
 
@@ -190,11 +194,95 @@ describe("report_client_presence route", () => {
   test("returns recorded false when no connected client matches", () => {
     const handler = findHandler("report_client_presence");
     const result = handler({
-      headers: { "x-vellum-client-id": "client-gone" },
+      headers: {
+        "x-vellum-client-id": "client-gone",
+        "x-vellum-actor-principal-id": "user-A",
+      },
       body: { state: "idle" },
     }) as { recorded: boolean };
 
     expect(result).toEqual({ recorded: false });
+  });
+
+  test("returns recorded false when the caller does not own the client", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("report_client_presence");
+    handler({
+      headers: {
+        "x-vellum-client-id": "client-A1",
+        "x-vellum-actor-principal-id": "user-A",
+      },
+      body: { state: "active" },
+    });
+
+    const result = handler({
+      headers: {
+        "x-vellum-client-id": "client-A1",
+        "x-vellum-actor-principal-id": "user-B",
+      },
+      body: { state: "away" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: false });
+    expect(assistantEventHub.getClientById("client-A1")?.presence?.state).toBe(
+      "active",
+    );
+  });
+
+  test("returns recorded false when the caller sends no principal header", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: { "x-vellum-client-id": "client-A1" },
+      body: { state: "active" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: false });
+    expect(
+      assistantEventHub.getClientById("client-A1")?.presence,
+    ).toBeUndefined();
+  });
+
+  test("returns recorded false for a client with no stored actorPrincipalId", () => {
+    registerClient({
+      clientId: "client-noprincipal",
+      actorPrincipalId: undefined,
+    });
+
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: {
+        "x-vellum-client-id": "client-noprincipal",
+        "x-vellum-actor-principal-id": "user-A",
+      },
+      body: { state: "active" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: false });
+    expect(
+      assistantEventHub.getClientById("client-noprincipal")?.presence,
+    ).toBeUndefined();
+  });
+
+  test("dev-bypass mode records presence without an ownership check", () => {
+    fakeHttpAuthDisabled = true;
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: {
+        "x-vellum-client-id": "client-A1",
+        "x-vellum-actor-principal-id": "user-B",
+      },
+      body: { state: "idle" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: true });
+    expect(assistantEventHub.getClientById("client-A1")?.presence?.state).toBe(
+      "idle",
+    );
   });
 
   test("throws BadRequestError when the client-id header is missing", () => {
@@ -215,7 +303,10 @@ describe("report_client_presence route", () => {
 
     expect(() =>
       handler({
-        headers: { "x-vellum-client-id": "client-A1" },
+        headers: {
+          "x-vellum-client-id": "client-A1",
+          "x-vellum-actor-principal-id": "user-A",
+        },
         body: { state: "asleep" },
       }),
     ).toThrow(BadRequestError);

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -1,10 +1,13 @@
 /**
- * Tests for the GET /v1/clients (list_clients) route.
+ * Tests for the client registry routes.
  *
- * Validates the same-user filter applied to client listings:
+ * GET /v1/clients (list_clients) applies a same-user filter to listings:
  * - Caller sees only clients owned by their `actorPrincipalId`.
  * - Clients with no stored `actorPrincipalId` are filtered out (fail-closed).
  * - Dev-bypass mode (`isHttpAuthDisabled()`) returns all clients.
+ *
+ * POST /v1/clients/presence (report_client_presence) records presence keyed
+ * off the `x-vellum-client-id` header.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -22,6 +25,7 @@ mock.module("../../../config/env.js", () => ({
 
 import { assistantEventHub } from "../../assistant-event-hub.js";
 import { ROUTES } from "../client-routes.js";
+import { BadRequestError } from "../errors.js";
 import type { RouteDefinition } from "../types.js";
 
 afterAll(() => {
@@ -159,5 +163,64 @@ describe("list_clients route — same-user filter", () => {
 
     expect(result.clients).toHaveLength(1);
     expect(result.clients[0].degraded).toBe(false);
+  });
+});
+
+describe("report_client_presence route", () => {
+  beforeEach(() => {
+    fakeHttpAuthDisabled = false;
+    clearHub();
+  });
+
+  test("records presence against the client named by the header", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: { "x-vellum-client-id": "client-A1" },
+      body: { state: "active" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: true });
+    expect(assistantEventHub.getClientById("client-A1")?.presence?.state).toBe(
+      "active",
+    );
+  });
+
+  test("returns recorded false when no connected client matches", () => {
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: { "x-vellum-client-id": "client-gone" },
+      body: { state: "idle" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: false });
+  });
+
+  test("throws BadRequestError when the client-id header is missing", () => {
+    const handler = findHandler("report_client_presence");
+
+    expect(() => handler({ body: { state: "active" } })).toThrow(
+      BadRequestError,
+    );
+    expect(() =>
+      handler({ headers: { "x-vellum-client-id": "  " }, body: {} }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects an unknown presence state", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("report_client_presence");
+
+    expect(() =>
+      handler({
+        headers: { "x-vellum-client-id": "client-A1" },
+        body: { state: "asleep" },
+      }),
+    ).toThrow(BadRequestError);
+    expect(
+      assistantEventHub.getClientById("client-A1")?.presence,
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -163,6 +163,27 @@ export const ROUTES: RouteDefinition[] = [
         );
       }
       const { state } = parseBody(PresenceBodySchema, body);
+
+      // Only the actor that opened the target client's SSE stream may report
+      // its presence, so a caller who learns another user's clientId cannot
+      // spoof that desktop. Clients with no stored `actorPrincipalId` (legacy
+      // SSE subscribers, service-gateway tokens) never match: fail-closed, the
+      // same posture as the listing filter above. Dev-bypass mode
+      // (DISABLE_HTTP_AUTH=true) skips the check for platform-managed
+      // deployments where the platform handles auth.
+      if (!isHttpAuthDisabled()) {
+        const callerPrincipalId = headers?.["x-vellum-actor-principal-id"];
+        const ownerPrincipalId =
+          assistantEventHub.getActorPrincipalIdForClient(clientId);
+        if (
+          ownerPrincipalId === undefined ||
+          ownerPrincipalId !== callerPrincipalId
+        ) {
+          // Answering like "no match" keeps the reply from probing client ids.
+          return { recorded: false };
+        }
+      }
+
       // A report racing an SSE reconnect matches nothing; normal, so not a 404.
       return { recorded: assistantEventHub.setClientPresence(clientId, state) };
     },

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -10,14 +10,35 @@ import { z } from "zod";
 import type { HostProxyCapability } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { datesToISO } from "../../util/json.js";
+import type { DesktopPresenceState } from "../assistant-event-hub.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
   isClientDegraded,
 } from "../client-health.js";
-import { NotFoundError } from "./errors.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition } from "./types.js";
+
+/**
+ * States the client may report. `satisfies` keeps this tuple a subset of
+ * {@link DesktopPresenceState}, so the wire enum cannot drift past the type.
+ */
+const PRESENCE_STATES = [
+  "active",
+  "idle",
+  "away",
+] as const satisfies readonly DesktopPresenceState[];
+
+/**
+ * Body of `POST /v1/clients/presence`, declared as the route's `requestBody`
+ * and parsed by the handler, so the OpenAPI contract and the runtime check are
+ * one schema rather than two hand-kept copies.
+ */
+const PresenceBodySchema = z.object({
+  state: z.enum(PRESENCE_STATES).describe("Reported desktop presence state."),
+});
 
 export const ROUTES: RouteDefinition[] = [
   {
@@ -114,6 +135,36 @@ export const ROUTES: RouteDefinition[] = [
         throw new NotFoundError(`No connected client with id "${clientId}"`);
       }
       return { disconnected: count };
+    },
+  },
+  {
+    operationId: "report_client_presence",
+    endpoint: "clients/presence",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Report desktop presence",
+    description:
+      "Record the desktop presence state reported by the client identified by the X-Vellum-Client-Id header.",
+    tags: ["clients"],
+    requestBody: PresenceBodySchema,
+    responseBody: z.object({
+      recorded: z
+        .boolean()
+        .describe("Whether a connected client matched the reporting clientId."),
+    }),
+    handler: ({ body, headers }) => {
+      const clientId = headers?.["x-vellum-client-id"]?.trim();
+      if (!clientId) {
+        throw new BadRequestError(
+          "x-vellum-client-id header is required to report presence.",
+        );
+      }
+      const { state } = parseBody(PresenceBodySchema, body);
+      // A report racing an SSE reconnect matches nothing; normal, so not a 404.
+      return { recorded: assistantEventHub.setClientPresence(clientId, state) };
     },
   },
 ];

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -10,8 +10,10 @@ import { z } from "zod";
 import type { HostProxyCapability } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { datesToISO } from "../../util/json.js";
-import type { DesktopPresenceState } from "../assistant-event-hub.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  assistantEventHub,
+  DESKTOP_PRESENCE_STATES,
+} from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -22,22 +24,14 @@ import { parseBody } from "./parse-body.js";
 import type { RouteDefinition } from "./types.js";
 
 /**
- * States the client may report. `satisfies` keeps this tuple a subset of
- * {@link DesktopPresenceState}, so the wire enum cannot drift past the type.
- */
-const PRESENCE_STATES = [
-  "active",
-  "idle",
-  "away",
-] as const satisfies readonly DesktopPresenceState[];
-
-/**
  * Body of `POST /v1/clients/presence`, declared as the route's `requestBody`
  * and parsed by the handler, so the OpenAPI contract and the runtime check are
  * one schema rather than two hand-kept copies.
  */
 const PresenceBodySchema = z.object({
-  state: z.enum(PRESENCE_STATES).describe("Reported desktop presence state."),
+  state: z
+    .enum(DESKTOP_PRESENCE_STATES)
+    .describe("Reported desktop presence state."),
 });
 
 export const ROUTES: RouteDefinition[] = [


### PR DESCRIPTION
## Summary
- Adds `POST /v1/clients/presence`, recording a reported desktop presence state against the hub entry matching the `X-Vellum-Client-Id` header
- Reads the client id from the header rather than the body, so presence lands on the same entry the SSE registration created
- An unmatched client id returns `200 { recorded: false }` rather than a 404, because a report racing an SSE reconnect is normal

Part of plan: presence-gated-reply-push.md (PR 3 of 7)