### PR TITLE
fix(web): switch-telemetry detail convention and reason granularity

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -474,7 +474,7 @@ describe("chat-session-store: switch telemetry gate", () => {
       "context_change",
       "context_change",
       "context_change",
-      "context_change",
+      "draft_resolution",
     ]);
   });
 

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -465,7 +465,7 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
     // opened under the draft key can only be closed by a paint under that key,
     // and the transcript paints under the server id, so close it here.
     if (state.draftConversationIdResolution) {
-      abandonSwitchMeasurement("context_change");
+      abandonSwitchMeasurement("draft_resolution");
       set({ draftConversationIdResolution: false });
       return;
     }

--- a/clients/web/src/lib/telemetry/switch-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.test.ts
@@ -140,14 +140,14 @@ describe("switch telemetry", () => {
     const sample = onlySample();
     expect(sample.checkName).toBe("client_switch.transcript_painted");
     expect(sample.value).toBe(412);
-    expect(sample.detail.had_history).toBe("true");
+    expect(sample.detail.had_history).toBe(true);
   });
 
   test("labels an empty incoming conversation with had_history false", () => {
     noteConversationSwitchStarted("conv-1");
     noteSwitchTranscriptPainted("conv-1", { hadHistory: false });
 
-    expect(onlySample().detail.had_history).toBe("false");
+    expect(onlySample().detail.had_history).toBe(false);
   });
 
   test("ignores a paint for a different conversation and keeps the window", () => {
@@ -232,8 +232,8 @@ describe("switch telemetry", () => {
   });
 
   test("a context change abandons the window and cancels its stall", () => {
-    // The store takes this branch for assistant switches, re-entering the same
-    // conversation, and draft-key resolution.
+    // The store takes this branch for assistant switches and for re-entering
+    // the same conversation; draft-key resolution has its own reason.
     noteConversationSwitchStarted("conv-1");
     clock += 300;
     abandonSwitchMeasurement("context_change");
@@ -293,7 +293,7 @@ describe("useSwitchPaintMeasurement", () => {
     const sample = onlySample();
     expect(sample.checkName).toBe("client_switch.transcript_painted");
     expect(sample.value).toBe(120);
-    expect(sample.detail.had_history).toBe("true");
+    expect(sample.detail.had_history).toBe(true);
   });
 
   test("closes a window whose incoming transcript was already cached", () => {

--- a/clients/web/src/lib/telemetry/switch-telemetry.ts
+++ b/clients/web/src/lib/telemetry/switch-telemetry.ts
@@ -10,7 +10,8 @@
  * `client_switch.abandoned` when the switch is cut short (history error, app
  * backgrounded, panel unmounted, a re-switch, or a move the family does not
  * measure). Painted plus stalled plus abandoned is therefore the full set of
- * measured switches, so no attempt silently leaves the denominator.
+ * measured switches, so no attempt silently leaves the denominator, apart from
+ * subscription teardown, which drops an open window silently.
  *
  * The TTL is 15s rather than the resume family's 10s because a cold history
  * fetch through the proxy chain can legitimately take that long on LTE. The
@@ -32,8 +33,13 @@ const STALL_TTL_MS = 15_000;
  * Why a measured switch ended without painting. A closed set so the abandoned
  * series stays a groupable dimension rather than an open string.
  */
-export type SwitchAbandonReason =
-  "history_error" | "hidden" | "unmount" | "superseded" | "context_change";
+type SwitchAbandonReason =
+  | "history_error"
+  | "hidden"
+  | "unmount"
+  | "superseded"
+  | "context_change"
+  | "draft_resolution";
 
 let pending: {
   conversationId: string;
@@ -97,7 +103,7 @@ export function noteSwitchTranscriptPainted(
   const elapsedMs = performance.now() - pending.at;
   clearPending();
   emitClientPerfEvent("client_switch.transcript_painted", elapsedMs, {
-    had_history: String(extra.hadHistory),
+    had_history: extra.hadHistory,
   });
 }
 


### PR DESCRIPTION
## Summary
- had_history rides as a raw boolean per the client-perf detail convention (was the last stringified scalar in the family)
- Draft-key resolution abandons get their own draft_resolution reason so they group separately from unmeasured context changes
- Denominator docstring now names the deliberate teardown exception

Fixes gaps found during round-2 plan self-review for measure-first-telemetry-followups.md