### PR TITLE
fix(assistant): tighten presence staleness and drop unused presence state

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -11,6 +11,7 @@ import {
   getReplayWindow,
 } from "../runtime/assistant-stream-state.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { registerHubClient } from "./helpers/hub-clients.js";
 
 function makeEvent(
   overrides: Partial<AssistantEventEnvelope> = {},
@@ -438,30 +439,19 @@ describe("AssistantEventHub — actorPrincipalId on ClientEntry", () => {
 // ── ClientEntry desktop presence ─────────────────────────────────────────────
 
 describe("AssistantEventHub client presence", () => {
-  function subscribeClient(hub: AssistantEventHub, clientId: string): void {
-    hub.subscribe({
-      type: "client",
-      clientId,
-      interfaceId: "macos",
-      capabilities: [],
-      callback: () => {},
-    });
-  }
-
   test("records presence on a matching client", () => {
     const hub = new AssistantEventHub();
-    subscribeClient(hub, "mac-1");
+    registerHubClient({ hub, clientId: "mac-1" });
 
     expect(hub.setClientPresence("mac-1", "active")).toBe(true);
 
     const presence = hub.getClientById("mac-1")!.presence!;
     expect(presence.state).toBe("active");
-    expect(presence.since.getTime()).toBe(presence.reportedAt.getTime());
   });
 
-  test("preserves since when the same state is re-reported", async () => {
+  test("reportedAt advances on every report", async () => {
     const hub = new AssistantEventHub();
-    subscribeClient(hub, "mac-1");
+    registerHubClient({ hub, clientId: "mac-1" });
 
     hub.setClientPresence("mac-1", "idle");
     const first = hub.getClientById("mac-1")!.presence!;
@@ -470,31 +460,14 @@ describe("AssistantEventHub client presence", () => {
     hub.setClientPresence("mac-1", "idle");
     const second = hub.getClientById("mac-1")!.presence!;
 
-    expect(second.since.getTime()).toBe(first.since.getTime());
     expect(second.reportedAt.getTime()).toBeGreaterThan(
       first.reportedAt.getTime(),
     );
   });
 
-  test("advances since on a state transition", async () => {
-    const hub = new AssistantEventHub();
-    subscribeClient(hub, "mac-1");
-
-    hub.setClientPresence("mac-1", "active");
-    const first = hub.getClientById("mac-1")!.presence!;
-
-    await Bun.sleep(5);
-    hub.setClientPresence("mac-1", "away");
-    const second = hub.getClientById("mac-1")!.presence!;
-
-    expect(second.state).toBe("away");
-    expect(second.since.getTime()).toBeGreaterThan(first.since.getTime());
-    expect(second.since.getTime()).toBe(second.reportedAt.getTime());
-  });
-
   test("returns false for an unknown clientId", () => {
     const hub = new AssistantEventHub();
-    subscribeClient(hub, "mac-1");
+    registerHubClient({ hub, clientId: "mac-1" });
 
     expect(hub.setClientPresence("does-not-exist", "active")).toBe(false);
     expect(hub.getClientById("mac-1")?.presence).toBeUndefined();
@@ -502,7 +475,7 @@ describe("AssistantEventHub client presence", () => {
 
   test("a disposed client no longer accepts presence", () => {
     const hub = new AssistantEventHub();
-    subscribeClient(hub, "mac-1");
+    registerHubClient({ hub, clientId: "mac-1" });
 
     expect(hub.disposeClient("mac-1")).toBe(1);
     expect(hub.setClientPresence("mac-1", "active")).toBe(false);

--- a/assistant/src/__tests__/helpers/hub-clients.ts
+++ b/assistant/src/__tests__/helpers/hub-clients.ts
@@ -1,0 +1,45 @@
+/**
+ * Register and tear down client subscribers on an assistant event hub.
+ *
+ * Defaults to the process singleton, which is what route and policy tests
+ * exercise. Pass `hub` to drive a standalone instance instead.
+ */
+import type { HostProxyCapability, InterfaceId } from "../../channels/types.js";
+import type {
+  AssistantEventHub,
+  DesktopPresenceState,
+} from "../../runtime/assistant-event-hub.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+
+export interface RegisterHubClientArgs {
+  clientId: string;
+  hub?: AssistantEventHub;
+  interfaceId?: InterfaceId;
+  capabilities?: HostProxyCapability[];
+  actorPrincipalId?: string;
+  /** Reported immediately after subscribing, when supplied. */
+  presence?: DesktopPresenceState;
+}
+
+export function registerHubClient(args: RegisterHubClientArgs): void {
+  const hub = args.hub ?? assistantEventHub;
+  hub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: args.interfaceId ?? "macos",
+    capabilities: args.capabilities ?? [],
+    actorPrincipalId: args.actorPrincipalId,
+    callback: () => {},
+  });
+  if (args.presence) {
+    hub.setClientPresence(args.clientId, args.presence);
+  }
+}
+
+export function clearHubClients(
+  hub: AssistantEventHub = assistantEventHub,
+): void {
+  for (const client of hub.listClients()) {
+    hub.disposeClient(client.clientId);
+  }
+}

--- a/assistant/src/runtime/__tests__/desktop-presence.test.ts
+++ b/assistant/src/runtime/__tests__/desktop-presence.test.ts
@@ -10,11 +10,11 @@
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 
-import type { InterfaceId } from "../../channels/types.js";
 import {
-  assistantEventHub,
-  type DesktopPresenceState,
-} from "../assistant-event-hub.js";
+  clearHubClients,
+  registerHubClient,
+} from "../../__tests__/helpers/hub-clients.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   isDesktopAttended,
   PRESENCE_STALE_AFTER_MS,
@@ -22,70 +22,45 @@ import {
 
 // ── Test helpers ──────────────────────────────────────────────────────────
 
-function registerClient(args: {
-  clientId: string;
-  interfaceId?: InterfaceId;
-  presence?: DesktopPresenceState;
-  actorPrincipalId?: string;
-}): void {
-  assistantEventHub.subscribe({
-    type: "client",
-    clientId: args.clientId,
-    interfaceId: args.interfaceId ?? "macos",
-    capabilities: [],
-    actorPrincipalId: args.actorPrincipalId,
-    callback: () => {},
-  });
-  if (args.presence) {
-    assistantEventHub.setClientPresence(args.clientId, args.presence);
-  }
-}
-
-function clearHub(): void {
-  for (const client of assistantEventHub.listClients()) {
-    assistantEventHub.disposeClient(client.clientId);
-  }
-}
-
 /** A `now` far enough past every report to push all of them out of the window. */
 function afterStaleness(): Date {
   return new Date(Date.now() + PRESENCE_STALE_AFTER_MS + 1_000);
 }
 
 afterEach(() => {
-  clearHub();
+  clearHubClients();
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 describe("isDesktopAttended", () => {
   test("fresh active macos client is attended", () => {
-    registerClient({ clientId: "mac-1", presence: "active" });
+    registerHubClient({ clientId: "mac-1", presence: "active" });
     expect(isDesktopAttended()).toBe(true);
   });
 
   test("active report older than the staleness bound is not attended", () => {
-    registerClient({ clientId: "mac-1", presence: "active" });
+    registerHubClient({ clientId: "mac-1", presence: "active" });
     expect(isDesktopAttended({ now: afterStaleness() })).toBe(false);
   });
 
   test("idle is not attended", () => {
-    registerClient({ clientId: "mac-1", presence: "idle" });
+    registerHubClient({ clientId: "mac-1", presence: "idle" });
     expect(isDesktopAttended()).toBe(false);
   });
 
   test("away is not attended", () => {
-    registerClient({ clientId: "mac-1", presence: "away" });
+    registerHubClient({ clientId: "mac-1", presence: "away" });
     expect(isDesktopAttended()).toBe(false);
   });
 
   test("client that never reported presence is not attended", () => {
-    registerClient({ clientId: "mac-1" });
+    registerHubClient({ clientId: "mac-1" });
     expect(isDesktopAttended()).toBe(false);
   });
 
   test("active web client does not count as desktop presence", () => {
-    registerClient({
+    registerHubClient({
       clientId: "web-1",
       interfaceId: "web",
       presence: "active",
@@ -112,15 +87,15 @@ describe("isDesktopAttended", () => {
   });
 
   test("one active macos client among several is enough", () => {
-    registerClient({ clientId: "mac-1", presence: "away" });
-    registerClient({ clientId: "mac-2", presence: "active" });
+    registerHubClient({ clientId: "mac-1", presence: "away" });
+    registerHubClient({ clientId: "mac-2", presence: "active" });
     expect(isDesktopAttended()).toBe(true);
   });
 });
 
 describe("isDesktopAttended scoped to an actor principal", () => {
   test("matching actor principal is attended", () => {
-    registerClient({
+    registerHubClient({
       clientId: "mac-1",
       presence: "active",
       actorPrincipalId: "actor-a",
@@ -129,7 +104,7 @@ describe("isDesktopAttended scoped to an actor principal", () => {
   });
 
   test("another actor's attended mac does not count", () => {
-    registerClient({
+    registerHubClient({
       clientId: "mac-1",
       presence: "active",
       actorPrincipalId: "actor-a",
@@ -138,12 +113,12 @@ describe("isDesktopAttended scoped to an actor principal", () => {
   });
 
   test("client with no principal does not match a supplied principal", () => {
-    registerClient({ clientId: "mac-1", presence: "active" });
+    registerHubClient({ clientId: "mac-1", presence: "active" });
     expect(isDesktopAttended({ actorPrincipalId: "actor-a" })).toBe(false);
   });
 
   test("omitting the principal counts any attended macos client", () => {
-    registerClient({
+    registerHubClient({
       clientId: "mac-1",
       presence: "active",
       actorPrincipalId: "actor-a",
@@ -152,7 +127,7 @@ describe("isDesktopAttended scoped to an actor principal", () => {
   });
 
   test("target actor's stale report is not attended", () => {
-    registerClient({
+    registerHubClient({
       clientId: "mac-1",
       presence: "active",
       actorPrincipalId: "actor-a",
@@ -166,12 +141,12 @@ describe("isDesktopAttended scoped to an actor principal", () => {
   });
 
   test("only the non-target actor is active among several clients", () => {
-    registerClient({
+    registerHubClient({
       clientId: "mac-1",
       presence: "active",
       actorPrincipalId: "actor-a",
     });
-    registerClient({
+    registerHubClient({
       clientId: "mac-2",
       presence: "away",
       actorPrincipalId: "actor-b",

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -105,8 +105,6 @@ export type DesktopPresenceState = (typeof DESKTOP_PRESENCE_STATES)[number];
 
 export interface ClientPresence {
   state: DesktopPresenceState;
-  /** When the client entered this state. Preserved across re-reports. */
-  since: Date;
   /** When the daemon last heard from the client. Drives staleness. */
   reportedAt: Date;
 }
@@ -428,18 +426,29 @@ export class AssistantEventHub {
   }
 
   /**
-   * Return the active client subscriber with the given clientId, or
-   * `undefined` if no such subscriber exists.
+   * Yield every active client entry with the given clientId. A reconnecting
+   * client can briefly own more than one entry, so callers that mutate state
+   * must consume all of them.
    */
-  getClientById(clientId: string): ClientEntry | undefined {
+  private *activeClientEntries(clientId: string): Generator<ClientEntry> {
     for (const entry of this.subscribers) {
       if (
         entry.active &&
         entry.type === "client" &&
         entry.clientId === clientId
       ) {
-        return entry;
+        yield entry;
       }
+    }
+  }
+
+  /**
+   * Return the active client subscriber with the given clientId, or
+   * `undefined` if no such subscriber exists.
+   */
+  getClientById(clientId: string): ClientEntry | undefined {
+    for (const entry of this.activeClientEntries(clientId)) {
+      return entry;
     }
     return undefined;
   }
@@ -533,39 +542,22 @@ export class AssistantEventHub {
    */
   touchClient(clientId: string): void {
     const now = new Date();
-    for (const entry of this.subscribers) {
-      if (
-        entry.active &&
-        entry.type === "client" &&
-        entry.clientId === clientId
-      ) {
-        entry.lastActiveAt = now;
-      }
+    for (const entry of this.activeClientEntries(clientId)) {
+      entry.lastActiveAt = now;
     }
   }
 
   /**
-   * Record the desktop presence state reported by a client. `since` is kept
-   * when the state is unchanged, so consumers can tell how long the client has
-   * held it; `reportedAt` always advances. Returns true when at least one
-   * active client entry matched.
+   * Record the desktop presence state reported by a client. `reportedAt`
+   * always advances. Returns true when at least one active client entry
+   * matched.
    */
   setClientPresence(clientId: string, state: DesktopPresenceState): boolean {
     const now = new Date();
     let matched = false;
-    for (const entry of this.subscribers) {
-      if (
-        entry.active &&
-        entry.type === "client" &&
-        entry.clientId === clientId
-      ) {
-        entry.presence = {
-          state,
-          since: entry.presence?.state === state ? entry.presence.since : now,
-          reportedAt: now,
-        };
-        matched = true;
-      }
+    for (const entry of this.activeClientEntries(clientId)) {
+      entry.presence = { state, reportedAt: now };
+      matched = true;
     }
     return matched;
   }

--- a/assistant/src/runtime/desktop-presence.ts
+++ b/assistant/src/runtime/desktop-presence.ts
@@ -16,8 +16,11 @@ import { assistantEventHub } from "./assistant-event-hub.js";
 
 const log = getLogger("desktop-presence");
 
-/** Must exceed the client's report interval with margin, so a single dropped report does not read as absent. */
-export const PRESENCE_STALE_AFTER_MS = 3 * 60_000;
+/**
+ * Bounds how long suppression can outlive the Mac going to sleep or dropping
+ * off, while still tolerating two dropped reports at the 30s report interval.
+ */
+export const PRESENCE_STALE_AFTER_MS = 90_000;
 
 export interface DesktopAttendanceOptions {
   /**

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -24,6 +24,10 @@ mock.module("../../../config/env.js", () => ({
 
 // ── Real imports (after mocks) ────────────────────────────────────────────
 
+import {
+  clearHubClients,
+  registerHubClient,
+} from "../../../__tests__/helpers/hub-clients.js";
 import { assistantEventHub } from "../../assistant-event-hub.js";
 import { ROUTES } from "../client-routes.js";
 import { BadRequestError } from "../errors.js";
@@ -59,21 +63,11 @@ function registerClient(args: {
   clientId: string;
   actorPrincipalId?: string;
 }): void {
-  assistantEventHub.subscribe({
-    type: "client",
+  registerHubClient({
     clientId: args.clientId,
-    interfaceId: "macos",
     capabilities: ["host_bash", "host_file", "host_cu"],
     actorPrincipalId: args.actorPrincipalId,
-    callback: () => {},
   });
-}
-
-function clearHub(): void {
-  const ids = assistantEventHub.listClients().map((c) => c.clientId);
-  for (const id of ids) {
-    assistantEventHub.disposeClient(id);
-  }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -81,7 +75,7 @@ function clearHub(): void {
 describe("list_clients route — same-user filter", () => {
   beforeEach(() => {
     fakeHttpAuthDisabled = false;
-    clearHub();
+    clearHubClients();
   });
 
   test("returns only clients owned by the calling actor", () => {
@@ -170,7 +164,7 @@ describe("list_clients route — same-user filter", () => {
 describe("report_client_presence route", () => {
   beforeEach(() => {
     fakeHttpAuthDisabled = false;
-    clearHub();
+    clearHubClients();
   });
 
   test("records presence against the client named by the header", () => {


### PR DESCRIPTION
## Summary
- Reduces `PRESENCE_STALE_AFTER_MS` from 3 minutes to 90s, halving the window in which a lost sleep-time `away` report keeps suppressing pushes, while still tolerating two dropped reports at the 30s cadence
- Deletes `ClientPresence.since`, which nothing read
- Extracts the hub's repeated active-client match predicate into one private iterator
- Extracts the duplicated hub client-registration test helpers into `src/__tests__/helpers/hub-clients.ts`

Fixes gaps found during plan self-review for presence-gated-reply-push.md