### PR TITLE
feat(oauth): add tasks and calendar googleapis hosts to google injection templates

### DIFF
--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -23,7 +23,7 @@ describe("oauth provider profiles (DB-seeded)", () => {
     );
   });
 
-  test("google provider row contains bearer injection templates for 4 Google API hosts", () => {
+  test("google provider row contains bearer injection templates for 6 Google API hosts", () => {
     const provider = getProvider("google");
 
     expect(provider).toBeDefined();
@@ -36,7 +36,7 @@ describe("oauth provider profiles (DB-seeded)", () => {
       valuePrefix: string;
     }>;
 
-    expect(templates).toHaveLength(4);
+    expect(templates).toHaveLength(6);
 
     const byHost = new Map(templates.map((t) => [t.hostPattern, t]));
 
@@ -45,6 +45,8 @@ describe("oauth provider profiles (DB-seeded)", () => {
       "www.googleapis.com",
       "people.googleapis.com",
       "docs.googleapis.com",
+      "tasks.googleapis.com",
+      "calendar.googleapis.com",
     ]) {
       const tpl = byHost.get(host);
       expect(tpl).toBeDefined();

--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -21,6 +21,29 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     );
   });
 
+  test("google injection templates cover all Google product hosts", () => {
+    // BYO-mode CES header injection only fires for hosts with a matching
+    // template; a missing host means requests go out with no Authorization
+    // header. Keep this list in sync with the Google products we call.
+    const templates = PROVIDER_SEED_DATA.google.injectionTemplates ?? [];
+    const hosts = templates.map((t) => t.hostPattern);
+    expect(hosts).toEqual(
+      expect.arrayContaining([
+        "gmail.googleapis.com",
+        "www.googleapis.com",
+        "people.googleapis.com",
+        "docs.googleapis.com",
+        "tasks.googleapis.com",
+        "calendar.googleapis.com",
+      ]),
+    );
+    for (const template of templates) {
+      expect(template.injectionType).toBe("header");
+      expect(template.headerName).toBe("Authorization");
+      expect(template.valuePrefix).toBe("Bearer ");
+    }
+  });
+
   test("every managedServiceConfigKey resolves to a ServicesSchema key", () => {
     // Cross-repo invariant: a provider with managedServiceConfigKey but no
     // matching ServicesSchema entry silently falls back to BYO mode in

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -137,6 +137,18 @@ export const PROVIDER_SEED_DATA: Record<
         headerName: "Authorization",
         valuePrefix: "Bearer ",
       },
+      {
+        hostPattern: "tasks.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+      {
+        hostPattern: "calendar.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
     ],
     revokeUrl: "https://oauth2.googleapis.com/revoke",
     revokeBodyTemplate: { token: "{access_token}" },


### PR DESCRIPTION
## Summary
- Adds tasks.googleapis.com and calendar.googleapis.com Authorization header injection templates to the google provider seed
- Existing installs pick these up via the startup upsert (injectionTemplates are overwritten on every start)

Part of plan: managed-oauth-scopes.md (PR 6 of 6)