### PR TITLE
fix(macos): seed presence on SSE connect and treat unrecorded reports as failures

### DIFF
--- a/clients/macos/src/main/host-proxy-poster.test.ts
+++ b/clients/macos/src/main/host-proxy-poster.test.ts
@@ -299,7 +299,7 @@ describe("HostProxyPoster", () => {
 
   describe("postPresence", () => {
     test("sends correct URL, method, headers, and body", async () => {
-      const { fetchFn, captured } = createMockFetch();
+      const { fetchFn, captured } = createMockFetch(200, { recorded: true });
       const poster = makeLocalPoster(fetchFn);
 
       const result = await poster.postPresence({ state: "active" });
@@ -335,6 +335,56 @@ describe("HostProxyPoster", () => {
       const result = await poster.postPresence({ state: "away" });
 
       expect(result).toBe(false);
+    });
+
+    test("treats an accepted but unrecorded report as a failure", async () => {
+      // The daemon answers 200 with recorded false when it discarded the
+      // report. Scoring that as success is the silent death of the feature:
+      // every post accepted, nothing recorded, nothing logged.
+      const { fetchFn } = createMockFetch(200, { recorded: false });
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postPresence({ state: "active" })).toBe(false);
+    });
+
+    test("returns false when the response omits recorded", async () => {
+      const { fetchFn } = createMockFetch(200, { accepted: true });
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postPresence({ state: "active" })).toBe(false);
+    });
+
+    test("returns false without throwing on a malformed body", async () => {
+      const { fetchFn } = createMockFetch(200, "<html>not json</html>");
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postPresence({ state: "active" })).toBe(false);
+    });
+
+    test("returns false when the body is a bare JSON null", async () => {
+      const { fetchFn } = createMockFetch(200, null);
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postPresence({ state: "active" })).toBe(false);
+    });
+  });
+
+  describe("result posts ignore the response body", () => {
+    // The presence body parse must not have leaked into the generic path:
+    // every other endpoint still scores purely on the status.
+    test("a 2xx with an unrelated body still counts as success", async () => {
+      const { fetchFn } = createMockFetch(200, { recorded: false });
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postBashResult({ requestId: "r1" })).toBe(true);
+      expect(await poster.postFileResult({ requestId: "f1" })).toBe(true);
+    });
+
+    test("a 2xx with a malformed body still counts as success", async () => {
+      const { fetchFn } = createMockFetch(200, "<html>not json</html>");
+      const poster = makeLocalPoster(fetchFn);
+
+      expect(await poster.postBashResult({ requestId: "r1" })).toBe(true);
     });
   });
 

--- a/clients/macos/src/main/host-proxy-poster.ts
+++ b/clients/macos/src/main/host-proxy-poster.ts
@@ -179,8 +179,26 @@ export class HostProxyPoster {
     return this.postJson("/host-ui-snapshot-result", result);
   }
 
+  /**
+   * A 2xx only means the daemon accepted the request. It answers
+   * `{ recorded: false }` when it discarded the report (no connected client
+   * with this id, or the caller does not own that client), which is the
+   * silent-death mode for presence gating, so only a recorded report counts
+   * as success. A body it cannot read is treated the same way: unproven.
+   */
   async postPresence(payload: PresencePayload): Promise<boolean> {
-    return this.postJson("/clients/presence", payload);
+    const recorded = await this.sendJson(
+      "/clients/presence",
+      payload,
+      async (res) => {
+        if (!res.ok) {
+          return false;
+        }
+        const body = (await res.json()) as { recorded?: unknown } | null;
+        return body?.recorded === true;
+      },
+    );
+    return recorded ?? false;
   }
 
   // -----------------------------------------------------------------------
