### PR TITLE
fix(assistant): require per-row OS evidence before suppressing a reply push

### DIFF
--- a/assistant/src/__tests__/client-os-metadata-persistence.test.ts
+++ b/assistant/src/__tests__/client-os-metadata-persistence.test.ts
@@ -65,6 +65,7 @@ import type {
 import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
 import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
 import type { MessageQueue } from "../daemon/conversation-queue-manager.js";
+import { isMacOriginatedUserMessage } from "../persistence/conversation-types.js";
 
 function createWebTurnContext(
   clientOs: string | undefined,
@@ -171,5 +172,103 @@ describe("client OS surface metadata persistence", () => {
       os: "ios",
       browser_family: "safari",
     });
+  });
+});
+
+/**
+ * `Conversation.clientOs` is a live field that only a transport-carrying
+ * message refreshes, so a transport-less turn stamps whatever an earlier send
+ * left there. `clientOsFromRequest` separates the two, and
+ * {@link isMacOriginatedUserMessage} (the row-origin read behind the
+ * `chat.assistant_reply` presence gate) requires it before letting an attended
+ * Mac suppress a push.
+ */
+describe("client OS per-row evidence marker", () => {
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+  });
+
+  test("marks an OS this row's own transport reported", async () => {
+    const ctx = createWebTurnContext("macos");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-transport-os",
+      requestClientOs: "macos",
+    });
+
+    expect(lastUserMetadata().client).toEqual({ os: "macos" });
+    expect(lastUserMetadata().clientOsFromRequest).toBe(true);
+    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(true);
+  });
+
+  test("marks an OS this row's own request headers reported", async () => {
+    const ctx = createWebTurnContext(undefined);
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-header-os",
+      metadata: { client: { os: "macos", interface_version: "0.8.2" } },
+    });
+
+    expect(lastUserMetadata().clientOsFromRequest).toBe(true);
+    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(true);
+  });
+
+  // The bug shape: a button tapped on the phone reaches a conversation whose
+  // last desktop send left `clientOs: "macos"` behind. The row still carries
+  // the inherited OS for telemetry, but nothing says this turn came from the
+  // Mac, so the reply push must survive.
+  test("leaves an inherited OS unmarked and not Mac-originated", async () => {
+    const ctx = createWebTurnContext("macos");
+    await persistQueuedMessageBody(ctx, {
+      content: "[User action on card surface: submit]",
+      requestId: "req-inherited-os",
+    });
+
+    expect(lastUserMetadata().client).toEqual({ os: "macos" });
+    expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
+    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+  });
+
+  // The marker vouches for the `client.os` that actually landed, not for
+  // whatever the row reported: a reported OS the stamp disagrees with is no
+  // evidence at all.
+  test("leaves the marker off when the reported OS is not the stamped one", async () => {
+    const ctx = createWebTurnContext("macos");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-mismatched-os",
+      requestClientOs: "ios",
+    });
+
+    expect(lastUserMetadata().client).toEqual({ os: "macos" });
+    expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
+    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+  });
+
+  // The marker is derived from what this persist can see, so a bag value
+  // riding in from a caller must not survive the metadata spread and assert an
+  // origin the row never reported.
+  test("drops a caller-supplied marker from the metadata bag", async () => {
+    const ctx = createWebTurnContext("macos");
+    await persistQueuedMessageBody(ctx, {
+      content: "[User action on card surface: submit]",
+      requestId: "req-spoofed-marker",
+      metadata: { clientOsFromRequest: true },
+    });
+
+    expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
+    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+  });
+
+  test("leaves the marker off for a reported OS outside the vocabulary", async () => {
+    const ctx = createWebTurnContext(undefined);
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-unknown-os",
+      requestClientOs: "windows",
+    });
+
+    expect(lastUserMetadata().client).toBeUndefined();
+    expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -676,6 +676,62 @@ describe("Conversation message queue", () => {
     expect(pendingRuns.length).toBe(3);
   });
 
