### PR TITLE
fix: em-dash sweep and type/prose dedup for managed OAuth scopes

### DIFF
--- a/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
+++ b/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
@@ -1,7 +1,9 @@
+import type { OAuthConnectSurfaceData } from "../../../api/surfaces.js";
+
 export interface OAuthConnectSurfaceNextAction {
   type: "ui_show";
   surfaceType: "oauth_connect";
-  data: { providerKey: string; requestedScopes?: string[] };
+  data: Pick<OAuthConnectSurfaceData, "providerKey" | "requestedScopes">;
 }
 
 export interface OAuthConnectSurfaceRedirect {
@@ -28,7 +30,7 @@ export function oauthConnectSurfaceHint(
   return (
     base +
     ` Include data.requestedScopes verbatim from nextAction.data in the ` +
-    `\`ui_show\` call — it is a full replacement set, so list every default ` +
+    `\`ui_show\` call: it is a full replacement set, so list every default ` +
     `scope you want to keep, not just the new ones.`
   );
 }

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -132,7 +132,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   oauth_connect: {
     purpose: "managed OAuth connection button for an integration account",
     shape:
-      "{ providerKey, requestedScopes?, displayName?, description?, logoUrl? } — managed OAuth connection CTA; use when the task needs a managed integration account (Google, Linear, GitHub, ...) instead of settings or shell OAuth. requestedScopes is an optional FULL replacement set of OAuth scopes — when set, the connection is granted exactly these scopes instead of the platform defaults, so include every scope the connection should keep; omit it to use the platform's default scopes",
+      "{ providerKey, requestedScopes?, displayName?, description?, logoUrl? }: managed OAuth connection CTA; use when the task needs a managed integration account (Google, Linear, GitHub, ...) instead of settings or shell OAuth. requestedScopes is an optional FULL replacement set of OAuth scopes: when set, the connection is granted exactly these scopes instead of the platform defaults, so include every scope the connection should keep; omit it to use the platform's default scopes",
     missingContent: (data) =>
       isNonEmptyString(data.providerKey)
         ? null

--- a/clients/web/src/domains/chat/api/managed-oauth.test.ts
+++ b/clients/web/src/domains/chat/api/managed-oauth.test.ts
@@ -10,10 +10,11 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { assistantsOauthStartCreate } from "@/generated/api/sdk.gen";
 import { oauthCompletionStorageKey } from "@/lib/auth/oauth-popup";
 
 const startCreateMock = mock(
-  async (_options: { body: { requested_scopes: string[] } }) => ({
+  async (_options: Parameters<typeof assistantsOauthStartCreate>[0]) => ({
     data: {
       connect_url:
         "https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=x&redirect_uri=y",
@@ -94,7 +95,7 @@ beforeEach(() => {
 });
 
 /**
- * Flush microtasks until the start endpoint has been invoked — the connect
+ * Flush microtasks until the start endpoint has been invoked: the connect
  * flow awaits identity resolution and a connections baseline first.
  */
 async function waitForStartCall(): Promise<void> {
@@ -175,7 +176,7 @@ describe("connectManagedOAuthProvider requested scopes", () => {
     const connect = connectManagedOAuthProvider({ ...OPTS, requestedScopes });
 
     await waitForStartCall();
-    expect(startCreateMock.mock.calls[0]?.[0].body.requested_scopes).toEqual(
+    expect(startCreateMock.mock.calls[0]?.[0].body?.requested_scopes).toEqual(
       requestedScopes,
     );
 
@@ -187,7 +188,7 @@ describe("connectManagedOAuthProvider requested scopes", () => {
     const connect = connectManagedOAuthProvider(OPTS);
 
     await waitForStartCall();
-    expect(startCreateMock.mock.calls[0]?.[0].body.requested_scopes).toEqual(
+    expect(startCreateMock.mock.calls[0]?.[0].body?.requested_scopes).toEqual(
       [],
     );
 

--- a/clients/web/src/domains/chat/api/managed-oauth.ts
+++ b/clients/web/src/domains/chat/api/managed-oauth.ts
@@ -35,9 +35,9 @@ export interface ManagedOAuthConnectOptions {
   providerKey: string;
   providerLabel: string;
   /**
-   * Full replacement set: when present, the platform uses exactly these
-   * scopes instead of its defaults (it does not merge). Omit to use the
-   * platform's default scopes.
+   * Full replacement set of OAuth scopes; see
+   * OAuthConnectSurfaceData.requestedScopes for semantics.
+   * Omit to use platform defaults.
    */
   requestedScopes?: string[];
 }
@@ -417,7 +417,7 @@ const inFlightManagedOAuthConnects = new Map<
  * flipped to "Connected" even though the account did connect (JARVIS-1286).
  *
  * Returning the already-running promise means repeat triggers latch onto the
- * one popup + one listener set that will actually resolve — even when the
+ * one popup + one listener set that will actually resolve, even when the
  * repeat trigger's `requestedScopes` differ, since two concurrent connects
  * for the same provider are inherently conflicting regardless of scopes.
  */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for managed-oauth-scopes.md.

**Gap:** new lines violated the AGENTS.md em-dash ban (including two model-facing strings flagged by Codex on #40086/#40087); CLI guidance shadow-typed the canonical surface data; duplicated full-replacement-set prose and a hand-declared SDK body type in tests.