### PR TITLE
feat(api): add optional requestedScopes to the oauth_connect surface data schema

### DIFF
--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -204,6 +204,7 @@ describe("choice and copy_block surface proxying", () => {
       providerKey: "google",
       displayName: "Google",
       description: "Connect Gmail for this task.",
+      requestedScopes: ["gmail.readonly"],
     });
     expect(ctx.pendingSurfaceActions.get(showMessage.surfaceId)).toEqual({
       surfaceType: "oauth_connect",

--- a/assistant/src/api/surfaces-oauth-connect.test.ts
+++ b/assistant/src/api/surfaces-oauth-connect.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OAuthConnectSurfaceDataSchema,
+  type OAuthConnectSurfaceData,
+} from "./surfaces.js";
+
+describe("OAuthConnectSurfaceDataSchema requestedScopes", () => {
+  test("parses a valid scopes array and preserves order", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+      requestedScopes: [
+        "https://www.googleapis.com/auth/tasks",
+        "https://www.googleapis.com/auth/calendar",
+        "openid",
+      ],
+    });
+    expect(parsed.requestedScopes).toEqual([
+      "https://www.googleapis.com/auth/tasks",
+      "https://www.googleapis.com/auth/calendar",
+      "openid",
+    ]);
+  });
+
+  test("absent requestedScopes parses to undefined", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+    });
+    expect(parsed.requestedScopes).toBeUndefined();
+  });
+
+  test("an empty array collapses to undefined", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+      requestedScopes: [],
+    });
+    expect(parsed.requestedScopes).toBeUndefined();
+  });
+
+  test("non-array values collapse to undefined instead of rejecting", () => {
+    for (const value of [
+      "https://www.googleapis.com/auth/tasks, openid",
+      42,
+      true,
+      { scope: "openid" },
+      null,
+    ]) {
+      const parsed = OAuthConnectSurfaceDataSchema.parse({
+        providerKey: "google",
+        requestedScopes: value,
+      });
+      expect(parsed.requestedScopes).toBeUndefined();
+    }
+  });
+
+  test("an array of blanks collapses to undefined", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+      requestedScopes: ["", "   ", "\t"],
+    });
+    expect(parsed.requestedScopes).toBeUndefined();
+  });
+
+  test("entries are trimmed and blank or non-string junk is dropped", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+      requestedScopes: [
+        "  https://www.googleapis.com/auth/tasks  ",
+        "",
+        null,
+        { nope: true },
+        "openid",
+      ],
+    });
+    expect(parsed.requestedScopes).toEqual([
+      "https://www.googleapis.com/auth/tasks",
+      "openid",
+    ]);
+  });
+
+  test("a bare string is not split on commas (scopes are opaque URIs)", () => {
+    const parsed = OAuthConnectSurfaceDataSchema.parse({
+      providerKey: "google",
+      requestedScopes: "a,b,c",
+    });
+    expect(parsed.requestedScopes).toBeUndefined();
+  });
+
+  test("legacy payload { providerKey: 'google' } still parses (skew guard)", () => {
+    const parsed: OAuthConnectSurfaceData = OAuthConnectSurfaceDataSchema.parse(
+      { providerKey: "google" },
+    );
+    expect(parsed.providerKey).toBe("google");
+    expect(parsed.requestedScopes).toBeUndefined();
+  });
+});

--- a/assistant/src/api/surfaces-oauth-connect.test.ts
+++ b/assistant/src/api/surfaces-oauth-connect.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  OAuthConnectSurfaceDataSchema,
   type OAuthConnectSurfaceData,
