### PR TITLE
refactor(providers): derive dispatch auth from the connection provider

### DIFF
--- a/assistant/src/providers/__tests__/inference.test.ts
+++ b/assistant/src/providers/__tests__/inference.test.ts
@@ -181,6 +181,46 @@ describe("Connection CRUD", () => {
     expect(fetched?.auth.type).toBe("api_key");
   });
 
+  test("updateConnection — provider correction rides an auth rewrite", () => {
+    // The ChatGPT sign-in flow stamps provider "openai" when it writes
+    // subscription auth, so a claiming row with another provider cannot
+    // strand the fresh token behind derived platform auth.
+    const { db } = setupDb();
+    createConnection(db, {
+      name: "chatgpt-subscription",
+      provider: "vellum",
+      auth: { type: "platform" },
+    });
+    const result = updateConnection(db, "chatgpt-subscription", {
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+      provider: "openai",
+    });
+    expect(result.ok).toBe(true);
+    const fetched = getConnection(db, "chatgpt-subscription");
+    expect(fetched?.provider).toBe("openai");
+    expect(fetched?.auth.type).toBe("oauth_subscription");
+  });
+
+  test("updateConnection — rejects an unknown provider", () => {
+    const { db } = setupDb();
+    createConnection(db, {
+      name: "updatable-provider",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    const result = updateConnection(db, "updatable-provider", {
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+      provider: "not-a-provider",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("invalid_provider");
+    }
+  });
+
   test("updateConnection — rejects unknown name", () => {
     const { db } = setupDb();
     const result = updateConnection(db, "ghost", { auth: { type: "none" } });

--- a/assistant/src/providers/__tests__/inference.test.ts
+++ b/assistant/src/providers/__tests__/inference.test.ts
@@ -181,7 +181,7 @@ describe("Connection CRUD", () => {
     expect(fetched?.auth.type).toBe("api_key");
   });
 
-  test("updateConnection — provider correction rides an auth rewrite", () => {
+  test("updateConnection: provider correction rides an auth rewrite", () => {
     // The ChatGPT sign-in flow stamps provider "openai" when it writes
     // subscription auth, so a claiming row with another provider cannot
     // strand the fresh token behind derived platform auth.
@@ -204,7 +204,7 @@ describe("Connection CRUD", () => {
     expect(fetched?.auth.type).toBe("oauth_subscription");
   });
 
-  test("updateConnection — rejects an unknown provider", () => {
+  test("updateConnection: rejects an unknown provider", () => {
     const { db } = setupDb();
     createConnection(db, {
       name: "updatable-provider",

--- a/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
@@ -9,8 +9,9 @@ import { migrateProviderConnectionStatusLabel } from "../../persistence/migratio
 import { migrateProviderConnectionBaseUrlAndModels } from "../../persistence/migrations/250-provider-connection-base-url-and-models.js";
 import * as schema from "../../persistence/schema/index.js";
 import { createAdapterFromConnection } from "../inference/adapter-factory.js";
-import type { ProviderConnection } from "../inference/auth.js";
+import type { Auth, ProviderConnection } from "../inference/auth.js";
 import type { ResolvedAuth } from "../inference/auth.js";
+import { effectiveConnectionAuth } from "../inference/auth.js";
 import {
   createConnection,
   getConnection,
@@ -74,6 +75,41 @@ describe("vellum connection routing", () => {
       },
     );
     expect(adapter).not.toBeNull();
+  });
+});
+
+describe("effectiveConnectionAuth", () => {
+  test("a vellum row dispatches on platform auth regardless of the stored variant", () => {
+    for (const stored of [
+      { type: "api_key", credential: "vault/x" },
+      { type: "none" },
+      { type: "platform" },
+    ] as Auth[]) {
+      expect(
+        effectiveConnectionAuth({ provider: "vellum", auth: stored }),
+      ).toEqual({ type: "platform" });
+    }
+  });
+
+  test("payload-carrying rows keep their stored auth verbatim", () => {
+    const keyed: Auth = { type: "api_key", credential: "vault/anthropic" };
+    expect(
+      effectiveConnectionAuth({ provider: "anthropic", auth: keyed }),
+    ).toBe(keyed);
+    const subscription: Auth = { type: "oauth_subscription" } as Auth;
+    expect(
+      effectiveConnectionAuth({ provider: "openai", auth: subscription }),
+    ).toBe(subscription);
+  });
+
+  test("a deliberately keyed keyless provider keeps its key", () => {
+    // Keyless means no key REQUIRED, not no key possible: the ollama adapter
+    // accepts one, so stored api_key auth on an ollama row is payload and
+    // must never be derived away.
+    const keyed: Auth = { type: "api_key", credential: "vault/ollama" };
+    expect(effectiveConnectionAuth({ provider: "ollama", auth: keyed })).toBe(
+      keyed,
+    );
   });
 });
 

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -38,6 +38,7 @@ import { isVellumManagedConnection } from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
+import { effectiveConnectionAuth } from "./auth.js";
 import { resolveAuth } from "./resolve-auth.js";
 
 /** Unified construction opts. Adapters ignore fields they don't consume. */
@@ -245,9 +246,11 @@ export function createAdapterFromConnection(
   function makeCredentialRefresher(): () => Promise<Provider | null> {
     let lastAuth = JSON.stringify(resolvedAuth);
     return async (): Promise<Provider | null> => {
-      const refreshedAuth = await resolveAuth(connection.auth, provider, {
-        baseUrl: connection.baseUrl,
-      });
+      const refreshedAuth = await resolveAuth(
+        effectiveConnectionAuth(connection),
+        provider,
+        { baseUrl: connection.baseUrl },
+      );
       if (!refreshedAuth.ok) {
         return null;
       }

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -269,16 +269,17 @@ export function createAdapterFromConnection(
   // would leak internal Vellum metadata, so gate on the managed connection
   // identity, the only route that flows through our proxy.
   const isManagedProxy = isVellumManagedConnection(connection);
+  const effectiveAuth = effectiveConnectionAuth(connection);
   return new UsageTrackingProvider(
     new RetryProvider(adapter, {
       forwardUsageAttributionHeaders: isManagedProxy,
       credentialSource: isManagedProxy
         ? "vellum-managed"
-        : connection.auth.type === "api_key"
+        : effectiveAuth.type === "api_key"
           ? "byok"
-          : connection.auth.type === "oauth_subscription"
+          : effectiveAuth.type === "oauth_subscription"
             ? "oauth-subscription"
-            : connection.auth.type === "none"
+            : effectiveAuth.type === "none"
               ? "no-auth"
               : undefined,
       connectionName: connection.name,
@@ -324,7 +325,8 @@ function buildConnectionAdapter(
       : undefined;
 
   const codexSubscription =
-    connection.auth.type === "oauth_subscription" && provider === "openai";
+    effectiveConnectionAuth(connection).type === "oauth_subscription" &&
+    provider === "openai";
 
   const adapter = buildProviderAdapter(provider, {
     apiKey,

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -72,6 +72,22 @@ export function deriveAuthForProvider(
   return credential ? { type: "api_key", credential } : null;
 }
 
+/**
+ * The auth a connection dispatches with. The stored auth object is
+ * authoritative only where it carries a payload (an api_key credential ref,
+ * the oauth_subscription marker, a deliberately keyed keyless provider);
+ * the vellum provider IS the managed route, so its auth derives from the
+ * provider and the stored value can never mislead dispatch.
+ */
+export function effectiveConnectionAuth(connection: {
+  provider: string;
+  auth: Auth;
+}): Auth {
+  return connection.provider === VELLUM_MANAGED_PROVIDER
+    ? { type: "platform" }
+    : connection.auth;
+}
+
 // ---------------------------------------------------------------------------
 // ResolvedAuth — what the dispatcher hands to each adapter
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -163,6 +163,14 @@ export type CreateConnectionInput = {
 
 export type UpdateConnectionInput = {
   auth: Auth;
+  /**
+   * Optional provider correction. The HTTP PATCH route never passes this
+   * (provider is immutable there); it exists for owners of well-known rows
+   * to keep the provider truthful when they rewrite the auth, e.g. the
+   * ChatGPT sign-in flow stamping "openai" on the subscription row so a
+   * claiming row with a different provider cannot strand the fresh token.
+   */
+  provider?: string;
   label?: string | null;
   baseUrl?: string | null;
   models?: ConnectionModel[] | null;
@@ -178,6 +186,7 @@ export type ConnectionCreateError =
 export type ConnectionUpdateError =
   | { code: "not_found" }
   | { code: "invalid_auth" }
+  | { code: "invalid_provider"; provider: string }
   | { code: "base_url_required" }
   | { code: "models_required" };
 
@@ -278,12 +287,23 @@ export function updateConnection(
     return { ok: false, error: { code: "invalid_auth" } };
   }
 
+  if (
+    input.provider !== undefined &&
+    !VALID_CONNECTION_PROVIDERS.includes(input.provider as never)
+  ) {
+    return {
+      ok: false,
+      error: { code: "invalid_provider", provider: input.provider },
+    };
+  }
+  const nextProvider = input.provider ?? existing.provider;
+
   const nextBaseUrl =
     input.baseUrl !== undefined ? input.baseUrl : existing.baseUrl;
   const nextModels =
     input.models !== undefined ? input.models : existing.models;
 
-  if (PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(existing.provider)) {
+  if (PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(nextProvider)) {
     if (!nextBaseUrl) {
       return { ok: false, error: { code: "base_url_required" } };
     }
@@ -296,10 +316,14 @@ export function updateConnection(
   const setClause: {
     auth: string;
     updatedAt: number;
+    provider?: string;
     label?: string | null;
     baseUrl?: string | null;
     models?: string | null;
   } = { auth: JSON.stringify(auth), updatedAt: now };
+  if (input.provider !== undefined) {
+    setClause.provider = input.provider;
+  }
   if (input.label !== undefined) {
     setClause.label = input.label;
   }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -17,7 +17,10 @@ import {
 // Per-connection provider cache (mix-and-match support)
 // ---------------------------------------------------------------------------
 import type { ProviderConnection } from "./inference/auth.js";
-import { ROUTING_IDENTITY_PROVIDERS } from "./inference/auth.js";
+import {
+  effectiveConnectionAuth,
+  ROUTING_IDENTITY_PROVIDERS,
+} from "./inference/auth.js";
 import { resolveAuth } from "./inference/resolve-auth.js";
 import { isModelInCatalog, PROVIDER_CATALOG } from "./model-catalog.js";
 import { getProviderDefaultModel } from "./model-intents.js";
@@ -333,9 +336,11 @@ export async function resolveProviderFromConnection(
   // re-read from the store below, so a key rotated since the entry was cached
   // is picked up here rather than served stale forever.
 
-  const authResult = await resolveAuth(connection.auth, effectiveProvider, {
-    baseUrl: connection.baseUrl,
-  });
+  const authResult = await resolveAuth(
+    effectiveConnectionAuth(connection),
+    effectiveProvider,
+    { baseUrl: connection.baseUrl },
+  );
   if (!authResult.ok) {
     const err = authResult.error;
     if (err.code === "not_implemented") {

--- a/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
+++ b/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
@@ -159,8 +159,13 @@ async function handleExchange(args: RouteHandlerArgs) {
 
   const existing = getConnection(db, CONNECTION_NAME);
   if (existing) {
+    // Stamp the provider with the auth: this row is the subscription
+    // connection by name, and dispatch derives auth from the provider for
+    // managed rows, so a claiming row with e.g. provider "vellum" would
+    // otherwise strand the fresh token behind derived platform auth.
     const updateResult = updateConnection(db, CONNECTION_NAME, {
       auth: authInput,
+      provider: "openai",
     });
     if (!updateResult.ok) {
       log.error(


### PR DESCRIPTION
## Summary

Step 0 of the 13b sequencing (`.private/plans/entries-model-13b.md`): the stored auth object stops being trusted where it carries no information. A `provider: "vellum"` row IS the managed route, so both `resolveAuth` call sites (`registry.ts` adapter construction, `adapter-factory.ts` credential refresher) now dispatch it on derived `{type: "platform"}` auth via a shared `effectiveConnectionAuth` helper, regardless of what the auth column holds.

With #39906's migration 361 already normalizing stored rows, this makes the stored platform variant fully inert: it is still written (boot seeding, derivation, client resends) and still travels the wire for compat, but nothing reads it to make a decision. Stopping the writes and removing the stored variant folds into 13b, where the chatgpt row gains its own provider identity and auth type becomes row-derivable everywhere.

## Scope note

Derivation is deliberately vellum-only. Keyless catalog providers (ollama) are NOT derived to `none`: keyless means no key *required*, not no key *possible* — the ollama adapter accepts an optional key, so a stored `api_key` on a keyless row is meaningful payload. A test documents this boundary.

These were the only two readers left: `connection-availability` and preflight already short-circuit vellum rows on the provider (via `isVellumManagedConnection` since #39906) before touching stored auth.

## Testing

Unit tests on `effectiveConnectionAuth` (vellum row with each stored variant → platform; api_key/oauth_subscription rows keep stored auth by reference; keyed-keyless case). Both call-site changes are argument swaps covered by the existing dispatch suites — all pass in isolation; `tsc` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma7ZMzsQkJCG4t4uSGLoLT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->