### PR TITLE
fix(web): separable first-page diagnostics with consistent list kinds

### DIFF
--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -35,6 +35,7 @@ const {
   listConversationsFirstPage,
   listOriginChannelConversations,
   listScheduledConversations,
+  listScheduledConversationsFirstPage,
 } = await import("@/utils/conversation-list-fetchers");
 
 const ASSISTANT_ID = "assistant-1";
@@ -153,7 +154,10 @@ describe("conversation list drain diagnostics", () => {
       count: 2,
       hasMore: true,
       bytes: 100,
+      listKind: "foreground",
+      source: "drain",
     });
+    expect(events[0]?.details).not.toHaveProperty("conversationType");
 
     expect(events[1]?.details).toMatchObject({
       assistantId: ASSISTANT_ID,
@@ -193,6 +197,7 @@ describe("conversation list drain diagnostics", () => {
       assistantId: ASSISTANT_ID,
       offset: 50,
       status: 500,
+      bytes: null,
       conversationType: null,
       archiveStatus: null,
     });
@@ -204,6 +209,64 @@ describe("conversation list drain diagnostics", () => {
       rows: 1,
       totalBytes: 100,
     });
+  });
+
+  test("a failing page's error entry carries the response size", async () => {
+    stubPages([{ ids: [], hasMore: false, status: 500, contentLength: "77" }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listConversations(ASSISTANT_ID).catch(() => undefined),
+    );
+
+    const errorEntry = events.find(
+      (event) => event.kind === "conversation_list_page_fetch_error",
+    );
+    expect(errorEntry?.details).toMatchObject({ status: 500, bytes: 77 });
+  });
+
+  test("page-0 entries carry the drain's list kind and a drain source", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+    const background = await diagnosticsDuring(() =>
+      listBackgroundConversations(ASSISTANT_ID),
+    );
+
+    expect(background.events[0]?.details).toMatchObject({
+      offset: 0,
+      listKind: "background",
+      source: "drain",
+    });
+
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "10" }]);
+    const channel = await diagnosticsDuring(() =>
+      listOriginChannelConversations(ASSISTANT_ID, "slack"),
+    );
+
+    expect(channel.events[0]?.details).toMatchObject({
+      offset: 0,
+      listKind: "origin_channel",
+      source: "drain",
+    });
+
+    // The archive page drains the foreground and background buckets, so both
+    // of its page-0 entries are archive-page cost.
+    stubPages([
+      { ids: ["c-0"], hasMore: false, contentLength: "10" },
+      { ids: ["c-1"], hasMore: false, contentLength: "20" },
+    ]);
+    const archived = await diagnosticsDuring(() =>
+      listArchivedConversations(ASSISTANT_ID),
+    );
+    const pageEntries = archived.events.filter(
+      (event) => event.kind === "conversation_list_page_fetch",
+    );
+
+    expect(pageEntries).toHaveLength(2);
+    for (const entry of pageEntries) {
+      expect(entry.details).toMatchObject({
+        listKind: "archived",
+        source: "drain",
+      });
+    }
   });
 
   test("bytes is null when content-length is absent and numeric when present", async () => {
@@ -283,14 +346,15 @@ describe("first-page fetch diagnostics", () => {
       count: 2,
       hasMore: true,
       bytes: 128,
-      conversationType: null,
+      listKind: "foreground",
+      source: "first_page_refresh",
     });
     expect(typeof events[0]?.details.durationMs).toBe("number");
     // A single page is not a drain, so nothing reaches the telemetry rail.
     expect(emitClientPerfEventMock.mock.calls).toHaveLength(0);
   });
 
