### PR TITLE
fix(macos): keep pack running when actool is unavailable

### DIFF
--- a/clients/macos/scripts/generate-icon.sh
+++ b/clients/macos/scripts/generate-icon.sh
@@ -245,6 +245,14 @@ iconutil --convert icns --output "$OUTPUT_DIR/icon.icns" "$ICONSET_DIR"
 
 echo "generate-icon: wrote $OUTPUT_DIR/icon.icns ($VELLUM_ENVIRONMENT)"
 
+# actool ships with full Xcode, not the Command Line Tools. Without it there is
+# no Assets.car, so Finder falls back to the icon.icns written above via
+# CFBundleIconFile. afterPack.js copies Assets.car only when it exists.
+if ! xcrun -f actool >/dev/null 2>&1; then
+    echo "generate-icon: actool unavailable (requires full Xcode); skipping Assets.car, using icon.icns fallback." >&2
+    exit 0
+fi
+
 # Compile the Icon Composer .icon bundle into Assets.car so Finder/Dock can use
 # the Liquid Glass icon on Tahoe and actool's rounded raster fallback on pre-Tahoe.
 # The .icns above is a full-bleed square (required for Tahoe edge-alpha check) and


### PR DESCRIPTION
actool ships with full Xcode rather than the Command Line Tools, so generate-icon.sh aborted pack.sh on machines that only have the CLI tools installed. Skip the Assets.car step when actool is missing and rely on the icon.icns fallback written just above, which afterPack.js already copies conditionally.

A genuine actool failure on a machine that has it stays fatal, so CI behavior is unchanged.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
