### PR TITLE
fix(web): list/history telemetry consistency and first-page coverage

### DIFF
--- a/clients/web/src/domains/chat/api/history.test.ts
+++ b/clients/web/src/domains/chat/api/history.test.ts
@@ -33,7 +33,7 @@ interface CapturedRequest {
 
 function makeJsonResponse(
   body: unknown,
-  init: { status?: number; contentLength?: number } = {},
+  init: { status?: number; contentLength?: number | string } = {},
 ): Response {
   const status = init.status ?? 200;
   return new Response(JSON.stringify(body), {
@@ -549,6 +549,31 @@ describe("fetch diagnostics", () => {
     const details = lastDiagnostic("history_page_fetch");
     expect(details.bytes).toBeNull();
     expectDurationMs(details);
+  });
+
+  test("bytes is null for a malformed content-length, never NaN", async () => {
+    nextResponse = makeJsonResponse(
+      { messages: [], hasMore: false },
+      { contentLength: "not-a-number" },
+    );
+
+    await fetchLatestHistoryPage("asst-1", "K");
+
+    const details = lastDiagnostic("history_page_fetch");
+    expect(details.bytes).toBeNull();
+    expect(Number.isNaN(details.bytes)).toBe(false);
+  });
+
+  test("bytes is null for a blank content-length, never zero", async () => {
+    nextResponse = makeJsonResponse(
+      { messages: [], hasMore: false },
+      { contentLength: "" },
+    );
+
+    await fetchLatestHistoryPage("asst-1", "K");
+
+    const details = lastDiagnostic("history_page_fetch");
+    expect(details.bytes).toBeNull();
   });
 
   test("history_page_fetch_error carries durationMs and bytes", async () => {

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -17,6 +17,7 @@ import {
   extractErrorMessage,
 } from "@/utils/api-errors";
 import { recordDiagnostic } from "@/lib/diagnostics";
+import { readContentLength } from "@/utils/content-length";
 import { getSeqGeneration } from "@/lib/streaming/reconnect-cursor";
 import { summarizeDisplayMessages } from "@/domains/chat/utils/diagnostics";
 
@@ -108,8 +109,7 @@ async function fetchPaginatedHistory(
 
   assertHasResponse(response, error, "Failed to fetch history");
   const durationMs = Math.round(performance.now() - startedAt);
-  const contentLength = response.headers.get("content-length");
-  const bytes = contentLength === null ? null : Number(contentLength);
+  const bytes = readContentLength(response);
   if (!response.ok) {
     recordDiagnostic("history_page_fetch_error", {
       assistantId,

--- a/clients/web/src/utils/content-length.ts
+++ b/clients/web/src/utils/content-length.ts
@@ -1,0 +1,21 @@
+/**
+ * Response payload size for fetch diagnostics.
+ */
+
+/**
+ * Byte size of a response body read from its `content-length` header, or null
+ * when the header is absent, blank, or not a finite number.
+ *
+ * Diagnostics record the result verbatim, so an unusable header has to stay
+ * distinguishable from a real size: `Number("")` is 0 (a plausible body size)
+ * and `Number("abc")` is NaN (which JSON-stringifies to null, so it reads back
+ * exactly like an absent header). Both collapse to an explicit null here.
+ */
+export function readContentLength(response: Response): number | null {
+  const header = response.headers.get("content-length");
+  if (header === null || header.trim() === "") {
+    return null;
+  }
+  const bytes = Number(header);
+  return Number.isFinite(bytes) ? bytes : null;
+}

--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -4,7 +4,8 @@
  * The ring holds 200 entries, so a multi-page drain must contribute a bounded
  * handful of them: the first page (the request that gates first paint), one
  * summary, and one entry per failed page. These tests pin that budget, plus
- * the one aggregate watchdog event each drain puts on the telemetry rail.
+ * the one aggregate watchdog event each drain puts on the telemetry rail and
+ * the single entry each standalone first-page fetch contributes.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -18,14 +19,20 @@ const emitClientPerfEventMock = mock(
   (_checkName: string, _value: number, _detail?: Record<string, unknown>) => {},
 );
 
+// `mock.module` replaces the module process-wide, so it has to stand in for the
+// full export surface or an unrelated importer picks up an undefined binding.
 mock.module("@/lib/telemetry/client-perf", () => ({
   emitClientPerfEvent: emitClientPerfEventMock,
+  setClientPerfBootId: () => {},
+  __resetClientPerfForTests: () => {},
 }));
 
 const {
   listArchivedConversations,
   listBackgroundConversations,
+  listBackgroundConversationsFirstPage,
   listConversations,
+  listConversationsFirstPage,
   listOriginChannelConversations,
   listScheduledConversations,
 } = await import("@/utils/conversation-list-fetchers");
@@ -68,18 +75,20 @@ function stubPages(fixtures: PageFixture[]): { offsets: number[] } {
         throw new Error(`test setup has no fixture for request ${index}`);
       }
       const status = fixture.status ?? 200;
+      const ok = status < 400;
       const body = {
         conversations: fixture.ids.map(makeRaw),
         hasMore: fixture.hasMore,
       };
       return {
-        data: status === 200 ? body : null,
-        error: status === 200 ? null : { message: "boom" },
+        data: ok ? body : null,
+        error: ok ? null : { message: "boom" },
         response: new Response(JSON.stringify(body), {
           status,
-          headers: fixture.contentLength
-            ? { "content-length": fixture.contentLength }
-            : {},
+          headers:
+            fixture.contentLength === undefined
+              ? {}
+              : { "content-length": fixture.contentLength },
         }),
       };
     },
@@ -215,6 +224,26 @@ describe("conversation list drain diagnostics", () => {
     expect(withHeader.events[1]?.details.totalBytes).toBe(4096);
   });
 
+  test("bytes is null for a malformed or blank content-length", async () => {
+    stubPages([
+      { ids: ["c-0"], hasMore: false, contentLength: "not-a-number" },
+    ]);
+    const malformed = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(malformed.events[0]?.details.bytes).toBeNull();
+    expect(malformed.events[1]?.details.totalBytes).toBeNull();
+
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "" }]);
+    const blank = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID),
+    );
+
+    expect(blank.events[0]?.details.bytes).toBeNull();
+    expect(blank.events[1]?.details.totalBytes).toBeNull();
+  });
+
   test("every recorded detail value is a scalar or null", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
 
@@ -236,6 +265,67 @@ describe("conversation list drain diagnostics", () => {
   });
 });
 
+describe("first-page fetch diagnostics", () => {
+  test("records a page entry with the response's real status and bytes", async () => {
+    stubPages([
+      { ids: ["c-0", "c-1"], hasMore: true, status: 206, contentLength: "128" },
+    ]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listConversationsFirstPage(ASSISTANT_ID),
+    );
+
+    expect(events.map((e) => e.kind)).toEqual(["conversation_list_page_fetch"]);
+    expect(events[0]?.details).toMatchObject({
+      assistantId: ASSISTANT_ID,
+      offset: 0,
+      status: 206,
+      count: 2,
+      hasMore: true,
+      bytes: 128,
+      conversationType: null,
+    });
+    expect(typeof events[0]?.details.durationMs).toBe("number");
+    // A single page is not a drain, so nothing reaches the telemetry rail.
+    expect(emitClientPerfEventMock.mock.calls).toHaveLength(0);
+  });
+
+  test("labels the background bucket's entry with its conversation type", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "12" }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listBackgroundConversationsFirstPage(ASSISTANT_ID),
+    );
+
+    expect(events[0]?.details).toMatchObject({
+      offset: 0,
+      status: 200,
+      conversationType: "background",
+      bytes: 12,
+    });
+  });
+
+  test("bytes is null for a malformed content-length", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "abc" }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listConversationsFirstPage(ASSISTANT_ID),
+    );
+
+    expect(events[0]?.details.bytes).toBeNull();
+  });
+
+  test("returns only the public page shape, with no timing fields", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: true, contentLength: "128" }]);
+
+    const page = await listConversationsFirstPage(ASSISTANT_ID);
+
+    expect(Object.keys(page).sort()).toEqual(["conversations", "hasMore"]);
+    expect(page.hasMore).toBe(true);
+    expect(page.conversations).toHaveLength(1);
+  });
+});
+
 describe("conversation list drain telemetry", () => {
   test("a 3-page drain emits one client_list.drain, not one per page", async () => {
     stubPages([
@@ -252,10 +342,10 @@ describe("conversation list drain telemetry", () => {
     expect(typeof emits[0]?.value).toBe("number");
     expect(emits[0]?.detail).toEqual({
       outcome: "ok",
-      pages: "3",
-      rows: "3",
-      max_page_ms: expect.any(String),
-      total_bytes: "350",
+      pages: 3,
+      rows: 3,
+      max_page_ms: expect.any(Number),
+      total_bytes: 350,
       list_kind: "foreground",
     });
   });
@@ -269,7 +359,7 @@ describe("conversation list drain telemetry", () => {
     expect(emits).toHaveLength(1);
     expect(emits[0]?.detail).toMatchObject({
       outcome: "ok",
-      pages: "1",
+      pages: 1,
       list_kind: "background",
     });
   });
@@ -293,7 +383,7 @@ describe("conversation list drain telemetry", () => {
     expect(emits).toHaveLength(1);
     expect(emits[0]?.detail).toMatchObject({
       outcome: "ok",
-      pages: "1",
+      pages: 1,
       list_kind: "origin_channel",
     });
   });
@@ -316,7 +406,7 @@ describe("conversation list drain telemetry", () => {
     ]);
   });
 
-  test("the detail bag carries no assistant id, and unknown bytes when content-length is absent", async () => {
+  test("the detail bag carries no assistant id, and null bytes when content-length is absent", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false }]);
 
     await listConversations(ASSISTANT_ID);
@@ -328,7 +418,18 @@ describe("conversation list drain telemetry", () => {
       expect(key.toLowerCase()).not.toContain("assistant");
     }
     expect(Object.values(detail)).not.toContain(ASSISTANT_ID);
-    expect(detail.total_bytes).toBe("unknown");
+    expect(detail.total_bytes).toBeNull();
+  });
+
+  test("the numeric detail fields ride as raw numbers, not strings", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "64" }]);
+
+    await listConversations(ASSISTANT_ID);
+
+    const detail = drainEmits()[0]!.detail;
+    for (const key of ["pages", "rows", "max_page_ms", "total_bytes"]) {
+      expect(typeof detail[key]).toBe("number");
+    }
   });
 
   test("a failing drain emits outcome error and still rethrows", async () => {
@@ -347,8 +448,8 @@ describe("conversation list drain telemetry", () => {
     expect(emits).toHaveLength(1);
     expect(emits[0]?.detail).toMatchObject({
       outcome: "error",
-      pages: "1",
-      rows: "1",
+      pages: 1,
+      rows: 1,
       list_kind: "foreground",
     });
   });

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -25,6 +25,7 @@ import {
 import { recordDiagnostic } from "@/lib/diagnostics";
 import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 import type { Conversation } from "@/types/conversation-types";
+import { readContentLength } from "@/utils/content-length";
 import { isScheduledConversation } from "@/utils/conversation-predicates";
 import { toConversation } from "@/utils/conversation-transforms";
 
@@ -160,22 +161,35 @@ export type ConversationListPage = {
 };
 
 /**
- * A page plus what it cost to fetch. The timings stay internal to this module
- * so the public {@link ConversationListPage} contract is unchanged.
+ * A page plus what it cost to fetch. Module-private, and every exported
+ * fetcher projects it down to the {@link ConversationListPage} fields by hand,
+ * so the cost fields never reach callers.
  */
 type TimedConversationListPage = ConversationListPage & {
+  /** HTTP status of the response that produced this page (always 2xx). */
+  status: number;
   durationMs: number;
-  /** `content-length` in bytes, or null when the server omits the header. */
+  /** `content-length` in bytes, or null when the header is missing or junk. */
   bytes: number | null;
 };
 
-function readContentLength(response: Response): number | null {
-  const header = response.headers.get("content-length");
-  if (header === null) {
-    return null;
-  }
-  const bytes = Number(header);
-  return Number.isFinite(bytes) ? bytes : null;
+type FirstPageFetchDiagnostic = {
+  assistantId: string;
+  status: number;
+  count: number;
+  hasMore: boolean;
+  durationMs: number;
+  bytes: number | null;
+  conversationType: "background" | "scheduled" | null;
+};
+
+/**
+ * Ring entry for one offset-0 list GET, shared by the drain's first page and
+ * the standalone first-page fetchers. The standalone ones run debounced (250ms)
+ * behind sync events, so their share of the 200-entry ring stays small.
+ */
+function recordFirstPageFetch(entry: FirstPageFetchDiagnostic): void {
+  recordDiagnostic("conversation_list_page_fetch", { ...entry, offset: 0 });
 }
 
 async function fetchConversationListPage(
@@ -218,6 +232,7 @@ async function fetchConversationListPage(
   return {
     conversations: (data?.conversations ?? []).map(toConversation),
     hasMore: data?.hasMore ?? false,
+    status: response.status,
     durationMs,
     bytes: readContentLength(response),
   };
@@ -253,10 +268,10 @@ async function fetchConversationList(
     // metadata only.
     emitClientPerfEvent("client_list.drain", totalMs, {
       outcome,
-      pages: String(pages),
-      rows: String(all.length),
-      max_page_ms: String(maxPageMs),
-      total_bytes: totalBytes === null ? "unknown" : String(totalBytes),
+      pages,
+      rows: all.length,
+      max_page_ms: maxPageMs,
+      total_bytes: totalBytes,
       list_kind: drainListKind(options),
     });
   };
@@ -264,7 +279,7 @@ async function fetchConversationList(
   try {
     for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
       const offset = page * CONVERSATION_LIST_PAGE_SIZE;
-      const { conversations, hasMore, durationMs, bytes } =
+      const { conversations, hasMore, status, durationMs, bytes } =
         await fetchConversationListPage(assistantId, offset, options);
       pages++;
       maxPageMs = Math.max(maxPageMs, durationMs);
@@ -272,14 +287,14 @@ async function fetchConversationList(
         totalBytes = (totalBytes ?? 0) + bytes;
       }
       if (page === 0) {
-        recordDiagnostic("conversation_list_page_fetch", {
+        recordFirstPageFetch({
           assistantId,
-          offset: 0,
-          status: 200,
+          status,
           count: conversations.length,
           hasMore,
           durationMs,
           bytes,
+          conversationType: options.conversationType ?? null,
         });
       }
       for (const conversation of conversations) {
@@ -490,12 +505,20 @@ export async function listArchivedConversations(
 export async function listConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0);
+  const { conversations, hasMore, status, durationMs, bytes } =
+    await fetchConversationListPage(assistantId, 0);
+  recordFirstPageFetch({
+    assistantId,
+    status,
+    count: conversations.length,
+    hasMore,
+    durationMs,
+    bytes,
+    conversationType: null,
+  });
   return {
-    ...page,
-    conversations: [...page.conversations].sort(
-      byTimestampDesc("lastMessageAt"),
-    ),
+    conversations: [...conversations].sort(byTimestampDesc("lastMessageAt")),
+    hasMore,
   };
 }
 
@@ -503,14 +526,24 @@ export async function listConversationsFirstPage(
 export async function listBackgroundConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0, {
+  const { conversations, hasMore, status, durationMs, bytes } =
+    await fetchConversationListPage(assistantId, 0, {
+      conversationType: "background",
+    });
+  recordFirstPageFetch({
+    assistantId,
+    status,
+    count: conversations.length,
+    hasMore,
+    durationMs,
+    bytes,
     conversationType: "background",
   });
   return {
-    ...page,
-    conversations: page.conversations
+    conversations: conversations
       .filter((c) => !isScheduledConversation(c))
       .sort(byTimestampDesc("lastMessageAt")),
+    hasMore,
   };
 }
 
@@ -518,14 +551,22 @@ export async function listBackgroundConversationsFirstPage(
 export async function listScheduledConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0, {
+  const { conversations, hasMore, status, durationMs, bytes } =
+    await fetchConversationListPage(assistantId, 0, {
+      conversationType: "scheduled",
+    });
+  recordFirstPageFetch({
+    assistantId,
+    status,
+    count: conversations.length,
+    hasMore,
+    durationMs,
+    bytes,
     conversationType: "scheduled",
   });
   return {
-    ...page,
-    conversations: [...page.conversations].sort(
-      byTimestampDesc("lastMessageAt"),
-    ),
+    conversations: [...conversations].sort(byTimestampDesc("lastMessageAt")),
+    hasMore,
   };
 }
 


### PR DESCRIPTION
## Summary
- One guarded content-length parser shared by list and history diagnostics (no NaN, empty-string safe)
- First-page fetchers return exactly the public shape (timing fields can no longer leak into cache consumers) and now record ring diagnostics with the real HTTP status, covering the post-resume refresh path
- client_list.drain detail uses raw numerics and null instead of stringified values and an unknown sentinel

Fixes gaps found during plan self-review for measure-first-telemetry-followups.md