### PR TITLE
fix(web): share the guarded random-id fallback with client identity

### DIFF
--- a/clients/web/src/lib/telemetry/client-identity.test.ts
+++ b/clients/web/src/lib/telemetry/client-identity.test.ts
@@ -65,6 +65,39 @@ function withNavigatorValues<T>(
   }
 }
 
+/**
+ * Swap `crypto.randomUUID` for the duration of `callback`, restoring the
+ * original descriptor afterwards. Pass `undefined` to model a non-secure
+ * context, where the property is absent entirely.
+ */
+async function withRandomUUID<T>(
+  implementation: (() => string) | undefined,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const cryptoObject = globalThis.crypto as unknown as {
+    randomUUID?: () => string;
+  };
+  const descriptor = Object.getOwnPropertyDescriptor(
+    cryptoObject,
+    "randomUUID",
+  );
+
+  Object.defineProperty(cryptoObject, "randomUUID", {
+    configurable: true,
+    value: implementation,
+    writable: true,
+  });
+  try {
+    return await callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(cryptoObject, "randomUUID", descriptor);
+    } else {
+      delete cryptoObject.randomUUID;
+    }
+  }
+}
+
 describe("client-identity", () => {
   test("getClientId returns a UUID", async () => {
     const mod = await freshImport();
@@ -91,6 +124,34 @@ describe("client-identity", () => {
     const b = await freshImport();
 
     expect(a.getClientId()).not.toBe(b.getClientId());
+  });
+
+  test("getClientId prefers the native UUID when crypto.randomUUID is available", async () => {
+    const NATIVE_UUID = "00000000-0000-4000-8000-000000000001";
+    await withRandomUUID(
+      () => NATIVE_UUID,
+      async () => {
+        const mod = await freshImport();
+        expect(mod.getClientId()).toBe(NATIVE_UUID);
+      },
+    );
+  });
+
+  test("getClientId returns a stable id when crypto.randomUUID is unavailable", async () => {
+    // Non-secure contexts (plain-http LAN dev, self-hosted over http) expose
+    // no `crypto.randomUUID`. Throwing here would break every telemetry
+    // family and the client-registration headers, so the id falls back.
+    await withRandomUUID(undefined, async () => {
+      const mod = await freshImport();
+      const first = mod.getClientId();
+
+      expect(typeof first).toBe("string");
+      expect(first).not.toBe("");
+      expect(mod.getClientId()).toBe(first);
+      expect(mod.getClientRegistrationHeaders()["X-Vellum-Client-Id"]).toBe(
+        first,
+      );
+    });
   });
 
   test("does not read from sessionStorage", async () => {

--- a/clients/web/src/lib/telemetry/client-identity.ts
+++ b/clients/web/src/lib/telemetry/client-identity.ts
@@ -8,13 +8,16 @@ import {
   detectClientOs,
 } from "@/runtime/platform-detection";
 
+import { mintRandomId } from "./random-id";
+
 let cached: string | null = null;
 
 /**
- * Returns a UUID identifying this page load.
+ * Returns an opaque id identifying this page load (a UUID wherever
+ * `crypto.randomUUID` is reachable, see `mintRandomId`).
  *
  * Generated on first call, cached in module memory for the rest of the
- * page's lifetime. Not persisted anywhere — each page load (initial nav,
+ * page's lifetime. Not persisted anywhere: each page load (initial nav,
  * reload, duplicated tab, restored bfcache entry) produces a fresh id.
  *
  * This is the unit the assistant daemon's self-echo suppression keys off:
@@ -27,7 +30,7 @@ export function getClientId(): string {
   if (cached) {
     return cached;
   }
-  cached = crypto.randomUUID();
+  cached = mintRandomId();
   return cached;
 }
 

--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -5,8 +5,9 @@
  *   - Nothing is emitted without analytics consent.
  *   - `boot_id` appears only once a boot id has been registered.
  *   - A throwing transport never propagates to the caller.
- *   - The page-load key is minted lazily and survives a runtime with no
- *     `crypto.randomUUID` (non-secure contexts).
+ *   - The page-load key is minted lazily, and it, the event id, and the
+ *     transport's client id all survive a runtime with no `crypto.randomUUID`
+ *     (non-secure contexts).
  *   - Surface and os come from a single platform probe per emit.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -29,6 +30,9 @@ mock.module("@/runtime/platform-detection", () => ({
   detectClientOs: detectClientOsMock,
   isNativeIOS: () => nativeIOS,
   isNativeAndroid: () => nativeAndroid,
+  // Unused by the emitter, present so `client-identity` (imported by the
+  // crypto-fallback test) still resolves its imports against this stub.
+  detectBrowserInfo: () => ({}),
 }));
 
 const { __resetClientPerfForTests, emitClientPerfEvent, setClientPerfBootId } =
@@ -46,14 +50,24 @@ function lastDetail(): Record<string, unknown> {
   return lastEvent().detail as Record<string, unknown>;
 }
 
-/** Every member of the exported union, so a dropped name fails to compile. */
-const ALL_CHECK_NAMES: readonly ClientPerfCheckName[] = [
+/**
+ * Every member of the exported union. `satisfies` rejects an entry that is not
+ * a check name, and the `AssertNever` alias below rejects a check name that is
+ * missing from the tuple, so the list stays exhaustive in both directions.
+ */
+const ALL_CHECK_NAMES = [
   "client_switch.transcript_painted",
   "client_switch.stalled",
   "client_switch.abandoned",
   "client_resume.request_count",
   "client_list.drain",
-];
+] as const satisfies readonly ClientPerfCheckName[];
+
+type AssertNever<T extends never> = T;
+
+type _UncoveredCheckNames = AssertNever<
+  Exclude<ClientPerfCheckName, (typeof ALL_CHECK_NAMES)[number]>
+>;
 
 beforeEach(() => {
   consent = true;
@@ -84,7 +98,7 @@ describe("emitClientPerfEvent", () => {
     expect(typeof detail.os).toBe("string");
   });
 
-  test("accepts every check name in the exported union", () => {
+  test("emits every check name in the union verbatim", () => {
     for (const checkName of ALL_CHECK_NAMES) {
       emitClientPerfEvent(checkName, 1);
       expect(lastEvent().check_name).toBe(checkName);
@@ -153,10 +167,14 @@ describe("emitClientPerfEvent", () => {
     expect(lastDetail().surface).toBe("android_native");
   });
 
-  test("still emits when crypto.randomUUID is unavailable", () => {
+  test("still emits when crypto.randomUUID is unavailable", async () => {
     const cryptoObject = globalThis.crypto as unknown as {
       randomUUID?: () => string;
     };
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      cryptoObject,
+      "randomUUID",
+    );
     Object.defineProperty(cryptoObject, "randomUUID", {
       configurable: true,
       value: undefined,
@@ -164,9 +182,25 @@ describe("emitClientPerfEvent", () => {
     });
 
     try {
+      // The real transport stamps the payload's `device_id` from
+      // `getClientId()`, so a throw there lands in the emitter's catch and
+      // drops the sample. Import it fresh so its cache is cold under this
+      // runtime, and read it from the transport stub the way ingest does.
+      const { getClientId } = (await import(
+        `@/lib/telemetry/client-identity?t=${Math.random()}`
+      )) as typeof import("./client-identity");
+      let deviceId: string | null = null;
+      postTelemetryEventsMock.mockImplementation(() => {
+        deviceId = getClientId();
+      });
+
       expect(() => {
         emitClientPerfEvent("client_list.drain", 1);
       }).not.toThrow();
+
+      expect(postTelemetryEventsMock).toHaveBeenCalledTimes(1);
+      expect(typeof deviceId).toBe("string");
+      expect(deviceId).not.toBe("");
 
       const event = lastEvent();
       expect(typeof event.daemon_event_id).toBe("string");
@@ -176,7 +210,11 @@ describe("emitClientPerfEvent", () => {
       emitClientPerfEvent("client_list.drain", 2);
       expect(lastDetail().page_load_id).toBe(pageLoadId);
     } finally {
-      delete cryptoObject.randomUUID;
+      if (originalDescriptor) {
+        Object.defineProperty(cryptoObject, "randomUUID", originalDescriptor);
+      } else {
+        delete cryptoObject.randomUUID;
+      }
     }
   });
 });

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -1,5 +1,6 @@
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+import { mintRandomId } from "@/lib/telemetry/random-id";
 import {
   detectClientOs,
   isNativeAndroid,
@@ -40,18 +41,6 @@ export type ClientPerfCheckName =
   | "client_switch.abandoned"
   | "client_resume.request_count"
   | "client_list.drain";
-
-/**
- * `crypto.randomUUID` is unavailable in non-secure contexts (plain-http LAN
- * dev, self-hosted over http), so fall back rather than throw. This module sits
- * on the eager boot import chain, where a throw would take the app down with
- * it.
- */
-function mintRandomId(): string {
-  return typeof globalThis.crypto?.randomUUID === "function"
-    ? globalThis.crypto.randomUUID()
-    : `perf-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
 
 let pageLoadId: string | null = null;
 

--- a/clients/web/src/lib/telemetry/random-id.ts
+++ b/clients/web/src/lib/telemetry/random-id.ts
@@ -1,0 +1,19 @@
+/**
+ * Mints an opaque id for telemetry grouping keys and client identity.
+ *
+ * `crypto.randomUUID` is unavailable in non-secure contexts (plain-http LAN
+ * dev, self-hosted over http), so fall back rather than throw. The callers sit
+ * on the eager boot import chain and on the fire-and-forget telemetry path,
+ * where a throw either takes the app down or silently drops every sample.
+ *
+ * Both consumers treat the result as an opaque string: the daemon reads
+ * `X-Vellum-Client-Id` as a free-form header and the platform's ingest
+ * endpoint stores `device_id` as a free-form field. The `fallback-` prefix
+ * marks ids minted without `crypto` so they stay distinguishable downstream
+ * from real UUIDs.
+ */
+export function mintRandomId(): string {
+  return typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : `fallback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}


### PR DESCRIPTION
## Summary
- getClientId now uses the same guarded randomUUID fallback as client-perf, so telemetry on non-secure contexts is emitted instead of silently swallowed by the emitter's try/catch
- Helper placed to avoid an import cycle (client-perf -> ingest -> client-identity)
- client-perf test's hand-duplicated check-name loop replaced with a compile-time exhaustiveness check

Fixes gaps found during round-2 plan self-review for measure-first-telemetry-followups.md