### PR TITLE
fix(web): client-perf boot safety, typed check names, detail convention

### DIFF
--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -5,17 +5,30 @@
  *   - Nothing is emitted without analytics consent.
  *   - `boot_id` appears only once a boot id has been registered.
  *   - A throwing transport never propagates to the caller.
+ *   - The page-load key is minted lazily and survives a runtime with no
+ *     `crypto.randomUUID` (non-secure contexts).
+ *   - Surface and os come from a single platform probe per emit.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { ClientPerfCheckName } from "./client-perf";
+
 let consent = true;
+let nativeIOS = false;
+let nativeAndroid = false;
 const postTelemetryEventsMock = mock((_events: readonly object[]) => {});
+const detectClientOsMock = mock(() => "web");
 
 mock.module("@/lib/telemetry/consent", () => ({
   readAnalyticsConsent: () => consent,
 }));
 mock.module("@/lib/telemetry/ingest", () => ({
   postTelemetryEvents: postTelemetryEventsMock,
+}));
+mock.module("@/runtime/platform-detection", () => ({
+  detectClientOs: detectClientOsMock,
+  isNativeIOS: () => nativeIOS,
+  isNativeAndroid: () => nativeAndroid,
 }));
 
 const { __resetClientPerfForTests, emitClientPerfEvent, setClientPerfBootId } =
@@ -33,10 +46,22 @@ function lastDetail(): Record<string, unknown> {
   return lastEvent().detail as Record<string, unknown>;
 }
 
+/** Every member of the exported union, so a dropped name fails to compile. */
+const ALL_CHECK_NAMES: readonly ClientPerfCheckName[] = [
+  "client_switch.transcript_painted",
+  "client_switch.stalled",
+  "client_switch.abandoned",
+  "client_resume.request_count",
+  "client_list.drain",
+];
+
 beforeEach(() => {
   consent = true;
+  nativeIOS = false;
+  nativeAndroid = false;
   postTelemetryEventsMock.mockClear();
   postTelemetryEventsMock.mockImplementation(() => {});
+  detectClientOsMock.mockClear();
   __resetClientPerfForTests();
 });
 
@@ -59,9 +84,17 @@ describe("emitClientPerfEvent", () => {
     expect(typeof detail.os).toBe("string");
   });
 
+  test("accepts every check name in the exported union", () => {
+    for (const checkName of ALL_CHECK_NAMES) {
+      emitClientPerfEvent(checkName, 1);
+      expect(lastEvent().check_name).toBe(checkName);
+    }
+  });
+
   test("groups events from the same page load under one page_load_id", () => {
     emitClientPerfEvent("client_list.drain", 1);
     const first = lastDetail().page_load_id;
+    expect(typeof first).toBe("string");
     emitClientPerfEvent("client_list.drain", 2);
     expect(lastDetail().page_load_id).toBe(first);
   });
