### PR TITLE
fix(macos): probe paired assistants' health instead of reporting them reachable unconditionally

### DIFF
--- a/clients/macos/src/main/connectivity-probe.test.ts
+++ b/clients/macos/src/main/connectivity-probe.test.ts
@@ -12,9 +12,10 @@ mock.module("./status", () => ({
   },
 }));
 
-// Track net.fetch calls so tests can assert on the probe target.
+// Track net.fetch calls so tests can assert on the probe target and headers.
 let fetchCalls: string[] = [];
-let fetchResponseOk = true;
+let fetchHeaders: (Record<string, string> | undefined)[] = [];
+let fetchBehavior: "ok" | "http-error" | "reject" = "ok";
 mock.module("electron", () => ({
   app: {
     on: () => {},
@@ -23,12 +24,13 @@ mock.module("electron", () => ({
     getAllWindows: () => [],
   },
   net: {
-    fetch: (url: string) => {
+    fetch: (url: string, init?: { headers?: Record<string, string> }) => {
       fetchCalls.push(url);
-      if (fetchResponseOk) {
-        return Promise.resolve({ ok: true } as Response);
+      fetchHeaders.push(init?.headers);
+      if (fetchBehavior === "reject") {
+        return Promise.reject(new Error("connection refused"));
       }
-      return Promise.reject(new Error("connection refused"));
+      return Promise.resolve({ ok: fetchBehavior === "ok" } as Response);
     },
   },
   powerMonitor: {
@@ -69,7 +71,8 @@ const runProbe = installConnectivityProbe(["/mock/lockfile.json"]);
 beforeEach(() => {
   backendReachableCalls = [];
   fetchCalls = [];
-  fetchResponseOk = true;
+  fetchHeaders = [];
+  fetchBehavior = "ok";
   mockLockfileData = { ok: true, data: { assistants: [], activeAssistant: null } };
 });
 
@@ -96,6 +99,8 @@ describe("connectivity-probe", () => {
     await runProbe();
 
     expect(fetchCalls).toEqual(["http://127.0.0.1:7830/healthz"]);
+    // Local probes carry no extra headers.
+    expect(fetchHeaders).toEqual([undefined]);
     expect(backendReachableCalls).toEqual([true]);
   });
 
@@ -258,7 +263,7 @@ describe("connectivity-probe", () => {
   });
 
   test("sets backend reachable=false when local gateway is unreachable", async () => {
-    fetchResponseOk = false;
+    fetchBehavior = "reject";
     mockLockfileData = {
       ok: true,
       data: {
@@ -281,7 +286,7 @@ describe("connectivity-probe", () => {
 
   test("clears stale unreachable when switching from local to cloud assistant", async () => {
     // First probe: local assistant with a dead gateway.
-    fetchResponseOk = false;
+    fetchBehavior = "reject";
     mockLockfileData = {
       ok: true,
       data: {
@@ -305,7 +310,7 @@ describe("connectivity-probe", () => {
     expect(backendReachableCalls).toEqual([false]);
 
     // Simulate lockfile change: active assistant is now the cloud one.
-    fetchResponseOk = true;
+    fetchBehavior = "ok";
     mockLockfileData = {
       ok: true,
       data: {
@@ -330,5 +335,133 @@ describe("connectivity-probe", () => {
     expect(backendReachableCalls).toEqual([false, true]);
     // No fetch was made for the cloud probe.
     expect(fetchCalls).toEqual(["http://127.0.0.1:7830/healthz"]);
+  });
+
+  test("probes a paired assistant's tunnel /healthz with the ngrok skip header", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "https://abc123.ngrok.app",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["https://abc123.ngrok.app/healthz"]);
+    expect(fetchHeaders).toEqual([{ "ngrok-skip-browser-warning": "true" }]);
+    expect(backendReachableCalls).toEqual([true]);
+  });
+
+  test("strips trailing slashes from the paired runtimeUrl before appending /healthz", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "https://abc123.ngrok.app/",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["https://abc123.ngrok.app/healthz"]);
+    expect(backendReachableCalls).toEqual([true]);
+  });
+
+  test("sets backend reachable=false when the paired tunnel is dead", async () => {
+    fetchBehavior = "reject";
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "https://abc123.ngrok.app",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["https://abc123.ngrok.app/healthz"]);
+    expect(backendReachableCalls).toEqual([false]);
+  });
+
+  test("sets backend reachable=false when the paired tunnel answers non-2xx", async () => {
+    fetchBehavior = "http-error";
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "https://abc123.ngrok.app",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual(["https://abc123.ngrok.app/healthz"]);
+    expect(backendReachableCalls).toEqual([false]);
+  });
+
+  test("sets backend reachable=false when a paired entry has an unusable runtimeUrl", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "not-a-url",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual([]);
+    expect(backendReachableCalls).toEqual([false]);
+  });
+
+  test("sets backend reachable=false when a paired entry has no runtimeUrl", async () => {
+    mockLockfileData = {
+      ok: true,
+      data: {
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+          },
+        ],
+        activeAssistant: "paired-1",
+      },
+    };
+
+    await runProbe();
+
+    expect(fetchCalls).toEqual([]);
+    expect(backendReachableCalls).toEqual([false]);
   });
 });

--- a/clients/macos/src/main/connectivity-probe.ts
+++ b/clients/macos/src/main/connectivity-probe.ts
@@ -4,6 +4,8 @@ import { getLockfileData } from "@vellumai/local-mode";
 import {
   getLoopbackGatewayPort,
   isLoopbackGatewayCloud,
+  isUsableRuntimeUrl,
+  resolveCloud,
 } from "@vellumai/local-mode/contract";
 
 import { setBackendReachable } from "./status";
@@ -20,11 +22,17 @@ let probing = false;
  * - `"local"`: the active assistant runs its gateway on a loopback port
  *   of this machine; the caller should fetch the returned URL and set
  *   reachability from the response.
+ * - `"paired"`: the active assistant is a remote instance paired from
+ *   another machine; the caller should fetch its tunnel `/healthz` and set
+ *   reachability from the response.
  * - `"non-local"`: the active assistant is cloud-hosted or self-hosted
  *   remote; there is no local gateway to probe, and any prior
  *   `backendReachable = false` from a stale local-assistant entry should
  *   be cleared. Non-local assistant health is tracked separately via the
  *   platform's operational-status polling.
+ * - `"unreachable"`: the active entry is paired but its runtimeUrl is
+ *   unusable, so there is nothing to probe and the tunnel cannot be
+ *   reached. The caller should report unreachable.
  * - `"unknown"`: the lockfile could not be read, there is no active
  *   assistant, or the active entry is a local runtime without a gateway
  *   port. The caller should not change the reachability state, because
@@ -32,7 +40,9 @@ let probing = false;
  */
 type ProbeTarget =
   | { kind: "local"; url: string }
+  | { kind: "paired"; url: string }
   | { kind: "non-local" }
+  | { kind: "unreachable" }
   | { kind: "unknown" };
 
 function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
@@ -45,6 +55,16 @@ function resolveProbeTarget(lockfilePaths: string[]): ProbeTarget {
   // Cloud wins over resources: merges can leave a stale gatewayPort on a
   // non-local entry, and it must not be loopback-probed.
   if (!isLoopbackGatewayCloud(entry.cloud)) {
+    if (resolveCloud(entry) === "paired") {
+      const { runtimeUrl } = entry;
+      if (typeof runtimeUrl !== "string" || !isUsableRuntimeUrl(runtimeUrl)) {
+        return { kind: "unreachable" };
+      }
+      return {
+        kind: "paired",
+        url: `${runtimeUrl.replace(/\/+$/, "")}/healthz`,
+      };
+    }
     return { kind: "non-local" };
   }
   const port = getLoopbackGatewayPort(entry);
@@ -67,9 +87,21 @@ async function runProbeOnce(lockfilePaths: string[]): Promise<void> {
       setBackendReachable(true);
       return;
     }
+    if (target.kind === "unreachable") {
+      setBackendReachable(false);
+      return;
+    }
+    // Paired runtimeUrls are commonly ngrok tunnels; free-tier ngrok answers
+    // browser User-Agents with an interstitial unless this header is present
+    // (mirrors sanitizePairedForwardHeaders in local-mode's gateway-proxy).
+    const headers =
+      target.kind === "paired"
+        ? { "ngrok-skip-browser-warning": "true" }
+        : undefined;
     const ok = await net
       .fetch(target.url, {
         method: "GET",
+        headers,
         signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
       })
       .then((r) => r.ok)


### PR DESCRIPTION
## Summary
- Classify paired lockfile entries as probeable targets against <runtimeUrl>/healthz
- Probe with net.fetch, 5s timeout, and ngrok-skip-browser-warning; non-2xx/rejection reports unreachable
- Paired entries with unusable runtimeUrl report unreachable instead of green

Part of plan: macos-paired-assistants.md (PR 3 of 10)