### PR TITLE
fix(macos): do not let a presence install failure abort app startup

### DIFF
--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -868,6 +868,32 @@ describe("host-proxy-router", () => {
       expect(mockPresenceTeardown).toHaveBeenCalledTimes(2);
     });
 
+    test("keeps the bridge alive when the monitor fails to install", async () => {
+      mockInstallPresenceMonitor.mockImplementationOnce(() => {
+        throw new Error("powerMonitor unavailable");
+      });
+
+      // The bridge installs inside app.whenReady() ahead of the tray, native
+      // auth, and the main window, so a throw escaping here would cost the
+      // user the app for the sake of a notification optimization.
+      let teardown: (() => void) | undefined;
+      expect(() => {
+        teardown = installHostProxyBridge(fakeCliResolver);
+      }).not.toThrow();
+
+      expect(__testing.executors.has("host_bash")).toBe(true);
+      expect(__testing.executors.has("host_browser")).toBe(true);
+
+      lockfileListener?.(MIXED_LOCKFILE);
+      await flush();
+      expect(__testing.connections.has("local-1")).toBe(true);
+      expect(__testing.connections.has("cloud-1")).toBe(true);
+
+      expect(() => teardown?.()).not.toThrow();
+      expect(mockPresenceTeardown).not.toHaveBeenCalled();
+      expect(__testing.connections.size).toBe(0);
+    });
+
     test("keeps reporting to siblings when one poster rejects", async () => {
       installHostProxyBridge(fakeCliResolver);
       const unreachable = addPresenceConnection("a1", { reject: true });

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -543,7 +543,17 @@ export function installHostProxyBridge(
   // monitor first keeps a second install from leaking its interval and
   // powerMonitor listeners.
   stopPresenceMonitor?.();
-  stopPresenceMonitor = installPresenceMonitor(reportPresence);
+  // Guarded because this install runs inside `app.whenReady()` ahead of the
+  // tray, native auth, and the main window, so a throw escaping here would
+  // take the rest of app startup with it. Presence is an optional
+  // optimization and losing it lets the mobile push through, which is the
+  // safe direction; losing the app is not. Left null so teardown no-ops.
+  stopPresenceMonitor = null;
+  try {
+    stopPresenceMonitor = installPresenceMonitor(reportPresence);
+  } catch (err) {
+    log.warn("[host-proxy-router] presence monitor install failed", { err });
+  }
 
   return () => {
     stopPresenceMonitor?.();


### PR DESCRIPTION
## Summary
- `installHostProxyBridge` runs inside `app.whenReady()` before the tray, native auth, and main window are installed, so an unguarded throw from the presence monitor would take app startup down with it
- Presence is an optional notification optimization: losing it sends the iOS push, which is the safe direction, while losing startup is not
- The install is now guarded and logged, leaving the teardown a no-op

Fixes an issue found during plan self-review for presence-gated-reply-push.md