### PR TITLE
fix(assistant): warn only on a genuine presence ownership mismatch

### DIFF
--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -426,9 +426,9 @@ export class AssistantEventHub {
   }
 
   /**
-   * Yield every active client entry with the given clientId. A reconnecting
-   * client can briefly own more than one entry, so callers that mutate state
-   * must consume all of them.
+   * Yield every active client entry with the given clientId. `subscribe`
+   * disposes any prior entries for the same clientId, so at most one entry
+   * matches.
    */
   private *activeClientEntries(clientId: string): Generator<ClientEntry> {
     for (const entry of this.subscribers) {

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -8,7 +8,10 @@
  *
  * POST /v1/clients/presence (report_client_presence) records presence keyed
  * off the `x-vellum-client-id` header, and applies the same ownership posture:
- * only the actor that owns the target client may report its presence.
+ * only the actor that owns the target client may report its presence. The
+ * handler resolves the client before comparing owners, so an unconnected
+ * clientId (a report racing an SSE reconnect) and a connected-but-unowned one
+ * are distinct paths that both answer `{ recorded: false }`.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -185,7 +188,9 @@ describe("report_client_presence route", () => {
     );
   });
 
-  test("returns recorded false when no connected client matches", () => {
+  test("returns recorded false when the reported client is not connected", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
     const handler = findHandler("report_client_presence");
     const result = handler({
       headers: {
@@ -196,6 +201,9 @@ describe("report_client_presence route", () => {
     }) as { recorded: boolean };
 
     expect(result).toEqual({ recorded: false });
+    expect(
+      assistantEventHub.getClientById("client-A1")?.presence,
+    ).toBeUndefined();
   });
 
   test("returns recorded false when the caller does not own the client", () => {
@@ -277,6 +285,21 @@ describe("report_client_presence route", () => {
     expect(assistantEventHub.getClientById("client-A1")?.presence?.state).toBe(
       "idle",
     );
+  });
+
+  test("dev-bypass mode returns recorded false for an unconnected client", () => {
+    fakeHttpAuthDisabled = true;
+
+    const handler = findHandler("report_client_presence");
+    const result = handler({
+      headers: {
+        "x-vellum-client-id": "client-gone",
+        "x-vellum-actor-principal-id": "user-A",
+      },
+      body: { state: "idle" },
+    }) as { recorded: boolean };
+
+    expect(result).toEqual({ recorded: false });
   });
 
   test("throws BadRequestError when the client-id header is missing", () => {

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -161,6 +161,20 @@ export const ROUTES: RouteDefinition[] = [
       }
       const { state } = parseBody(PresenceBodySchema, body);
 
+      // Resolving the client first separates "nobody is listening" from
+      // "somebody else owns this", so only the second one is worth a warn.
+      const client = assistantEventHub.getClientById(clientId);
+      if (!client) {
+        // Debug, not warn: a report racing an SSE reconnect matches nothing,
+        // and a reconnect storm would otherwise emit a warn per client every
+        // 30 seconds for a benign race. Not a 404 either, for the same reason.
+        log.debug(
+          { op: "report_client_presence", state },
+          "Presence report matched no connected client",
+        );
+        return { recorded: false };
+      }
+
       // Only the actor that opened the target client's SSE stream may report
       // its presence, so a caller who learns another user's clientId cannot
       // spoof that desktop. Clients with no stored `actorPrincipalId` (legacy
@@ -170,25 +184,23 @@ export const ROUTES: RouteDefinition[] = [
       // deployments where the platform handles auth.
       if (!isHttpAuthDisabled()) {
         const callerPrincipalId = headers?.["x-vellum-actor-principal-id"];
-        const ownerPrincipalId =
-          assistantEventHub.getActorPrincipalIdForClient(clientId);
+        const ownerPrincipalId = client.actorPrincipalId;
         if (
           ownerPrincipalId === undefined ||
           ownerPrincipalId !== callerPrincipalId
         ) {
-          // Warn, not debug: a mismatch means the gateway stopped forwarding
-          // the actor header, a scope profile shifted, or a caller is probing
-          // someone else's client. Without this line presence gating dies
-          // silently and every suppressed push quietly resumes. Client and
-          // principal ids stay out of the entry so the log cannot be used to
-          // enumerate them.
+          // Warn, not debug: the client is connected, so a mismatch means the
+          // gateway stopped forwarding the actor header, a scope profile
+          // shifted, or a caller is probing someone else's client. Without this
+          // line presence gating dies silently and every suppressed push
+          // quietly resumes. Client and principal ids stay out of the entry so
+          // the log cannot be used to enumerate them.
           log.warn(
             {
               op: "report_client_presence",
               hasStoredOwner: ownerPrincipalId !== undefined,
               hasCallerPrincipal: callerPrincipalId !== undefined,
-              targetInterfaceId:
-                assistantEventHub.getClientById(clientId)?.interfaceId,
+              targetInterfaceId: client.interfaceId,
             },
             "Rejecting presence report from a caller that does not own the client",
           );
@@ -197,17 +209,9 @@ export const ROUTES: RouteDefinition[] = [
         }
       }
 
-      // A report racing an SSE reconnect matches nothing; normal, so not a 404.
-      const recorded = assistantEventHub.setClientPresence(clientId, state);
-      if (!recorded) {
-        // Debug, not warn: a reconnect storm would otherwise emit a warn per
-        // client every 30 seconds for a benign race.
-        log.debug(
-          { op: "report_client_presence", state },
-          "Presence report matched no connected client",
-        );
-        return { recorded };
-      }
+      // The lookup ran in this same synchronous handler, so the write lands on
+      // the entry it resolved.
+      assistantEventHub.setClientPresence(clientId, state);
 
       // Records which state a client actually reported. Nothing else persists
       // it, so this is the only evidence for why a machine did or did not
@@ -217,11 +221,11 @@ export const ROUTES: RouteDefinition[] = [
         {
           op: "report_client_presence",
           state,
-          interfaceId: assistantEventHub.getClientById(clientId)?.interfaceId,
+          interfaceId: client.interfaceId,
         },
         "Recorded desktop presence",
       );
-      return { recorded };
+      return { recorded: true };
     },
   },
 ];


### PR DESCRIPTION
## Summary
- Distinguishes an unconnected client from an unowned one, so a presence report racing an SSE reconnect logs at debug instead of warning once per assistant every 30s
- The warn is now reserved for a connected client whose stored owner is absent or does not match the caller, which is the misconfiguration the log was added to surface
- Response contract, dev-bypass carve-out, and the ownership guarantee are unchanged

Fixes a regression found during plan self-review for presence-gated-reply-push.md