### PR TITLE
feat(schedules): show and change a schedule's model in the web UI

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -27062,8 +27062,10 @@ paths:
       operationId: schedules_reassignprofile_post
       summary: Reassign schedules to another inference profile
       description:
-        Move every schedule pinned to one inference profile onto another, so deleting a profile does not leave its
-        schedules pointing at a name that no longer exists.
+        Move schedules onto one inference profile. Pass 'from' to move only the schedules pinned to that profile,
+        so deleting a profile does not leave its schedules pointing at a name that no longer exists. Omit 'from' to move
+        every schedule, which re-pins the whole set onto one profile. Schedules already pinned to the target are
+        skipped.
       tags:
         - schedules
       requestBody:
@@ -27074,13 +27076,12 @@ paths:
               type: object
               properties:
                 from:
+                  description: Inference profile key the schedules are pinned to now; omit to select every schedule
                   type: string
-                  description: Inference profile key the schedules are pinned to now
                 to:
                   type: string
                   description: Inference profile key to move them to; must be configured
               required:
-                - from
                 - to
       responses:
         "200":

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1763,13 +1763,13 @@ describe("POST /schedules/reassign-profile", () => {
     expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 
-  test("requires both from and to", async () => {
-    await expect(
-      reassignRoute().handler({ body: { to: "balanced" } }),
-    ).rejects.toThrow("from is required");
+  test("requires to, and rejects an empty from", async () => {
     await expect(
       reassignRoute().handler({ body: { from: "cost-optimized" } }),
     ).rejects.toThrow("to is required");
+    await expect(
+      reassignRoute().handler({ body: { from: "  ", to: "balanced" } }),
+    ).rejects.toThrow("from must name an inference profile when provided");
   });
 
   test("is a no-op when nothing is pinned to the source profile", async () => {
@@ -1816,5 +1816,82 @@ describe("POST /schedules/reassign-profile", () => {
 
     expect(result.reassigned).toBe(1);
     expect(listSchedules()[0].inferenceProfile).toBe(resolvedDefault!);
+  });
+
+  test("omitting from moves every schedule and skips the ones already there", async () => {
+    const resolvedDefault = resolveDefaultScheduleInferenceProfile();
+    expect(resolvedDefault).not.toBe("cost-optimized");
+
+    await createSchedule({
+      name: "Cheap digest",
+      description: "Cheap digest",
+      cronExpression: "0 * * * *",
+      message: "digest",
+      syntax: "cron",
+      inferenceProfile: "cost-optimized",
+    });
+    const dangling = await createSchedule({
+      name: "Dangling pin",
+      description: "Dangling pin",
+      cronExpression: "15 * * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+    rawRun(
+      "test:setDanglingInferenceProfile",
+      "UPDATE cron_jobs SET inference_profile = ? WHERE id = ?",
+      "deleted-profile",
+      dangling.id,
+    );
+    // Already on the target: counted as untouched, and its updatedAt proves it.
+    await createSchedule({
+      name: "Already default",
+      description: "Already default",
+      cronExpression: "30 * * * *",
+      message: "hi",
+      syntax: "cron",
+      inferenceProfile: resolvedDefault!,
+    });
+    const untouchedBefore = listSchedules().find(
+      (job) => job.name === "Already default",
+    )!.updatedAt;
+
+    const result = (await reassignRoute().handler({
+      body: { to: resolvedDefault! },
+    })) as { reassigned: number };
+
+    // Two moved (the cheap one and the dangling one); the third was already
+    // on the target, so it is neither counted nor rewritten.
+    expect(result.reassigned).toBe(2);
+    expect(
+      listSchedules().every((job) => job.inferenceProfile === resolvedDefault),
+    ).toBe(true);
+    expect(
+      listSchedules().find((job) => job.name === "Already default")!.updatedAt,
+    ).toBe(untouchedBefore);
+  });
+
+  test("omitting from still refuses a non-owner caller when a wake row would move", async () => {
+    const resolvedDefault = resolveDefaultScheduleInferenceProfile();
+    await createSchedule({
+      name: "Deferred wake",
+      description: "Deferred wake",
+      message: "wake up",
+      nextRunAt: Date.now() + 60_000,
+      mode: "wake",
+      wakeConversationId: "conv-abc",
+      createdBy: "defer",
+      inferenceProfile: "cost-optimized",
+    });
+
+    await expect(
+      reassignRoute().handler({
+        body: { to: resolvedDefault! },
+        headers: { "x-vellum-principal-type": "actor" },
+      }),
+    ).rejects.toThrow(
+      "Deferred wake schedules can only be changed by the assistant's owner",
+    );
+    expect(listSchedules()[0].inferenceProfile).toBe("cost-optimized");
   });
 });

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1871,6 +1871,83 @@ describe("POST /schedules/reassign-profile", () => {
     ).toBe(untouchedBefore);
   });
 
+  test("omitting from leaves fired and cancelled one-shots alone", async () => {
+    const resolvedDefault = resolveDefaultScheduleInferenceProfile();
+    expect(resolvedDefault).not.toBe("cost-optimized");
+
+    const fired = await createSchedule({
+      name: "Already fired",
+      description: "Already fired",
+      message: "hi",
+      nextRunAt: Date.now() - 60_000,
+      inferenceProfile: "cost-optimized",
+    });
+    const cancelled = await createSchedule({
+      name: "Cancelled",
+      description: "Cancelled",
+      message: "hi",
+      nextRunAt: Date.now() + 60_000,
+      inferenceProfile: "cost-optimized",
+    });
+    rawRun(
+      "test:setTerminalScheduleStatuses",
+      "UPDATE cron_jobs SET status = CASE id WHEN ? THEN 'fired' ELSE 'cancelled' END WHERE id IN (?, ?)",
+      fired.id,
+      fired.id,
+      cancelled.id,
+    );
+    const live = await createSchedule({
+      name: "Still running",
+      description: "Still running",
+      cronExpression: "0 * * * *",
+      message: "digest",
+      syntax: "cron",
+      inferenceProfile: "cost-optimized",
+    });
+    const byId = new Map(listSchedules().map((job) => [job.id, job]));
+    const firedBefore = byId.get(fired.id)!.updatedAt;
+    const cancelledBefore = byId.get(cancelled.id)!.updatedAt;
+
+    const result = (await reassignRoute().handler({
+      body: { to: resolvedDefault! },
+    })) as { reassigned: number };
+
+    // Their profile is history, so counting them would report a bigger move
+    // than the user was shown.
+    expect(result.reassigned).toBe(1);
+    const after = new Map(listSchedules().map((job) => [job.id, job]));
+    expect(after.get(live.id)!.inferenceProfile).toBe(resolvedDefault!);
+    expect(after.get(fired.id)!.inferenceProfile).toBe("cost-optimized");
+    expect(after.get(cancelled.id)!.inferenceProfile).toBe("cost-optimized");
+    expect(after.get(fired.id)!.updatedAt).toBe(firedBefore);
+    expect(after.get(cancelled.id)!.updatedAt).toBe(cancelledBefore);
+  });
+
+  test("an explicit from still sweeps a fired one-shot's dangling pin", async () => {
+    const resolvedDefault = resolveDefaultScheduleInferenceProfile();
+    const fired = await createSchedule({
+      name: "Already fired",
+      description: "Already fired",
+      message: "hi",
+      nextRunAt: Date.now() - 60_000,
+      inferenceProfile: "cost-optimized",
+    });
+    rawRun(
+      "test:setFiredScheduleStatus",
+      "UPDATE cron_jobs SET status = 'fired' WHERE id = ?",
+      fired.id,
+    );
+
+    // Deleting a profile has to clear every row naming it, including rows that
+    // will never fire again: the pin is what the delete is removing.
+    const result = (await reassignRoute().handler({
+      body: { from: "cost-optimized", to: resolvedDefault! },
+    })) as { reassigned: number };
+
+    expect(result.reassigned).toBe(1);
+    expect(listSchedules()[0].inferenceProfile).toBe(resolvedDefault!);
+  });
+
   test("omitting from still refuses a non-owner caller when a wake row would move", async () => {
     const resolvedDefault = resolveDefaultScheduleInferenceProfile();
     await createSchedule({

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -224,6 +224,15 @@ function getCadenceDescription(
 }
 
 /**
+ * Whether a schedule still has a firing ahead of it. `fired` and `cancelled`
+ * are the two terminal states a one-shot lands in; everything else (including
+ * a disabled row, which fires again once re-enabled) can still run.
+ */
+function canScheduleStillRun(job: Pick<ScheduleJob, "status">): boolean {
+  return job.status !== "fired" && job.status !== "cancelled";
+}
+
+/**
  * Presentation-layer one-shot flag. A COUNT=1 rrule fires exactly once and
  * should read as one-time in clients, even though the scheduler internally
  * treats expression-backed jobs as recurring (retry policy, conversation
@@ -310,13 +319,25 @@ function handleGetSchedule(id: string) {
 }
 
 /**
- * Move every schedule pinned to `from` onto `to`.
+ * Move schedules onto the `to` inference profile.
  *
- * This is the companion to deleting an inference profile: without it the
- * profile's schedules keep a pin that no longer names anything. The dangling
- * pin is not fatal (the resolver drops a missing override and falls through to
- * the call site's own selection), so this exists to keep the user's stated
- * model choice rather than to prevent a failure.
+ * `from` narrows the move to the schedules pinned to that profile. It is the
+ * companion to deleting an inference profile: without it the profile's
+ * schedules keep a pin that no longer names anything. The dangling pin is not
+ * fatal (the resolver drops a missing override and falls through to the call
+ * site's own selection), so this exists to keep the user's stated model choice
+ * rather than to prevent a failure.
+ *
+ * Omitting `from` selects every schedule that can still run, which is what
+ * re-pinning the whole set onto the current default needs: schedules pinned by
+ * earlier defaults name several different profiles, so there is no single
+ * source to move from. A one-shot that already fired and a cancelled row are
+ * left out: their profile is history, and rewriting them would report a move
+ * larger than the set the user was looking at. An explicit `from` still
+ * selects exactly the rows pinned to it, dead or not, since a deleted profile
+ * has to be swept out of every row that names it. Rows already pinned to `to`
+ * are skipped either way, so the returned count is the number of schedules
+ * whose model actually changed.
  *
  * Each row goes through `updateSchedule`, so the store's profile validation
  * and re-snapshot semantics apply exactly as they do to a single-row PATCH.
@@ -326,16 +347,19 @@ function handleGetSchedule(id: string) {
  * those rows as well, which is what `include_all` plus the serialized
  * `isDeferred` flag on the list route are for. Moving one is a guardian-owned
  * state change, so the whole call requires owner authority as soon as a wake
- * row is in scope.
+ * row is in the selected set.
  */
 async function handleReassignScheduleInferenceProfile(
   body: Record<string, unknown>,
   headers?: Record<string, string>,
 ) {
+  const hasFrom = body.from !== undefined && body.from !== null;
   const from = typeof body.from === "string" ? body.from.trim() : "";
   const to = typeof body.to === "string" ? body.to.trim() : "";
-  if (!from) {
-    throw new BadRequestError("from is required");
+  if (hasFrom && !from) {
+    throw new BadRequestError(
+      "from must name an inference profile when provided",
+    );
   }
   if (!to) {
     throw new BadRequestError("to is required");
@@ -347,11 +371,14 @@ async function handleReassignScheduleInferenceProfile(
     throw new BadRequestError(profileError);
   }
 
-  const matches = listSchedules({ inferenceProfile: from });
+  const selected = hasFrom
+    ? listSchedules({ inferenceProfile: from })
+    : listSchedules().filter(canScheduleStillRun);
+  const matches = selected.filter((job) => job.inferenceProfile !== to);
   // The guard depends only on the caller, so its answer is the same for every
   // row: settle it once for the whole set. Checking per row would spend a
   // cache-bypassing gateway round trip per matching reminder, and a profile
-  // that many reminders point at would take seconds to delete or time out.
+  // that many reminders point at would take seconds to move or time out.
   // All-or-nothing either way: one wake row in scope refuses the whole call
   // before anything moves.
   const wakeMatch = matches.find((job) => job.mode === "wake") ?? null;
@@ -365,7 +392,10 @@ async function handleReassignScheduleInferenceProfile(
     }
   }
   if (reassigned > 0) {
-    log.info({ from, to, reassigned }, "Schedules reassigned to new profile");
+    log.info(
+      { from: hasFrom ? from : null, to, reassigned },
+      "Schedules reassigned to new profile",
+    );
   }
   return { reassigned };
 }
@@ -890,12 +920,15 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Reassign schedules to another inference profile",
     description:
-      "Move every schedule pinned to one inference profile onto another, so deleting a profile does not leave its schedules pointing at a name that no longer exists.",
+      "Move schedules onto one inference profile. Pass 'from' to move only the schedules pinned to that profile, so deleting a profile does not leave its schedules pointing at a name that no longer exists. Omit 'from' to move every schedule, which re-pins the whole set onto one profile. Schedules already pinned to the target are skipped.",
     tags: ["schedules"],
     requestBody: z.object({
       from: z
         .string()
-        .describe("Inference profile key the schedules are pinned to now"),
+        .optional()
+        .describe(
+          "Inference profile key the schedules are pinned to now; omit to select every schedule",
+        ),
       to: z
         .string()
         .describe("Inference profile key to move them to; must be configured"),

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * Tests for the schedule detail panel's model-profile field.
+ *
+ * The invariants this PR adds:
+ *  - a schedule shows the profile it is pinned to, by display label;
+ *  - changing it PATCHes that one schedule with the chosen profile key;
+ *  - the picker offers no "Default" option, because writing null re-snapshots
+ *    the current default rather than unpinning;
+ *  - a workflow-mode schedule presents no governing pin, since a workflow's
+ *    own steps resolve their models independently of the schedule's.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+
+const CONFIG = {
+  llm: {
+    profiles: {
+      quality: {
+        label: "Quality",
+        provider: "anthropic",
+        model: "claude-opus-5",
+      },
+      thrifty: {
+        label: "Thrifty",
+        provider: "anthropic",
+        model: "claude-haiku-5",
+      },
+    },
+    profileOrder: ["quality", "thrifty"],
+    activeProfile: "quality",
+    callSites: {},
+  },
+};
+
+const CATALOG = {
+  domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+  callSites: [
+    {
+      id: "mainAgent",
+      displayName: "Main Agent",
+      description: "The primary chat agent.",
+      domain: "agentLoop",
+      defaultProfile: "quality",
+    },
+  ],
+};
+
+let patchCalls: Array<{ id: string; body: unknown }> = [];
+let patchFails = false;
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  configGet: mock(async () => ({ data: CONFIG })),
+  configLlmCallsitesGet: mock(async () => ({ data: CATALOG })),
+  schedulesByIdRunsGet: mock(async () => ({
+    data: { runs: [], nextCursor: null },
+    response: { ok: true, status: 200 },
+  })),
+  schedulesByIdPatch: mock(
+    async (options?: { path?: { id?: string }; body?: unknown }) => {
+      patchCalls.push({ id: options?.path?.id ?? "", body: options?.body });
+      return patchFails
+        ? { response: { ok: false, status: 500 }, error: undefined }
+        : { response: { ok: true, status: 200 }, data: {} };
+    },
+  ),
+}));
+
+const { ScheduleDetailPanel } = await import("./schedule-detail-panel");
+
+type PanelSchedule = Parameters<typeof ScheduleDetailPanel>[0]["schedule"];
+
+const BASE_SCHEDULE = {
+  id: "sched-1",
+  name: "Morning digest",
+  description: "Morning digest",
+  enabled: true,
+  syntax: "cron",
+  expression: "0 9 * * *",
+  cronExpression: "0 9 * * *",
+  cadenceDescription: "Every day at 9:00",
+  timezone: null,
+  message: "digest",
+  script: null,
+  mode: "execute",
+  nextRunAt: 1_700_000_000_000,
+  lastRunAt: null,
+  lastStatus: null,
+  isOneShot: false,
+  inferenceProfile: "thrifty",
+} as unknown as PanelSchedule;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return createElement(
+    QueryClientProvider,
+    { client },
+    createElement(MemoryRouter, null, children),
+  );
+}
+
+function renderPanel(schedule: PanelSchedule, isPast = false) {
+  return render(
+    <Wrapper>
+      <ScheduleDetailPanel
+        schedule={schedule}
+        assistantId="asst-1"
+        usage={{ status: "loading" }}
+        isPast={isPast}
+        onClose={() => {}}
+        onDeleted={() => {}}
+      />
+    </Wrapper>,
+  );
+}
+
+function profileTrigger(): HTMLElement | undefined {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+  ).find((trigger) => trigger.getAttribute("aria-label") === "Model profile");
+}
+
+function renderedText(): string {
+  return document.body.textContent ?? "";
+}
+
+beforeEach(() => {
+  patchCalls = [];
+  patchFails = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ScheduleDetailPanel model profile", () => {
+  test("shows the profile the schedule is pinned to", async () => {
+    renderPanel(BASE_SCHEDULE);
+    await waitFor(() => {
+      expect(profileTrigger()?.textContent).toContain("Thrifty");
+    });
+    expect(renderedText()).toContain("Model profile");
+  });
+
+  test("offers no Default option, because null re-snapshots the default", async () => {
+    renderPanel(BASE_SCHEDULE);
+    await waitFor(() => {
+      expect(profileTrigger()).toBeDefined();
+    });
+
+    fireEvent.click(profileTrigger()!);
+    const optionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((option) => option.textContent?.trim());
+    expect(optionLabels).toEqual(["Quality", "Thrifty"]);
+  });
+
+  test("picking a profile patches that schedule with the chosen key", async () => {
+    renderPanel(BASE_SCHEDULE);
+    await waitFor(() => {
+      expect(profileTrigger()).toBeDefined();
+    });
+
+    fireEvent.click(profileTrigger()!);
+    const quality = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((option) => option.textContent?.trim() === "Quality");
+    expect(quality).toBeDefined();
+    fireEvent.click(quality!);
+
+    await waitFor(() => {
+      expect(patchCalls).toHaveLength(1);
+    });
+    expect(patchCalls[0]).toEqual({
+      id: "sched-1",
+      body: { inferenceProfile: "quality" },
+    });
+  });
+
+  test("re-picking the profile already in force patches nothing", async () => {
+    renderPanel(BASE_SCHEDULE);
+    await waitFor(() => {
+      expect(profileTrigger()).toBeDefined();
+    });
+
+    fireEvent.click(profileTrigger()!);
+    const thrifty = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((option) => option.textContent?.trim() === "Thrifty");
+    fireEvent.click(thrifty!);
+
+    await waitFor(() => {
+      expect(profileTrigger()?.textContent).toContain("Thrifty");
+    });
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  test("a workflow schedule presents no pin it does not govern", async () => {
+    renderPanel({ ...BASE_SCHEDULE, mode: "workflow" } as PanelSchedule);
+    await waitFor(() => {
+      expect(renderedText()).toContain("Not used for workflow runs");
+    });
+    expect(profileTrigger()).toBeUndefined();
+    expect(renderedText()).toContain("Each step of a workflow picks its own");
+    // The pinned profile is never named, so nothing implies it governs the run.
+    expect(renderedText()).not.toContain("Thrifty");
+  });
+
+  test("a pin naming a deleted profile asks for a choice", async () => {
+    renderPanel({
+      ...BASE_SCHEDULE,
+      inferenceProfile: "deleted-profile",
+    } as PanelSchedule);
+    await waitFor(() => {
+      expect(profileTrigger()?.textContent).toContain("Choose a model");
+    });
+  });
+
+  test("a one-shot that already fired shows its profile read-only", async () => {
+    renderPanel(
+      { ...BASE_SCHEDULE, isOneShot: true } as PanelSchedule,
+      /* isPast */ true,
+    );
+    await waitFor(() => {
+      expect(renderedText()).toContain("Thrifty");
+    });
+    expect(profileTrigger()).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   BarChart3,
   ChevronRight,
@@ -17,7 +17,10 @@ import {
   deleteSchedule,
   fetchScheduleRuns,
   runScheduleNow,
+  updateSchedule,
 } from "@/domains/settings/api/schedules";
+import { ModelProfileRow } from "@/domains/settings/components/model-profile-row";
+import { ModelProfileSelect } from "@/domains/settings/components/model-profile-select";
 import { StatusDot } from "@/domains/settings/components/schedule-shared-ui";
 import {
   formatDuration,
@@ -29,7 +32,10 @@ import {
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
 import { captureError } from "@/lib/sentry/capture-error";
-import { schedulesByIdRunsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  schedulesByIdRunsGetQueryKey,
+  schedulesGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { Button, Skeleton, Typography, cn } from "@vellumai/design-library";
@@ -59,6 +65,117 @@ function InfoRow({ label, value }: { label: string; value: ReactNode }) {
         {value}
       </span>
     </div>
+  );
+}
+
+/**
+ * The schedule's pinned inference profile, and the control that changes it.
+ *
+ * Two modes get something other than a picker:
+ *
+ * - **Workflow schedules.** They carry a pin like every other schedule, but
+ *   nothing reads it: a workflow's LLM calls resolve under their own per-leaf
+ *   call sites. A picker here would claim a setting governs the run when it
+ *   does not, so the row states the situation instead.
+ * - **One-shots that have already fired.** Their model is history; there is no
+ *   future run for a change to reach, so the pin is shown read-only.
+ */
+function ScheduleModelProfileField({
+  schedule,
+  assistantId,
+  isPast,
+}: {
+  schedule: Schedule;
+  assistantId: string;
+  isPast: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const schedulesQueryKey = schedulesGetQueryKey({
+    path: { assistant_id: assistantId },
+  });
+
+  const profileMutation = useMutation({
+    mutationFn: (inferenceProfile: string) =>
+      updateSchedule(assistantId, schedule.id, { inferenceProfile }),
+    onMutate: async (inferenceProfile) => {
+      await queryClient.cancelQueries({ queryKey: schedulesQueryKey });
+      const previousProfile = queryClient
+        .getQueryData<Schedule[]>(schedulesQueryKey)
+        ?.find((row) => row.id === schedule.id)?.inferenceProfile;
+      queryClient.setQueryData<Schedule[]>(schedulesQueryKey, (rows) =>
+        rows?.map((row) =>
+          row.id === schedule.id ? { ...row, inferenceProfile } : row,
+        ),
+      );
+      return { previousProfile };
+    },
+    onError: (error, _inferenceProfile, context) => {
+      // Restore the profile alone. A snapshot of the whole list would undo a
+      // toggle or another schedule's edit that landed while this was in flight.
+      const previousProfile = context?.previousProfile;
+      if (previousProfile !== undefined) {
+        queryClient.setQueryData<Schedule[]>(schedulesQueryKey, (rows) =>
+          rows?.map((row) =>
+            row.id === schedule.id
+              ? { ...row, inferenceProfile: previousProfile }
+              : row,
+          ),
+        );
+      }
+      captureError(error, { context: "schedule_update_inference_profile" });
+      toast.error("Failed to change the model.");
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: schedulesQueryKey }),
+  });
+
+  if (schedule.mode === "workflow") {
+    return (
+      <>
+        <InfoRow label="Model profile" value="Not used for workflow runs" />
+        <p className="pb-1 text-body-small-default text-[var(--content-tertiary)]">
+          Each step of a workflow picks its own model, so this schedule has no
+          model setting to change.
+        </p>
+      </>
+    );
+  }
+
+  if (isPast) {
+    return (
+      <div className="py-1 text-body-medium-lighter text-[var(--content-default)]">
+        <ModelProfileRow
+          assistantId={assistantId}
+          pinnedProfile={schedule.inferenceProfile}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <InfoRow
+      label="Model profile"
+      value={
+        <ModelProfileSelect
+          assistantId={assistantId}
+          value={schedule.inferenceProfile}
+          onChange={(profileKey) => {
+            if (profileKey && profileKey !== schedule.inferenceProfile) {
+              profileMutation.mutate(profileKey);
+            }
+          }}
+          // A schedule always carries a concrete profile, and writing null
+          // re-snapshots the current default rather than unpinning, so there
+          // is no "follow my default" state to offer.
+          includeDefaultOption={false}
+          // A pin naming a deleted profile matches no option, so the trigger
+          // asks for a choice instead of rendering blank.
+          placeholder="Choose a model"
+          isSaving={profileMutation.isPending}
+          className="min-w-[11rem]"
+        />
+      }
+    />
   );
 }
 
@@ -337,6 +454,8 @@ export interface ScheduleDetailPanelProps {
   schedule: Schedule;
   assistantId: string;
   usage: ScheduleRowUsage;
+  /** True for a one-shot that has already fired, which is read-only. */
+  isPast?: boolean;
   isMobile?: boolean;
   onClose: () => void;
   onDeleted: () => void;
@@ -351,6 +470,7 @@ export function ScheduleDetailPanel({
   schedule,
   assistantId,
   usage,
+  isPast = false,
   isMobile,
   onClose,
   onDeleted,
@@ -436,6 +556,11 @@ export function ScheduleDetailPanel({
               <InfoRow label="Cadence" value={schedule.cadenceDescription} />
             ) : null}
             <InfoRow label="Mode" value={schedule.mode} />
+            <ScheduleModelProfileField
+              schedule={schedule}
+              assistantId={assistantId}
+              isPast={isPast}
+            />
             <InfoRow
               label="Status"
               value={schedule.enabled ? "Enabled" : "Disabled"}

--- a/clients/web/src/domains/schedules/components/schedules-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedules-panel.tsx
@@ -30,6 +30,14 @@ export interface SchedulesPanelProps {
   pastOpen: boolean;
   onPastOpenChange: (open: boolean) => void;
   /**
+   * Opens the "move every schedule onto the current default model" flow.
+   * Omitted when there is nothing to move, so the action only appears once
+   * some schedule is running on a model other than the current default.
+   */
+  onRebaseProfiles?: () => void;
+  /** Display name of the profile the rebase would move schedules onto. */
+  defaultProfileLabel?: string;
+  /**
    * Built-in system schedules (heartbeat, consolidation, memory retrospective),
    * rendered below the user list so both share one scroll region. Self-hides
    * when there are no system tasks to show.
@@ -52,6 +60,8 @@ export function SchedulesPanel({
   onCreateSchedule,
   pastOpen,
   onPastOpenChange,
+  onRebaseProfiles,
+  defaultProfileLabel,
   systemTasksSlot,
 }: SchedulesPanelProps) {
   const renderScheduleRow = (schedule: Schedule) => (
@@ -165,6 +175,18 @@ export function SchedulesPanel({
 
     return (
       <div>
+        {onRebaseProfiles && defaultProfileLabel ? (
+          <div className="mb-1 flex min-w-0 justify-end">
+            <Button
+              variant="outlined"
+              size="compact"
+              onClick={onRebaseProfiles}
+              className="max-w-full truncate"
+            >
+              {`Use ${defaultProfileLabel} for all schedules`}
+            </Button>
+          </div>
+        ) : null}
         {recurring.map(renderScheduleRow)}
         {oneTime.length > 0 ? (
           <>

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -3,10 +3,7 @@ import { Loader2, Play, Settings, X } from "lucide-react";
 import { useNavigate } from "react-router";
 
 import { SCHEDULE_RUNS_PAGE_SIZE } from "@/domains/settings/api/schedules";
-import {
-  ModelProfileRow,
-  type ScheduleModelProfileCallSite,
-} from "@/domains/settings/components/model-profile-row";
+import { ModelProfileRow } from "@/domains/settings/components/model-profile-row";
 import { RecentRunsCard } from "@/domains/settings/components/recent-runs-card";
 import {
   consolidationSubtitle,
@@ -29,11 +26,12 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { SystemTaskKind } from "@/domains/settings/types/schedules";
+import type { ResolvableCallSite } from "@/hooks/use-call-site-default-profile";
 
 // Each system task resolves its model from a dedicated LLM call site.
 const SYSTEM_TASK_PROFILE_CALL_SITES: Record<
   SystemTaskKind,
-  ScheduleModelProfileCallSite
+  ResolvableCallSite
 > = {
   heartbeat: "heartbeatAgent",
   consolidation: "memoryV2Consolidation",

--- a/clients/web/src/domains/schedules/schedules-page.tsx
+++ b/clients/web/src/domains/schedules/schedules-page.tsx
@@ -207,9 +207,7 @@ export function SchedulesPage() {
       pastOpen={pastSchedulesOpen}
       onPastOpenChange={setPastSchedulesOpen}
       onRebaseProfiles={
-        profileRebase.offDefaultCount > 0
-          ? profileRebase.requestRebase
-          : undefined
+        profileRebase.canRebase ? profileRebase.requestRebase : undefined
       }
       defaultProfileLabel={profileRebase.defaultProfileLabel ?? undefined}
       systemTasksSlot={

--- a/clients/web/src/domains/schedules/schedules-page.tsx
+++ b/clients/web/src/domains/schedules/schedules-page.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailDrawer, MobileDetailOverlay } from "@/components/detail-drawer";
 import { CreateScheduleModal } from "@/domains/settings/components/create-schedule-modal";
+import {
+  ScheduleProfileRebaseDialog,
+  useScheduleProfileRebase,
+} from "@/domains/settings/components/schedule-profile-rebase";
 import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
 import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
 import { useAssistantCapability } from "@/hooks/use-assistant-capability";
@@ -141,11 +145,28 @@ export function SchedulesPage() {
     navigateToNewConversation(navigate);
   }, [navigate]);
 
+  const listedSchedules = useMemo(
+    () => [
+      ...schedules.recurring,
+      ...schedules.oneTime,
+      ...schedules.pastOneTime,
+    ],
+    [schedules.recurring, schedules.oneTime, schedules.pastOneTime],
+  );
+  const profileRebase = useScheduleProfileRebase(
+    assistantId,
+    listedSchedules,
+    schedules.refetch,
+  );
+
   const scheduleDetail = selectedSchedule ? (
     <ScheduleDetailPanel
       schedule={selectedSchedule}
       assistantId={assistantId}
       usage={schedules.usageForSchedule(selectedSchedule.id)}
+      isPast={schedules.pastOneTime.some(
+        (schedule) => schedule.id === selectedSchedule.id,
+      )}
       isMobile={isMobile}
       onClose={() => handleSelectScheduleId(null)}
       onDeleted={() => {
@@ -185,6 +206,12 @@ export function SchedulesPage() {
       onCreateSchedule={() => setCreateScheduleOpen(true)}
       pastOpen={pastSchedulesOpen}
       onPastOpenChange={setPastSchedulesOpen}
+      onRebaseProfiles={
+        profileRebase.offDefaultCount > 0
+          ? profileRebase.requestRebase
+          : undefined
+      }
+      defaultProfileLabel={profileRebase.defaultProfileLabel ?? undefined}
       systemTasksSlot={
         <SystemTasksSection
           heartbeatConfig={systemTasks.heartbeatConfig}
@@ -204,10 +231,19 @@ export function SchedulesPage() {
     />
   );
 
+  const rebaseDialog = (
+    <ScheduleProfileRebaseDialog {...profileRebase.dialogProps} />
+  );
+
   // On mobile the detail takes over the whole screen; on desktop it opens as
   // a drawer beside the list, under the layout's fixed heading.
   if (detail && isMobile) {
-    return <MobileDetailOverlay>{detail}</MobileDetailOverlay>;
+    return (
+      <>
+        <MobileDetailOverlay>{detail}</MobileDetailOverlay>
+        {rebaseDialog}
+      </>
+    );
   }
 
   return (
@@ -231,6 +267,7 @@ export function SchedulesPage() {
           schedules.refetch();
         }}
       />
+      {rebaseDialog}
     </>
   );
 }

--- a/clients/web/src/domains/settings/api/schedules.ts
+++ b/clients/web/src/domains/settings/api/schedules.ts
@@ -68,6 +68,12 @@ export async function createSchedule(
 
 export interface UpdateSchedulePayload {
   timeoutMs?: number | null;
+  /**
+   * Inference profile the schedule runs on. Every schedule carries a concrete
+   * pin, so sending `null` does not unpin it: the daemon re-snapshots the
+   * currently resolved default. Send a profile key to move the schedule.
+   */
+  inferenceProfile?: string | null;
 }
 
 export async function updateSchedule(
@@ -94,21 +100,29 @@ export async function fetchSchedules(assistantId: string): Promise<Schedule[]> {
 }
 
 const REASSIGN_PROFILE_ERROR =
-  "Failed to move schedules to the replacement profile.";
+  "Failed to move schedules to the selected profile.";
 
 /**
- * Move every schedule pinned to `fromProfile` onto `toProfile`, returning how
- * many moved. Used by the profile-delete flow so a deleted inference profile
- * never leaves schedules naming it.
+ * Move schedules onto `toProfile`, returning how many actually moved.
+ *
+ * `fromProfile` narrows the move to the schedules pinned to that profile,
+ * which is what the profile-delete flow needs so a deleted inference profile
+ * never leaves schedules naming it. Passing `null` selects every schedule,
+ * which is what re-pinning the whole set onto the current default needs:
+ * schedules pinned under earlier defaults name several different profiles.
+ * Schedules already on `toProfile` are skipped either way.
  */
 export async function reassignScheduleInferenceProfile(
   assistantId: string,
-  fromProfile: string,
+  fromProfile: string | null,
   toProfile: string,
 ): Promise<number> {
   const { data, error, response } = await schedulesReassignprofilePost({
     path: { assistant_id: assistantId },
-    body: { from: fromProfile, to: toProfile },
+    body: {
+      ...(fromProfile == null ? {} : { from: fromProfile }),
+      to: toProfile,
+    },
     throwOnError: false,
   });
   assertHasResponse(response, error, REASSIGN_PROFILE_ERROR);

--- a/clients/web/src/domains/settings/components/model-profile-row.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-row.tsx
@@ -1,20 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import {
-  configGetOptions,
-  configLlmCallsitesGetOptions,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useCallSiteDefaultProfile } from "@/hooks/use-call-site-default-profile";
 import { extractUsageProfileMetadata } from "@/utils/profile-metadata";
 
 import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+import type { ResolvableCallSite } from "@/hooks/use-call-site-default-profile";
 import type { UsageProfileMetadataMap } from "@/utils/profile-metadata";
-
-export type ScheduleModelProfileCallSite =
-  | "mainAgent"
-  | "heartbeatAgent"
-  | "memoryV2Consolidation"
-  | "memoryRetrospective";
 
 const DEFAULT_MAIN_AGENT_PROFILE_LABEL = "Default (assistant's main model)";
 const CUSTOM_CALL_SITE_MODEL_LABEL = "Custom call-site model";
@@ -55,7 +48,7 @@ export function ModelProfileRow({
 }: {
   assistantId: string;
   pinnedProfile?: string | null;
-  defaultCallSite?: ScheduleModelProfileCallSite;
+  defaultCallSite?: ResolvableCallSite;
   fallbackLabel?: string;
   respectCallSiteOverride?: boolean;
 }) {
@@ -69,11 +62,11 @@ export function ModelProfileRow({
     () => (daemonConfig ? extractUsageProfileMetadata(daemonConfig) : {}),
     [daemonConfig],
   );
-  const { data: callSiteCatalog } = useQuery({
-    ...configLlmCallsitesGetOptions({ path: { assistant_id: assistantId } }),
-    enabled: Boolean(assistantId) && shouldResolveDefault,
-    staleTime: 60_000,
-  });
+  const { label: defaultProfileLabel } = useCallSiteDefaultProfile(
+    assistantId,
+    defaultCallSite,
+    { enabled: shouldResolveDefault },
+  );
 
   const overrideLabel =
     shouldResolveDefault && respectCallSiteOverride
@@ -82,18 +75,13 @@ export function ModelProfileRow({
           profileMetadata,
         )
       : undefined;
-  const defaultProfile = shouldResolveDefault
-    ? callSiteCatalog?.callSites.find(
-        (callSite) => callSite.id === defaultCallSite,
-      )?.defaultProfile
-    : undefined;
   const profileLabel =
     pinnedProfile != null
       ? profileDisplayName(pinnedProfile, profileMetadata)
       : overrideLabel != null
         ? overrideLabel
-        : defaultProfile != null
-          ? `Default (${profileDisplayName(defaultProfile, profileMetadata)})`
+        : defaultProfileLabel != null
+          ? `Default (${defaultProfileLabel})`
           : fallbackLabel;
 
   return (

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -21,6 +21,21 @@ export interface ModelProfileSelectProps {
   disabled?: boolean;
   isSaving?: boolean;
   className?: string;
+  /**
+   * Whether to offer the "Default" (null) option.
+   *
+   * Set false wherever null is not a state the subject can rest in. A schedule
+   * is the case that matters: it always carries a concrete profile, and writing
+   * null re-snapshots the current default rather than unpinning, so offering
+   * "Default" there would promise a schedule can float with the user's default
+   * when it cannot.
+   */
+  includeDefaultOption?: boolean;
+  /**
+   * Trigger text when `value` matches no offered option, which happens when a
+   * pin names a profile that has since been deleted.
+   */
+  placeholder?: string;
 }
 
 export function ModelProfileSelect({
@@ -30,19 +45,23 @@ export function ModelProfileSelect({
   disabled = false,
   isSaving = false,
   className,
+  includeDefaultOption = true,
+  placeholder,
 }: ModelProfileSelectProps) {
-  const options = useProfileOptions(assistantId, value).map((option) => ({
-    ...(option.issue === "undispatchable"
-      ? {
-          icon: (
-            <AlertCircle className="h-3.5 w-3.5 text-[var(--system-mid-strong)]" />
-          ),
-          ...(option.reason ? { tooltip: option.reason } : {}),
-        }
-      : {}),
-    value: profileOptionToDropdownValue(option.value),
-    label: option.label,
-  }));
+  const options = useProfileOptions(assistantId, value)
+    .filter((option) => includeDefaultOption || option.value != null)
+    .map((option) => ({
+      ...(option.issue === "undispatchable"
+        ? {
+            icon: (
+              <AlertCircle className="h-3.5 w-3.5 text-[var(--system-mid-strong)]" />
+            ),
+            ...(option.reason ? { tooltip: option.reason } : {}),
+          }
+        : {}),
+      value: profileOptionToDropdownValue(option.value),
+      label: option.label,
+    }));
 
   return (
     <Dropdown
@@ -50,6 +69,7 @@ export function ModelProfileSelect({
       onChange={(selected) => onChange(dropdownValueToProfileOption(selected))}
       options={options}
       disabled={disabled || isSaving}
+      placeholder={placeholder}
       className={className}
       aria-label="Model profile"
     />

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
@@ -78,11 +78,24 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 
 const { ScheduleProfileRebaseDialog, useScheduleProfileRebase } =
   await import("./schedule-profile-rebase");
+const { MIN_VERSION } =
+  await import("@/lib/backwards-compat/use-supports-schedule-profile-moves");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
 
 type RebaseSchedule = Parameters<typeof useScheduleProfileRebase>[1][number];
 
-function schedule(id: string, inferenceProfile: string | null) {
-  return { id, name: id, inferenceProfile } as unknown as RebaseSchedule;
+function schedule(
+  id: string,
+  inferenceProfile: string | null,
+  status: string = "active",
+) {
+  return {
+    id,
+    name: id,
+    inferenceProfile,
+    status,
+  } as unknown as RebaseSchedule;
 }
 
 const SCHEDULES = [
@@ -103,6 +116,7 @@ function Harness({ schedules = SCHEDULES }: { schedules?: RebaseSchedule[] }) {
         request
       </button>
       <span data-testid="off-default">{rebase.offDefaultCount}</span>
+      <span data-testid="can-rebase">{String(rebase.canRebase)}</span>
       <span data-testid="label">{rebase.defaultProfileLabel ?? ""}</span>
       <ScheduleProfileRebaseDialog {...rebase.dialogProps} />
     </>
@@ -135,6 +149,8 @@ function renderedText(): string {
 }
 
 beforeEach(() => {
+  // The bulk move needs an assistant carrying the reassign route.
+  useAssistantIdentityStore.getState().setIdentity("asst-1", MIN_VERSION);
   reassignBodies = [];
   reassignedCount = 2;
   reassignFails = false;
@@ -145,6 +161,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
 });
 
 describe("useScheduleProfileRebase", () => {
@@ -163,6 +180,83 @@ describe("useScheduleProfileRebase", () => {
     expect(
       document.querySelector('[data-testid="off-default"]')?.textContent,
     ).toBe("2");
+    expect(
+      document.querySelector('[data-testid="can-rebase"]')?.textContent,
+    ).toBe("true");
+  });
+
+  test("schedules that already fired or were cancelled are not counted", async () => {
+    render(
+      <Wrapper>
+        <Harness
+          schedules={[
+            schedule("fired-one", "thrifty", "fired"),
+            schedule("cancelled-one", "thrifty", "cancelled"),
+            schedule("live-one", "thrifty"),
+          ]}
+        />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+    // Their profile is history; the daemon leaves them alone, so offering them
+    // would promise a bigger move than the one that comes back.
+    expect(
+      document.querySelector('[data-testid="off-default"]')?.textContent,
+    ).toBe("1");
+  });
+
+  test("the action is withheld when every schedule is already dead", async () => {
+    render(
+      <Wrapper>
+        <Harness
+          schedules={[
+            schedule("fired-one", "thrifty", "fired"),
+            schedule("cancelled-one", "thrifty", "cancelled"),
+          ]}
+        />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+    expect(
+      document.querySelector('[data-testid="can-rebase"]')?.textContent,
+    ).toBe("false");
+  });
+
+  // An assistant older than the reassign route requires `from` and answers a
+  // blanket move with a 400, so the action must not be offered at all.
+  test("the action is withheld on an assistant without the reassign route", async () => {
+    useAssistantIdentityStore.getState().setIdentity("asst-1", "0.11.2");
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+    expect(
+      document.querySelector('[data-testid="off-default"]')?.textContent,
+    ).toBe("2");
+    expect(
+      document.querySelector('[data-testid="can-rebase"]')?.textContent,
+    ).toBe("false");
+
+    // Even if the confirm is requested directly, the dialog stays shut.
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).toBeNull();
+    });
+    expect(reassignBodies).toHaveLength(0);
   });
 
   test("requesting the rebase confirms first and moves nothing", async () => {

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Tests for the bulk "use my current default model for every schedule" flow.
+ *
+ * The invariants: the action never fires without an explicit confirm, the
+ * confirm reaches the daemon as one reassign call with no `from` (so the move
+ * covers schedules pinned to any profile, including rows the list hides), and
+ * the user is told what actually moved.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+
+const CONFIG = {
+  llm: {
+    profiles: {
+      quality: {
+        label: "Quality",
+        provider: "anthropic",
+        model: "claude-opus-5",
+      },
+      thrifty: {
+        label: "Thrifty",
+        provider: "anthropic",
+        model: "claude-haiku-5",
+      },
+    },
+    profileOrder: ["quality", "thrifty"],
+    activeProfile: "quality",
+    callSites: {},
+  },
+};
+
+const CATALOG = {
+  domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+  callSites: [
+    {
+      id: "mainAgent",
+      displayName: "Main Agent",
+      description: "The primary chat agent.",
+      domain: "agentLoop",
+      defaultProfile: "quality",
+    },
+  ],
+};
+
+let reassignBodies: unknown[] = [];
+let reassignedCount = 2;
+let reassignFails = false;
+let successToasts: string[] = [];
+let errorToasts: string[] = [];
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  configGet: mock(async () => ({ data: CONFIG })),
+  configLlmCallsitesGet: mock(async () => ({ data: CATALOG })),
+  schedulesReassignprofilePost: mock(async (options?: { body?: unknown }) => {
+    reassignBodies.push(options?.body);
+    return reassignFails
+      ? { response: { ok: false, status: 500 }, error: undefined }
+      : {
+          response: { ok: true, status: 200 },
+          data: { reassigned: reassignedCount },
+        };
+  }),
+}));
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => successToasts.push(message),
+    error: (message: string) => errorToasts.push(message),
+  },
+}));
+
+const { ScheduleProfileRebaseDialog, useScheduleProfileRebase } =
+  await import("./schedule-profile-rebase");
+
+type RebaseSchedule = Parameters<typeof useScheduleProfileRebase>[1][number];
+
+function schedule(id: string, inferenceProfile: string | null) {
+  return { id, name: id, inferenceProfile } as unknown as RebaseSchedule;
+}
+
+const SCHEDULES = [
+  schedule("sched-1", "thrifty"),
+  schedule("sched-2", "quality"),
+  schedule("sched-3", null),
+];
+
+let rebasedCalls = 0;
+
+function Harness({ schedules = SCHEDULES }: { schedules?: RebaseSchedule[] }) {
+  const rebase = useScheduleProfileRebase("asst-1", schedules, () => {
+    rebasedCalls += 1;
+  });
+  return (
+    <>
+      <button type="button" onClick={rebase.requestRebase}>
+        request
+      </button>
+      <span data-testid="off-default">{rebase.offDefaultCount}</span>
+      <span data-testid="label">{rebase.defaultProfileLabel ?? ""}</span>
+      <ScheduleProfileRebaseDialog {...rebase.dialogProps} />
+    </>
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function clickByText(text: string) {
+  const button = Array.from(
+    document.querySelectorAll<HTMLElement>("button"),
+  ).find((el) => el.textContent?.trim() === text);
+  expect(button).toBeDefined();
+  act(() => {
+    button?.click();
+  });
+}
+
+function confirmButton(): HTMLElement | null {
+  return document.querySelector("[data-confirm-dialog-confirm]");
+}
+
+function renderedText(): string {
+  return document.body.textContent ?? "";
+}
+
+beforeEach(() => {
+  reassignBodies = [];
+  reassignedCount = 2;
+  reassignFails = false;
+  successToasts = [];
+  errorToasts = [];
+  rebasedCalls = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useScheduleProfileRebase", () => {
+  test("counts the schedules not already on the resolved default", async () => {
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+    // sched-1 (thrifty) and sched-3 (no pin) differ from the default.
+    expect(
+      document.querySelector('[data-testid="off-default"]')?.textContent,
+    ).toBe("2");
+  });
+
+  test("requesting the rebase confirms first and moves nothing", async () => {
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).not.toBeNull();
+    });
+    expect(renderedText()).toContain("Use Quality for every schedule?");
+    expect(renderedText()).toContain("2 of the schedules below run");
+    expect(reassignBodies).toHaveLength(0);
+  });
+
+  test("cancelling closes the dialog without moving anything", async () => {
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).not.toBeNull();
+    });
+    clickByText("Cancel");
+    await waitFor(() => {
+      expect(confirmButton()).toBeNull();
+    });
+    expect(reassignBodies).toHaveLength(0);
+  });
+
+  test("confirming moves every schedule and reports the result", async () => {
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).not.toBeNull();
+    });
+    clickByText("Move schedules");
+
+    await waitFor(() => {
+      expect(reassignBodies).toHaveLength(1);
+    });
+    // No `from`: the move must cover schedules pinned to any profile, not just
+    // one source.
+    expect(reassignBodies[0]).toEqual({ to: "quality" });
+    await waitFor(() => {
+      expect(successToasts).toEqual(["Moved 2 schedules to Quality."]);
+    });
+    expect(rebasedCalls).toBe(1);
+    expect(confirmButton()).toBeNull();
+  });
+
+  test("reports a no-op run honestly", async () => {
+    reassignedCount = 0;
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).not.toBeNull();
+    });
+    clickByText("Move schedules");
+
+    await waitFor(() => {
+      expect(successToasts).toEqual([
+        "Every schedule already runs on Quality.",
+      ]);
+    });
+  });
+
+  test("a failed move is surfaced and leaves the dialog open", async () => {
+    reassignFails = true;
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="label"]')?.textContent).toBe(
+        "Quality",
+      );
+    });
+
+    clickByText("request");
+    await waitFor(() => {
+      expect(confirmButton()).not.toBeNull();
+    });
+    clickByText("Move schedules");
+
+    await waitFor(() => {
+      expect(errorToasts).toEqual(["Failed to move the schedules."]);
+    });
+    expect(successToasts).toEqual([]);
+    expect(confirmButton()).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.test.tsx
@@ -150,7 +150,7 @@ function renderedText(): string {
 
 beforeEach(() => {
   // The bulk move needs an assistant carrying the reassign route.
-  useAssistantIdentityStore.getState().setIdentity("asst-1", MIN_VERSION);
+  useAssistantIdentityStore.getState().setIdentity("asst-1", MIN_VERSION, "asst-1");
   reassignBodies = [];
   reassignedCount = 2;
   reassignFails = false;
@@ -233,7 +233,7 @@ describe("useScheduleProfileRebase", () => {
   // An assistant older than the reassign route requires `from` and answers a
   // blanket move with a 400, so the action must not be offered at all.
   test("the action is withheld on an assistant without the reassign route", async () => {
-    useAssistantIdentityStore.getState().setIdentity("asst-1", "0.11.2");
+    useAssistantIdentityStore.getState().setIdentity("asst-1", "0.11.2", "asst-1");
     render(
       <Wrapper>
         <Harness />

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
@@ -1,0 +1,129 @@
+import { useMutation } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { reassignScheduleInferenceProfile } from "@/domains/settings/api/schedules";
+import { useCallSiteDefaultProfile } from "@/hooks/use-call-site-default-profile";
+import { captureError } from "@/lib/sentry/capture-error";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import type { Schedule } from "@/domains/settings/types/schedules";
+
+export interface ScheduleProfileRebaseDialogProps {
+  open: boolean;
+  /** Display name of the profile every schedule would move onto. */
+  profileLabel: string | null;
+  /** How many of the listed schedules run on some other profile today. */
+  offDefaultCount: number;
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export interface ScheduleProfileRebase {
+  /**
+   * Display name of the profile a new schedule would be pinned to right now,
+   * or null while the config loads or when no named profile wins.
+   */
+  defaultProfileLabel: string | null;
+  /** How many of the given schedules run on some other profile. */
+  offDefaultCount: number;
+  requestRebase: () => void;
+  dialogProps: ScheduleProfileRebaseDialogProps;
+}
+
+/**
+ * The "move every schedule onto my current default model" flow.
+ *
+ * Each schedule is pinned to a concrete profile taken from the default in
+ * force when it was created, which is what keeps its cost from moving under
+ * the user. The cost of that guarantee is drift: change the default and the
+ * schedules made under the old one stay where they were. This is the escape
+ * hatch, and it reassigns server-side in one call rather than fanning out a
+ * PATCH per row, so the set that moves is the set the daemon sees, including
+ * the deferred reminders the list does not show.
+ */
+export function useScheduleProfileRebase(
+  assistantId: string,
+  schedules: Schedule[],
+  onRebased: () => void,
+): ScheduleProfileRebase {
+  const defaultProfile = useCallSiteDefaultProfile(assistantId, "mainAgent");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const offDefaultCount = useMemo(() => {
+    if (!defaultProfile.key) {
+      return 0;
+    }
+    return schedules.filter(
+      (schedule) => schedule.inferenceProfile !== defaultProfile.key,
+    ).length;
+  }, [defaultProfile.key, schedules]);
+
+  const label = defaultProfile.label;
+
+  const rebase = useMutation({
+    mutationFn: (toProfile: string) =>
+      reassignScheduleInferenceProfile(assistantId, null, toProfile),
+    onSuccess: (moved) => {
+      setConfirmOpen(false);
+      onRebased();
+      toast.success(
+        moved === 0
+          ? `Every schedule already runs on ${label}.`
+          : `Moved ${moved} ${moved === 1 ? "schedule" : "schedules"} to ${label}.`,
+      );
+    },
+    onError: (error) => {
+      captureError(error, { context: "schedules_rebase_inference_profile" });
+      toast.error("Failed to move the schedules.");
+    },
+  });
+
+  return {
+    defaultProfileLabel: label,
+    offDefaultCount,
+    requestRebase: () => setConfirmOpen(true),
+    dialogProps: {
+      open: confirmOpen && defaultProfile.key != null,
+      profileLabel: label,
+      offDefaultCount,
+      isPending: rebase.isPending,
+      onConfirm: () => {
+        if (defaultProfile.key) {
+          rebase.mutate(defaultProfile.key);
+        }
+      },
+      onCancel: () => setConfirmOpen(false),
+    },
+  };
+}
+
+/**
+ * Confirmation gate for {@link useScheduleProfileRebase}. The rebase touches
+ * every schedule at once, including ones the user deliberately moved off the
+ * default, so it never runs without an explicit confirm that names both the
+ * destination and the blast radius.
+ */
+export function ScheduleProfileRebaseDialog({
+  open,
+  profileLabel,
+  offDefaultCount,
+  isPending,
+  onConfirm,
+  onCancel,
+}: ScheduleProfileRebaseDialogProps) {
+  return (
+    <ConfirmDialog
+      open={open}
+      title={`Use ${profileLabel} for every schedule?`}
+      message={`${offDefaultCount} of the schedules below ${
+        offDefaultCount === 1 ? "runs" : "run"
+      } on a different model. This moves every schedule, including reminders your assistant set aside for later, onto ${profileLabel}, your current default. Schedules you deliberately put on another model move too.`}
+      confirmLabel="Move schedules"
+      isPending={isPending}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
@@ -2,7 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
 import { reassignScheduleInferenceProfile } from "@/domains/settings/api/schedules";
+import { canScheduleStillRun } from "@/domains/settings/utils/schedule-formatters";
 import { useCallSiteDefaultProfile } from "@/hooks/use-call-site-default-profile";
+import { useSupportsScheduleProfileMoves } from "@/lib/backwards-compat/use-supports-schedule-profile-moves";
 import { captureError } from "@/lib/sentry/capture-error";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -26,8 +28,18 @@ export interface ScheduleProfileRebase {
    * or null while the config loads or when no named profile wins.
    */
   defaultProfileLabel: string | null;
-  /** How many of the given schedules run on some other profile. */
+  /**
+   * How many of the given schedules can still run and are on some other
+   * profile. Rows that already fired or were cancelled keep their profile only
+   * as history, and the daemon leaves them alone, so counting them here would
+   * offer a move that reports back a smaller number than it promised.
+   */
   offDefaultCount: number;
+  /**
+   * Whether to offer the action at all: something has to move, and the
+   * assistant has to be able to serve the move.
+   */
+  canRebase: boolean;
   requestRebase: () => void;
   dialogProps: ScheduleProfileRebaseDialogProps;
 }
@@ -42,6 +54,10 @@ export interface ScheduleProfileRebase {
  * hatch, and it reassigns server-side in one call rather than fanning out a
  * PATCH per row, so the set that moves is the set the daemon sees, including
  * the deferred reminders the list does not show.
+ *
+ * The move needs an assistant carrying the reassign route, which the same gate
+ * the profile-delete flow uses reports. An older one rejects a request with no
+ * `from` outright, so the action stays hidden rather than failing on click.
  */
 export function useScheduleProfileRebase(
   assistantId: string,
@@ -49,6 +65,7 @@ export function useScheduleProfileRebase(
   onRebased: () => void,
 ): ScheduleProfileRebase {
   const defaultProfile = useCallSiteDefaultProfile(assistantId, "mainAgent");
+  const supportsProfileMoves = useSupportsScheduleProfileMoves();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const offDefaultCount = useMemo(() => {
@@ -56,7 +73,9 @@ export function useScheduleProfileRebase(
       return 0;
     }
     return schedules.filter(
-      (schedule) => schedule.inferenceProfile !== defaultProfile.key,
+      (schedule) =>
+        canScheduleStillRun(schedule) &&
+        schedule.inferenceProfile !== defaultProfile.key,
     ).length;
   }, [defaultProfile.key, schedules]);
 
@@ -83,9 +102,10 @@ export function useScheduleProfileRebase(
   return {
     defaultProfileLabel: label,
     offDefaultCount,
+    canRebase: supportsProfileMoves && offDefaultCount > 0,
     requestRebase: () => setConfirmOpen(true),
     dialogProps: {
-      open: confirmOpen && defaultProfile.key != null,
+      open: confirmOpen && supportsProfileMoves && defaultProfile.key != null,
       profileLabel: label,
       offDefaultCount,
       isPending: rebase.isPending,

--- a/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
+++ b/clients/web/src/domains/settings/components/schedule-profile-rebase.tsx
@@ -65,7 +65,7 @@ export function useScheduleProfileRebase(
   onRebased: () => void,
 ): ScheduleProfileRebase {
   const defaultProfile = useCallSiteDefaultProfile(assistantId, "mainAgent");
-  const supportsProfileMoves = useSupportsScheduleProfileMoves();
+  const supportsProfileMoves = useSupportsScheduleProfileMoves(assistantId);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const offDefaultCount = useMemo(() => {

--- a/clients/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.ts
@@ -245,11 +245,23 @@ export interface GroupedSchedules {
   pastOneTime: Schedule[];
 }
 
+/**
+ * Whether a schedule still has a firing ahead of it. `fired` and `cancelled`
+ * are the two terminal states a one-shot lands in; everything else (including
+ * a disabled row, which fires again once re-enabled) can still run.
+ *
+ * This mirrors the rule the daemon applies when re-pinning every schedule onto
+ * one profile, so the count offered here is the count that comes back.
+ */
+export function canScheduleStillRun(schedule: Schedule): boolean {
+  return schedule.status !== "fired" && schedule.status !== "cancelled";
+}
+
 // Keyed on the lifecycle status, not lastRunAt/nextRunAt alone: a failed
 // attempt awaiting retry keeps lastRunAt set, and an in-flight run is
 // `firing` with nextRunAt already due — both are still live, not past.
 function isPastOneTime(schedule: Schedule, now: number): boolean {
-  if (schedule.status === "fired" || schedule.status === "cancelled") {
+  if (!canScheduleStillRun(schedule)) {
     return true;
   }
   if (schedule.status === "firing") {

--- a/clients/web/src/hooks/use-call-site-default-profile.ts
+++ b/clients/web/src/hooks/use-call-site-default-profile.ts
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  configGetOptions,
+  configLlmCallsitesGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { extractUsageProfileMetadata } from "@/utils/profile-metadata";
+
+/** LLM call sites whose default profile the UI resolves for display. */
+export type ResolvableCallSite =
+  | "mainAgent"
+  | "heartbeatAgent"
+  | "memoryV2Consolidation"
+  | "memoryRetrospective";
+
+export interface CallSiteDefaultProfile {
+  /**
+   * Inference profile key the call site resolves to when nothing pins it, or
+   * null when the winner is the code-owned anchor rather than a named profile.
+   */
+  key: string | null;
+  /** Display label for `key`, or null when there is no named profile. */
+  label: string | null;
+}
+
+/**
+ * The inference profile a call site falls back to, as the daemon resolves it.
+ *
+ * The catalog endpoint runs the same `resolveDefaultProfileKey` the daemon uses
+ * when it pins a new schedule, so this is the one answer to "which profile
+ * would this run on if nobody chose". Reading it from the catalog rather than
+ * re-deriving the precedence chain client-side is what keeps the label the user
+ * sees and the profile a schedule is pinned to from drifting apart.
+ */
+export function useCallSiteDefaultProfile(
+  assistantId: string,
+  callSite: ResolvableCallSite,
+  options?: { enabled?: boolean },
+): CallSiteDefaultProfile {
+  const enabled = Boolean(assistantId) && options?.enabled !== false;
+  const { data: catalog } = useQuery({
+    ...configLlmCallsitesGetOptions({ path: { assistant_id: assistantId } }),
+    enabled,
+    staleTime: 60_000,
+  });
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled,
+    staleTime: 60_000,
+  });
+
+  const key =
+    catalog?.callSites.find((entry) => entry.id === callSite)?.defaultProfile ??
+    null;
+  if (key == null) {
+    return { key: null, label: null };
+  }
+  const metadata = daemonConfig
+    ? extractUsageProfileMetadata(daemonConfig)
+    : {};
+  return { key, label: metadata[key]?.displayName ?? key };
+}


### PR DESCRIPTION
Closes #40079. Fourth and final PR of the stack, based on #40115.

## Why

The rest of the stack made every schedule carry a concrete inference profile. Until now that pin was completely invisible in the web UI and could not be changed there. This PR is the reason the rest exists.

## What changed

- **The detail panel shows the profile and lets you change it**, adopting `ModelProfileSelect`, a component added in #36045 under the title "add schedule model profile picker" and never wired to anything.
- **A bulk action moves every schedule onto the current default**, for someone who has accumulated schedules pinned to older defaults. It extends the reassign route from #40115 to make `from` optional (omitted means every schedule) rather than adding a second endpoint or fanning out N calls from the client.
- **A shared `useCallSiteDefaultProfile` hook** replaces two separate re-derivations of "the mainAgent default plus its display name".

## Decisions

**The "Default" option is suppressed for schedules.** `ModelProfileSelect` offers a null "Default" entry. Under this stack, writing null re-snapshots the current default rather than unpinning, so an option labelled "Default" would promise a resting state that does not exist. Added `includeDefaultOption` (defaults true, so existing behavior is unchanged for future callers) and the schedule field passes false.

**Workflow mode shows no pin.** A workflow-mode schedule carries a pin that nothing reads: workflow leaves resolve their own per-leaf call sites, deliberately, because pinning a managed profile breaks BYO-key installs. Rather than showing a value and disclaiming it, the row reads `Not used for workflow runs` with a one-line explanation. Showing a value then undercutting it is the more confusing option. Whether workflow mode should honor the pin is #40083.

**No profile on the list row.** The row already carries a toggle, a truncating name, a truncating meta line, cost, run count, and a chevron. A chip there would steal width from the name or push cost off, and the value is near-constant across rows. The detail panel is one click away and is where it is editable.

**A fired one-shot is read-only**, since offering to configure a run that will never happen is noise.

## Copy

- Workflow mode: `Model profile` / `Not used for workflow runs`, then `Each step of a workflow picks its own model, so this schedule has no model setting to change.`
- Bulk action: `Use Quality for all schedules`
- Confirm: `Use Quality for every schedule?` / `2 of the schedules below run on a different model. This moves every schedule, including reminders your assistant set aside for later, onto Quality, your current default. Schedules you deliberately put on another model move too.`
- Result: `Moved 2 schedules to Quality.` / `Every schedule already runs on Quality.`

## Review focus

**One degenerate behavior change on the route #40115 just shipped.** `reassign-profile` with `from === to` used to rewrite every matching row and bump `updatedAt`; rows already on the target are now filtered out before the writes, so it is a no-op returning 0 and the count reflects schedules whose model actually changed. No caller does that today.

**The bulk action is all-or-nothing and includes deliberate pins.** Someone who put a nightly digest on a cheap profile on purpose will have it moved. The confirm says so explicitly. The alternative is per-row multi-select, a much larger surface.

**The confirm's count comes from the visible list, not the server**, so it says "N of the schedules below", which is true, while the server may move more because deferred reminders are hidden from that list. The copy discloses that reminders are included, and the post-run toast reports the server's real count.

**Adopting `ModelProfileSelect` cements a deprecated primitive.** It is built on `Dropdown`, which is marked `@deprecated` in favor of `Select`. Migrating it is a reasonable follow-up but was out of scope here.
