### PR TITLE
fix(web): switch-telemetry window lifecycle and abandoned-sample emission

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -14,18 +14,24 @@ import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 const CONV = "conv-A";
 
-// Records which conversations opened a switch-telemetry window, so the gate in
-// `switchToConversation` can be asserted without reaching the ingest layer.
-// The module's other exports are stubbed too: a module mock is process-wide, so
-// a sibling file sharing this Bun process must still find them.
+// Records which conversations opened a switch-telemetry window and why one was
+// closed, so the gate in `switchToConversation` can be asserted without
+// reaching the ingest layer. The module's other exports are stubbed too: a
+// module mock is process-wide, so a sibling file sharing this Bun process must
+// still find them.
 const switchStartedConversationIds: string[] = [];
+const switchAbandonReasons: string[] = [];
 mock.module("@/lib/telemetry/switch-telemetry", () => ({
   noteConversationSwitchStarted: (conversationId: string) => {
     switchStartedConversationIds.push(conversationId);
   },
   noteSwitchTranscriptPainted: () => {},
-  abandonSwitchMeasurement: () => {},
+  abandonSwitchMeasurement: (reason: string) => {
+    switchAbandonReasons.push(reason);
+  },
+  useSwitchPaintMeasurement: () => {},
   subscribeSwitchTelemetry: () => () => {},
+  __resetSwitchTelemetryForTests: () => {},
 }));
 
 function snapshot(
@@ -373,6 +379,7 @@ describe("chat-session-store — snapshot + optimistic", () => {
 describe("chat-session-store: switch telemetry gate", () => {
   beforeEach(() => {
     switchStartedConversationIds.length = 0;
+    switchAbandonReasons.length = 0;
     useChatSessionStore.setState({
       previousConversationId: null,
       previousAssistantId: null,
@@ -440,5 +447,48 @@ describe("chat-session-store: switch telemetry gate", () => {
     });
 
     expect(switchStartedConversationIds).toEqual([]);
+  });
+
+  test("every unmeasured move closes any window it inherited", () => {
+    // Each of these leaves the panel on a conversation that cannot paint under
+    // the id of a window an earlier switch opened.
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    store().switchToConversation({
+      assistantId: "asst-2",
+      activeConversationId: "conv-B",
+    });
+    store().switchToConversation({
+      assistantId: "asst-2",
+      activeConversationId: "conv-B",
+    });
+    store().markDraftResolution();
+    store().switchToConversation({
+      assistantId: "asst-2",
+      activeConversationId: "conv-server-1",
+    });
+
+    expect(switchAbandonReasons).toEqual([
+      "context_change",
+      "context_change",
+      "context_change",
+      "context_change",
+    ]);
+  });
+
+  test("a measured move opens a window instead of abandoning", () => {
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-A",
+    });
+    switchAbandonReasons.length = 0;
+    store().switchToConversation({
+      assistantId: "asst-1",
+      activeConversationId: "conv-B",
+    });
+
+    expect(switchAbandonReasons).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -49,7 +49,10 @@ import {
 } from "@/domains/chat/transcript/rolling-snapshot";
 import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
 import { getSseEnvelopesSince } from "@/lib/streaming/stream-debug";
-import { noteConversationSwitchStarted } from "@/lib/telemetry/switch-telemetry";
+import {
+  abandonSwitchMeasurement,
+  noteConversationSwitchStarted,
+} from "@/lib/telemetry/switch-telemetry";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 
 // ---------------------------------------------------------------------------
@@ -458,8 +461,11 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
   switchToConversation: ({ assistantId, activeConversationId }) => {
     const state = get();
 
-    // Draft-key resolution (draft→server ID) is not a real switch.
+    // Draft-key resolution (draft→server ID) is not a real switch. A window
+    // opened under the draft key can only be closed by a paint under that key,
+    // and the transcript paints under the server id, so close it here.
     if (state.draftConversationIdResolution) {
+      abandonSwitchMeasurement("context_change");
       set({ draftConversationIdResolution: false });
       return;
     }
@@ -524,6 +530,10 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
     // would mix first-fetch time into the switch distribution.
     if (isConversationSwitch && !isAssistantSwitch) {
       noteConversationSwitchStarted(activeConversationId);
+    } else {
+      // Unmeasured move: nothing will paint under the pending window's id, so
+      // close it here instead of letting the TTL bill it as a stall.
+      abandonSwitchMeasurement("context_change");
     }
 
     set({

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -56,10 +56,7 @@ import { useVisionAttachmentGate } from "@/lib/backwards-compat/vision-attachmen
 import { useSupportsNewChatPlugins } from "@/lib/backwards-compat/use-supports-new-chat-plugins";
 import { recordCommit } from "@/lib/commit-pressure";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
-import {
-  abandonSwitchMeasurement,
-  noteSwitchTranscriptPainted,
-} from "@/lib/telemetry/switch-telemetry";
+import { useSwitchPaintMeasurement } from "@/lib/telemetry/switch-telemetry";
 import { NewChatPluginsSection } from "@/domains/chat/components/new-chat-plugins/new-chat-plugins-section";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { ActiveProcessOverlay } from "@/domains/chat/process-registry/active-process-overlay";
@@ -518,36 +515,17 @@ export function ChatMainPanel({
   // conversation's first paint. It runs from an ancestor effect
   // (`ActiveChatView`), which React commits after this one, so the render that
   // first carries the new id finds no pending window and measures nothing.
-  // A failed initial `/messages` fetch clears `isLoadingHistory` with no
-  // messages, which reads exactly like an instant empty conversation, so the
-  // query's own error state has to veto the paint. An older-page failure keeps
-  // `isSuccess`, and the transcript it already painted still counts.
-  const historyLoadFailed =
-    historyPagination.isError && !historyPagination.isSuccess;
-  const switchTranscriptPainted =
-    !historyLoadFailed && !(isLoadingHistory && messages.length === 0);
-  useEffect(() => {
-    if (!activeConversationId) {
-      return;
-    }
-    if (historyLoadFailed) {
-      // A failed load is neither a paint nor a stall. The failure is already
-      // visible as `history_page_fetch_error`, and leaving the window open
-      // would let the 15s TTL bill a fast-failing fetch as a slow switch.
-      abandonSwitchMeasurement();
-      return;
-    }
-    if (switchTranscriptPainted) {
-      noteSwitchTranscriptPainted(activeConversationId, {
-        hadHistory: messages.length > 0,
-      });
-    }
-  }, [
-    switchTranscriptPainted,
+  // A history fetch that errored with nothing on screen reads exactly like an
+  // instant empty conversation, so it has to veto the paint; an error that
+  // still has a painted transcript behind it (a failed older page, a failed
+  // background refetch) does not.
+  const historyLoadFailed = historyPagination.isError && messages.length === 0;
+  useSwitchPaintMeasurement({
+    conversationId: activeConversationId,
     historyLoadFailed,
-    activeConversationId,
-    messages.length,
-  ]);
+    transcriptPainted: !(isLoadingHistory && messages.length === 0),
+    hadHistory: messages.length > 0,
+  });
 
   // Clear staged quotes and dismiss the reply bubble when the active
   // conversation changes to prevent quotes from one conversation leaking

--- a/clients/web/src/lib/telemetry/switch-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.test.ts
@@ -1,23 +1,31 @@
 /**
  * Pins the conversation-switch paint measurement:
- *   - one sample per switch, painted or stalled, never both
+ *   - one sample per opened window: painted, stalled, or abandoned, never two
  *   - a paint for a different conversation leaves the window open
- *   - a re-switch supersedes the pending sample silently
- *   - `app.hidden` abandons it so backgrounded switches never land
- *   - a failed history load abandons it: neither a paint nor a stall
- *   - nothing is emitted without analytics consent
+ *   - every way a switch can end early emits its own abandon reason, so the
+ *     three series together cover every attempt
+ *   - `useSwitchPaintMeasurement` observes a switch whose incoming transcript
+ *     was already cached, and abandons anything still open on unmount
  *   - no emitted detail carries a conversation id
+ *
+ * The emitter itself is mocked: its envelope, consent gate, and surface labels
+ * are `client-perf`'s contract and are pinned by `client-perf.test.ts`.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
 
-let consent = true;
-const postTelemetryEventsMock = mock((_events: readonly object[]) => {});
+const emitClientPerfEventMock = mock(
+  (
+    _checkName: string,
+    _value: number,
+    _detail?: Record<string, unknown>,
+  ): void => {},
+);
 
-mock.module("@/lib/telemetry/consent", () => ({
-  readAnalyticsConsent: () => consent,
-}));
-mock.module("@/lib/telemetry/ingest", () => ({
-  postTelemetryEvents: postTelemetryEventsMock,
+mock.module("@/lib/telemetry/client-perf", () => ({
+  emitClientPerfEvent: emitClientPerfEventMock,
+  setClientPerfBootId: () => {},
+  __resetClientPerfForTests: () => {},
 }));
 
 const { publish, __resetForTesting } = await import("@/lib/event-bus");
@@ -27,6 +35,7 @@ const {
   noteConversationSwitchStarted,
   noteSwitchTranscriptPainted,
   subscribeSwitchTelemetry,
+  useSwitchPaintMeasurement,
 } = await import("./switch-telemetry");
 
 // The module reads `performance.now()` for elapsed time and schedules the TTL
@@ -47,20 +56,50 @@ function runScheduledTimers(): void {
   }
 }
 
-function emittedEvents(): Record<string, unknown>[] {
-  return postTelemetryEventsMock.mock.calls.flatMap(
-    (call) => call[0] as Record<string, unknown>[],
+type Sample = {
+  checkName: string;
+  value: number;
+  detail: Record<string, unknown>;
+};
+
+function emittedSamples(): Sample[] {
+  return emitClientPerfEventMock.mock.calls.map((call) => ({
+    checkName: call[0],
+    value: call[1],
+    detail: call[2] ?? {},
+  }));
+}
+
+function onlySample(): Sample {
+  const samples = emittedSamples();
+  expect(samples).toHaveLength(1);
+  return samples[0]!;
+}
+
+type PaintProps = {
+  conversationId: string | null;
+  historyLoadFailed: boolean;
+  transcriptPainted: boolean;
+  hadHistory: boolean;
+};
+
+const PAINTED_PROPS: PaintProps = {
+  conversationId: "conv-1",
+  historyLoadFailed: false,
+  transcriptPainted: true,
+  hadHistory: true,
+};
+
+function renderPaintMeasurement(props: PaintProps) {
+  return renderHook(
+    (current: PaintProps) => useSwitchPaintMeasurement(current),
+    {
+      initialProps: props,
+    },
   );
 }
 
-function onlyEvent(): Record<string, unknown> {
-  const events = emittedEvents();
-  expect(events).toHaveLength(1);
-  return events[0]!;
-}
-
 beforeEach(() => {
-  consent = true;
   clock = 1_000;
   timers = new Map();
   nextTimerId = 1;
@@ -78,12 +117,13 @@ beforeEach(() => {
       timers.delete(id);
     }
   }) as unknown as typeof globalThis.clearTimeout;
-  postTelemetryEventsMock.mockClear();
+  emitClientPerfEventMock.mockClear();
   __resetForTesting();
   __resetSwitchTelemetryForTests();
 });
 
 afterEach(() => {
+  cleanup();
   performance.now = realNow;
   globalThis.setTimeout = realSetTimeout;
   globalThis.clearTimeout = realClearTimeout;
@@ -97,57 +137,60 @@ describe("switch telemetry", () => {
     clock += 412;
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
 
-    const event = onlyEvent();
-    expect(event.check_name).toBe("client_switch.transcript_painted");
-    expect(event.value).toBe(412);
-    expect((event.detail as Record<string, unknown>).had_history).toBe("true");
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.transcript_painted");
+    expect(sample.value).toBe(412);
+    expect(sample.detail.had_history).toBe("true");
   });
 
   test("labels an empty incoming conversation with had_history false", () => {
     noteConversationSwitchStarted("conv-1");
     noteSwitchTranscriptPainted("conv-1", { hadHistory: false });
 
-    expect((onlyEvent().detail as Record<string, unknown>).had_history).toBe(
-      "false",
-    );
+    expect(onlySample().detail.had_history).toBe("false");
   });
 
   test("ignores a paint for a different conversation and keeps the window", () => {
     noteConversationSwitchStarted("conv-1");
     noteSwitchTranscriptPainted("conv-2", { hadHistory: true });
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
 
     clock += 50;
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-    expect(onlyEvent().value).toBe(50);
+    expect(onlySample().value).toBe(50);
   });
 
-  test("a re-switch supersedes the pending sample without emitting", () => {
+  test("a re-switch closes the previous window as superseded", () => {
     noteConversationSwitchStarted("conv-1");
     clock += 90;
     noteConversationSwitchStarted("conv-2");
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
 
+    const superseded = onlySample();
+    expect(superseded.checkName).toBe("client_switch.abandoned");
+    expect(superseded.value).toBe(90);
+    expect(superseded.detail.reason).toBe("superseded");
+
+    // The superseded window is gone: only the newest one can still paint.
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    expect(emittedSamples()).toHaveLength(1);
 
     clock += 10;
     noteSwitchTranscriptPainted("conv-2", { hadHistory: true });
-    expect(onlyEvent().value).toBe(10);
+    expect(emittedSamples()[1]!.value).toBe(10);
   });
 
   test("emits one stall sample when the window outlives its TTL", () => {
     noteConversationSwitchStarted("conv-1");
     runScheduledTimers();
 
-    const event = onlyEvent();
-    expect(event.check_name).toBe("client_switch.stalled");
-    expect(event.value).toBe(15_000);
-    expect((event.detail as Record<string, unknown>).reason).toBe("timeout");
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.stalled");
+    expect(sample.value).toBe(15_000);
+    expect(sample.detail.reason).toBe("timeout");
 
     // The stall closed the window: a late paint is not a second sample.
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-    expect(emittedEvents()).toHaveLength(1);
+    expect(emittedSamples()).toHaveLength(1);
   });
 
   test("a paint cancels the stall so a switch never reports both", () => {
@@ -156,52 +199,63 @@ describe("switch telemetry", () => {
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
     runScheduledTimers();
 
-    expect(onlyEvent().check_name).toBe("client_switch.transcript_painted");
+    expect(onlySample().checkName).toBe("client_switch.transcript_painted");
   });
 
-  test("app.hidden abandons the pending sample silently", () => {
+  test("app.hidden abandons the pending sample as hidden", () => {
     const unsubscribe = subscribeSwitchTelemetry();
     noteConversationSwitchStarted("conv-1");
+    clock += 70;
     publish("app.hidden", { signal: "visibility" });
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
 
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.abandoned");
+    expect(sample.value).toBe(70);
+    expect(sample.detail.reason).toBe("hidden");
+
+    // The window went with it, so neither a stall nor a late paint follows.
     runScheduledTimers();
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    expect(emittedSamples()).toHaveLength(1);
 
     unsubscribe();
   });
 
-  test("a failed history load abandons the window without a sample", () => {
-    // The panel calls this on the error path instead of reporting a paint.
+  test("unsubscribing drops a pending window with no sample and no stall", () => {
+    const unsubscribe = subscribeSwitchTelemetry();
     noteConversationSwitchStarted("conv-1");
-    clock += 300;
-    abandonSwitchMeasurement();
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    unsubscribe();
 
-    // The stall timer went with it, so the failure never lands as a slow switch.
     runScheduledTimers();
-    noteSwitchTranscriptPainted("conv-1", { hadHistory: false });
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
   });
 
-  test("abandoning with no pending window is a no-op", () => {
-    abandonSwitchMeasurement();
+  test("a context change abandons the window and cancels its stall", () => {
+    // The store takes this branch for assistant switches, re-entering the same
+    // conversation, and draft-key resolution.
+    noteConversationSwitchStarted("conv-1");
+    clock += 300;
+    abandonSwitchMeasurement("context_change");
+
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.abandoned");
+    expect(sample.value).toBe(300);
+    expect(sample.detail.reason).toBe("context_change");
+
+    runScheduledTimers();
+    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
+    expect(emittedSamples()).toHaveLength(1);
+  });
+
+  test("abandoning with no pending window emits nothing", () => {
+    abandonSwitchMeasurement("unmount");
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+
     noteConversationSwitchStarted("conv-1");
     clock += 40;
     noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-
-    expect(onlyEvent().value).toBe(40);
-  });
-
-  test("emits nothing without analytics consent", () => {
-    consent = false;
-    noteConversationSwitchStarted("conv-1");
-    clock += 100;
-    noteSwitchTranscriptPainted("conv-1", { hadHistory: true });
-    runScheduledTimers();
-
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    expect(onlySample().value).toBe(40);
   });
 
   test("never puts a conversation id in an emitted detail bag", () => {
@@ -209,18 +263,107 @@ describe("switch telemetry", () => {
     clock += 5;
     noteSwitchTranscriptPainted("conv-secret-1", { hadHistory: true });
     noteConversationSwitchStarted("conv-secret-2");
+    abandonSwitchMeasurement("hidden");
+    noteConversationSwitchStarted("conv-secret-3");
     runScheduledTimers();
 
-    const events = emittedEvents();
-    expect(events).toHaveLength(2);
-    for (const event of events) {
-      const serialized = JSON.stringify(event.detail);
-      expect(serialized).not.toContain("conv-secret-1");
-      expect(serialized).not.toContain("conv-secret-2");
-      for (const key of Object.keys(event.detail as Record<string, unknown>)) {
+    const samples = emittedSamples();
+    expect(samples).toHaveLength(3);
+    for (const sample of samples) {
+      const serialized = JSON.stringify(sample.detail);
+      expect(serialized).not.toContain("conv-secret-");
+      for (const key of Object.keys(sample.detail)) {
         expect(key).not.toContain("conversation");
         expect(key).not.toContain("assistant");
       }
     }
+  });
+});
+
+describe("useSwitchPaintMeasurement", () => {
+  test("reports the paint for the conversation it renders", () => {
+    const { rerender } = renderPaintMeasurement({
+      ...PAINTED_PROPS,
+      transcriptPainted: false,
+    });
+    noteConversationSwitchStarted("conv-1");
+    clock += 120;
+    rerender(PAINTED_PROPS);
+
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.transcript_painted");
+    expect(sample.value).toBe(120);
+    expect(sample.detail.had_history).toBe("true");
+  });
+
+  test("closes a window whose incoming transcript was already cached", () => {
+    // A cache-warm switch batches the transcript reset and the cached snapshot
+    // into one commit, so the panel can re-render with every observed value
+    // identical. The window still has to close, or the TTL bills an instant
+    // switch as a stall.
+    const { rerender } = renderPaintMeasurement(PAINTED_PROPS);
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+
+    noteConversationSwitchStarted("conv-1");
+    clock += 8;
+    rerender(PAINTED_PROPS);
+
+    expect(onlySample().checkName).toBe("client_switch.transcript_painted");
+
+    runScheduledTimers();
+    expect(emittedSamples()).toHaveLength(1);
+  });
+
+  test("a failed history load abandons the window instead of painting", () => {
+    const { rerender } = renderPaintMeasurement({
+      ...PAINTED_PROPS,
+      transcriptPainted: false,
+    });
+    noteConversationSwitchStarted("conv-1");
+    clock += 250;
+    rerender({
+      conversationId: "conv-1",
+      historyLoadFailed: true,
+      transcriptPainted: true,
+      hadHistory: false,
+    });
+
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.abandoned");
+    expect(sample.value).toBe(250);
+    expect(sample.detail.reason).toBe("history_error");
+
+    // The stall timer went with it, so the failure never lands as a slow switch.
+    runScheduledTimers();
+    expect(emittedSamples()).toHaveLength(1);
+  });
+
+  test("unmounting abandons a window that is still open", () => {
+    const { unmount } = renderPaintMeasurement({
+      ...PAINTED_PROPS,
+      transcriptPainted: false,
+    });
+    noteConversationSwitchStarted("conv-1");
+    clock += 33;
+    unmount();
+
+    const sample = onlySample();
+    expect(sample.checkName).toBe("client_switch.abandoned");
+    expect(sample.value).toBe(33);
+    expect(sample.detail.reason).toBe("unmount");
+
+    runScheduledTimers();
+    expect(emittedSamples()).toHaveLength(1);
+  });
+
+  test("renders with no active conversation without touching the window", () => {
+    const { rerender } = renderPaintMeasurement({
+      ...PAINTED_PROPS,
+      conversationId: null,
+    });
+    noteConversationSwitchStarted("conv-1");
+    rerender({ ...PAINTED_PROPS, conversationId: null });
+
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/lib/telemetry/switch-telemetry.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.ts
@@ -4,10 +4,13 @@
  * `switchToConversation` opens a pending window at the instant the transcript
  * is blanked, and only for a real move between two conversations of the same
  * assistant; the chat panel closes it on the first render that is no longer an
- * empty loading transcript. One `client_switch.transcript_painted` sample per
- * switch, or one `client_switch.stalled` if the window outlives its TTL. Never
- * both: whichever lands first clears the pending window. A window whose history
- * fetch failed is abandoned without a sample.
+ * empty loading transcript. Exactly one sample per opened window:
+ * `client_switch.transcript_painted` when the transcript lands,
+ * `client_switch.stalled` when the window outlives its TTL, or
+ * `client_switch.abandoned` when the switch is cut short (history error, app
+ * backgrounded, panel unmounted, a re-switch, or a move the family does not
+ * measure). Painted plus stalled plus abandoned is therefore the full set of
+ * measured switches, so no attempt silently leaves the denominator.
  *
  * The TTL is 15s rather than the resume family's 10s because a cold history
  * fetch through the proxy chain can legitimately take that long on LTE. The
@@ -18,10 +21,19 @@
  * window and never reaches an emitted detail bag.
  */
 
+import { useEffect } from "react";
+
 import { subscribe } from "@/lib/event-bus";
 import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 
 const STALL_TTL_MS = 15_000;
+
+/**
+ * Why a measured switch ended without painting. A closed set so the abandoned
+ * series stays a groupable dimension rather than an open string.
+ */
+export type SwitchAbandonReason =
+  "history_error" | "hidden" | "unmount" | "superseded" | "context_change";
 
 let pending: {
   conversationId: string;
@@ -29,7 +41,8 @@ let pending: {
   timer: ReturnType<typeof setTimeout>;
 } | null = null;
 
-function abandonPending(): void {
+/** Drops the window and its TTL without emitting anything. */
+function clearPending(): void {
   if (pending === null) {
     return;
   }
@@ -38,11 +51,26 @@ function abandonPending(): void {
 }
 
 /**
- * Opens the pending window. An impatient re-switch supersedes the previous
- * sample silently: counting superseded switches is deliberately out of scope.
+ * Closes the pending window with a `client_switch.abandoned` sample, so a
+ * switch that never painted still lands in the family's denominator. A no-op
+ * when no window is open, which is what makes it safe to call from render-path
+ * effects and from store paths that may or may not have opened one.
+ */
+export function abandonSwitchMeasurement(reason: SwitchAbandonReason): void {
+  if (pending === null) {
+    return;
+  }
+  const elapsedMs = performance.now() - pending.at;
+  clearPending();
+  emitClientPerfEvent("client_switch.abandoned", elapsedMs, { reason });
+}
+
+/**
+ * Opens the pending window. An impatient re-switch closes the previous window
+ * as `superseded` rather than dropping it, so the abandoned rate stays honest.
  */
 export function noteConversationSwitchStarted(conversationId: string): void {
-  abandonPending();
+  abandonSwitchMeasurement("superseded");
   pending = {
     conversationId,
     at: performance.now(),
@@ -67,28 +95,71 @@ export function noteSwitchTranscriptPainted(
     return;
   }
   const elapsedMs = performance.now() - pending.at;
-  abandonPending();
+  clearPending();
   emitClientPerfEvent("client_switch.transcript_painted", elapsedMs, {
     had_history: String(extra.hadHistory),
   });
 }
 
 /**
- * Drops the pending window without emitting anything. Used when the switch
- * neither painted nor stalled, so there is no sample to attribute to it.
+ * Closes the pending window from the chat tree: reports the paint, vetoes it
+ * when the history fetch failed, and abandons anything still open when the
+ * panel goes away.
+ *
+ * The reporting effect is deliberately dependency-less. A switch into a
+ * conversation whose history is already cached batches the transcript reset and
+ * the cached snapshot into a single commit, so none of the values below have to
+ * change between the switch and the paint; running on every commit is the only
+ * way to observe that switch. Both calls are no-ops unless a window for
+ * `conversationId` is open, so the extra invocations cost a comparison.
  */
-export function abandonSwitchMeasurement(): void {
-  abandonPending();
+export function useSwitchPaintMeasurement({
+  conversationId,
+  historyLoadFailed,
+  transcriptPainted,
+  hadHistory,
+}: {
+  conversationId: string | null;
+  historyLoadFailed: boolean;
+  transcriptPainted: boolean;
+  hadHistory: boolean;
+}): void {
+  useEffect(() => {
+    if (conversationId === null) {
+      return;
+    }
+    if (historyLoadFailed) {
+      abandonSwitchMeasurement("history_error");
+      return;
+    }
+    if (transcriptPainted) {
+      noteSwitchTranscriptPainted(conversationId, { hadHistory });
+    }
+  });
+
+  useEffect(() => {
+    return () => {
+      abandonSwitchMeasurement("unmount");
+    };
+  }, []);
 }
 
 /**
  * Abandons any pending window when the app is backgrounded, so a switch the
- * user walked away from never contaminates the p95. Returns an unsubscribe.
+ * user walked away from never contaminates the p95. The returned unsubscribe
+ * also drops any window still open, so tearing the subscription down cannot
+ * leave a TTL running with nothing left to close it.
  */
 export function subscribeSwitchTelemetry(): () => void {
-  return subscribe("app.hidden", abandonPending);
+  const unsubscribe = subscribe("app.hidden", () => {
+    abandonSwitchMeasurement("hidden");
+  });
+  return () => {
+    unsubscribe();
+    clearPending();
+  };
 }
 
 export function __resetSwitchTelemetryForTests(): void {
-  abandonPending();
+  clearPending();
 }


### PR DESCRIPTION
## Summary
- Abandons the pending switch window on assistant switches, draft resolution, unmount, and cache-warm batched renders, so client_switch.stalled can no longer fire for moves that were never measured
- Replaces the dead isError && !isSuccess veto with errored-and-nothing-painted and corrects the TanStack v5 comment
- Adds client_switch.abandoned (closed reason set) so failing or abandoned switches stay visible in the denominator
- Test hygiene: full process-wide mock surfaces, emitter-level mocking, regression tests for every abandon path

Fixes gaps found during plan self-review for measure-first-telemetry-followups.md