### PR TITLE
feat(macos): connect host tools to paired assistants over the remote gateway with the guardian bearer

### DIFF
--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -17,6 +17,7 @@ const mockGetGuardianAccessToken = mock(
 mock.module("@vellumai/local-mode", () => ({
   getGuardianAccessToken: mockGetGuardianAccessToken,
   resolveConfigDir: () => "/tmp/test-config",
+  resolveEnvironmentName: () => "test",
 }));
 
 // Minimal lockfile-watcher stub — capture the listener
@@ -427,6 +428,151 @@ describe("host-proxy-router", () => {
       lockfileListener?.(lockfile);
       await flush();
       expect(__testing.connections.get("cloud-1")!.sse).toBe(firstSse);
+    });
+  });
+
+  // -- Paired lifecycle ----------------------------------------------------
+
+  describe("paired lifecycle", () => {
+    /** Swap globalThis.fetch for one that records every request it serves. */
+    function recordingFetch(): { url: string; headers: Record<string, string> }[] {
+      const requests: { url: string; headers: Record<string, string> }[] = [];
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({
+          url: String(input),
+          headers: { ...((init?.headers ?? {}) as Record<string, string>) },
+        });
+        return new Response("ok");
+      }) as typeof globalThis.fetch;
+      return requests;
+    }
+
+    test("connects with the guardian bearer against the remote events URL", async () => {
+      const requests = recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("paired-1")).toBe(true);
+      expect(__testing.connections.get("paired-1")!.fingerprint).toBe(
+        "paired:https://tunnel.example.com:paired-1",
+      );
+
+      const sseRequest = requests.find((r) => r.url === "https://tunnel.example.com/v1/events");
+      expect(sseRequest).toBeDefined();
+      expect(sseRequest!.headers.Authorization).toBe("Bearer test-token");
+      expect(sseRequest!.headers["ngrok-skip-browser-warning"]).toBe("true");
+    });
+
+    test("never issues a token-exchange request for a paired entry", async () => {
+      const requests = recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      expect(__testing.connections.has("paired-1")).toBe(true);
+      expect(requests.some((r) => r.url.includes("/auth/token"))).toBe(false);
+    });
+
+    test("trailing slashes on runtimeUrl are stripped from the events URL", async () => {
+      const requests = recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com//" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      expect(requests.some((r) => r.url === "https://tunnel.example.com/v1/events")).toBe(true);
+    });
+
+    test("reconnects when the runtimeUrl changes", async () => {
+      recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://old-tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+      const firstSse = __testing.connections.get("paired-1")!.sse;
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://new-tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      expect(__testing.connections.get("paired-1")!.sse).not.toBe(firstSse);
+      expect(__testing.connections.get("paired-1")!.fingerprint).toBe(
+        "paired:https://new-tunnel.example.com:paired-1",
+      );
+    });
+
+    test("skips paired entries without a usable runtimeUrl", async () => {
+      recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-no-url", cloud: "paired" },
+          { assistantId: "paired-bad-url", cloud: "paired", runtimeUrl: "not-a-url" },
+        ],
+        activeAssistant: null,
+      });
+      await flush();
+
+      expect(__testing.connections.size).toBe(0);
+    });
+
+    test("guardian-token failure skips the paired entry without breaking other connections", async () => {
+      recordingFetch();
+      mockGetGuardianAccessToken.mockImplementation(
+        async () => ({ ok: false, status: 401, error: "expired" }),
+      );
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com" },
+          { assistantId: "cloud-1", cloud: "vellum", runtimeUrl: "https://platform.vellum.ai" },
+        ],
+        activeAssistant: "paired-1",
+      };
+      lockfileListener?.(lockfile);
+      await flush();
+
+      // Paired skipped, cloud unaffected
+      expect(__testing.connections.has("paired-1")).toBe(false);
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+
+      // Token becomes available: retried on the next lockfile cycle
+      mockGetGuardianAccessToken.mockImplementation(
+        async () => ({ ok: true, accessToken: "fresh-token" }),
+      );
+      lockfileListener?.(lockfile);
+      await flush();
+
+      expect(__testing.connections.has("paired-1")).toBe(true);
     });
   });
 

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -214,6 +214,39 @@ describe("host-proxy-router", () => {
       expect(lockfileListener).toBeNull();
     });
 
