### PR TITLE
feat(web): thread requestedScopes through the managed OAuth connect client

### DIFF
--- a/clients/web/src/domains/chat/api/managed-oauth.test.ts
+++ b/clients/web/src/domains/chat/api/managed-oauth.test.ts
@@ -12,15 +12,19 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { oauthCompletionStorageKey } from "@/lib/auth/oauth-popup";
 
-mock.module("@/generated/api/sdk.gen", () => ({
-  assistantsOauthStartCreate: mock(async () => ({
+const startCreateMock = mock(
+  async (_options: { body: { requested_scopes: string[] } }) => ({
     data: {
       connect_url:
         "https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=x&redirect_uri=y",
     },
     error: null,
     response: new Response(),
-  })),
+  }),
+);
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsOauthStartCreate: startCreateMock,
   assistantsOauthConnectionsList: mock(async () => ({
     data: [],
     error: null,
@@ -67,6 +71,7 @@ let requestIds: string[];
  * specific in-flight connect via its `storage` completion channel.
  */
 beforeEach(() => {
+  startCreateMock.mockClear();
   requestIds = [];
   let counter = 0;
   globalThis.crypto.randomUUID = (() => {
@@ -87,6 +92,17 @@ beforeEach(() => {
   });
   window.open = openSpy as unknown as typeof window.open;
 });
+
+/**
+ * Flush microtasks until the start endpoint has been invoked — the connect
+ * flow awaits identity resolution and a connections baseline first.
+ */
+async function waitForStartCall(): Promise<void> {
+  for (let i = 0; i < 100 && startCreateMock.mock.calls.length === 0; i += 1) {
+    await Promise.resolve();
+  }
+  expect(startCreateMock).toHaveBeenCalledTimes(1);
+}
 
 /** Settle an in-flight connect through the localStorage completion channel. */
 function settleFailed(requestId: string): void {
@@ -147,5 +163,35 @@ describe("connectManagedOAuthProvider dedupe", () => {
     expect(openSpy).toHaveBeenCalledTimes(2);
     settleFailed(requestIds[1]!);
     await second;
+  });
+});
+
+describe("connectManagedOAuthProvider requested scopes", () => {
+  test("requestedScopes are sent as requested_scopes in the start body", async () => {
+    const requestedScopes = [
+      "https://www.googleapis.com/auth/tasks",
+      "https://www.googleapis.com/auth/calendar",
+    ];
+    const connect = connectManagedOAuthProvider({ ...OPTS, requestedScopes });
+
+    await waitForStartCall();
+    expect(startCreateMock.mock.calls[0]?.[0].body.requested_scopes).toEqual(
+      requestedScopes,
+    );
+
+    settleFailed(requestIds[0]!);
+    await connect;
+  });
+
+  test("omitting requestedScopes sends an empty requested_scopes array", async () => {
+    const connect = connectManagedOAuthProvider(OPTS);
+
+    await waitForStartCall();
+    expect(startCreateMock.mock.calls[0]?.[0].body.requested_scopes).toEqual(
+      [],
+    );
+
+    settleFailed(requestIds[0]!);
+    await connect;
   });
 });

--- a/clients/web/src/domains/chat/api/managed-oauth.ts
+++ b/clients/web/src/domains/chat/api/managed-oauth.ts
@@ -34,6 +34,12 @@ export interface ManagedOAuthConnectOptions {
   assistantId: string;
   providerKey: string;
   providerLabel: string;
+  /**
+   * Full replacement set: when present, the platform uses exactly these
+   * scopes instead of its defaults (it does not merge). Omit to use the
+   * platform's default scopes.
+   */
+  requestedScopes?: string[];
 }
 
 export type ManagedOAuthConnectResult =
@@ -124,12 +130,13 @@ async function startManagedOAuth(
   providerKey: string,
   requestId: string,
   native: boolean,
+  requestedScopes: string[] | undefined,
 ): Promise<string> {
   const redirectAfterConnect = `${routes.account.oauth.popupComplete}?requestId=${requestId}${native ? "&native=1" : ""}`;
   const { data, error, response } = await assistantsOauthStartCreate({
     path: { assistant_id: assistantId, provider: providerKey },
     body: {
-      requested_scopes: [],
+      requested_scopes: requestedScopes ?? [],
       redirect_after_connect: redirectAfterConnect,
     },
     throwOnError: false,
@@ -164,6 +171,7 @@ function runManagedOAuthConnect({
   assistantId,
   providerKey,
   providerLabel,
+  requestedScopes,
 }: ManagedOAuthConnectOptions): Promise<ManagedOAuthConnectResult> {
   const requestId = crypto.randomUUID();
   const native = isNativePlatform();
@@ -345,6 +353,7 @@ function runManagedOAuthConnect({
           providerKey,
           requestId,
           native,
+          requestedScopes,
         );
 
         if (native) {
@@ -408,7 +417,9 @@ const inFlightManagedOAuthConnects = new Map<
  * flipped to "Connected" even though the account did connect (JARVIS-1286).
  *
  * Returning the already-running promise means repeat triggers latch onto the
- * one popup + one listener set that will actually resolve.
+ * one popup + one listener set that will actually resolve — even when the
+ * repeat trigger's `requestedScopes` differ, since two concurrent connects
+ * for the same provider are inherently conflicting regardless of scopes.
  */
 export function connectManagedOAuthProvider(
   options: ManagedOAuthConnectOptions,


### PR DESCRIPTION
## Summary
- ManagedOAuthConnectOptions gains optional requestedScopes (full-replacement-set semantics)
- startManagedOAuth sends requested_scopes from the option instead of a hardcoded empty array
- Tests cover scoped and default (empty) start bodies

Part of plan: managed-oauth-scopes.md (PR 2 of 6)