@@ -256,6 +274,20 @@ export class HostProxyPoster {
     path: string,
     payload: object,
   ): Promise<boolean> {
+    const ok = await this.sendJson(path, payload, async (res) => res.ok);
+    return ok ?? false;
+  }
+
+  /**
+   * POST a JSON body and let the caller interpret the response. `readResponse`
+   * runs while the request timeout is still armed, so reading the body cannot
+   * hang past it. Resolves null if the request or the read fails.
+   */
+  private async sendJson<T>(
+    path: string,
+    payload: object,
+    readResponse: (res: Response) => Promise<T>,
+  ): Promise<T | null> {
     try {
       const body = JSON.stringify(payload);
       const timeout = computeTimeout(Buffer.byteLength(body, "utf-8"));
@@ -270,12 +302,12 @@ export class HostProxyPoster {
           body,
           signal: controller.signal,
         });
-        return res.ok;
+        return await readResponse(res);
       } finally {
         clearTimeout(timer);
       }
     } catch {
-      return false;
+      return null;
     }
   }
 }

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -88,8 +88,61 @@ async function flush(ms = 20): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-// Mock globalThis.fetch for the /auth/token exchange (local gateway). Cloud
-// connections resolve their org from the lockfile, so they make no fetch here.
+/**
+ * Event-stream responses that stay open, so the SSE clients the router builds
+ * report connected the way they do against a live daemon. Presence posting is
+ * gated on that, and the seed rides the connected transition.
+ */
+const openEventStreams: ReadableStreamDefaultController<Uint8Array>[] = [];
+
+function openEventStream(): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      openEventStreams.push(controller);
+      controller.enqueue(new TextEncoder().encode(": ok\n\n"));
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** Drop every live stream, which is what a daemon restart looks like. */
+function closeEventStreams(): void {
+  const controllers = openEventStreams.splice(0, openEventStreams.length);
+  for (const controller of controllers) {
+    try {
+      controller.close();
+    } catch {
+      // Already closed.
+    }
+  }
+}
+
+// While set, event-stream requests park here, so a test can observe the window
+// where connect() has been called but no stream is live yet.
+let eventStreamGate: Promise<void> | null = null;
+let openEventStreamGate: (() => void) | null = null;
+
+function holdEventStreams(): () => void {
+  eventStreamGate = new Promise<void>((resolve) => {
+    openEventStreamGate = resolve;
+  });
+  return releaseEventStreams;
+}
+
+/** Let any parked event-stream request through. A no-op if none is held. */
+function releaseEventStreams(): void {
+  const open = openEventStreamGate;
+  eventStreamGate = null;
+  openEventStreamGate = null;
+  open?.();
+}
+
+// Mock globalThis.fetch for the /auth/token exchange (local gateway) and the
+// event streams. Cloud connections resolve their org from the lockfile, so
+// they make no token fetch here.
 const originalFetch = globalThis.fetch;
 const mockGatewayTokenFetch = async (input: string | URL | Request) => {
   const url = String(input);
@@ -99,21 +152,37 @@ const mockGatewayTokenFetch = async (input: string | URL | Request) => {
       headers: { "Content-Type": "application/json" },
     });
   }
+  if (url.endsWith("/events")) {
+    if (eventStreamGate) {
+      await eventStreamGate;
+    }
+    return openEventStream();
+  }
   return new Response("ok");
 };
 globalThis.fetch = mockGatewayTokenFetch as typeof globalThis.fetch;
 
 type Connection = NonNullable<ReturnType<typeof __testing.connections.get>>;
 
