### PR TITLE
feat(schedule): run script-mode wakes on the schedule's pinned profile

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9623,6 +9623,9 @@ paths:
                 cronRunId:
                   type: string
                   minLength: 1
+                scheduleId:
+                  type: string
+                  minLength: 1
                 persist:
                   type: boolean
                 externalContent:

--- a/assistant/src/cli/commands/__tests__/conversations-wake.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-wake.test.ts
@@ -1,8 +1,10 @@
 /**
- * CLI plumbing tests for untrusted-content input on `assistant conversations
- * wake`. Inline `--external-content` resolves to the fenced `externalContent`
- * body field and implies `--persist`. The route fences the resulting string
- * (see wake-conversation-routes.test.ts).
+ * CLI plumbing tests for `assistant conversations wake`. Inline
+ * `--external-content` resolves to the fenced `externalContent` body field and
+ * implies `--persist`; a script-mode schedule's environment resolves to the
+ * `cronRunId` and `scheduleId` body fields. The route fences the untrusted
+ * string and applies the schedule's pinned profile (see
+ * wake-conversation-routes.test.ts).
  */
 
 import * as nodeFs from "node:fs";
@@ -88,15 +90,19 @@ function lastBody(): Record<string, unknown> {
 }
 
 let savedRunId: string | undefined;
+let savedScheduleId: string | undefined;
 
 beforeEach(() => {
   lastIpcCall = null;
   loggerCalls.length = 0;
   process.exitCode = 0;
-  // The wake action reads __SCHEDULE_RUN_ID for cost attribution; clear it so
-  // it never leaks a cronRunId into the captured body.
+  // The wake action reads __SCHEDULE_RUN_ID for cost attribution and
+  // __SCHEDULE_ID for the schedule's pinned inference profile; clear both so
+  // they never leak into the captured body.
   savedRunId = process.env.__SCHEDULE_RUN_ID;
+  savedScheduleId = process.env.__SCHEDULE_ID;
   delete process.env.__SCHEDULE_RUN_ID;
+  delete process.env.__SCHEDULE_ID;
 });
 
 describe("conversations wake untrusted-content input", () => {
@@ -149,9 +155,48 @@ describe("conversations wake untrusted-content input", () => {
   });
 });
 
