### PR TITLE
polish(web): source-labeled list fetch errors

### DIFF
--- a/clients/web/src/utils/conversation-list-fetchers.test.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.test.ts
@@ -28,6 +28,7 @@ mock.module("@/lib/telemetry/client-perf", () => ({
 }));
 
 const {
+  hasAnyActiveConversation,
   listArchivedConversations,
   listBackgroundConversations,
   listBackgroundConversationsFirstPage,
@@ -200,6 +201,7 @@ describe("conversation list drain diagnostics", () => {
       status: 500,
       bytes: null,
       listKind: "foreground",
+      source: "drain",
     });
     expect(events[1]?.details).not.toHaveProperty("conversationType");
     expect(events[1]?.details).not.toHaveProperty("archiveStatus");
@@ -236,8 +238,31 @@ describe("conversation list drain diagnostics", () => {
     const errorEntry = events.find(
       (event) => event.kind === "conversation_list_page_fetch_error",
     );
-    expect(errorEntry?.details).toMatchObject({ listKind: "background" });
+    expect(errorEntry?.details).toMatchObject({
+      listKind: "background",
+      source: "drain",
+    });
     expect(errorEntry?.details).not.toHaveProperty("archiveStatus");
+  });
+
+  test("a failing existence probe is labeled so it cannot pass as a drain failure", async () => {
+    stubPages([{ ids: [], hasMore: false, status: 500 }]);
+
+    const { events, result } = await diagnosticsDuring(() =>
+      hasAnyActiveConversation(ASSISTANT_ID).catch(() => "threw"),
+    );
+
+    expect(result).toBe("threw");
+    const errorEntry = events.find(
+      (event) => event.kind === "conversation_list_page_fetch_error",
+    );
+    expect(errorEntry?.details).toMatchObject({
+      listKind: "foreground",
+      source: "existence_probe",
+    });
+    expect(
+      events.filter((event) => event.kind === "conversation_list_page_fetch"),
+    ).toHaveLength(0);
   });
 
   test("both archive-page drain summaries are labeled archived", async () => {

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -178,6 +178,13 @@ type TimedConversationListPage = ConversationListPage & {
 type FirstPageFetchSource = "drain" | "first_page_refresh";
 
 /**
+ * Superset of {@link FirstPageFetchSource} for the error entry, which any
+ * caller of {@link fetchConversationListPage} can produce, including the
+ * onboarding existence probe.
+ */
+type ListFetchSource = FirstPageFetchSource | "existence_probe";
+
+/**
  * Ring entry for one offset-0 list GET, shared by the drain's first page and
  * the standalone first-page fetchers. The standalone ones run debounced (250ms)
  * behind sync events, so their share of the 200-entry ring stays small.
@@ -186,9 +193,11 @@ type FirstPageFetchSource = "drain" | "first_page_refresh";
  * bucket's first page reads as the same offset-0 request, and a slow entry is
  * not attributable to the path the user waited on.
  *
- * {@link hasAnyActiveConversation} deliberately records nothing: it is an
+ * {@link hasAnyActiveConversation} contributes no success entry: it is an
  * offset-0 existence probe on the onboarding path, not a list the user is
  * waiting to see, so keeping it out preserves the ring for real list fetches.
+ * A failed probe still lands one `conversation_list_page_fetch_error`, labeled
+ * `source: "existence_probe"` so it cannot be mistaken for a drain failure.
  */
 function recordFirstPageFetch(
   assistantId: string,
@@ -212,6 +221,7 @@ function recordFirstPageFetch(
 async function fetchConversationListPage(
   assistantId: string,
   offset: number,
+  source: ListFetchSource,
   options: FetchConversationListOptions = {},
 ): Promise<TimedConversationListPage> {
   const { conversationType, archiveStatus, originChannel } = options;
@@ -237,6 +247,7 @@ async function fetchConversationListPage(
       durationMs,
       bytes: readContentLength(response),
       listKind: drainListKind(options),
+      source,
     });
     const msg = extractErrorMessage(
       error,
@@ -299,6 +310,7 @@ async function fetchConversationList(
       const result = await fetchConversationListPage(
         assistantId,
         offset,
+        "drain",
         options,
       );
       pages++;
@@ -428,7 +440,11 @@ export async function listConversations(
 export async function hasAnyActiveConversation(
   assistantId: string,
 ): Promise<boolean> {
-  const { conversations } = await fetchConversationListPage(assistantId, 0);
+  const { conversations } = await fetchConversationListPage(
+    assistantId,
+    0,
+    "existence_probe",
+  );
   return conversations.length > 0;
 }
 
@@ -522,7 +538,11 @@ export async function listArchivedConversations(
 export async function listConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0);
+  const page = await fetchConversationListPage(
+    assistantId,
+    0,
+    "first_page_refresh",
+  );
   recordFirstPageFetch(assistantId, page, "foreground", "first_page_refresh");
   return {
     conversations: [...page.conversations].sort(
@@ -536,9 +556,12 @@ export async function listConversationsFirstPage(
 export async function listBackgroundConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0, {
-    conversationType: "background",
-  });
+  const page = await fetchConversationListPage(
+    assistantId,
+    0,
+    "first_page_refresh",
+    { conversationType: "background" },
+  );
   recordFirstPageFetch(assistantId, page, "background", "first_page_refresh");
   return {
     conversations: page.conversations
@@ -552,9 +575,12 @@ export async function listBackgroundConversationsFirstPage(
 export async function listScheduledConversationsFirstPage(
   assistantId: string,
 ): Promise<ConversationListPage> {
-  const page = await fetchConversationListPage(assistantId, 0, {
-    conversationType: "scheduled",
-  });
+  const page = await fetchConversationListPage(
+    assistantId,
+    0,
+    "first_page_refresh",
+    { conversationType: "scheduled" },
+  );
   recordFirstPageFetch(assistantId, page, "scheduled", "first_page_refresh");
   return {
     conversations: [...page.conversations].sort(


### PR DESCRIPTION
## Summary
- conversation_list_page_fetch_error now carries source (drain / first_page_refresh / existence_probe), so a failing onboarding probe can no longer read as a sidebar drain failure
- The recordFirstPageFetch docstring now states the probe's actual behavior: no success entry, source-labeled error entry on failure
- Regression test: a failing probe produces exactly one error entry labeled existence_probe and no success entry

Fixes the final gap found during round-4 plan self-review for measure-first-telemetry-followups.md