### PR TITLE
fix(macos): return structured 502s from the paired gateway forward instead of raw ERR_FAILED

### DIFF
--- a/clients/macos/src/main/gateway-forward.test.ts
+++ b/clients/macos/src/main/gateway-forward.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  executeGatewayForwardPlan,
   planGatewayForward,
   planPairedGatewayForward,
+  type GatewayForwardPlan,
 } from "./gateway-forward";
+import {
+  PROXY_ERROR_HEADER,
+  PROXY_NETWORK_ERROR_CODE,
+} from "./platform-forward";
 
 const allow =
   (...ports: number[]) =>
@@ -203,5 +209,170 @@ describe("planPairedGatewayForward", () => {
     }
     expect(plan.headers.get("authorization")).toBe("Bearer guardian-token");
     expect(plan.headers.get("accept")).toBe("text/event-stream");
+  });
+});
+
+describe("executeGatewayForwardPlan", () => {
+  const noBody = { body: null };
+  const quietRetries = { sleep: async () => {}, onError: () => {} };
+
+  const forwardPlan = (
+    planner: () => GatewayForwardPlan,
+  ): Extract<GatewayForwardPlan, { kind: "forward" }> => {
+    const plan = planner();
+    if (plan.kind !== "forward") {
+      throw new Error("expected forward");
+    }
+    return plan;
+  };
+
+  const loopbackPlan = (method = "GET") =>
+    forwardPlan(() =>
+      planGatewayForward(
+        request("/__gateway/8080/v1/foo", { method }),
+        allow(8080),
+      ),
+    );
+
+  const pairedPlan = (method = "GET") =>
+    forwardPlan(() =>
+      planPairedGatewayForward(
+        request("/__gateway-paired/abc/v1/foo", { method }),
+        pair({ abc: "https://gw.example.com" }),
+      ),
+    );
+
+  const rejectingFetcher =
+    (message: string, calls?: { count: number }) => async () => {
+      if (calls) {
+        calls.count += 1;
+      }
+      throw new Error(message);
+    };
+
+  test("returns null on a pass plan so the caller serves static assets", () => {
+    expect(
+      executeGatewayForwardPlan({ kind: "pass" }, noBody, async () => {
+        throw new Error("must not fetch");
+      }),
+    ).toBeNull();
+  });
+
+  test("turns a reject plan into its error response", async () => {
+    const result = executeGatewayForwardPlan(
+      { kind: "reject", status: 403, message: "Forbidden" },
+      noBody,
+      async () => {
+        throw new Error("must not fetch");
+      },
+    );
+    if (!(result instanceof Response)) {
+      throw new Error("expected a Response");
+    }
+    expect(result.status).toBe(403);
+    expect(await result.text()).toBe("Forbidden");
+  });
+
+  test("forwards with manual redirects and a half-duplex streamed body", async () => {
+    const body = new ReadableStream<Uint8Array>();
+    const seen: { url: string; init: RequestInit & { duplex?: "half" } }[] = [];
+    const plan = loopbackPlan("POST");
+    await executeGatewayForwardPlan(plan, { body }, async (url, init) => {
+      seen.push({ url, init });
+      return new Response("ok");
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.url).toBe("http://127.0.0.1:8080/v1/foo");
+    expect(seen[0]!.init.method).toBe("POST");
+    expect(seen[0]!.init.headers).toBe(plan.headers);
+    expect(seen[0]!.init.body).toBe(body);
+    expect(seen[0]!.init.duplex).toBe("half");
+    expect(seen[0]!.init.redirect).toBe("manual");
+  });
+
+  test("omits body and duplex for bodiless requests", async () => {
+    const seen: (RequestInit & { duplex?: "half" })[] = [];
+    await executeGatewayForwardPlan(pairedPlan(), noBody, async (_url, init) => {
+      seen.push(init);
+      return new Response("ok");
+    });
+
+    expect(seen[0]!.body).toBeUndefined();
+    expect(seen[0]!.duplex).toBeUndefined();
+    expect(seen[0]!.redirect).toBe("manual");
+  });
+
+  test("passes the upstream Response through by identity, body unconsumed", async () => {
+    // SSE and chunked transfers rely on the streaming Response reaching the
+    // renderer verbatim; buffering here would stall live streams.
+    const upstream = new Response(new ReadableStream<Uint8Array>(), {
+      headers: { "content-type": "text/event-stream" },
+    });
+    const result = await executeGatewayForwardPlan(
+      pairedPlan(),
+      noBody,
+      async () => upstream,
+    );
+
+    expect(result).toBe(upstream);
+    expect(upstream.bodyUsed).toBe(false);
+  });
+
+  test("a loopback fetch rejection propagates to the caller", async () => {
+    const result = executeGatewayForwardPlan(
+      loopbackPlan(),
+      noBody,
+      rejectingFetcher("net::ERR_CONNECTION_REFUSED"),
+    );
+    await expect(result as Promise<Response>).rejects.toThrow(
+      "net::ERR_CONNECTION_REFUSED",
+    );
+  });
+
+  test("a paired fetch rejection becomes the structured 502", async () => {
+    const result = await executeGatewayForwardPlan(
+      pairedPlan(),
+      noBody,
+      rejectingFetcher("net::ERR_TUNNEL_CONNECTION_FAILED"),
+      quietRetries,
+    );
+
+    if (!(result instanceof Response)) {
+      throw new Error("expected a Response");
+    }
+    expect(result.status).toBe(502);
+    expect(result.headers.get("content-type")).toBe("application/json");
+    expect(result.headers.get(PROXY_ERROR_HEADER)).toBe("network");
+    const body = (await result.json()) as Record<string, unknown>;
+    expect(body.code).toBe(PROXY_NETWORK_ERROR_CODE);
+    expect(typeof body.detail).toBe("string");
+    expect(body.detail).not.toContain("net::");
+  });
+
+  test("a paired GET retries a transient failure once, then returns the 502", async () => {
+    const calls = { count: 0 };
+    const result = await executeGatewayForwardPlan(
+      pairedPlan(),
+      noBody,
+      rejectingFetcher("net::ERR_NETWORK_CHANGED", calls),
+      quietRetries,
+    );
+
+    expect(calls.count).toBe(2);
+    expect((result as Response).status).toBe(502);
+  });
+
+  test("a paired POST is not retried: its body stream is single-use", async () => {
+    const calls = { count: 0 };
+    const result = await executeGatewayForwardPlan(
+      pairedPlan("POST"),
+      noBody,
+      rejectingFetcher("net::ERR_NETWORK_CHANGED", calls),
+      quietRetries,
+    );
+
+    expect(calls.count).toBe(1);
+    expect((result as Response).status).toBe(502);
   });
 });

--- a/clients/macos/src/main/gateway-forward.ts
+++ b/clients/macos/src/main/gateway-forward.ts
@@ -4,16 +4,22 @@ import {
   sanitizePairedForwardHeaders,
 } from "@vellumai/local-mode";
 
+import {
+  fetchForwardPlanWithRetry,
+  type ForwardFetchRetryOptions,
+} from "./platform-forward";
+
 /**
- * Pure planning for the gateway data-plane proxies: the loopback
+ * Planning and execution for the gateway data-plane proxies: the loopback
  * `/assistant/__gateway/{port}/*` forward and the paired-remote
  * `/assistant/__gateway-paired/{assistantId}/*` forward.
  *
  * Lives in its own file — like `app-protocol.ts` — so the URL/header logic is
  * testable without importing `src/main/index.ts` (which evaluates the full
  * lifecycle wiring at module load) or mocking Electron's `net`. The caller in
- * `index.ts` turns a `forward` plan into a single `net.fetch` and returns its
- * streaming `Response` verbatim.
+ * `index.ts` supplies `net.fetch`; `executeGatewayForwardPlan` turns a
+ * `forward` plan into a single fetch and returns its streaming `Response`
+ * verbatim.
  */
 export type GatewayForwardPlan =
   | { kind: "pass" }
@@ -24,6 +30,12 @@ export type GatewayForwardPlan =
       method: string;
       headers: Headers;
       hasBody: boolean;
+      /**
+       * Remote hops (paired gateways reached over a tunnel) collapse
+       * transport failures into the structured proxy 502 with a bounded
+       * GET/HEAD retry; loopback hops propagate rejections untouched.
+       */
+      remote: boolean;
     };
 
 export interface GatewayForwardRequest {
@@ -82,6 +94,7 @@ export function planGatewayForward(
         method: request.method,
         headers,
         hasBody: request.method !== "GET" && request.method !== "HEAD",
+        remote: false,
       };
     }
   }
