### PR TITLE
fix(web): collapse the iOS visibility+app_state lifecycle double-publish at the bus source

### DIFF
--- a/clients/web/docs/EVENT_BUS.md
+++ b/clients/web/docs/EVENT_BUS.md
@@ -41,6 +41,7 @@ Centralizing through a bus also gives us:
 | `clients/web/src/hooks/use-bus-subscription.ts` | React hook wrapping `useEffect` + `subscribe` with a stable handler ref so inline arrows don't re-register on every render. |
 | `clients/web/src/hooks/use-event-bus-init.ts` | Thin React adapter. Wires the signal sources at mount and calls `sseService.attach` whenever the active assistant changes. Mounted exactly once by `RootLayout` so the bus is alive on every authenticated route. |
 | `clients/web/src/runtime/event-sources/*` | One file per host-environment signal (DOM visibility, network online/offline, Capacitor app state, Electron `powerMonitor`, Electron deep links). Each calls `publish` directly and returns an unsubscribe. |
+| `clients/web/src/runtime/event-sources/lifecycle-edge.ts` | Not a source: the shared seam the DOM-visibility and Capacitor app-state sources publish through. Collapses their two reports of one physical foreground / background edge into a single `app.resume` / `app.hidden`. |
 | `clients/web/src/lib/lifecycle-diagnostics.ts` | Bus consumer that records `app.*` / `power.*` signals into the durable lifecycle diagnostics ring so support bundles show whether any resume / visibility / network signal fired. Attached once alongside the signal sources in `use-event-bus-init.ts`. |
 | `clients/web/src/assistant/sse-service.ts` | Non-React owner of the assistant-scoped SSE connection. Opens the stream, republishes envelopes as `sse.event`, drives the bounce policy from `app.*` / `power.*` / `reachability.*` signals. |
 
@@ -64,8 +65,8 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 | `sse.event` | `AssistantEventEnvelope` | Every event the bus-owned SSE connection sees. The envelope carries transport metadata (`seq`, `conversationId`, `emittedAt`); subscribers narrow on `envelope.message.type` and filter on `envelope.conversationId` themselves. |
 | `sse.opened` | `{ assistantId; cause: "fresh" \| "error" \| "watchdog" \| "resume" \| "debug" \| "anchor" }` | After each successful (re)open. `cause` lets consumers distinguish a fresh connection from a reconnect. `"debug"` is a manual `_vellumDebug.events.reconnectClient()` trigger; `"anchor"` is a cold-start anchored-replay reopen. |
 | `sse.closed` | `{ reason }` | Transport error on the SSE connection. Not published for intentional teardowns (hidden tab, reachability bounce). |