+/** A stand-in SSE whose connectedness a test can flip mid-run. */
+function fakeSse(): { isConnected: boolean; disconnect: () => void } {
+  return { isConnected: true, disconnect: () => {} };
+}
+
 /**
  * Register a connection whose poster records the presence states it receives.
  * `opts` is read on every post, so a test holding the object can flip a
  * connection between healthy and unreachable mid-run: `reject` stands in for
- * a throw, `ok: false` for the non-2xx that postJson folds into `false`.
+ * a throw, `ok: false` for the failure postPresence folds every non-2xx,
+ * throw, and unrecorded reply into.
  */
 function addPresenceConnection(
   assistantId: string,
-  opts: { reject?: boolean; ok?: boolean } = {},
+  opts: {
+    reject?: boolean;
+    ok?: boolean;
+    sse?: ReturnType<typeof fakeSse>;
+  } = {},
 ): PresenceState[] {
   const received: PresenceState[] = [];
   const poster = {
@@ -129,7 +198,7 @@ function addPresenceConnection(
     },
   };
   __testing.connections.set(assistantId, {
-    sse: { disconnect: () => {} },
+    sse: opts.sse ?? fakeSse(),
     poster,
     fingerprint: `test:${assistantId}`,
   } as unknown as Connection);
@@ -138,7 +207,7 @@ function addPresenceConnection(
 
 /**
  * Route presence POSTs into a captured list, leaving every other request
- * (the gateway token exchange) on its normal mock.
+ * (the gateway token exchange, the event streams) on its normal mock.
  */
 function capturePresencePosts(): { url: string; body: string }[] {
   const posts: { url: string; body: string }[] = [];
@@ -146,7 +215,10 @@ function capturePresencePosts(): { url: string; body: string }[] {
     const url = String(input);
     if (url.endsWith("/clients/presence")) {
       posts.push({ url, body: String(init?.body) });
-      return new Response("ok");
+      return new Response(JSON.stringify({ recorded: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }
     return mockGatewayTokenFetch(input);
   }) as typeof globalThis.fetch;
@@ -184,6 +256,10 @@ function capturingPoster(): { poster: InstanceType<typeof HostProxyPoster>; body
 describe("host-proxy-router", () => {
   afterEach(() => {
     __testing.reset();
+    // After reset nothing wants to reconnect, so the streams can be dropped
+    // without the clients redialing into the next test.
+    releaseEventStreams();
+    closeEventStreams();
     lockfileListener = null;
     mockGetGuardianAccessToken.mockReset();
     mockGetGuardianAccessToken.mockImplementation(
@@ -698,6 +774,75 @@ describe("host-proxy-router", () => {
         "https://platform.vellum.ai/v1/assistants/cloud-1/clients/presence",
       ]);
       expect(JSON.parse(presencePosts[0]!.body)).toEqual({ state: "idle" });
+    });
+
+    test("holds the seed until the SSE stream is live", async () => {
+      const presencePosts = capturePresencePosts();
+      const releaseStreams = holdEventStreams();
+
+      installHostProxyBridge(fakeCliResolver);
+      presenceReporter?.("idle");
+      await flush();
+
+      lockfileListener?.(MIXED_LOCKFILE);
+      await flush();
+
+      // Both connections exist and have called connect(), but no stream is up
+      // yet, so the daemon has no subscriber to attribute a report to.
+      expect(__testing.connections.size).toBe(2);
+      expect(presencePosts).toEqual([]);
+
+      releaseStreams();
+      await flush();
+
+      expect(presencePosts.map((post) => post.url).sort()).toEqual([
+        "http://127.0.0.1:9001/v1/clients/presence",
+        "https://platform.vellum.ai/v1/assistants/cloud-1/clients/presence",
+      ]);
+      expect(JSON.parse(presencePosts[0]!.body)).toEqual({ state: "idle" });
+    });
+
+    test("re-seeds when a dropped SSE stream reconnects", async () => {
+      const presencePosts = capturePresencePosts();
+
+      installHostProxyBridge(fakeCliResolver);
+      presenceReporter?.("idle");
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+      expect(presencePosts).toHaveLength(1);
+
+      // A dropped stream takes the daemon's subscriber and its presence record
+      // with it, so the reconnect has to say it again.
+      closeEventStreams();
+      await flush(1_500);
+
+      expect(presencePosts.length).toBeGreaterThanOrEqual(2);
+      expect(JSON.parse(presencePosts[1]!.body)).toEqual({ state: "idle" });
+    });
+
+    test("skips posts while the SSE stream is down", async () => {
+      installHostProxyBridge(fakeCliResolver);
+      const sse = fakeSse();
+      const received = addPresenceConnection("a1", { sse });
+
+      presenceReporter?.("active");
+      await flush();
+      expect(received).toEqual(["active"]);
+
+      mockLogWarn.mockClear();
+      sse.isConnected = false;
+      presenceReporter?.("idle");
+      await flush();
+
+      // Nothing sent, and nothing logged: an unattributable report is not a
+      // presence failure, and no record on file lets the push through.
+      expect(received).toEqual(["active"]);
+      expect(mockLogWarn).not.toHaveBeenCalled();
     });
 
     test("sends nothing to a new connection before any report", async () => {

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -204,17 +204,25 @@ let lastPresenceState: PresenceState | null = null;
 /**
  * Post one report, logging only the first failure of a run.
  *
- * postPresence folds every non-2xx and every throw into `false`, so a daemon
- * that stops accepting reports would otherwise take presence down in total
- * silence. Warning on each attempt instead would put a line in the log every
- * poll interval for the length of the outage, so the connection stays quiet
- * until a post succeeds and re-arms the warning.
+ * postPresence folds every non-2xx, every throw, and every reply that says the
+ * report was accepted but not recorded into `false`, so a daemon that stops
+ * recording reports would otherwise take presence down in total silence.
+ * Warning on each attempt instead would put a line in the log every poll
+ * interval for the length of the outage, so the connection stays quiet until a
+ * post succeeds and re-arms the warning.
  */
 async function postPresenceTo(
   assistantId: string,
   conn: AssistantConnection,
   state: PresenceState,
 ): Promise<void> {
+  // The daemon attributes a report to the client behind its live SSE stream,
+  // so a report sent while the stream is down is discarded anyway. Skipping is
+  // also the fail-open direction: with no presence record the push goes out.
+  if (!conn.sse.isConnected) {
+    return;
+  }
+
   let posted = false;
   try {
     posted = await conn.poster.postPresence({ state });
@@ -252,10 +260,14 @@ function reportPresence(state: PresenceState): void {
 }
 
 /**
- * Report to an assistant the moment it joins. A monitor report only reaches
- * whoever is connected when it fires, and a local assistant connects
- * asynchronously, so without this the common desktop case would go
- * unreported until the next poll tick.
+ * Report to an assistant the moment its SSE stream goes live. A monitor report
+ * only reaches whoever is connected when it fires, so without this a stream
+ * that comes up between poll ticks would go unreported until the next one.
+ *
+ * Keyed to the stream rather than to the connection being created, because the
+ * daemon can only attribute a report once it has this client's subscriber. The
+ * same reason makes it fire on reconnects: the daemon dropped the subscriber
+ * and its presence record with it.
  */
 function seedPresence(assistantId: string): void {
   if (lastPresenceState === null) {
@@ -371,14 +383,19 @@ async function connectLocalAssistant(
   const eventsUrl = `http://127.0.0.1:${gatewayPort}/v1/events`;
   const endpointBase = `http://127.0.0.1:${gatewayPort}/v1`;
 
-  const sse = new HostProxySseClient({ eventsUrl, authHeaders, onRefreshToken });
+  const sse = new HostProxySseClient({
+    eventsUrl,
+    authHeaders,
+    onRefreshToken,
+    onConnected: () => seedPresence(assistantId),
+  });
   const poster = new HostProxyPoster({ endpointBase, authHeaders });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
-  sse.connect();
 
+  // Registered before the stream opens so the onConnected seed can find it.
   connections.set(assistantId, { sse, poster, fingerprint: localFingerprint(gatewayPort) });
-  seedPresence(assistantId);
+  sse.connect();
   log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
 }
 
@@ -410,18 +427,22 @@ function connectCloudAssistant(
   const eventsUrl = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/events`;
   const endpointBase = `${baseUrl}/v1/assistants/${encodeURIComponent(assistantId)}`;
 
-  const sse = new HostProxySseClient({ eventsUrl, authHeaders });
+  const sse = new HostProxySseClient({
+    eventsUrl,
+    authHeaders,
+    onConnected: () => seedPresence(assistantId),
+  });
   const poster = new HostProxyPoster({ endpointBase, authHeaders });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
-  sse.connect();
 
+  // Registered before the stream opens so the onConnected seed can find it.
   connections.set(assistantId, {
     sse,
     poster,
     fingerprint: cloudFingerprint(runtimeUrl, organizationId),
   });
-  seedPresence(assistantId);
+  sse.connect();
   log.info("[host-proxy-router] connected to cloud assistant", { assistantId, runtimeUrl, organizationId });
 }
 

--- a/clients/macos/src/main/host-proxy-sse.test.ts
+++ b/clients/macos/src/main/host-proxy-sse.test.ts
@@ -165,6 +165,83 @@ describe("HostProxySseClient", () => {
     expect(client.isConnected).toBe(false);
   });
 
+  // -- Connected notifications --------------------------------------------
+
+  test("onConnected fires when the stream goes live, not when connect is called", async () => {
+    const { stream } = controllableStream();
+    let connectedCount = 0;
+
+    client = new HostProxySseClient({
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
+      fetch: mockFetch(stream),
+      onConnected: () => {
+        connectedCount++;
+      },
+    });
+
+    client.connect();
+    // connect() only starts the fetch, so nothing is subscribed yet.
+    expect(connectedCount).toBe(0);
+    expect(client.isConnected).toBe(false);
+
+    await flush(50);
+
+    expect(connectedCount).toBe(1);
+    expect(client.isConnected).toBe(true);
+  });
+
+  test("onConnected fires again on every reconnect", async () => {
+    const connectedStates: boolean[] = [];
+    let fetchCount = 0;
+
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      return new Response(sseStream([`data: {"type":"n${fetchCount}"}\n\n`]), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    client = new HostProxySseClient({
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
+      fetch: fakeFetch,
+      onConnected: () => {
+        connectedStates.push(client.isConnected);
+      },
+    });
+    client.connect();
+
+    // Each stream closes as soon as it is drained, so the client redials.
+    await flush(1_500);
+
+    expect(connectedStates.length).toBeGreaterThanOrEqual(2);
+    // The stream is live whenever the callback runs, so a subscriber can act
+    // on it straight away.
+    expect(connectedStates.every((connected) => connected)).toBe(true);
+  });
+
+  test("a throwing onConnected does not take the stream down", async () => {
+    const messages: HostProxySseMessage[] = [];
+    const body = sseStream(['data: {"type":"ping"}\n\n']);
+
+    client = new HostProxySseClient({
+      eventsUrl: "http://127.0.0.1:9999/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
+      fetch: mockFetch(body),
+      onConnected: () => {
+        throw new Error("subscriber blew up");
+      },
+    });
+    client.setMessageCallback((m) => messages.push(m));
+    client.connect();
+
+    await flush(50);
+
+    expect(messages.map((m) => m.type)).toEqual(["ping"]);
+  });
+
   // -- Reconnection on error ---------------------------------------------
 
   test("reconnects with backoff on fetch failure", async () => {

--- a/clients/macos/src/main/host-proxy-sse.ts
+++ b/clients/macos/src/main/host-proxy-sse.ts
@@ -27,6 +27,12 @@ export interface HostProxySseOptions {
   idleCheckIntervalMs?: number;
   /** Called before each reconnect — return a fresh token or null. */
   onRefreshToken?: () => Promise<string | null>;
+  /**
+   * Called every time a stream goes live, reconnects included. A reconnect is
+   * when the daemon has dropped this client's subscriber, so anything keyed to
+   * the subscriber existing has to be redone rather than only set up once.
+   */
+  onConnected?: () => void;
 }
 
 export interface HostProxySseMessage {
@@ -48,6 +54,7 @@ export class HostProxySseClient {
   private readonly idleTimeoutMs: number;
   private readonly idleCheckIntervalMs: number;
   private readonly onRefreshToken: (() => Promise<string | null>) | null;
+  private readonly onConnected: (() => void) | null;
   private onMessage: MessageCallback | null = null;
 
   private abortController: AbortController | null = null;
@@ -65,6 +72,7 @@ export class HostProxySseClient {
     this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
     this.idleCheckIntervalMs = options.idleCheckIntervalMs ?? IDLE_CHECK_INTERVAL_MS;
     this.onRefreshToken = options.onRefreshToken ?? null;
+    this.onConnected = options.onConnected ?? null;
   }
 
   /** Register a callback for parsed SSE messages. */
@@ -131,6 +139,7 @@ export class HostProxySseClient {
     this.reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
     this.lastTrafficAt = Date.now();
     this.startIdleWatchdog();
+    this.notifyConnected();
 
     try {
       await this.readStream(response.body);
@@ -141,6 +150,17 @@ export class HostProxySseClient {
     this._connected = false;
     if (this.shouldReconnect) {
       this.scheduleReconnect();
+    }
+  }
+
+  private notifyConnected(): void {
+    if (!this.onConnected) {
+      return;
+    }
+    try {
+      this.onConnected();
+    } catch {
+      // A subscriber's failure must not take the stream down with it.
     }
   }
 

--- a/clients/macos/src/main/presence.test.ts
+++ b/clients/macos/src/main/presence.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // them at will, and `off` removes them so teardown is observable.
 type PowerListener = () => void;
 const powerListeners = new Map<string, Set<PowerListener>>();
+// Set to an event name to make that subscription blow up, standing in for an
+// electron build where one of the six events is unavailable.
+let attachFailsOn: string | null = null;
 const powerOnMock = mock((event: string, listener: PowerListener) => {
+  if (event === attachFailsOn) {
+    throw new Error(`cannot subscribe to ${event}`);
+  }
   const existing = powerListeners.get(event) ?? new Set<PowerListener>();
   existing.add(listener);
   powerListeners.set(event, existing);
@@ -29,6 +35,29 @@ mock.module("electron", () => ({
     getSystemIdleTime: getSystemIdleTimeMock,
   },
 }));
+
+// Stub electron-log so the module's logger import stays inert under test.
+const mockLogWarn = mock((..._args: unknown[]) => {});
+mock.module("electron-log/main", () => {
+  const noop = () => {};
+  return {
+    default: {
+      info: noop,
+      warn: mockLogWarn,
+      error: noop,
+      debug: noop,
+      initialize: noop,
+      transports: {
+        file: {
+          maxSize: 0,
+          fileName: "",
+          format: "",
+          getFile: () => ({ path: "" }),
+        },
+      },
+    },
+  };
+});
 
 const { IDLE_THRESHOLD_MS, POLL_INTERVAL_MS, installPresenceMonitor } =
   await import("./presence");
@@ -59,6 +88,8 @@ beforeEach(() => {
   powerOnMock.mockClear();
   powerOffMock.mockClear();
   getSystemIdleTimeMock.mockClear();
+  mockLogWarn.mockClear();
+  attachFailsOn = null;
   idleSeconds = 0;
   idleThrows = false;
   intervalCallback = null;
@@ -263,6 +294,35 @@ describe("installPresenceMonitor", () => {
     secondTeardown();
     expect(listenerCount()).toBe(6);
     expect(clearIntervalMock).not.toHaveBeenCalled();
+  });
+
+  test("a refused install says so in the log", () => {
+    install();
+
+    mockLogWarn.mockClear();
+    const secondTeardown = installPresenceMonitor(() => {});
+
+    // A caller that silently gets nothing would otherwise be invisible.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    secondTeardown();
+  });
+
+  test("a throw while attaching listeners leaves the latch clear", () => {
+    attachFailsOn = "user-did-resign-active";
+    expect(() => installPresenceMonitor(() => {})).toThrow();
+
+    // Latching before the listeners are up would strand the process with no
+    // monitor, no teardown, and no way to try again.
+    attachFailsOn = null;
+    idleSeconds = 0;
+    const reports: string[] = [];
+    activeTeardown = installPresenceMonitor((state) => reports.push(state));
+
+    expect(reports).toEqual(["active"]);
+    expect(intervalCallback).not.toBeNull();
+
+    fire("lock-screen");
+    expect(reports).toEqual(["active", "away"]);
   });
 
   test("a fresh install works again after teardown", () => {

--- a/clients/macos/src/main/presence.ts
+++ b/clients/macos/src/main/presence.ts
@@ -1,5 +1,7 @@
 import { powerMonitor } from "electron";
 
+import log from "./logger";
+
 /**
  * Desktop presence, derived from system-wide HID idle time plus screen
  * lock, suspend, and login-session activation.
@@ -33,11 +35,12 @@ export const installPresenceMonitor = (
 ): (() => void) => {
   // A second install would leak the first monitor's interval and listeners
   // and double the report rate, so it hands back a teardown that owns
-  // nothing rather than a live second monitor.
+  // nothing rather than a live second monitor. The caller gets no reports at
+  // all from it, which is worth a line in the log.
   if (installed) {
+    log.warn("[presence] monitor already installed, ignoring second install");
     return (): void => {};
   }
-  installed = true;
 
   // Three independently owned reasons the desktop is unreachable, each
   // cleared only by its paired event. A locked machine that sleeps and wakes
@@ -104,6 +107,12 @@ export const installPresenceMonitor = (
   powerMonitor.on("resume", onResume);
   powerMonitor.on("user-did-become-active", onSessionBecameActive);
   powerMonitor.on("user-did-resign-active", onSessionResigned);
+
+  // Latched only once the monitor is fully wired. Claiming it up front would
+  // leave a throw from any attachment above with the latch set and no teardown
+  // in the caller's hands, and nothing else can clear it, so presence would be
+  // dead for the life of the process.
+  installed = true;
 
   // Establishes a state immediately instead of waiting out the first tick,
   // so a message sent right after launch is judged against real presence


### PR DESCRIPTION
## Summary
- Seeds presence when the SSE connection reports connected rather than when connect() is called, so the seed reaches a daemon that can actually attribute it, and re-seeds on reconnect
- Skips presence posts while the SSE is down, which is the fail-open direction and stops the 30s poll hammering a daemon that cannot attribute the report
- Treats a 200 with recorded false as a failure, so an accepted-but-discarded report trips the existing first-failure-only warn instead of scoring as success
- Sets the install latch only after all listeners attach, so a throw during attachment cannot permanently disable presence

Fixes regressions found during plan self-review for presence-gated-reply-push.md