### PR TITLE
JARVIS-1448: end the onboarding tour on the voice button

### DIFF
--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -42,6 +42,9 @@ export function LiveVoiceButton({
       // fill) — rather than a low-emphasis ghost that reads as secondary.
       variant="primary"
       iconOnly={<AudioLines strokeWidth={2} />}
+      // Anchor for the in-chat tour's closing beat, which lands the assistant's
+      // avatar on this control.
+      data-tour-id="voice-mode"
       onClick={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
         onStart({

--- a/clients/web/src/domains/chat/in-chat-onboarding/avatar-tour.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/avatar-tour.tsx
@@ -13,6 +13,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
+import { TourButtonLanding } from "./tour-button-landing";
 import { TourMenuFlood } from "./tour-menu-flood";
 import {
   FLOOD_EXIT_MS,
@@ -26,6 +27,7 @@ import {
   TOUR_INTRO,
   TOUR_SIDEBAR,
   TOUR_STEPS,
+  TOUR_VOICE,
   type TourStep,
 } from "./tour-steps";
 
@@ -52,7 +54,8 @@ type TourBeat =
   | { kind: "intro" }
   | { kind: "menu"; rect: TourTargetRect }
   | { kind: "row"; step: TourStep; rect: TourTargetRect; label: string }
-  | { kind: "composer" };
+  | { kind: "composer" }
+  | { kind: "voice" };
 
 interface LandedStop {
   step: TourStep;
@@ -144,6 +147,31 @@ function measureComposerRect(): TourTargetRect | null {
   };
 }
 
+/** Viewport rect of the composer's live-voice button, or null when the
+ *  assistant serves no live voice (the button is the entry point, so where it
+ *  is absent the beat has nothing to land on and is dropped). Prefers the tour
+ *  overlay's scenery composer over the app's, and is measured at beat entry,
+ *  for the same reasons as {@link measureComposerRect}. */
+function measureVoiceRect(): TourTargetRect | null {
+  const el =
+    document.querySelector<HTMLElement>(
+      '[data-tour-composer] [data-tour-id="voice-mode"]',
+    ) ?? document.querySelector<HTMLElement>('[data-tour-id="voice-mode"]');
+  if (!el) {
+    return null;
+  }
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return null;
+  }
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -189,7 +217,8 @@ export function AvatarTour({
   onDone,
   ref,
 }: AvatarTourProps) {
-  const { components, traits } = useAssistantAvatar(assistantId);
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
   const setNavTourActive = useInChatOnboardingStore.use.setNavTourActive();
   const setTourSidebarRevealed =
     useInChatOnboardingStore.use.setTourSidebarRevealed();
@@ -203,6 +232,10 @@ export function AvatarTour({
     null,
   );
   const [composerPhase, setComposerPhase] = useState<TourFloodPhase>("enter");
+  const [buttonLanding, setButtonLanding] = useState<TourTargetRect | null>(
+    null,
+  );
+  const [buttonPhase, setButtonPhase] = useState<TourFloodPhase>("enter");
   const [beatIndex, setBeatIndex] = useState(-1);
   const [beatCount, setBeatCount] = useState(0);
 
@@ -211,9 +244,9 @@ export function AvatarTour({
    *  await and bail when superseded. */
   const epochRef = useRef(0);
   /** Which overlay is currently on screen, for the exit leg of a jump. */
-  const visualRef = useRef<"none" | "page" | "menu" | "row" | "composer">(
-    "none",
-  );
+  const visualRef = useRef<
+    "none" | "page" | "menu" | "row" | "composer" | "voice"
+  >("none");
   const activeRef = useRef(false);
 
   const accent =
@@ -298,6 +331,13 @@ export function AvatarTour({
           return;
         }
         setComposerFlood(null);
+      } else if (visual === "voice") {
+        setButtonPhase("exit");
+        await sleep(FLOOD_EXIT_MS);
+        if (superseded()) {
+          return;
+        }
+        setButtonLanding(null);
       }
       visualRef.current = "none";
 
@@ -351,6 +391,19 @@ export function AvatarTour({
         setComposerPhase("enter");
         visualRef.current = "composer";
         onStepChange(TOUR_COMPOSER);
+      } else if (beat.kind === "voice") {
+        setTourSidebarRevealed(true);
+        const rect = measureVoiceRect();
+        if (!rect) {
+          // Voice button gone (an assistant swap mid-tour dropped live-voice
+          // support), so end past the finale.
+          onDone();
+          return;
+        }
+        setButtonLanding(rect);
+        setButtonPhase("enter");
+        visualRef.current = "voice";
+        onStepChange(TOUR_VOICE);
       } else {
         setTourSidebarRevealed(true);
         setLanded({ step: beat.step, rect: beat.rect, label: beat.label });
@@ -393,10 +446,17 @@ export function AvatarTour({
           beats.push({ kind: "row", step, ...placement });
         }
       }
-      // The finale — the composer's rect is measured at entry, since the
+      // The chat beat, whose composer rect is measured at entry, since the
       // sidebar reveal reflows the main column under it.
       if (measureComposerRect()) {
         beats.push({ kind: "composer" });
+      }
+      // The finale, on the voice button inside that composer. Presence is
+      // probed here against the app's own composer (the scenery one is not
+      // mounted until the first beat lands), so an assistant without live
+      // voice never gets the beat and the tour ends on the chat beat.
+      if (measureVoiceRect()) {
+        beats.push({ kind: "voice" });
       }
       beatsRef.current = beats;
       setBeatCount(beats.length);
@@ -473,6 +533,15 @@ export function AvatarTour({
           phase={composerPhase}
           eyesWidthFraction={COMPOSER_EYES_WIDTH_FRACTION}
           eyesBottomCutFraction={COMPOSER_EYES_BOTTOM_CUT_FRACTION}
+        />
+      ) : null}
+      {buttonLanding ? (
+        <TourButtonLanding
+          rect={buttonLanding}
+          components={components}
+          traits={traits}
+          customImageUrl={customImageUrl}
+          phase={buttonPhase}
         />
       ) : null}
     </>,

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-button-landing.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-button-landing.tsx
@@ -1,0 +1,86 @@
+import { motion } from "motion/react";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+
+import {
+  FLOOD_EXIT_MS,
+  type TourFloodPhase,
+  type TourTargetRect,
+} from "./tour-nav-flood";
+
+/** The landed avatar's diameter, as a multiple of the target's short side. */
+const AVATAR_OVERSIZE = 1.5;
+/** How far the avatar settles into the control's top edge, as a fraction of
+ *  its own diameter. Enough that it reads as planted on the button rather
+ *  than hovering above it. */
+const PERCH_SINK = 0.12;
+/** Where the avatar falls from, as a multiple of its own diameter. */
+const DROP_HEIGHT = 1.1;
+
+interface TourButtonLandingProps {
+  rect: TourTargetRect;
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  customImageUrl: string | null;
+  /** `enter`: the avatar drops onto the control's top edge. `exit`: it lifts
+   *  back off the way it came. */
+  phase: TourFloodPhase;
+}
+
+/**
+ * The "avatar lands on this control" treatment: the avatar drops from above
+ * and perches on the target's top edge, leaving the control itself untouched.
+ *
+ * Distinct from `TourNavFlood`, which floods a row with the avatar's color and
+ * surfaces the eyes through its bottom edge. That one is tuned for the
+ * sidebar's wide rows, where the eyes have room to rest in their own slot
+ * beside the row's text. A single small control gives them neither, and
+ * coloring it would bury the very affordance the beat is pointing at, so the
+ * whole character lands on top of it instead.
+ */
+export function TourButtonLanding({
+  rect,
+  components,
+  traits,
+  customImageUrl,
+  phase,
+}: TourButtonLandingProps) {
+  const size = Math.min(rect.width, rect.height) * AVATAR_OVERSIZE;
+  const dropY = -size * DROP_HEIGHT;
+  const entering = phase === "enter";
+
+  return (
+    <motion.div
+      aria-hidden
+      className="pointer-events-none fixed z-[65]"
+      style={{
+        left: rect.left + rect.width / 2 - size / 2,
+        // Rests on the control's top edge rather than over its face, so the
+        // button stays exactly as the user will meet it a moment later.
+        top: rect.top - size + size * PERCH_SINK,
+        width: size,
+        height: size,
+      }}
+      initial={{ y: dropY, opacity: 0 }}
+      animate={entering ? { y: 0, opacity: 1 } : { y: dropY, opacity: 0 }}
+      transition={
+        entering
+          ? // Lands with a little overshoot, so it reads as arriving rather
+            // than fading in on the spot.
+            { type: "spring", stiffness: 420, damping: 18, delay: 0.1 }
+          : { duration: FLOOD_EXIT_MS / 1000, ease: "easeIn" }
+      }
+    >
+      {/* Sized to the wrapper, which is centered on the control's width and
+          resting on its top edge. The avatar plays its own mount spring on
+          top of the drop, so the landing carries its usual pop. */}
+      <ChatAvatar
+        components={components}
+        traits={traits}
+        customImageUrl={customImageUrl}
+        size={size}
+      />
+    </motion.div>
+  );
+}

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-overlay.tsx
@@ -3,9 +3,10 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
+import { type VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 
 import { TourNarration } from "./tour-narration";
-import { TOUR_COMPOSER, type TourStep } from "./tour-steps";
+import { TOUR_COMPOSER, TOUR_VOICE, type TourStep } from "./tour-steps";
 
 interface TourOverlayProps {
   assistantId: string | null;
@@ -24,10 +25,11 @@ interface TourOverlayProps {
  * the transcript area (the sidebar stays fully visible beside it) and
  * rebuild the chat's anatomy over it: the narration typewrites where the
  * conversation's messages live, and the REAL composer component sits in its
- * usual spot at the bottom — inert, purely scenery, and the target the
- * finale beat floods. The intro beat renders none of that: the full-page
- * flood (portaled underneath at z-61) provides the color, and the flooded
- * nav targets portal in above at z-64.
+ * usual spot at the bottom, inert and purely scenery. The chat beat floods it
+ * whole; the finale lands the avatar on the voice button within it. The intro
+ * beat renders none of that: the full-page flood (portaled underneath at
+ * z-61) provides the color, and the flooded nav targets portal in above at
+ * z-64.
  */
 export function TourOverlay({
   assistantId,
@@ -43,7 +45,18 @@ export function TourOverlay({
   /** The narration column's top — the side menu's top edge, so the step
    *  title aligns with the top of the menu panel. */
   const [columnTop, setColumnTop] = useState(0);
+  // The chat beat floods the whole composer and the finale lands the avatar on
+  // the voice button inside it, so the composer holds the stage across both.
+  const composerHoldsStage =
+    step?.id === TOUR_COMPOSER.id || step?.id === TOUR_VOICE.id;
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
+  // Supplying both voice props is what makes the scenery composer render its
+  // voice controls at all (`showVoiceInput` tests for exactly this pair), and
+  // the finale beat lands the avatar on the live-voice button among them.
+  // Inert like the rest of the scenery: the wrapper below is
+  // `pointer-events-none`, so the handle is never driven and the transcript
+  // callback never fires.
+  const sceneryVoiceInputRef = useRef<VoiceInputButtonHandle | null>(null);
 
   // The sidebar bounces in mid-tour, so these edges are re-measured on
   // every beat (and window resizes), not once.
@@ -103,7 +116,7 @@ export function TourOverlay({
         }}
         initial={{ opacity: 0 }}
         animate={{
-          opacity: !onIntroBeat && step?.id === TOUR_COMPOSER.id ? 0.6 : 0,
+          opacity: !onIntroBeat && composerHoldsStage ? 0.6 : 0,
         }}
         transition={{ duration: 0.3 }}
       />
@@ -129,10 +142,10 @@ export function TourOverlay({
           <div
             data-tour-composer="true"
             className="pointer-events-none shrink-0 px-4 pb-4 sm:px-6"
-            // Dimmed until its own beat — each step pulls everything else
-            // out of the attention field.
+            // Dimmed until its own beats, since each step pulls everything
+            // else out of the attention field.
             style={{
-              opacity: step?.id === TOUR_COMPOSER.id ? 1 : 0.4,
+              opacity: composerHoldsStage ? 1 : 0.4,
               transition: "opacity 300ms ease",
             }}
           >
@@ -146,6 +159,8 @@ export function TourOverlay({
                 onStopGenerating={() => {}}
                 isAssistantBusy={false}
                 assistantId={assistantId}
+                voiceInputRef={sceneryVoiceInputRef}
+                onVoiceTranscript={() => {}}
               />
             </div>
           </div>

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-steps.ts
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-steps.ts
@@ -1,4 +1,5 @@
 import {
+  AudioLines,
   Brain,
   CircleUser,
   MessageCircle,
@@ -47,16 +48,34 @@ export const TOUR_SIDEBAR: TourStep = {
 };
 
 /**
- * The finale: the chat composer gets the same takeover treatment as the
- * side menu — the flood pours over the input with the eyes surfacing —
- * ending the tour where the real conversation starts. Targets the
- * composer's `data-slot` anchor rather than a `data-tour-id`.
+ * The chat beat: the composer gets the same takeover treatment as the side
+ * menu, the flood pouring over the input with the eyes surfacing, landing the
+ * tour where the real conversation starts. Targets the composer's `data-slot`
+ * anchor rather than a `data-tour-id`.
  */
 export const TOUR_COMPOSER: TourStep = {
   id: "chat-composer",
   title: "Your chat",
   body: "I have tons of features, but let's chat before you start exploring!",
   icon: MessageCircle,
+};
+
+/**
+ * The finale: the composer flood drains and the whole avatar drops onto the
+ * voice button, perching on its top edge. The control itself is left alone,
+ * so the tour ends pointing at the affordance the user meets next rather than
+ * covering it.
+ *
+ * Targets `data-tour-id="voice-mode"` inside the overlay's scenery composer.
+ * The button renders only for an assistant that serves live voice, and a beat
+ * whose anchor is missing is skipped, so an ineligible assistant ends the tour
+ * on the chat beat instead.
+ */
+export const TOUR_VOICE: TourStep = {
+  id: "voice-mode",
+  title: "Voice mode",
+  body: "Or we can speak to each other. It's faster and more natural.",
+  icon: AudioLines,
 };
 
 export const TOUR_STEPS: TourStep[] = [


### PR DESCRIPTION
## What

The in-chat onboarding tour walked the sidebar and ended on the composer without ever mentioning voice mode, so nothing in the product told a new user it exists. The tour now closes on the voice button itself: the avatar drops from above and perches on the button's top edge while the narration offers speaking instead of typing.

> **Voice mode**
> Or we can speak to each other. It's faster and more natural.

The control is left untouched, no color and no overlay, so the beat points at the affordance the user meets next rather than covering it.

## How

`TourButtonLanding` is a new treatment rather than the existing nav flood at small scale. `TourNavFlood` is tuned for the sidebar's wide rows: the eyes rest in a right-hand slot at a fixed size (up to ~46px) beside the row's own text. On a ~36px icon button that sprite gets clipped and the label falls back to the raw anchor id, which reads as a sticker stuck to the button.

Two pieces of plumbing make the beat land on the right element:

- **The overlay's scenery composer now receives the voice props.** `showVoiceInput` is `voiceInputRef !== undefined && onVoiceTranscript !== undefined`, and the overlay passed neither, so the voice button never rendered in the composer the tour actually paints. Both are inert: the wrapper is already `pointer-events-none`.
- **The beat measures the scenery instance first.** A bare `document.querySelector` finds the app's own composer, which sits behind the backdrop, so `measureVoiceRect` prefers `[data-tour-composer]` exactly as `measureComposerRect` already does.

## Degradation

The voice button renders only for an assistant that serves live voice, and a beat whose anchor is missing is skipped, so an ineligible assistant ends the tour on the chat beat as it does today. Presence is probed at build time against the app's composer, since the scenery one is not mounted until the first beat lands.

## Experiment note

This changes the `tour` arm of the running `in-chat-onboarding-tour` experiment (70/30, desktop only, post-hatch handoff only). The `control` arm is untouched.

## Testing

Typecheck, lint, and prettier clean. Played the tour locally via `?onboarding=1` with the arm forced through `localStorage.setItem("vellum:ff-str:inChatOnboardingTour", "tour")`, and iterated on the landing with @alexnork until it read right.

The three geometry constants in `tour-button-landing.tsx` (`AVATAR_OVERSIZE`, `PERCH_SINK`, `DROP_HEIGHT`) are isolated at the top of the file so they can be tuned without touching the sequencer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)