### PR TITLE
feat(schedule): pin every schedule to a concrete inference profile

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25681,6 +25681,8 @@ paths:
                   description:
                     Inference profile (llm.profiles key) the schedule's runs use. Omitted or null pins the schedule to the
                     currently resolved default profile, so its model does not move when that default changes.
+                    Workflow-mode schedules resolve a model per workflow step, so the pin is recorded but does not
+                    govern their runs.
               required:
                 - name
                 - expression
@@ -26232,7 +26234,8 @@ paths:
                     - type: "null"
                   description:
                     Inference profile (llm.profiles key) the schedule's runs use; null re-pins the schedule to the currently
-                    resolved default profile
+                    resolved default profile. Workflow-mode schedules resolve a model per workflow step, so the pin is
+                    recorded but does not govern their runs.
       responses:
         "200":
           description: Successful response

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25679,8 +25679,8 @@ paths:
                     - type: string
                     - type: "null"
                   description:
-                    Inference profile (llm.profiles key) the schedule's runs use. Omitted or null = default, i.e. the mainAgent
-                    call-site model selection.
+                    Inference profile (llm.profiles key) the schedule's runs use. Omitted or null pins the schedule to the
+                    currently resolved default profile, so its model does not move when that default changes.
               required:
                 - name
                 - expression
@@ -26231,8 +26231,8 @@ paths:
                     - type: string
                     - type: "null"
                   description:
