### PR TITLE
fix(web): resume-counter background safety, endpoint coverage, gate-aware counting

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -83,12 +83,17 @@ mock.module("@/lib/auth/hard-navigate", () => ({
 }));
 
 // Post-resume request counter, stubbed so a test can make it throw and prove
-// the interceptor still returns its request.
+// the interceptor still returns its request. `isResumeWindowOpen` defaults to
+// true so counting is exercised; a test flips it to pin the idle fast path.
 let noteDaemonApiRequestImpl: (url: string) => void = () => {};
+let resumeWindowOpen = true;
 const noteDaemonApiRequestMock = mock((url: string) => {
   noteDaemonApiRequestImpl(url);
 });
+const isResumeWindowOpenMock = mock(() => resumeWindowOpen);
 mock.module("@/lib/telemetry/resume-request-counter", () => ({
+  __resetResumeRequestCounterForTests: () => {},
+  isResumeWindowOpen: isResumeWindowOpenMock,
   noteDaemonApiRequest: noteDaemonApiRequestMock,
   subscribeResumeRequestCounter: () => () => {},
 }));
@@ -1687,12 +1692,18 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
 describe("api-interceptors / post-resume request counting", () => {
   beforeEach(() => {
     noteDaemonApiRequestMock.mockClear();
+    isResumeWindowOpenMock.mockClear();
     noteDaemonApiRequestImpl = () => {};
+    resumeWindowOpen = true;
   });
 
   afterEach(() => {
     noteDaemonApiRequestImpl = () => {};
+    resumeWindowOpen = true;
     setSelfHostedConnection(null);
+    window.__VELLUM_CONFIG__ = undefined;
+    isLocalClientMock.mockImplementation(() => !process.env.VITE_PLATFORM_MODE);
+    isPlatformDisabledMock.mockImplementation(() => false);
   });
 
   test("notes daemon requests", async () => {
@@ -1733,6 +1744,60 @@ describe("api-interceptors / post-resume request counting", () => {
       ),
     );
     expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("does not count when no resume window is open", async () => {
+    resumeWindowOpen = false;
+    await daemonRequestInterceptor(
+      new Request("https://platform.test/v1/assistants/a1/conversations"),
+    );
+    await requestInterceptor(
+      new Request(
+        `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/events/`,
+      ),
+    );
+
+    expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("does not count a platform request the features gate aborts", async () => {
+    isLocalClientMock.mockImplementation(() => true);
+    isPlatformDisabledMock.mockImplementation(() => true);
+    // No ingress registered, so the daemon-bound path is not rewritten and the
+    // gate downstream aborts it. An aborted request never reaches the network.
+    const input = new Request(
+      `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/conversations/`,
+    );
+
+    const output = await requestInterceptor(input);
+
+    expect(platformFeaturesGate(output).signal.aborted).toBe(true);
+    expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("does not count a platform request aborted in remote-gateway mode", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    const input = new Request(
+      `${window.location.origin}/v1/assistants/${SELF_HOSTED_ID}/conversations/`,
+    );
+
+    const output = await requestInterceptor(input);
+
+    expect(platformFeaturesGate(output).signal.aborted).toBe(true);
+    expect(noteDaemonApiRequestMock).not.toHaveBeenCalled();
+  });
+
+  test("counts a gate-passing platform request exactly once", async () => {
+    isLocalClientMock.mockImplementation(() => true);
+    isPlatformDisabledMock.mockImplementation(() => true);
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const url = `https://platform.test${RUNTIME_PROXIED_PATH}`;
+
+    const output = await requestInterceptor(new Request(url));
+
+    expect(platformFeaturesGate(output).signal.aborted).toBe(false);
+    expect(noteDaemonApiRequestMock).toHaveBeenCalledTimes(1);
+    expect(noteDaemonApiRequestMock.mock.calls.at(-1)?.[0]).toBe(url);
   });
 
   test("a throwing counter leaves the request path intact", async () => {

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -46,7 +46,10 @@ import {
   getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
-import { noteDaemonApiRequest } from "@/lib/telemetry/resume-request-counter";
+import {
+  isResumeWindowOpen,
+  noteDaemonApiRequest,
+} from "@/lib/telemetry/resume-request-counter";
 import { getDeviceId } from "@/runtime/device-id";
 import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
@@ -318,34 +321,44 @@ export function authorizeRemoteGatewayRequest(
 /**
  * Builds a request interceptor for a HeyAPI client.
  *
- * @param skipSegmentAllowlist — `true` for the daemon client (every
- *   daemon SDK endpoint is a daemon route by definition, so all
- *   assistant sub-resource paths are forwarded to the self-hosted
- *   gateway unconditionally). `false` for the platform and auth
- *   clients (only allowlisted segments are forwarded; platform-owned
- *   routes like maintenance-mode, system-events, etc. fall through
- *   to Django).
- * @param countEveryRequest `true` for the daemon + gateway clients, where every
- *   request is daemon traffic by definition. The platform and auth clients
- *   count only their daemon-bound paths ({@link isDaemonBoundPath}), the SSE
- *   reopen among them, so the post-resume burst is measured whole while
- *   platform-owned traffic stays out of it. One count per request: this is the
- *   single choke point on each client's chain.
+ * @param isDaemonClient `true` for the daemon + gateway clients, where every
+ *   endpoint is a daemon route by definition. Two things follow from it: all
+ *   assistant sub-resource paths are forwarded to the self-hosted gateway
+ *   without consulting {@link RUNTIME_PROXIED_FIRST_SEGMENTS}, and every
+ *   request counts toward the post-resume burst. `false` for the platform and
+ *   auth clients, where only allowlisted segments are forwarded (platform-owned
+ *   routes like maintenance-mode, system-events, etc. fall through to Django)
+ *   and only daemon-bound paths ({@link isDaemonBoundPath}) count, the SSE
+ *   reopen among them.
+ *
+ * Counting happens once per request, after the routing decision, and this is
+ * the single choke point on each client's chain. On the platform chain it is
+ * additionally conditioned on {@link platformFeaturesGateAllows}, the gate
+ * registered downstream, so a request that gate aborts is never counted. The
+ * auth chain reaches neither test: allauth endpoints live under `/_allauth/`
+ * and are never daemon-bound.
  */
 function createInterceptor({
-  skipSegmentAllowlist = false,
+  isDaemonClient = false,
   allowRemoteGatewayDirect = false,
-  countEveryRequest = false,
 } = {}) {
-  return async (request: Request): Promise<Request> => {
-    try {
-      if (countEveryRequest || isDaemonBoundPath(request.url)) {
-        noteDaemonApiRequest(request.url);
-      }
-    } catch {
-      // Telemetry must never fail a request.
+  /**
+   * `outgoing` is the request the chain hands downstream; `url` is the original
+   * one, which still carries the platform-shaped path a self-hosted rewrite
+   * would have replaced.
+   */
+  function shouldCount(url: string, outgoing: Request): boolean {
+    // Cheapest test first: outside a resume window nothing here parses a URL.
+    if (!isResumeWindowOpen()) {
+      return false;
     }
+    if (isDaemonClient) {
+      return true;
+    }
+    return isDaemonBoundPath(url) && platformFeaturesGateAllows(outgoing);
+  }
 
+  const route = async (request: Request): Promise<Request> => {
     const newRequest = new Request(request);
 
     // Per-tab client identity — sent on *every* request (GET included)
@@ -362,7 +375,7 @@ function createInterceptor({
     // gateway directly instead of stamping the platform's session/CSRF
     // headers.
     const selfHosted = await rewriteForSelfHostedIngress(newRequest, {
-      skipSegmentAllowlist,
+      skipSegmentAllowlist: isDaemonClient,
     });
     if (selfHosted) {
       return selfHosted;
@@ -411,6 +424,18 @@ function createInterceptor({
 
     return newRequest;
   };
+
+  return async (request: Request): Promise<Request> => {
+    const outgoing = await route(request);
+    try {
+      if (shouldCount(request.url, outgoing)) {
+        noteDaemonApiRequest(request.url);
+      }
+    } catch {
+      // Telemetry must never fail a request.
+    }
+    return outgoing;
+  };
 }
 
 /** Platform + auth clients: uses the segment allowlist. */
@@ -418,9 +443,8 @@ export const requestInterceptor = createInterceptor();
 
 /** Daemon client: bypasses the segment allowlist. */
 export const daemonRequestInterceptor = createInterceptor({
-  skipSegmentAllowlist: true,
+  isDaemonClient: true,
   allowRemoteGatewayDirect: true,
-  countEveryRequest: true,
 });
 
 /**
@@ -773,8 +797,39 @@ function arePlatformFeaturesEnabled(): boolean {
 }
 
 /**
+ * Whether {@link platformFeaturesGate} forwards this request.
+ *
+ * Takes the request as the gate sees it: the gate is registered after
+ * {@link requestInterceptor}, so a self-hosted rewrite (gateway origin, bearer
+ * auth) has already happened by the time it runs.
+ */
+function platformFeaturesGateAllows(request: Request): boolean {
+  if (isRemoteGatewayMode()) {
+    return (
+      request.headers
+        .get("Authorization")
+        ?.toLowerCase()
+        .startsWith("bearer ") ?? false
+    );
+  }
+
+  if (!isLocalClient()) {
+    return true;
+  }
+  if (arePlatformFeaturesEnabled()) {
+    return true;
+  }
+
+  const ingressUrl = getSelfHostedIngressUrl();
+  if (!ingressUrl) {
+    return false;
+  }
+  return new URL(request.url).origin === new URL(ingressUrl).origin;
+}
+
+/**
  * In local mode with platform features disabled, abort platform client
- * requests that still target the platform — but let through requests
+ * requests that still target the platform, but let through requests
  * already rewritten to the self-hosted gateway by the preceding
  * {@link requestInterceptor}. Without this check, daemon endpoints
  * (skills, memories, etc.) that route through the platform client would
@@ -783,49 +838,25 @@ function arePlatformFeaturesEnabled(): boolean {
  * Exported for direct unit testing.
  */
 export function platformFeaturesGate(request: Request): Request {
-  if (isRemoteGatewayMode()) {
-    if (
-      request.headers.get("Authorization")?.toLowerCase().startsWith("bearer ")
-    ) {
-      return request;
-    }
-    console.debug(
-      "remote-gateway mode — no-op platform request:",
-      new URL(request.url).pathname,
-    );
-    const aborted = new AbortController();
-    aborted.abort(
-      new DOMException(
-        "Platform routes disabled in remote-gateway mode",
-        "AbortError",
-      ),
-    );
-    return new Request(request.url, { signal: aborted.signal });
-  }
-
-  if (!isLocalClient()) {
-    return request;
-  }
-  if (arePlatformFeaturesEnabled()) {
+  if (platformFeaturesGateAllows(request)) {
     return request;
   }
 
-  const ingressUrl = getSelfHostedIngressUrl();
-  if (ingressUrl) {
-    const requestOrigin = new URL(request.url).origin;
-    const gatewayOrigin = new URL(ingressUrl).origin;
-    if (requestOrigin === gatewayOrigin) {
-      return request;
-    }
-  }
-
+  const remoteGateway = isRemoteGatewayMode();
   console.debug(
-    "VELLUM_DISABLE_PLATFORM is set — no-op platform request:",
+    remoteGateway
+      ? "remote-gateway mode, no-op platform request:"
+      : "VELLUM_DISABLE_PLATFORM is set, no-op platform request:",
     new URL(request.url).pathname,
   );
   const aborted = new AbortController();
   aborted.abort(
-    new DOMException("Platform features disabled in local mode", "AbortError"),
+    new DOMException(
+      remoteGateway
+        ? "Platform routes disabled in remote-gateway mode"
+        : "Platform features disabled in local mode",
+      "AbortError",
+    ),
   );
   return new Request(request.url, { signal: aborted.signal });
 }

--- a/clients/web/src/lib/telemetry/resume-request-counter.test.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.test.ts
@@ -1,13 +1,17 @@
 /**
  * Pins the post-resume request counter's contract:
  *   - one window per foreground, even when iOS publishes two resume signals;
+ *   - a backgrounding drops the window instead of emitting a partial sample;
+ *   - a window whose timer was frozen while backgrounded is replaced, so the
+ *     next foreground gets its own window attributed to its own signal;
  *   - only requests inside the window are counted;
  *   - endpoint labels come from the closed set, never a raw path;
  *   - a zero-count window still emits, and unsubscribe cancels silently.
  *
  * bun:test has no fake-timer API, so `setTimeout` / `clearTimeout` are swapped
  * for a capturing stub and fired by hand, the same idiom
- * `use-feature-flag-bus-sync.test.tsx` uses.
+ * `use-feature-flag-bus-sync.test.tsx` uses. `performance.now` is stubbed the
+ * same way so the frozen-timer case can be reproduced without waiting.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,23 +20,30 @@ const emitClientPerfEventMock = mock(
   (_checkName: string, _value: number, _detail?: Record<string, unknown>) => {},
 );
 
+// Module mocks are process-wide, so this stands in for client-perf in every
+// test file that shares the process. Mirror its full export surface.
 mock.module("@/lib/telemetry/client-perf", () => ({
   emitClientPerfEvent: emitClientPerfEventMock,
+  setClientPerfBootId: () => {},
+  __resetClientPerfForTests: () => {},
 }));
 
 const { publish, __resetForTesting } = await import("@/lib/event-bus");
 const {
   __resetResumeRequestCounterForTests,
+  isResumeWindowOpen,
   noteDaemonApiRequest,
   subscribeResumeRequestCounter,
 } = await import("./resume-request-counter");
 
 const originalSetTimeout = globalThis.setTimeout;
 const originalClearTimeout = globalThis.clearTimeout;
+const originalPerformanceNow = performance.now.bind(performance);
 
 let pendingTimers = new Map<number, () => void>();
 let nextTimerId = 1;
 let lastDelay: number | undefined;
+let nowMs = 0;
 
 function fireTimers(): void {
   const callbacks = Array.from(pendingTimers.values());
@@ -64,6 +75,8 @@ beforeEach(() => {
   pendingTimers = new Map();
   nextTimerId = 1;
   lastDelay = undefined;
+  nowMs = 0;
+  performance.now = () => nowMs;
   globalThis.setTimeout = ((callback: TimerHandler, delay?: number) => {
     const id = nextTimerId++;
     lastDelay = delay;
@@ -87,6 +100,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.setTimeout = originalSetTimeout;
   globalThis.clearTimeout = originalClearTimeout;
+  performance.now = originalPerformanceNow;
 });
 
 describe("subscribeResumeRequestCounter", () => {
@@ -123,6 +137,71 @@ describe("subscribeResumeRequestCounter", () => {
     unsubscribe();
   });
 
+  test("drops the window on app.hidden without emitting", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "app_state" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+
+    publish("app.hidden", { signal: "app_state" });
+
+    expect(isResumeWindowOpen()).toBe(false);
+    expect(pendingTimers.size).toBe(0);
+    fireTimers();
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  test("counts the next foreground after a hidden edge", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    publish("app.hidden", { signal: "visibility" });
+
+    publish("app.resume", { signal: "app_state" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/skills");
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    expect(lastEmit().value).toBe(1);
+    expect(lastEmit().detail.signal).toBe("app_state");
+    expect(byGroup()).toEqual({ skills: 1 });
+    unsubscribe();
+  });
+
+  test("replaces a window whose timer was frozen while backgrounded", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+
+    // WKWebView suspends timers in the background, so the 10s timer is still
+    // pending a minute later when the app foregrounds again.
+    nowMs = 60_000;
+    publish("app.resume", { signal: "app_state" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/integrations");
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    const { value, detail } = lastEmit();
+    expect(value).toBe(1);
+    expect(detail.signal).toBe("app_state");
+    expect(byGroup()).toEqual({ integrations: 1 });
+    unsubscribe();
+  });
+
+  test("keeps the first window when the second resume lands inside its span", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+
+    nowMs = 9_999;
+    publish("app.resume", { signal: "app_state" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    fireTimers();
+
+    expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
+    expect(lastEmit().detail.signal).toBe("visibility");
+    unsubscribe();
+  });
+
   test("labels endpoints from the closed set and emits no path strings", () => {
     const unsubscribe = subscribeResumeRequestCounter();
     publish("app.resume", { signal: "app_state" });
@@ -141,6 +220,32 @@ describe("subscribeResumeRequestCounter", () => {
     expect(serialized).not.toContain("assistants");
     expect(serialized).not.toContain("http");
     expect(serialized).not.toContain("frobnicate");
+    unsubscribe();
+  });
+
+  test("labels the daemon's high-traffic segments instead of pooling them", () => {
+    const unsubscribe = subscribeResumeRequestCounter();
+    publish("app.resume", { signal: "app_state" });
+
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/integrations");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/skills/some-skill");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/inference/models");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/subagents");
+    noteDaemonApiRequest("https://api.test/v1/heartbeat");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/disk-pressure");
+    fireTimers();
+
+    expect(byGroup()).toEqual({
+      integrations: 1,
+      skills: 1,
+      inference: 1,
+      subagents: 1,
+      heartbeat: 1,
+      "disk-pressure": 1,
+    });
+    for (const count of Object.values(byGroup())) {
+      expect(typeof count).toBe("number");
+    }
     unsubscribe();
   });
 
@@ -204,5 +309,21 @@ describe("noteDaemonApiRequest", () => {
       noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
     }).not.toThrow();
     expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("isResumeWindowOpen", () => {
+  test("tracks the window so callers can skip work on the request path", () => {
+    expect(isResumeWindowOpen()).toBe(false);
+
+    const unsubscribe = subscribeResumeRequestCounter();
+    expect(isResumeWindowOpen()).toBe(false);
+
+    publish("app.resume", { signal: "visibility" });
+    expect(isResumeWindowOpen()).toBe(true);
+
+    fireTimers();
+    expect(isResumeWindowOpen()).toBe(false);
+    unsubscribe();
   });
 });

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -6,6 +6,10 @@
  * instead of an anecdote: one `client_resume.request_count` event per resume,
  * carrying the total and a per-endpoint-group breakdown.
  *
+ * Only whole windows are reported. A backgrounding truncates the burst and
+ * freezes the WKWebView's timers, so a window that spans a background is a
+ * contaminated sample and is dropped rather than emitted.
+ *
  * Metadata only. Endpoint labels come from a closed set; raw pathnames and
  * URLs are never stored or emitted.
  *
@@ -19,6 +23,13 @@ import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
 
 const WINDOW_MS = 10_000;
 
+/**
+ * Closed label set for the `by_group` breakdown, covering the daemon's
+ * high-traffic first segments (`/v1/<segment>` or
+ * `/v1/assistants/<id>/<segment>`). Every entry is a real first segment in the
+ * generated daemon SDK; `"other"` is the catch-all, so an unlisted or new route
+ * is folded into it rather than leaking a path into telemetry.
+ */
 const ENDPOINT_GROUPS = [
   "conversations",
   "messages",
@@ -30,6 +41,20 @@ const ENDPOINT_GROUPS = [
   "apps",
   "plugins",
   "memory",
+  "integrations",
+  "oauth",
+  "skills",
+  "inference",
+  "documents",
+  "avatar",
+  "home",
+  "heartbeat",
+  "notifications",
+  "lifecycle",
+  "settings",
+  "disk-pressure",
+  "background-tools",
+  "subagents",
   "other",
 ] as const;
 
@@ -64,65 +89,100 @@ function groupForUrl(url: string): EndpointGroup {
   }
 }
 
-let window_: {
+type ResumeWindow = {
   timer: ReturnType<typeof setTimeout>;
+  /** Monotonic open time, used to detect a window whose timer was frozen. */
+  openedAt: number;
   total: number;
   byGroup: Record<string, number>;
   signal: AppResumeSignal;
-} | null = null;
+};
+
+let resumeWindow: ResumeWindow | null = null;
 
 /** Drops any open window without emitting. */
 function cancelOpenWindow(): void {
-  if (!window_) {
+  if (!resumeWindow) {
     return;
   }
-  clearTimeout(window_.timer);
-  window_ = null;
+  clearTimeout(resumeWindow.timer);
+  resumeWindow = null;
+}
+
+function openWindow(signal: AppResumeSignal): void {
+  const timer = setTimeout(() => {
+    const closed = resumeWindow;
+    resumeWindow = null;
+    if (!closed) {
+      return;
+    }
+    // A zero here is the signal we are looking for once the storm is fixed,
+    // so emit regardless of the count.
+    emitClientPerfEvent("client_resume.request_count", closed.total, {
+      by_group: closed.byGroup,
+      window_ms: WINDOW_MS,
+      signal: closed.signal,
+    });
+  }, WINDOW_MS);
+  resumeWindow = {
+    timer,
+    openedAt: performance.now(),
+    total: 0,
+    byGroup: {},
+    signal,
+  };
 }
 
 /**
- * Records one outgoing daemon request. No-op outside a resume window, so the
- * steady-state cost is a single null check on the request path.
+ * True while a resume window is counting. Callers on the request path check
+ * this before doing any work of their own (URL parsing, allowlist lookups), so
+ * the steady-state cost of the counter is a single boolean read.
  */
+export function isResumeWindowOpen(): boolean {
+  return resumeWindow !== null;
+}
+
+/** Records one outgoing daemon request. No-op outside a resume window. */
 export function noteDaemonApiRequest(url: string): void {
-  if (!window_) {
+  if (!resumeWindow) {
     return;
   }
   const group = groupForUrl(url);
-  window_.total += 1;
-  window_.byGroup[group] = (window_.byGroup[group] ?? 0) + 1;
+  resumeWindow.total += 1;
+  resumeWindow.byGroup[group] = (resumeWindow.byGroup[group] ?? 0) + 1;
 }
 
 /**
- * Opens a counting window on each `app.resume`. Returns an unsubscribe that
- * also drops any window still open, without emitting.
+ * Opens a counting window on each `app.resume` and drops it on `app.hidden`.
+ * Returns an unsubscribe that also drops any window still open, without
+ * emitting.
  */
 export function subscribeResumeRequestCounter(): () => void {
-  const unsubscribe = subscribe("app.resume", ({ signal }) => {
-    // iOS publishes both a visibility and an app_state resume for a single
-    // foreground; first edge wins so the burst is counted once.
-    if (window_) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      const closed = window_;
-      window_ = null;
-      if (!closed) {
+  const unsubscribeResume = subscribe("app.resume", ({ signal }) => {
+    if (resumeWindow) {
+      // iOS publishes both a visibility and an app_state resume for a single
+      // foreground; the first edge wins so the burst is counted once. A window
+      // older than its own span is one whose timer was frozen while the app was
+      // backgrounded: its counts belong to an earlier foreground, so drop it
+      // and start a fresh window for this resume.
+      if (performance.now() - resumeWindow.openedAt < WINDOW_MS) {
         return;
       }
-      // A zero here is the signal we are looking for once the storm is fixed,
-      // so emit regardless of the count.
-      emitClientPerfEvent("client_resume.request_count", closed.total, {
-        by_group: closed.byGroup,
-        window_ms: WINDOW_MS,
-        signal: closed.signal,
-      });
-    }, WINDOW_MS);
-    window_ = { timer, total: 0, byGroup: {}, signal };
+      cancelOpenWindow();
+    }
+    openWindow(signal);
+  });
+
+  // A backgrounding cuts the burst short, so whatever the window has counted so
+  // far is a partial sample. Drop it rather than emit a number that reads as a
+  // quiet resume.
+  const unsubscribeHidden = subscribe("app.hidden", () => {
+    cancelOpenWindow();
   });
 
   return () => {
-    unsubscribe();
+    unsubscribeResume();
+    unsubscribeHidden();
     cancelOpenWindow();
   };
 }


### PR DESCRIPTION
## Summary
- app.hidden cancels an open counting window and a stale (timer-frozen) window is replaced on the next resume, so iOS backgrounding can no longer merge two foregrounds into one sample
- ENDPOINT_GROUPS extended to the daemon's real high-traffic first segments so the by_group breakdown attributes the storm instead of collapsing into other
- Platform-chain requests are counted only when they pass the features gate (no counting of aborted requests); counting short-circuits on a cheap window-open check before any URL parsing; redundant interceptor knob consolidated
- window_ renamed, process-wide mocks carry the full export surface

Fixes gaps found during plan self-review for measure-first-telemetry-followups.md