### PR TITLE
feat(macos): show paired assistants in the tray switcher with remove-from-this-Mac

### DIFF
--- a/clients/macos/src/main/commands.ts
+++ b/clients/macos/src/main/commands.ts
@@ -44,6 +44,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   chooseAssistant: "",
   createAssistant: "",
   retireAssistant: "",
+  removePairedAssistant: "",
   quickInputSubmit: "",
   cancelDictation: "",
   replayOnboarding: "",

--- a/clients/macos/src/main/tray.test.ts
+++ b/clients/macos/src/main/tray.test.ts
@@ -110,18 +110,6 @@ mock.module("./lockfile-watcher", () => ({
   getWatchedLockfile: () => watchedLockfile,
 }));
 
-// Partial local-mode mock: the tray's paired "Remove from this Mac…" item
-// calls `unpairAssistant` with host-resolved lockfile paths and config dir.
-const unpairAssistantMock = mock((..._args: unknown[]) => ({
-  ok: true as const,
-  lockfile: { assistants: [], activeAssistant: null },
-}));
-mock.module("@vellumai/local-mode", () => ({
-  resolveLockfilePaths: () => ["/fake/.vellum.lock.json"],
-  resolveConfigDir: () => "/fake/config",
-  unpairAssistant: unpairAssistantMock,
-}));
-
 mock.module("./logger", () => ({
   default: { info: () => {}, warn: () => {}, error: () => {} },
 }));
