### PR TITLE
feat(web): simplify bell notification rows and move the unread dot left

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -75,14 +75,17 @@ const UNREAD_DOT = 'data-testid="notifications-bell-unread-dot"';
 const UNREAD_LABEL = 'aria-label="Notifications (unread)"';
 const READ_LABEL = 'aria-label="Notifications"';
 
+const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
+
 function feedItem(overrides: Partial<FeedItem>): FeedItem {
+  const timestamp = new Date(Date.now() - THREE_HOURS_MS).toISOString();
   return {
     id: "item-1",
     type: "notification",
     priority: 50,
     summary: "Something happened",
-    timestamp: "2026-07-16T10:00:00Z",
-    createdAt: "2026-07-16T10:00:00Z",
+    timestamp,
+    createdAt: timestamp,
     status: "new",
     ...overrides,
   };
@@ -155,7 +158,7 @@ describe("NotificationsBell unread dot", () => {
 });
 
 describe("NotificationsBell panel", () => {
-  test("renders each row as a card with category, title, and preview", async () => {
+  test("renders each row with title, timestamp, and preview", async () => {
     feedRef.items = [
       feedItem({
         category: "background",
@@ -166,11 +169,26 @@ describe("NotificationsBell panel", () => {
 
     await openBell();
 
-    expect(screen.getByText("Background")).toBeTruthy();
     expect(screen.getByText("Watcher job failed")).toBeTruthy();
+    expect(screen.getByText("3h ago")).toBeTruthy();
     expect(
       screen.getByText("The watcher job could not reach the upstream service."),
     ).toBeTruthy();
+  });
+
+  test("rows drop the category chip and the source label", async () => {
+    feedRef.items = [
+      feedItem({
+        category: "background",
+        sourceLabel: "Heartbeat",
+        title: "Watcher job failed",
+      }),
+    ];
+
+    await openBell();
+
+    expect(screen.queryByText("Background")).toBeNull();
+    expect(screen.queryByText("Heartbeat")).toBeNull();
   });
 
   test("keeps its own unread dot distinct from the rows'", async () => {

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -33,11 +33,11 @@ export interface ActivityLocationState {
 }
 
 // Caps the visible list at five compact cards plus the four 8px gaps between
-// them. A compact card is 94.25px tall: 2px borders, 16px padding, a 32px meta
-// row (sized by the h-8 hover actions), two 2px gaps, a 19.25px title line, and
-// a 21px preview line. 5 * 94.25 + 4 * 8 = 503.25, rounded up here. Older
-// notifications stay reachable by scrolling.
-const LIST_MAX_HEIGHT_CLASS = "max-h-[504px]";
+// them. A compact card is 73px tall: 2px borders, 16px padding, a 32px title
+// line (sized by the h-8 hover actions that share it with the timestamp), a 2px
+// gap, and a 21px preview line. 5 * 73 + 4 * 8 = 397. Older notifications stay
+// reachable by scrolling.
+const LIST_MAX_HEIGHT_CLASS = "max-h-[397px]";
 
 /**
  * Notification bell for the top nav: a ghost icon button with an unread dot

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -236,24 +236,85 @@ describe("HomeRecapRow card content", () => {
     },
   );
 
-  test("marks an unread item with a dot", () => {
+  test("marks an unread item with a dot inside the gutter", () => {
     renderRow();
 
-    expect(screen.getByTestId("home-recap-row-unread-dot")).toBeTruthy();
+    const dot = screen.getByTestId("home-recap-row-unread-dot");
+
+    expect(dot.parentElement).toBe(
+      screen.getByTestId("home-recap-row-dot-gutter"),
+    );
   });
 
-  test("omits the dot for an already-read item", () => {
-    renderRow({ item: makeItem({ status: "seen" }) });
+  test.each(["comfortable", "compact"] as const)(
+    "%s density keeps the dot's gutter for an already-read item",
+    (density) => {
+      renderRow({ density, item: makeItem({ status: "seen" }) });
 
-    expect(screen.queryByTestId("home-recap-row-unread-dot")).toBeNull();
+      expect(screen.getByTestId("home-recap-row-dot-gutter")).toBeTruthy();
+      expect(screen.queryByTestId("home-recap-row-unread-dot")).toBeNull();
+    },
+  );
+
+  test("the gutter leads the card, with the content stack beside it", () => {
+    renderRow();
+    const gutter = screen.getByTestId("home-recap-row-dot-gutter");
+    const title = screen.getByTestId("home-recap-row-title");
+
+    expect(gutter.nextElementSibling?.contains(title)).toBe(true);
+  });
+});
+
+describe("HomeRecapRow density", () => {
+  test("comfortable keeps the category chip and the source label", () => {
+    renderRow({ item: makeItem({ sourceLabel: "Heartbeat" }) });
+
+    expect(screen.getByText("Background")).toBeTruthy();
+    expect(screen.getByText("Heartbeat")).toBeTruthy();
   });
 
-  test("compact density renders and differs from the comfortable default", () => {
-    const comfortable = renderRow().container.innerHTML;
-    cleanup();
-    const { container } = renderRow({ density: "compact" });
+  test("compact drops the category chip and the source label", () => {
+    renderRow({
+      density: "compact",
+      item: makeItem({ sourceLabel: "Heartbeat" }),
+    });
+
+    expect(screen.queryByText("Background")).toBeNull();
+    expect(screen.queryByText("Heartbeat")).toBeNull();
+  });
+
+  test("compact keeps the title, the timestamp, and the preview", () => {
+    renderRow({ density: "compact" });
 
     expect(screen.getByText("Watcher job failed")).toBeTruthy();
-    expect(container.innerHTML).not.toBe(comfortable);
+    expect(screen.getByText("3d ago")).toBeTruthy();
+    expect(
+      screen.getByText("The watcher job could not reach the upstream service."),
+    ).toBeTruthy();
+  });
+
+  // happy-dom does no layout, so this asserts the structure the card's
+  // no-overlap behaviour rests on: one line carrying both the title and the
+  // timestamp, with the title in its own element so it can shrink.
+  test("a long compact title shares its line with the timestamp", () => {
+    const longTitle = "Averylongunbreakablenotificationtitle".repeat(4);
+    renderRow({ density: "compact", item: makeItem({ title: longTitle }) });
+
+    const title = screen.getByTestId("home-recap-row-title");
+    const timestampLine =
+      screen.getByText("3d ago").parentElement?.parentElement;
+
+    expect(title.textContent).toBe(longTitle);
+    expect(timestampLine?.contains(title)).toBe(true);
+  });
+
+  test("comfortable puts the title under the meta row, not on it", () => {
+    renderRow();
+
+    const title = screen.getByTestId("home-recap-row-title");
+    const timestampLine =
+      screen.getByText("3d ago").parentElement?.parentElement;
+
+    expect(timestampLine?.contains(title)).toBe(false);
   });
 });

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -52,30 +52,42 @@ const GENERIC_SOURCE_LABELS = new Set(["Conversation", "Other"]);
 /**
  * Name for an item with neither a title nor a summary that renders as text, so
  * the card's click target always has an accessible name. The category is not
- * used here: its chip is already on the card, and repeating it would read the
- * same word twice.
+ * used here: where the card carries its chip, repeating it would read the same
+ * word twice.
  */
 const UNNAMED_ITEM_TITLE = "Notification";
 
 export type HomeRecapRowDensity = "comfortable" | "compact";
 
 interface DensityStyle {
-  /** Card padding and the gap between the meta row, title, and preview. */
+  /** Card padding. */
   card: string;
+  /** Gap between the rows of the content stack. */
+  stack: string;
   titleVariant: TypographyVariant;
   clamp: string;
+  /**
+   * Whether the first line is a meta row naming the item's category and
+   * source, with the title on its own line under it. Without that row the
+   * title takes the first line and shares it with the timestamp.
+   */
+  showsMetaRow: boolean;
 }
 
 const DENSITY_STYLES: Record<HomeRecapRowDensity, DensityStyle> = {
   comfortable: {
-    card: "gap-[var(--app-spacing-xs)] p-[var(--app-spacing-md)]",
+    card: "p-[var(--app-spacing-md)]",
+    stack: "gap-[var(--app-spacing-xs)]",
     titleVariant: "title-small",
     clamp: "line-clamp-2",
+    showsMetaRow: true,
   },
   compact: {
-    card: "gap-[var(--app-spacing-xxs)] p-[var(--app-spacing-sm)]",
+    card: "p-[var(--app-spacing-sm)]",
+    stack: "gap-[var(--app-spacing-xxs)]",
     titleVariant: "body-medium-default",
     clamp: "line-clamp-1",
+    showsMetaRow: false,
   },
 };
 
@@ -129,10 +141,29 @@ export function HomeRecapRow({
     [title, item.summary],
   );
 
+  // leading-snug: the title-small token is line-height:1, and line-clamp's
+  // overflow clipping would cut descenders without real line height.
+  const titleLine = (
+    <Typography
+      data-testid="home-recap-row-title"
+      variant={densityStyle.titleVariant}
+      className={cn(
+        "leading-snug text-[var(--content-default)]",
+        // On the first line the title has to yield to the timestamp beside it,
+        // so it shrinks and ellipsizes rather than pushing the timestamp out.
+        densityStyle.showsMetaRow
+          ? densityStyle.clamp
+          : "min-w-0 flex-1 truncate",
+      )}
+    >
+      {title}
+    </Typography>
+  );
+
   return (
     <div
       className={cn(
-        "group relative flex w-full flex-col",
+        "group relative flex w-full items-start gap-[var(--app-spacing-sm)]",
         "rounded-[var(--radius-lg)] border border-[var(--border-base)]",
         "transition-[background-color,opacity] duration-150",
         densityStyle.card,
@@ -152,127 +183,136 @@ export function HomeRecapRow({
         className="absolute inset-0 w-full cursor-pointer rounded-[var(--radius-lg)]"
       />
 
-      <div className="pointer-events-none relative flex items-center gap-[var(--app-spacing-sm)]">
-        <FeedCategoryChip category={item.category} />
-
-        {sourceLabel !== null && (
-          <Typography
-            variant="body-small-default"
-            className="min-w-0 truncate text-[var(--content-tertiary)]"
-          >
-            {sourceLabel}
-          </Typography>
-        )}
-
-        {/* Timestamp and actions share one grid cell so the card keeps a stable
-            width as they cross-fade. */}
-        <span className="ml-auto grid shrink-0 items-center justify-items-end">
+      {/* The gutter is reserved whether or not the item is unread, so a card
+          keeps the same text alignment once it is marked read. h-8 is the
+          height of the first line, which the h-8 hover actions set, so the dot
+          sits against the meta row or the title depending on density. */}
+      <div
+        data-testid="home-recap-row-dot-gutter"
+        className="pointer-events-none relative flex h-8 w-2 shrink-0 items-center"
+      >
+        {isUnread && (
           <span
-            className={cn(
-              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-xs)]",
-              "transition-opacity duration-150",
-              "group-hover:opacity-0 group-focus-within:opacity-0",
-            )}
-          >
+            data-testid="home-recap-row-unread-dot"
+            aria-hidden="true"
+            className="h-2 w-2 rounded-full bg-[var(--system-mid-strong)]"
+          />
+        )}
+      </div>
+
+      <div
+        className={cn(
+          "pointer-events-none relative flex min-w-0 flex-1 flex-col",
+          densityStyle.stack,
+        )}
+      >
+        <div className="flex items-center gap-[var(--app-spacing-sm)]">
+          {densityStyle.showsMetaRow ? (
+            <>
+              <FeedCategoryChip category={item.category} />
+
+              {sourceLabel !== null && (
+                <Typography
+                  variant="body-small-default"
+                  className="min-w-0 truncate text-[var(--content-tertiary)]"
+                >
+                  {sourceLabel}
+                </Typography>
+              )}
+            </>
+          ) : (
+            titleLine
+          )}
+
+          {/* Timestamp and actions share one grid cell so the card keeps a
+              stable width as they cross-fade. */}
+          <span className="ml-auto grid shrink-0 items-center justify-items-end">
             <Typography
               variant="body-small-default"
-              className="text-[var(--content-tertiary)]"
+              className={cn(
+                "col-start-1 row-start-1 text-[var(--content-tertiary)]",
+                "transition-opacity duration-150",
+                "group-hover:opacity-0 group-focus-within:opacity-0",
+              )}
             >
               {formatRelativeDate(item.timestamp)}
             </Typography>
-            {isUnread && (
-              <span
-                data-testid="home-recap-row-unread-dot"
-                aria-hidden="true"
-                className="h-2 w-2 shrink-0 rounded-full bg-[var(--system-mid-strong)]"
-              />
-            )}
-          </span>
 
-          <span
-            className={cn(
-              "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
-              "pointer-events-none opacity-0 transition-opacity duration-150",
-              "group-hover:pointer-events-auto group-hover:opacity-100",
-              "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-            )}
-          >
-            {isRestore ? (
-              <HoverIconButton
-                label="Restore"
-                onClick={() => onDismiss(item.id)}
-                className="w-auto gap-[var(--app-spacing-xs)] px-2"
-              >
-                <RotateCcw width={16} height={16} aria-hidden="true" />
-                <span className="text-body-small-default">Restore</span>
-              </HoverIconButton>
-            ) : (
-              <>
-                {onToggleRead && (
-                  <HoverIconButton
-                    label={isUnread ? "Mark as read" : "Mark as unread"}
-                    onClick={() =>
-                      onToggleRead(item.id, isUnread ? "seen" : "new")
-                    }
-                  >
-                    {isUnread ? (
-                      <MailOpen width={16} height={16} />
-                    ) : (
-                      <Mail width={16} height={16} />
-                    )}
-                  </HoverIconButton>
-                )}
-                {onGoToThread &&
-                  item.conversationId &&
-                  (!validConversationIds ||
-                    validConversationIds.has(item.conversationId)) && (
+            <span
+              className={cn(
+                "col-start-1 row-start-1 flex items-center gap-[var(--app-spacing-sm)]",
+                "pointer-events-none opacity-0 transition-opacity duration-150",
+                "group-hover:pointer-events-auto group-hover:opacity-100",
+                "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+              )}
+            >
+              {isRestore ? (
+                <HoverIconButton
+                  label="Restore"
+                  onClick={() => onDismiss(item.id)}
+                  className="w-auto gap-[var(--app-spacing-xs)] px-2"
+                >
+                  <RotateCcw width={16} height={16} aria-hidden="true" />
+                  <span className="text-body-small-default">Restore</span>
+                </HoverIconButton>
+              ) : (
+                <>
+                  {onToggleRead && (
                     <HoverIconButton
-                      label="Go to thread"
-                      onClick={() => {
-                        if (isUnread && onToggleRead) {
-                          onToggleRead(item.id, "seen");
-                        }
-                        onGoToThread(item.conversationId!);
-                      }}
+                      label={isUnread ? "Mark as read" : "Mark as unread"}
+                      onClick={() =>
+                        onToggleRead(item.id, isUnread ? "seen" : "new")
+                      }
                     >
-                      <MessageSquare width={16} height={16} />
+                      {isUnread ? (
+                        <MailOpen width={16} height={16} />
+                      ) : (
+                        <Mail width={16} height={16} />
+                      )}
                     </HoverIconButton>
                   )}
-                <HoverIconButton
-                  label="Dismiss"
-                  onClick={() => onDismiss(item.id)}
-                >
-                  <Trash2 width={16} height={16} />
-                </HoverIconButton>
-              </>
-            )}
+                  {onGoToThread &&
+                    item.conversationId &&
+                    (!validConversationIds ||
+                      validConversationIds.has(item.conversationId)) && (
+                      <HoverIconButton
+                        label="Go to thread"
+                        onClick={() => {
+                          if (isUnread && onToggleRead) {
+                            onToggleRead(item.id, "seen");
+                          }
+                          onGoToThread(item.conversationId!);
+                        }}
+                      >
+                        <MessageSquare width={16} height={16} />
+                      </HoverIconButton>
+                    )}
+                  <HoverIconButton
+                    label="Dismiss"
+                    onClick={() => onDismiss(item.id)}
+                  >
+                    <Trash2 width={16} height={16} />
+                  </HoverIconButton>
+                </>
+              )}
+            </span>
           </span>
-        </span>
-      </div>
+        </div>
 
-      {/* leading-snug: the title-small token is line-height:1, and line-clamp's
-          overflow clipping would cut descenders without real line height. */}
-      <Typography
-        variant={densityStyle.titleVariant}
-        className={cn(
-          "pointer-events-none relative leading-snug text-[var(--content-default)]",
-          densityStyle.clamp,
+        {densityStyle.showsMetaRow && titleLine}
+
+        {preview !== null && (
+          <Typography
+            variant="body-medium-lighter"
+            className={cn(
+              "leading-normal text-[var(--content-secondary)]",
+              densityStyle.clamp,
+            )}
+          >
+            {preview}
+          </Typography>
         )}
-      >
-        {title}
-      </Typography>
-
-      {preview !== null && (
-        <Typography
-          variant="body-medium-lighter"
-          className={cn(
-            "pointer-events-none relative leading-normal text-[var(--content-secondary)]",
-            densityStyle.clamp,
-          )}
-        >
-          {preview}
-        </Typography>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The notifications bell drops the category chip and source label, and puts the timestamp inline with the title, right-aligned, with the title truncating so the two never collide.
- The unread dot moves to a reserved left gutter in both densities, so rows stay aligned when an item is marked read.
- The Activity page keeps its category chip and source label.