### PR TITLE
fix: align oauth skill and help guidance with requestedScopes

### DIFF
--- a/assistant/src/cli/commands/oauth/connect-surface-guidance.test.ts
+++ b/assistant/src/cli/commands/oauth/connect-surface-guidance.test.ts
@@ -36,5 +36,21 @@ describe("OAuth connect surface guidance", () => {
     expect(hint).toContain('surface_type "oauth_connect"');
     expect(hint).toContain('data.providerKey "google"');
     expect(hint).toContain("paste an OAuth URL");
+    expect(hint).not.toContain("requestedScopes");
+  });
+
+  test("hint with scopes teaches the full replacement set semantics", () => {
+    const hint = oauthConnectSurfaceHint("google", ["a", "b"]);
+    expect(hint).toContain("data.requestedScopes");
+    expect(hint).toContain("full replacement set");
+  });
+
+  test("redirect with scopes carries requestedScopes in the next action", () => {
+    const redirect = buildOAuthConnectSurfaceRedirect("google", ["a", "b"]);
+    expect(redirect.nextAction.data).toEqual({
+      providerKey: "google",
+      requestedScopes: ["a", "b"],
+    });
+    expect(redirect.hint).toBe(oauthConnectSurfaceHint("google", ["a", "b"]));
   });
 });

--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -691,7 +691,9 @@ Important for chat/UI turns: do not run this command just to let the user
 connect a managed provider. Render the first-class connect surface instead:
 call \`ui_show\` with surface_type "oauth_connect" and data.providerKey set to
 the provider (for example, "google"). That surface starts the managed OAuth UI
-and avoids pasting raw authorization links into the conversation.
+and avoids pasting raw authorization links into the conversation. If the user
+needs non-default scopes, also pass data.requestedScopes as a full replacement
+set (list every scope the connection should keep, not just the new ones).
 
 Examples:
   $ assistant oauth connect google

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -508,7 +508,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-08-03T23:08:27.000Z"
+      "updatedAt": "2026-08-03T23:57:15.000Z"
     },
     {
       "id": "llm-provider-setup",
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T15:54:16.000Z"
+      "updatedAt": "2026-08-05T00:08:38.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -41,7 +41,7 @@ If there are none, see [Configuring a New OAuth Application](CONFIGURING_APPLICA
 
 ## Choosing Scopes
 
-For managed mode, do not choose or display scopes yourself. Managed providers use the platform's configured scopes, and the chat surface handles the connection affordance.
+In managed mode, connections use the platform's default scopes unless you pass `data.requestedScopes` on the oauth_connect surface. When you do, it is a full replacement set: the platform uses exactly those scopes instead of the defaults, so include every scope the connection should keep, not just the new ones. The chat surface handles the connection affordance.
 
 For your-own mode, consider what the user is trying to accomplish and request only the scopes needed for that task. You can see what scopes are available for a provider with:
 
@@ -59,7 +59,7 @@ If the user later needs additional scopes for a different task in your-own mode,
 
 If the provider is in managed mode, use `ui_show` with `surface_type: "oauth_connect"`. This is the same managed connection path available through Settings, but presented in chat at the moment the task needs it.
 
-Use a short task-specific description, and let the client own the action label. Do not include scopes, raw OAuth URLs, or a custom connect button label in the surface.
+Use a short task-specific description, and let the client own the action label. Do not include raw OAuth URLs or a custom connect button label in the surface. If the task needs non-default scopes, pass them in the optional `data.requestedScopes` field; that is the supported way to request them.
 
 ```json
 {
@@ -72,6 +72,8 @@ Use a short task-specific description, and let the client own the action label. 
   }
 }
 ```
+
+To request non-default scopes, add an optional `data.requestedScopes` array of scopes. Remember it is a full replacement set, not a merge with the defaults.
 
 Wait for the user to complete or dismiss the surface before proceeding. If they connect, verify the connection before making requests. If they dismiss it, continue only if the task can proceed without that account.
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for managed-oauth-scopes.md.

**Gap:** the vellum-oauth-integrations skill and the oauth connect help text still forbade or omitted scopes on the oauth_connect surface, contradicting the new requestedScopes support; the scopes-aware redirect hint had no test coverage.