### PR TITLE
fix(web): resume-counter registration order, timer staleness guard, gate reasons

### DIFF
--- a/clients/web/src/hooks/use-event-bus-init.test.tsx
+++ b/clients/web/src/hooks/use-event-bus-init.test.tsx
@@ -12,7 +12,8 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 import { sseService } from "@/assistant/sse-service";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
-import { __resetForTesting } from "@/lib/event-bus";
+import { publish, __resetForTesting } from "@/lib/event-bus";
+import { isResumeWindowOpen } from "@/lib/telemetry/resume-request-counter";
 
 const detachMock = mock(() => {});
 const attachSpy = spyOn(sseService, "attach").mockImplementation(
@@ -61,5 +62,23 @@ describe("useEventBusInit — attach gating", () => {
     );
     expect(attachSpy).toHaveBeenCalledTimes(1);
     expect(attachSpy.mock.calls[0]![0]).toBe("asst-1");
+  });
+});
+
+// The post-resume request counter is deliberately not one of this hook's
+// subscribers. React runs descendant effects before ancestor ones, so a
+// counter registered here would open its window after the subscribers inside
+// the tree had already fired their resume requests. It installs from
+// `lib/api-interceptors.ts` module scope instead, which nothing in this file
+// imports.
+describe("useEventBusInit resume-counter registration", () => {
+  test("does not register the counter, so no window opens on resume", () => {
+    renderHook(() =>
+      useEventBusInit({ assistantId: "asst-1", isAssistantActive: true }),
+    );
+
+    publish("app.resume", { signal: "visibility" });
+
+    expect(isResumeWindowOpen()).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -27,7 +27,6 @@ import { useEffect } from "react";
 import { sseService } from "@/assistant/sse-service";
 import { subscribeLifecycleDiagnostics } from "@/lib/lifecycle-diagnostics";
 import { setupQueryFocusManager } from "@/lib/query-focus-manager";
-import { subscribeResumeRequestCounter } from "@/lib/telemetry/resume-request-counter";
 import { subscribeSwitchTelemetry } from "@/lib/telemetry/switch-telemetry";
 import { publishCapacitorAppStateSource } from "@/runtime/event-sources/capacitor-app-state";
 import { publishCapacitorDeepLinksSource } from "@/runtime/event-sources/capacitor-deep-links";
@@ -68,7 +67,6 @@ export function useEventBusInit({
       publishElectronDeepLinksSource(),
       publishElectronConnectivitySource(),
       subscribeLifecycleDiagnostics(),
-      subscribeResumeRequestCounter(),
       subscribeSwitchTelemetry(),
       setupQueryFocusManager(),
     ];

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -91,11 +91,16 @@ const noteDaemonApiRequestMock = mock((url: string) => {
   noteDaemonApiRequestImpl(url);
 });
 const isResumeWindowOpenMock = mock(() => resumeWindowOpen);
+// `installResumeRequestCounter` is stubbed for surface parity only. The module
+// under test calls it at module scope, and ESM imports are hoisted above these
+// `mock.module` calls, so that one call already ran against the real
+// implementation before the stub took over. It subscribes to the bus and
+// nothing here publishes to it.
 mock.module("@/lib/telemetry/resume-request-counter", () => ({
   __resetResumeRequestCounterForTests: () => {},
+  installResumeRequestCounter: () => {},
   isResumeWindowOpen: isResumeWindowOpenMock,
   noteDaemonApiRequest: noteDaemonApiRequestMock,
-  subscribeResumeRequestCounter: () => () => {},
 }));
 
 import { client as daemonClient } from "@/generated/daemon/client.gen";
@@ -867,6 +872,9 @@ describe("api-interceptors / platform features gate", () => {
     const input = new Request("https://platform.test/v1/organizations/");
     const output = platformFeaturesGate(input);
     expect(output.signal.aborted).toBe(true);
+    expect((output.signal.reason as DOMException).message).toBe(
+      "Platform features disabled in local mode",
+    );
   });
 
   test("passes through gateway-rewritten requests when platform is disabled", () => {
@@ -893,6 +901,9 @@ describe("api-interceptors / platform features gate", () => {
     );
     const output = platformFeaturesGate(input);
     expect(output.signal.aborted).toBe(true);
+    expect((output.signal.reason as DOMException).message).toBe(
+      "Platform routes disabled in remote-gateway mode",
+    );
   });
 
   test("passes bearer-authenticated gateway requests in remote-gateway mode", () => {

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -21,7 +21,9 @@
  * error state).
  *
  * Import this module for its side effects in the app entrypoint
- * (`main.tsx`) so interceptors are installed before any API call fires.
+ * (`main.tsx`) so interceptors are installed before any API call fires. The
+ * same import installs the post-resume request counter these interceptors feed,
+ * which needs to be subscribed to `app.resume` before React mounts.
  *
  * Reference: https://heyapi.dev/openapi-ts/clients/fetch#interceptors
  */
@@ -47,6 +49,7 @@ import {
 } from "@/lib/self-hosted/connection";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity";
 import {
+  installResumeRequestCounter,
   isResumeWindowOpen,
   noteDaemonApiRequest,
 } from "@/lib/telemetry/resume-request-counter";
@@ -355,7 +358,9 @@ function createInterceptor({
     if (isDaemonClient) {
       return true;
     }
-    return isDaemonBoundPath(url) && platformFeaturesGateAllows(outgoing);
+    return (
+      isDaemonBoundPath(url) && platformFeaturesGateAllows(outgoing) === "allow"
+    );
   }
 
   const route = async (request: Request): Promise<Request> => {
@@ -743,6 +748,14 @@ export function daemonErrorInterceptor(
   return toApiError(error, response);
 }
 
+// Register the post-resume counting window here, alongside the interceptors
+// that feed it. `main.tsx` imports this module for its side effects before
+// React renders, so the counter's `app.resume` handler lands ahead of every
+// subscriber the React tree adds and the requests they fire synchronously on
+// resume are counted. See the function's docstring for why a React effect
+// cannot give that guarantee.
+installResumeRequestCounter();
+
 daemonClient.interceptors.request.use(daemonRequestInterceptor);
 daemonClient.interceptors.response.use(daemonUnreachableInterceptor);
 daemonClient.interceptors.response.use(localGatewayAuthRecoveryInterceptor);
@@ -797,34 +810,44 @@ function arePlatformFeaturesEnabled(): boolean {
 }
 
 /**
- * Whether {@link platformFeaturesGate} forwards this request.
+ * What {@link platformFeaturesGate} does with a request. A deny carries the
+ * reason it was denied, so the gate reports it without re-probing the mode this
+ * function already looked at; a third reason cannot be mislabelled as one of
+ * the existing two.
+ */
+type PlatformGateDecision = "allow" | "deny_remote_gateway" | "deny_local";
+
+/**
+ * The decision {@link platformFeaturesGate} reaches for this request.
  *
  * Takes the request as the gate sees it: the gate is registered after
  * {@link requestInterceptor}, so a self-hosted rewrite (gateway origin, bearer
  * auth) has already happened by the time it runs.
  */
-function platformFeaturesGateAllows(request: Request): boolean {
+function platformFeaturesGateAllows(request: Request): PlatformGateDecision {
   if (isRemoteGatewayMode()) {
-    return (
+    const hasBearer =
       request.headers
         .get("Authorization")
         ?.toLowerCase()
-        .startsWith("bearer ") ?? false
-    );
+        .startsWith("bearer ") ?? false;
+    return hasBearer ? "allow" : "deny_remote_gateway";
   }
 
   if (!isLocalClient()) {
-    return true;
+    return "allow";
   }
   if (arePlatformFeaturesEnabled()) {
-    return true;
+    return "allow";
   }
 
   const ingressUrl = getSelfHostedIngressUrl();
   if (!ingressUrl) {
-    return false;
+    return "deny_local";
   }
-  return new URL(request.url).origin === new URL(ingressUrl).origin;
+  return new URL(request.url).origin === new URL(ingressUrl).origin
+    ? "allow"
+    : "deny_local";
 }
 
 /**
@@ -838,11 +861,12 @@ function platformFeaturesGateAllows(request: Request): boolean {
  * Exported for direct unit testing.
  */
 export function platformFeaturesGate(request: Request): Request {
-  if (platformFeaturesGateAllows(request)) {
+  const decision = platformFeaturesGateAllows(request);
+  if (decision === "allow") {
     return request;
   }
 
-  const remoteGateway = isRemoteGatewayMode();
+  const remoteGateway = decision === "deny_remote_gateway";
   console.debug(
     remoteGateway
       ? "remote-gateway mode, no-op platform request:"

--- a/clients/web/src/lib/telemetry/resume-request-counter.test.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.test.ts
@@ -2,11 +2,13 @@
  * Pins the post-resume request counter's contract:
  *   - one window per foreground, even when iOS publishes two resume signals;
  *   - a backgrounding drops the window instead of emitting a partial sample;
- *   - a window whose timer was frozen while backgrounded is replaced, so the
- *     next foreground gets its own window attributed to its own signal;
+ *   - a window whose timer was frozen while suspended is replaced on the next
+ *     resume, and discarded outright when the frozen timer thaws first;
+ *   - requests a later-registered resume subscriber fires synchronously are
+ *     counted, which is what installing at module scope buys;
  *   - only requests inside the window are counted;
  *   - endpoint labels come from the closed set, never a raw path;
- *   - a zero-count window still emits, and unsubscribe cancels silently.
+ *   - a zero-count window still emits.
  *
  * bun:test has no fake-timer API, so `setTimeout` / `clearTimeout` are swapped
  * for a capturing stub and fired by hand, the same idiom
@@ -28,12 +30,14 @@ mock.module("@/lib/telemetry/client-perf", () => ({
   __resetClientPerfForTests: () => {},
 }));
 
-const { publish, __resetForTesting } = await import("@/lib/event-bus");
+const { publish, subscribe, __resetForTesting } = await import(
+  "@/lib/event-bus"
+);
 const {
   __resetResumeRequestCounterForTests,
+  installResumeRequestCounter,
   isResumeWindowOpen,
   noteDaemonApiRequest,
-  subscribeResumeRequestCounter,
 } = await import("./resume-request-counter");
 
 const originalSetTimeout = globalThis.setTimeout;
@@ -103,9 +107,9 @@ afterEach(() => {
   performance.now = originalPerformanceNow;
 });
 
-describe("subscribeResumeRequestCounter", () => {
+describe("installResumeRequestCounter", () => {
   test("counts one window across the iOS double-publish", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
     publish("app.resume", { signal: "app_state" });
 
@@ -120,11 +124,46 @@ describe("subscribeResumeRequestCounter", () => {
     expect(detail.window_ms).toBe(10_000);
     expect(detail.signal).toBe("visibility");
     expect(lastDelay).toBe(10_000);
-    unsubscribe();
+  });
+
+  test("counts requests a later-registered resume handler fires synchronously", () => {
+    installResumeRequestCounter();
+    // Stands in for a subscriber the React tree registers (the timezone sync,
+    // the runtime-upgrade banner): it fires daemon requests synchronously from
+    // inside its own `app.resume` handler. Production guarantees this ordering
+    // by installing the counter from module scope, before React mounts.
+    const unsubscribeSubscriber = subscribe("app.resume", () => {
+      noteDaemonApiRequest("https://api.test/v1/assistants/a1/config");
+      noteDaemonApiRequest("https://api.test/v1/assistants/a1/home");
+    });
+
+    publish("app.resume", { signal: "app_state" });
+    fireTimers();
+
+    expect(lastEmit().value).toBe(2);
+    expect(byGroup()).toEqual({ config: 1, home: 1 });
+    unsubscribeSubscriber();
+  });
+
+  test("a resume handler registered before the counter is not counted", () => {
+    // The bus dispatches in registration order, so this is the ordering the
+    // counter has to beat: the head of the burst is gone before the window
+    // opens. Pins why the install happens at module scope rather than from a
+    // React effect, which descendant subscribers would run ahead of.
+    const unsubscribeSubscriber = subscribe("app.resume", () => {
+      noteDaemonApiRequest("https://api.test/v1/assistants/a1/config");
+    });
+    installResumeRequestCounter();
+
+    publish("app.resume", { signal: "app_state" });
+    fireTimers();
+
+    expect(lastEmit().value).toBe(0);
+    unsubscribeSubscriber();
   });
 
   test("ignores requests before the window opens and after it closes", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
 
     publish("app.resume", { signal: "visibility" });
@@ -134,11 +173,10 @@ describe("subscribeResumeRequestCounter", () => {
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
     expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
     expect(lastEmit().value).toBe(1);
-    unsubscribe();
   });
 
   test("drops the window on app.hidden without emitting", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "app_state" });
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
 
@@ -148,11 +186,10 @@ describe("subscribeResumeRequestCounter", () => {
     expect(pendingTimers.size).toBe(0);
     fireTimers();
     expect(emitClientPerfEventMock).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
   test("counts the next foreground after a hidden edge", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
     publish("app.hidden", { signal: "visibility" });
@@ -165,11 +202,10 @@ describe("subscribeResumeRequestCounter", () => {
     expect(lastEmit().value).toBe(1);
     expect(lastEmit().detail.signal).toBe("app_state");
     expect(byGroup()).toEqual({ skills: 1 });
-    unsubscribe();
   });
 
   test("replaces a window whose timer was frozen while backgrounded", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
 
@@ -185,11 +221,25 @@ describe("subscribeResumeRequestCounter", () => {
     expect(value).toBe(1);
     expect(detail.signal).toBe("app_state");
     expect(byGroup()).toEqual({ integrations: 1 });
-    unsubscribe();
+  });
+
+  test("drops a window whose frozen timer thaws long after its span", () => {
+    installResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+
+    // Desktop system sleep with a focused tab fires no visibilitychange, so
+    // nothing cancels the window; the timer freezes and thaws minutes later,
+    // with counts spanning the whole sleep rather than the labelled 10s.
+    nowMs = 300_000;
+    fireTimers();
+
+    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
+    expect(isResumeWindowOpen()).toBe(false);
   });
 
   test("keeps the first window when the second resume lands inside its span", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
 
     nowMs = 9_999;
@@ -199,11 +249,10 @@ describe("subscribeResumeRequestCounter", () => {
 
     expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
     expect(lastEmit().detail.signal).toBe("visibility");
-    unsubscribe();
   });
 
   test("labels endpoints from the closed set and emits no path strings", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "app_state" });
 
     noteDaemonApiRequest("/v1/assistants/x/conversations?limit=50");
@@ -220,11 +269,10 @@ describe("subscribeResumeRequestCounter", () => {
     expect(serialized).not.toContain("assistants");
     expect(serialized).not.toContain("http");
     expect(serialized).not.toContain("frobnicate");
-    unsubscribe();
   });
 
   test("labels the daemon's high-traffic segments instead of pooling them", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "app_state" });
 
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/integrations");
@@ -246,34 +294,20 @@ describe("subscribeResumeRequestCounter", () => {
     for (const count of Object.values(byGroup())) {
       expect(typeof count).toBe("number");
     }
-    unsubscribe();
   });
 
   test("emits a zero-count window", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "online" });
     fireTimers();
 
     expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
     expect(lastEmit().value).toBe(0);
     expect(byGroup()).toEqual({});
-    unsubscribe();
-  });
-
-  test("unsubscribe cancels an open window without emitting", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
-    publish("app.resume", { signal: "visibility" });
-    noteDaemonApiRequest("https://api.test/v1/assistants/a1/messages");
-
-    unsubscribe();
-    fireTimers();
-
-    expect(emitClientPerfEventMock).not.toHaveBeenCalled();
-    expect(pendingTimers.size).toBe(0);
   });
 
   test("opens a fresh window on the next resume", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/events");
     fireTimers();
@@ -285,13 +319,12 @@ describe("subscribeResumeRequestCounter", () => {
     expect(emitClientPerfEventMock).toHaveBeenCalledTimes(2);
     expect(lastEmit().value).toBe(1);
     expect(byGroup()).toEqual({ config: 1 });
-    unsubscribe();
   });
 });
 
 describe("noteDaemonApiRequest", () => {
   test("never throws on a malformed url", () => {
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     publish("app.resume", { signal: "visibility" });
 
     expect(() => {
@@ -301,7 +334,6 @@ describe("noteDaemonApiRequest", () => {
 
     expect(lastEmit().value).toBe(1);
     expect(byGroup()).toEqual({ other: 1 });
-    unsubscribe();
   });
 
   test("is a no-op outside a window", () => {
@@ -316,7 +348,7 @@ describe("isResumeWindowOpen", () => {
   test("tracks the window so callers can skip work on the request path", () => {
     expect(isResumeWindowOpen()).toBe(false);
 
-    const unsubscribe = subscribeResumeRequestCounter();
+    installResumeRequestCounter();
     expect(isResumeWindowOpen()).toBe(false);
 
     publish("app.resume", { signal: "visibility" });
@@ -324,6 +356,5 @@ describe("isResumeWindowOpen", () => {
 
     fireTimers();
     expect(isResumeWindowOpen()).toBe(false);
-    unsubscribe();
   });
 });

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -6,9 +6,19 @@
  * instead of an anecdote: one `client_resume.request_count` event per resume,
  * carrying the total and a per-endpoint-group breakdown.
  *
- * Only whole windows are reported. A backgrounding truncates the burst and
- * freezes the WKWebView's timers, so a window that spans a background is a
- * contaminated sample and is dropped rather than emitted.
+ * Only whole windows are reported. `app.hidden` is the primary defence: a
+ * backgrounding truncates the burst and freezes the host's timers, so the open
+ * window is dropped rather than emitted. The `openedAt` staleness checks, one
+ * on the resume edge and one in the timer callback, are the fallback for a
+ * suspension that fires no hidden edge at all: desktop system sleep with a
+ * focused tab, and the WKWebView paths that suspend without a visibility
+ * change. Their timers thaw far past the window's span, so the observed age of
+ * the window is the only thing left that gives them away.
+ *
+ * {@link installResumeRequestCounter} runs from `lib/api-interceptors.ts`
+ * module scope, before React renders, so the counter's `app.resume` handler is
+ * registered ahead of every subscriber the React tree adds and the requests
+ * those subscribers fire synchronously on resume land inside the window.
  *
  * Metadata only. Endpoint labels come from a closed set; raw pathnames and
  * URLs are never stored or emitted.
@@ -94,7 +104,7 @@ type ResumeWindow = {
   /** Monotonic open time, used to detect a window whose timer was frozen. */
   openedAt: number;
   total: number;
-  byGroup: Record<string, number>;
+  byGroup: Partial<Record<EndpointGroup, number>>;
   signal: AppResumeSignal;
 };
 
@@ -114,6 +124,13 @@ function openWindow(signal: AppResumeSignal): void {
     const closed = resumeWindow;
     resumeWindow = null;
     if (!closed) {
+      return;
+    }
+    // Fallback for a suspension that fired no `app.hidden`. A frozen timer
+    // thaws long past the span it was scheduled for, so its counts cover the
+    // whole suspension rather than the `window_ms` they would be labelled
+    // with. Discard the contaminated sample instead of emitting it.
+    if (performance.now() - closed.openedAt >= WINDOW_MS * 2) {
       return;
     }
     // A zero here is the signal we are looking for once the storm is fixed,
@@ -152,19 +169,39 @@ export function noteDaemonApiRequest(url: string): void {
   resumeWindow.byGroup[group] = (resumeWindow.byGroup[group] ?? 0) + 1;
 }
 
+let installed = false;
+
 /**
  * Opens a counting window on each `app.resume` and drops it on `app.hidden`.
- * Returns an unsubscribe that also drops any window still open, without
- * emitting.
+ * Idempotent.
+ *
+ * Called from `lib/api-interceptors.ts` module scope rather than from a React
+ * effect, and the ordering is the whole point. React runs descendant effects
+ * before ancestor ones, so a subscriber registered from inside the tree (the
+ * timezone sync, the runtime-upgrade banner) would run ahead of a counter
+ * registered in `RootLayout`, and the daemon requests it fires synchronously in
+ * its own `app.resume` handler would land before the window opened. `main.tsx`
+ * imports the interceptor module for its side effects before React renders, so
+ * installing there puts this handler first.
+ *
+ * The subscription lasts for the document. Nothing owns it that could unmount,
+ * and it holds no per-consumer state: two bus handlers and one module-level
+ * window. That is the same document lifetime the interceptors it installs
+ * alongside already have.
  */
-export function subscribeResumeRequestCounter(): () => void {
-  const unsubscribeResume = subscribe("app.resume", ({ signal }) => {
+export function installResumeRequestCounter(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  subscribe("app.resume", ({ signal }) => {
     if (resumeWindow) {
       // iOS publishes both a visibility and an app_state resume for a single
       // foreground; the first edge wins so the burst is counted once. A window
       // older than its own span is one whose timer was frozen while the app was
-      // backgrounded: its counts belong to an earlier foreground, so drop it
-      // and start a fresh window for this resume.
+      // suspended: its counts belong to an earlier foreground, so drop it and
+      // start a fresh window for this resume.
       if (performance.now() - resumeWindow.openedAt < WINDOW_MS) {
         return;
       }
@@ -176,17 +213,16 @@ export function subscribeResumeRequestCounter(): () => void {
   // A backgrounding cuts the burst short, so whatever the window has counted so
   // far is a partial sample. Drop it rather than emit a number that reads as a
   // quiet resume.
-  const unsubscribeHidden = subscribe("app.hidden", () => {
+  subscribe("app.hidden", () => {
     cancelOpenWindow();
   });
-
-  return () => {
-    unsubscribeResume();
-    unsubscribeHidden();
-    cancelOpenWindow();
-  };
 }
 
+/**
+ * Drops the open window and clears the install latch. Pairs with the bus's
+ * `__resetForTesting()`, which drops the handlers themselves.
+ */
 export function __resetResumeRequestCounterForTests(): void {
   cancelOpenWindow();
+  installed = false;
 }


### PR DESCRIPTION
## Summary
- The counter now subscribes before any React-registered app.resume handler, so requests fired synchronously by early subscribers (timezone sync, upgrade banner) are counted
- The window timer re-checks openedAt on fire, so a sleep-frozen timer discards its contaminated sample instead of emitting it; app.hidden remains the primary defence and the docstring says so
- platformFeaturesGateAllows returns allow/deny reasons so the gate no longer re-derives them; byGroup is typed to the closed EndpointGroup set

Fixes gaps found during round-2 plan self-review for measure-first-telemetry-followups.md