### PR TITLE
fix(web): treat an answered 401 healthz as auth-stale, not an unreachable assistant

### DIFF
--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -145,6 +145,13 @@ mock.module("@/lib/local-mode", () => ({
   syncPlatformAssistantsToLockfile: async () => {},
 }));
 
+const refreshRemoteGatewaySessionMock = mock(async () => true);
+mock.module("@/lib/auth/remote-gateway-session", () => ({
+  refreshRemoteGatewaySession: refreshRemoteGatewaySessionMock,
+  remoteGatewayPublicPathPrefix: () => "",
+  remoteGatewayApiPath: (path: string) => path,
+}));
+
 const getLocalAssistantStatusHostMock = mock(
   async (_assistantId: string): Promise<LocalAssistantStatusResult> => ({
     ok: false,
@@ -219,6 +226,7 @@ beforeEach(() => {
   isGatewayAuthModeMock.mockImplementation(() => false);
   isLocalClientMock.mockImplementation(() => false);
   isRemoteGatewayModeMock.mockImplementation(() => false);
+  refreshRemoteGatewaySessionMock.mockClear();
   getSelectedAssistantMock.mockImplementation(() => undefined);
   getLocalGatewayUrlMock.mockImplementation(() => undefined);
   getPairedGatewayUrlMock.mockImplementation(() => undefined);
@@ -1218,6 +1226,118 @@ describe("lifecycleService — local health heartbeat", () => {
     expect(getLocalAssistantStatusHostMock).toHaveBeenCalledWith(
       "local-selected",
     );
+  });
+
+  /** Drive to a healthy gateway-auth active state, then run one more probe. */
+  async function driveHealthyThenProbe(
+    nextHealthz: () => Promise<unknown>,
+  ): Promise<void> {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+    await waitFor(() => {
+      const s = useAssistantLifecycleStore.getState().assistantState;
+      return s.kind === "active" && s.health === "healthy";
+    });
+    getAssistantHealthzMock.mockImplementation(
+      nextHealthz as () => Promise<{ ok: true }>,
+    );
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+    if (!assistantId) {
+      throw new Error("expected an active assistant id");
+    }
+    await (
+      lifecycleService as unknown as {
+        probeReachability(id: string): Promise<void>;
+      }
+    ).probeReachability(assistantId);
+  }
+
+  test("a 401 healthz keeps the last known health (stale bearer, not a down assistant)", async () => {
+    await driveHealthyThenProbe(async () => ({ ok: false, status: 401 }));
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.health).toBe("healthy");
+      expect(state.reachable).toBe(true);
+    }
+  });
+
+  test("a 401 healthz in remote-gateway mode nudges the session refresh", async () => {
+    isRemoteGatewayModeMock.mockImplementation(() => true);
+    await driveHealthyThenProbe(async () => ({ ok: false, status: 401 }));
+
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalled();
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.health).toBe("healthy");
+    }
+  });
+
+  test("one dropped probe keeps a healthy state; the second consecutive failure flips it", async () => {
+    await driveHealthyThenProbe(async () => {
+      throw new Error("network error");
+    });
+
+    const afterOne = useAssistantLifecycleStore.getState().assistantState;
+    expect(afterOne.kind).toBe("active");
+    if (afterOne.kind === "active") {
+      expect(afterOne.health).toBe("healthy");
+      expect(afterOne.reachable).toBe(true);
+    }
+
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+    await (
+      lifecycleService as unknown as {
+        probeReachability(id: string): Promise<void>;
+      }
+    ).probeReachability(assistantId!);
+
+    const afterTwo = useAssistantLifecycleStore.getState().assistantState;
+    expect(afterTwo.kind).toBe("active");
+    if (afterTwo.kind === "active") {
+      expect(afterTwo.health).toBe("unreachable");
+      expect(afterTwo.reachable).toBe(false);
+    }
+  });
+
+  test("a successful probe resets the failure streak", async () => {
+    await driveHealthyThenProbe(async () => {
+      throw new Error("network error");
+    });
+
+    const probe = (
+      lifecycleService as unknown as {
+        probeReachability(id: string): Promise<void>;
+      }
+    ).probeReachability.bind(lifecycleService);
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+
+    getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
+    await probe(assistantId!);
+
+    getAssistantHealthzMock.mockImplementation(async () => {
+      throw new Error("network error");
+    });
+    await probe(assistantId!);
+
+    // Fail, succeed, fail: the streak restarted, so the single trailing
+    // failure must not flip a healthy state.
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.health).toBe("healthy");
+      expect(state.reachable).toBe(true);
+    }
   });
 });
 

--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -1309,6 +1309,40 @@ describe("lifecycleService — local health heartbeat", () => {
     }
   });
 