-| `app.resume` | `{ signal: "visibility" \| "app_state" \| "online" }` | Page visible, app foregrounded, or network came back online. |
-| `app.hidden` | `{ signal: "visibility" \| "app_state" }` | Page hidden or app backgrounded. |
+| `app.resume` | `{ signal: "visibility" \| "app_state" \| "online" }` | Page visible, app foregrounded, or network came back online. At most one per physical foreground edge: iOS reports the same edge twice (`visibilitychange` and Capacitor `appStateChange`, milliseconds apart) and `runtime/event-sources/lifecycle-edge.ts` collapses the pair, keeping the label of whichever source arrived first. `signal: "online"` is outside that dedup and always fires. |
+| `app.hidden` | `{ signal: "visibility" \| "app_state" }` | Page hidden or app backgrounded. Deduped per physical edge exactly like `app.resume`. Only repeats of the same edge collapse, so a hide landing between two foregrounds is always delivered. |
 | `app.online` | `{}` | `window.online` fired. Always accompanies a paired `app.resume{signal:"online"}`. |
 | `app.offline` | `{}` | `window.offline` fired. |
 | `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded; the bus bounces its SSE. |
@@ -166,6 +167,9 @@ Rules:
 2. **No `bus` parameter.** Sources call `publish` directly from
    `@/lib/event-bus`. Tests spy on `eventBus.publish` via
    `spyOn(eventBus, "publish")` after `import * as eventBus from "@/lib/event-bus"`.
+   The lifecycle pair is the one exception: the DOM-visibility and
+   Capacitor app-state sources call `publishLifecycleEdge` instead, so
+   the edge they both observe reaches the bus once.
 3. **No-op off-platform.** If the source is platform-conditioned
    (Capacitor-only, Electron-only), early-return a no-op
    unsubscribe. `useEventBusInit` calls every source unconditionally.
@@ -210,6 +214,13 @@ Rules:
   visibility, app foregrounding, AND network online. A handler that
   only cares about real foregrounding can early-return when
   `signal === "online"` (see `use-home-feed-query.ts`).
+- **One resume per foreground, plus a separate `"online"`.** A handler
+  does not have to collapse the iOS `"visibility"` + `"app_state"`
+  double-fire itself: `lifecycle-edge.ts` publishes that pair once, and
+  which of the two labels survives depends on which source the OS
+  reached first, so treat them as interchangeable. The `"online"`
+  caveat above still stands, because a reachability flip is published
+  independently and can land right next to a foreground.
 
 ## Common patterns
 

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -32,10 +32,10 @@ import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
  * `"visibility"`: `document.visibilitychange` fired with
  * `visibilityState === "visible"` on a web client.
  * `"app_state"`: Capacitor `App.appStateChange` fired with `isActive`
- * in the iOS native shell. Web + Capacitor consumers must dedup
- * `"visibility"` and `"app_state"` themselves when both arrive in
- * close succession (the bus does not — its purpose is to deliver
- * every signal it sees).
+ * in the iOS native shell. Both describe the same physical edge on iOS,
+ * where they fire milliseconds apart, so
+ * `runtime/event-sources/lifecycle-edge.ts` publishes the pair once and
+ * consumers see either label depending on which source arrived first.
  * `"online"`: `window.online` fired after `navigator.onLine` flipped
  * back to true; surfaced as a resume so consumers that just want
  * "we're probably stale, refresh" can subscribe to a single channel.

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.ts
@@ -1,5 +1,5 @@
-import { publish } from "@/lib/event-bus";
 import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
+import { publishLifecycleEdge } from "@/runtime/event-sources/lifecycle-edge";
 
 /**
  * Capacitor iOS shell's `App.appStateChange` →
@@ -9,6 +9,10 @@ import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
  * `publishVisibilitySource` / `publishWindowOnlineSource`
  * / `publishElectronPowerSource` instead.
  *
+ * On iOS `visibilitychange` fires for the same physical edge, so both this
+ * source and `publishVisibilitySource` go through
+ * `runtime/event-sources/lifecycle-edge.ts` and the bus sees the edge once.
+ *
  * Lazy inline `@capacitor/app` import per CAPACITOR.md's "lazy-import rule".
  */
 export function publishCapacitorAppStateSource(): () => void {
@@ -16,9 +20,9 @@ export function publishCapacitorAppStateSource(): () => void {
     const { App } = await import("@capacitor/app");
     return App.addListener("appStateChange", ({ isActive }) => {
       if (isActive) {
-        publish("app.resume", { signal: "app_state" });
+        publishLifecycleEdge("resume", "app_state");
       } else {
-        publish("app.hidden", { signal: "app_state" });
+        publishLifecycleEdge("hidden", "app_state");
       }
     });
   });

--- a/clients/web/src/runtime/event-sources/dom-visibility.ts
+++ b/clients/web/src/runtime/event-sources/dom-visibility.ts
@@ -1,4 +1,4 @@
-import { publish } from "@/lib/event-bus";
+import { publishLifecycleEdge } from "@/runtime/event-sources/lifecycle-edge";
 
 /**
  * `document.visibilitychange` → `app.resume(signal: "visibility")` on
@@ -6,10 +6,10 @@ import { publish } from "@/lib/event-bus";
  * bus is the consumer; SSE policy (in `assistant/sse-service.ts`)
  * teardowns on hidden and reopens on resume.
  *
- * The Capacitor iOS shell fires `appStateChange` too, which the bus
- * sees through `publishCapacitorAppStateSource` with `signal: "app_state"`.
- * Consumers that want to dedup between the two collapse them on their
- * own — the bus delivers every signal it sees.
+ * The Capacitor iOS shell fires `appStateChange` for the same physical
+ * edge, which the bus sees through `publishCapacitorAppStateSource` with
+ * `signal: "app_state"`. Both go through
+ * `runtime/event-sources/lifecycle-edge.ts`, which publishes the edge once.
  *
  * Browser-only; the caller is responsible for not invoking this in an
  * environment without `document` (SSR / Node). `useEventBusInit` guards
@@ -18,9 +18,9 @@ import { publish } from "@/lib/event-bus";
 export function publishVisibilitySource(): () => void {
   const handler = () => {
     if (document.visibilityState === "hidden") {
-      publish("app.hidden", { signal: "visibility" });
+      publishLifecycleEdge("hidden", "visibility");
     } else {
-      publish("app.resume", { signal: "visibility" });
+      publishLifecycleEdge("resume", "visibility");
     }
   };
   document.addEventListener("visibilitychange", handler);

--- a/clients/web/src/runtime/event-sources/lifecycle-edge.test.ts
+++ b/clients/web/src/runtime/event-sources/lifecycle-edge.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pins the lifecycle-edge dedup contract:
+ *   - the iOS visibility + app_state pair collapses into one publish;
+ *   - whichever source reaches the edge first keeps its `signal` label;
+ *   - an opposite edge is never swallowed, so a hidden between two resumes
+ *     still reaches the SSE teardown policy;
+ *   - a repeat of the same edge past the window is a real edge again.
+ *
+ * The module reads `Date.now`, so the clock is driven with bun:test's
+ * `setSystemTime` and restored in `afterEach`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  spyOn,
+  test,
+} from "bun:test";
+
+import * as eventBus from "@/lib/event-bus";
+import {
+  __resetLifecycleEdgeForTests,
+  publishLifecycleEdge,
+} from "@/runtime/event-sources/lifecycle-edge";
+
+const publishSpy = spyOn(eventBus, "publish");
+
+const START = new Date("2026-01-01T00:00:00.000Z").getTime();
+
+/** Move the clock to `offsetMs` past the start of the current test. */
+const setClock = (offsetMs: number): void => {
+  setSystemTime(new Date(START + offsetMs));
+};
+
+beforeEach(() => {
+  setClock(0);
+  __resetLifecycleEdgeForTests();
+  publishSpy.mockClear();
+});
+
+afterEach(() => {
+  setSystemTime();
+  publishSpy.mockClear();
+});
+
+describe("publishLifecycleEdge", () => {
+  test("collapses the visibility + app_state resume pair into one publish", () => {
+    publishLifecycleEdge("resume", "visibility");
+    setClock(5);
+    publishLifecycleEdge("resume", "app_state");
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith("app.resume", {
+      signal: "visibility",
+    });
+  });
+
+  test("keeps the label of whichever source reached the resume edge first", () => {
+    publishLifecycleEdge("resume", "app_state");
+    setClock(5);
+    publishLifecycleEdge("resume", "visibility");
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith("app.resume", {
+      signal: "app_state",
+    });
+  });
+
+  test("collapses the hidden pair the same way", () => {
+    publishLifecycleEdge("hidden", "visibility");
+    setClock(5);
+    publishLifecycleEdge("hidden", "app_state");
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith("app.hidden", {
+      signal: "visibility",
+    });
+  });
+
+  test("never swallows a hidden edge between two resumes inside the window", () => {
+    publishLifecycleEdge("resume", "visibility");
+    setClock(100);
+    publishLifecycleEdge("hidden", "visibility");
+    setClock(200);
+    publishLifecycleEdge("resume", "visibility");
+
+    expect(publishSpy.mock.calls).toEqual([
+      ["app.resume", { signal: "visibility" }],
+      ["app.hidden", { signal: "visibility" }],
+      ["app.resume", { signal: "visibility" }],
+    ]);
+  });
+
+  test("publishes a repeat of the same edge once the window has elapsed", () => {
+    publishLifecycleEdge("resume", "visibility");
+    setClock(1_500);
+    publishLifecycleEdge("resume", "app_state");
+
+    expect(publishSpy).toHaveBeenCalledTimes(2);
+    expect(publishSpy).toHaveBeenLastCalledWith("app.resume", {
+      signal: "app_state",
+    });
+  });
+
+  test("the reset seam clears the recorded edge", () => {
+    publishLifecycleEdge("resume", "visibility");
+    __resetLifecycleEdgeForTests();
+    setClock(5);
+    publishLifecycleEdge("resume", "app_state");
+
+    expect(publishSpy).toHaveBeenCalledTimes(2);
+    expect(publishSpy).toHaveBeenLastCalledWith("app.resume", {
+      signal: "app_state",
+    });
+  });
+});

--- a/clients/web/src/runtime/event-sources/lifecycle-edge.ts
+++ b/clients/web/src/runtime/event-sources/lifecycle-edge.ts
@@ -1,0 +1,68 @@
+/**
+ * Collapses the two signal sources that describe the same physical
+ * lifecycle edge into one bus publish: `document.visibilitychange`
+ * (`runtime/event-sources/dom-visibility.ts`, `signal: "visibility"`) and
+ * Capacitor `App.appStateChange`
+ * (`runtime/event-sources/capacitor-app-state.ts`, `signal: "app_state"`).
+ * Foregrounding the iOS native shell fires both within milliseconds, and
+ * every `app.resume` subscriber that kicks off work would otherwise do it
+ * twice. The bus therefore delivers at most one `app.resume` and one
+ * `app.hidden` per physical edge for that pair.
+ *
+ * The first source to reach an edge wins it, and its `signal` label is the
+ * one subscribers see. Which of the two arrives first is not fixed, so
+ * consumers must treat `"visibility"` and `"app_state"` as interchangeable
+ * descriptions of the same foreground or background transition.
+ *
+ * Only repeats of the SAME edge are dropped. The opposite edge always
+ * publishes and restarts the window, so an `app.hidden` landing between two
+ * resumes still reaches the SSE teardown policy (`assistant/sse-service.ts`
+ * documents what a suppressed reopen would strand).
+ *
+ * `signal: "online"` resumes from `runtime/event-sources/window-online.ts`
+ * are not routed through here. They report reachability rather than a
+ * foreground edge, they have no second source to collapse against, and
+ * consumers branch on the label (`lib/query-focus-manager.ts`).
+ */
+
+import { publish } from "@/lib/event-bus";
+
+const LIFECYCLE_EDGE_DEDUP_MS = 1_000;
+
+type LifecycleEdge = "resume" | "hidden";
+
+/** The two signal sources that can describe a single lifecycle edge. */
+type LifecycleEdgeSignal = "visibility" | "app_state";
+
+let lastEdge: LifecycleEdge | null = null;
+let lastAt = 0;
+
+/**
+ * Publish `app.resume` / `app.hidden` for a lifecycle edge, unless the same
+ * edge was already published inside {@link LIFECYCLE_EDGE_DEDUP_MS}.
+ *
+ * A dropped publish does not extend the window: the timestamp stays on the
+ * edge that won, so a source firing steadily just under the window cannot
+ * starve the next real edge.
+ */
+export function publishLifecycleEdge(
+  edge: LifecycleEdge,
+  signal: LifecycleEdgeSignal,
+): void {
+  const now = Date.now();
+  if (lastEdge === edge && now - lastAt < LIFECYCLE_EDGE_DEDUP_MS) {
+    return;
+  }
+  lastEdge = edge;
+  lastAt = now;
+  if (edge === "resume") {
+    publish("app.resume", { signal });
+  } else {
+    publish("app.hidden", { signal });
+  }
+}
+
+export function __resetLifecycleEdgeForTests(): void {
+  lastEdge = null;
+  lastAt = 0;
+}


### PR DESCRIPTION
## Summary
- New lifecycle-edge dedupe: at most one app.resume/app.hidden per physical edge for the visibility+app_state pair; opposite edges never swallowed; online resumes untouched
- Contract change documented in EVENT_BUS.md and source docstrings; downstream self-dedups left in place as harmless guards

Part of plan: resume-storm-fixes.md (PR 1 of 3)