-                    Inference profile (llm.profiles key) the schedule's runs use; null clears it back to the default mainAgent
-                    call-site model selection
+                    Inference profile (llm.profiles key) the schedule's runs use; null re-pins the schedule to the currently
+                    resolved default profile
       responses:
         "200":
           description: Successful response

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -58,6 +58,7 @@ import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
+import { resolveDefaultScheduleInferenceProfile } from "../schedule/inference-profile.js";
 import {
   completeScheduleRun,
   createSchedule,
@@ -1230,14 +1231,20 @@ describe("POST /schedules — create", () => {
     expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 
-  test("defaults inferenceProfile to null when omitted", async () => {
+  test("pins inferenceProfile to the resolved default when omitted", async () => {
+    const expected = resolveDefaultScheduleInferenceProfile();
+    // A schedule that followed the global default would change model whenever
+    // the user changed that default, so creation snapshots it instead.
+    expect(expected).not.toBeNull();
+
     const result = await postCreate({
       name: "Default profile",
-      description: "Runs on the main-agent selection",
+      description: "Runs on the resolved default profile",
       expression: "0 9 * * *",
       message: "hi",
     });
-    expect(result.schedule.inferenceProfile).toBeNull();
+    expect(result.schedule.inferenceProfile).toBe(expected!);
+    expect(listSchedules()[0].inferenceProfile).toBe(expected!);
   });
 
   test("rejects an unknown inferenceProfile", async () => {
@@ -1296,7 +1303,10 @@ describe("PATCH /schedules/:id — description", () => {
     expect(listSchedules()[0].description).toBe("Updated description");
   });
 
-  test("sets, validates, and clears inferenceProfile", async () => {
+  test("sets, validates, and re-snapshots inferenceProfile", async () => {
+    const resolvedDefault = resolveDefaultScheduleInferenceProfile();
+    expect(resolvedDefault).not.toBe("cost-optimized");
+
     const schedule = await createSchedule({
       name: "Profile pin",
       description: "Pinned profile schedule",
@@ -1308,9 +1318,9 @@ describe("PATCH /schedules/:id — description", () => {
 
     await route.handler({
       pathParams: { id: schedule.id },
-      body: { inferenceProfile: "balanced" },
+      body: { inferenceProfile: "cost-optimized" },
     });
-    expect(listSchedules()[0].inferenceProfile).toBe("balanced");
+    expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
 
     await expect(
       route.handler({
@@ -1318,13 +1328,14 @@ describe("PATCH /schedules/:id — description", () => {
         body: { inferenceProfile: "does-not-exist" },
       }),
     ).rejects.toThrow('Inference profile "does-not-exist" is not defined');
-    expect(listSchedules()[0].inferenceProfile).toBe("balanced");
+    expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
 
+    // Null is a reset to the current default, not an unpin.
     await route.handler({
       pathParams: { id: schedule.id },
       body: { inferenceProfile: null },
     });
-    expect(listSchedules()[0].inferenceProfile).toBeNull();
+    expect(listSchedules()[0].inferenceProfile).toBe(resolvedDefault);
   });
 
   test("re-derives syntax when the expression switches cron to rrule", async () => {

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1231,6 +1231,36 @@ describe("POST /schedules — create", () => {
     expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 
+  // The endpoint validates inferenceProfile once, before branching on mode, so
+  // every mode it accepts has to honour the value it just validated.
+  test("persists a valid inferenceProfile on a workflow-mode create", async () => {
+    const result = await postCreate({
+      name: "Cheap triage",
+      description: "Workflow run on a cheap model",
+      expression: "0 * * * *",
+      message: "trigger",
+      mode: "workflow",
+      workflowName: "triage-inbox",
+      inferenceProfile: "cost-optimized",
+    });
+    expect(result.schedule.inferenceProfile).toBe("cost-optimized");
+    expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
+  });
+
+  test("persists a valid inferenceProfile on a script-mode create", async () => {
+    const result = await postCreate({
+      name: "Cheap script",
+      description: "Script run on a cheap model",
+      expression: "0 * * * *",
+      message: "trigger",
+      mode: "script",
+      script: "console.log('hi')",
+      inferenceProfile: "cost-optimized",
+    });
+    expect(result.schedule.inferenceProfile).toBe("cost-optimized");
+    expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
+  });
+
   test("pins inferenceProfile to the resolved default when omitted", async () => {
     const expected = resolveDefaultScheduleInferenceProfile();
     // A schedule that followed the global default would change model whenever

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -14,6 +14,10 @@ mock.module("../background-wake/publisher.js", () => ({
 
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import {
+  createConversation,
+  setConversationInferenceProfile,
+} from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -22,6 +26,7 @@ import {
   LEGACY_DEFER_CREATED_BY,
   OWNER_DEFER_CREATED_BY,
 } from "../schedule/defer-provenance.js";
+import { resolveDefaultScheduleInferenceProfile } from "../schedule/inference-profile.js";
 import {
   cancelSchedule,
   claimDueSchedules,
@@ -1504,5 +1509,94 @@ describe("owner-defer provenance", () => {
     expect(updated!.message).toBe("something else");
     expect(updated!.wakeConversationId).toBe("conv-elsewhere");
     expect(hasOwnerDeferProvenance(updated!.createdBy)).toBe(false);
+  });
+});
+
+// ── Inference-profile pinning ─────────────────────────────────────────────
+
+/**
+ * Every assertion below compares against the live resolution rather than a
+ * literal key, so the tests describe the invariant (a schedule is pinned to
+ * whatever the default resolves to at write time) instead of freezing this
+ * workspace's shipped profile catalog.
+ */
+describe("inference-profile pinning", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM cron_runs");
+    getDb().run("DELETE FROM cron_jobs");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  test("creation with no profile pins the resolved default", async () => {
+    const expected = resolveDefaultScheduleInferenceProfile();
+    expect(expected).not.toBeNull();
+
+    const job = await createSchedule({
+      name: "Unpinned",
+      message: "hi",
+      cronExpression: "0 9 * * *",
+    });
+
+    expect(job.inferenceProfile).toBe(expected!);
+    expect(getSchedule(job.id)!.inferenceProfile).toBe(expected!);
+  });
+
+  test("creation with an explicit profile keeps it", async () => {
+    expect(resolveDefaultScheduleInferenceProfile()).not.toBe("cost-optimized");
+
+    const job = await createSchedule({
+      name: "Pinned",
+      message: "hi",
+      cronExpression: "0 9 * * *",
+      inferenceProfile: "cost-optimized",
+    });
+
+    expect(job.inferenceProfile).toBe("cost-optimized");
+  });
+
+  test("updating to null re-snapshots the default instead of unpinning", async () => {
+    const job = await createSchedule({
+      name: "Repinned",
+      message: "hi",
+      cronExpression: "0 9 * * *",
+      inferenceProfile: "cost-optimized",
+    });
+
+    const updated = await updateSchedule(job.id, { inferenceProfile: null });
+
+    expect(updated!.inferenceProfile).toBe(
+      resolveDefaultScheduleInferenceProfile()!,
+    );
+  });
+
+  test("a defer seeds the source conversation's pinned profile", async () => {
+    const conversation = createConversation({ id: "conv-pinned" });
+    setConversationInferenceProfile(conversation.id, "cost-optimized");
+    expect(resolveDefaultScheduleInferenceProfile()).not.toBe("cost-optimized");
+
+    const job = await createOwnerDeferredWake({
+      conversationId: conversation.id,
+      hint: "check back",
+      fireAt: Date.now() + 60_000,
+    });
+
+    // The wake resumes this conversation and forces the row's pin as the
+    // turn's override, so seeding from the global default would move a pinned
+    // conversation's own follow-up onto a different model.
+    expect(job.inferenceProfile).toBe("cost-optimized");
+  });
+
+  test("a defer from an unpinned conversation seeds the default", async () => {
+    const conversation = createConversation({ id: "conv-unpinned" });
+
+    const job = await createOwnerDeferredWake({
+      conversationId: conversation.id,
+      hint: "check back",
+      fireAt: Date.now() + 60_000,
+    });
+
+    expect(job.inferenceProfile).toBe(
+      resolveDefaultScheduleInferenceProfile()!,
+    );
   });
 });

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1623,4 +1623,24 @@ describe("inference-profile pinning", () => {
       resolveDefaultScheduleInferenceProfile()!,
     );
   });
+
+  test("any wake row seeds its target's pin, not just a defer", async () => {
+    const conversation = createConversation({ id: "conv-wake-target" });
+    setConversationInferenceProfile(conversation.id, "cost-optimized");
+    expect(resolveDefaultScheduleInferenceProfile()).not.toBe("cost-optimized");
+
+    // Seeding is keyed on `mode: "wake"` at the insert chokepoint rather than
+    // on defer provenance: every wake row forces its pin as the woken turn's
+    // override, so a wake minted any other way must not flatten its target's
+    // choice onto the global default either.
+    const job = await createSchedule({
+      name: "Wake pinned conversation",
+      message: "resume",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: conversation.id,
+    });
+
+    expect(job.inferenceProfile).toBe("cost-optimized");
+  });
 });

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -17,6 +17,7 @@ import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
   createConversation,
   setConversationInferenceProfile,
+  setConversationInferenceProfileSession,
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -1584,6 +1585,29 @@ describe("inference-profile pinning", () => {
     // turn's override, so seeding from the global default would move a pinned
     // conversation's own follow-up onto a different model.
     expect(job.inferenceProfile).toBe("cost-optimized");
+  });
+
+  test("a defer does not freeze the source conversation's profile session", async () => {
+    const conversation = createConversation({ id: "conv-session" });
+    setConversationInferenceProfileSession(
+      conversation.id,
+      "cost-optimized",
+      "session-1",
+      Date.now() + 10 * 60_000,
+    );
+
+    const job = await createOwnerDeferredWake({
+      conversationId: conversation.id,
+      hint: "check back",
+      fireAt: Date.now() + 7 * 24 * 60 * 60_000,
+    });
+
+    // A profile session is a deliberately temporary choice. Snapshotting it
+    // into the row would keep billing that model every time the wake fires,
+    // long after the ten-minute session lapsed.
+    expect(job.inferenceProfile).toBe(
+      resolveDefaultScheduleInferenceProfile()!,
+    );
   });
 
   test("a defer from an unpinned conversation seeds the default", async () => {

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { resolveDefaultScheduleInferenceProfile } from "../schedule/inference-profile.js";
 import {
   createOwnerDeferredWake,
   createSchedule,
@@ -82,6 +83,9 @@ describe("scheduler wake mode", () => {
       source: "defer",
       persistTriggerAsEvent: true,
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+      // Every schedule is pinned at creation, so the row always carries a
+      // profile for the woken turn to run under.
+      forceOverrideProfile: resolveDefaultScheduleInferenceProfile()!,
     });
 
     // AND processMessage is never called (wake mode doesn't use it)
@@ -113,6 +117,7 @@ describe("scheduler wake mode", () => {
       hint: "Follow up",
       source: "defer",
       persistTriggerAsEvent: true,
+      forceOverrideProfile: resolveDefaultScheduleInferenceProfile()!,
     });
   });
 

--- a/assistant/src/cli/commands/schedules.help.ts
+++ b/assistant/src/cli/commands/schedules.help.ts
@@ -68,8 +68,9 @@ Arguments:
 Behavior:
   Prints every stored field of the schedule: name, description, mode,
   expression/syntax, timezone, enabled state, status, next/last run times,
-  message or script body, inference profile (shown as 'default (mainAgent)'
-  when none is pinned), routing intent, and retry policy. Works for
+  message or script body, inference profile (shown as 'none (mainAgent
+  call-site default)' when no named profile resolves), routing intent, and
+  retry policy. Works for
   deferred schedules that 'assistant schedules list' hides by default.
   Aliased as 'inspect'.
 
@@ -149,7 +150,7 @@ Examples:
         {
           flags: "--profile <name>",
           description:
-            "Inference profile (llm.profiles key) the schedule's runs use; defaults to the mainAgent model selection when omitted",
+            "Inference profile (llm.profiles key) the schedule's runs use; when omitted the schedule is pinned to your current default profile",
         },
         {
           flags: "--no-enabled",
@@ -170,8 +171,9 @@ Options:
   --timeout-ms <ms>         Script timeout override in ms (--mode script).
   -t, --timezone <tz>       IANA timezone applied to the expression.
   --profile <name>          Inference profile (llm.profiles key) the schedule's
-                            runs use. When omitted, runs use the default —
-                            the mainAgent call site's model selection.
+                            runs use. When omitted, the schedule is pinned to
+                            your current default profile so its model stays
+                            put when that default changes.
   --no-enabled              Create the schedule disabled. Defaults to enabled.
   --json                    Output the updated schedule list as compact JSON.
 
@@ -279,12 +281,12 @@ Examples:
         {
           flags: "--profile <name>",
           description:
-            "Inference profile (llm.profiles key) the schedule's runs use; the default when unset is the mainAgent model selection",
+            "Inference profile (llm.profiles key) the schedule's runs use",
         },
         {
           flags: "--clear-profile",
           description:
-            "Clear the inference profile and revert to the default mainAgent model selection",
+            "Re-pin the schedule to your current default inference profile",
         },
         {
           flags: "--json",
@@ -310,11 +312,11 @@ Options:
   --clear-timeout           Remove the timeout override (mutually exclusive
                             with --timeout-ms).
   --profile <name>          Inference profile (llm.profiles key) the schedule's
-                            runs use. When no profile is set, runs use the
-                            default — the mainAgent call site's model selection.
-  --clear-profile           Remove the inference profile and revert to the
-                            default mainAgent model selection (mutually
-                            exclusive with --profile).
+                            runs use. Every schedule is pinned to one, so its
+                            model stays put when your default changes.
+  --clear-profile           Re-pin the schedule to your current default
+                            inference profile (mutually exclusive with
+                            --profile).
   --json                    Output the updated schedule list as compact JSON.
 
 Arguments:

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -203,6 +203,11 @@ export function registerSchedulesCommand(program: Command): void {
             return;
           }
 
+          // Lazily loaded so the schedule module stays out of the CLI's
+          // static graph (cli/no-daemon-internals).
+          const { formatScheduleInferenceProfile } =
+            await import("../../schedule/inference-profile.js");
+
           const fields: Array<[string, string]> = [
             ["ID", schedule.id],
             ["Name", schedule.name],
@@ -222,7 +227,7 @@ export function registerSchedulesCommand(program: Command): void {
             ["Script", schedule.script ?? "—"],
             [
               "Inference profile",
-              schedule.inferenceProfile ?? "default (mainAgent)",
+              formatScheduleInferenceProfile(schedule.inferenceProfile),
             ],
             ["Routing intent", schedule.routingIntent],
             ["Reuse conversation", schedule.reuseConversation ? "yes" : "no"],
@@ -500,7 +505,7 @@ export function registerSchedulesCommand(program: Command): void {
 
           if (opts.clearProfile && opts.profile != null) {
             fail(
-              "--profile and --clear-profile are mutually exclusive; pass --profile to set a profile or --clear-profile to revert to the default mainAgent model selection",
+              "--profile and --clear-profile are mutually exclusive; pass --profile to pin a specific profile or --clear-profile to re-pin the schedule to your current default profile",
             );
             return;
           }

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -123,6 +123,8 @@ assistant conversations wake "$id" --hint "Summarize the new items" --external-c
 
 Every schedule carries a pinned `inference_profile` (a key from `llm.profiles`), so a recurring task keeps running on the model (and the price) it was created under even when the user later changes their default profile. Creating a schedule without `inference_profile` pins it to the user's current default; pass one explicitly when a task should run on a specific model, e.g. a cost-optimized profile for a high-frequency digest. Passing `inference_profile: null` on update re-pins the schedule to the user's current default rather than unpinning it. The pinned profile is shown on the schedule's details page in settings.
 
+Workflow-mode schedules are the exception: each step of a workflow resolves its own model, so a workflow schedule's pin does not govern its runs.
+
 ## Conversation Group
 
 Conversations created by a schedule's runs land in the sidebar's Scheduled section by default. Pass `group` (a group name or id) on create or update to file them into a custom sidebar group instead, e.g. a "Briefs" group for a morning digest. The group must already exist (create it with the conversation-groups skill); pass `group: null` on update to revert to the default. If the group is later deleted, runs fall back to the Scheduled section. Changing the group affects future runs only; move an existing conversation with `conversation_move_to_group`.

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -121,7 +121,7 @@ assistant conversations wake "$id" --hint "Summarize the new items" --external-c
 
 ## Inference Profile
 
-Execute-mode runs use the default `mainAgent` model selection unless the schedule pins an `inference_profile` (a key from `llm.profiles`). Pin a profile when a recurring task should run on a specific model — e.g. a cost-optimized profile for a high-frequency digest. Pass `inference_profile: null` on update to revert to the default. The pinned profile is shown on the schedule's details page in settings.
+Every schedule carries a pinned `inference_profile` (a key from `llm.profiles`), so a recurring task keeps running on the model (and the price) it was created under even when the user later changes their default profile. Creating a schedule without `inference_profile` pins it to the user's current default; pass one explicitly when a task should run on a specific model, e.g. a cost-optimized profile for a high-frequency digest. Passing `inference_profile: null` on update re-pins the schedule to the user's current default rather than unpinning it. The pinned profile is shown on the schedule's details page in settings.
 
 ## Conversation Group
 

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -110,7 +110,7 @@
           },
           "inference_profile": {
             "type": "string",
-            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use, e.g. to run a heavy task on a cheaper model. When omitted, runs use the default mainAgent model selection. Must name a configured profile."
+            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use, e.g. to run a heavy task on a cheaper model. When omitted, the schedule is pinned to the user's current default profile so its model does not change later. Must name a configured profile."
           },
           "group": {
             "type": "string",
@@ -233,7 +233,7 @@
           },
           "inference_profile": {
             "type": ["string", "null"],
-            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use. Pass null to clear the override and revert to the default mainAgent model selection. Must name a configured profile."
+            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use. Pass null to re-pin the schedule to the user's current default profile. Must name a configured profile."
           },
           "group": {
             "type": ["string", "null"],

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -110,7 +110,7 @@
           },
           "inference_profile": {
             "type": "string",
-            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use, e.g. to run a heavy task on a cheaper model. When omitted, the schedule is pinned to the user's current default profile so its model does not change later. Must name a configured profile."
+            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use, e.g. to run a heavy task on a cheaper model. When omitted, the schedule is pinned to the user's current default profile so its model does not change later. Must name a configured profile. Workflow-mode schedules resolve a model per workflow step, so the pin does not govern their runs."
           },
           "group": {
             "type": "string",
@@ -233,7 +233,7 @@
           },
           "inference_profile": {
             "type": ["string", "null"],
-            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use. Pass null to re-pin the schedule to the user's current default profile. Must name a configured profile."
+            "description": "Inference profile (a key from llm.profiles) the schedule's LLM-executed runs should use. Pass null to re-pin the schedule to the user's current default profile. Must name a configured profile. Workflow-mode schedules resolve a model per workflow step, so the pin does not govern their runs."
           },
           "group": {
             "type": ["string", "null"],

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3255,6 +3255,50 @@ export function getConversationOverrideProfile(
   return resolveOverrideProfile(getConversation(conversationId));
 }
 
+/**
+ * The conversation fields needed to tell a durable inference-profile pin from
+ * a session-backed one. Extends {@link OverrideProfileFields} with the session
+ * marker, so callers can decide from a {@link ConversationRow} or a live
+ * in-memory `Conversation` without a redundant row fetch.
+ */
+export interface DurableProfileFields extends OverrideProfileFields {
+  inferenceProfileSessionId?: string | null;
+}
+
+/**
+ * Resolve a conversation's inference-profile pin only when the user set it to
+ * stick, ignoring a TTL-limited profile session.
+ *
+ * {@link resolveOverrideProfile} is read at use time, so a lapsed session
+ * simply reads as absent on the next turn. Anything that copies a pin into a
+ * record outliving that read (a schedule row that fires days later) needs the
+ * stricter question: a copied session would keep billing the model the user
+ * picked for ten minutes long after the session ended.
+ *
+ * A session-backed pin carries a non-null `inferenceProfileSessionId`;
+ * {@link setConversationInferenceProfile}, the sticky setter, clears those
+ * columns. So a null session id is exactly the durable case.
+ */
+export function resolveDurableProfile(
+  fields: DurableProfileFields | null,
+): string | undefined {
+  if (fields?.inferenceProfileSessionId != null) {
+    return undefined;
+  }
+  return resolveOverrideProfile(fields);
+}
+
+/**
+ * Resolve a conversation's durable inference-profile pin by id. Convenience
+ * wrapper over {@link resolveDurableProfile} for callers that don't already
+ * hold the row.
+ */
+export function getConversationDurableProfile(
+  conversationId: string,
+): string | undefined {
+  return resolveDurableProfile(getConversation(conversationId));
+}
+
 export function setLastNotifiedInferenceProfile(
   conversationId: string,
   profileKey: string | null,

--- a/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.test.ts
+++ b/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.test.ts
@@ -1,0 +1,108 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+// The migration snapshots whatever the shared schedule helper resolves, so the
+// helper is stubbed to drive both of its outcomes: a named profile and the
+// code-owned anchor (null), which has no key to record.
+let resolvedDefault: string | null = "balanced";
+mock.module("../../schedule/inference-profile.js", () => ({
+  resolveDefaultScheduleInferenceProfile: () => resolvedDefault,
+}));
+
+import * as schema from "../schema.js";
+import { migrateBackfillScheduleInferenceProfile } from "./363-backfill-schedule-inference-profile.js";
+
+function createTestDb(withProfileColumn = true) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      message TEXT NOT NULL,
+      next_run_at INTEGER NOT NULL${withProfileColumn ? ",\n      inference_profile TEXT" : ""}
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function insertJob(
+  sqlite: Database,
+  id: string,
+  inferenceProfile: string | null,
+): void {
+  sqlite
+    .query(
+      "INSERT INTO cron_jobs (id, name, message, next_run_at, inference_profile) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(id, id, "hi", 1000, inferenceProfile);
+}
+
+function profileOf(sqlite: Database, id: string): unknown {
+  return (
+    sqlite
+      .query("SELECT inference_profile FROM cron_jobs WHERE id = ?")
+      .get(id) as { inference_profile: unknown }
+  ).inference_profile;
+}
+
+describe("migration 363: backfill cron_jobs.inference_profile", () => {
+  beforeEach(() => {
+    resolvedDefault = "balanced";
+  });
+
+  test("pins unpinned rows to the resolved default", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "unpinned-1", null);
+    insertJob(sqlite, "unpinned-2", null);
+
+    migrateBackfillScheduleInferenceProfile(db);
+
+    expect(profileOf(sqlite, "unpinned-1")).toBe("balanced");
+    expect(profileOf(sqlite, "unpinned-2")).toBe("balanced");
+  });
+
+  test("leaves an existing pin alone", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "pinned", "cost-optimized");
+
+    migrateBackfillScheduleInferenceProfile(db);
+
+    expect(profileOf(sqlite, "pinned")).toBe("cost-optimized");
+  });
+
+  test("is idempotent: a second run changes nothing", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "unpinned", null);
+
+    migrateBackfillScheduleInferenceProfile(db);
+    resolvedDefault = "cost-optimized";
+    migrateBackfillScheduleInferenceProfile(db);
+
+    // The row was pinned by the first run, so the later default does not
+    // overwrite it. That is what makes a schedule's cost stable.
+    expect(profileOf(sqlite, "unpinned")).toBe("balanced");
+  });
+
+  test("leaves rows null when no named profile resolves", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "unpinned", null);
+    resolvedDefault = null;
+
+    migrateBackfillScheduleInferenceProfile(db);
+
+    expect(profileOf(sqlite, "unpinned")).toBeNull();
+  });
+
+  test("skips an install that has no inference_profile column yet", () => {
+    const { sqlite, db } = createTestDb(false);
+    sqlite
+      .query(
+        "INSERT INTO cron_jobs (id, name, message, next_run_at) VALUES ('legacy', 'legacy', 'hi', 1000)",
+      )
+      .run();
+
+    expect(() => migrateBackfillScheduleInferenceProfile(db)).not.toThrow();
+  });
+});

--- a/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.test.ts
+++ b/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.test.ts
@@ -3,12 +3,21 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-// The migration snapshots whatever the shared schedule helper resolves, so the
-// helper is stubbed to drive both of its outcomes: a named profile and the
-// code-owned anchor (null), which has no key to record.
+import {
+  type DurableProfileFields,
+  resolveDurableProfile,
+} from "../conversation-crud.js";
+
+// The migration resolves through the shared schedule helpers, which read the
+// workspace config. The default is stubbed so both of its outcomes can be
+// driven: a named profile, and the code-owned anchor (null), which has no key
+// to record. The wake seed keeps the real durable-pin reader so the
+// session-backed vs. sticky distinction under test is the production one.
 let resolvedDefault: string | null = "balanced";
 mock.module("../../schedule/inference-profile.js", () => ({
   resolveDefaultScheduleInferenceProfile: () => resolvedDefault,
+  resolveWakeScheduleInferenceProfile: (target: DurableProfileFields | null) =>
+    resolveDurableProfile(target) ?? resolvedDefault,
 }));
 
 import * as schema from "../schema.js";
@@ -21,7 +30,16 @@ function createTestDb(withProfileColumn = true) {
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
       message TEXT NOT NULL,
-      next_run_at INTEGER NOT NULL${withProfileColumn ? ",\n      inference_profile TEXT" : ""}
+      next_run_at INTEGER NOT NULL,
+      mode TEXT NOT NULL DEFAULT 'execute',
+      wake_conversation_id TEXT${withProfileColumn ? ",\n      inference_profile TEXT" : ""}
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      conversation_type TEXT,
+      inference_profile TEXT,
+      inference_profile_session_id TEXT,
+      inference_profile_expires_at INTEGER
     );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };
@@ -37,6 +55,39 @@ function insertJob(
       "INSERT INTO cron_jobs (id, name, message, next_run_at, inference_profile) VALUES (?, ?, ?, ?, ?)",
     )
     .run(id, id, "hi", 1000, inferenceProfile);
+}
+
+function insertWakeJob(
+  sqlite: Database,
+  id: string,
+  wakeConversationId: string,
+): void {
+  sqlite
+    .query(
+      "INSERT INTO cron_jobs (id, name, message, next_run_at, mode, wake_conversation_id, inference_profile) VALUES (?, ?, ?, ?, 'wake', ?, NULL)",
+    )
+    .run(id, id, "hi", 1000, wakeConversationId);
+}
+
+function insertConversation(
+  sqlite: Database,
+  id: string,
+  fields: {
+    inferenceProfile?: string | null;
+    sessionId?: string | null;
+    expiresAt?: number | null;
+  } = {},
+): void {
+  sqlite
+    .query(
+      "INSERT INTO conversations (id, conversation_type, inference_profile, inference_profile_session_id, inference_profile_expires_at) VALUES (?, 'chat', ?, ?, ?)",
+    )
+    .run(
+      id,
+      fields.inferenceProfile ?? null,
+      fields.sessionId ?? null,
+      fields.expiresAt ?? null,
+    );
 }
 
 function profileOf(sqlite: Database, id: string): unknown {
@@ -104,5 +155,75 @@ describe("migration 363: backfill cron_jobs.inference_profile", () => {
       .run();
 
     expect(() => migrateBackfillScheduleInferenceProfile(db)).not.toThrow();
+  });
+
+  // A pending wake fires with no forced override today, so it resolves its
+  // target conversation's pin live. The backfill has to preserve that, or a
+  // reminder set inside a pinned conversation silently moves to the global
+  // default.
+  describe("wake rows seed from their target conversation", () => {
+    test("takes the target's durable pin", () => {
+      const { sqlite, db } = createTestDb();
+      insertConversation(sqlite, "conv-pinned", {
+        inferenceProfile: "cost-optimized",
+      });
+      insertWakeJob(sqlite, "wake-pinned", "conv-pinned");
+
+      migrateBackfillScheduleInferenceProfile(db);
+
+      expect(profileOf(sqlite, "wake-pinned")).toBe("cost-optimized");
+    });
+
+    test("takes the default when the target has no pin, as does an ordinary schedule", () => {
+      const { sqlite, db } = createTestDb();
+      insertConversation(sqlite, "conv-unpinned");
+      insertWakeJob(sqlite, "wake-unpinned", "conv-unpinned");
+      insertJob(sqlite, "ordinary", null);
+
+      migrateBackfillScheduleInferenceProfile(db);
+
+      expect(profileOf(sqlite, "wake-unpinned")).toBe("balanced");
+      expect(profileOf(sqlite, "ordinary")).toBe("balanced");
+    });
+
+    test("ignores a session-backed pin on the target", () => {
+      const { sqlite, db } = createTestDb();
+      insertConversation(sqlite, "conv-session", {
+        inferenceProfile: "cost-optimized",
+        sessionId: "session-1",
+        expiresAt: Date.now() + 600_000,
+      });
+      insertWakeJob(sqlite, "wake-session", "conv-session");
+
+      migrateBackfillScheduleInferenceProfile(db);
+
+      // The session lapses in minutes; the row it seeded would keep billing
+      // that model for as long as the wake stays pending.
+      expect(profileOf(sqlite, "wake-session")).toBe("balanced");
+    });
+
+    test("takes the default when the target conversation is gone", () => {
+      const { sqlite, db } = createTestDb();
+      insertWakeJob(sqlite, "wake-orphan", "conv-deleted");
+
+      migrateBackfillScheduleInferenceProfile(db);
+
+      expect(profileOf(sqlite, "wake-orphan")).toBe("balanced");
+    });
+
+    test("keeps the target's pin even when no default resolves", () => {
+      const { sqlite, db } = createTestDb();
+      resolvedDefault = null;
+      insertConversation(sqlite, "conv-pinned", {
+        inferenceProfile: "cost-optimized",
+      });
+      insertWakeJob(sqlite, "wake-pinned", "conv-pinned");
+      insertJob(sqlite, "ordinary", null);
+
+      migrateBackfillScheduleInferenceProfile(db);
+
+      expect(profileOf(sqlite, "wake-pinned")).toBe("cost-optimized");
+      expect(profileOf(sqlite, "ordinary")).toBeNull();
+    });
   });
 });

--- a/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.ts
+++ b/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.ts
@@ -1,48 +1,127 @@
-import { resolveDefaultScheduleInferenceProfile } from "../../schedule/inference-profile.js";
+import type { Database } from "bun:sqlite";
+
+import {
+  resolveDefaultScheduleInferenceProfile,
+  resolveWakeScheduleInferenceProfile,
+} from "../../schedule/inference-profile.js";
+import type { DurableProfileFields } from "../conversation-crud.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 
+/** Columns a wake row's seed needs on `cron_jobs` and `conversations`. */
+const WAKE_JOB_COLUMNS = ["mode", "wake_conversation_id"] as const;
+const CONVERSATION_PIN_COLUMNS = [
+  "conversation_type",
+  "inference_profile",
+  "inference_profile_session_id",
+  "inference_profile_expires_at",
+] as const;
+
+function hasColumns(
+  raw: Database,
+  table: string,
+  required: readonly string[],
+): boolean {
+  const columns = raw.prepare(`PRAGMA table_info(${table})`).all() as {
+    name: string;
+  }[];
+  const present = new Set(columns.map((c) => c.name));
+  return required.every((name) => present.has(name));
+}
+
 /**
- * Pin every unpinned schedule to the currently resolved default inference
- * profile.
+ * Pin every unpinned schedule to a concrete inference profile.
  *
  * A schedule with no pin follows `llm.activeProfile`, so changing the global
  * default silently moves every such schedule onto a different model and a
- * different price. Schedules created from now on snapshot the resolved default
- * at write time (`insertSchedule`); this backfill gives the rows that predate
- * that the same stability, on the profile they are running under today.
+ * different price. Schedules created from now on snapshot a profile at write
+ * time (`insertSchedule`); this backfill gives the rows that predate that the
+ * same stability, on the profile they are running under today.
+ *
+ * "Running under today" is not the global default for every row. An unpinned
+ * wake row reaches `buildWakeScheduleOptions` with no forced override, so its
+ * firing resolves the target conversation's own pin live. Stamping the global
+ * default over it would silently re-point a pending reminder that was created
+ * inside a pinned conversation, so wake rows seed through the same
+ * {@link resolveWakeScheduleInferenceProfile} the create path uses: the
+ * target's durable pin, else the default. Every other row takes the default.
  *
  * Rows keep a NULL pin when no named profile resolves at all (the winner is
  * the code-owned anchor). That is the same value they carry now and resolves
  * identically at run time, through the `mainAgent` call-site configuration.
  *
- * Only `cron_jobs` is touched. `conversations` carries a pin the user sets per
- * conversation, and the telemetry tables (tool_invocations, llm_usage_events,
- * skill_loaded_events) carry an `inference_profile` recording what actually
- * ran, which must keep its historical value.
+ * Only `cron_jobs` is written. `conversations` carries a pin the user sets per
+ * conversation (read here, never modified), and the telemetry tables
+ * (tool_invocations, llm_usage_events, skill_loaded_events) carry an
+ * `inference_profile` recording what actually ran, which must keep its
+ * historical value.
  *
  * Idempotent: `WHERE inference_profile IS NULL` matches nothing once a row is
- * pinned, and the PRAGMA guard skips an install that has not created the
- * column yet.
+ * pinned, and the PRAGMA guards skip an install that has not created the
+ * columns yet.
  */
 export function migrateBackfillScheduleInferenceProfile(
   database: DrizzleDb,
 ): void {
+  const raw = getSqliteFrom(database);
+  if (!hasColumns(raw, "cron_jobs", ["inference_profile"])) {
+    return;
+  }
+
+  if (
+    hasColumns(raw, "cron_jobs", WAKE_JOB_COLUMNS) &&
+    hasColumns(raw, "conversations", CONVERSATION_PIN_COLUMNS)
+  ) {
+    backfillWakeRows(raw);
+  }
+
   const profile = resolveDefaultScheduleInferenceProfile();
   if (profile === null) {
     return;
   }
-
-  const raw = getSqliteFrom(database);
-  const columns = raw.prepare(`PRAGMA table_info(cron_jobs)`).all() as {
-    name: string;
-  }[];
-  if (!columns.some((c) => c.name === "inference_profile")) {
-    return;
-  }
-
   raw
     .prepare(
       `UPDATE cron_jobs SET inference_profile = ? WHERE inference_profile IS NULL`,
     )
     .run(profile);
+}
+
+function backfillWakeRows(raw: Database): void {
+  const rows = raw
+    .prepare(
+      `SELECT id, wake_conversation_id AS wakeConversationId
+         FROM cron_jobs
+        WHERE inference_profile IS NULL
+          AND mode = 'wake'
+          AND wake_conversation_id IS NOT NULL`,
+    )
+    .all() as { id: string; wakeConversationId: string }[];
+  if (rows.length === 0) {
+    return;
+  }
+
+  const selectTarget = raw.prepare(
+    `SELECT conversation_type AS conversationType,
+            inference_profile AS inferenceProfile,
+            inference_profile_session_id AS inferenceProfileSessionId,
+            inference_profile_expires_at AS inferenceProfileExpiresAt
+       FROM conversations
+      WHERE id = ?`,
+  );
+  const pin = raw.prepare(
+    `UPDATE cron_jobs SET inference_profile = ? WHERE id = ? AND inference_profile IS NULL`,
+  );
+
+  for (const row of rows) {
+    // A target deleted since the wake was created reads as null and falls
+    // through to the default, the same value the firing would resolve.
+    const target =
+      (selectTarget.get(
+        row.wakeConversationId,
+      ) as DurableProfileFields | null) ?? null;
+    const profile = resolveWakeScheduleInferenceProfile(target);
+    if (profile === null) {
+      continue;
+    }
+    pin.run(profile, row.id);
+  }
 }

--- a/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.ts
+++ b/assistant/src/persistence/migrations/363-backfill-schedule-inference-profile.ts
@@ -1,0 +1,48 @@
+import { resolveDefaultScheduleInferenceProfile } from "../../schedule/inference-profile.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Pin every unpinned schedule to the currently resolved default inference
+ * profile.
+ *
+ * A schedule with no pin follows `llm.activeProfile`, so changing the global
+ * default silently moves every such schedule onto a different model and a
+ * different price. Schedules created from now on snapshot the resolved default
+ * at write time (`insertSchedule`); this backfill gives the rows that predate
+ * that the same stability, on the profile they are running under today.
+ *
+ * Rows keep a NULL pin when no named profile resolves at all (the winner is
+ * the code-owned anchor). That is the same value they carry now and resolves
+ * identically at run time, through the `mainAgent` call-site configuration.
+ *
+ * Only `cron_jobs` is touched. `conversations` carries a pin the user sets per
+ * conversation, and the telemetry tables (tool_invocations, llm_usage_events,
+ * skill_loaded_events) carry an `inference_profile` recording what actually
+ * ran, which must keep its historical value.
+ *
+ * Idempotent: `WHERE inference_profile IS NULL` matches nothing once a row is
+ * pinned, and the PRAGMA guard skips an install that has not created the
+ * column yet.
+ */
+export function migrateBackfillScheduleInferenceProfile(
+  database: DrizzleDb,
+): void {
+  const profile = resolveDefaultScheduleInferenceProfile();
+  if (profile === null) {
+    return;
+  }
+
+  const raw = getSqliteFrom(database);
+  const columns = raw.prepare(`PRAGMA table_info(cron_jobs)`).all() as {
+    name: string;
+  }[];
+  if (!columns.some((c) => c.name === "inference_profile")) {
+    return;
+  }
+
+  raw
+    .prepare(
+      `UPDATE cron_jobs SET inference_profile = ? WHERE inference_profile IS NULL`,
+    )
+    .run(profile);
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -470,6 +470,7 @@ import { migrateMoveMemorySummariesToMemoryDb } from "./migrations/359-move-memo
 import { migrateAddDocumentWorkspacePath } from "./migrations/360-add-document-workspace-path.js";
 import { migrateNormalizeManagedConnectionRows } from "./migrations/361-normalize-managed-connection-rows.js";
 import { migrateAddConversationSubagentKind } from "./migrations/362-add-conversation-subagent-kind.js";
+import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfill-schedule-inference-profile.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1559,5 +1560,13 @@ export const migrationSteps: MigrationStep[] = [
     // The backfill reads the `subagents` table (migration 311), so that table
     // must exist and be checkpointed first.
     dependsOn: ["migrateCreateSubagentsTable"],
+  },
+  {
+    name: "migrateBackfillScheduleInferenceProfile",
+    run: migrateBackfillScheduleInferenceProfile,
+    // The column-exists guard treats a missing column as nothing-to-do, so
+    // without this dependency a failed column add followed by repair would
+    // permanently checkpoint the backfill as a no-op.
+    dependsOn: ["migrateScheduleInferenceProfile"],
   },
 ];

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -382,6 +382,7 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
         timezone,
         expression: normalized.expression,
         syntax: normalized.syntax,
+        inferenceProfile,
       });
       log.info(
         { id: job.id, name: job.name, workflowName },
@@ -420,6 +421,7 @@ async function handleCreateSchedule(body: Record<string, unknown>) {
         expression: normalized.expression,
         syntax: normalized.syntax,
         timeoutMs,
+        inferenceProfile,
       });
       log.info({ id: job.id, name: job.name }, "Script schedule created");
       return { schedule: serializeSchedule(job, new Map()) };

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -884,7 +884,7 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .nullable()
         .describe(
-          "Inference profile (llm.profiles key) the schedule's runs use. Omitted or null pins the schedule to the currently resolved default profile, so its model does not move when that default changes.",
+          "Inference profile (llm.profiles key) the schedule's runs use. Omitted or null pins the schedule to the currently resolved default profile, so its model does not move when that default changes. Workflow-mode schedules resolve a model per workflow step, so the pin is recorded but does not govern their runs.",
         )
         .optional(),
     }),
@@ -1004,7 +1004,7 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .nullable()
         .describe(
-          "Inference profile (llm.profiles key) the schedule's runs use; null re-pins the schedule to the currently resolved default profile",
+          "Inference profile (llm.profiles key) the schedule's runs use; null re-pins the schedule to the currently resolved default profile. Workflow-mode schedules resolve a model per workflow step, so the pin is recorded but does not govern their runs.",
         )
         .optional(),
     }),

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -625,8 +625,8 @@ async function handleUpdateSchedule(
     }
   }
 
-  // Inference profile: null clears the override (back to the default
-  // main-agent model selection); a string must name a configured profile.
+  // Inference profile: null re-pins to the currently resolved default; a
+  // string must name a configured profile.
   if ("inferenceProfile" in body) {
     const inferenceProfile = body.inferenceProfile;
     if (inferenceProfile !== null && typeof inferenceProfile !== "string") {
@@ -882,7 +882,7 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .nullable()
         .describe(
-          "Inference profile (llm.profiles key) the schedule's runs use. Omitted or null = default, i.e. the mainAgent call-site model selection.",
+          "Inference profile (llm.profiles key) the schedule's runs use. Omitted or null pins the schedule to the currently resolved default profile, so its model does not move when that default changes.",
         )
         .optional(),
     }),
@@ -1002,7 +1002,7 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .nullable()
         .describe(
-          "Inference profile (llm.profiles key) the schedule's runs use; null clears it back to the default mainAgent call-site model selection",
+          "Inference profile (llm.profiles key) the schedule's runs use; null re-pins the schedule to the currently resolved default profile",
         )
         .optional(),
     }),

--- a/assistant/src/schedule/inference-profile.ts
+++ b/assistant/src/schedule/inference-profile.ts
@@ -1,6 +1,10 @@
 import { validateInferenceProfileKey } from "../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
+import {
+  type DurableProfileFields,
+  resolveDurableProfile,
+} from "../persistence/conversation-crud.js";
 
 /**
  * Validate a schedule's inference-profile key against the configured
@@ -35,6 +39,32 @@ export function validateScheduleInferenceProfile(
  */
 export function resolveDefaultScheduleInferenceProfile(): string | null {
   return resolveDefaultProfileKey("mainAgent", getConfig().llm) ?? null;
+}
+
+/**
+ * The profile a wake schedule pins when its creator names none.
+ *
+ * A wake resumes an existing conversation and forces the row's pin as the
+ * woken turn's override, so the target's own choice, not the global default,
+ * is what the user expects it to fire on. Only a *durable* pin seeds the row
+ * ({@link resolveDurableProfile}): a TTL-limited profile session is a
+ * deliberately temporary choice, and freezing one into a row that fires next
+ * week would keep billing that model long after the session lapsed. A target
+ * with no durable pin falls through to the same default every other schedule
+ * snapshots.
+ *
+ * Both the create path and the backfill of rows that predate it resolve
+ * through here, so a pending wake keeps firing on the profile it would have
+ * resolved live.
+ *
+ * @param target The wake's target conversation, or null when it has none.
+ */
+export function resolveWakeScheduleInferenceProfile(
+  target: DurableProfileFields | null,
+): string | null {
+  return (
+    resolveDurableProfile(target) ?? resolveDefaultScheduleInferenceProfile()
+  );
 }
 
 /**

--- a/assistant/src/schedule/inference-profile.ts
+++ b/assistant/src/schedule/inference-profile.ts
@@ -1,16 +1,47 @@
 import { validateInferenceProfileKey } from "../config/inference-profile-validation.js";
+import { resolveDefaultProfileKey } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
 
 /**
  * Validate a schedule's inference-profile key against the configured
  * `llm.profiles` catalog. Returns a user-facing error message when the key is
  * empty or unknown, or `null` when valid.
  *
- * Only create/update paths validate — a profile deleted after a schedule was
- * created degrades gracefully at run time (the resolver silently drops a
- * missing `overrideProfile` reference and falls through to the defaults).
+ * Only create/update paths validate. A profile deleted after a schedule was
+ * pinned to it degrades gracefully at run time: the resolver silently drops a
+ * missing `overrideProfile` reference and falls through to the defaults, so
+ * the schedule keeps firing on the call site's own model selection.
  */
 export function validateScheduleInferenceProfile(
   profile: string,
 ): string | null {
   return validateInferenceProfileKey(profile);
+}
+
+/**
+ * The inference-profile key a schedule is pinned to when its creator names
+ * none, and the key a `null` update re-snapshots to.
+ *
+ * Every schedule carries a concrete profile so its cost is stable: an unpinned
+ * schedule would follow `llm.activeProfile`, silently moving to a different
+ * model (and a different price) whenever the user changes their global
+ * default. Snapshotting the resolved default at write time keeps the schedule
+ * on the model it was created under until someone re-pins it.
+ *
+ * `mainAgent` is the call site scheduled turns run under (see `scheduler.ts`).
+ * Returns `null` when the resolved winner is the code-owned anchor rather than
+ * a named profile: there is no key to record, and the run resolves through the
+ * `mainAgent` call-site configuration exactly as an unpinned schedule did.
+ */
+export function resolveDefaultScheduleInferenceProfile(): string | null {
+  return resolveDefaultProfileKey("mainAgent", getConfig().llm) ?? null;
+}
+
+/**
+ * Render a schedule's pinned profile for CLI and tool output. A `null` pin has
+ * no named profile behind it, so it is reported as the call site's own
+ * selection rather than as a profile key.
+ */
+export function formatScheduleInferenceProfile(profile: string | null): string {
+  return profile ?? "none (mainAgent call-site default)";
 }

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -2,7 +2,7 @@ import { Cron } from "croner";
 import { and, asc, desc, eq, inArray, isNull, lt, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConversationOverrideProfile } from "../persistence/conversation-crud.js";
+import { getConversation } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { getGroup } from "../persistence/group-crud.js";
 import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
@@ -18,7 +18,10 @@ import {
   LEGACY_DEFER_CREATED_BY,
   OWNER_DEFER_CREATED_BY,
 } from "./defer-provenance.js";
-import { resolveDefaultScheduleInferenceProfile } from "./inference-profile.js";
+import {
+  resolveDefaultScheduleInferenceProfile,
+  resolveWakeScheduleInferenceProfile,
+} from "./inference-profile.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -332,8 +335,9 @@ export async function createSchedule(
  * Callers must have established owner authority first; `defer/create` is the
  * only production caller and is gated accordingly.
  *
- * The pin seeds from the source conversation rather than the global default.
- * A defer resumes the very conversation it was created in, and
+ * The pin seeds from the source conversation's durable choice rather than the
+ * global default, via {@link resolveWakeScheduleInferenceProfile}. A defer
+ * resumes the very conversation it was created in, and
  * `buildWakeScheduleOptions` forces the row's pin as the woken turn's
  * override, so a defer created inside a conversation the user pinned to a
  * specific profile must fire on that profile. Seeding lives here rather than
@@ -350,8 +354,7 @@ export async function createOwnerDeferredWake(params: {
 }): Promise<ScheduleJob> {
   const inferenceProfile =
     params.inferenceProfile ??
-    getConversationOverrideProfile(params.conversationId) ??
-    null;
+    resolveWakeScheduleInferenceProfile(getConversation(params.conversationId));
   return insertSchedule({
     name: params.name ?? "Deferred wake",
     message: params.hint,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -232,11 +232,24 @@ async function insertSchedule(
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
   const timeoutMs = params.timeoutMs ?? null;
   // The single chokepoint that pins every schedule to a concrete profile: a
-  // caller that names none gets a snapshot of the currently resolved default,
-  // so the schedule's cost stays put when the user changes their global
-  // default profile.
+  // caller that names none gets a snapshot of what that row resolves today, so
+  // the schedule's cost stays put when the user changes their global default
+  // profile.
+  //
+  // A wake row snapshots its target conversation's durable pin instead of the
+  // global default, because `buildWakeScheduleOptions` forces the row's pin as
+  // the woken turn's override: an unpinned wake resolves the target's own
+  // choice live, so seeding anything else would silently re-point it. Seeding
+  // here rather than in `createOwnerDeferredWake` makes the rule structural —
+  // it holds for every wake row however it was minted — and matches what
+  // migration 363 backfills onto the rows that predate the pin.
   const inferenceProfile =
-    params.inferenceProfile ?? resolveDefaultScheduleInferenceProfile();
+    params.inferenceProfile ??
+    (mode === "wake"
+      ? resolveWakeScheduleInferenceProfile(
+          getConversation(params.wakeConversationId!) ?? null,
+        )
+      : resolveDefaultScheduleInferenceProfile());
   const groupId = params.groupId ?? null;
   const createdFromConversationId = params.createdFromConversationId ?? null;
   const description = normalizeDescription(
@@ -336,14 +349,13 @@ export async function createSchedule(
  * only production caller and is gated accordingly.
  *
  * The pin seeds from the source conversation's durable choice rather than the
- * global default, via {@link resolveWakeScheduleInferenceProfile}. A defer
- * resumes the very conversation it was created in, and
+ * global default. A defer resumes the very conversation it was created in, and
  * `buildWakeScheduleOptions` forces the row's pin as the woken turn's
  * override, so a defer created inside a conversation the user pinned to a
- * specific profile must fire on that profile. Seeding lives here rather than
- * in the defer route because this function is what makes a row a defer: every
- * defer creator inherits the behaviour, and ordinary schedule creation, which
- * cannot reach this path, keeps the plain global default.
+ * specific profile must fire on that profile. That seeding lives in
+ * `insertSchedule`, keyed on `mode: "wake"` rather than on defer provenance,
+ * so no wake row can be minted that overrides its target's pin with the global
+ * default.
  */
 export async function createOwnerDeferredWake(params: {
   conversationId: string;
@@ -352,9 +364,6 @@ export async function createOwnerDeferredWake(params: {
   name?: string;
   inferenceProfile?: string | null;
 }): Promise<ScheduleJob> {
-  const inferenceProfile =
-    params.inferenceProfile ??
-    resolveWakeScheduleInferenceProfile(getConversation(params.conversationId));
   return insertSchedule({
     name: params.name ?? "Deferred wake",
     message: params.hint,
@@ -364,7 +373,7 @@ export async function createOwnerDeferredWake(params: {
     createdBy: OWNER_DEFER_CREATED_BY,
     nextRunAt: params.fireAt,
     quiet: true,
-    inferenceProfile,
+    inferenceProfile: params.inferenceProfile ?? null,
   });
 }
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -2,6 +2,7 @@ import { Cron } from "croner";
 import { and, asc, desc, eq, inArray, isNull, lt, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConversationOverrideProfile } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { getGroup } from "../persistence/group-crud.js";
 import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
@@ -17,6 +18,7 @@ import {
   LEGACY_DEFER_CREATED_BY,
   OWNER_DEFER_CREATED_BY,
 } from "./defer-provenance.js";
+import { resolveDefaultScheduleInferenceProfile } from "./inference-profile.js";
 import {
   computeNextRunAt as computeNextRunAtEngine,
   isValidScheduleExpression,
@@ -77,7 +79,11 @@ export interface ScheduleJob {
   timeoutMs: number | null;
   /**
    * Inference profile (`llm.profiles` key) applied to the schedule's
-   * LLM-executed runs; null = default main-agent model selection.
+   * LLM-executed runs. Pinned at creation from the caller's choice or a
+   * snapshot of the resolved default, so the schedule's model (and cost) does
+   * not move when the global default changes. Null only where no named profile
+   * resolves at all, in which case runs follow the `mainAgent` call-site
+   * configuration.
    */
   inferenceProfile: string | null;
   /**
@@ -222,7 +228,12 @@ async function insertSchedule(
   const maxRetries = params.maxRetries ?? 3;
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
   const timeoutMs = params.timeoutMs ?? null;
-  const inferenceProfile = params.inferenceProfile ?? null;
+  // The single chokepoint that pins every schedule to a concrete profile: a
+  // caller that names none gets a snapshot of the currently resolved default,
+  // so the schedule's cost stays put when the user changes their global
+  // default profile.
+  const inferenceProfile =
+    params.inferenceProfile ?? resolveDefaultScheduleInferenceProfile();
   const groupId = params.groupId ?? null;
   const createdFromConversationId = params.createdFromConversationId ?? null;
   const description = normalizeDescription(
@@ -320,6 +331,15 @@ export async function createSchedule(
  *
  * Callers must have established owner authority first; `defer/create` is the
  * only production caller and is gated accordingly.
+ *
+ * The pin seeds from the source conversation rather than the global default.
+ * A defer resumes the very conversation it was created in, and
+ * `buildWakeScheduleOptions` forces the row's pin as the woken turn's
+ * override, so a defer created inside a conversation the user pinned to a
+ * specific profile must fire on that profile. Seeding lives here rather than
+ * in the defer route because this function is what makes a row a defer: every
+ * defer creator inherits the behaviour, and ordinary schedule creation, which
+ * cannot reach this path, keeps the plain global default.
  */
 export async function createOwnerDeferredWake(params: {
   conversationId: string;
@@ -328,6 +348,10 @@ export async function createOwnerDeferredWake(params: {
   name?: string;
   inferenceProfile?: string | null;
 }): Promise<ScheduleJob> {
+  const inferenceProfile =
+    params.inferenceProfile ??
+    getConversationOverrideProfile(params.conversationId) ??
+    null;
   return insertSchedule({
     name: params.name ?? "Deferred wake",
     message: params.hint,
@@ -337,9 +361,7 @@ export async function createOwnerDeferredWake(params: {
     createdBy: OWNER_DEFER_CREATED_BY,
     nextRunAt: params.fireAt,
     quiet: true,
-    ...(params.inferenceProfile !== undefined
-      ? { inferenceProfile: params.inferenceProfile }
-      : {}),
+    inferenceProfile,
   });
 }
 
@@ -610,7 +632,12 @@ export async function updateSchedule(
     set.timeoutMs = updates.timeoutMs;
   }
   if (updates.inferenceProfile !== undefined) {
-    set.inferenceProfile = updates.inferenceProfile;
+    // Null re-snapshots the currently resolved default instead of unpinning:
+    // "follow whatever my global default happens to be" is not a state a
+    // schedule can rest in, since it would let a later default change move the
+    // schedule's model and price without the user touching the schedule.
+    set.inferenceProfile =
+      updates.inferenceProfile ?? resolveDefaultScheduleInferenceProfile();
   }
   if (updates.groupId !== undefined) {
     set.groupId = updates.groupId;

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { formatScheduleInferenceProfile } from "../../schedule/inference-profile.js";
 import { hasSetConstructs } from "../../schedule/recurrence-engine.js";
 import {
   describeCronExpression,
@@ -93,7 +94,7 @@ export async function executeScheduleList(
       `  Enabled: ${job.enabled}`,
       `  Quiet: ${job.quiet}`,
       `  Reuse conversation: ${job.reuseConversation}`,
-      `  Inference profile: ${job.inferenceProfile ?? "default (mainAgent)"}`,
+      `  Inference profile: ${formatScheduleInferenceProfile(job.inferenceProfile)}`,
       `  Message: ${job.message}`,
     );
 

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { resolveCapabilities } from "../../runtime/capabilities.js";
-import { validateScheduleInferenceProfile } from "../../schedule/inference-profile.js";
+import {
+  formatScheduleInferenceProfile,
+  validateScheduleInferenceProfile,
+} from "../../schedule/inference-profile.js";
 import { validateRruleSetLines } from "../../schedule/recurrence-engine.js";
 import {
   detectScheduleSyntax,
@@ -45,8 +48,9 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
  *   preprocessing that would silently turn an explicit update into a no-op.
  * - `timezone` and `script` are nullable at runtime though advertised as
  *   plain strings: `updateSchedule` persists null as "clear this field".
- * - `timeout_ms` / `inference_profile` / `group` advertise null (it reverts
- *   to the default); the executor's bespoke handling stays.
+ * - `timeout_ms` / `group` advertise null (it reverts to the default), and
+ *   `inference_profile` advertises null (it re-pins to the current default);
+ *   the executor's bespoke handling stays.
  * - `mode`, `routing_intent`, `workflow_name`, and `workflow_args` are
  *   deliberately UNDECLARED (loose passthrough): the first two keep bespoke
  *   `VALID_*` errors; `workflow_name` has bespoke coercion semantics in the
@@ -203,8 +207,8 @@ export async function executeScheduleUpdate(
     updates.retryBackoffMs = parsed.retry_backoff_ms;
   }
 
-  // Inference profile override (null clears it, reverting to the default
-  // main-agent model selection)
+  // Inference profile (null re-pins the schedule to the currently resolved
+  // default rather than leaving it to follow whatever the default becomes)
   if (parsed.inference_profile !== undefined) {
     if (parsed.inference_profile === null) {
       updates.inferenceProfile = null;
@@ -369,7 +373,7 @@ export async function executeScheduleUpdate(
         `  Description: ${job.description}`,
         `  Syntax: ${job.syntax}`,
         `  Mode: ${job.mode}`,
-        `  Inference profile: ${job.inferenceProfile ?? "default (mainAgent)"}`,
+        `  Inference profile: ${formatScheduleInferenceProfile(job.inferenceProfile)}`,
         `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ""}`,
         `  Enabled: ${job.enabled}`,
         `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : "n/a (disabled)"}`,

--- a/clients/docs/src/app/docs/_components/skills-reference-schedule-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-schedule-content.tsx
@@ -121,6 +121,11 @@ export function SkillsReferenceScheduleContent() {
               &ldquo;workflow&rdquo; (run a saved workflow)
             </li>
             <li>Timezone-aware</li>
+            <li>
+              Each schedule is pinned to a model profile when it is created, so
+              changing your default model later does not change what your
+              existing schedules cost
+            </li>
           </ul>
         </section>
 

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "e1f2df88ed707ebf4a630d12d90ad5247642ceacb8d30293feb7e7933e0b0339"
+      "sha256": "246f8f929a31d16a91c4a0a1cbdb65bb9754c0c37ef16ae651df2b95434c4702"
     },
     "skill-management": {
       "docsSlug": "skill-management",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "629b5815eb736b46f1af5faf57a5a74788e3b43bbf08371c654eddc3f788557d"
+      "sha256": "e1f2df88ed707ebf4a630d12d90ad5247642ceacb8d30293feb7e7933e0b0339"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
Part of #40079. First of four stacked PRs.

## Why

A schedule's `inferenceProfile` is optional today, and usually null. An unpinned schedule resolves through the normal chain and lands on `llm.activeProfile`, the user's global default. So changing the default profile in Settings silently retargets every unpinned schedule, and the change is amplified because an unpinned schedule forwards its resolved profile down to any subagents it spawns.

Nobody edits a morning digest and expects last week's model switch to have re-priced it. This makes a schedule's model a property of the schedule.

Pinning to a *profile* rather than a model keeps the upside of managed profiles: a schedule pinned to a managed profile still improves whenever that profile is updated, with no user action. What stops is the schedule moving when the user changes their own default.

## What changed

- **Auto-fill at the single insert chokepoint.** `insertSchedule` is the only row insert for schedules, so both public creators inherit it. A caller that names no profile gets a snapshot of the currently resolved default, via one shared helper that create, update, and the backfill all call.
- **Deferred wakes seed from their source conversation.** A defer resumes the conversation it was created in, and its firing forces the row's pin as the woken turn's override. Seeding a defer from the global default would silently move that conversation's own follow-up onto another model. The seeding lives in `createOwnerDeferredWake` because that function is what makes a row a defer; ordinary schedule creation cannot reach it.
- **`null` on update re-snapshots instead of clearing.** "Follow my global default" stops being a state a schedule can rest in. Implemented once in `updateSchedule`, so the tool, the HTTP route, and the CLI's `--clear-profile` all inherit it. The flag and the null API value keep working and now mean "reset to my current default".
- **Migration 363** backfills existing unpinned rows with the same resolved default.

## Review focus

**The column stays nullable.** SQLite cannot add `NOT NULL` in place, and a live-table rebuild of `cron_jobs` is more risk than the constraint is worth. The invariant is enforced on the write path, and a residual null resolves exactly as it does today. `resolveDefaultProfileKey` genuinely can return undefined when the winner is the code-owned anchor rather than a named profile, so null remains reachable by design.

**Where the defer seeding lives** is the main judgement call worth a second opinion.

**Usage attribution shifts as a side effect.** Every scheduled run now passes an `overrideProfile`, and `resolveUsageAttribution` classifies an override winner as `profileSource: "conversation"`. Same model billed, different telemetry bucket, which makes scheduled spend look user-driven. This is already true for explicitly pinned schedules; this PR makes it universal. Not fixable here because the value ships to the platform as a header and the enum is platform-side. Tracked as #40093.

**Residual gap:** a non-defer wake schedule targeting a pinned conversation would override that conversation's pin. No production caller can create one today, so it is theoretical, but it is the same regression class the defer seeding avoids.