@@ -224,7 +212,7 @@ beforeEach(() => {
   avatarListeners.clear();
   watchedLockfile = { assistants: [], activeAssistant: null };
   featureFlags = null;
-  unpairAssistantMock.mockClear();
+  dispatchToMainMock.mockClear();
   buildFromTemplateMock.mockClear();
   statusFramesMock.mockClear();
   invalidateIconCacheMock.mockClear();
@@ -492,18 +480,19 @@ describe("assistant switcher", () => {
     expect(labels.some((label) => label.startsWith("Retire"))).toBe(false);
   });
 
-  test("Remove from this Mac unpairs the active assistant with host-resolved paths", () => {
+  test("Remove from this Mac surfaces the window and dispatches removePairedAssistant", async () => {
     watchedLockfile = { assistants: [pairedEntry], activeAssistant: "paired-1" };
     const template = popMenu();
+    const beforeEnsure = handlers.ensureMainWindow.mock.calls.length;
+    const beforeDispatch = dispatchToMainMock.mock.calls.length;
 
-    template.find((i) => i.label === "Remove from this Mac…")?.click?.();
+    await template.find((i) => i.label === "Remove from this Mac…")?.click?.();
 
-    expect(unpairAssistantMock).toHaveBeenCalledTimes(1);
-    expect(unpairAssistantMock.mock.calls[0]).toEqual([
-      ["/fake/.vellum.lock.json"],
-      "/fake/config",
-      "paired-1",
-    ]);
+    expect(handlers.ensureMainWindow.mock.calls.length).toBe(beforeEnsure + 1);
+    expect(dispatchToMainMock.mock.calls[beforeDispatch]?.[0]).toEqual({
+      kind: "removePairedAssistant",
+      assistantId: "paired-1",
+    });
   });
 
   test("a managed active entry keeps the Retire item and offers no Remove", async () => {
@@ -523,7 +512,12 @@ describe("assistant switcher", () => {
       kind: "retireAssistant",
       assistantId: "managed-1",
     });
-    expect(unpairAssistantMock).not.toHaveBeenCalled();
+    expect(
+      dispatchToMainMock.mock.calls.some(
+        (call) =>
+          (call[0] as { kind?: string })?.kind === "removePairedAssistant",
+      ),
+    ).toBe(false);
   });
 
   test("an empty switcher shows the managed-or-paired empty state", () => {

--- a/clients/macos/src/main/tray.test.ts
+++ b/clients/macos/src/main/tray.test.ts
@@ -100,15 +100,39 @@ mock.module("./menu-icon", () => ({
   menuIcon: () => ({ __kind: "template-icon" }),
 }));
 
+// Controllable lockfile snapshot standing in for the watcher's cache, so
+// switcher tests can stage managed/paired/local entries per test.
+let watchedLockfile: {
+  assistants: Array<Record<string, unknown>>;
+  activeAssistant: string | null;
+} = { assistants: [], activeAssistant: null };
 mock.module("./lockfile-watcher", () => ({
-  getWatchedLockfile: () => ({ assistants: [], activeAssistant: null }),
+  getWatchedLockfile: () => watchedLockfile,
+}));
+
+// Partial local-mode mock: the tray's paired "Remove from this Mac…" item
+// calls `unpairAssistant` with host-resolved lockfile paths and config dir.
+const unpairAssistantMock = mock((..._args: unknown[]) => ({
+  ok: true as const,
+  lockfile: { assistants: [], activeAssistant: null },
+}));
+mock.module("@vellumai/local-mode", () => ({
+  resolveLockfilePaths: () => ["/fake/.vellum.lock.json"],
+  resolveConfigDir: () => "/fake/config",
+  unpairAssistant: unpairAssistantMock,
+}));
+
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
 }));
 
 // Full `./settings` surface so this mock — which leaks into co-run test files
 // via the global module registry — doesn't break sibling modules that import
-// `writeSetting`/`onSettingChange` (e.g. `hotkeys.ts`).
+// `writeSetting`/`onSettingChange` (e.g. `hotkeys.ts`). Feature flags are
+// controllable so the assistant-switcher gate can be exercised.
+let featureFlags: Record<string, boolean> | null = null;
 mock.module("./settings", () => ({
-  readSetting: () => null,
+  readSetting: (key: string) => (key === "featureFlags" ? featureFlags : null),
   readHotkeyOverride: () => null,
   writeSetting: () => {},
   onSettingChange: () => () => {},
@@ -198,6 +222,9 @@ beforeEach(() => {
   appListeners.clear();
   themeListeners.clear();
   avatarListeners.clear();
+  watchedLockfile = { assistants: [], activeAssistant: null };
+  featureFlags = null;
+  unpairAssistantMock.mockClear();
   buildFromTemplateMock.mockClear();
   statusFramesMock.mockClear();
   invalidateIconCacheMock.mockClear();
@@ -377,6 +404,134 @@ describe("installTray", () => {
     expect(dispatchToMainMock.mock.calls[beforeDispatch]?.[0]).toEqual({
       kind: "newConversation",
     });
+  });
+});
+
+describe("assistant switcher", () => {
+  type MenuItem = {
+    label?: string;
+    type?: string;
+    checked?: boolean;
+    enabled?: boolean;
+    click?: () => void | Promise<void>;
+  };
+
+  const popMenu = (): MenuItem[] => {
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    return calls[calls.length - 1]?.[0] as MenuItem[];
+  };
+
+  const managedEntry = {
+    assistantId: "managed-1",
+    name: "Managed One",
+    cloud: "vellum",
+  };
+  const pairedEntry = {
+    assistantId: "paired-1",
+    name: "Remote One",
+    cloud: "paired",
+    runtimeUrl: "https://tunnel.example.com",
+  };
+
+  beforeEach(() => {
+    featureFlags = { "multi-platform-assistant": true };
+  });
+
+  test("lists paired entries alongside managed ones, labeled with the remote host; local entries stay excluded", () => {
+    watchedLockfile = {
+      assistants: [
+        managedEntry,
+        pairedEntry,
+        { assistantId: "local-1", name: "Local One", cloud: "local" },
+      ],
+      activeAssistant: null,
+    };
+
+    const labels = popMenu().map((item) => item.label);
+    expect(labels).toContain("Managed One");
+    expect(labels).toContain("Remote One (Paired · tunnel.example.com)");
+    expect(labels).not.toContain("Local One");
+  });
+
+  test("a paired entry with an unparseable runtimeUrl falls back to a plain Paired suffix", () => {
+    watchedLockfile = {
+      assistants: [{ ...pairedEntry, runtimeUrl: "not a url" }],
+      activeAssistant: null,
+    };
+
+    expect(popMenu().map((item) => item.label)).toContain(
+      "Remote One (Paired)",
+    );
+  });
+
+  test("selecting a paired entry surfaces the window and dispatches selectAssistant", async () => {
+    watchedLockfile = { assistants: [pairedEntry], activeAssistant: null };
+    const template = popMenu();
+    const beforeDispatch = dispatchToMainMock.mock.calls.length;
+
+    await template
+      .find((i) => i.label === "Remote One (Paired · tunnel.example.com)")
+      ?.click?.();
+
+    expect(dispatchToMainMock.mock.calls[beforeDispatch]?.[0]).toEqual({
+      kind: "selectAssistant",
+      assistantId: "paired-1",
+    });
+  });
+
+  test("a paired active entry offers Remove from this Mac, never Retire", () => {
+    watchedLockfile = {
+      assistants: [managedEntry, pairedEntry],
+      activeAssistant: "paired-1",
+    };
+
+    const labels = popMenu().map((item) => item.label ?? "");
+    expect(labels).toContain("Remove from this Mac…");
+    expect(labels.some((label) => label.startsWith("Retire"))).toBe(false);
+  });
+
+  test("Remove from this Mac unpairs the active assistant with host-resolved paths", () => {
+    watchedLockfile = { assistants: [pairedEntry], activeAssistant: "paired-1" };
+    const template = popMenu();
+
+    template.find((i) => i.label === "Remove from this Mac…")?.click?.();
+
+    expect(unpairAssistantMock).toHaveBeenCalledTimes(1);
+    expect(unpairAssistantMock.mock.calls[0]).toEqual([
+      ["/fake/.vellum.lock.json"],
+      "/fake/config",
+      "paired-1",
+    ]);
+  });
+
+  test("a managed active entry keeps the Retire item and offers no Remove", async () => {
+    watchedLockfile = {
+      assistants: [managedEntry],
+      activeAssistant: "managed-1",
+    };
+    const template = popMenu();
+
+    const labels = template.map((item) => item.label);
+    expect(labels).toContain("Retire Managed One…");
+    expect(labels).not.toContain("Remove from this Mac…");
+
+    const beforeDispatch = dispatchToMainMock.mock.calls.length;
+    await template.find((i) => i.label === "Retire Managed One…")?.click?.();
+    expect(dispatchToMainMock.mock.calls[beforeDispatch]?.[0]).toEqual({
+      kind: "retireAssistant",
+      assistantId: "managed-1",
+    });
+    expect(unpairAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("an empty switcher shows the managed-or-paired empty state", () => {
+    const empty = popMenu().find(
+      (i) => i.label === "No managed or paired assistants",
+    );
+    expect(empty).toBeDefined();
+    expect(empty?.enabled).toBe(false);
   });
 });
 

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -101,7 +101,9 @@ const assistantDisplayTitle = (assistant: LockfileAssistant): string => {
  */
 const assistantMenuLabel = (assistant: LockfileAssistant): string => {
   const title = assistantDisplayTitle(assistant);
-  if (assistant.cloud !== "paired") return title;
+  if (assistant.cloud !== "paired") {
+    return title;
+  }
   let suffix = "Paired";
   if (assistant.runtimeUrl) {
     try {

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -1,5 +1,10 @@
 import { Menu, Tray, app, nativeTheme, shell } from "electron";
 
+import {
+  resolveConfigDir,
+  resolveLockfilePaths,
+  unpairAssistant,
+} from "@vellumai/local-mode";
 import type { LockfileAssistant } from "@vellumai/local-mode/contract";
 
 import {
@@ -15,6 +20,7 @@ import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands";
 import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
+import log from "./logger";
 import { dispatchToMain } from "./main-window";
 import { menuIcon } from "./menu-icon";
 import { readSetting } from "./settings";
@@ -95,6 +101,25 @@ const assistantDisplayTitle = (assistant: LockfileAssistant): string => {
 };
 
 /**
+ * Switcher label for a lockfile assistant. Paired entries carry a suffix
+ * naming the remote host (the chooser's paired labeling) so they read as
+ * remote pairings, not managed assistants.
+ */
+const assistantMenuLabel = (assistant: LockfileAssistant): string => {
+  const title = assistantDisplayTitle(assistant);
+  if (assistant.cloud !== "paired") return title;
+  let suffix = "Paired";
+  if (assistant.runtimeUrl) {
+    try {
+      suffix = `Paired \u00b7 ${new URL(assistant.runtimeUrl).hostname}`;
+    } catch {
+      // Unparseable runtimeUrl: plain "Paired".
+    }
+  }
+  return `${title} (${suffix})`;
+};
+
+/**
  * Whether the multi-platform-assistant feature flag is currently enabled.
  * Checked at menu-build time so toggling the flag takes effect on the next
  * right-click without requiring an app restart.
@@ -130,23 +155,24 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
   // Reads from the lockfile watcher's in-memory cache (no disk I/O).
   if (isMultiAssistantEnabled() && !onboarding) {
     const lockfile = getWatchedLockfile();
-    // Only managed (platform-hosted) assistants belong in the switcher,
-    // mirroring the native client's `isManaged` filter (cloud === "vellum").
-    // Local/Docker lockfile entries are handled by separate flows and would
-    // mis-route through the platform selection path.
-    const assistants = lockfile.assistants.filter((a) => a.cloud === "vellum");
+    // Managed (platform-hosted) and paired (remote, imported) assistants
+    // belong in the switcher. Local/Docker lockfile entries are handled by
+    // separate flows and would mis-route through the platform selection path.
+    const assistants = lockfile.assistants.filter(
+      (a) => a.cloud === "vellum" || a.cloud === "paired",
+    );
     const activeId = lockfile.activeAssistant;
 
     items.push({ type: "separator" });
     items.push({ label: "Assistants", enabled: false });
 
     if (assistants.length === 0) {
-      items.push({ label: "No managed assistants", enabled: false });
+      items.push({ label: "No managed or paired assistants", enabled: false });
     } else {
       for (const assistant of assistants) {
         const isActive = assistant.assistantId === activeId;
         items.push({
-          label: assistantDisplayTitle(assistant),
+          label: assistantMenuLabel(assistant),
           type: "radio",
           checked: isActive,
           click: async () => {
@@ -173,7 +199,26 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
       const activeAssistant = assistants.find(
         (a) => a.assistantId === activeId,
       );
-      if (activeAssistant) {
+      if (activeAssistant?.cloud === "paired") {
+        // A paired entry is a pairing record on this machine, so forget it
+        // (entry + stored guardian token) rather than retire the remote
+        // assistant: the same call the vellum:localMode:unpair handler makes.
+        items.push({
+          label: "Remove from this Mac\u2026",
+          click: () => {
+            const result = unpairAssistant(
+              resolveLockfilePaths(process.env),
+              resolveConfigDir(process.env),
+              activeAssistant.assistantId,
+            );
+            if (!result.ok) {
+              log.error(
+                `Tray unpair of ${activeAssistant.assistantId} failed: ${result.error}`,
+              );
+            }
+          },
+        });
+      } else if (activeAssistant) {
         items.push({
           label: `Retire ${assistantDisplayTitle(activeAssistant)}\u2026`,
           click: async () => {

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -1,10 +1,5 @@
 import { Menu, Tray, app, nativeTheme, shell } from "electron";
 
-import {
-  resolveConfigDir,
-  resolveLockfilePaths,
-  unpairAssistant,
-} from "@vellumai/local-mode";
 import type { LockfileAssistant } from "@vellumai/local-mode/contract";
 
 import {
@@ -20,7 +15,6 @@ import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands";
 import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
-import log from "./logger";
 import { dispatchToMain } from "./main-window";
 import { menuIcon } from "./menu-icon";
 import { readSetting } from "./settings";
@@ -201,21 +195,18 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
       );
       if (activeAssistant?.cloud === "paired") {
         // A paired entry is a pairing record on this machine, so forget it
-        // (entry + stored guardian token) rather than retire the remote
-        // assistant: the same call the vellum:localMode:unpair handler makes.
+        // rather than retire the remote assistant. The renderer owns the
+        // removal (confirm dialog + unpair host op + session cleanup) \u2014
+        // unpairing here in main would leave the window selected on, and
+        // still authenticated to, the removed assistant.
         items.push({
           label: "Remove from this Mac\u2026",
-          click: () => {
-            const result = unpairAssistant(
-              resolveLockfilePaths(process.env),
-              resolveConfigDir(process.env),
-              activeAssistant.assistantId,
-            );
-            if (!result.ok) {
-              log.error(
-                `Tray unpair of ${activeAssistant.assistantId} failed: ${result.error}`,
-              );
-            }
+          click: async () => {
+            await handlers.ensureMainWindow();
+            dispatchToMain({
+              kind: "removePairedAssistant",
+              assistantId: activeAssistant.assistantId,
+            });
           },
         });
       } else if (activeAssistant) {

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the host-command switch/remove service. Pins the two
+ * behaviors the tray commands rely on: a paired entry connects through
+ * `connectPairedAssistant` (never the bare selection write), and a paired
+ * removal clears the lifecycle's active id and routes to the chooser when
+ * the removed entry was the effective selection.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- mutable mock state (set per test) --- //
+
+let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
+let selectedAssistant: { assistantId: string } | undefined = undefined;
+let removeFromLockfileResult: { ok: boolean; error?: string } = { ok: true };
+let connectPairedShouldThrow = false;
+let activeAssistantId: string | null = null;
+
+// --- module mocks --- //
+
+const removePairedFromLockfileMock = mock(
+  async (_id: string) => removeFromLockfileResult,
+);
+mock.module("@/lib/local-mode", () => ({
+  getLockfileAssistant: (id: string) =>
+    lockfileAssistants.find((a) => a.assistantId === id),
+  getSelectedAssistant: () => selectedAssistant,
+  isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
+  removePairedAssistantFromLockfile: removePairedFromLockfileMock,
+}));
+
+const connectPairedAssistantMock = mock(async (_id: string) => {
+  if (connectPairedShouldThrow) {
+    throw new Error("guardian lease failed");
+  }
+});
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({ connectPairedAssistant: connectPairedAssistantMock }),
+  },
+}));
+
+const setSelectedAssistantMock = mock(async (_id: string | null) => {});
+mock.module("@/assistant/selection", () => ({
+  setSelectedAssistant: setSelectedAssistantMock,
+}));
+
+const setActiveAssistantIdMock = mock((id: string | null) => {
+  activeAssistantId = id;
+});
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({
+      activeAssistantId,
+      setActiveAssistantId: setActiveAssistantIdMock,
+    }),
+  },
+}));
+
+mock.module("@/utils/routes", () => ({
+  routes: {
+    selectAssistant: "/assistant/select-assistant",
+  },
+}));
+
+const { removePairedAssistant, switchToAssistant } = await import(
+  "./switch-service"
+);
+
+beforeEach(() => {
+  lockfileAssistants = [];
+  selectedAssistant = undefined;
+  removeFromLockfileResult = { ok: true };
+  connectPairedShouldThrow = false;
+  activeAssistantId = null;
+  removePairedFromLockfileMock.mockClear();
+  connectPairedAssistantMock.mockClear();
+  setSelectedAssistantMock.mockClear();
+  setActiveAssistantIdMock.mockClear();
+});
+
+describe("switchToAssistant", () => {
+  test("a paired entry connects through connectPairedAssistant, not the selection write", async () => {
+    lockfileAssistants = [{ assistantId: "pr1", cloud: "paired" }];
+
+    const outcome = await switchToAssistant("pr1");
+
+    expect(outcome.ok).toBe(true);
+    expect(connectPairedAssistantMock).toHaveBeenCalledWith("pr1");
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a managed entry goes through the platform selection path", async () => {
+    lockfileAssistants = [{ assistantId: "m1", cloud: "vellum" }];
+
+    const outcome = await switchToAssistant("m1");
+
+    expect(outcome.ok).toBe(true);
+    expect(setSelectedAssistantMock).toHaveBeenCalledWith("m1");
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("an id with no lockfile entry falls back to the selection write", async () => {
+    const outcome = await switchToAssistant("ghost");
+
+    expect(outcome.ok).toBe(true);
+    expect(setSelectedAssistantMock).toHaveBeenCalledWith("ghost");
+  });
+
+  test("a failed paired connect surfaces an error outcome", async () => {
+    lockfileAssistants = [{ assistantId: "pr1", cloud: "paired" }];
+    connectPairedShouldThrow = true;
+
+    const outcome = await switchToAssistant("pr1");
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBe("Failed to connect to the assistant.");
+    }
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("removePairedAssistant", () => {
+  test("removing the selected pairing clears the active id and routes to the chooser", async () => {
+    lockfileAssistants = [{ assistantId: "pr1", cloud: "paired" }];
+    selectedAssistant = { assistantId: "pr1" };
+    activeAssistantId = "pr1";
+
+    const outcome = await removePairedAssistant("pr1");
+
+    expect(removePairedFromLockfileMock).toHaveBeenCalledWith("pr1");
+    expect(setActiveAssistantIdMock).toHaveBeenCalledWith(null);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.nextRoute).toBe(
+        "/assistant/select-assistant?noAutoSkip=1",
+      );
+    }
+  });
+
+  test("removing a non-selected pairing stays put and leaves the active id alone", async () => {
+    lockfileAssistants = [
+      { assistantId: "pr1", cloud: "paired" },
+      { assistantId: "m1", cloud: "vellum" },
+    ];
+    selectedAssistant = { assistantId: "m1" };
+    activeAssistantId = "m1";
+
+    const outcome = await removePairedAssistant("pr1");
+
+    expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.nextRoute).toBeNull();
+    }
+  });
+
+  test("a failed host removal surfaces the error and touches nothing", async () => {
+    selectedAssistant = { assistantId: "pr1" };
+    activeAssistantId = "pr1";
+    removeFromLockfileResult = { ok: false, error: "host says no" };
+
+    const outcome = await removePairedAssistant("pr1");
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBe("host says no");
+    }
+    expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -169,4 +169,20 @@ describe("removePairedAssistant", () => {
     }
     expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
   });
+
+  test("a rejected host removal resolves to an error outcome instead of throwing", async () => {
+    selectedAssistant = { assistantId: "pr1" };
+    activeAssistantId = "pr1";
+    removePairedFromLockfileMock.mockImplementationOnce(async () => {
+      throw new Error("ipc channel gone");
+    });
+
+    const outcome = await removePairedAssistant("pr1");
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBe("Failed to remove assistant.");
+    }
+    expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
+  });
 });

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -1,0 +1,72 @@
+import { setSelectedAssistant } from "@/assistant/selection";
+import {
+  getLockfileAssistant,
+  getSelectedAssistant,
+  isPairedAssistant,
+  removePairedAssistantFromLockfile,
+} from "@/lib/local-mode";
+import { useAuthStore } from "@/stores/auth-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
+
+/**
+ * Host-command (tray, command palette) entry points for switching to and
+ * removing assistants by id. Extracted from the layout's command handlers so
+ * the paired-vs-managed routing is testable without mounting the app shell.
+ */
+
+export type SwitchOutcome = { ok: true } | { ok: false; error: string };
+
+/**
+ * Switch to an assistant by id. A paired entry needs the paired connect flow
+ * (guardian-token lease + gateway session seed) — the bare selection write
+ * would record it active without credentials. Everything else goes through
+ * the platform selection path; local assistants never reach this handler
+ * (the tray and palette exclude them).
+ */
+export async function switchToAssistant(
+  assistantId: string,
+): Promise<SwitchOutcome> {
+  const entry = getLockfileAssistant(assistantId);
+  if (entry && isPairedAssistant(entry)) {
+    try {
+      await useAuthStore.getState().connectPairedAssistant(assistantId);
+    } catch (err) {
+      console.error("switchToAssistant.connectPairedAssistant failed", err);
+      return { ok: false, error: "Failed to connect to the assistant." };
+    }
+    return { ok: true };
+  }
+  await setSelectedAssistant(assistantId);
+  return { ok: true };
+}
+
+export type RemovePairedOutcome =
+  | { ok: true; nextRoute: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Forget a paired assistant on this device, with full renderer cleanup: the
+ * host removes the entry + stored guardian token, the lockfile helper clears
+ * the session residue (selection key, gateway token, self-hosted connection),
+ * and the lifecycle's active id is dropped so a stale connection can't be
+ * admitted. When the removed entry was the effective selection the caller
+ * should route to the chooser (`nextRoute`); otherwise stay put (`null`).
+ */
+export async function removePairedAssistant(
+  assistantId: string,
+): Promise<RemovePairedOutcome> {
+  const wasSelected = getSelectedAssistant()?.assistantId === assistantId;
+  const result = await removePairedAssistantFromLockfile(assistantId);
+  if (!result.ok) {
+    return { ok: false, error: result.error ?? "Failed to remove assistant." };
+  }
+  const resolvedStore = useResolvedAssistantsStore.getState();
+  if (resolvedStore.activeAssistantId === assistantId) {
+    resolvedStore.setActiveAssistantId(null);
+  }
+  return {
+    ok: true,
+    nextRoute: wasSelected ? `${routes.selectAssistant}?noAutoSkip=1` : null,
+  };
+}

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -19,7 +19,7 @@ export type SwitchOutcome = { ok: true } | { ok: false; error: string };
 
 /**
  * Switch to an assistant by id. A paired entry needs the paired connect flow
- * (guardian-token lease + gateway session seed) — the bare selection write
+ * (guardian-token lease + gateway session seed); the bare selection write
  * would record it active without credentials. Everything else goes through
  * the platform selection path; local assistants never reach this handler
  * (the tray and palette exclude them).
@@ -57,7 +57,13 @@ export async function removePairedAssistant(
   assistantId: string,
 ): Promise<RemovePairedOutcome> {
   const wasSelected = getSelectedAssistant()?.assistantId === assistantId;
-  const result = await removePairedAssistantFromLockfile(assistantId);
+  let result: Awaited<ReturnType<typeof removePairedAssistantFromLockfile>>;
+  try {
+    result = await removePairedAssistantFromLockfile(assistantId);
+  } catch (err) {
+    console.error("removePairedAssistant.removeFromLockfile failed", err);
+    return { ok: false, error: "Failed to remove assistant." };
+  }
   if (!result.ok) {
     return { ok: false, error: result.error ?? "Failed to remove assistant." };
   }

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -11,8 +11,8 @@ import { routes } from "@/utils/routes";
 
 /**
  * Host-command (tray, command palette) entry points for switching to and
- * removing assistants by id. Extracted from the layout's command handlers so
- * the paired-vs-managed routing is testable without mounting the app shell.
+ * removing assistants by id, so the paired-vs-managed routing is testable
+ * without mounting the app shell.
  */
 
 export type SwitchOutcome = { ok: true } | { ok: false; error: string };

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -17,7 +17,11 @@ import {
   useHasPlatformSession,
 } from "@/stores/auth-store";
 import { handleLogout } from "@/lib/auth/handle-logout";
-import { getSelectedAssistant, isLocalClient } from "@/lib/local-mode";
+import {
+  getLockfileAssistant,
+  getSelectedAssistant,
+  isLocalClient,
+} from "@/lib/local-mode";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { useVellumCommands } from "@/runtime/vellum-commands";
@@ -59,9 +63,13 @@ import { TimezoneSync } from "@/components/timezone-sync";
 import { StatusBanner } from "@/components/status-banner";
 import { UpdateToast } from "@/components/update-toast";
 import { retireAssistant } from "@/assistant/retire-service";
-import { setSelectedAssistant } from "@/assistant/selection";
+import {
+  removePairedAssistant,
+  switchToAssistant,
+} from "@/assistant/switch-service";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
 const ShareFeedbackModal = lazy(() =>
@@ -195,6 +203,9 @@ export function RootLayout() {
   // the retire can run without first routing the user to settings.
   const [retireId, setRetireId] = useState<string | null>(null);
   const [retirePending, setRetirePending] = useState(false);
+  // Id of the paired assistant a tray "Remove from this Mac…" command targets.
+  const [removePairedId, setRemovePairedId] = useState<string | null>(null);
+  const [removePairedPending, setRemovePairedPending] = useState(false);
   // Whether the tray "New Assistant…" name-prompt dialog is open.
   const [createOpen, setCreateOpen] = useState(false);
 
@@ -229,10 +240,15 @@ export function RootLayout() {
     shareFeedback: () => setFeedbackOpen(true),
     selectAssistant: (command) => {
       if (command.kind === "selectAssistant") {
-        // The tray lists managed (platform-hosted) assistants, so switching
-        // goes through the platform selection path — not connectLocalAssistant,
-        // which primes a local gateway and no-ops for managed assistants.
-        void setSelectedAssistant(command.assistantId);
+        // Paired-aware switch: paired entries connect through
+        // connectPairedAssistant, managed ones through the platform
+        // selection path (see switch-service).
+        void switchToAssistant(command.assistantId).then((outcome) => {
+          if (!outcome.ok) {
+            toast.error(outcome.error);
+            void navigate(routes.selectAssistant);
+          }
+        });
       }
     },
     chooseAssistant: () => {
@@ -253,6 +269,11 @@ export function RootLayout() {
         setRetireId(command.assistantId);
       }
     },
+    removePairedAssistant: (command) => {
+      if (command.kind === "removePairedAssistant") {
+        setRemovePairedId(command.assistantId);
+      }
+    },
     quickInputSubmit: (command) => {
       if (command.kind !== "quickInputSubmit") {
         return;
@@ -271,6 +292,23 @@ export function RootLayout() {
       void navigate(`${routes.onboarding.hatching}?preview=true&fail=1`);
     },
   });
+
+  const handleConfirmRemovePaired = async () => {
+    if (!removePairedId) {
+      return;
+    }
+    setRemovePairedPending(true);
+    const outcome = await removePairedAssistant(removePairedId);
+    setRemovePairedPending(false);
+    setRemovePairedId(null);
+    if (!outcome.ok) {
+      toast.error(outcome.error);
+      return;
+    }
+    if (outcome.nextRoute) {
+      void navigate(outcome.nextRoute, { replace: true });
+    }
+  };
 
   const handleConfirmRetire = async () => {
     if (!retireId) {
@@ -388,6 +426,28 @@ export function RootLayout() {
         isPending={retirePending}
         onConfirm={handleConfirmRetire}
         onCancel={() => setRetireId(null)}
+      />
+
+      {/* Confirmation for the tray "Remove from this Mac…" command. Same copy
+          as the chooser's remove dialog: forgetting the pairing on this device
+          never touches the assistant on its host machine. */}
+      <ConfirmDialog
+        open={removePairedId !== null}
+        title="Remove from this device?"
+        message={
+          <>
+            This won&rsquo;t affect{" "}
+            {(removePairedId && getLockfileAssistant(removePairedId)?.name) ||
+              "the assistant"}{" "}
+            on its host machine. It only forgets the pairing on this device.
+            Pair again anytime with vellum connect import.
+          </>
+        }
+        confirmLabel="Remove"
+        destructive
+        isPending={removePairedPending}
+        onConfirm={() => void handleConfirmRemovePaired()}
+        onCancel={() => setRemovePairedId(null)}
       />
 
       {/* Name-prompt for the tray "New Assistant…" command — hatches an

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -54,6 +54,7 @@ export type VellumCommand =
   | { kind: "chooseAssistant" }
   | { kind: "createAssistant" }
   | { kind: "retireAssistant"; assistantId: string }
+  | { kind: "removePairedAssistant"; assistantId: string }
   | { kind: "quickInputSubmit"; message: string }
   | { kind: "cancelDictation" }
   | { kind: "replayOnboarding" }


### PR DESCRIPTION
## Summary
- Include cloud=paired entries in the tray switcher (still behind the multi-platform-assistant flag gate, same as managed entries)
- Paired active assistant gets 'Remove from this Mac…' wired to unpairAssistant instead of 'Retire'
- Label paired entries with their runtimeUrl host; updated empty-state copy

Part of plan: macos-paired-assistants.md (PR 4 of 10)