### PR TITLE
perf(macos): resolve paired gateway targets from the watched lockfile instead of per-request sync reads

### DIFF
--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
 import {
+  pairedGatewayTargetsFromLockfile,
   readAllowedGatewayPorts,
   readPairedGatewayTargets,
   resolveLocalConfigFromEnv,
@@ -62,7 +63,10 @@ import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
 import { installLoginItem, installLoginItemIpc } from "./login-item";
-import { installLockfileWatcher } from "./lockfile-watcher";
+import {
+  getWatchedLockfileSnapshot,
+  installLockfileWatcher,
+} from "./lockfile-watcher";
 import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
 import log from "./logger";
@@ -234,8 +238,14 @@ const registerAppProtocol = (): void => {
   const lockfilePaths = resolveLockfilePaths(process.env);
   const getAllowedGatewayPorts = (): Set<number> =>
     readAllowedGatewayPorts(lockfilePaths);
-  const getPairedGatewayTargets = (): Map<string, string> =>
-    readPairedGatewayTargets(lockfilePaths);
+  // Prefer the watcher's in-memory snapshot so paired requests never read
+  // disk; the direct read covers only the window before the watcher installs.
+  const getPairedGatewayTargets = (): Map<string, string> => {
+    const watched = getWatchedLockfileSnapshot();
+    return watched
+      ? pairedGatewayTargetsFromLockfile(watched)
+      : readPairedGatewayTargets(lockfilePaths);
+  };
   const { platformUrl } = resolveLocalConfigFromEnv(process.env);
 
   protocol.handle(APP_PROTOCOL, async (request) => {

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -106,6 +106,14 @@ mock.module("./session-token-store", () => ({
   getSessionToken: () => mockSessionToken,
 }));
 
+// The unpair handler refreshes the lockfile watcher so the paired-gateway
+// allowlist reflects the removal immediately. Stub the watcher module so
+// the test asserts the hook fires without installing a real poller.
+const refreshLockfileNowMock = mock(() => {});
+mock.module("./lockfile-watcher", () => ({
+  refreshLockfileNow: refreshLockfileNowMock,
+}));
+
 const { installLocalMode } = await import("./local-mode");
 const { resolveAllowedOrigin } = await import("./app-origin");
 
@@ -167,6 +175,7 @@ afterEach(() => {
   cliInstallerState.isInstalled = false;
   cliInstallerState.installError = null;
   mockSessionToken = null;
+  refreshLockfileNowMock.mockClear();
   delete process.env.VELLUM_CLI_PATH;
   for (const key of Object.keys(existsSyncOverrides)) {
     delete existsSyncOverrides[key];
@@ -632,6 +641,32 @@ describe("vellum:localMode:unpair handler", () => {
     expect(result.lockfile.assistants).toEqual([]);
     expect(fs.existsSync(tokenPath("paired-1"))).toBe(false);
     expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("a successful unpair refreshes the lockfile watcher in the same tick", () => {
+    saveLockfileAssistant(
+      { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://h" },
+      "paired-1",
+    );
+    refreshLockfileNowMock.mockClear();
+
+    const result = unpair("paired-1");
+
+    expect(result.ok).toBe(true);
+    expect(refreshLockfileNowMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed unpair does not refresh the lockfile watcher", () => {
+    saveLockfileAssistant(
+      { assistantId: "local-1", cloud: "local" },
+      "local-1",
+    );
+    refreshLockfileNowMock.mockClear();
+
+    const result = unpair("local-1");
+
+    expect(result.ok).toBe(false);
+    expect(refreshLockfileNowMock).not.toHaveBeenCalled();
   });
 
   test("refuses a non-paired entry", () => {

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -32,6 +32,7 @@ import {
   getBundledBunPath,
   getCliBinPath,
 } from "./cli-installer";
+import { refreshLockfileNow } from "./lockfile-watcher";
 import { getSessionToken } from "./session-token-store";
 
 /**
@@ -322,9 +323,14 @@ export const installLocalMode = (): void => {
         return { ok: false, error: "Missing assistantId" };
       }
       const result = unpairAssistant(lockfilePaths, configDir, assistantId);
-      return result.ok
-        ? { ok: true, lockfile: result.lockfile }
-        : { ok: false, error: result.error };
+      if (!result.ok) {
+        return { ok: false, error: result.error };
+      }
+      // The paired-gateway forward resolves its allowlist from the watcher's
+      // snapshot; refresh it now so the unpaired entry is rejected in the
+      // same tick instead of after the next poll.
+      refreshLockfileNow();
+      return { ok: true, lockfile: result.lockfile };
     },
   );
 

--- a/clients/macos/src/main/lockfile-watcher.ts
+++ b/clients/macos/src/main/lockfile-watcher.ts
@@ -103,6 +103,38 @@ const checkForChanges = (): void => {
 export const getWatchedLockfile = (): Lockfile => cachedLockfile;
 
 /**
+ * Return the cached lockfile, or null before {@link installLockfileWatcher}
+ * has produced a snapshot. Callers with a disk-reading fallback (the
+ * app-protocol paired-gateway forward) use the null to cover the startup
+ * window where the watcher is not installed yet.
+ */
+export const getWatchedLockfileSnapshot = (): Lockfile | null =>
+  lockfilePath ? cachedLockfile : null;
+
+/**
+ * Re-read the watched lockfile immediately, bypassing the poll interval and
+ * any pending debounce. For lockfile writes performed by this process (e.g.
+ * unpair) whose consumers must observe the change in the same tick rather
+ * than after the next poll. No-op before the watcher is installed.
+ */
+export const refreshLockfileNow = (): void => {
+  if (!lockfilePath) {
+    return;
+  }
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  try {
+    lastMtimeMs = fs.statSync(lockfilePath).mtimeMs;
+  } catch {
+    lastMtimeMs = 0;
+  }
+  cachedLockfile = readAndParse();
+  notifyListeners();
+};
+
+/**
  * Subscribe to lockfile changes. The listener fires whenever the lockfile's
  * mtime changes (debounced). Returns an unsubscribe function.
  */

--- a/packages/local-mode/src/__tests__/gateway-proxy.test.ts
+++ b/packages/local-mode/src/__tests__/gateway-proxy.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  pairedGatewayTargetsFromLockfile,
   parsePairedGatewayUrl,
   readAllowedGatewayPorts,
   readPairedGatewayTargets,
@@ -325,6 +326,72 @@ describe("resolvePairedGatewayProxyTarget", () => {
     expect(reads).toBe(0);
     resolvePairedGatewayProxyTarget("/__gateway-paired/abc/v1", counting);
     expect(reads).toBe(1);
+  });
+});
+
+describe("pairedGatewayTargetsFromLockfile", () => {
+  test("maps paired entries with usable runtimeUrls, excluding everything else", () => {
+    expect(
+      pairedGatewayTargetsFromLockfile({
+        assistants: [
+          {
+            assistantId: "paired-a",
+            cloud: "paired",
+            runtimeUrl: "https://gw.example.com",
+          },
+          {
+            assistantId: "paired-b",
+            cloud: "paired",
+            runtimeUrl: "http://192.0.2.10:8443/edge",
+          },
+          // Non-paired entries never become forwardable.
+          { assistantId: "local-a", cloud: "local" },
+          {
+            assistantId: "docker-a",
+            cloud: "docker",
+            runtimeUrl: "http://localhost:7930",
+          },
+          {
+            assistantId: "remote-a",
+            cloud: "gcp",
+            runtimeUrl: "https://assistant.example.com:8443",
+          },
+          // Paired entries without a usable absolute http(s) runtimeUrl are
+          // excluded rather than forwarded blind.
+          { assistantId: "paired-no-url", cloud: "paired" },
+          {
+            assistantId: "paired-bad-scheme",
+            cloud: "paired",
+            runtimeUrl: "ssh://gw.example.com",
+          },
+          {
+            assistantId: "paired-relative",
+            cloud: "paired",
+            runtimeUrl: "/not-absolute",
+          },
+          // Malformed entries are tolerated, not fatal.
+          null,
+          "not-an-object",
+          { cloud: "paired", runtimeUrl: "https://gw.example.com" },
+          {
+            assistantId: "",
+            cloud: "paired",
+            runtimeUrl: "https://gw.example.com",
+          },
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ["paired-a", "https://gw.example.com"],
+        ["paired-b", "http://192.0.2.10:8443/edge"],
+      ]),
+    );
+  });
+
+  test("returns an empty map for a lockfile with no assistants", () => {
+    expect(pairedGatewayTargetsFromLockfile({ assistants: [] })).toEqual(
+      new Map(),
+    );
   });
 });
 

--- a/packages/local-mode/src/gateway-proxy.ts
+++ b/packages/local-mode/src/gateway-proxy.ts
@@ -306,41 +306,54 @@ export function readAllowedGatewayPorts(lockfilePaths: string[]): Set<number> {
 }
 
 /**
- * Read the paired-gateway allowlist from the lockfile: assistantId to the
- * recorded remote `runtimeUrl`, for entries whose resolved cloud is "paired"
- * and whose runtimeUrl is usable ({@link isUsableRuntimeUrl}). Tolerant of
- * malformed entries. Path selection matches the unpair write path
- * (`readRawLockfile` in lockfile.ts): the first readable, parseable lockfile
- * is authoritative even when it yields no targets, so a pairing removed by an
- * unpair write can never survive in a stale fallback file's allowlist.
+ * Compute the paired-gateway allowlist from a lockfile's assistant entries:
+ * assistantId to the recorded remote `runtimeUrl`, for entries whose resolved
+ * cloud is "paired" and whose runtimeUrl is usable
+ * ({@link isUsableRuntimeUrl}). Tolerant of malformed entries. Pure, so a host
+ * holding an in-memory lockfile snapshot (e.g. the Electron lockfile watcher)
+ * derives the allowlist without touching disk on the request path.
+ */
+export function pairedGatewayTargetsFromLockfile(lockfile: {
+  assistants: readonly unknown[];
+}): Map<string, string> {
+  const targets = new Map<string, string>();
+  for (const entry of lockfile.assistants) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const assistant = entry as Record<string, unknown>;
+    if (resolveCloud(assistant) !== "paired") {
+      continue;
+    }
+    const { assistantId, runtimeUrl } = assistant;
+    if (typeof assistantId !== "string" || assistantId === "") {
+      continue;
+    }
+    if (typeof runtimeUrl !== "string" || !isUsableRuntimeUrl(runtimeUrl)) {
+      continue;
+    }
+    targets.set(assistantId, runtimeUrl);
+  }
+  return targets;
+}
+
+/**
+ * Read the paired-gateway allowlist from the lockfile on disk
+ * ({@link pairedGatewayTargetsFromLockfile} over the first readable
+ * candidate). Path selection matches the unpair write path (`readRawLockfile`
+ * in lockfile.ts): the first readable, parseable lockfile is authoritative
+ * even when it yields no targets, so a pairing removed by an unpair write can
+ * never survive in a stale fallback file's allowlist.
  */
 export function readPairedGatewayTargets(
   lockfilePaths: string[],
 ): Map<string, string> {
-  const targets = new Map<string, string>();
   for (const candidate of lockfilePaths) {
     const read = readLockfileAssistantEntries(candidate);
     if (read.kind !== "ok") {
       continue;
     }
-    for (const entry of read.assistants) {
-      if (!entry || typeof entry !== "object") {
-        continue;
-      }
-      const assistant = entry as Record<string, unknown>;
-      if (resolveCloud(assistant) !== "paired") {
-        continue;
-      }
-      const { assistantId, runtimeUrl } = assistant;
-      if (typeof assistantId !== "string" || assistantId === "") {
-        continue;
-      }
-      if (typeof runtimeUrl !== "string" || !isUsableRuntimeUrl(runtimeUrl)) {
-        continue;
-      }
-      targets.set(assistantId, runtimeUrl);
-    }
-    return targets;
+    return pairedGatewayTargetsFromLockfile({ assistants: read.assistants });
   }
-  return targets;
+  return new Map<string, string>();
 }

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -71,6 +71,7 @@ export {
   readAllowedGatewayPorts,
   resolveGatewayProxyTarget,
   parsePairedGatewayUrl,
+  pairedGatewayTargetsFromLockfile,
   readPairedGatewayTargets,
   resolvePairedGatewayProxyTarget,
   sanitizePairedForwardHeaders,


### PR DESCRIPTION
## Summary
- Extract pure pairedGatewayTargetsFromLockfile and back the Electron paired forward with the watched lockfile snapshot
- Disk read remains only as a startup fallback before the watcher primes
- Unpair forces a watcher refresh so the allowlist drops the entry immediately

Part of plan: macos-paired-assistants.md (PR 2 of 10)