+  test("an auth-stale probe resets the failure streak", async () => {
+    await driveHealthyThenProbe(async () => {
+      throw new Error("network error");
+    });
+
+    const probe = (
+      lifecycleService as unknown as {
+        probeReachability(id: string): Promise<void>;
+      }
+    ).probeReachability.bind(lifecycleService);
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+
+    getAssistantHealthzMock.mockImplementation(async () => ({
+      ok: false,
+      status: 401,
+    }));
+    await probe(assistantId!);
+
+    getAssistantHealthzMock.mockImplementation(async () => {
+      throw new Error("network error");
+    });
+    await probe(assistantId!);
+
+    // Drop, answered-401, drop: the 401 proved the gateway reachable, so the
+    // two drops are not consecutive and health must hold.
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.health).toBe("healthy");
+      expect(state.reachable).toBe(true);
+    }
+  });
+
   test("a successful probe resets the failure streak", async () => {
     await driveHealthyThenProbe(async () => {
       throw new Error("network error");

--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -1343,6 +1343,37 @@ describe("lifecycleService — local health heartbeat", () => {
     }
   });
 
+  test("a probe's own 5xx does not double-count via the unreachable bus", async () => {
+    // The daemon response interceptor fires the unreachable bus synchronously
+    // while the heartbeat's own healthz request is still in flight; that must
+    // count as ONE failed probe, not two, so a single 503 blip on a healthy
+    // assistant stays debounced.
+    await driveHealthyThenProbe(async () => {
+      capturedUnreachableListener?.();
+      return { ok: false, status: 503 };
+    });
+
+    const afterOne = useAssistantLifecycleStore.getState().assistantState;
+    expect(afterOne.kind).toBe("active");
+    if (afterOne.kind === "active") {
+      expect(afterOne.health).toBe("healthy");
+    }
+
+    const assistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
+    await (
+      lifecycleService as unknown as {
+        probeReachability(id: string): Promise<void>;
+      }
+    ).probeReachability(assistantId!);
+
+    const afterTwo = useAssistantLifecycleStore.getState().assistantState;
+    expect(afterTwo.kind).toBe("active");
+    if (afterTwo.kind === "active") {
+      expect(afterTwo.health).toBe("unreachable");
+    }
+  });
+
   test("a successful probe resets the failure streak", async () => {
     await driveHealthyThenProbe(async () => {
       throw new Error("network error");

--- a/clients/web/src/assistant/lifecycle-service.ts
+++ b/clients/web/src/assistant/lifecycle-service.ts
@@ -890,11 +890,15 @@ class AssistantLifecycleService {
       return;
     }
     this.transition({ ...this.state, reachable: false });
-    // The bus/SSE failure that triggered this probe is itself evidence of
-    // trouble: count it as the first strike so the pulled-forward probe's
-    // own failure flips health immediately instead of being debounced like
-    // a lone heartbeat blip.
-    this.probeFailureStreak = Math.max(this.probeFailureStreak, 1);
+    // A bus/SSE failure that arrives while no probe is in flight is
+    // independent evidence of trouble: count it as the first strike so the
+    // pulled-forward probe's own failure flips health immediately instead
+    // of being debounced like a lone heartbeat blip. A notification raised
+    // by an in-flight probe's own 5xx response must not seed the streak, or
+    // that probe's failure would be counted twice.
+    if (!this.reachabilityProbeInFlightIds.has(assistantId)) {
+      this.probeFailureStreak = Math.max(this.probeFailureStreak, 1);
+    }
     if (this.healthHeartbeatId === assistantId) {
       // The heartbeat owns the cadence — just pull the next probe
       // forward instead of racing a second retry loop against it.

--- a/clients/web/src/assistant/lifecycle-service.ts
+++ b/clients/web/src/assistant/lifecycle-service.ts
@@ -44,6 +44,7 @@ import { deriveLocalAssistantHealth } from "@/assistant/local-health";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { AssistantState, LocalAssistantHealth } from "@/assistant/types";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
+import { refreshRemoteGatewaySession } from "@/lib/auth/remote-gateway-session";
 import {
   getSelectedAssistant,
   getAuthGatewayIngressUrl,
@@ -130,6 +131,14 @@ class AssistantLifecycleService {
    * degraded without recursively starting another `/healthz` request.
    */
   private reachabilityProbeInFlightIds = new Set<string>();
+  /**
+   * Consecutive health probes that came back unreachable. A single failed
+   * probe is weak evidence over a tunnel or during a token rollover, so the
+   * healthy-to-unreachable flip (and the banners keyed off it) waits for a
+   * second consecutive failure. Reset on any successful probe and on
+   * heartbeat teardown.
+   */
+  private probeFailureStreak = 0;
   /**
    * Tracks the assistant being actively probed. Non-null when a probe
    * loop is running (timer pending OR tick in-flight). Prevents
@@ -678,9 +687,22 @@ class AssistantLifecycleService {
 
       if (health !== "upgrading") {
         try {
-          health = deriveLocalAssistantHealth(
-            await getAssistantHealthz(assistantId),
-          );
+          const healthz = await getAssistantHealthz(assistantId);
+          // An answered 401/403 proves the gateway is up: the session bearer
+          // went stale (remote-web access tokens rotate continuously), not
+          // the assistant. Mapping it to "unreachable" flashed the wake
+          // banner on every rollover, so keep the last known health and
+          // nudge the session refresh instead.
+          if (
+            !healthz.ok &&
+            (healthz.status === 401 || healthz.status === 403)
+          ) {
+            if (isRemoteGatewayMode()) {
+              void refreshRemoteGatewaySession();
+            }
+            return;
+          }
+          health = deriveLocalAssistantHealth(healthz);
         } catch {
           health = "unreachable";
         }
@@ -713,6 +735,24 @@ class AssistantLifecycleService {
         useResolvedAssistantsStore.getState().activeAssistantId !== assistantId
       ) {
         return;
+      }
+      if (health === "unreachable") {
+        this.probeFailureStreak += 1;
+        const lastKnownHealth =
+          this.state.kind === "self_hosted" ||
+          (this.state.kind === "active" && this.state.isLocal)
+            ? this.state.health
+            : undefined;
+        // Debounce the healthy-to-unreachable flip: one dropped probe on an
+        // otherwise-responding assistant is not enough to declare it down.
+        if (
+          this.probeFailureStreak < 2 &&
+          (lastKnownHealth === "healthy" || lastKnownHealth === "unhealthy")
+        ) {
+          return;
+        }
+      } else {
+        this.probeFailureStreak = 0;
       }
       if (this.state.kind === "self_hosted") {
         if (this.state.health !== health) {
@@ -817,6 +857,7 @@ class AssistantLifecycleService {
   private cancelHealthHeartbeat(): void {
     this.healthHeartbeatToken++;
     this.healthHeartbeatId = null;
+    this.probeFailureStreak = 0;
     if (this.healthHeartbeatTimer) {
       clearTimeout(this.healthHeartbeatTimer);
       this.healthHeartbeatTimer = null;
@@ -848,6 +889,11 @@ class AssistantLifecycleService {
       return;
     }
     this.transition({ ...this.state, reachable: false });
+    // The bus/SSE failure that triggered this probe is itself evidence of
+    // trouble: count it as the first strike so the pulled-forward probe's
+    // own failure flips health immediately instead of being debounced like
+    // a lone heartbeat blip.
+    this.probeFailureStreak = Math.max(this.probeFailureStreak, 1);
     if (this.healthHeartbeatId === assistantId) {
       // The heartbeat owns the cadence — just pull the next probe
       // forward instead of racing a second retry loop against it.

--- a/clients/web/src/assistant/lifecycle-service.ts
+++ b/clients/web/src/assistant/lifecycle-service.ts
@@ -690,13 +690,14 @@ class AssistantLifecycleService {
           const healthz = await getAssistantHealthz(assistantId);
           // An answered 401/403 proves the gateway is up: the session bearer
           // went stale (remote-web access tokens rotate continuously), not
-          // the assistant. Mapping it to "unreachable" flashed the wake
-          // banner on every rollover, so keep the last known health and
-          // nudge the session refresh instead.
+          // the assistant. Keep the last known health, count the answer as
+          // evidence of reachability for the failure streak, and nudge the
+          // session refresh.
           if (
             !healthz.ok &&
             (healthz.status === 401 || healthz.status === 403)
           ) {
+            this.probeFailureStreak = 0;
             if (isRemoteGatewayMode()) {
               void refreshRemoteGatewaySession();
             }


### PR DESCRIPTION
## Summary
- An answered 401/403 from the healthz probe proves the gateway is up: keep the last known health and (in remote-gateway mode) nudge the session refresh, instead of mapping it to unreachable. Remote-web access tokens rotate continuously, so the old mapping flashed the "Your assistant runs locally" wake banner on every rollover.
- Debounce the healthy-to-unreachable flip to two consecutive probe failures so a single dropped request over a tunnel can't flash the down-banners; the acute unreachable-bus path seeds the streak so bus-confirmed failures still surface immediately.

## Original prompt
While testing the paired-assistant flow over an ngrok tunnel, the remote-web UI at the gateway-served origin showed a rhythmically flashing "Your assistant runs locally" banner. Network capture showed the healthz heartbeat cycling 200/200/401 with each access-token rollover, and the lifecycle mapping that 401 to "unreachable", which renders the wake banner in sessions with no local-mode host. The fix was requested after diagnosing this in-session: treat auth-stale probe answers as auth-staleness (with a refresh nudge), and add small hysteresis for genuine transport blips.