### PR TITLE
fix(local-mode): paired-aware guardian refresh-failure guidance and guardianToken IPC coverage

### DIFF
--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -11,7 +11,9 @@ mock.module("./device-id", () => ({
 }));
 
 const mockGetGuardianAccessToken = mock(
-  async (): Promise<{ ok: true; accessToken: string } | { ok: false; status: number; error: string }> =>
+  async (
+    ..._args: unknown[]
+  ): Promise<{ ok: true; accessToken: string } | { ok: false; status: number; error: string }> =>
     ({ ok: true, accessToken: "test-token" }),
 );
 mock.module("@vellumai/local-mode", () => ({
@@ -501,6 +503,10 @@ describe("host-proxy-router", () => {
       expect(sseRequest).toBeDefined();
       expect(sseRequest!.headers.Authorization).toBe("Bearer test-token");
       expect(sseRequest!.headers["ngrok-skip-browser-warning"]).toBe("true");
+
+      // The paired flag rides along so an expired-refresh failure surfaces
+      // re-pair guidance instead of hatch/wake.
+      expect(mockGetGuardianAccessToken.mock.calls[0]?.[5]).toEqual({ paired: true });
     });
 
     test("never issues a token-exchange request for a paired entry", async () => {

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -17,6 +17,7 @@ import {
   resolveConfigDir,
   resolveEnvironmentName,
   type CliInvocation,
+  type GuardianTokenOptions,
 } from "@vellumai/local-mode";
 import { isUsableRuntimeUrl, type Lockfile } from "@vellumai/local-mode/contract";
 
@@ -230,7 +231,10 @@ async function exchangeForGatewayToken(
   }
 }
 
-async function acquireGuardianToken(assistantId: string): Promise<string | null> {
+async function acquireGuardianToken(
+  assistantId: string,
+  options?: GuardianTokenOptions,
+): Promise<string | null> {
   if (!resolveCliInvocation) return null;
 
   const configDir = resolveConfigDir(process.env);
@@ -252,6 +256,7 @@ async function acquireGuardianToken(assistantId: string): Promise<string | null>
     invocation,
     true,
     { VELLUM_ENVIRONMENT: resolveEnvironmentName(process.env) },
+    options,
   );
 
   if (!tokenResult.ok) {
@@ -358,7 +363,7 @@ async function connectPairedAssistant(
   const pending: PendingConnect = { fingerprint };
   pendingConnects.set(assistantId, pending);
   try {
-    const guardianToken = await acquireGuardianToken(assistantId);
+    const guardianToken = await acquireGuardianToken(assistantId, { paired: true });
     if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
       log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId, runtimeUrl });
       return;
@@ -391,7 +396,7 @@ function openPairedConnection(
   });
 
   const onRefreshToken = async (): Promise<string | null> => {
-    const fresh = await acquireGuardianToken(assistantId);
+    const fresh = await acquireGuardianToken(assistantId, { paired: true });
     if (fresh) currentToken = fresh;
     return fresh;
   };

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -386,6 +386,11 @@ const upgrade = (assistantId?: unknown, options?: unknown): Promise<unknown> =>
     assistantId,
     options,
   ) as Promise<unknown>;
+const guardianToken = (assistantId?: unknown): Promise<unknown> =>
+  handlers["vellum:localMode:guardianToken"](
+    allowedEvent,
+    assistantId,
+  ) as Promise<unknown>;
 
 describe("lockfile IPC handlers", () => {
   beforeEach(() => {
@@ -599,13 +604,13 @@ describe("vellum:localMode:retire handler", () => {
   });
 });
 
-describe("vellum:localMode:unpair handler", () => {
-  // Matches the module's `resolveConfigDir(process.env)` under the
-  // production + XDG_CONFIG_HOME environment pinned above.
-  const configDir = path.join(configHomeDir, "vellum");
-  const tokenPath = (assistantId: string): string =>
-    path.join(configDir, "assistants", assistantId, "guardian-token.json");
+// Matches the module's `resolveConfigDir(process.env)` under the
+// production + XDG_CONFIG_HOME environment pinned above.
+const configDir = path.join(configHomeDir, "vellum");
+const tokenPath = (assistantId: string): string =>
+  path.join(configDir, "assistants", assistantId, "guardian-token.json");
 
+describe("vellum:localMode:unpair handler", () => {
   beforeEach(() => {
     fs.rmSync(lockfilePath, { force: true });
     fs.rmSync(path.join(configDir, "assistants"), {
@@ -752,5 +757,141 @@ describe("vellum:localMode:upgrade handler", () => {
     lastChild.emit("close", 0);
 
     await expect(pending).resolves.toEqual({ ok: true, version: "v1.2.3" });
+  });
+});
+
+describe("vellum:localMode:guardianToken handler", () => {
+  const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const PAST = new Date(Date.now() - 60_000).toISOString();
+
+  const writeToken = (
+    assistantId: string,
+    over: Record<string, unknown>,
+  ): void => {
+    fs.mkdirSync(path.dirname(tokenPath(assistantId)), { recursive: true });
+    fs.writeFileSync(
+      tokenPath(assistantId),
+      JSON.stringify({
+        guardianPrincipalId: "principal",
+        accessToken: "stored-token",
+        accessTokenExpiresAt: FUTURE,
+        refreshToken: "refresh",
+        refreshTokenExpiresAt: FUTURE,
+        refreshAfter: FUTURE,
+        isNew: false,
+        deviceId: "device",
+        leasedAt: new Date().toISOString(),
+        ...over,
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    fs.rmSync(lockfilePath, { force: true });
+    fs.rmSync(path.join(configDir, "assistants"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("returns a fresh token from the file without spawning the CLI", async () => {
+    writeToken("asst-g", {});
+
+    expect(await guardianToken("asst-g")).toEqual({
+      ok: true,
+      accessToken: "stored-token",
+    });
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("expired access token spawns `... gateway token refresh <id>` with the pinned env", async () => {
+    writeToken("asst-g", { accessTokenExpiresAt: PAST });
+
+    const pending = guardianToken("asst-g");
+    await tick();
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      [
+        "run",
+        path.join("/repo", "cli", "src", "index.ts"),
+        "gateway",
+        "token",
+        "refresh",
+        "asst-g",
+      ],
+    ]);
+    expect(
+      (spawnOptions[0] as { env?: NodeJS.ProcessEnv }).env?.VELLUM_ENVIRONMENT,
+    ).toBe("production");
+
+    lastChild.stdout.emit("data", Buffer.from("refreshed-token\n"));
+    lastChild.emit("close", 0);
+    expect(await pending).toEqual({ ok: true, accessToken: "refreshed-token" });
+  });
+
+  test("expired refresh token resolves a structured 401 with hatch/wake guidance", async () => {
+    writeToken("asst-g", {
+      accessTokenExpiresAt: PAST,
+      refreshTokenExpiresAt: PAST,
+    });
+
+    const result = (await guardianToken("asst-g")) as {
+      ok: boolean;
+      status: number;
+      error: string;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toContain("vellum hatch");
+    expect(result.error).toContain("vellum wake");
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("expired refresh token for a paired lockfile entry directs to re-pairing", async () => {
+    saveLockfileAssistant(
+      { assistantId: "paired-g", cloud: "paired", runtimeUrl: "https://h" },
+      "paired-g",
+    );
+    writeToken("paired-g", {
+      accessTokenExpiresAt: PAST,
+      refreshTokenExpiresAt: PAST,
+    });
+
+    const result = (await guardianToken("paired-g")) as {
+      ok: boolean;
+      status: number;
+      error: string;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toContain("vellum pair");
+    expect(result.error).toContain("vellum connect import");
+    expect(result.error).not.toContain("vellum hatch");
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("missing token file resolves a structured 404 without spawning", async () => {
+    expect(await guardianToken("asst-missing")).toEqual({
+      ok: false,
+      status: 404,
+      error: "Guardian token not found",
+    });
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("rejects a missing assistant id with a structured error", async () => {
+    expect(await guardianToken("")).toEqual({
+      ok: false,
+      status: 400,
+      error: "Missing assistantId",
+    });
+    expect(await guardianToken(undefined)).toEqual({
+      ok: false,
+      status: 400,
+      error: "Missing assistantId",
+    });
+    expect(spawnArgs).toHaveLength(0);
   });
 });

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -366,12 +366,21 @@ export const installLocalMode = (): void => {
       } catch (err) {
         return { ok: false, status: 500, error: (err as Error).message };
       }
+      // Paired entries have no local daemon, so token-failure guidance must
+      // say re-pair rather than hatch/wake.
+      const lockfile = getLockfileData(lockfilePaths);
+      const paired =
+        lockfile.ok &&
+        lockfile.data.assistants.some(
+          (a) => a.assistantId === assistantId && a.cloud === "paired",
+        );
       return getGuardianAccessToken(
         assistantId,
         configDir,
         invocation,
         true,
         guardianTokenEnv,
+        { paired },
       );
     },
   );

--- a/packages/local-mode/src/__tests__/guardian-token.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getGuardianAccessToken,
+  saveGuardianToken,
+  type GuardianTokenData,
+} from "../guardian-token";
+import type { CliInvocation } from "../util";
+
+// An invocation that would fail loudly if any tested branch spawned the CLI.
+const invocation: CliInvocation = { command: "false", baseArgs: [] };
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const PAST = new Date(Date.now() - 60_000).toISOString();
+
+function makeTokenData(over: Partial<GuardianTokenData>): GuardianTokenData {
+  return {
+    guardianPrincipalId: "principal",
+    accessToken: "access",
+    accessTokenExpiresAt: FUTURE,
+    refreshToken: "refresh",
+    refreshTokenExpiresAt: FUTURE,
+    refreshAfter: FUTURE,
+    isNew: false,
+    deviceId: "device",
+    leasedAt: new Date().toISOString(),
+    ...over,
+  };
+}
+
+describe("getGuardianAccessToken", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "guardian-token-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("returns the stored token while the access token is fresh", async () => {
+    saveGuardianToken(configDir, "asst-1", makeTokenData({}));
+
+    expect(
+      await getGuardianAccessToken("asst-1", configDir, invocation, true),
+    ).toEqual({ ok: true, accessToken: "access" });
+  });
+
+  test("returns a structured 404 when no token file exists", async () => {
+    expect(
+      await getGuardianAccessToken("missing", configDir, invocation, true),
+    ).toEqual({ ok: false, status: 404, error: "Guardian token not found" });
+  });
+
+  test("expired refresh token yields hatch/wake guidance by default", async () => {
+    saveGuardianToken(
+      configDir,
+      "asst-1",
+      makeTokenData({ accessTokenExpiresAt: PAST, refreshTokenExpiresAt: PAST }),
+    );
+
+    const result = await getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error: "Guardian token expired. Re-run `vellum hatch` or `vellum wake`.",
+    });
+  });
+
+  test("expired refresh token yields re-pair guidance for a paired entry", async () => {
+    saveGuardianToken(
+      configDir,
+      "asst-1",
+      makeTokenData({ accessTokenExpiresAt: PAST, refreshTokenExpiresAt: PAST }),
+    );
+
+    const result = await getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+      undefined,
+      { paired: true },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      error:
+        "Guardian token expired. Run `vellum pair` on the assistant's machine, then re-import it from the app's connect flow or with `vellum connect import`.",
+    });
+  });
+
+  test("an explicit paired: false keeps the hatch/wake guidance", async () => {
+    saveGuardianToken(
+      configDir,
+      "asst-1",
+      makeTokenData({ accessTokenExpiresAt: PAST, refreshTokenExpiresAt: PAST }),
+    );
+
+    const result = await getGuardianAccessToken(
+      "asst-1",
+      configDir,
+      invocation,
+      true,
+      undefined,
+      { paired: false },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("vellum hatch");
+  });
+});

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -57,12 +57,22 @@ export type TokenResult =
   | { ok: true; accessToken: string }
   | { ok: false; status: number; error: string };
 
+export interface GuardianTokenOptions {
+  /**
+   * True when the entry was imported from another machine via `vellum pair`.
+   * A paired entry has no local daemon, so expired-refresh guidance points at
+   * re-pairing instead of `vellum hatch`/`vellum wake`.
+   */
+  paired?: boolean;
+}
+
 export function getGuardianAccessToken(
   assistantId: string,
   configDir: string,
   invocation: CliInvocation,
   isLoopback: boolean,
   env?: Record<string, string>,
+  options?: GuardianTokenOptions,
 ): Promise<TokenResult> {
   if (!isLoopback) {
     return Promise.resolve({ ok: false, status: 403, error: "Forbidden" });
@@ -92,7 +102,9 @@ export function getGuardianAccessToken(
     return Promise.resolve({
       ok: false,
       status: 401,
-      error: "Guardian token expired — re-run `vellum hatch` or `vellum wake`",
+      error: options?.paired
+        ? "Guardian token expired. Run `vellum pair` on the assistant's machine, then re-import it from the app's connect flow or with `vellum connect import`."
+        : "Guardian token expired. Re-run `vellum hatch` or `vellum wake`.",
     });
   }
 

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -65,7 +65,11 @@ export type {
   LocalAssistantStatusResult,
 } from "./status";
 export { getGuardianAccessToken, saveGuardianToken } from "./guardian-token";
-export type { TokenResult, GuardianTokenData } from "./guardian-token";
+export type {
+  TokenResult,
+  GuardianTokenData,
+  GuardianTokenOptions,
+} from "./guardian-token";
 export {
   parseGatewayUrl,
   readAllowedGatewayPorts,


### PR DESCRIPTION
## Summary
- getGuardianAccessToken gains {paired} option; expired-refresh guidance now says re-pair and re-import instead of hatch/wake for paired entries
- macOS guardianToken IPC handler and host-proxy paired call site pass the flag
- First test coverage for the guardianToken IPC handler (fresh, refresh-spawn, expired-refresh both copies, missing file)

Part of plan: macos-paired-assistants.md (PR 10 of 10)