@@ -138,7 +151,70 @@ export function planPairedGatewayForward(
         method: request.method,
         headers,
         hasBody: request.method !== "GET" && request.method !== "HEAD",
+        remote: true,
       };
+    }
+  }
+}
+
+/** Injectable stand-in for Electron's `net.fetch`. */
+export type GatewayForwardFetcher = (
+  url: string,
+  init: RequestInit & { duplex?: "half" },
+) => Promise<Response>;
+
+export interface GatewayForwardBodySource {
+  body: ReadableStream | null;
+}
+
+/**
+ * Turn a gateway forward plan into its effect: `null` on `pass` so the caller
+ * serves the request as a static asset, otherwise the plan's rejection or a
+ * single fetch whose streaming `Response` is returned verbatim, preserving
+ * SSE and chunked transfers (Electron's `stream: true` scheme privilege).
+ * The plan owns the allowlist and header decisions.
+ *
+ * Remote (paired) hops ride a tunnel that can drop mid-session, so their
+ * transport failures become the structured proxy 502 (with one in-proxy
+ * retry for transient GET/HEAD failures) instead of a rejected promise the
+ * renderer would render as a raw `net::ERR_*` string. No overall response
+ * timeout is applied: SSE streams over this forward are long-lived.
+ */
+export function executeGatewayForwardPlan(
+  plan: GatewayForwardPlan,
+  request: GatewayForwardBodySource,
+  fetcher: GatewayForwardFetcher,
+  retryOptions: ForwardFetchRetryOptions = {},
+): Promise<Response> | Response | null {
+  switch (plan.kind) {
+    case "pass":
+      return null;
+    case "reject":
+      return new Response(plan.message, { status: plan.status });
+    case "forward": {
+      const doFetch = () =>
+        fetcher(plan.url, {
+          method: plan.method,
+          headers: plan.headers,
+          body: plan.hasBody ? request.body : undefined,
+          // Stream the request body instead of buffering it; required by the
+          // fetch spec whenever a `ReadableStream` body is supplied.
+          ...(plan.hasBody ? { duplex: "half" as const } : {}),
+          redirect: "manual",
+        });
+      if (!plan.remote) {
+        return doFetch();
+      }
+      return fetchForwardPlanWithRetry(plan, doFetch, {
+        retries: 1,
+        onError: (err, attempt) => {
+          console.error(
+            `[gateway-forward] fetch failed (attempt ${attempt + 1}) for ${plan.method} ${plan.url}:`,
+            err,
+          );
+        },
+        ...retryOptions,
+      });
     }
   }
 }

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -23,9 +23,10 @@ import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
 import { registerVellumAppProtocol } from "./vellumapp-protocol";
 import {
+  executeGatewayForwardPlan,
   planGatewayForward,
   planPairedGatewayForward,
-  type GatewayForwardPlan,
+  type GatewayForwardFetcher,
 } from "./gateway-forward";
 import {
   fetchForwardPlanWithRetry,
@@ -294,34 +295,8 @@ const fileExists = async (candidate: string): Promise<boolean> => {
   }
 };
 