+  // `Conversation.clientOs` is a live field that only a transport-carrying
+  // message refreshes, so a transport-less drain (a surface action, a signal)
+  // persists the OS of an earlier send. Both rows keep that OS for telemetry;
+  // only the row that reported it claims the surface, which is what stops an
+  // attended Mac from suppressing the push for a button tapped on the phone.
+  test("[experimental] only a queued send that reported its own OS claims that surface", async () => {
+    capturedAddMessages.length = 0;
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      onEvent: () => {},
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    conversation.enqueueMessage({
+      content: "from-the-mac",
+      onEvent: () => {},
+      requestId: "req-mac",
+      transport: { channelId: "vellum", interfaceId: "web", clientOs: "macos" },
+    });
+    // A surface action: no transport, so the drain leaves the conversation's
+    // `clientOs` on the macOS value the send above applied.
+    conversation.enqueueMessage({
+      content: "[User action on card surface: submit]",
+      onEvent: () => {},
+      requestId: "req-surface-action",
+    });
+
+    await resolveRun(0);
+    await p1;
+    await waitForPendingRun(2);
+    await resolveRun(1);
+    await waitForPendingRun(3);
+
+    const macRow = capturedAddMessages.find(
+      (m) => m.role === "user" && m.content.includes("from-the-mac"),
+    );
+    expect(macRow).toBeDefined();
+    expect(macRow!.metadata?.client).toEqual({ os: "macos" });
+    expect(macRow!.metadata?.clientOsFromRequest).toBe(true);
+
+    const surfaceActionRow = capturedAddMessages.find(
+      (m) => m.role === "user" && m.content.includes("User action on card"),
+    );
+    expect(surfaceActionRow).toBeDefined();
+    expect(surfaceActionRow!.metadata?.client).toEqual({ os: "macos" });
+    expect(surfaceActionRow!.metadata?.clientOsFromRequest).toBeUndefined();
+
+    await resolveRun(2);
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
   test("[experimental] queued passthrough siblings viewing different apps do NOT batch", async () => {
     // A batched turn applies only the head's `visibleAppId`, which drives the
     // `visible_app:` context line. Coalescing messages sent while different

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -650,6 +650,50 @@ describe("HTTP POST /v1/messages client metadata headers", () => {
     ];
     expect(persistOptions.metadata).toBeUndefined();
   });
+
+  // Persistence merges the row's `client.os` from two sources and only one of
+  // them is this row's own: the request. Threading the body's `clientOs` is
+  // what lets it tell a reported OS apart from the one a transport-less turn
+  // inherits off the live conversation.
+  test("threads the body clientOs as this row's own OS evidence", async () => {
+    const persistUserMessage = mock(
+      async (_options: { requestClientOs?: string }) => ({
+        id: "persisted-msg-id",
+        deduplicated: false,
+      }),
+    );
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage("hello", conversation, {
+      clientOs: "macos",
+    });
+
+    expect(res.status).toBe(202);
+    const [persistOptions] = persistUserMessage.mock.calls[0] as unknown as [
+      { requestClientOs?: string },
+    ];
+    expect(persistOptions.requestClientOs).toBe("macos");
+  });
+
+  test("omits the OS evidence when the body reports no clientOs", async () => {
+    const persistUserMessage = mock(
+      async (_options: { requestClientOs?: string }) => ({
+        id: "persisted-msg-id",
+        deduplicated: false,
+      }),
+    );
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage("hello", conversation);
+
+    expect(res.status).toBe(202);
+    const [persistOptions] = persistUserMessage.mock.calls[0] as unknown as [
+      { requestClientOs?: string },
+    ];
+    expect(persistOptions.requestClientOs).toBeUndefined();
+  });
 });
 
 // ============================================================================

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -702,6 +702,19 @@ export interface PersistMessageOptions {
    * thread it: the queue round-trips `metadata`, not these options.
    */
   scripted?: boolean;
+  /**
+   * OS surface this row's own request or transport reported, threaded by the
+   * ingress that built it (the send route's request body, a queued message's
+   * `transport`). Stamps `metadata.clientOsFromRequest` when it matches the
+   * `client.os` this row persists.
+   *
+   * `ctx.clientOs` alone is not that evidence: it is a live conversation
+   * field only a transport-carrying message refreshes, so a transport-less
+   * turn (surface action, signal ingress) inherits whatever an earlier send
+   * left there. Omitting this option therefore reads as "inherited", which is
+   * what a consumer that must not misattribute a turn to a surface needs.
+   */
+  requestClientOs?: string;
 }
 
 // ── persistUserMessage ───────────────────────────────────────────────
@@ -810,6 +823,7 @@ export async function persistQueuedMessageBody(
     displayContent,
     clientMessageId,
     skipIndexing,
+    requestClientOs,
   } = options;
   const attachmentInputs: MessageAttachmentInput[] = attachments.map(
     (attachment) => ({
@@ -842,13 +856,19 @@ export async function persistQueuedMessageBody(
     // non-boolean through would be worse than dropping it: sqlite stores it
     // verbatim, and `turn-events-store` narrows anything that isn't 1 to
     // `false`, turning a junk string into a confident "the user typed this".
+    // `clientOsFromRequest` comes out for the same reason and a sharper one:
+    // it is derived below from what this persist can actually see, and a bag
+    // value surviving the spread would let a caller assert an origin the row
+    // never reported.
     const {
       slackInbound: rawSlackInbound,
       scripted: rawScriptedFromMetadata,
+      clientOsFromRequest: _rawClientOsFromRequest,
       ...metadataWithoutSlackInbound
     } = (metadata ?? {}) as Record<string, unknown> & {
       slackInbound?: SlackInboundMessageMetadata;
       scripted?: unknown;
+      clientOsFromRequest?: unknown;
     };
     const slackMeta = buildSlackMetaForPersistence({
       slackInbound: rawSlackInbound,
@@ -898,6 +918,22 @@ export async function persistQueuedMessageBody(
     const clientBag =
       Object.keys(clientEntries).length > 0 ? { client: clientEntries } : {};
 
+    // Per-row evidence for the `client.os` stamped just above, kept as a
+    // sibling of the bag so `TurnTelemetryEvent.client` stays exactly the
+    // forwarded `$.client`. Set only when this row itself reported the OS:
+    // through the caller's own client bag (the request's client-metadata
+    // headers, round-tripped through the queue) or through this row's
+    // transport, which `requestClientOs` carries. An inherited `ctx.clientOs`
+    // names the surface of an EARLIER turn, so it leaves the marker off and a
+    // consumer reading origin (the reply-push presence gate) treats the turn
+    // as coming from somewhere unknown.
+    const callerOs = callerClient?.os;
+    const resolvedRequestClientOs = parseClientOs(requestClientOs);
+    const clientOsFromRequest =
+      (typeof callerOs === "string" && callerOs.length > 0) ||
+      (resolvedRequestClientOs !== null &&
+        resolvedRequestClientOs === clientOs);
+
     const mergedMetadata = {
       ...metadataWithoutSlackInbound,
       ...provenance,
@@ -914,6 +950,7 @@ export async function persistQueuedMessageBody(
           }
         : {}),
       ...clientBag,
+      ...(clientOsFromRequest ? { clientOsFromRequest: true } : {}),
       ...(imageSourcePaths ? { imageSourcePaths } : {}),
       ...(slackMeta ? { slackMeta } : {}),
       // Scripted-turn marker, forwarded by `turn-events-store` onto

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1112,6 +1112,9 @@ async function drainSingleMessage(
       metadata: { ...next.metadata, sentAt: next.sentAt },
       displayContent: next.displayContent,
       clientMessageId: next.clientMessageId,
+      ...(next.transport?.clientOs
+        ? { requestClientOs: next.transport.clientOs }
+        : {}),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1462,6 +1465,9 @@ async function drainBatch(
         metadata: { ...qm.metadata, sentAt: qm.sentAt },
         displayContent: qm.displayContent,
         clientMessageId: qm.clientMessageId,
+        ...(qm.transport?.clientOs
+          ? { requestClientOs: qm.transport.clientOs }
+          : {}),
       };
       if (i === 0) {
         batchPersistResult =

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -167,7 +167,9 @@ function makeMessage(overrides: Partial<MessageRow> = {}): MessageRow {
 /**
  * A turn opened from the macOS app. The `client` bag's `os` entry is the only
  * per-platform attribution: the interface stamp is "web" for the macOS app,
- * the iOS app, and a desktop browser alike.
+ * the iOS app, and a desktop browser alike. `clientOsFromRequest` says the
+ * send itself reported that OS, which is what separates it from a row that
+ * inherited the conversation's live client state.
  */
 function makeMacOriginatedMessage(): MessageRow {
   return makeMessage({
@@ -175,6 +177,7 @@ function makeMacOriginatedMessage(): MessageRow {
       userMessageChannel: "vellum",
       userMessageInterface: "web",
       client: { os: "macos" },
+      clientOsFromRequest: true,
     }),
   });
 }
@@ -350,13 +353,37 @@ describe("emitAssistantReplyNotification", () => {
     // can send from the phone minutes after last touching the keyboard, which
     // is exactly the reply this producer exists to push.
     const NON_MAC_ORIGIN_CASES: Array<{ name: string; metadata: unknown }> = [
-      { name: "the iOS app", metadata: { client: { os: "ios" } } },
-      { name: "a browser", metadata: { client: { os: "web" } } },
-      { name: "a client that reports no OS", metadata: { client: {} } },
+      {
+        name: "the iOS app",
+        metadata: { client: { os: "ios" }, clientOsFromRequest: true },
+      },
+      {
+        name: "a browser",
+        metadata: { client: { os: "web" }, clientOsFromRequest: true },
+      },
+      {
+        name: "a client that reports no OS",
+        metadata: { client: {} },
+      },
       { name: "a row with no client bag", metadata: {} },
       {
         name: "a client reporting an unknown OS",
-        metadata: { client: { os: "bsd" } },
+        metadata: { client: { os: "bsd" }, clientOsFromRequest: true },
+      },
+      // The fail-closed shape this gate exists to refuse: a surface action
+      // tapped on the phone carries no transport, so persistence stamps the
+      // `macos` the conversation's live client state kept from an earlier
+      // desktop send. Without the marker that OS names an earlier turn, not
+      // this one, and the push the user is waiting for on their phone would
+      // be dropped by the attended Mac.
+      {
+        name: "a row whose macOS OS was inherited, not reported",
+        metadata: { userMessageInterface: "web", client: { os: "macos" } },
+      },
+      // A marker without a matching OS is not evidence of anything.
+      {
+        name: "a row marked request-reported with no client bag",
+        metadata: { clientOsFromRequest: true },
       },
     ];
 
@@ -394,6 +421,7 @@ describe("emitAssistantReplyNotification", () => {
         metadata: JSON.stringify({
           userMessageChannel: "not-a-channel",
           client: { os: "macos" },
+          clientOsFromRequest: true,
         }),
       });
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -10,7 +10,6 @@
 
 import type pino from "pino";
 
-import { parseClientOs } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
@@ -24,6 +23,7 @@ import {
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import {
+  isMacOriginatedUserMessage,
   isReplyPushIneligibleUserMessage,
   resolveConversationKind,
 } from "../persistence/conversation-types.js";
@@ -96,24 +96,6 @@ function readSuppressionMarkers(
     return validated;
   }
   return metadataJson ? safeParseRecord(metadataJson) : undefined;
-}
-
-/**
- * True when the row that opened the turn was sent from the macOS app.
- *
- * The `client` bag's `os` entry is the only per-platform attribution on a
- * message: `userMessageInterface` is `"web"` for the macOS app, the iOS app,
- * and a desktop browser alike. An absent or unrecognized value reads as
- * not-macOS, so a turn whose origin cannot be established keeps its push.
- */
-function isMacOriginatedTurn(
-  metadata: Record<string, unknown> | undefined,
-): boolean {
-  const client = metadata?.client;
-  if (typeof client !== "object" || client === null) {
-    return false;
-  }
-  return parseClientOs((client as Record<string, unknown>).os) === "macos";
 }
 
 /**
@@ -223,12 +205,12 @@ export async function emitAssistantReplyNotification(params: {
     );
 
     // Read as close to the emit as possible: nothing short-circuits on it.
-    // Presence only speaks for a turn the Mac itself opened. A turn sent from
-    // the phone still needs its push while the Mac sits idle within the
-    // desktop client's attendance window.
+    // Presence only speaks for a turn the Mac itself opened, on that row's own
+    // OS evidence. A turn sent from the phone still needs its push while the
+    // Mac sits idle within the desktop client's attendance window.
     const desktopAttended =
       isAssistantFeatureFlagEnabled(DESKTOP_PRESENCE_FLAG) &&
-      isMacOriginatedTurn(initiatingMetadata) &&
+      isMacOriginatedUserMessage(initiatingMetadata) &&
       readDesktopAttended(rlog);
 
     await emitNotificationSignal({

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -264,6 +264,20 @@ export const messageMetadataSchema = z
      * require a migration -- dbt can unpack later via JSON_VALUE.
      */
     client: z.record(z.string(), z.unknown()).optional(),
+    /**
+     * True when the `client.os` above was reported by this row's own request
+     * or transport rather than inherited from the conversation's live client
+     * state. `Conversation.clientOs` is refreshed only by a message that
+     * carries transport metadata, so a transport-less turn (surface action,
+     * signal ingress) stamps the OS of an earlier send. Consumers that must
+     * not misattribute a turn to a surface require this marker (the
+     * `chat.assistant_reply` presence gate, which drops the push when the Mac
+     * that opened the turn is attended). Absent reads as "origin unknown".
+     * Deliberately a sibling of `client` rather than an entry inside it:
+     * `turn-events-store` forwards `$.client` verbatim onto
+     * `TurnTelemetryEvent.client`.
+     */
+    clientOsFromRequest: z.boolean().optional(),
     subagentNotification: subagentNotificationSchema.optional(),
     acpNotification: acpNotificationSchema.optional(),
     /**

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -7,7 +7,7 @@
 // `resolveConversationKind` classifier, and the pure predicates over a
 // persisted message's `metadata` record.
 
-import { parseChannelId } from "../channels/types.js";
+import { parseChannelId, parseClientOs } from "../channels/types.js";
 
 /**
  * Canonical `conversations.source` string for background memory v2
@@ -146,6 +146,34 @@ export function isVoiceSessionUserMessage(
   metadata: Record<string, unknown> | undefined,
 ): boolean {
   return metadata?.voiceSessionTurn === true;
+}
+
+/**
+ * True when the row that opened the turn was sent from the macOS app, on that
+ * row's own evidence.
+ *
+ * Two markers, both required. The `client` bag's `os` entry is the only
+ * per-platform attribution on a message: `userMessageInterface` is `"web"` for
+ * the macOS app, the iOS app, and a desktop browser alike. `clientOsFromRequest`
+ * says that `os` was reported by this row's request or transport rather than
+ * inherited from the conversation's live client state, which names the surface
+ * of an earlier turn: a button tapped on the phone against a conversation last
+ * sent to from the Mac persists `os: "macos"` with no marker.
+ *
+ * Origin a row did not report itself is origin unknown. Callers gate
+ * suppression on this, so unknown has to read as not-macOS.
+ */
+export function isMacOriginatedUserMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  if (metadata?.clientOsFromRequest !== true) {
+    return false;
+  }
+  const client = metadata.client;
+  if (typeof client !== "object" || client === null) {
+    return false;
+  }
+  return parseClientOs((client as Record<string, unknown>).os) === "macos";
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2010,6 +2010,7 @@ export async function handleSendMessage(
         requestId: uuidv7(),
         metadata: greetingMeta,
         clientMessageId,
+        ...(clientOs ? { requestClientOs: clientOs } : {}),
       });
 
       const conversationId = mapping.conversationId;
@@ -2340,6 +2341,7 @@ export async function handleSendMessage(
         requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
+        ...(clientOs ? { requestClientOs: clientOs } : {}),
       });
       if (persisted.deduplicated) {
         return {
@@ -2439,6 +2441,7 @@ export async function handleSendMessage(
         requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
+        ...(clientOs ? { requestClientOs: clientOs } : {}),
       });
     } catch (err) {
       // The fire-and-forget compaction below owns clearing `processing`, but a
@@ -2533,6 +2536,7 @@ export async function handleSendMessage(
         requestId: uuidv7(),
         metadata: withClientMetadata(slashMeta, clientMetadata),
         clientMessageId,
+        ...(clientOs ? { requestClientOs: clientOs } : {}),
       });
       if (persisted.deduplicated) {
         return {
@@ -2602,6 +2606,7 @@ export async function handleSendMessage(
     ),
     scripted: body.scripted,
     clientMessageId,
+    ...(clientOs ? { requestClientOs: clientOs } : {}),
   });
 
   const messageId = persistResult.id;


### PR DESCRIPTION
## Summary
- A transport-less turn (surface action, signal ingress) inherited `clientOs` from an earlier send on the same conversation, so a button tapped on the phone could be stamped as Mac-originated and have its push suppressed
- Suppression now requires the OS attribution to have come from the turn's own request or transport, not from a previous turn
- `client.os` itself, turn telemetry, the client_os context line, and the batching split are unchanged

Fixes a fail-closed path found during plan self-review for presence-gated-reply-push.md