+    test("retiring an assistant during token acquisition aborts the stale connect", async () => {
+      const requests: string[] = [];
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        requests.push(String(input));
+        return mockGatewayTokenFetch(input);
+      }) as typeof globalThis.fetch;
+      let resolveToken: ((result: { ok: true; accessToken: string }) => void) | null = null;
+      mockGetGuardianAccessToken.mockImplementation(
+        () => new Promise((resolve) => { resolveToken = resolve; }),
+      );
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+      expect(__testing.pendingConnects.has("a1")).toBe(true);
+
+      // Retired before the token resolves — the pending connect is cancelled.
+      lockfileListener?.({ assistants: [], activeAssistant: null });
+      expect(__testing.pendingConnects.has("a1")).toBe(false);
+
+      resolveToken!({ ok: true, accessToken: "test-token" });
+      await flush();
+
+      expect(requests.some((url) => url.includes("/v1/events"))).toBe(false);
+      expect(__testing.connections.has("a1")).toBe(false);
+      expect(__testing.pendingConnects.size).toBe(0);
+    });
+
     test("does not connect when guardian token fetch fails", async () => {
       mockGetGuardianAccessToken.mockImplementation(
         async () => ({ ok: false, status: 401, error: "expired" }),
@@ -542,6 +575,112 @@ describe("host-proxy-router", () => {
       await flush();
 
       expect(__testing.connections.size).toBe(0);
+    });
+
+    test("unpairing during token acquisition aborts the stale connect", async () => {
+      const requests = recordingFetch();
+      let resolveToken: ((result: { ok: true; accessToken: string }) => void) | null = null;
+      mockGetGuardianAccessToken.mockImplementation(
+        () => new Promise((resolve) => { resolveToken = resolve; }),
+      );
+      installHostProxyBridge(fakeCliResolver);
+
+      // Paired entry appears; connect blocks on the slow token acquisition.
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://stale-tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+      expect(__testing.pendingConnects.has("paired-1")).toBe(true);
+
+      // Unpaired before the token resolves — the pending connect is cancelled.
+      lockfileListener?.({ assistants: [], activeAssistant: null });
+      expect(__testing.pendingConnects.has("paired-1")).toBe(false);
+
+      resolveToken!({ ok: true, accessToken: "test-token" });
+      await flush();
+
+      // No SSE was opened or recorded against the stale runtimeUrl.
+      expect(requests.some((r) => r.url.startsWith("https://stale-tunnel.example.com"))).toBe(false);
+      expect(__testing.connections.has("paired-1")).toBe(false);
+      expect(__testing.pendingConnects.size).toBe(0);
+    });
+
+    test("retargeting during token acquisition connects only to the new runtimeUrl", async () => {
+      const requests = recordingFetch();
+      let resolveFirstToken: ((result: { ok: true; accessToken: string }) => void) | null = null;
+      let tokenCalls = 0;
+      mockGetGuardianAccessToken.mockImplementation(() => {
+        tokenCalls += 1;
+        if (tokenCalls === 1) {
+          return new Promise((resolve) => { resolveFirstToken = resolve; });
+        }
+        return Promise.resolve({ ok: true, accessToken: "fresh-token" });
+      });
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://old-tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      // Retarget while the first token acquisition is still pending.
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://new-tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+      expect(__testing.connections.get("paired-1")!.fingerprint).toBe(
+        "paired:https://new-tunnel.example.com:paired-1",
+      );
+
+      // The stale connect resolves late and must not open SSE or clobber the entry.
+      resolveFirstToken!({ ok: true, accessToken: "stale-token" });
+      await flush();
+
+      expect(requests.some((r) => r.url.startsWith("https://old-tunnel.example.com"))).toBe(false);
+      expect(__testing.connections.get("paired-1")!.fingerprint).toBe(
+        "paired:https://new-tunnel.example.com:paired-1",
+      );
+      expect(__testing.pendingConnects.size).toBe(0);
+    });
+
+    test("repeated lockfile updates during a pending connect do not stack connects", async () => {
+      recordingFetch();
+      let resolveToken: ((result: { ok: true; accessToken: string }) => void) | null = null;
+      const tokenPromises: Promise<{ ok: true; accessToken: string }>[] = [];
+      mockGetGuardianAccessToken.mockImplementation(() => {
+        const p = new Promise<{ ok: true; accessToken: string }>((resolve) => { resolveToken = resolve; });
+        tokenPromises.push(p);
+        return p;
+      });
+      installHostProxyBridge(fakeCliResolver);
+
+      const lockfile: Lockfile = {
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      };
+      lockfileListener?.(lockfile);
+      lockfileListener?.(lockfile);
+      lockfileListener?.(lockfile);
+      await flush();
+
+      // Only one token acquisition in flight for the unchanged fingerprint.
+      expect(tokenPromises.length).toBe(1);
+
+      resolveToken!({ ok: true, accessToken: "test-token" });
+      await flush();
+      expect(__testing.connections.has("paired-1")).toBe(true);
+      expect(__testing.pendingConnects.size).toBe(0);
     });
 
     test("guardian-token failure skips the paired entry without breaking other connections", async () => {

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -235,7 +235,7 @@ describe("host-proxy-router", () => {
       await flush();
       expect(__testing.pendingConnects.has("a1")).toBe(true);
 
-      // Retired before the token resolves — the pending connect is cancelled.
+      // Retired before the token resolves, so the pending connect is cancelled.
       lockfileListener?.({ assistants: [], activeAssistant: null });
       expect(__testing.pendingConnects.has("a1")).toBe(false);
 
@@ -595,7 +595,7 @@ describe("host-proxy-router", () => {
       await flush();
       expect(__testing.pendingConnects.has("paired-1")).toBe(true);
 
-      // Unpaired before the token resolves — the pending connect is cancelled.
+      // Unpaired before the token resolves, so the pending connect is cancelled.
       lockfileListener?.({ assistants: [], activeAssistant: null });
       expect(__testing.pendingConnects.has("paired-1")).toBe(false);
 

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -59,6 +59,18 @@ interface AssistantConnection {
 // ---------------------------------------------------------------------------
 
 const connections = new Map<string, AssistantConnection>();
+
+// Connects that are still awaiting token acquisition. Registered synchronously
+// before the first await so the lockfile reconcile pass can cancel them; a
+// connect whose entry is gone (or replaced) when the await resolves must abort
+// instead of opening SSE to a possibly stale target. Entries are compared by
+// identity so a cancel-then-reconnect with the same fingerprint can't be
+// completed by the superseded attempt.
+interface PendingConnect {
+  fingerprint: string;
+}
+const pendingConnects = new Map<string, PendingConnect>();
+
 const executors = new Map<string, HostProxyExecutor>();
 
 // Injected by installHostProxyBridge; kept at module scope so the
@@ -282,14 +294,35 @@ async function connectLocalAssistant(
   assistantId: string,
   gatewayPort: number,
 ): Promise<void> {
+  const fingerprint = localFingerprint(gatewayPort);
   if (connections.has(assistantId)) return;
+  if (pendingConnects.get(assistantId)?.fingerprint === fingerprint) return;
 
-  const gatewayToken = await acquireGatewayToken(assistantId, gatewayPort);
-  if (!gatewayToken) {
-    log.warn("[host-proxy-router] could not acquire gateway token, skipping connection", { assistantId });
-    return;
+  const pending: PendingConnect = { fingerprint };
+  pendingConnects.set(assistantId, pending);
+  try {
+    const gatewayToken = await acquireGatewayToken(assistantId, gatewayPort);
+    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
+      log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId });
+      return;
+    }
+    if (!gatewayToken) {
+      log.warn("[host-proxy-router] could not acquire gateway token, skipping connection", { assistantId });
+      return;
+    }
+
+    openLocalConnection(assistantId, gatewayPort, gatewayToken, fingerprint);
+  } finally {
+    if (pendingConnects.get(assistantId) === pending) pendingConnects.delete(assistantId);
   }
+}
 
+function openLocalConnection(
+  assistantId: string,
+  gatewayPort: number,
+  gatewayToken: string,
+  fingerprint: string,
+): void {
   let currentToken = gatewayToken;
   const authHeaders = () => ({ Authorization: `Bearer ${currentToken}` });
 
@@ -308,7 +341,7 @@ async function connectLocalAssistant(
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, { sse, poster, fingerprint: localFingerprint(gatewayPort) });
+  connections.set(assistantId, { sse, poster, fingerprint });
   log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
 }
 
@@ -318,14 +351,35 @@ async function connectPairedAssistant(
   assistantId: string,
   runtimeUrl: string,
 ): Promise<void> {
+  const fingerprint = pairedFingerprint(runtimeUrl, assistantId);
   if (connections.has(assistantId)) return;
+  if (pendingConnects.get(assistantId)?.fingerprint === fingerprint) return;
 
-  const guardianToken = await acquireGuardianToken(assistantId);
-  if (!guardianToken) {
-    log.warn("[host-proxy-router] could not acquire guardian token, skipping paired connection", { assistantId });
-    return;
+  const pending: PendingConnect = { fingerprint };
+  pendingConnects.set(assistantId, pending);
+  try {
+    const guardianToken = await acquireGuardianToken(assistantId);
+    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
+      log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId, runtimeUrl });
+      return;
+    }
+    if (!guardianToken) {
+      log.warn("[host-proxy-router] could not acquire guardian token, skipping paired connection", { assistantId });
+      return;
+    }
+
+    openPairedConnection(assistantId, runtimeUrl, guardianToken, fingerprint);
+  } finally {
+    if (pendingConnects.get(assistantId) === pending) pendingConnects.delete(assistantId);
   }
+}
 
+function openPairedConnection(
+  assistantId: string,
+  runtimeUrl: string,
+  guardianToken: string,
+  fingerprint: string,
+): void {
   let currentToken = guardianToken;
   // The guardian access token is the bearer on the remote hop; the
   // /auth/token exchange is loopback-only and never runs for paired entries.
@@ -352,11 +406,7 @@ async function connectPairedAssistant(
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
 
-  connections.set(assistantId, {
-    sse,
-    poster,
-    fingerprint: pairedFingerprint(runtimeUrl, assistantId),
-  });
+  connections.set(assistantId, { sse, poster, fingerprint });
   log.info("[host-proxy-router] connected to paired assistant", { assistantId, runtimeUrl });
 }
 
@@ -405,6 +455,9 @@ function connectCloudAssistant(
 // -- Disconnect -------------------------------------------------------------
 
 function disconnectAssistant(assistantId: string): void {
+  if (pendingConnects.delete(assistantId)) {
+    log.info("[host-proxy-router] cancelled pending connection", { assistantId });
+  }
   const conn = connections.get(assistantId);
   if (!conn) return;
   conn.sse.disconnect();
@@ -434,10 +487,11 @@ function handleLockfileChange(lockfile: Lockfile): void {
         : cloudFingerprint(assistant.runtimeUrl!, assistant.organizationId);
 
     const existing = connections.get(assistant.assistantId);
-    if (existing && existing.fingerprint !== fp) {
+    const pending = pendingConnects.get(assistant.assistantId);
+    if ((existing && existing.fingerprint !== fp) || (pending && pending.fingerprint !== fp)) {
       log.info("[host-proxy-router] connection config changed, reconnecting", {
         assistantId: assistant.assistantId,
-        oldFingerprint: existing.fingerprint,
+        oldFingerprint: existing?.fingerprint ?? pending?.fingerprint,
         newFingerprint: fp,
       });
       disconnectAssistant(assistant.assistantId);
@@ -457,8 +511,8 @@ function handleLockfileChange(lockfile: Lockfile): void {
     }
   }
 
-  // Disconnect assistants that are no longer in the lockfile
-  for (const assistantId of connections.keys()) {
+  // Disconnect assistants (including in-flight connects) no longer in the lockfile
+  for (const assistantId of new Set([...connections.keys(), ...pendingConnects.keys()])) {
     if (!activeIds.has(assistantId)) {
       disconnectAssistant(assistantId);
     }
@@ -501,7 +555,7 @@ export function installHostProxyBridge(
   return () => {
     unsubscribe?.();
     unsubscribe = null;
-    for (const assistantId of [...connections.keys()]) {
+    for (const assistantId of new Set([...connections.keys(), ...pendingConnects.keys()])) {
       disconnectAssistant(assistantId);
     }
     browserExecutor.destroy();
@@ -521,6 +575,9 @@ export const __testing = {
   get connections() {
     return connections;
   },
+  get pendingConnects() {
+    return pendingConnects;
+  },
   get executors() {
     return executors;
   },
@@ -531,7 +588,7 @@ export const __testing = {
   disconnectAssistant,
   handleLockfileChange,
   reset() {
-    for (const assistantId of [...connections.keys()]) {
+    for (const assistantId of new Set([...connections.keys(), ...pendingConnects.keys()])) {
       disconnectAssistant(assistantId);
     }
     executors.clear();

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -4,7 +4,9 @@
  * Listens for lockfile changes and maintains an SSE + poster pair for each
  * assistant. Local assistants (with a gatewayPort) connect to the loopback
  * gateway; cloud/managed assistants connect to the platform via
- * assistant-scoped URLs with session-token auth.
+ * assistant-scoped URLs with session-token auth; paired assistants connect to
+ * the remote gateway at their runtimeUrl with the guardian access token as
+ * the bearer.
  *
  * Incoming SSE messages are dispatched to pluggable executors; unimplemented
  * executors post error results so daemon requests don't hang.
@@ -13,9 +15,10 @@
 import {
   getGuardianAccessToken,
   resolveConfigDir,
+  resolveEnvironmentName,
   type CliInvocation,
 } from "@vellumai/local-mode";
-import type { Lockfile } from "@vellumai/local-mode/contract";
+import { isUsableRuntimeUrl, type Lockfile } from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
@@ -215,10 +218,7 @@ async function exchangeForGatewayToken(
   }
 }
 
-async function acquireGatewayToken(
-  assistantId: string,
-  gatewayPort: number,
-): Promise<string | null> {
+async function acquireGuardianToken(assistantId: string): Promise<string | null> {
   if (!resolveCliInvocation) return null;
 
   const configDir = resolveConfigDir(process.env);
@@ -231,11 +231,15 @@ async function acquireGatewayToken(
     return null;
   }
 
+  // Pin the environment the guardian-token CLI subprocess (refresh) sees to
+  // the same one `configDir` is resolved from, so the token is always read
+  // and written under the same env dir.
   const tokenResult = await getGuardianAccessToken(
     assistantId,
     configDir,
     invocation,
     true,
+    { VELLUM_ENVIRONMENT: resolveEnvironmentName(process.env) },
   );
 
   if (!tokenResult.ok) {
@@ -246,7 +250,17 @@ async function acquireGatewayToken(
     return null;
   }
 
-  const exchanged = await exchangeForGatewayToken(gatewayPort, tokenResult.accessToken);
+  return tokenResult.accessToken;
+}
+
+async function acquireGatewayToken(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<string | null> {
+  const guardianToken = await acquireGuardianToken(assistantId);
+  if (!guardianToken) return null;
+
+  const exchanged = await exchangeForGatewayToken(gatewayPort, guardianToken);
   if (!exchanged) return null;
 
   return exchanged.token;
@@ -259,6 +273,8 @@ async function acquireGatewayToken(
 const localFingerprint = (gatewayPort: number): string => `local:${gatewayPort}`;
 const cloudFingerprint = (runtimeUrl: string, organizationId?: string): string =>
   `cloud:${runtimeUrl}:${organizationId ?? ""}`;
+const pairedFingerprint = (runtimeUrl: string, assistantId: string): string =>
+  `paired:${runtimeUrl}:${assistantId}`;
 
 // -- Local assistant connection ---------------------------------------------
 
@@ -294,6 +310,54 @@ async function connectLocalAssistant(
 
   connections.set(assistantId, { sse, poster, fingerprint: localFingerprint(gatewayPort) });
   log.info("[host-proxy-router] connected to local assistant", { assistantId, gatewayPort });
+}
+
+// -- Paired assistant connection --------------------------------------------
+
+async function connectPairedAssistant(
+  assistantId: string,
+  runtimeUrl: string,
+): Promise<void> {
+  if (connections.has(assistantId)) return;
+
+  const guardianToken = await acquireGuardianToken(assistantId);
+  if (!guardianToken) {
+    log.warn("[host-proxy-router] could not acquire guardian token, skipping paired connection", { assistantId });
+    return;
+  }
+
+  let currentToken = guardianToken;
+  // The guardian access token is the bearer on the remote hop; the
+  // /auth/token exchange is loopback-only and never runs for paired entries.
+  // Paired runtimeUrls are commonly ngrok tunnels; free-tier edges intercept
+  // requests lacking the skip header with an interstitial page.
+  const authHeaders = () => ({
+    Authorization: `Bearer ${currentToken}`,
+    "ngrok-skip-browser-warning": "true",
+  });
+
+  const onRefreshToken = async (): Promise<string | null> => {
+    const fresh = await acquireGuardianToken(assistantId);
+    if (fresh) currentToken = fresh;
+    return fresh;
+  };
+
+  const base = runtimeUrl.replace(/\/+$/, "");
+  const eventsUrl = `${base}/v1/events`;
+  const endpointBase = `${base}/v1`;
+
+  const sse = new HostProxySseClient({ eventsUrl, authHeaders, onRefreshToken });
+  const poster = new HostProxyPoster({ endpointBase, authHeaders });
+
+  sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
+  sse.connect();
+
+  connections.set(assistantId, {
+    sse,
+    poster,
+    fingerprint: pairedFingerprint(runtimeUrl, assistantId),
+  });
+  log.info("[host-proxy-router] connected to paired assistant", { assistantId, runtimeUrl });
 }
 
 // -- Cloud assistant connection ---------------------------------------------
@@ -358,12 +422,16 @@ function handleLockfileChange(lockfile: Lockfile): void {
   for (const assistant of lockfile.assistants) {
     const port = assistant.resources?.gatewayPort;
     const isCloud = !port && assistant.cloud === "vellum" && assistant.runtimeUrl;
-    if (!port && !isCloud) continue;
+    const isPaired =
+      !port && assistant.cloud === "paired" && isUsableRuntimeUrl(assistant.runtimeUrl);
+    if (!port && !isCloud && !isPaired) continue;
 
     activeIds.add(assistant.assistantId);
     const fp = port
       ? localFingerprint(port)
-      : cloudFingerprint(assistant.runtimeUrl!, assistant.organizationId);
+      : isPaired
+        ? pairedFingerprint(assistant.runtimeUrl!, assistant.assistantId)
+        : cloudFingerprint(assistant.runtimeUrl!, assistant.organizationId);
 
     const existing = connections.get(assistant.assistantId);
     if (existing && existing.fingerprint !== fp) {
@@ -377,6 +445,8 @@ function handleLockfileChange(lockfile: Lockfile): void {
     if (!connections.has(assistant.assistantId)) {
       if (port) {
         void connectLocalAssistant(assistant.assistantId, port);
+      } else if (isPaired) {
+        void connectPairedAssistant(assistant.assistantId, assistant.runtimeUrl!);
       } else {
         connectCloudAssistant(
           assistant.assistantId,
@@ -457,6 +527,7 @@ export const __testing = {
   dispatchMessage,
   connectLocalAssistant,
   connectCloudAssistant,
+  connectPairedAssistant,
   disconnectAssistant,
   handleLockfileChange,
   reset() {

--- a/clients/macos/src/main/host-proxy-sse.test.ts
+++ b/clients/macos/src/main/host-proxy-sse.test.ts
@@ -226,6 +226,46 @@ describe("HostProxySseClient", () => {
     expect(messages.some((m) => m.type === "ok")).toBe(true);
   });
 
+  test("disconnect during a slow token refresh stops the pending reconnect", async () => {
+    let fetchCount = 0;
+    const fakeFetch: typeof globalThis.fetch = (async () => {
+      fetchCount++;
+      // Every attempt fails, driving the client into the reconnect path
+      throw new Error("network error");
+    }) as unknown as typeof globalThis.fetch;
+
+    let refreshStarted = false;
+    let resolveRefresh: (token: string | null) => void = () => {};
+    const onRefreshToken = (): Promise<string | null> => {
+      refreshStarted = true;
+      return new Promise((r) => {
+        resolveRefresh = r;
+      });
+    };
+
+    client = new HostProxySseClient({
+      eventsUrl: "https://stale.example.ngrok.app/v1/events",
+      authHeaders: () => ({ Authorization: "Bearer tok" }),
+      fetch: fakeFetch,
+      onRefreshToken,
+    });
+    client.connect();
+
+    // First attempt fails immediately; the reconnect timer fires after ~1s
+    // and blocks awaiting the slow token refresh.
+    await flush(1_200);
+    expect(fetchCount).toBe(1);
+    expect(refreshStarted).toBe(true);
+
+    // Unpair while the refresh is still in flight, then let it complete.
+    client.disconnect();
+    resolveRefresh("fresh-token");
+    await flush(200);
+
+    // The stale client must not dial the old eventsUrl again.
+    expect(fetchCount).toBe(1);
+  });
+
   // -- Idle watchdog ------------------------------------------------------
 
   test("idle watchdog triggers reconnect when no traffic arrives", async () => {

--- a/clients/macos/src/main/host-proxy-sse.ts
+++ b/clients/macos/src/main/host-proxy-sse.ts
@@ -215,8 +215,12 @@ export class HostProxySseClient {
         try {
           await this.onRefreshToken();
         } catch {
-          // Token refresh failed — reconnect with existing headers
+          // Token refresh failed, reconnect with existing headers
         }
+        // disconnect() may have been called while the refresh was in
+        // flight; without this recheck the stale client would resume
+        // streaming against an endpoint the router no longer tracks.
+        if (!this.shouldReconnect) return;
       }
       this.startStream();
     }, delay);


### PR DESCRIPTION
## Summary
- Paired lockfile entries now qualify for host-proxy connections: SSE + poster against <runtimeUrl>/v1/events with the guardian access token as the bearer (no /auth/token exchange)
- pairedFingerprint tears down and reconnects on runtimeUrl changes; guardian-token failures degrade to not-connected without affecting local/cloud connections
- ngrok-skip-browser-warning set on the remote hops

Note on the poster base: the plan sketch said endpointBase = <runtimeUrl>, but HostProxyPoster appends /host-*-result and the daemon result routes are /v1/host-*-result (the local branch uses a /v1 base for the same reason), so the paired endpointBase is <runtimeUrl>/v1. A bare-runtimeUrl base would 404 every result post.

The guardian-token acquisition (configDir + VELLUM_ENVIRONMENT pinning, CLI-subprocess refresh) is factored into acquireGuardianToken, shared by the local token-exchange path and the paired direct-bearer path.

## Security posture
This grants a paired remote assistant reach into this Mac's host tools (host_bash, host_file, host_transfer, host_browser, host_cu, host_app_control, host_ui_snapshot), governed by the same approvals/consent surfaces as local assistants. Reviewers: please check that assumption holds for every host tool routed here.

Part of plan: macos-paired-assistants.md (PR 5 of 10)