### PR TITLE
docs(ui-surface): document requestedScopes on the oauth_connect surface shape

### DIFF
--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -132,7 +132,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   oauth_connect: {
     purpose: "managed OAuth connection button for an integration account",
     shape:
-      "{ providerKey, displayName?, description?, logoUrl? } — managed OAuth connection CTA; use when the task needs a managed integration account (Google, Linear, GitHub, ...) instead of settings or shell OAuth. Do not include OAuth scopes; managed providers use the platform's configured scopes",
+      "{ providerKey, requestedScopes?, displayName?, description?, logoUrl? } — managed OAuth connection CTA; use when the task needs a managed integration account (Google, Linear, GitHub, ...) instead of settings or shell OAuth. requestedScopes is an optional FULL replacement set of OAuth scopes — when set, the connection is granted exactly these scopes instead of the platform defaults, so include every scope the connection should keep; omit it to use the platform's default scopes",
     missingContent: (data) =>
       isNonEmptyString(data.providerKey)
         ? null


### PR DESCRIPTION
## Summary
- ui_show oauth_connect shape now documents requestedScopes with full-replacement-set semantics
- Removes the outdated instruction forbidding scopes on managed connections

Part of plan: managed-oauth-scopes.md (PR 5 of 6)