+describe("conversations wake schedule environment", () => {
+  test("script-mode env threads the run id and the schedule id", async () => {
+    process.env.__SCHEDULE_RUN_ID = "run-9";
+    process.env.__SCHEDULE_ID = "sched-9";
+    const code = await runWake([
+      "wake",
+      "conv-6",
+      "--hint",
+      "Digest ready",
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    expect(lastBody()).toMatchObject({
+      cronRunId: "run-9",
+      scheduleId: "sched-9",
+    });
+  });
+
+  test("outside a script run neither field is sent", async () => {
+    const code = await runWake([
+      "wake",
+      "conv-7",
+      "--hint",
+      "Digest ready",
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    expect(lastBody().cronRunId).toBeUndefined();
+    expect(lastBody().scheduleId).toBeUndefined();
+  });
+});
+
 afterEach(() => {
   if (savedRunId !== undefined) {
     process.env.__SCHEDULE_RUN_ID = savedRunId;
+  } else {
+    delete process.env.__SCHEDULE_RUN_ID;
+  }
+  if (savedScheduleId !== undefined) {
+    process.env.__SCHEDULE_ID = savedScheduleId;
+  } else {
+    delete process.env.__SCHEDULE_ID;
   }
   process.exitCode = 0;
 });

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -422,10 +422,13 @@ export function registerConversationsCommand(program: Command): void {
             json?: boolean;
           },
         ) => {
-          // A script-mode schedule injects __SCHEDULE_RUN_ID into its env
-          // (see schedule/run-script.ts). When set, thread it through so the
-          // woken turn's usage is attributed to the firing.
+          // A script-mode schedule injects __SCHEDULE_RUN_ID and __SCHEDULE_ID
+          // into its env (see schedule/run-script.ts). The run id attributes the
+          // woken turn's usage to the firing; the schedule id lets the turn run
+          // on the schedule's pinned inference profile, the same profile
+          // execute-mode and wake-mode runs of that schedule use.
           const cronRunId = process.env.__SCHEDULE_RUN_ID;
+          const scheduleId = process.env.__SCHEDULE_ID;
 
           // Fencing only exists on the persisted-event path, so
           // --external-content implies --persist.
@@ -442,6 +445,7 @@ export function registerConversationsCommand(program: Command): void {
               hint: opts.hint,
               source: opts.source,
               ...(cronRunId ? { cronRunId } : {}),
+              ...(scheduleId ? { scheduleId } : {}),
               ...(persist ? { persist: true } : {}),
               ...(externalContent !== undefined ? { externalContent } : {}),
             },

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -123,6 +123,8 @@ assistant conversations wake "$id" --hint "Summarize the new items" --external-c
 
 Every schedule carries a pinned `inference_profile` (a key from `llm.profiles`), so a recurring task keeps running on the model (and the price) it was created under even when the user later changes their default profile. Creating a schedule without `inference_profile` pins it to the user's current default; pass one explicitly when a task should run on a specific model, e.g. a cost-optimized profile for a high-frequency digest. Passing `inference_profile: null` on update re-pins the schedule to the user's current default rather than unpinning it. The pinned profile is shown on the schedule's details page in settings.
 
+The pin covers the turns a schedule runs, including ones a script-mode schedule hands off to the agent loop with `assistant conversations wake`. The schedule id travels in the script's environment, so those turns run on the pinned profile with no flag to pass.
+
 Workflow-mode schedules are the exception: each step of a workflow resolves its own model, so a workflow schedule's pin does not govern its runs.
 
 ## Conversation Group

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -123,7 +123,7 @@ assistant conversations wake "$id" --hint "Summarize the new items" --external-c
 
 Every schedule carries a pinned `inference_profile` (a key from `llm.profiles`), so a recurring task keeps running on the model (and the price) it was created under even when the user later changes their default profile. Creating a schedule without `inference_profile` pins it to the user's current default; pass one explicitly when a task should run on a specific model, e.g. a cost-optimized profile for a high-frequency digest. Passing `inference_profile: null` on update re-pins the schedule to the user's current default rather than unpinning it. The pinned profile is shown on the schedule's details page in settings.
 
-The pin covers the turns a schedule runs, including ones a script-mode schedule hands off to the agent loop with `assistant conversations wake`. The schedule id travels in the script's environment, so those turns run on the pinned profile with no flag to pass.
+The pin governs the agent turns a schedule runs: an execute-mode run, a wake-mode run, and the turns a script-mode schedule hands off to the agent loop with `assistant conversations wake`. The schedule id travels in the script's environment, so those handoff turns run on the pinned profile with no flag to pass. Notify-mode schedules run no agent turn at all, so their pin never comes into play.
 
 Workflow-mode schedules are the exception: each step of a workflow resolves its own model, so a workflow schedule's pin does not govern its runs.
 

--- a/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/wake-conversation-routes.test.ts
@@ -2,8 +2,10 @@
  * Asserts the `wake_conversation` route elevates trust from the caller's
  * verified principal type, never the request body: a `local` (CLI/IPC) caller
  * runs the woken turn as a non-interactive guardian (clientless + guardian
- * trustContext) and may attribute cost to a body-supplied `cronRunId`; a remote
- * `actor` stays `unknown`/interactive and its body `cronRunId` is ignored.
+ * trustContext) and may attribute cost to a body-supplied `cronRunId` and run
+ * on a body-supplied schedule's pinned inference profile; a remote `actor`
+ * stays `unknown`/interactive and its body `cronRunId` and `scheduleId` are
+ * ignored.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -13,6 +15,7 @@ interface CapturedWake {
   hint: string;
   trustContext?: { sourceChannel: string; trustClass: string };
   cronRunId?: string;
+  forceOverrideProfile?: string;
   clientless?: boolean;
   persistTriggerAsEvent?: boolean;
   untrustedOutput?: { content: string; source: string };
@@ -23,6 +26,14 @@ mock.module("../../agent-wake.js", () => ({
     wakeCalls.push(opts);
     return { invoked: true, producedToolCalls: false };
   },
+}));
+
+const schedules = new Map<string, { inferenceProfile: string | null }>([
+  ["sched-pinned", { inferenceProfile: "profile-cheap" }],
+  ["sched-unpinned", { inferenceProfile: null }],
+]);
+mock.module("../../../schedule/schedule-store.js", () => ({
+  getSchedule: (id: string) => schedules.get(id) ?? null,
 }));
 
 import { createConversation } from "../../../persistence/conversation-crud.js";
@@ -82,6 +93,53 @@ describe("wake_conversation principal-gated elevation", () => {
     expect(wakeCalls[0].trustContext).toBeUndefined();
     expect(wakeCalls[0].clientless).toBeUndefined();
     expect(wakeCalls[0].cronRunId).toBeUndefined();
+  });
+});
+
+describe("wake_conversation schedule profile pin", () => {
+  test("local principal → woken turn runs on the schedule's pinned profile", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    await handler({
+      body: { conversationId, hint: "poll result", scheduleId: "sched-pinned" },
+      headers: { "x-vellum-principal-type": "local" },
+    });
+    expect(wakeCalls[0].forceOverrideProfile).toBe("profile-cheap");
+  });
+
+  test("schedule with no pinned profile leaves resolution unchanged", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    await handler({
+      body: {
+        conversationId,
+        hint: "poll result",
+        scheduleId: "sched-unpinned",
+      },
+      headers: { "x-vellum-principal-type": "local" },
+    });
+    expect(wakeCalls[0].forceOverrideProfile).toBeUndefined();
+  });
+
+  test("unknown scheduleId resolves as an ordinary wake", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    const result = await handler({
+      body: { conversationId, hint: "poll result", scheduleId: "sched-gone" },
+      headers: { "x-vellum-principal-type": "local" },
+    });
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(wakeCalls[0].forceOverrideProfile).toBeUndefined();
+  });
+
+  test("actor principal → body scheduleId is ignored", async () => {
+    wakeCalls.length = 0;
+    const conversationId = makeConversation();
+    await handler({
+      body: { conversationId, hint: "poll result", scheduleId: "sched-pinned" },
+      headers: { "x-vellum-principal-type": "actor" },
+    });
+    expect(wakeCalls[0].forceOverrideProfile).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
+import { getSchedule } from "../../schedule/schedule-store.js";
 import { wakeAgentForOpportunity } from "../agent-wake.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { NotFoundError } from "./errors.js";
@@ -20,6 +21,10 @@ const WakeConversationBody = z.object({
   // Honored only for a `local` caller (see handler) — a remote `actor` could
   // otherwise attribute its wake's cost to an arbitrary firing.
   cronRunId: z.string().min(1).optional(),
+  // Runs the turn on this schedule's pinned inference profile. Honored only for
+  // a `local` caller (see handler): a remote `actor` could otherwise run turns
+  // under an arbitrary schedule's profile and spend the owner's money.
+  scheduleId: z.string().min(1).optional(),
   // Persist the trigger as a background event rather than an ephemeral hint, so
   // repeated wakes stay prompt-cache-friendly.
   persist: z.boolean().optional(),
@@ -53,6 +58,7 @@ export const ROUTES: RouteDefinition[] = [
         hint,
         source,
         cronRunId,
+        scheduleId,
         persist,
         externalContent,
       } = WakeConversationBody.parse(body);
@@ -72,6 +78,18 @@ export const ROUTES: RouteDefinition[] = [
       // local caller.
       const isLocal = headers?.["x-vellum-principal-type"] === "local";
 
+      // A script-mode schedule hands off to the agent loop through this route,
+      // so the schedule's pinned profile has to be applied here for the woken
+      // turn to run on the model the schedule was created under. The pin is a
+      // per-turn override rather than a durable conversation pin: the script's
+      // conversation is `scheduled`, and override profiles do not resolve for
+      // that conversation type. A schedule with no pin resolves as any other
+      // turn does.
+      const scheduleProfile =
+        isLocal && scheduleId
+          ? (getSchedule(scheduleId)?.inferenceProfile ?? null)
+          : null;
+
       return wakeAgentForOpportunity({
         conversationId,
         hint,
@@ -80,6 +98,7 @@ export const ROUTES: RouteDefinition[] = [
           ? { trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT, clientless: true }
           : {}),
         ...(isLocal && cronRunId ? { cronRunId } : {}),
+        ...(scheduleProfile ? { forceOverrideProfile: scheduleProfile } : {}),
         ...(persist ? { persistTriggerAsEvent: true } : {}),
         ...(externalContent !== undefined
           ? { untrustedOutput: { content: externalContent, source: "webhook" } }

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -80,11 +80,15 @@ export const ROUTES: RouteDefinition[] = [
 
       // A script-mode schedule hands off to the agent loop through this route,
       // so the schedule's pinned profile has to be applied here for the woken
-      // turn to run on the model the schedule was created under. The pin is a
-      // per-turn override rather than a durable conversation pin: the script's
-      // conversation is `scheduled`, and override profiles do not resolve for
-      // that conversation type. A schedule with no pin resolves as any other
-      // turn does.
+      // turn to run on the model the schedule was created under.
+      //
+      // The pin applies per turn rather than as a durable conversation pin,
+      // and it wins over the target conversation's own pin for turns the
+      // schedule triggers. That matters because a script may wake any
+      // conversation it names, not only the `scheduled` one it created:
+      // waking an interactive chat runs that one turn on the schedule's
+      // profile, while the user's own replies keep using their selection.
+      // A schedule with no pin resolves as any other turn does.
       const scheduleProfile =
         isLocal && scheduleId
           ? (getSchedule(scheduleId)?.inferenceProfile ?? null)

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "9e950d0c36af21e2dc585c93bde0e6c8ee5b49a0bb96f8d05a107f3e424b028c"
+      "sha256": "74891c880acb0c8d3a6ac5ba11ba05ee19adf46ce5a873e719875a066a7c6391"
     },
     "skill-management": {
       "docsSlug": "skill-management",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "246f8f929a31d16a91c4a0a1cbdb65bb9754c0c37ef16ae651df2b95434c4702"
+      "sha256": "9e950d0c36af21e2dc585c93bde0e6c8ee5b49a0bb96f8d05a107f3e424b028c"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
Part of #40079. Second of four stacked PRs, based on #40113.

## Why

Execute-mode schedule runs apply the pinned inference profile as a per-turn override, and wake-mode schedules apply it as `forceOverrideProfile`. Script-mode schedules stored the field and displayed it but never used it: when a script hands off to the agent loop via the documented `assistant conversations new` + `assistant conversations wake` pattern, only `__SCHEDULE_RUN_ID` was threaded through, so the woken turn resolved as a plain `mainAgent` turn on the user's current chat model.

On its own that affected only the minority of schedules that were explicitly pinned. #40113 pins every schedule, which makes this the systematic gap: every script-mode schedule now has a pin it ignores. #40116 puts that pin on screen, so without this PR the UI would display a setting that does nothing.

## Why per-turn rather than a durable conversation pin

The mechanism forces the choice. `assistant conversations new` already creates script-mode conversations with `conversationType: "scheduled"`, and `resolveOverrideProfile` returns undefined for `scheduled` and `background` conversations. A durable pin written onto that conversation would read back as absent. Forcing the profile per-turn at wake time is the only thing that works, and it keeps the desirable property that schedule profile edits take effect on the next run while user replies in the conversation keep using the user's own model selection.

## What changed

- The `conversations wake` CLI action reads `__SCHEDULE_ID` alongside `__SCHEDULE_RUN_ID` and sends it as `scheduleId`. Both are already injected into every script run.
- The wake route accepts `scheduleId`, honored only for a `local` caller behind the same gate `cronRunId` uses, and forces the schedule's pinned profile for that turn. The schedule lookup is skipped entirely for remote callers, so a remote actor cannot run turns under an arbitrary schedule's profile.

## Review focus

**Scope was verified, not assumed.** Every operation reachable from the CLI was enumerated: `conversations wake` is the only path that starts an agent turn on an existing conversation. `schedules execute` goes through the scheduler, which already applies the pin.

**One adjacent behavior worth an opinion:** a script-mode schedule that calls `conversations defer` produces a defer schedule pinned to the user's current default, not to the parent schedule's pin. That is consistent with a defer being its own schedule entity with its own visible pin, but it does mean pins do not inherit across schedule creation. Left as-is deliberately.

**Workflow-mode schedules still ignore their pin**, by design, because workflow leaves deliberately carry no pinned profile so they resolve to a credentialed provider on BYO-key installs. #40116 makes the UI honest about that, and the underlying question is #40083.