+  OAuthConnectSurfaceDataSchema,
 } from "./surfaces.js";
 
 describe("OAuthConnectSurfaceDataSchema requestedScopes", () => {

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -250,7 +250,7 @@ export type ChoiceSurfaceData = z.infer<typeof ChoiceSurfaceDataSchema>;
  * Requested OAuth scopes for an `oauth_connect` surface.
  *
  * Unlike `FileUploadAcceptedTypesSchema`, a bare string is NOT split on
- * commas — OAuth scopes are opaque URIs, so only arrays are accepted.
+ * commas: OAuth scopes are opaque URIs, so only arrays are accepted.
  * Entries are stringified and trimmed, blanks are dropped, and an empty
  * result or any non-array value collapses to `undefined` (use defaults).
  */
@@ -269,7 +269,7 @@ export const OAuthConnectSurfaceDataSchema = z.object({
     .catch(""),
   /**
    * Optional OAuth scopes to request for the managed connection. A full
-   * replacement set — when present, the platform uses exactly these scopes
+   * replacement set: when present, the platform uses exactly these scopes
    * instead of its defaults (it does not merge). Omit to use the platform's
    * default scopes for the provider.
    */

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -121,6 +121,21 @@ export const CardSurfaceDataSchema = z.object({
 export type CardSurfaceData = z.infer<typeof CardSurfaceDataSchema>;
 
 /**
+ * Stringify+trim entries, drop blanks and non-scalars, and collapse an
+ * empty result to `undefined` so a schema treats it as "field absent".
+ */
+function cleanedStringEntries(items: unknown[]): string[] | undefined {
+  const cleaned = items
+    .map((item) =>
+      typeof item === "string" || typeof item === "number"
+        ? String(item).trim()
+        : "",
+    )
+    .filter((item) => item.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
  * Accepted MIME-type / extension patterns for a `file_upload` surface.
  *
  * The renderer consumes this as a `string[]` — it calls `.join`/`.some`/
@@ -137,14 +152,7 @@ const FileUploadAcceptedTypesSchema = z.preprocess((value) => {
       : Array.isArray(value)
         ? value
         : [];
-  const cleaned = items
-    .map((item) =>
-      typeof item === "string" || typeof item === "number"
-        ? String(item).trim()
-        : "",
-    )
-    .filter((item) => item.length > 0);
-  return cleaned.length > 0 ? cleaned : undefined;
+  return cleanedStringEntries(items);
 }, z.array(z.string()).optional());
 
 export const FileUploadSurfaceDataSchema = z.object({
@@ -238,6 +246,19 @@ export const ChoiceSurfaceDataSchema = z.object({
 });
 export type ChoiceSurfaceData = z.infer<typeof ChoiceSurfaceDataSchema>;
 
+/**
+ * Requested OAuth scopes for an `oauth_connect` surface.
+ *
+ * Unlike `FileUploadAcceptedTypesSchema`, a bare string is NOT split on
+ * commas — OAuth scopes are opaque URIs, so only arrays are accepted.
+ * Entries are stringified and trimmed, blanks are dropped, and an empty
+ * result or any non-array value collapses to `undefined` (use defaults).
+ */
+const RequestedScopesSchema = z.preprocess(
+  (value) => (Array.isArray(value) ? cleanedStringEntries(value) : undefined),
+  z.array(z.string()).optional(),
+);
+
 export const OAuthConnectSurfaceDataSchema = z.object({
   /** OAuth provider key from the managed provider catalog, e.g. "google". */
   providerKey: z
@@ -246,6 +267,13 @@ export const OAuthConnectSurfaceDataSchema = z.object({
       z.string(),
     )
     .catch(""),
+  /**
+   * Optional OAuth scopes to request for the managed connection. A full
+   * replacement set — when present, the platform uses exactly these scopes
+   * instead of its defaults (it does not merge). Omit to use the platform's
+   * default scopes for the provider.
+   */
+  requestedScopes: RequestedScopesSchema,
   /** Optional display label. The client falls back to the provider catalog. */
   displayName: tolerantString(),
   /** Optional helper text. The client falls back to the provider catalog. */


### PR DESCRIPTION
## Summary
- Adds a tolerant optional requestedScopes array to OAuthConnectSurfaceDataSchema (full-replacement-set semantics, documented on the field)
- New colocated test covers ordering, trimming, blank/non-array collapse, and legacy-payload skew safety

Part of plan: managed-oauth-scopes.md (PR 1 of 6)