@@ -99,5 +132,51 @@ describe("emitClientPerfEvent", () => {
     expect(() => {
       emitClientPerfEvent("client_switch.stalled", 1);
     }).not.toThrow();
+  });
+
+  test("probes the client OS once per emit", () => {
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(detectClientOsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("labels the native shells from the platform predicates", () => {
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(lastDetail().surface).toBe("web");
+
+    nativeIOS = true;
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(lastDetail().surface).toBe("ios_native");
+
+    nativeIOS = false;
+    nativeAndroid = true;
+    emitClientPerfEvent("client_list.drain", 1);
+    expect(lastDetail().surface).toBe("android_native");
+  });
+
+  test("still emits when crypto.randomUUID is unavailable", () => {
+    const cryptoObject = globalThis.crypto as unknown as {
+      randomUUID?: () => string;
+    };
+    Object.defineProperty(cryptoObject, "randomUUID", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    try {
+      expect(() => {
+        emitClientPerfEvent("client_list.drain", 1);
+      }).not.toThrow();
+
+      const event = lastEvent();
+      expect(typeof event.daemon_event_id).toBe("string");
+      const pageLoadId = lastDetail().page_load_id;
+      expect(typeof pageLoadId).toBe("string");
+
+      emitClientPerfEvent("client_list.drain", 2);
+      expect(lastDetail().page_load_id).toBe(pageLoadId);
+    } finally {
+      delete cryptoObject.randomUUID;
+    }
   });
 });

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -1,16 +1,28 @@
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { postTelemetryEvents } from "@/lib/telemetry/ingest";
-import { detectClientOs, isNativeMobile } from "@/runtime/platform-detection";
+import {
+  detectClientOs,
+  isNativeAndroid,
+  isNativeIOS,
+} from "@/runtime/platform-detection";
 
 /**
  * Shared emitter for the `client_*` performance families.
  *
- * Rides the existing `watchdog` event shape: `check_name` is an open string,
- * `value` a float magnitude, `detail` an open JSON bag. So a new family lands
- * in the existing `stg_telemetry__watchdog` BigQuery model with no platform
- * work. This is the same ride-an-existing-shape move `memory-telemetry.ts`
- * makes on the `onboarding` event type, and boot-telemetry makes on
- * `watchdog`.
+ * Rides the existing `watchdog` event shape: `check_name` is a closed union
+ * client-side but an open string on the wire, `value` a float magnitude,
+ * `detail` an open JSON bag. So a new family lands in the existing
+ * `stg_telemetry__watchdog` BigQuery model with no platform work. This is the
+ * same ride-an-existing-shape move `memory-telemetry.ts` makes on the
+ * `onboarding` event type.
+ *
+ * Detail-bag convention, so the families stay queryable together:
+ *   - Values are raw JSON scalars. Numbers stay numbers, booleans stay
+ *     booleans. Never stringify a numeric, and never use a string sentinel
+ *     like "unknown": both force a cast before any aggregation.
+ *   - An unknown or unavailable value is `null`.
+ *   - A bounded nested object is allowed when its keys are a closed set (for
+ *     example a per-endpoint-group count map). Unbounded key spaces are not.
  *
  * Metadata only: detail bags carry no conversation or assistant ids and no
  * raw pathnames. Consent is read at emit time through the shared
@@ -18,18 +30,46 @@ import { detectClientOs, isNativeMobile } from "@/runtime/platform-detection";
  */
 
 /**
- * Groups every perf event from a single page load. Same semantics as
- * boot-telemetry's `boot_id`, minted independently so this module stands alone;
- * the two converge once a caller registers the boot id via
- * `setClientPerfBootId`.
+ * Every check name the `client_*` perf families emit. Each member is a series
+ * queried by name downstream, so the union is closed: a typo is a compile
+ * error rather than a silent phantom series.
  */
-const pageLoadId = crypto.randomUUID();
+export type ClientPerfCheckName =
+  | "client_switch.transcript_painted"
+  | "client_switch.stalled"
+  | "client_switch.abandoned"
+  | "client_resume.request_count"
+  | "client_list.drain";
+
+/**
+ * `crypto.randomUUID` is unavailable in non-secure contexts (plain-http LAN
+ * dev, self-hosted over http), so fall back rather than throw. This module sits
+ * on the eager boot import chain, where a throw would take the app down with
+ * it.
+ */
+function mintRandomId(): string {
+  return typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : `perf-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+let pageLoadId: string | null = null;
+
+/**
+ * Groups every perf event from a single page load. Minted on first emit and
+ * held for the rest of the page's lifetime, so importing this module has no
+ * side effects.
+ */
+function getPageLoadId(): string {
+  pageLoadId ??= mintRandomId();
+  return pageLoadId;
+}
 
 let bootId: string | null = null;
 
 /**
- * Registers the boot-telemetry boot id so perf families become joinable with
- * the boot series. Called by `startBootTelemetry` once that lands.
+ * Registers a boot id so the perf families become joinable with a boot series.
+ * Until a caller registers one, `boot_id` is absent from the detail bag.
  */
 export function setClientPerfBootId(id: string): void {
   bootId = id;
@@ -37,13 +77,14 @@ export function setClientPerfBootId(id: string): void {
 
 type PerfSurface = "ios_native" | "android_native" | "web";
 
-/** Mirrors boot-telemetry's surface detection so the labels match its series. */
 function detectSurface(): PerfSurface {
-  const os = detectClientOs();
-  if (!isNativeMobile()) {
-    return "web";
+  if (isNativeIOS()) {
+    return "ios_native";
   }
-  return os === "android" ? "android_native" : "ios_native";
+  if (isNativeAndroid()) {
+    return "android_native";
+  }
+  return "web";
 }
 
 /**
@@ -51,10 +92,13 @@ function detectSurface(): PerfSurface {
  * on a hot render or navigation path without adding a failure mode.
  */
 export function emitClientPerfEvent(
-  checkName: string,
+  checkName: ClientPerfCheckName,
   value: number,
   detail?: Record<string, unknown>,
 ): void {
+  if (typeof window === "undefined") {
+    return;
+  }
   try {
     if (!readAnalyticsConsent()) {
       return;
@@ -62,12 +106,12 @@ export function emitClientPerfEvent(
     postTelemetryEvents([
       {
         type: "watchdog",
-        daemon_event_id: crypto.randomUUID(),
+        daemon_event_id: mintRandomId(),
         recorded_at: Date.now(),
         check_name: checkName,
         value: Math.round(value),
         detail: {
-          page_load_id: pageLoadId,
+          page_load_id: getPageLoadId(),
           surface: detectSurface(),
           os: detectClientOs(),
           ...(bootId === null ? {} : { boot_id: bootId }),
@@ -82,4 +126,5 @@ export function emitClientPerfEvent(
 
 export function __resetClientPerfForTests(): void {
   bootId = null;
+  pageLoadId = null;
 }


### PR DESCRIPTION
## Summary
- pageLoadId is lazily minted with a guarded randomUUID fallback so module init can never throw on insecure contexts; emitter gains the SSR window guard
- Surface/os derived from one platform probe using the precise predicates; labels unchanged
- checkName narrowed to a ClientPerfCheckName union (typos can no longer mint phantom BigQuery series); detail-bag convention documented (raw scalars, null for unknown)
- Comments no longer describe planned modules as existing code

Fixes gaps found during plan self-review for measure-first-telemetry-followups.md