### PR TITLE
feat(cli): include requested scopes in the oauth_connect surface redirect

### DIFF
--- a/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
+++ b/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
@@ -1,7 +1,7 @@
 export interface OAuthConnectSurfaceNextAction {
   type: "ui_show";
   surfaceType: "oauth_connect";
-  data: { providerKey: string };
+  data: { providerKey: string; requestedScopes?: string[] };
 }
 
 export interface OAuthConnectSurfaceRedirect {
@@ -12,35 +12,51 @@ export interface OAuthConnectSurfaceRedirect {
   nextAction: OAuthConnectSurfaceNextAction;
 }
 
-export function oauthConnectSurfaceHint(provider: string): string {
-  return (
+export function oauthConnectSurfaceHint(
+  provider: string,
+  requestedScopes?: string[],
+): string {
+  const base =
     `To let the user connect, render the connect button: call ` +
     `\`ui_show\` with surface_type "oauth_connect" and ` +
     `data.providerKey "${provider}". That surface is always available — do ` +
     `not run further \`oauth\`/\`channels\` commands, paste an OAuth URL, or ` +
-    `load a setup skill just to display it.`
+    `load a setup skill just to display it.`;
+  if (!requestedScopes?.length) {
+    return base;
+  }
+  return (
+    base +
+    ` Include data.requestedScopes verbatim from nextAction.data in the ` +
+    `\`ui_show\` call — it is a full replacement set, so list every default ` +
+    `scope you want to keep, not just the new ones.`
   );
 }
 
 export function buildOAuthConnectSurfaceNextAction(
   provider: string,
+  requestedScopes?: string[],
 ): OAuthConnectSurfaceNextAction {
   return {
     type: "ui_show",
     surfaceType: "oauth_connect",
-    data: { providerKey: provider },
+    data: {
+      providerKey: provider,
+      ...(requestedScopes?.length ? { requestedScopes } : {}),
+    },
   };
 }
 
 export function buildOAuthConnectSurfaceRedirect(
   provider: string,
+  requestedScopes?: string[],
 ): OAuthConnectSurfaceRedirect {
   return {
     ok: false,
     code: "use_oauth_connect_surface",
     provider,
-    hint: oauthConnectSurfaceHint(provider),
-    nextAction: buildOAuthConnectSurfaceNextAction(provider),
+    hint: oauthConnectSurfaceHint(provider, requestedScopes),
+    nextAction: buildOAuthConnectSurfaceNextAction(provider, requestedScopes),
   };
 }
 

--- a/assistant/src/cli/commands/oauth/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/connect.test.ts
@@ -70,7 +70,7 @@ afterEach(() => {
   process.exitCode = 0;
 });
 
-async function runConnectCommand(): Promise<{
+async function runConnectCommand(extraArgs: string[] = []): Promise<{
   stdout: string;
   exitCode: number;
 }> {
@@ -94,6 +94,7 @@ async function runConnectCommand(): Promise<{
       "--json",
       "connect",
       "google",
+      ...extraArgs,
     ]);
   } catch {
     // Commander may throw under exitOverride for parse errors; the assertions
@@ -122,5 +123,29 @@ describe("oauth connect", () => {
       "oauth_providers_by_providerKey_get",
       "oauth_mode_get",
     ]);
+  });
+
+  test("managed provider in a conversation shell includes requested scopes in the oauth_connect guidance", async () => {
+    const { stdout, exitCode } = await runConnectCommand([
+      "--scopes",
+      "https://www.googleapis.com/auth/tasks",
+      "https://www.googleapis.com/auth/calendar",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed.code).toBe("use_oauth_connect_surface");
+    expect(parsed.nextAction).toEqual({
+      type: "ui_show",
+      surfaceType: "oauth_connect",
+      data: {
+        providerKey: "google",
+        requestedScopes: [
+          "https://www.googleapis.com/auth/tasks",
+          "https://www.googleapis.com/auth/calendar",
+        ],
+      },
+    });
+    expect(openedUrls).toEqual([]);
   });
 });

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -141,7 +141,10 @@ export function registerConnectCommand(oauth: Command): void {
             // =============================================================
 
             if (isModelSpawnedConversationShell()) {
-              const redirect = buildOAuthConnectSurfaceRedirect(provider);
+              const redirect = buildOAuthConnectSurfaceRedirect(
+                provider,
+                opts.scopes,
+              );
               writeOutput(cmd, redirect);
               process.exitCode = 1;
               return;


### PR DESCRIPTION
## Summary
- The managed-path surface redirect now carries --scopes as nextAction.data.requestedScopes
- Hint text instructs the model to forward scopes verbatim and explains full-replacement-set semantics
- Tests cover scoped and no-scopes redirect payloads

Part of plan: managed-oauth-scopes.md (PR 4 of 6)