-  test("labels the background bucket's entry with its conversation type", async () => {
+  test("labels the background bucket's entry with its list kind", async () => {
     stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "12" }]);
 
     const { events } = await diagnosticsDuring(() =>
@@ -300,8 +364,23 @@ describe("first-page fetch diagnostics", () => {
     expect(events[0]?.details).toMatchObject({
       offset: 0,
       status: 200,
-      conversationType: "background",
+      listKind: "background",
+      source: "first_page_refresh",
       bytes: 12,
+    });
+  });
+
+  test("labels the scheduled bucket's entry with its list kind", async () => {
+    stubPages([{ ids: ["c-0"], hasMore: false, contentLength: "12" }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listScheduledConversationsFirstPage(ASSISTANT_ID),
+    );
+
+    expect(events[0]?.details).toMatchObject({
+      offset: 0,
+      listKind: "scheduled",
+      source: "first_page_refresh",
     });
   });
 

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -127,9 +127,10 @@ type FetchConversationListOptions = {
 };
 
 /**
- * Closed set of `list_kind` labels for the `client_list.drain` watchdog event.
- * One label per real caller, so the archive page and the channel sections stay
- * distinguishable from the sidebar's foreground drain in the timing metric.
+ * Closed set of list labels carried by the `client_list.drain` watchdog event
+ * and the `conversation_list_page_fetch` ring entry. One label per real caller,
+ * so the archive page and the channel sections stay distinguishable from the
+ * sidebar's foreground drain in both rails.
  */
 type DrainListKind =
   "foreground" | "background" | "scheduled" | "archived" | "origin_channel";
@@ -173,23 +174,35 @@ type TimedConversationListPage = ConversationListPage & {
   bytes: number | null;
 };
 
-type FirstPageFetchDiagnostic = {
-  assistantId: string;
-  status: number;
-  count: number;
-  hasMore: boolean;
-  durationMs: number;
-  bytes: number | null;
-  conversationType: "background" | "scheduled" | null;
-};
+/** Which path issued an offset-0 list GET. */
+type FirstPageFetchSource = "drain" | "first_page_refresh";
 
 /**
  * Ring entry for one offset-0 list GET, shared by the drain's first page and
  * the standalone first-page fetchers. The standalone ones run debounced (250ms)
  * behind sync events, so their share of the 200-entry ring stays small.
+ *
+ * `listKind` and `source` together fingerprint the caller: without them every
+ * bucket's first page reads as the same offset-0 request, and a slow entry is
+ * not attributable to the path the user waited on.
  */
-function recordFirstPageFetch(entry: FirstPageFetchDiagnostic): void {
-  recordDiagnostic("conversation_list_page_fetch", { ...entry, offset: 0 });
+function recordFirstPageFetch(
+  assistantId: string,
+  page: TimedConversationListPage,
+  listKind: DrainListKind,
+  source: FirstPageFetchSource,
+): void {
+  recordDiagnostic("conversation_list_page_fetch", {
+    assistantId,
+    offset: 0,
+    status: page.status,
+    count: page.conversations.length,
+    hasMore: page.hasMore,
+    durationMs: page.durationMs,
+    bytes: page.bytes,
+    listKind,
+    source,
+  });
 }
 
 async function fetchConversationListPage(
@@ -218,6 +231,7 @@ async function fetchConversationListPage(
       offset,
       status: response.status,
       durationMs,
+      bytes: readContentLength(response),
       conversationType: conversationType ?? null,
       archiveStatus: archiveStatus ?? null,
     });
@@ -279,36 +293,36 @@ async function fetchConversationList(
   try {
     for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
       const offset = page * CONVERSATION_LIST_PAGE_SIZE;
-      const { conversations, hasMore, status, durationMs, bytes } =
-        await fetchConversationListPage(assistantId, offset, options);
+      const result = await fetchConversationListPage(
+        assistantId,
+        offset,
+        options,
+      );
       pages++;
-      maxPageMs = Math.max(maxPageMs, durationMs);
-      if (bytes !== null) {
-        totalBytes = (totalBytes ?? 0) + bytes;
+      maxPageMs = Math.max(maxPageMs, result.durationMs);
+      if (result.bytes !== null) {
+        totalBytes = (totalBytes ?? 0) + result.bytes;
       }
       if (page === 0) {
-        recordFirstPageFetch({
+        recordFirstPageFetch(
           assistantId,
-          status,
-          count: conversations.length,
-          hasMore,
-          durationMs,
-          bytes,
-          conversationType: options.conversationType ?? null,
-        });
+          result,
+          drainListKind(options),
+          "drain",
+        );
       }
-      for (const conversation of conversations) {
+      for (const conversation of result.conversations) {
         if (!seen.has(conversation.conversationId)) {
           seen.add(conversation.conversationId);
           all.push(conversation);
         }
       }
 
-      if (!hasMore) {
+      if (!result.hasMore) {
         break;
       }
 
-      if (conversations.length === 0) {
+      if (result.conversations.length === 0) {
         break;
       }
     }
@@ -505,20 +519,13 @@ export async function listArchivedConversations(
 export async function listConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const { conversations, hasMore, status, durationMs, bytes } =
-    await fetchConversationListPage(assistantId, 0);
-  recordFirstPageFetch({
-    assistantId,
-    status,
-    count: conversations.length,
-    hasMore,
-    durationMs,
-    bytes,
-    conversationType: null,
-  });
+  const page = await fetchConversationListPage(assistantId, 0);
+  recordFirstPageFetch(assistantId, page, "foreground", "first_page_refresh");
   return {
-    conversations: [...conversations].sort(byTimestampDesc("lastMessageAt")),
-    hasMore,
+    conversations: [...page.conversations].sort(
+      byTimestampDesc("lastMessageAt"),
+    ),
+    hasMore: page.hasMore,
   };
 }
 
@@ -526,24 +533,15 @@ export async function listConversationsFirstPage(
 export async function listBackgroundConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const { conversations, hasMore, status, durationMs, bytes } =
-    await fetchConversationListPage(assistantId, 0, {
-      conversationType: "background",
-    });
-  recordFirstPageFetch({
-    assistantId,
-    status,
-    count: conversations.length,
-    hasMore,
-    durationMs,
-    bytes,
+  const page = await fetchConversationListPage(assistantId, 0, {
     conversationType: "background",
   });
+  recordFirstPageFetch(assistantId, page, "background", "first_page_refresh");
   return {
-    conversations: conversations
+    conversations: page.conversations
       .filter((c) => !isScheduledConversation(c))
       .sort(byTimestampDesc("lastMessageAt")),
-    hasMore,
+    hasMore: page.hasMore,
   };
 }
 
@@ -551,22 +549,15 @@ export async function listBackgroundConversationsFirstPage(
 export async function listScheduledConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const { conversations, hasMore, status, durationMs, bytes } =
-    await fetchConversationListPage(assistantId, 0, {
-      conversationType: "scheduled",
-    });
-  recordFirstPageFetch({
-    assistantId,
-    status,
-    count: conversations.length,
-    hasMore,
-    durationMs,
-    bytes,
+  const page = await fetchConversationListPage(assistantId, 0, {
     conversationType: "scheduled",
   });
+  recordFirstPageFetch(assistantId, page, "scheduled", "first_page_refresh");
   return {
-    conversations: [...conversations].sort(byTimestampDesc("lastMessageAt")),
-    hasMore,
+    conversations: [...page.conversations].sort(
+      byTimestampDesc("lastMessageAt"),
+    ),
+    hasMore: page.hasMore,
   };
 }
 


### PR DESCRIPTION
## Summary
- conversation_list_page_fetch ring entries now carry listKind (matching the client_list.drain closed set) and a drain vs first_page_refresh source, so a slow offset-0 fetch is attributable to the path the user actually waited on
- recordFirstPageFetch reads its fields from the timed page (four literal arg-bags deleted); error diagnostics carry bytes like the history rail

Fixes gaps found during round-2 plan self-review for measure-first-telemetry-followups.md