### PR TITLE
feat(daily-limit): proactive banner and durable mid-turn error marker

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2406,12 +2406,11 @@ describe("session-agent-loop", () => {
     });
 
     test("persists the synthetic error row when a daily-limit error kills the run mid-turn", async () => {
-      // The regression this pins: a run that already completed a tool
-      // round-trip carries assistant `tool_use` messages, so a "did any
-      // assistant message exist?" guard treated the run as having replied and
-      // skipped the whole persist branch. The turn then left nothing durable
-      // behind — a reload showed the tool call with no explanation of why the
-      // assistant stopped.
+      // Mid-turn shape: the run already carries assistant `tool_use` messages
+      // from the completed tool round-trip, and only the failing follow-up
+      // call lacks a reply. The synthetic error row must persist for this
+      // shape too, so a reload explains why the assistant stopped instead of
+      // ending on a bare tool call.
       reserveMessageMock
         .mockImplementationOnce(async () => ({ id: "msg-reserve-1" }))
         .mockImplementationOnce(async () => ({ id: "msg-reserve-2" }))

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -864,6 +864,24 @@ function makeCtx(
   return ctx;
 }
 
+/**
+ * What `classifyConversationError` returns for a daily-credit-limit 402 (see
+ * `dailyLimitClassification` in conversation-error.ts). Its `userMessage` is
+ * banner voice; the loop swaps in {@link DAILY_LIMIT_ASSISTANT_REPLY} for the
+ * transcript row.
+ */
+const DAILY_LIMIT_CLASSIFICATION = {
+  code: "PROVIDER_BILLING",
+  userMessage:
+    "You've hit your daily credit limit. Raise the limit in Billing settings to keep going today.",
+  retryable: false,
+  errorCategory: "daily_limit_reached",
+};
+
+/** Mirrors `DAILY_LIMIT_REACHED_ASSISTANT_REPLY` in conversation-agent-loop.ts. */
+const DAILY_LIMIT_ASSISTANT_REPLY =
+  "I had to stop because you hit your daily credit limit. Raise the limit in Settings → Billing and we can pick up where we left off, or I can continue once it resets.";
+
 type CompactionResult = Parameters<typeof applyCompactionResult>[1];
 
 function makeCompactionResult(
@@ -2348,6 +2366,135 @@ describe("session-agent-loop", () => {
         messageKind: "provider_error",
         providerErrorCode: "PROVIDER_BILLING",
         providerErrorCategory: "credits_exhausted",
+      });
+    });
+
+    test("persists assistant-voice daily-limit copy on a first-call rejection", async () => {
+      mockConversationErrorClassification = DAILY_LIMIT_CLASSIFICATION;
+
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("Payment Required");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(addMessageMock).toHaveBeenCalledTimes(1);
+      const addCall = addMessageMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        { metadata?: Record<string, unknown> },
+      ];
+      expect(addCall[1]).toBe("assistant");
+      // Like the credits-exhausted row, the daily-limit row re-enters LLM
+      // history and renders as assistant speech, so it carries first-person
+      // copy rather than the banner-voice classification text.
+      const persistedBlocks = JSON.parse(addCall[2]) as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(persistedBlocks[0]?.text).toBe(DAILY_LIMIT_ASSISTANT_REPLY);
+      expect(addCall[3]?.metadata).toMatchObject({
+        messageKind: "provider_error",
+        providerErrorCode: "PROVIDER_BILLING",
+        providerErrorCategory: "daily_limit_reached",
+      });
+    });
+
+    test("persists the synthetic error row when a daily-limit error kills the run mid-turn", async () => {
+      // The regression this pins: a run that already completed a tool
+      // round-trip carries assistant `tool_use` messages, so a "did any
+      // assistant message exist?" guard treated the run as having replied and
+      // skipped the whole persist branch. The turn then left nothing durable
+      // behind — a reload showed the tool call with no explanation of why the
+      // assistant stopped.
+      reserveMessageMock
+        .mockImplementationOnce(async () => ({ id: "msg-reserve-1" }))
+        .mockImplementationOnce(async () => ({ id: "msg-reserve-2" }))
+        .mockImplementationOnce(async () => ({ id: "msg-reserve-3" }));
+      mockConversationErrorClassification = DAILY_LIMIT_CLASSIFICATION;
+
+      // GIVEN a run whose first call asks for a tool, the tool succeeds, and
+      // the follow-up call is rejected with a daily-limit 402.
+      const ctx = makeCtx({
+        providerResponses: [
+          toolUseResponse("tu-1", "file_read", {}),
+          new Error("Payment Required"),
+        ],
+        loopTools: [
+          {
+            name: "file_read",
+            description: "Read a file",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        toolExecutor: async () => ({ content: "file content", isError: false }),
+      } as unknown as Partial<Conversation>);
+
+      await runAgentLoopImpl(ctx, "hello", "msg-user-daily", () => {});
+
+      // (a) The synthetic provider-error row is persisted with the
+      // assistant-voice daily-limit copy and the classification metadata.
+      expect(addMessageMock).toHaveBeenCalledTimes(1);
+      const addCall = addMessageMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        { metadata?: Record<string, unknown> },
+      ];
+      expect(addCall[1]).toBe("assistant");
+      const persistedBlocks = JSON.parse(addCall[2]) as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(persistedBlocks[0]?.text).toBe(DAILY_LIMIT_ASSISTANT_REPLY);
+      expect(addCall[3]?.metadata).toMatchObject({
+        messageKind: "provider_error",
+        providerErrorCode: "PROVIDER_BILLING",
+        providerErrorCategory: "daily_limit_reached",
+      });
+
+      // (b) The empty row the failing call reserved at `llm_call_started` is
+      // dropped, so the transcript carries the error row instead of a stranded
+      // blank bubble. The failing call reserves last (after the first call's
+      // assistant row and the grouped tool-result row).
+      expect(deleteMessageByIdMock).toHaveBeenCalledTimes(1);
+      const deleteCall = deleteMessageByIdMock.mock.calls[0] as unknown as [
+        string,
+      ];
+      expect(deleteCall[0]).toBe("msg-reserve-3");
+
+      // (c) The turn is stamped failed with the classified code.
+      const outcomeStamps = (
+        updateMessageMetadataMock.mock.calls as unknown as Array<
+          [string, Record<string, unknown>]
+        >
+      ).filter((call) => call[1]?.turnOutcome !== undefined);
+      expect(outcomeStamps).toHaveLength(1);
+      expect(outcomeStamps[0]?.[0]).toBe("msg-user-daily");
+      expect(outcomeStamps[0]?.[1]).toMatchObject({
+        turnOutcome: "failed",
+        turnFailureCode: "PROVIDER_BILLING",
+      });
+
+      // (d) History ends tool_use -> tool_result -> error text, so the row
+      // never lands between a tool_use and its tool_result on replay.
+      const tail = ctx.messages.slice(-3) as Array<{
+        role: string;
+        content: Array<{ type: string; text?: string }>;
+      }>;
+      expect(tail[0]?.role).toBe("assistant");
+      expect(tail[0]?.content[0]?.type).toBe("tool_use");
+      expect(tail[1]?.role).toBe("user");
+      expect(tail[1]?.content[0]?.type).toBe("tool_result");
+      expect(tail[2]?.role).toBe("assistant");
+      expect(tail[2]?.content[0]).toEqual({
+        type: "text",
+        text: DAILY_LIMIT_ASSISTANT_REPLY,
       });
     });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -152,6 +152,43 @@ const DISK_PRESSURE_ERROR_CATEGORY = "disk_pressure";
 const OUT_OF_CREDITS_ASSISTANT_REPLY =
   "I couldn't reply because you ran out of credits. Add credits in Settings → Billing and we can pick up where we left off.";
 
+/**
+ * Assistant-voice wording persisted as the synthetic assistant row when a turn
+ * terminates because the daily credit limit is reached. The shared
+ * classification (`dailyLimitClassification` in conversation-error.ts) keeps
+ * its `userMessage` in banner voice because it also feeds the live
+ * `conversation_error` event the composer renders; here the row re-enters LLM
+ * history and is displayed as assistant speech, so first-person copy is
+ * accurate. Says "stop" rather than "reply" because the row can land mid-turn,
+ * after a tool round-trip the user already saw. Phrased about the past failure,
+ * not the current limit, because the row stays in the transcript (and renders
+ * as a plain bubble) after the limit resets.
+ */
+const DAILY_LIMIT_REACHED_ASSISTANT_REPLY =
+  "I had to stop because you hit your daily credit limit. Raise the limit in Settings → Billing and we can pick up where we left off, or I can continue once it resets.";
+
+/**
+ * The assistant-voice text a managed-billing failure persists in place of the
+ * classification's own `userMessage`, or `null` when the classification copy is
+ * already right for a transcript row.
+ */
+function managedBillingAssistantReply(
+  providerErrorCode: string | null,
+  providerErrorCategory: string | null,
+): string | null {
+  if (providerErrorCode !== "PROVIDER_BILLING") {
+    return null;
+  }
+  switch (providerErrorCategory) {
+    case "credits_exhausted":
+      return OUT_OF_CREDITS_ASSISTANT_REPLY;
+    case "daily_limit_reached":
+      return DAILY_LIMIT_REACHED_ASSISTANT_REPLY;
+    default:
+      return null;
+  }
+}
+
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {
   bash: "Run Command",
@@ -1348,9 +1385,16 @@ export async function runAgentLoopImpl(
       return { ...msg, content: cleanedBlocks };
     });
 
-    const hasAssistantResponse = newMessages.some(
-      (msg) => msg.role === "assistant",
-    );
+    // "The run delivered a final assistant reply", not "the run produced any
+    // assistant-role message". A run that called tools already carries
+    // assistant `tool_use` messages, and those are not a delivered reply: a
+    // provider error that kills the run mid-turn leaves the tail as the
+    // tool_result (user role), while a run that replied normally ends on the
+    // assistant message. Testing only the tail keeps the synthetic error row
+    // below reachable for mid-turn failures, which is the only durable record
+    // of why the turn stopped.
+    const hasAssistantResponse =
+      newMessages[newMessages.length - 1]?.role === "assistant";
     if (
       !hasAssistantResponse &&
       state.providerErrorUserMessage &&
@@ -1410,13 +1454,13 @@ export async function runAgentLoopImpl(
           providerErrorCategory: state.providerErrorCategory ?? undefined,
         };
         // The persisted row re-enters LLM history and is displayed as
-        // assistant speech, so managed-credits exhaustion swaps the
-        // context-neutral classification copy for assistant-voice wording.
+        // assistant speech, so the managed-billing categories swap the
+        // banner-voice classification copy for assistant-voice wording.
         const persistedErrorText =
-          state.providerErrorCode === "PROVIDER_BILLING" &&
-          state.providerErrorCategory === "credits_exhausted"
-            ? OUT_OF_CREDITS_ASSISTANT_REPLY
-            : state.providerErrorUserMessage;
+          managedBillingAssistantReply(
+            state.providerErrorCode,
+            state.providerErrorCategory,
+          ) ?? state.providerErrorUserMessage;
         const errorAssistantMessage =
           createAssistantMessage(persistedErrorText);
         const errorRow = await addMessage(

--- a/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.stories.tsx
@@ -7,11 +7,14 @@
  *      CTA.
  *
  * Which of the composer banners is shown is decided by the pure resolver
- * `resolveComposerBillingBanner` (`utils/error-classification.ts:111`), whose
- * precedence is strict: daily_limit > provider_billing > managed_credits
- * (which renders nothing here, since the transcript's credit wall owns it) >
- * low_balance. The credit wall itself lives in its own story file, since its
- * CTA is the one that forks between Add credits and View plans.
+ * `resolveComposerBillingBanner` (`utils/error-classification.ts`), whose
+ * precedence is strict. Error-driven decisions come first: daily_limit >
+ * provider_billing > managed_credits (which renders nothing here, since the
+ * transcript's credit wall owns it). With no error decision the billing
+ * summary's `daily_limit_reached` raises `DailyLimitBanner` proactively, and
+ * low_balance is the last fallback. The credit wall itself lives in its own
+ * story file, since its CTA is the one that forks between Add credits and
+ * View plans.
  *
  * Android consumption-only suppression applies to **purchase** surfaces only.
  * Among these three that is just `LowBalanceBanner`; `DailyLimitBanner` (a

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1098,6 +1098,9 @@ export function ChatMainPanel({
     billingBannerDecision,
     isLowBalance: balanceStatus.isLowBalance,
     dismissed: lowBalanceBannerDismissed,
+    // State-driven, so the banner is already up when the user returns to an
+    // app whose daily cap was reached by background turns.
+    dailyLimitReached: balanceStatus.dailyLimitReached,
   });
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -190,6 +190,89 @@ describe("resolveComposerBillingBanner", () => {
       }),
     ).toBeNull();
   });
+
+  test("the summary's daily-limit flag renders the banner with no error at all", () => {
+    // The proactive case: background turns exhausted the cap while the user
+    // was away, so nothing in this session has failed yet.
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: false,
+        dismissed: false,
+        dailyLimitReached: true,
+      }),
+    ).toBe("daily_limit");
+  });
+
+  test("the summary's daily-limit flag outranks the low-balance warning", () => {
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        ...lowBalanceInputs,
+        dailyLimitReached: true,
+      }),
+    ).toBe("daily_limit");
+  });
+
+  test("the daily-limit banner ignores the low-balance session dismissal", () => {
+    // Dismissal is the low-balance banner's affordance; the daily-limit
+    // banner has none, so a latched dismissal must not hide it.
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: true,
+        dismissed: true,
+        dailyLimitReached: true,
+      }),
+    ).toBe("daily_limit");
+  });
+
+  test("a provider-billing error still wins over the summary's daily-limit flag", () => {
+    // The error describes the send the user just watched fail, so it owns the
+    // slot even when the summary independently reports the cap.
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: "provider_billing",
+        isLowBalance: false,
+        dismissed: false,
+        dailyLimitReached: true,
+      }),
+    ).toBe("provider_billing");
+  });
+
+  test("managed_credits still suppresses the slot, summary daily-limit flag included", () => {
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: "managed_credits",
+        ...lowBalanceInputs,
+        dailyLimitReached: true,
+      }),
+    ).toBeNull();
+  });
+
+  test.each([
+    ["false", false],
+    ["undefined", undefined],
+  ] as const)(
+    "a %s daily-limit flag falls through to the low-balance leg",
+    (_label, dailyLimitReached) => {
+      expect(
+        resolveComposerBillingBanner({
+          billingBannerDecision: null,
+          ...lowBalanceInputs,
+          dailyLimitReached,
+        }),
+      ).toBe("low_balance");
+      expect(
+        resolveComposerBillingBanner({
+          billingBannerDecision: null,
+          isLowBalance: false,
+          dismissed: false,
+          dailyLimitReached,
+        }),
+      ).toBeNull();
+    },
+  );
 });
 
 describe("isCreditsExhaustedProviderError", () => {

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -96,13 +96,26 @@ export type ComposerBillingBanner =
   "daily_limit" | "provider_billing" | "low_balance";
 
 /**
- * Which banner the composer's billing slot renders. Error-driven banners take
- * precedence over the proactive low-balance warning. `managed_credits` maps
- * to no banner: the in-transcript credits upsell card owns that state, while
- * the classified error keeps the generic notice suppressed.
+ * Which banner the composer's billing slot renders, from three inputs in
+ * descending precedence: the error-driven classification, the billing
+ * summary's daily-limit state, and the proactive low-balance warning.
  *
- * The low-balance warning renders only when no error-driven decision is
- * active, the server reports `low_balance_warning` (`isLowBalance`), and the
+ * An error-driven decision always wins, because it describes the send the user
+ * just watched fail. `managed_credits` maps to no banner and short-circuits
+ * the state-driven legs below: the in-transcript credits upsell card owns an
+ * exhausted balance, while the classified error keeps the generic notice
+ * suppressed.
+ *
+ * With no error-driven decision, `dailyLimitReached` (the summary's
+ * server-computed `daily_limit_reached`) renders the daily-limit banner. That
+ * is what makes the banner state-driven rather than error-driven: background
+ * turns from other channels or clients can exhaust the cap while the user is
+ * away, and the banner appears on their return instead of waiting for a failed
+ * send. Like the error-driven daily-limit banner it is not dismissible, since
+ * the cap blocks every send until it is raised or the UTC day rolls over.
+ *
+ * The low-balance warning is last, and renders only when neither leg above
+ * applies, the server reports `low_balance_warning` (`isLowBalance`), and the
  * user has not dismissed the banner this session. The exhausted-credits
  * surfaces never overlap with it: the server keeps `low_balance_warning`
  * false while the balance is exhausted, and it is false for auto-top-up orgs
@@ -112,6 +125,11 @@ export function resolveComposerBillingBanner(args: {
   billingBannerDecision: ChatBillingBannerDecision | null;
   isLowBalance: boolean;
   dismissed: boolean;
+  /**
+   * The billing summary's `daily_limit_reached`. Absent wherever the summary
+   * is not read (gated-off queries, callers that only classify an error).
+   */
+  dailyLimitReached?: boolean;
 }): ComposerBillingBanner | null {
   if (args.billingBannerDecision === "daily_limit") {
     return "daily_limit";
@@ -121,6 +139,9 @@ export function resolveComposerBillingBanner(args: {
   }
   if (args.billingBannerDecision === "managed_credits") {
     return null;
+  }
+  if (args.dailyLimitReached === true) {
+    return "daily_limit";
   }
   return args.isLowBalance && !args.dismissed ? "low_balance" : null;
 }

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -9,7 +9,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
 import type { BillingSummaryResponse } from "@/generated/api/types.gen";
@@ -104,7 +104,12 @@ function setup({ seed }: { seed?: BillingSummaryResponse } = {}) {
   }
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client }, children);
-  return renderHook(() => useBillingBalanceStatus(), { wrapper });
+  return {
+    ...renderHook(() => useBillingBalanceStatus(), { wrapper }),
+    // Exposed so a test can stand in for a summary invalidation refetch by
+    // writing the refreshed response into the same cache entry.
+    client,
+  };
 }
 
 describe("useBillingBalanceStatus", () => {
@@ -124,6 +129,7 @@ describe("useBillingBalanceStatus", () => {
     expect(result.current).toEqual({
       isExhausted: false,
       isLowBalance: false,
+      dailyLimitReached: false,
       balance: "20.00",
       enabled: true,
     });
@@ -136,6 +142,7 @@ describe("useBillingBalanceStatus", () => {
     expect(result.current).toEqual({
       isExhausted: false,
       isLowBalance: true,
+      dailyLimitReached: false,
       balance: "3.00",
       enabled: true,
     });
@@ -173,6 +180,99 @@ describe("useBillingBalanceStatus", () => {
     ).toBeNull();
   });
 
+  test("daily limit: reflects the server-computed daily_limit_reached flag", () => {
+    // Orthogonal to the balance: the cap can be hit with credits to spare.
+    const { result } = setup({
+      seed: summary({ effective_balance: "20.00", daily_limit_reached: true }),
+    });
+    expect(result.current).toEqual({
+      isExhausted: false,
+      isLowBalance: false,
+      dailyLimitReached: true,
+      balance: "20.00",
+      enabled: true,
+    });
+  });
+
+  test("daily limit drives the composer banner with no chat error present", () => {
+    // The proactive path: background turns reached the cap while the user was
+    // away, so the banner must be up before any send fails.
+    const { result } = setup({
+      seed: summary({ daily_limit_reached: true }),
+    });
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: result.current.isLowBalance,
+        dismissed: false,
+        dailyLimitReached: result.current.dailyLimitReached,
+      }),
+    ).toBe("daily_limit");
+  });
+
+  test("daily limit outranks a co-reported low-balance warning", () => {
+    const { result } = setup({
+      seed: summary({
+        effective_balance: "3.00",
+        low_balance_warning: true,
+        daily_limit_reached: true,
+      }),
+    });
+    expect(result.current.isLowBalance).toBe(true);
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: result.current.isLowBalance,
+        dismissed: false,
+        dailyLimitReached: result.current.dailyLimitReached,
+      }),
+    ).toBe("daily_limit");
+  });
+
+  test("a gated-off hook never raises the daily-limit banner", () => {
+    // Cached summary, gated-off query: the inert status keeps the banner down
+    // for self-hosted and org-not-ready contexts.
+    isPlatformHosted = false;
+    const { result } = setup({ seed: summary({ daily_limit_reached: true }) });
+    expect(result.current.dailyLimitReached).toBe(false);
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: result.current.isLowBalance,
+        dismissed: false,
+        dailyLimitReached: result.current.dailyLimitReached,
+      }),
+    ).toBeNull();
+  });
+
+  test("raising the limit clears the banner once the summary refetches", () => {
+    // The settings card invalidates the summary on save; the refreshed
+    // response flips the flag and the banner drops on the next read.
+    const { result, rerender, client } = setup({
+      seed: summary({ daily_limit_reached: true }),
+    });
+    expect(result.current.dailyLimitReached).toBe(true);
+    act(() => {
+      client.setQueryData(
+        BILLING_SUMMARY_KEY,
+        summary({ daily_limit_reached: false }),
+      );
+    });
+    // Bun's preload does not set `IS_REACT_ACT_ENVIRONMENT`, so the query
+    // notification does not flush on its own here; the explicit rerender
+    // reads the hook against the refreshed cache entry.
+    rerender();
+    expect(result.current.dailyLimitReached).toBe(false);
+    expect(
+      resolveComposerBillingBanner({
+        billingBannerDecision: null,
+        isLowBalance: result.current.isLowBalance,
+        dismissed: false,
+        dailyLimitReached: result.current.dailyLimitReached,
+      }),
+    ).toBeNull();
+  });
+
   test("all-false while the summary is unresolved", () => {
     // No seeded data + a hanging fetch keeps the query pending.
     summaryHangs = true;
@@ -180,6 +280,7 @@ describe("useBillingBalanceStatus", () => {
     expect(result.current).toEqual({
       isExhausted: false,
       isLowBalance: false,
+      dailyLimitReached: false,
       balance: null,
       enabled: true,
     });
@@ -217,6 +318,7 @@ describe("useBillingBalanceStatus", () => {
     expect(result.current).toEqual({
       isExhausted: false,
       isLowBalance: false,
+      dailyLimitReached: false,
       balance: null,
       enabled: false,
     });
@@ -232,6 +334,7 @@ describe("useBillingBalanceStatus", () => {
     expect(result.current).toEqual({
       isExhausted: false,
       isLowBalance: false,
+      dailyLimitReached: false,
       balance: null,
       enabled: false,
     });

--- a/clients/web/src/hooks/use-billing-balance-status.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.ts
@@ -16,6 +16,13 @@ export interface BillingBalanceStatus {
    * platform; it is never re-derived client-side.
    */
   isLowBalance: boolean;
+  /**
+   * Server-computed daily-limit state: today's Vellum credit spend has reached
+   * the org's configured daily cap. Independent of the balance, so it holds
+   * even when credits remain. Drives the composer's daily-limit banner
+   * proactively, without waiting for a send to fail.
+   */
+  dailyLimitReached: boolean;
   /** Effective balance as a decimal string, or null when unknown. */
   balance: string | null;
   /** Whether the billing summary query is allowed to run at all. */
@@ -25,6 +32,7 @@ export interface BillingBalanceStatus {
 const INERT_STATUS: Omit<BillingBalanceStatus, "enabled"> = {
   isExhausted: false,
   isLowBalance: false,
+  dailyLimitReached: false,
   balance: null,
 };
 
@@ -45,13 +53,17 @@ export function useBillingBalanceQueryEnabled(): boolean {
 /**
  * Tri-state credit-balance status for the org's managed billing:
  * normal (both flags false), low ({@link BillingBalanceStatus.isLowBalance}),
- * or exhausted ({@link BillingBalanceStatus.isExhausted}).
+ * or exhausted ({@link BillingBalanceStatus.isExhausted}), plus the orthogonal
+ * daily-limit flag ({@link BillingBalanceStatus.dailyLimitReached}).
  *
  * Inert (all-false, null balance) for self-hosted assistants, missing platform
  * sessions, an unhydrated org store, and while the summary is loading: unknown
  * state must never flash a billing surface. Freshness rides the QueryClient
  * defaults (10s staleTime, refetch-on-focus) plus the turn-end invalidation in
- * `use-conversation-history`.
+ * `use-conversation-history`. Focus refetches reach Capacitor iOS and Electron
+ * too, because `lib/query-focus-manager` feeds TanStack Query's focusManager
+ * from the event bus's `app.resume` signal, so a user coming back to an
+ * already-open app sees the daily-limit banner without a reload.
  */
 export function useBillingBalanceStatus(): BillingBalanceStatus {
   const enabled = useBillingBalanceQueryEnabled();
@@ -65,6 +77,7 @@ export function useBillingBalanceStatus(): BillingBalanceStatus {
   return {
     isExhausted: Number(summary.effective_balance) <= 0,
     isLowBalance: summary.low_balance_warning === true,
+    dailyLimitReached: summary.daily_limit_reached === true,
     balance: summary.effective_balance,
     enabled,
   };


### PR DESCRIPTION
Follow-ups from live QA of the daily credit limit UX (companion to #39977 and platform PR vellum-ai/vellum-assistant-platform#9767; the third QA finding, a daily-limit email, ships separately in vellum-ai/vellum-assistant-platform#9775). Both changes are independent of those PRs and safe to merge in any order.

## What

**1. Proactive composer banner (web).** The "Daily credit limit reached" banner was error-driven only: a user returning to an app whose cap was burned by background turns saw nothing until their next send failed. The billing summary already computes `daily_limit_reached`, so `resolveComposerBillingBanner` now takes it as a third input with precedence error decision > summary daily-limit > low-balance warning (`managed_credits` still suppresses everything). Non-dismissible, same as the error-driven variant. Freshness needs no new machinery: the summary query rides the 10s staleTime + focus refetch (which `query-focus-manager` extends to Capacitor/Electron via `app.resume`) plus the turn-end invalidation in `use-conversation-history`, and raising the limit drops the banner via the settings card's existing summary invalidation (pinned by a test).

**2. Durable inline marker for mid-turn kills (daemon).** When a provider error (e.g. the daily-limit 402) killed a turn after tool round-trips, the transcript just stopped: the synthetic `provider_error` assistant row was gated on `newMessages.some(role === "assistant")`, which mid-turn `tool_use` messages always satisfy. The guard now checks the run ended on a delivered assistant reply, so mid-turn failures persist the inline row, stamp the failed turn outcome, delete the stranded reserved assistant row, and backfill log rows, exactly like first-call failures. Managed-billing daily-limit rows now persist assistant-voice copy (new `DAILY_LIMIT_REACHED_ASSISTANT_REPLY`, mirroring `OUT_OF_CREDITS_ASSISTANT_REPLY`), which also changes the first-call daily-limit inline copy from banner voice to assistant voice; the live `conversation_error` banner is untouched.

## Testing

- web: `bunx tsc --noEmit` clean, lint clean, `bun run test:ci` 846/846 files green; new precedence-matrix tests plus gating, dismissal-latch, and raise-clears-banner cases
- assistant: typecheck clean, scoped suites 240 tests 0 fail; new mid-turn regression test (one tool round-trip, second call throws) verified to fail against the old guard, asserting the persisted row, reservation cleanup, failed-outcome stamp, and tool_use -> tool_result -> error-text ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Screenshot

Fresh app open with the day's credits already consumed by background turns: the banner is up before any message is sent (the transcript behind it is the interrupted background task). Adjust Limit deep-links to Settings -> Billing.

<img width="1456" height="836" alt="daily-limit-banner-on-return" src="https://github.com/user-attachments/assets/7ad44406-261c-44ac-a6f9-8641abd3f3c2" />
