### PR TITLE
test: single-source the google injection host-list assertion

### DIFF
--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -21,29 +21,6 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     );
   });
 
-  test("google injection templates cover all Google product hosts", () => {
-    // BYO-mode CES header injection only fires for hosts with a matching
-    // template; a missing host means requests go out with no Authorization
-    // header. Keep this list in sync with the Google products we call.
-    const templates = PROVIDER_SEED_DATA.google.injectionTemplates ?? [];
-    const hosts = templates.map((t) => t.hostPattern);
-    expect(hosts).toEqual(
-      expect.arrayContaining([
-        "gmail.googleapis.com",
-        "www.googleapis.com",
-        "people.googleapis.com",
-        "docs.googleapis.com",
-        "tasks.googleapis.com",
-        "calendar.googleapis.com",
-      ]),
-    );
-    for (const template of templates) {
-      expect(template.injectionType).toBe("header");
-      expect(template.headerName).toBe("Authorization");
-      expect(template.valuePrefix).toBe("Bearer ");
-    }
-  });
-
   test("every managedServiceConfigKey resolves to a ServicesSchema key", () => {
     // Cross-repo invariant: a provider with managedServiceConfigKey but no
     // matching ServicesSchema entry silently falls back to BYO mode in


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for managed-oauth-scopes.md.

**Gap:** the 6-host google injection template list was asserted in both seed-providers-managed.test.ts and oauth-provider-profiles.test.ts; the weaker seed-constant copy is removed, keeping the stronger DB-seeded assertion as the single source.