### PR TITLE
refactor(local-mode): add pairAssistant (bundle import) to the shared package and route the CLI through it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -539,6 +539,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@vellumai/environments": "file:../environments",
+        "nanoid": "5.1.7",
         "zod": "4.3.6",
       },
       "devDependencies": {

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -90,7 +90,7 @@ export async function connectImport(): Promise<void> {
   console.log("");
   console.log(
     result.accessOnly
-      ? "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does."
-      : "Note: this connection includes a refresh credential, so it can renew itself — re-pair only if it's revoked or the refresh credential expires.",
+      ? "Note: the token is access-only and will expire. Re-run `vellum pair` and import again when it does."
+      : "Note: this connection includes a refresh credential, so it can renew itself. Re-pair only if it's revoked or the refresh credential expires.",
   );
 }

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -3,24 +3,20 @@
  *
  * Import a pairing bundle printed by `vellum pair` on another machine and
  * register it locally so `vellum client`/`message`/`events <name>` work against
- * the remote assistant.
- *
- * The bundle is base64(JSON.stringify({ gatewayUrl, assistantId, token,
- * deviceId })). We store the entry under a UNIQUE LOCAL id (not the bundle's
- * assistantId, which is typically "self" and would collide across hosts). This
- * is safe because the gateway's runtime proxy strips the `/v1/assistants/<id>/`
- * segment before forwarding, so the local id never has to match the remote one
- * — the token (validated by signature/audience) is what authorizes requests.
+ * the remote assistant. Decoding, id derivation, and the lockfile/token writes
+ * live in `pairAssistant` (`@vellumai/local-mode`); this command owns only the
+ * argv parsing and output copy.
  */
 
-import { nanoid } from "nanoid";
+import {
+  decodePairBundle,
+  pairAssistant,
+  resolveConfigDir,
+} from "@vellumai/local-mode";
 
 import { extractFlag } from "../../lib/arg-utils.js";
-import {
-  findAssistantByName,
-  saveAssistantEntry,
-} from "../../lib/assistant-config.js";
-import { saveGuardianToken } from "../../lib/guardian-token.js";
+import { getLockfilePaths } from "../../lib/environments/paths.js";
+import { getCurrentEnvironment } from "../../lib/environments/resolve.js";
 
 function printUsage(): void {
   console.log(`vellum connect import - Register an assistant paired from another machine
@@ -41,85 +37,6 @@ EXAMPLES:
 `);
 }
 
-interface PairBundle {
-  gatewayUrl: string;
-  token: string;
-  assistantId?: string;
-  deviceId?: string;
-  // Optional refresh credential. Present when the host's gateway issued a
-  // device-bound token pair; absent for older access-only bundles (which remain
-  // importable, just without auto-renewal). `refreshTokenExpiresAt` mirrors
-  // GuardianTokenData (ISO string OR epoch-ms number) so a numeric expiry isn't
-  // silently dropped on import.
-  refreshToken?: string;
-  refreshTokenExpiresAt?: string | number;
-  refreshAfter?: string;
-}
-
-/** Decode the base64 bundle, returning null if malformed or missing fields. */
-function decodeBundle(blob: string): PairBundle | null {
-  let json: unknown;
-  try {
-    json = JSON.parse(Buffer.from(blob, "base64").toString("utf8"));
-  } catch {
-    return null;
-  }
-  if (typeof json !== "object" || json === null) return null;
-  const b = json as Record<string, unknown>;
-  if (typeof b.gatewayUrl !== "string" || typeof b.token !== "string") {
-    return null;
-  }
-  // The gatewayUrl is persisted as runtimeUrl and used to build fetch URLs, so
-  // require an absolute http(s) URL here rather than letting an invalid string
-  // through (which would crash `new URL(...)` or break later client calls).
-  try {
-    const parsed = new URL(b.gatewayUrl);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return null;
-    }
-  } catch {
-    return null;
-  }
-  return {
-    gatewayUrl: b.gatewayUrl,
-    token: b.token,
-    assistantId: typeof b.assistantId === "string" ? b.assistantId : undefined,
-    deviceId: typeof b.deviceId === "string" ? b.deviceId : undefined,
-    refreshToken:
-      typeof b.refreshToken === "string" ? b.refreshToken : undefined,
-    refreshTokenExpiresAt:
-      typeof b.refreshTokenExpiresAt === "string" ||
-      typeof b.refreshTokenExpiresAt === "number"
-        ? b.refreshTokenExpiresAt
-        : undefined,
-    refreshAfter:
-      typeof b.refreshAfter === "string" ? b.refreshAfter : undefined,
-  };
-}
-
-/** Lowercase, collapse non-alphanumerics to single dashes, trim dashes. */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-/** Best-effort JWT `exp` (epoch seconds) → epoch ms; null if undecodable. */
-function jwtExpiryMs(token: string): number | null {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-  try {
-    const payload = JSON.parse(
-      Buffer.from(parts[1], "base64").toString("utf8"),
-    );
-    if (typeof payload.exp === "number") return payload.exp * 1000;
-  } catch {
-    /* fall through */
-  }
-  return null;
-}
-
 export async function connectImport(): Promise<void> {
   const rawArgs = process.argv.slice(4);
 
@@ -136,82 +53,44 @@ export async function connectImport(): Promise<void> {
     process.exit(1);
   }
 
-  const bundle = decodeBundle(blob);
-  if (!bundle) {
+  const decoded = decodePairBundle(blob);
+  if (!decoded.ok) {
     console.error(
       "Error: invalid pairing bundle. Paste the full base64 string printed by `vellum pair`.",
     );
     process.exit(1);
   }
 
-  // Unique local id: a --name slug, or paired-<deviceId> (deviceId is unique
-  // per pairing). Never the bundle's "self" assistantId — that would collide.
-  // The deviceId comes from an untrusted bundle and is used as a path component
-  // by saveGuardianToken, so it MUST be slugified (no `../` traversal); fall
-  // back to a random id if it sanitizes to empty.
-  const localId = nameFlag
-    ? slugify(nameFlag)
-    : `paired-${slugify(bundle.deviceId ?? "") || nanoid()}`;
-  if (!localId) {
-    console.error(
-      "Error: --name must contain at least one alphanumeric character.",
-    );
+  const result = pairAssistant(
+    getLockfilePaths(getCurrentEnvironment()),
+    resolveConfigDir(process.env),
+    { bundle: decoded.bundle, name: nameFlag },
+  );
+  if (!result.ok) {
+    if (result.status === 400) {
+      console.error(
+        "Error: --name must contain at least one alphanumeric character.",
+      );
+    } else if (result.status === 409) {
+      console.error(
+        `Error: an assistant named '${result.assistantId}' already exists locally. ` +
+          "Choose a different --name to avoid overwriting it.",
+      );
+    } else {
+      console.error(`Error: ${result.error}`);
+    }
     process.exit(1);
   }
-
-  // Don't clobber an existing assistant. Only update in place when the prior
-  // entry is itself a paired import (marked `paired: true`); otherwise the id
-  // collides with a real local/remote assistant and overwriting would drop its
-  // resources/runtime metadata. Reject and let the user pick a fresh --name.
-  const existing = findAssistantByName(localId);
-  if (existing && existing.paired !== true) {
-    console.error(
-      `Error: an assistant named '${localId}' already exists locally. ` +
-        "Choose a different --name to avoid overwriting it.",
-    );
-    process.exit(1);
-  }
-  const existed = existing !== null;
-
-  saveAssistantEntry({
-    assistantId: localId,
-    name: nameFlag ?? `paired (${new URL(bundle.gatewayUrl).host})`,
-    runtimeUrl: bundle.gatewayUrl,
-    // Paired entries are reached by bearer token at the remote runtimeUrl
-    // (a non-"vellum" cloud selects the bearer-token auth path in client.ts).
-    // The "paired" topology lets lifecycle/status commands (ps/wake/sleep)
-    // recognize this as a remote pairing rather than an on-machine process.
-    cloud: "paired",
-    // Marks this entry as a connect-import so re-imports update in place while
-    // imports never silently overwrite a non-paired assistant (see guard above).
-    paired: true,
-    species: "vellum",
-  });
-
-  const now = Date.now();
-  const hasRefresh = Boolean(bundle.refreshToken);
-  saveGuardianToken(localId, {
-    guardianPrincipalId: "imported",
-    accessToken: bundle.token,
-    accessTokenExpiresAt:
-      jwtExpiryMs(bundle.token) ?? now + 24 * 60 * 60 * 1000,
-    refreshToken: bundle.refreshToken ?? "",
-    refreshTokenExpiresAt: bundle.refreshTokenExpiresAt ?? 0,
-    refreshAfter: bundle.refreshAfter ?? "",
-    isNew: false,
-    deviceId: bundle.deviceId ?? "",
-    leasedAt: new Date(now).toISOString(),
-  });
 
   console.log(
-    `${existed ? "Updated" : "Imported"} paired assistant '${localId}'.`,
+    `${result.updated ? "Updated" : "Imported"} paired assistant '${result.assistantId}'.`,
   );
   console.log("");
-  console.log(`  Connect with:  vellum client ${localId}`);
+  console.log(`  Connect with:  vellum client ${result.assistantId}`);
   console.log("");
   console.log(
-    hasRefresh
-      ? "Note: this connection includes a refresh credential, so it can renew itself — re-pair only if it's revoked or the refresh credential expires."
-      : "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does.",
+    result.accessOnly
+      ? "Note: the token is access-only and will expire — re-run `vellum pair` and import again when it does."
+      : "Note: this connection includes a refresh credential, so it can renew itself — re-pair only if it's revoked or the refresh credential expires.",
   );
 }

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -17,7 +17,12 @@ import { platform } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS } from "@vellumai/environments";
-import { guardianTokenPath, resolveConfigDir } from "@vellumai/local-mode";
+import {
+  guardianTokenPath,
+  resolveConfigDir,
+  saveGuardianToken as writeGuardianToken,
+  type GuardianTokenData,
+} from "@vellumai/local-mode";
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
@@ -25,19 +30,7 @@ import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 const DEVICE_ID_SALT = "vellum-assistant-host-id";
 
-export interface GuardianTokenData {
-  guardianPrincipalId: string;
-  accessToken: string;
-  /** ISO date string or epoch-ms number as returned by the gateway. */
-  accessTokenExpiresAt: string | number;
-  refreshToken: string;
-  /** ISO date string or epoch-ms number as returned by the gateway. */
-  refreshTokenExpiresAt: string | number;
-  refreshAfter: string;
-  isNew: boolean;
-  deviceId: string;
-  leasedAt: string;
-}
+export type { GuardianTokenData };
 
 function getGuardianTokenPath(assistantId: string): string {
   // Resolve via the shared @vellumai/local-mode resolver — the same one every
@@ -178,15 +171,9 @@ export function saveGuardianToken(
   assistantId: string,
   data: GuardianTokenData,
 ): void {
-  const tokenPath = getGuardianTokenPath(assistantId);
-  const dir = dirname(tokenPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-  writeFileSync(tokenPath, JSON.stringify(data, null, 2) + "\n", {
-    mode: 0o600,
-  });
-  chmodSync(tokenPath, 0o600);
+  // Delegates to the shared @vellumai/local-mode writer (0700 dir, 0600 file)
+  // with the same env-resolved config dir the path resolver above uses.
+  writeGuardianToken(resolveConfigDir(process.env), assistantId, data);
 }
 
 /** Abort the refresh POST if the gateway is slow/unreachable (it's now on the

--- a/packages/local-mode/package.json
+++ b/packages/local-mode/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@vellumai/environments": "file:../environments",
+    "nanoid": "5.1.7",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/local-mode/src/__tests__/package-boundary.test.ts
+++ b/packages/local-mode/src/__tests__/package-boundary.test.ts
@@ -7,8 +7,9 @@
  *
  * Enforces that the package:
  * 1. Imports only node builtins, its own relative modules, `@vellumai/environments`,
- *    and `zod` (the lockfile contract's schema library) — nothing else.
- * 2. Declares exactly those two runtime dependencies.
+ *    `zod` (the lockfile contract's schema library), and `nanoid` (pair's
+ *    fallback local-id generator); nothing else.
+ * 2. Declares exactly those runtime dependencies.
  * 3. Is marked `private`.
  */
 
@@ -19,7 +20,7 @@ import { join, resolve } from "node:path";
 const PACKAGE_ROOT = resolve(import.meta.dirname, "../..");
 const SRC_DIR = join(PACKAGE_ROOT, "src");
 
-const ALLOWED_PACKAGES = new Set(["@vellumai/environments", "zod"]);
+const ALLOWED_PACKAGES = new Set(["@vellumai/environments", "zod", "nanoid"]);
 
 function collectSourceFiles(dir: string): string[] {
   const files: string[] = [];
@@ -91,13 +92,14 @@ describe("package boundary", () => {
     }
   });
 
-  test("package.json declares it as private with only its environments and zod dependencies", () => {
+  test("package.json declares it as private with only its allowed dependencies", () => {
     const pkg = JSON.parse(
       readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8"),
     );
     expect(pkg.private).toBe(true);
     expect(pkg.dependencies ?? {}).toEqual({
       "@vellumai/environments": "file:../environments",
+      nanoid: "5.1.7",
       zod: "4.3.6",
     });
   });

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -1,0 +1,422 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { guardianTokenPath } from "../config";
+import { decodePairBundle, pairAssistant, type PairBundle } from "../pair";
+
+let tmpDir: string;
+let lockfilePath: string;
+let configDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-pair-"));
+  lockfilePath = path.join(tmpDir, "lockfile.json");
+  configDir = path.join(tmpDir, "config");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const writeLockfile = (data: Record<string, unknown>): void => {
+  fs.writeFileSync(lockfilePath, JSON.stringify(data));
+};
+
+const readLockfileFromDisk = (): Record<string, unknown> =>
+  JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as Record<string, unknown>;
+
+const encodeBundle = (obj: Record<string, unknown>): string =>
+  Buffer.from(JSON.stringify(obj)).toString("base64");
+
+const bundle = (overrides: Partial<PairBundle> = {}): PairBundle => ({
+  gatewayUrl: "http://10.0.0.5:7830",
+  token: "test-token",
+  assistantId: "self",
+  deviceId: "dev-aaa",
+  ...overrides,
+});
+
+/** A syntactically valid JWT whose `exp` is 2030-01-01T00:00:00Z. */
+const JWT_EXP_S = 1893456000;
+const jwtWithExp = `h.${Buffer.from(JSON.stringify({ exp: JWT_EXP_S })).toString("base64")}.s`;
+
+describe("decodePairBundle", () => {
+  test("decodes a full bundle, preserving a numeric refreshTokenExpiresAt", () => {
+    const result = decodePairBundle(
+      encodeBundle({
+        gatewayUrl: "https://tunnel.example.com",
+        token: "tok",
+        assistantId: "self",
+        deviceId: "dev-1",
+        refreshToken: "refresh",
+        refreshTokenExpiresAt: 1893456000000,
+        refreshAfter: "2026-07-01T00:00:00.000Z",
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      bundle: {
+        gatewayUrl: "https://tunnel.example.com",
+        token: "tok",
+        assistantId: "self",
+        deviceId: "dev-1",
+        refreshToken: "refresh",
+        refreshTokenExpiresAt: 1893456000000,
+        refreshAfter: "2026-07-01T00:00:00.000Z",
+      },
+    });
+  });
+
+  test("drops malformed optional fields instead of failing", () => {
+    const result = decodePairBundle(
+      encodeBundle({
+        gatewayUrl: "http://10.0.0.5:7830",
+        token: "tok",
+        deviceId: 42,
+        refreshToken: { nope: true },
+        refreshAfter: 7,
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      bundle: {
+        gatewayUrl: "http://10.0.0.5:7830",
+        token: "tok",
+        assistantId: undefined,
+        deviceId: undefined,
+        refreshToken: undefined,
+        refreshTokenExpiresAt: undefined,
+        refreshAfter: undefined,
+      },
+    });
+  });
+
+  test("rejects garbage base64 and JSON non-objects without throwing", () => {
+    for (const encoded of [
+      "not-valid-base64!!",
+      Buffer.from(JSON.stringify("just a string")).toString("base64"),
+      Buffer.from("{truncated").toString("base64"),
+    ]) {
+      const result = decodePairBundle(encoded);
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        continue;
+      }
+      expect(typeof result.error).toBe("string");
+    }
+  });
+
+  test("rejects a bundle missing token or gatewayUrl", () => {
+    expect(decodePairBundle(encodeBundle({ token: "tok" })).ok).toBe(false);
+    expect(
+      decodePairBundle(encodeBundle({ gatewayUrl: "http://h" })).ok,
+    ).toBe(false);
+  });
+
+  test("rejects a non-http(s) or relative gatewayUrl", () => {
+    expect(
+      decodePairBundle(encodeBundle({ gatewayUrl: "ftp://nope", token: "t" }))
+        .ok,
+    ).toBe(false);
+    expect(
+      decodePairBundle(encodeBundle({ gatewayUrl: "/relative", token: "t" }))
+        .ok,
+    ).toBe(false);
+  });
+});
+
+describe("pairAssistant", () => {
+  test("writes the lockfile entry and guardian token with the exact CLI shapes and modes", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ token: jwtWithExp, deviceId: "dev-aaa" }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).toBe("paired-dev-aaa");
+    expect(result.updated).toBe(false);
+    expect(result.accessOnly).toBe(true);
+
+    // The on-disk entry matches what `vellum connect import` writes, field for
+    // field and in the same key order.
+    const onDisk = readLockfileFromDisk();
+    const entry = (onDisk.assistants as Array<Record<string, unknown>>)[0]!;
+    expect(entry).toEqual({
+      assistantId: "paired-dev-aaa",
+      name: "paired (10.0.0.5:7830)",
+      runtimeUrl: "http://10.0.0.5:7830",
+      cloud: "paired",
+      paired: true,
+      species: "vellum",
+    });
+    expect(Object.keys(entry)).toEqual([
+      "assistantId",
+      "name",
+      "runtimeUrl",
+      "cloud",
+      "paired",
+      "species",
+    ]);
+    // Importing never reassigns the active assistant.
+    expect(onDisk.activeAssistant ?? null).toBeNull();
+
+    const tokenPath = guardianTokenPath(configDir, "paired-dev-aaa");
+    const raw = fs.readFileSync(tokenPath, "utf-8");
+    expect(raw.endsWith("\n")).toBe(true);
+    const token = JSON.parse(raw) as Record<string, unknown>;
+    const { leasedAt, ...rest } = token;
+    expect(rest).toEqual({
+      guardianPrincipalId: "imported",
+      accessToken: jwtWithExp,
+      accessTokenExpiresAt: JWT_EXP_S * 1000,
+      refreshToken: "",
+      refreshTokenExpiresAt: 0,
+      refreshAfter: "",
+      isNew: false,
+      deviceId: "dev-aaa",
+    });
+    expect(new Date(leasedAt as string).toISOString()).toBe(
+      leasedAt as string,
+    );
+    expect(Object.keys(token)).toEqual([
+      "guardianPrincipalId",
+      "accessToken",
+      "accessTokenExpiresAt",
+      "refreshToken",
+      "refreshTokenExpiresAt",
+      "refreshAfter",
+      "isNew",
+      "deviceId",
+      "leasedAt",
+    ]);
+
+    expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.dirname(tokenPath)).mode & 0o777).toBe(0o700);
+  });
+
+  test("falls back to now+24h expiry for a non-JWT access token", () => {
+    const before = Date.now();
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ token: "opaque-token", deviceId: "dev-exp" }),
+    });
+    expect(result.ok).toBe(true);
+
+    const token = JSON.parse(
+      fs.readFileSync(guardianTokenPath(configDir, "paired-dev-exp"), "utf-8"),
+    ) as Record<string, unknown>;
+    const dayMs = 24 * 60 * 60 * 1000;
+    expect(token.accessTokenExpiresAt as number).toBeGreaterThanOrEqual(
+      before + dayMs,
+    );
+    expect(token.accessTokenExpiresAt as number).toBeLessThanOrEqual(
+      Date.now() + dayMs,
+    );
+  });
+
+  test("persists the refresh credential and reports accessOnly: false", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({
+        deviceId: "dev-refresh",
+        refreshToken: "refresh-tok",
+        refreshTokenExpiresAt: "2027-01-01T00:00:00.000Z",
+        refreshAfter: "2026-07-01T00:00:00.000Z",
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.accessOnly).toBe(false);
+    const token = JSON.parse(
+      fs.readFileSync(
+        guardianTokenPath(configDir, "paired-dev-refresh"),
+        "utf-8",
+      ),
+    ) as Record<string, unknown>;
+    expect(token.refreshToken).toBe("refresh-tok");
+    expect(token.refreshTokenExpiresAt).toBe("2027-01-01T00:00:00.000Z");
+    expect(token.refreshAfter).toBe("2026-07-01T00:00:00.000Z");
+  });
+
+  test("a name is slugified into the id while the entry keeps the raw name", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle(),
+      name: "Desk Box",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).toBe("desk-box");
+    const entry = (
+      readLockfileFromDisk().assistants as Array<Record<string, unknown>>
+    )[0]!;
+    expect(entry.name).toBe("Desk Box");
+  });
+
+  test("a name with no alphanumerics is refused with a 400", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle(),
+      name: "!!!",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.status).toBe(400);
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+  });
+
+  test("a malicious deviceId is slugified out of the path", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ deviceId: "-/../../tmp/x" }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).not.toContain("/");
+    expect(result.assistantId).not.toContain("..");
+    expect(
+      fs.existsSync(guardianTokenPath(configDir, result.assistantId)),
+    ).toBe(true);
+  });
+
+  test("a missing deviceId falls back to a random path-safe id", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ deviceId: undefined }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).toMatch(/^paired-[A-Za-z0-9_-]{21}$/);
+  });
+
+  test("refuses to clobber an existing non-paired assistant", () => {
+    writeLockfile({
+      assistants: [
+        {
+          assistantId: "desk",
+          cloud: "local",
+          runtimeUrl: "http://127.0.0.1:7830",
+        },
+      ],
+      activeAssistant: "desk",
+    });
+
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle(),
+      name: "desk",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.status).toBe(409);
+    expect(result.assistantId).toBe("desk");
+    // Nothing was written: the entry is untouched and no token exists.
+    expect(readLockfileFromDisk().assistants).toEqual([
+      {
+        assistantId: "desk",
+        cloud: "local",
+        runtimeUrl: "http://127.0.0.1:7830",
+      },
+    ]);
+    expect(fs.existsSync(guardianTokenPath(configDir, "desk"))).toBe(false);
+  });
+
+  test("re-importing over an existing paired entry updates it in place", () => {
+    const first = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ deviceId: "dev-re", token: "t1" }),
+    });
+    expect(first.ok).toBe(true);
+
+    const second = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({
+        deviceId: "dev-re",
+        token: "t2",
+        gatewayUrl: "https://new.example.com",
+      }),
+    });
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+    expect(second.updated).toBe(true);
+    const assistants = readLockfileFromDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]!.runtimeUrl).toBe("https://new.example.com");
+    const token = JSON.parse(
+      fs.readFileSync(guardianTokenPath(configDir, "paired-dev-re"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(token.accessToken).toBe("t2");
+  });
+
+  test("deletes the just-written token when the lockfile write fails", () => {
+    // A read-only lockfile directory makes the tmp-file write fail after the
+    // token has already been written.
+    const lockedDir = path.join(tmpDir, "locked");
+    fs.mkdirSync(lockedDir, { mode: 0o500 });
+    const tokenPath = guardianTokenPath(configDir, "paired-dev-aaa");
+
+    const result = pairAssistant(
+      [path.join(lockedDir, "lockfile.json")],
+      configDir,
+      { bundle: bundle() },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(tokenPath)).toBe(false);
+    // The per-assistant directory is cleaned up too.
+    expect(fs.existsSync(path.dirname(tokenPath))).toBe(false);
+  });
+
+  test("restores the prior token when a re-import's lockfile write fails", () => {
+    const first = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ deviceId: "dev-re", token: "t1" }),
+    });
+    expect(first.ok).toBe(true);
+    const tokenPath = guardianTokenPath(configDir, "paired-dev-re");
+    const priorContents = fs.readFileSync(tokenPath, "utf-8");
+
+    fs.chmodSync(tmpDir, 0o500);
+    try {
+      const result = pairAssistant([lockfilePath], configDir, {
+        bundle: bundle({ deviceId: "dev-re", token: "t2" }),
+      });
+
+      expect(result.ok).toBe(false);
+      expect(fs.readFileSync(tokenPath, "utf-8")).toBe(priorContents);
+    } finally {
+      fs.chmodSync(tmpDir, 0o700);
+    }
+  });
+
+  test("an unparseable gatewayUrl on an unvalidated bundle is refused, not thrown", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ gatewayUrl: "not a url" }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.status).toBe(422);
+  });
+});

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -369,14 +369,15 @@ describe("pairAssistant", () => {
   });
 
   test("deletes the just-written token when the lockfile write fails", () => {
-    // A read-only lockfile directory makes the tmp-file write fail after the
-    // token has already been written.
-    const lockedDir = path.join(tmpDir, "locked");
-    fs.mkdirSync(lockedDir, { mode: 0o500 });
+    // A lockfile path whose parent is a regular file makes the write fail
+    // deterministically (unlike chmod, which root ignores) after the token
+    // has already been written.
+    const notADir = path.join(tmpDir, "not-a-dir");
+    fs.writeFileSync(notADir, "");
     const tokenPath = guardianTokenPath(configDir, "paired-dev-aaa");
 
     const result = pairAssistant(
-      [path.join(lockedDir, "lockfile.json")],
+      [path.join(notADir, "lockfile.json")],
       configDir,
       { bundle: bundle() },
     );
@@ -395,17 +396,20 @@ describe("pairAssistant", () => {
     const tokenPath = guardianTokenPath(configDir, "paired-dev-re");
     const priorContents = fs.readFileSync(tokenPath, "utf-8");
 
-    fs.chmodSync(tmpDir, 0o500);
-    try {
-      const result = pairAssistant([lockfilePath], configDir, {
-        bundle: bundle({ deviceId: "dev-re", token: "t2" }),
-      });
+    // Reads fall back to the real lockfile (so the existing entry is found
+    // and this is a genuine re-import) while the write targets a path whose
+    // parent is a regular file and fails deterministically (unlike chmod,
+    // which root ignores).
+    const notADir = path.join(tmpDir, "not-a-dir");
+    fs.writeFileSync(notADir, "");
+    const result = pairAssistant(
+      [path.join(notADir, "lockfile.json"), lockfilePath],
+      configDir,
+      { bundle: bundle({ deviceId: "dev-re", token: "t2" }) },
+    );
 
-      expect(result.ok).toBe(false);
-      expect(fs.readFileSync(tokenPath, "utf-8")).toBe(priorContents);
-    } finally {
-      fs.chmodSync(tmpDir, 0o700);
-    }
+    expect(result.ok).toBe(false);
+    expect(fs.readFileSync(tokenPath, "utf-8")).toBe(priorContents);
   });
 
   test("an unparseable gatewayUrl on an unvalidated bundle is refused, not thrown", () => {

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -1,16 +1,44 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 
 import { guardianTokenPath } from "./config";
 import type { CliInvocation } from "./util";
 
 const GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS = 15_000;
 
-interface GuardianTokenData {
+/** The persisted shape of an assistant's guardian token file. */
+export interface GuardianTokenData {
+  guardianPrincipalId: string;
   accessToken: string;
+  /** ISO date string or epoch-ms number as returned by the gateway. */
   accessTokenExpiresAt: string | number;
   refreshToken: string;
+  /** ISO date string or epoch-ms number as returned by the gateway. */
   refreshTokenExpiresAt: string | number;
+  refreshAfter: string;
+  isNew: boolean;
+  deviceId: string;
+  leasedAt: string;
+}
+
+/**
+ * Persist an assistant's guardian token where every host-seam reader resolves
+ * it (`guardianTokenPath`). The per-assistant directory is created 0700 and the
+ * file written 0600; chmod after the write covers a pre-existing file whose
+ * mode drifted.
+ */
+export function saveGuardianToken(
+  configDir: string,
+  assistantId: string,
+  data: GuardianTokenData,
+): void {
+  const tokenPath = guardianTokenPath(configDir, assistantId);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(tokenPath, JSON.stringify(data, null, 2) + "\n", {
+    mode: 0o600,
+  });
+  fs.chmodSync(tokenPath, 0o600);
 }
 
 function isAccessTokenExpired(data: GuardianTokenData): boolean {

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -4,7 +4,8 @@
  * hatch/retire/wake lifecycle ops) over a loopback HTTP boundary. Consumed by the
  * CLI `client` server and the web app's dev-server middleware so the local
  * endpoint behaviour is defined exactly once instead of one host reaching into
- * another's source tree. Depends only on `@vellumai/environments`.
+ * another's source tree. `@vellumai/environments` is its only workspace
+ * dependency.
  */
 export {
   stripSensitiveFields,
@@ -45,6 +46,13 @@ export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireOptions, RetireResult } from "./retire";
 export { unpairAssistant } from "./unpair";
+export { decodePairBundle, pairAssistant } from "./pair";
+export type {
+  PairBundle,
+  DecodePairBundleResult,
+  PairOptions,
+  PairResult,
+} from "./pair";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";
@@ -56,8 +64,8 @@ export type {
   LocalAssistantRuntimeState,
   LocalAssistantStatusResult,
 } from "./status";
-export { getGuardianAccessToken } from "./guardian-token";
-export type { TokenResult } from "./guardian-token";
+export { getGuardianAccessToken, saveGuardianToken } from "./guardian-token";
+export type { TokenResult, GuardianTokenData } from "./guardian-token";
 export {
   parseGatewayUrl,
   readAllowedGatewayPorts,

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { nanoid } from "nanoid";
+
+import { guardianTokenPath } from "./config";
+import { saveGuardianToken } from "./guardian-token";
+import { readRawLockfile, upsertLockfileAssistant } from "./lockfile";
+import type { Lockfile } from "./lockfile-contract";
+
+/**
+ * A decoded `vellum pair` bundle: base64(JSON.stringify({ gatewayUrl, token,
+ * ... })) printed on the host machine and imported on this one.
+ */
+export interface PairBundle {
+  gatewayUrl: string;
+  token: string;
+  assistantId?: string;
+  deviceId?: string;
+  // Optional refresh credential. Present when the host's gateway issued a
+  // device-bound token pair; absent for older access-only bundles (which remain
+  // importable, just without auto-renewal). `refreshTokenExpiresAt` mirrors
+  // GuardianTokenData (ISO string OR epoch-ms number) so a numeric expiry isn't
+  // silently dropped on import.
+  refreshToken?: string;
+  refreshTokenExpiresAt?: string | number;
+  refreshAfter?: string;
+}
+
+export type DecodePairBundleResult =
+  | { ok: true; bundle: PairBundle }
+  | { ok: false; error: string };
+
+/**
+ * Decode and validate a base64 pairing bundle. Total and non-throwing:
+ * malformed input yields a typed failure. `gatewayUrl` is persisted as
+ * `runtimeUrl` and used to build fetch URLs, so it must be an absolute http(s)
+ * URL rather than letting an invalid string through (which would crash
+ * `new URL(...)` or break later client calls).
+ */
+export function decodePairBundle(encoded: string): DecodePairBundleResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+  } catch {
+    return { ok: false, error: "Bundle is not base64-encoded JSON" };
+  }
+  if (typeof json !== "object" || json === null) {
+    return { ok: false, error: "Bundle is not a JSON object" };
+  }
+  const b = json as Record<string, unknown>;
+  if (typeof b.gatewayUrl !== "string" || typeof b.token !== "string") {
+    return { ok: false, error: "Bundle is missing gatewayUrl or token" };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(b.gatewayUrl);
+  } catch {
+    return { ok: false, error: "Bundle gatewayUrl is not an absolute URL" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: "Bundle gatewayUrl is not an http(s) URL" };
+  }
+  return {
+    ok: true,
+    bundle: {
+      gatewayUrl: b.gatewayUrl,
+      token: b.token,
+      assistantId:
+        typeof b.assistantId === "string" ? b.assistantId : undefined,
+      deviceId: typeof b.deviceId === "string" ? b.deviceId : undefined,
+      refreshToken:
+        typeof b.refreshToken === "string" ? b.refreshToken : undefined,
+      refreshTokenExpiresAt:
+        typeof b.refreshTokenExpiresAt === "string" ||
+        typeof b.refreshTokenExpiresAt === "number"
+          ? b.refreshTokenExpiresAt
+          : undefined,
+      refreshAfter:
+        typeof b.refreshAfter === "string" ? b.refreshAfter : undefined,
+    },
+  };
+}
+
+/** Lowercase, collapse non-alphanumerics to single dashes, trim dashes. */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Best-effort JWT `exp` (epoch seconds) → epoch ms; null if undecodable. */
+function jwtExpiryMs(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64").toString("utf8"),
+    ) as Record<string, unknown>;
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export interface PairOptions {
+  /** A bundle validated by {@link decodePairBundle}. */
+  bundle: PairBundle;
+  /** Optional local name; its slug becomes the entry's assistantId. */
+  name?: string;
+}
+
+/**
+ * Failure statuses: 400 the name slugifies to nothing, 409 the id names an
+ * existing non-paired assistant (`assistantId` carries the refused id),
+ * 422 the bundle's gatewayUrl is unparseable, 500 a write failed.
+ */
+export type PairResult =
+  | {
+      ok: true;
+      lockfile: Lockfile;
+      /** The unique local id the pairing was registered under. */
+      assistantId: string;
+      /** True when an existing paired entry was updated in place. */
+      updated: boolean;
+      /** True when the bundle carried no refresh credential. */
+      accessOnly: boolean;
+    }
+  | { ok: false; status: number; error: string; assistantId?: string };
+
+/**
+ * Register a pairing bundle on this machine: persist the guardian token and
+ * upsert a `cloud: "paired"` lockfile entry, the write counterpart of
+ * `unpairAssistant`.
+ *
+ * The entry is stored under a UNIQUE LOCAL id (not the bundle's assistantId,
+ * which is typically "self" and would collide across hosts). This is safe
+ * because the gateway's runtime proxy strips the `/v1/assistants/<id>/` segment
+ * before forwarding, so the local id never has to match the remote one: the
+ * token (validated by signature/audience) is what authorizes requests.
+ */
+export function pairAssistant(
+  lockfilePaths: string[],
+  configDir: string,
+  { bundle, name }: PairOptions,
+): PairResult {
+  let gatewayHost: string;
+  try {
+    gatewayHost = new URL(bundle.gatewayUrl).host;
+  } catch {
+    return {
+      ok: false,
+      status: 422,
+      error: "Bundle gatewayUrl is not an absolute URL",
+    };
+  }
+
+  // Unique local id: a name slug, or paired-<deviceId> (deviceId is unique per
+  // pairing). Never the bundle's "self" assistantId, which would collide. The
+  // deviceId comes from an untrusted bundle and is used as a path component by
+  // saveGuardianToken, so it MUST be slugified (no `../` traversal); fall back
+  // to a random id if it sanitizes to empty.
+  const localId = name
+    ? slugify(name)
+    : `paired-${slugify(bundle.deviceId ?? "") || nanoid()}`;
+  if (!localId) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Name must contain at least one alphanumeric character",
+    };
+  }
+
+  // Don't clobber an existing assistant. Only update in place when the prior
+  // entry is itself a paired import (marked `paired: true`); otherwise the id
+  // collides with a real local/remote assistant and overwriting would drop its
+  // resources/runtime metadata. Reject and let the caller pick a fresh name.
+  const rawAssistants = readRawLockfile(lockfilePaths).assistants;
+  const existing = (
+    Array.isArray(rawAssistants)
+      ? (rawAssistants as Array<Record<string, unknown>>)
+      : []
+  ).find((a) => a?.assistantId === localId);
+  if (existing && existing.paired !== true) {
+    return {
+      ok: false,
+      status: 409,
+      error: `An assistant named '${localId}' already exists`,
+      assistantId: localId,
+    };
+  }
+
+  // Write the token BEFORE committing the lockfile entry, the mirror of
+  // unpair's ordering. A lockfile entry must never exist without its
+  // credential (every read path would 404 on the token), while a token
+  // without an entry is inert and overwritten by the next import. The prior
+  // token contents are kept in memory so a failed lockfile write below can
+  // roll the file back.
+  const tokenPath = guardianTokenPath(configDir, localId);
+  let priorToken: string | null;
+  try {
+    priorToken = fs.readFileSync(tokenPath, "utf-8");
+  } catch {
+    priorToken = null;
+  }
+
+  const now = Date.now();
+  try {
+    saveGuardianToken(configDir, localId, {
+      guardianPrincipalId: "imported",
+      accessToken: bundle.token,
+      accessTokenExpiresAt:
+        jwtExpiryMs(bundle.token) ?? now + 24 * 60 * 60 * 1000,
+      refreshToken: bundle.refreshToken ?? "",
+      refreshTokenExpiresAt: bundle.refreshTokenExpiresAt ?? 0,
+      refreshAfter: bundle.refreshAfter ?? "",
+      isNew: false,
+      deviceId: bundle.deviceId ?? "",
+      leasedAt: new Date(now).toISOString(),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      error: `Failed to write the guardian token: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  const result = upsertLockfileAssistant(
+    lockfilePaths,
+    {
+      assistantId: localId,
+      name: name ?? `paired (${gatewayHost})`,
+      runtimeUrl: bundle.gatewayUrl,
+      // Paired entries are reached by bearer token at the remote runtimeUrl
+      // (a non-"vellum" cloud selects the bearer-token auth path in client.ts).
+      // The "paired" topology lets lifecycle/status commands (ps/wake/sleep)
+      // recognize this as a remote pairing rather than an on-machine process.
+      cloud: "paired",
+      // Marks this entry as a connect-import so re-imports update in place
+      // while imports never silently overwrite a non-paired assistant (see
+      // guard above).
+      paired: true,
+      species: "vellum",
+    },
+    undefined,
+  );
+  if (!result.ok) {
+    // The entry was not registered, so undo the token write (best-effort;
+    // the write failure itself is what gets reported): restore the prior
+    // token of a re-import, or delete the freshly written one.
+    try {
+      if (priorToken !== null) {
+        fs.writeFileSync(tokenPath, priorToken, { mode: 0o600 });
+      } else {
+        fs.rmSync(tokenPath, { force: true });
+        fs.rmdirSync(path.dirname(tokenPath));
+      }
+    } catch {
+      // Rollback failed; the reported write error already covers the outcome.
+    }
+    return result;
+  }
+
+  return {
+    ok: true,
+    lockfile: result.lockfile,
+    assistantId: localId,
+    updated: existing !== undefined,
+    accessOnly: !bundle.refreshToken,
+  };
+}


### PR DESCRIPTION
## Summary
- Add decodePairBundle + pairAssistant to packages/local-mode as the write counterpart of unpairAssistant (token file first, lockfile second, cleanup on failure)
- Move saveGuardianToken into the package; CLI delegates to it
- vellum connect import now routes through pairAssistant with byte-identical lockfile/token output

Part of plan: macos-paired-assistants.md (PR 6 of 10)