-/**
- * Turn a gateway forward plan into its effect: `null` on `pass` so the caller
- * serves the request as a static asset, otherwise the plan's rejection or a
- * single `net.fetch` whose streaming `Response` is returned verbatim,
- * preserving SSE and chunked transfers (Electron's `stream: true` scheme
- * privilege). The plan owns the allowlist and header decisions.
- */
-const executeGatewayForwardPlan = (
-  plan: GatewayForwardPlan,
-  request: GlobalRequest,
-): Promise<Response> | Response | null => {
-  switch (plan.kind) {
-    case "pass":
-      return null;
-    case "reject":
-      return new Response(plan.message, { status: plan.status });
-    case "forward":
-      return net.fetch(plan.url, {
-        method: plan.method,
-        headers: plan.headers,
-        body: plan.hasBody ? request.body : undefined,
-        // Stream the request body instead of buffering it; required by the
-        // fetch spec whenever a `ReadableStream` body is supplied.
-        ...(plan.hasBody ? { duplex: "half" } : {}),
-        redirect: "manual",
-      });
-  }
-};
+const gatewayForwardFetcher: GatewayForwardFetcher = (url, init) =>
+  net.fetch(url, init);
 
 /**
  * Forward a gateway data-plane request (`/assistant/__gateway/{port}/*`) to the
@@ -334,7 +309,11 @@ const forwardGatewayRequest = async (
   request: GlobalRequest,
   getAllowedPorts: () => Set<number>,
 ): Promise<Response | null> =>
-  executeGatewayForwardPlan(planGatewayForward(request, getAllowedPorts), request);
+  executeGatewayForwardPlan(
+    planGatewayForward(request, getAllowedPorts),
+    request,
+    gatewayForwardFetcher,
+  );
 
 /**
  * Forward a paired-gateway data-plane request
@@ -347,7 +326,11 @@ const forwardPairedGatewayRequest = async (
   request: GlobalRequest,
   getTargets: () => Map<string, string>,
 ): Promise<Response | null> =>
-  executeGatewayForwardPlan(planPairedGatewayForward(request, getTargets), request);
+  executeGatewayForwardPlan(
+    planPairedGatewayForward(request, getTargets),
+    request,
+    gatewayForwardFetcher,
+  );
 
 const resolvedConfig = resolveLocalConfigFromEnv(process.env);
 handleSync("vellum:config:get", () => ({


### PR DESCRIPTION
## Summary
- Move gateway-forward execution out of index.ts into a testable module with an injectable fetcher
- Wrap the paired branch in retry/error-shaping so tunnel failures surface as structured 502s, not raw ERR_FAILED
- Cover 502 shaping, GET-only retry, and unbuffered SSE pass-through with tests

Part of plan: macos-paired-assistants.md (PR 1 of 10)