### PR TITLE
polish(web): telemetry ring-label consistency and final review fixes

### DIFF
--- a/clients/web/src/hooks/use-event-bus-init.test.tsx
+++ b/clients/web/src/hooks/use-event-bus-init.test.tsx
@@ -12,8 +12,7 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 import { sseService } from "@/assistant/sse-service";
 import { useEventBusInit } from "@/hooks/use-event-bus-init";
-import { publish, __resetForTesting } from "@/lib/event-bus";
-import { isResumeWindowOpen } from "@/lib/telemetry/resume-request-counter";
+import { __resetForTesting } from "@/lib/event-bus";
 
 const detachMock = mock(() => {});
 const attachSpy = spyOn(sseService, "attach").mockImplementation(
@@ -62,23 +61,5 @@ describe("useEventBusInit — attach gating", () => {
     );
     expect(attachSpy).toHaveBeenCalledTimes(1);
     expect(attachSpy.mock.calls[0]![0]).toBe("asst-1");
-  });
-});
-
-// The post-resume request counter is deliberately not one of this hook's
-// subscribers. React runs descendant effects before ancestor ones, so a
-// counter registered here would open its window after the subscribers inside
-// the tree had already fired their resume requests. It installs from
-// `lib/api-interceptors.ts` module scope instead, which nothing in this file
-// imports.
-describe("useEventBusInit resume-counter registration", () => {
-  test("does not register the counter, so no window opens on resume", () => {
-    renderHook(() =>
-      useEventBusInit({ assistantId: "asst-1", isAssistantActive: true }),
-    );
-
-    publish("app.resume", { signal: "visibility" });
-
-    expect(isResumeWindowOpen()).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-event-bus-init.ts
+++ b/clients/web/src/hooks/use-event-bus-init.ts
@@ -58,6 +58,10 @@ export function useEventBusInit({
     if (typeof window === "undefined") {
       return;
     }
+    // The post-resume request counter is deliberately absent: React runs
+    // descendant effects before ancestor ones, so a counter registered here
+    // would open its window after in-tree subscribers had already fired their
+    // resume requests. It installs from `lib/api-interceptors.ts` module scope.
     const unsubscribers = [
       publishVisibilitySource(),
       publishWindowOnlineSource(),

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -336,7 +336,7 @@ export function authorizeRemoteGatewayRequest(
  *
  * Counting happens once per request, after the routing decision, and this is
  * the single choke point on each client's chain. On the platform chain it is
- * additionally conditioned on {@link platformFeaturesGateAllows}, the gate
+ * additionally conditioned on {@link platformFeaturesGateDecision}, the gate
  * registered downstream, so a request that gate aborts is never counted. The
  * auth chain reaches neither test: allauth endpoints live under `/_allauth/`
  * and are never daemon-bound.
@@ -359,7 +359,8 @@ function createInterceptor({
       return true;
     }
     return (
-      isDaemonBoundPath(url) && platformFeaturesGateAllows(outgoing) === "allow"
+      isDaemonBoundPath(url) &&
+      platformFeaturesGateDecision(outgoing) === "allow"
     );
   }
 
@@ -811,11 +812,30 @@ function arePlatformFeaturesEnabled(): boolean {
 
 /**
  * What {@link platformFeaturesGate} does with a request. A deny carries the
- * reason it was denied, so the gate reports it without re-probing the mode this
- * function already looked at; a third reason cannot be mislabelled as one of
- * the existing two.
+ * reason it was denied, so the gate reports it without re-probing the mode the
+ * decision already looked at. {@link PLATFORM_GATE_DENIALS} keys off this
+ * union, so a third reason cannot be mislabelled as one of the existing two.
  */
 type PlatformGateDecision = "allow" | "deny_remote_gateway" | "deny_local";
+
+/**
+ * How each denial is reported. Keyed by every deny decision, so a new reason
+ * added to {@link PlatformGateDecision} fails to compile until it says what it
+ * logs and what it aborts with.
+ */
+const PLATFORM_GATE_DENIALS: Record<
+  Exclude<PlatformGateDecision, "allow">,
+  { log: string; abortMessage: string }
+> = {
+  deny_remote_gateway: {
+    log: "remote-gateway mode, no-op platform request:",
+    abortMessage: "Platform routes disabled in remote-gateway mode",
+  },
+  deny_local: {
+    log: "VELLUM_DISABLE_PLATFORM is set, no-op platform request:",
+    abortMessage: "Platform features disabled in local mode",
+  },
+};
 
 /**
  * The decision {@link platformFeaturesGate} reaches for this request.
@@ -824,7 +844,7 @@ type PlatformGateDecision = "allow" | "deny_remote_gateway" | "deny_local";
  * {@link requestInterceptor}, so a self-hosted rewrite (gateway origin, bearer
  * auth) has already happened by the time it runs.
  */
-function platformFeaturesGateAllows(request: Request): PlatformGateDecision {
+function platformFeaturesGateDecision(request: Request): PlatformGateDecision {
   if (isRemoteGatewayMode()) {
     const hasBearer =
       request.headers
@@ -861,27 +881,15 @@ function platformFeaturesGateAllows(request: Request): PlatformGateDecision {
  * Exported for direct unit testing.
  */
 export function platformFeaturesGate(request: Request): Request {
-  const decision = platformFeaturesGateAllows(request);
+  const decision = platformFeaturesGateDecision(request);
   if (decision === "allow") {
     return request;
   }
 
-  const remoteGateway = decision === "deny_remote_gateway";
-  console.debug(
-    remoteGateway
-      ? "remote-gateway mode, no-op platform request:"
-      : "VELLUM_DISABLE_PLATFORM is set, no-op platform request:",
-    new URL(request.url).pathname,
-  );
+  const denial = PLATFORM_GATE_DENIALS[decision];
+  console.debug(denial.log, new URL(request.url).pathname);
   const aborted = new AbortController();
-  aborted.abort(
-    new DOMException(
-      remoteGateway
-        ? "Platform routes disabled in remote-gateway mode"
-        : "Platform features disabled in local mode",
-      "AbortError",
-    ),
-  );
+  aborted.abort(new DOMException(denial.abortMessage, "AbortError"));
   return new Request(request.url, { signal: aborted.signal });
 }
 

--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -5,9 +5,8 @@
  *   - Nothing is emitted without analytics consent.
  *   - `boot_id` appears only once a boot id has been registered.
  *   - A throwing transport never propagates to the caller.
- *   - The page-load key is minted lazily, and it, the event id, and the
- *     transport's client id all survive a runtime with no `crypto.randomUUID`
- *     (non-secure contexts).
+ *   - The page-load key is minted lazily, and it and the event id both survive
+ *     a runtime with no `crypto.randomUUID` (non-secure contexts).
  *   - Surface and os come from a single platform probe per emit.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -30,9 +29,6 @@ mock.module("@/runtime/platform-detection", () => ({
   detectClientOs: detectClientOsMock,
   isNativeIOS: () => nativeIOS,
   isNativeAndroid: () => nativeAndroid,
-  // Unused by the emitter, present so `client-identity` (imported by the
-  // crypto-fallback test) still resolves its imports against this stub.
-  detectBrowserInfo: () => ({}),
 }));
 
 const { __resetClientPerfForTests, emitClientPerfEvent, setClientPerfBootId } =
@@ -167,7 +163,7 @@ describe("emitClientPerfEvent", () => {
     expect(lastDetail().surface).toBe("android_native");
   });
 
-  test("still emits when crypto.randomUUID is unavailable", async () => {
+  test("still emits when crypto.randomUUID is unavailable", () => {
     const cryptoObject = globalThis.crypto as unknown as {
       randomUUID?: () => string;
     };
@@ -182,25 +178,11 @@ describe("emitClientPerfEvent", () => {
     });
 
     try {
-      // The real transport stamps the payload's `device_id` from
-      // `getClientId()`, so a throw there lands in the emitter's catch and
-      // drops the sample. Import it fresh so its cache is cold under this
-      // runtime, and read it from the transport stub the way ingest does.
-      const { getClientId } = (await import(
-        `@/lib/telemetry/client-identity?t=${Math.random()}`
-      )) as typeof import("./client-identity");
-      let deviceId: string | null = null;
-      postTelemetryEventsMock.mockImplementation(() => {
-        deviceId = getClientId();
-      });
-
       expect(() => {
         emitClientPerfEvent("client_list.drain", 1);
       }).not.toThrow();
 
       expect(postTelemetryEventsMock).toHaveBeenCalledTimes(1);
-      expect(typeof deviceId).toBe("string");
-      expect(deviceId).not.toBe("");
 
       const event = lastEvent();
       expect(typeof event.daemon_event_id).toBe("string");

--- a/clients/web/src/lib/telemetry/random-id.ts
+++ b/clients/web/src/lib/telemetry/random-id.ts
@@ -2,15 +2,15 @@
  * Mints an opaque id for telemetry grouping keys and client identity.
  *
  * `crypto.randomUUID` is unavailable in non-secure contexts (plain-http LAN
- * dev, self-hosted over http), so fall back rather than throw. The callers sit
- * on the eager boot import chain and on the fire-and-forget telemetry path,
- * where a throw either takes the app down or silently drops every sample.
+ * dev, self-hosted over http), so fall back rather than throw: client-identity
+ * mints on the eager boot import chain, where a throw takes the app down, and
+ * client-perf mints on the fire-and-forget telemetry path, where one silently
+ * drops every sample.
  *
- * Both consumers treat the result as an opaque string: the daemon reads
- * `X-Vellum-Client-Id` as a free-form header and the platform's ingest
- * endpoint stores `device_id` as a free-form field. The `fallback-` prefix
- * marks ids minted without `crypto` so they stay distinguishable downstream
- * from real UUIDs.
+ * Every field the id lands in is free-form, so a non-UUID is safe:
+ * client-identity's `X-Vellum-Client-Id` header and `device_id`, client-perf's
+ * `page_load_id` and `daemon_event_id`. The `fallback-` prefix keeps ids minted
+ * without `crypto` distinguishable from real UUIDs.
  */
 export function mintRandomId(): string {
   return typeof globalThis.crypto?.randomUUID === "function"

--- a/clients/web/src/lib/telemetry/resume-request-counter.test.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.test.ts
@@ -7,6 +7,8 @@
  *   - requests a later-registered resume subscriber fires synchronously are
  *     counted, which is what installing at module scope buys;
  *   - only requests inside the window are counted;
+ *   - an emitted window reports the span it actually covered alongside the
+ *     span it was scheduled for;
  *   - endpoint labels come from the closed set, never a raw path;
  *   - a zero-count window still emits.
  *
@@ -115,6 +117,8 @@ describe("installResumeRequestCounter", () => {
 
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
     noteDaemonApiRequest("https://api.test/v1/assistants/a1/messages");
+    // A healthy timer fires at the end of the span it was scheduled for.
+    nowMs = 10_000;
     fireTimers();
 
     expect(emitClientPerfEventMock).toHaveBeenCalledTimes(1);
@@ -122,8 +126,26 @@ describe("installResumeRequestCounter", () => {
     expect(checkName).toBe("client_resume.request_count");
     expect(value).toBe(2);
     expect(detail.window_ms).toBe(10_000);
+    expect(typeof detail.observed_window_ms).toBe("number");
+    expect(detail.observed_window_ms).toBe(10_000);
     expect(detail.signal).toBe("visibility");
     expect(lastDelay).toBe(10_000);
+  });
+
+  test("reports the span a mildly thawed window actually covered", () => {
+    installResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+
+    // A short stall thaws inside the guard's 2x threshold, so the sample is
+    // kept and its real age rides along for downstream filtering.
+    nowMs = 15_500;
+    fireTimers();
+
+    const { value, detail } = lastEmit();
+    expect(value).toBe(1);
+    expect(detail.window_ms).toBe(10_000);
+    expect(detail.observed_window_ms).toBe(15_500);
   });
 
   test("counts requests a later-registered resume handler fires synchronously", () => {

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -13,7 +13,11 @@
  * suspension that fires no hidden edge at all: desktop system sleep with a
  * focused tab, and the WKWebView paths that suspend without a visibility
  * change. Their timers thaw far past the window's span, so the observed age of
- * the window is the only thing left that gives them away.
+ * the window is the only thing left that gives them away. A window either
+ * defence discards leaves no sample at all, so the series is a count of clean
+ * resumes rather than of every resume. `observed_window_ms` carries the span an
+ * emitted window actually covered, so a mildly thawed one that stayed under the
+ * guard is filterable downstream instead of riding on the `window_ms` label.
  *
  * {@link installResumeRequestCounter} runs from `lib/api-interceptors.ts`
  * module scope, before React renders, so the counter's `app.resume` handler is
@@ -129,8 +133,12 @@ function openWindow(signal: AppResumeSignal): void {
     // Fallback for a suspension that fired no `app.hidden`. A frozen timer
     // thaws long past the span it was scheduled for, so its counts cover the
     // whole suspension rather than the `window_ms` they would be labelled
-    // with. Discard the contaminated sample instead of emitting it.
-    if (performance.now() - closed.openedAt >= WINDOW_MS * 2) {
+    // with. Discard the contaminated sample instead of emitting it. The
+    // threshold is twice the span rather than once because a healthy timer
+    // fires at exactly `openedAt + WINDOW_MS`, so a 1x test would discard every
+    // healthy window; 2x only catches a genuine freeze.
+    const observedWindowMs = performance.now() - closed.openedAt;
+    if (observedWindowMs >= WINDOW_MS * 2) {
       return;
     }
     // A zero here is the signal we are looking for once the storm is fixed,
@@ -138,6 +146,7 @@ function openWindow(signal: AppResumeSignal): void {
     emitClientPerfEvent("client_resume.request_count", closed.total, {
       by_group: closed.byGroup,
       window_ms: WINDOW_MS,
+      observed_window_ms: Math.round(observedWindowMs),
       signal: closed.signal,
     });
   }, WINDOW_MS);
@@ -173,7 +182,9 @@ let installed = false;
 
 /**
  * Opens a counting window on each `app.resume` and drops it on `app.hidden`.
- * Idempotent.
+ * The latch makes a second call a no-op, so a second evaluation of the
+ * importing module (a dev-server module reload, say) cannot leave two handler
+ * pairs racing for the one module-level window.
  *
  * Called from `lib/api-interceptors.ts` module scope rather than from a React
  * effect, and the ordering is the whole point. React runs descendant effects

--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -166,8 +166,9 @@ describe("conversation list drain diagnostics", () => {
       // Deduped: "c-1" appears on both page 0 and page 1.
       rows: 4,
       totalBytes: 350,
-      conversationType: null,
+      listKind: "foreground",
     });
+    expect(events[1]?.details).not.toHaveProperty("conversationType");
   });
 
   test("a failing page records a page error plus an error summary and rethrows", async () => {
@@ -198,9 +199,10 @@ describe("conversation list drain diagnostics", () => {
       offset: 50,
       status: 500,
       bytes: null,
-      conversationType: null,
-      archiveStatus: null,
+      listKind: "foreground",
     });
+    expect(events[1]?.details).not.toHaveProperty("conversationType");
+    expect(events[1]?.details).not.toHaveProperty("archiveStatus");
 
     expect(events[2]?.details).toMatchObject({
       outcome: "error",
@@ -222,6 +224,42 @@ describe("conversation list drain diagnostics", () => {
       (event) => event.kind === "conversation_list_page_fetch_error",
     );
     expect(errorEntry?.details).toMatchObject({ status: 500, bytes: 77 });
+  });
+
+  test("a failing page's error entry carries the list kind", async () => {
+    stubPages([{ ids: [], hasMore: false, status: 500 }]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listBackgroundConversations(ASSISTANT_ID).catch(() => undefined),
+    );
+
+    const errorEntry = events.find(
+      (event) => event.kind === "conversation_list_page_fetch_error",
+    );
+    expect(errorEntry?.details).toMatchObject({ listKind: "background" });
+    expect(errorEntry?.details).not.toHaveProperty("archiveStatus");
+  });
+
+  test("both archive-page drain summaries are labeled archived", async () => {
+    // The archive page drains the foreground and background buckets, so one
+    // call produces two summaries, and both are archive-page cost.
+    stubPages([
+      { ids: ["c-0"], hasMore: false, contentLength: "10" },
+      { ids: ["c-1"], hasMore: false, contentLength: "20" },
+    ]);
+
+    const { events } = await diagnosticsDuring(() =>
+      listArchivedConversations(ASSISTANT_ID),
+    );
+    const summaries = events.filter(
+      (event) => event.kind === "conversation_list_drain",
+    );
+
+    expect(summaries).toHaveLength(2);
+    for (const summary of summaries) {
+      expect(summary.details).toMatchObject({ listKind: "archived" });
+      expect(summary.details).not.toHaveProperty("conversationType");
+    }
   });
 
   test("page-0 entries carry the drain's list kind and a drain source", async () => {

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -128,9 +128,9 @@ type FetchConversationListOptions = {
 
 /**
  * Closed set of list labels carried by the `client_list.drain` watchdog event
- * and the `conversation_list_page_fetch` ring entry. One label per real caller,
- * so the archive page and the channel sections stay distinguishable from the
- * sidebar's foreground drain in both rails.
+ * and by every conversation-list ring entry. One label per real caller, so the
+ * archive page and the channel sections stay distinguishable from the sidebar's
+ * foreground drain in both rails.
  */
 type DrainListKind =
   "foreground" | "background" | "scheduled" | "archived" | "origin_channel";
@@ -185,6 +185,10 @@ type FirstPageFetchSource = "drain" | "first_page_refresh";
  * `listKind` and `source` together fingerprint the caller: without them every
  * bucket's first page reads as the same offset-0 request, and a slow entry is
  * not attributable to the path the user waited on.
+ *
+ * {@link hasAnyActiveConversation} deliberately records nothing: it is an
+ * offset-0 existence probe on the onboarding path, not a list the user is
+ * waiting to see, so keeping it out preserves the ring for real list fetches.
  */
 function recordFirstPageFetch(
   assistantId: string,
@@ -232,8 +236,7 @@ async function fetchConversationListPage(
       status: response.status,
       durationMs,
       bytes: readContentLength(response),
-      conversationType: conversationType ?? null,
-      archiveStatus: archiveStatus ?? null,
+      listKind: drainListKind(options),
     });
     const msg = extractErrorMessage(
       error,
@@ -276,7 +279,7 @@ async function fetchConversationList(
       totalMs,
       maxPageMs,
       totalBytes,
-      conversationType: options.conversationType ?? null,
+      listKind: drainListKind(options),
     });
     // The ring keeps `assistantId` for feedback bundles; the telemetry rail is
     // metadata only.


### PR DESCRIPTION
## Summary
- conversation_list_drain and conversation_list_page_fetch_error now carry the same closed listKind labels as the page entries, so feedback-bundle entries join on one key
- client_resume.request_count carries observed_window_ms so mildly thawed windows are filterable; discard semantics documented honestly; gate deny reasons mapped exhaustively under a decision-named helper
- Redundant cross-file test scaffolding removed; random-id and install-latch docstrings state the actual contracts

Fixes gaps found during round-3 plan self-review for measure-first-telemetry-followups.md