### PR TITLE
fix(macos): seed presence per connection and guard double install

### DIFF
--- a/clients/macos/src/main/host-proxy-poster.ts
+++ b/clients/macos/src/main/host-proxy-poster.ts
@@ -14,6 +14,9 @@
  */
 
 import { getDeviceId } from "./device-id";
+// Type-only, so this stays erased at compile time and the poster picks up no
+// runtime dependency on electron from the presence module.
+import type { PresenceState } from "./presence";
 
 // ---------------------------------------------------------------------------
 // Payload interfaces — match the daemon route request bodies
@@ -86,7 +89,7 @@ export interface HostAppControlResultPayload {
 }
 
 export interface PresencePayload {
-  state: "active" | "idle" | "away";
+  state: PresenceState;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -106,18 +106,23 @@ globalThis.fetch = mockGatewayTokenFetch as typeof globalThis.fetch;
 type Connection = NonNullable<ReturnType<typeof __testing.connections.get>>;
 
 /**
- * Register a connection whose poster records the presence states it receives,
- * or rejects to stand in for an unreachable daemon.
+ * Register a connection whose poster records the presence states it receives.
+ * `opts` is read on every post, so a test holding the object can flip a
+ * connection between healthy and unreachable mid-run: `reject` stands in for
+ * a throw, `ok: false` for the non-2xx that postJson folds into `false`.
  */
 function addPresenceConnection(
   assistantId: string,
-  opts: { reject?: boolean } = {},
+  opts: { reject?: boolean; ok?: boolean } = {},
 ): PresenceState[] {
   const received: PresenceState[] = [];
   const poster = {
     postPresence: async ({ state }: { state: PresenceState }) => {
       if (opts.reject) {
         throw new Error("daemon unreachable");
+      }
+      if (opts.ok === false) {
+        return false;
       }
       received.push(state);
       return true;
@@ -130,6 +135,32 @@ function addPresenceConnection(
   } as unknown as Connection);
   return received;
 }
+
+/**
+ * Route presence POSTs into a captured list, leaving every other request
+ * (the gateway token exchange) on its normal mock.
+ */
+function capturePresencePosts(): { url: string; body: string }[] {
+  const posts: { url: string; body: string }[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url.endsWith("/clients/presence")) {
+      posts.push({ url, body: String(init?.body) });
+      return new Response("ok");
+    }
+    return mockGatewayTokenFetch(input);
+  }) as typeof globalThis.fetch;
+  return posts;
+}
+
+/** A lockfile with one local and one cloud assistant. */
+const MIXED_LOCKFILE: Lockfile = {
+  assistants: [
+    { assistantId: "local-1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+    { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
+  ],
+  activeAssistant: "local-1",
+};
 
 /** Create a poster that captures the first POST body for assertions. */
 function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; body: () => Record<string, unknown> | null } {
@@ -631,24 +662,10 @@ describe("host-proxy-router", () => {
     });
 
     test("posts presence to every connected assistant", async () => {
-      const presencePosts: { url: string; body: string }[] = [];
-      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-        const url = String(input);
-        if (url.endsWith("/clients/presence")) {
-          presencePosts.push({ url, body: String(init?.body) });
-          return new Response("ok");
-        }
-        return mockGatewayTokenFetch(input);
-      }) as typeof globalThis.fetch;
+      const presencePosts = capturePresencePosts();
 
       installHostProxyBridge(fakeCliResolver);
-      lockfileListener?.({
-        assistants: [
-          { assistantId: "local-1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
-          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
-        ],
-        activeAssistant: "local-1",
-      });
+      lockfileListener?.(MIXED_LOCKFILE);
       await flush();
 
       presenceReporter?.("idle");
@@ -659,6 +676,51 @@ describe("host-proxy-router", () => {
         "https://platform.vellum.ai/v1/assistants/cloud-1/clients/presence",
       ]);
       expect(JSON.parse(presencePosts[0]!.body)).toEqual({ state: "idle" });
+    });
+
+    test("seeds an assistant that connects after the last report", async () => {
+      const presencePosts = capturePresencePosts();
+
+      installHostProxyBridge(fakeCliResolver);
+      presenceReporter?.("idle");
+      await flush();
+      // Nothing was connected when the report fired.
+      expect(presencePosts).toEqual([]);
+
+      lockfileListener?.(MIXED_LOCKFILE);
+      await flush();
+
+      // Both are told the cached state as they join rather than waiting out
+      // the next poll tick. The local one connects asynchronously, so it is
+      // the case the install-time report cannot reach.
+      expect(presencePosts.map((post) => post.url).sort()).toEqual([
+        "http://127.0.0.1:9001/v1/clients/presence",
+        "https://platform.vellum.ai/v1/assistants/cloud-1/clients/presence",
+      ]);
+      expect(JSON.parse(presencePosts[0]!.body)).toEqual({ state: "idle" });
+    });
+
+    test("sends nothing to a new connection before any report", async () => {
+      const presencePosts = capturePresencePosts();
+
+      installHostProxyBridge(fakeCliResolver);
+      lockfileListener?.(MIXED_LOCKFILE);
+      await flush();
+
+      // No observed state means no claim about presence, which is the
+      // fail-open direction: the daemon lets the push through.
+      expect(presencePosts).toEqual([]);
+    });
+
+    test("a second install stops the previous monitor", () => {
+      installHostProxyBridge(fakeCliResolver);
+      const teardown = installHostProxyBridge(fakeCliResolver);
+
+      expect(mockInstallPresenceMonitor).toHaveBeenCalledTimes(2);
+      expect(mockPresenceTeardown).toHaveBeenCalledTimes(1);
+
+      teardown();
+      expect(mockPresenceTeardown).toHaveBeenCalledTimes(2);
     });
 
     test("keeps reporting to siblings when one poster rejects", async () => {
@@ -685,6 +747,57 @@ describe("host-proxy-router", () => {
       await flush();
 
       expect(received).toEqual(["active", "active", "active"]);
+    });
+
+    test("warns once for a run of failing posts, not once per report", async () => {
+      installHostProxyBridge(fakeCliResolver);
+      const daemon = { reject: true };
+      addPresenceConnection("a1", daemon);
+
+      mockLogWarn.mockClear();
+      presenceReporter?.("active");
+      await flush();
+      presenceReporter?.("active");
+      await flush();
+      presenceReporter?.("idle");
+      await flush();
+
+      expect(mockLogWarn).toHaveBeenCalledTimes(1);
+
+      // A success re-arms the warning, so the next outage is visible.
+      daemon.reject = false;
+      presenceReporter?.("active");
+      await flush();
+      daemon.reject = true;
+      presenceReporter?.("away");
+      await flush();
+
+      expect(mockLogWarn).toHaveBeenCalledTimes(2);
+    });
+
+    test("warns when a post is rejected without throwing", async () => {
+      installHostProxyBridge(fakeCliResolver);
+      addPresenceConnection("a1", { ok: false });
+
+      mockLogWarn.mockClear();
+      presenceReporter?.("active");
+      await flush();
+      presenceReporter?.("active");
+      await flush();
+
+      expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    });
+
+    test("a failing assistant does not silence its siblings", async () => {
+      installHostProxyBridge(fakeCliResolver);
+      addPresenceConnection("a1", { reject: true });
+      addPresenceConnection("a2", { ok: false });
+
+      mockLogWarn.mockClear();
+      presenceReporter?.("active");
+      await flush();
+
+      expect(mockLogWarn).toHaveBeenCalledTimes(2);
     });
 
     test("bridge teardown stops presence reporting", async () => {

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -50,6 +50,11 @@ interface AssistantConnection {
   poster: HostProxyPoster;
   /** Opaque string for detecting config changes that warrant a reconnect. */
   fingerprint: string;
+  /**
+   * Set while presence posts to this assistant are failing, so an outage is
+   * logged once rather than once per poll.
+   */
+  presencePostFailing?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +190,85 @@ function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster):
 }
 
 // ---------------------------------------------------------------------------
+// Presence reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * Most recent state seen from the presence monitor, used to seed an assistant
+ * that connects between poll ticks. Null until the first report: with no
+ * presence record on file the daemon lets the mobile push through, so sending
+ * nothing is the fail-open direction and a guessed state would be worse.
+ */
+let lastPresenceState: PresenceState | null = null;
+
+/**
+ * Post one report, logging only the first failure of a run.
+ *
+ * postPresence folds every non-2xx and every throw into `false`, so a daemon
+ * that stops accepting reports would otherwise take presence down in total
+ * silence. Warning on each attempt instead would put a line in the log every
+ * poll interval for the length of the outage, so the connection stays quiet
+ * until a post succeeds and re-arms the warning.
+ */
+async function postPresenceTo(
+  assistantId: string,
+  conn: AssistantConnection,
+  state: PresenceState,
+): Promise<void> {
+  let posted = false;
+  try {
+    posted = await conn.poster.postPresence({ state });
+  } catch {
+    posted = false;
+  }
+  if (posted) {
+    conn.presencePostFailing = false;
+    return;
+  }
+  if (!conn.presencePostFailing) {
+    conn.presencePostFailing = true;
+    log.warn("[host-proxy-router] presence post failed", { assistantId, state });
+  }
+}
+
+/**
+ * Fan a presence report out to every connected assistant: the lockfile can
+ * hold several (local and cloud) and the desktop is equally attended for all
+ * of them.
+ *
+ * Each post is fire-and-forget (postJson carries its own timeout) so a slow
+ * or unreachable daemon can't stall the reporter or its siblings, and
+ * allSettled keeps one failure from surfacing as an unhandled rejection. A
+ * dropped report is the safe direction: with no presence record on file the
+ * daemon lets the mobile push through.
+ */
+function reportPresence(state: PresenceState): void {
+  lastPresenceState = state;
+  void Promise.allSettled(
+    Array.from(connections, ([assistantId, conn]) =>
+      postPresenceTo(assistantId, conn, state),
+    ),
+  );
+}
+
+/**
+ * Report to an assistant the moment it joins. A monitor report only reaches
+ * whoever is connected when it fires, and a local assistant connects
+ * asynchronously, so without this the common desktop case would go
+ * unreported until the next poll tick.
+ */
+function seedPresence(assistantId: string): void {
+  if (lastPresenceState === null) {
+    return;
+  }
+  const conn = connections.get(assistantId);
+  if (!conn) {
+    return;
+  }
+  void postPresenceTo(assistantId, conn, lastPresenceState);
+}
+
+// ---------------------------------------------------------------------------
 // Lifecycle — connect / disconnect per assistant
 // ---------------------------------------------------------------------------
 
@@ -294,6 +378,7 @@ async function connectLocalAssistant(
   sse.connect();
 
   connections.set(assistantId, { sse, poster, fingerprint: localFingerprint(gatewayPort) });
+  seedPresence(assistantId);
   log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
 }
 
@@ -336,6 +421,7 @@ function connectCloudAssistant(
     poster,
     fingerprint: cloudFingerprint(runtimeUrl, organizationId),
   });
+  seedPresence(assistantId);
   log.info("[host-proxy-router] connected to cloud assistant", { assistantId, runtimeUrl, organizationId });
 }
 
@@ -397,27 +483,6 @@ function handleLockfileChange(lockfile: Lockfile): void {
 }
 
 // ---------------------------------------------------------------------------
-// Presence reporting
-// ---------------------------------------------------------------------------
-
-/**
- * Fan a presence report out to every connected assistant: the lockfile can
- * hold several (local and cloud) and the desktop is equally attended for all
- * of them.
- *
- * Each post is fire-and-forget (postJson carries its own timeout) so a slow
- * or unreachable daemon can't stall the reporter or its siblings, and
- * allSettled keeps one failure from surfacing as an unhandled rejection. A
- * dropped report is the safe direction: with no presence record on file the
- * daemon lets the mobile push through.
- */
-function reportPresence(state: PresenceState): void {
-  void Promise.allSettled(
-    Array.from(connections.values(), (conn) => conn.poster.postPresence({ state })),
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Public install / teardown
 // ---------------------------------------------------------------------------
 
@@ -451,13 +516,18 @@ export function installHostProxyBridge(
   const browserExecutor = new HostBrowserExecutor();
   setExecutor("host_browser", browserExecutor);
 
-  // Not gated on there being any connections: the monitor is cheap, and one
-  // added later by handleLockfileChange picks up the next poll tick.
+  // Not gated on there being any connections: the monitor is cheap, its
+  // first report primes the cache, and a connection added later by
+  // handleLockfileChange is seeded as it joins. Stopping any previous
+  // monitor first keeps a second install from leaking its interval and
+  // powerMonitor listeners.
+  stopPresenceMonitor?.();
   stopPresenceMonitor = installPresenceMonitor(reportPresence);
 
   return () => {
     stopPresenceMonitor?.();
     stopPresenceMonitor = null;
+    lastPresenceState = null;
     unsubscribe?.();
     unsubscribe = null;
     for (const assistantId of [...connections.keys()]) {
@@ -491,6 +561,7 @@ export const __testing = {
   reset() {
     stopPresenceMonitor?.();
     stopPresenceMonitor = null;
+    lastPresenceState = null;
     for (const assistantId of [...connections.keys()]) {
       disconnectAssistant(assistantId);
     }

--- a/clients/macos/src/main/presence.test.ts
+++ b/clients/macos/src/main/presence.test.ts
@@ -73,7 +73,13 @@ beforeEach(() => {
     clearIntervalMock as unknown as typeof clearInterval;
 });
 
+// The monitor refuses a second install while one is live, so every test has
+// to hand its own back before the next one starts.
+let activeTeardown: (() => void) | null = null;
+
 afterEach(() => {
+  activeTeardown?.();
+  activeTeardown = null;
   globalThis.setInterval = originalSetInterval;
   globalThis.clearInterval = originalClearInterval;
 });
@@ -83,6 +89,7 @@ afterEach(() => {
 const install = (): { reports: string[]; teardown: () => void } => {
   const reports: string[] = [];
   const teardown = installPresenceMonitor((state) => reports.push(state));
+  activeTeardown = teardown;
   reports.length = 0;
   return { reports, teardown };
 };
@@ -91,7 +98,7 @@ describe("installPresenceMonitor", () => {
   test("reports once at install, before the first poll tick", () => {
     const reports: string[] = [];
     idleSeconds = 0;
-    installPresenceMonitor((state) => reports.push(state));
+    activeTeardown = installPresenceMonitor((state) => reports.push(state));
 
     expect(reports).toEqual(["active"]);
   });
@@ -227,6 +234,48 @@ describe("installPresenceMonitor", () => {
     intervalCallback?.();
 
     expect(reports).toEqual(["idle"]);
+  });
+
+  test("a second install while one is live is a no-op", () => {
+    const { reports } = install();
+    expect(listenerCount()).toBe(6);
+    const firstTick = intervalCallback;
+
+    const secondReports: string[] = [];
+    const secondTeardown = installPresenceMonitor((state) =>
+      secondReports.push(state),
+    );
+
+    // No install report, no extra listeners, and the live monitor still owns
+    // the poll loop.
+    expect(secondReports).toEqual([]);
+    expect(listenerCount()).toBe(6);
+    expect(intervalCallback).toBe(firstTick);
+
+    idleSeconds = 0;
+    intervalCallback?.();
+    fire("lock-screen");
+    expect(reports).toEqual(["active", "away"]);
+    expect(secondReports).toEqual([]);
+
+    // The refused install's teardown owns nothing, so it must not detach the
+    // live monitor.
+    secondTeardown();
+    expect(listenerCount()).toBe(6);
+    expect(clearIntervalMock).not.toHaveBeenCalled();
+  });
+
+  test("a fresh install works again after teardown", () => {
+    const { teardown } = install();
+    teardown();
+    expect(listenerCount()).toBe(0);
+
+    idleSeconds = 0;
+    const reports: string[] = [];
+    activeTeardown = installPresenceMonitor((state) => reports.push(state));
+
+    expect(reports).toEqual(["active"]);
+    expect(listenerCount()).toBe(6);
   });
 
   test("teardown clears the interval and detaches every listener", () => {

--- a/clients/macos/src/main/presence.ts
+++ b/clients/macos/src/main/presence.ts
@@ -26,9 +26,19 @@ export const IDLE_THRESHOLD_MS = 10 * 60_000;
 
 export const POLL_INTERVAL_MS = 30_000;
 
+let installed = false;
+
 export const installPresenceMonitor = (
   onReport: (state: PresenceState) => void,
 ): (() => void) => {
+  // A second install would leak the first monitor's interval and listeners
+  // and double the report rate, so it hands back a teardown that owns
+  // nothing rather than a live second monitor.
+  if (installed) {
+    return (): void => {};
+  }
+  installed = true;
+
   // Three independently owned reasons the desktop is unreachable, each
   // cleared only by its paired event. A locked machine that sleeps and wakes
   // is still locked, and becoming the foreground login session says nothing
@@ -95,8 +105,10 @@ export const installPresenceMonitor = (
   powerMonitor.on("user-did-become-active", onSessionBecameActive);
   powerMonitor.on("user-did-resign-active", onSessionResigned);
 
-  // Seeds the daemon before the first tick, so a message sent right after
-  // launch is judged against real presence rather than none.
+  // Establishes a state immediately instead of waiting out the first tick,
+  // so a message sent right after launch is judged against real presence
+  // rather than none. This reaches whoever is connected at install time; the
+  // caller caches the state to cover assistants that connect later.
   report();
 
   // Reports on every tick, not only on transitions: the daemon expires
@@ -106,6 +118,7 @@ export const installPresenceMonitor = (
   const timer = setInterval(report, POLL_INTERVAL_MS);
 
   return (): void => {
+    installed = false;
     clearInterval(timer);
     powerMonitor.off("lock-screen", onLockScreen);
     powerMonitor.off("unlock-screen", onUnlockScreen);


### PR DESCRIPTION
## Summary
- Reports presence when a connection is added, so local assistants (which connect asynchronously) are seeded instead of waiting up to 30s for the first tick
- Guards against a double install leaking a second interval and listener set
- Types the poster payload from the module that owns the presence union rather than a second copy
- Logs the first consecutive presence-post failure per connection, so a silently dead reporting path is visible

Fixes gaps found during plan self-review for presence-gated-reply-push.md