### PR TITLE
fix(web): raise the SSE hidden-teardown grace on native mobile and reconnect after long backgrounds

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -674,6 +674,68 @@ describe("sseService.attach: background grace policy", () => {
   });
 });
 
+describe("sseService.attach: online resumes vs the hidden mark", () => {
+  test("an online resume mid-background leaves the later foreground resume its teardown-and-reopen", () => {
+    // GIVEN a backgrounded native app whose wifi flaps while it is still in
+    // the background, publishing app.resume(signal:"online") with no
+    // foreground behind it
+    nativeMobile = true;
+    const start = Date.now();
+    sseService.attach("asst-1");
+    activeOnStreamOpen!();
+    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // WHEN that online resume lands while the app is still hidden
+    setSystemTime(new Date(start + SHORT_BACKGROUND_MS));
+    eventBus.publish("app.resume", { signal: "online" });
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+
+    // THEN the real foreground resume, long past the suspect threshold,
+    // still finds the hidden mark and replaces the frozen socket. Had the
+    // online event consumed it, the dead connection would have survived
+    // until the 45s stream watchdog noticed
+    setSystemTime(new Date(start + LONG_BACKGROUND_MS));
+    eventBus.publish("app.resume", { signal: "app_state" });
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("an online resume mid-background does not cancel the pending grace teardown", async () => {
+    // GIVEN a backgrounded app with its grace teardown armed
+    nativeMobile = true;
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    sseService.attach("asst-1");
+    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // WHEN an online event arrives before the grace elapses
+    eventBus.publish("app.resume", { signal: "online" });
+
+    // THEN the teardown still fires: the app never came to the foreground,
+    // so nothing has happened that should keep the socket
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an online resume still reopens a downed connection while visible", () => {
+    // GIVEN a visible app whose socket died on a network fault, with no
+    // background involved
+    sseService.attach("asst-1");
+    activeOnStreamOpen!();
+    activeOnError!(new Error("network down"));
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+
+    // WHEN the network comes back
+    eventBus.publish("app.resume", { signal: "online" });
+
+    // THEN the reconnect-on-recovery path is unchanged: a down connection
+    // reopens, and nothing had to be torn down to get there
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+    expect(checkAssistantMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("sseService.attach — power-driven bounce", () => {
   test("power.suspend tears down a live SSE so the daemon sees us go away cleanly", () => {
     sseService.attach("asst-1");

--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  spyOn,
+  test,
+} from "bun:test";
 
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import * as eventBus from "@/lib/event-bus";
@@ -41,6 +50,13 @@ mock.module("@/lib/streaming/stream-transport", () => ({
   subscribeEvents: subscribeEventsMock,
 }));
 
+// The hidden-teardown grace is platform-dependent, so the specs below flip
+// this flag to choose which default the service resolves.
+let nativeMobile = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeMobile: () => nativeMobile,
+}));
+
 const checkAssistantMock = mock(async () => {});
 mock.module("@/assistant/lifecycle-service", () => ({
   lifecycleService: {
@@ -73,6 +89,13 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 // below the 1s resume dedup window so both can be exercised together.
 const TEST_HIDDEN_GRACE_MS = 20;
 
+// Backgrounds either side of the service's 30s `SUSPECT_SOCKET_AFTER_MS`.
+// Applied with `setSystemTime`, which moves `Date.now()` without touching
+// real `setTimeout` scheduling, so a minutes-long background is simulated
+// while the grace timers still fire in milliseconds.
+const LONG_BACKGROUND_MS = 45_000;
+const SHORT_BACKGROUND_MS = 10_000;
+
 // The real bus has the pub/sub semantics we need to exercise — no
 // reason to maintain a parallel mock. `__resetForTesting` gives
 // each test a clean handler registry; `spyOn` on the module
@@ -87,6 +110,7 @@ beforeEach(() => {
   // the shared `cancelMock` during a later test. Debounce specs opt into a
   // tiny window locally and await it.
   __setHiddenTeardownGraceMsForTesting(10_000);
+  nativeMobile = false;
   activeOnEvent = null;
   activeOnError = null;
   activeOnReconnect = null;
@@ -98,6 +122,10 @@ beforeEach(() => {
   checkAssistantMock.mockClear();
   resetReconnectCursorMock.mockClear();
   publishSpy.mockClear();
+});
+
+afterEach(() => {
+  setSystemTime();
 });
 
 describe("sseService.attach — connection lifecycle", () => {
@@ -490,6 +518,159 @@ describe("sseService.attach — visibility-driven bounce", () => {
       assistantId: "asst-1",
       cause: "resume",
     });
+  });
+});
+
+describe("sseService.attach: background grace policy", () => {
+  // Backgrounds the app and reports the delay its teardown timer was armed
+  // with. The grace resolves at arm time, so that delay is the observable
+  // form of which platform default is in force.
+  const hideAndReadArmedGrace = (): number | undefined => {
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    try {
+      eventBus.publish("app.hidden", { signal: "visibility" });
+      return setTimeoutSpy.mock.calls.at(-1)?.[1] as number | undefined;
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  };
+
+  test("native mobile arms the hidden teardown with the 60s grace", () => {
+    // GIVEN the native shell, where an app switch is the normal way to use
+    // the device and a 5s teardown made every glance elsewhere pay a cold
+    // reopen plus the whole sse.opened reconcile fan-out
+    nativeMobile = true;
+    __setHiddenTeardownGraceMsForTesting(null);
+    const detach = sseService.attach("asst-1");
+
+    // WHEN the app goes to the background
+    // THEN the socket is held for a full minute before teardown
+    expect(hideAndReadArmedGrace()).toBe(60_000);
+
+    detach();
+  });
+
+  test("desktop keeps the 5s grace (unchanged by the native bump)", () => {
+    nativeMobile = false;
+    __setHiddenTeardownGraceMsForTesting(null);
+    const detach = sseService.attach("asst-1");
+
+    expect(hideAndReadArmedGrace()).toBe(5_000);
+
+    detach();
+  });
+
+  test("a resume after a short background keeps the live socket", () => {
+    // GIVEN a native app switch shorter than the suspect threshold
+    nativeMobile = true;
+    const start = Date.now();
+    sseService.attach("asst-1");
+    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // WHEN the app foregrounds while the grace teardown is still pending
+    setSystemTime(new Date(start + SHORT_BACKGROUND_MS));
+    eventBus.publish("app.resume", { signal: "app_state" });
+
+    // THEN the same socket keeps streaming: nothing is torn down, nothing
+    // reopens, and no sse.opened reconcile fan-out is triggered
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a resume after a long background replaces the frozen socket exactly once", () => {
+    // GIVEN a background long enough that iOS froze JS before the grace
+    // timer could fire, so `current` still names a socket the OS has very
+    // likely killed underneath us
+    nativeMobile = true;
+    const start = Date.now();
+    sseService.attach("asst-1");
+    activeOnStreamOpen!();
+    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // WHEN the app foregrounds long after
+    setSystemTime(new Date(start + LONG_BACKGROUND_MS));
+    eventBus.publish("app.resume", { signal: "app_state" });
+
+    // THEN the suspect socket is dropped and a fresh one opened, rather
+    // than left in place until the 45s stream watchdog notices
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+
+    // AND the iOS double-fire's second resume neither bounces the fresh
+    // connection nor re-runs the check: the hidden mark was consumed on
+    // the first resume edge, ahead of the dedup window
+    eventBus.publish("app.resume", { signal: "visibility" });
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a deduped second resume does not bounce the socket the first one just opened", () => {
+    // GIVEN a long background whose socket died as a transport error rather
+    // than a teardown, so nothing along that path cleared the hidden mark
+    nativeMobile = true;
+    const start = Date.now();
+    sseService.attach("asst-1");
+    activeOnStreamOpen!();
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    setSystemTime(new Date(start + LONG_BACKGROUND_MS));
+    activeOnError!(new Error("stream closed"));
+
+    // WHEN the first resume reopens the down connection
+    eventBus.publish("app.resume", { signal: "app_state" });
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+
+    // THEN the iOS double-fire's second resume leaves the seconds-old socket
+    // alone: the mark is consumed on the first edge, so an old `hiddenAt`
+    // cannot make a freshly opened connection look suspect
+    eventBus.publish("app.resume", { signal: "visibility" });
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a resume after a teardown-and-reopen does not bounce the reopened socket", async () => {
+    // GIVEN the desktop path, where the grace teardown really does fire and
+    // a long system sleep then follows
+    nativeMobile = false;
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    const start = Date.now();
+    sseService.attach("asst-1");
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+
+    // WHEN wake reopens the connection well past the suspect threshold
+    setSystemTime(new Date(start + LONG_BACKGROUND_MS));
+    eventBus.publish("power.resume", {});
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+
+    // THEN the app.resume that follows leaves it alone. The teardown
+    // discarded the hidden mark along with the socket it described, so the
+    // long-gone background can't make this new connection look suspect
+    eventBus.publish("app.resume", { signal: "visibility" });
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a thawed grace timer does not cancel the connection a long-away resume just opened", async () => {
+    // GIVEN a grace timer armed before the freeze and thawed after it, with
+    // a background past the suspect threshold
+    nativeMobile = true;
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    const start = Date.now();
+    sseService.attach("asst-1");
+    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // WHEN the resume lands first and reconnects the suspect socket
+    setSystemTime(new Date(start + LONG_BACKGROUND_MS));
+    eventBus.publish("app.resume", { signal: "app_state" });
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+
+    // THEN the pending teardown, cleared by that bounce, can never fire and
+    // strand the fresh connection
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -37,6 +37,7 @@ import {
   subscribeEvents,
   type EventStream,
 } from "@/lib/streaming/stream-transport";
+import { isNativeMobile } from "@/runtime/platform-detection";
 import { useSSEConnectedStore } from "@/stores/sse-connected-store";
 
 const RESUME_DEDUP_WINDOW_MS = 1000;
@@ -51,16 +52,47 @@ const RESUME_DEDUP_WINDOW_MS = 1000;
 // keeps the socket. `power.suspend` (system sleep) is deliberately NOT
 // debounced — it still tears down immediately so the daemon sees a clean
 // disconnect.
-let hiddenTeardownGraceMs = 5_000;
+const DESKTOP_HIDDEN_TEARDOWN_GRACE_MS = 5_000;
+
+// Native mobile gets a far longer grace. Switching apps is the normal way
+// to use a phone, so at the desktop window every glance at another app
+// paid a teardown, a cold reopen, and the whole `sse.opened` reconcile
+// fan-out on return. A minute covers the quick switch and keeps the live
+// socket through it.
+const NATIVE_MOBILE_HIDDEN_TEARDOWN_GRACE_MS = 60_000;
+
+// How long a background has to run before a socket we still hold a handle
+// to is treated as dead on resume. iOS freezes JS shortly after
+// backgrounding, so under the native grace the teardown timer usually
+// never fires: the OS kills the connection while `current` still points
+// at it, and the resume path would otherwise keep that corpse until the
+// 45s stream watchdog notices. Past this threshold we reconnect
+// deliberately; below it the socket is assumed healthy and kept as is.
+const SUSPECT_SOCKET_AFTER_MS = 30_000;
+
+// Test-only override of the resolved grace window; `null` means use the
+// platform default.
+let hiddenTeardownGraceOverrideMs: number | null = null;
+
+// Resolved when the grace timer is armed rather than at module load, so
+// the platform probe cannot run before the Capacitor bridge is ready.
+const resolveHiddenTeardownGraceMs = (): number => {
+  if (hiddenTeardownGraceOverrideMs !== null) {
+    return hiddenTeardownGraceOverrideMs;
+  }
+  return isNativeMobile()
+    ? NATIVE_MOBILE_HIDDEN_TEARDOWN_GRACE_MS
+    : DESKTOP_HIDDEN_TEARDOWN_GRACE_MS;
+};
 
 /**
  * Override the hidden-teardown grace window. Test-only seam so specs can
- * exercise the debounce without real-time waits; never call from
- * production code.
+ * exercise the debounce without real-time waits; pass `null` to restore
+ * the platform default. Never call from production code.
  * @internal
  */
-export function __setHiddenTeardownGraceMsForTesting(ms: number): void {
-  hiddenTeardownGraceMs = ms;
+export function __setHiddenTeardownGraceMsForTesting(ms: number | null): void {
+  hiddenTeardownGraceOverrideMs = ms;
 }
 
 export interface SseService {
@@ -127,6 +159,10 @@ export const sseService: SseService = {
     // Pending grace timer for a hidden-tab teardown, so a resume within
     // the grace window (or a detach / other teardown) can cancel it.
     let hiddenTeardownTimer: ReturnType<typeof setTimeout> | null = null;
+    // When the pending grace teardown was armed, so a resume can tell a
+    // quick app switch from a background long enough that the socket we
+    // still hold is probably dead. Null whenever no background is pending.
+    let hiddenAt: number | null = null;
     const clearHiddenTeardownTimer = () => {
       if (hiddenTeardownTimer !== null) {
         clearTimeout(hiddenTeardownTimer);
@@ -213,8 +249,11 @@ export const sseService: SseService = {
     const teardown = () => {
       // A teardown by any path (grace timer, power, reachability, debug,
       // detach) makes a still-pending grace teardown moot — clear it so a
-      // late fire can't cancel a connection opened after it.
+      // late fire can't cancel a connection opened after it. The hidden
+      // mark goes with it: it describes the socket being dropped here, and
+      // whatever opens next is fresh rather than suspect.
       clearHiddenTeardownTimer();
+      hiddenAt = null;
       current?.cancel();
       setCurrent(null);
       setConnected(false);
@@ -222,10 +261,11 @@ export const sseService: SseService = {
 
     // App lifecycle (renderer-visibility): a hidden tab does NOT tear the
     // connection down immediately — see `handleAppHidden`, which debounces
-    // it behind `hiddenTeardownGraceMs`. On resume we cancel any pending
-    // grace teardown (so a brief tab-out keeps its live socket) and reopen
-    // only if the connection was actually torn down. The self-dedup window
-    // collapses double-fires from visibilitychange + Capacitor
+    // it behind the platform's grace window. On resume we cancel any
+    // pending grace teardown (so a brief tab-out keeps its live socket) and
+    // reopen only if the connection was torn down, or if the background ran
+    // long enough that the socket we still hold is suspect. The self-dedup
+    // window collapses double-fires from visibilitychange + Capacitor
     // appStateChange (both arrive in close succession on foregrounding the
     // iOS native shell).
     const handleAppResume = () => {
@@ -233,7 +273,25 @@ export const sseService: SseService = {
       // cancel the pending teardown and keep it. Resumed after it fired →
       // no-op here, and the reopen below handles the down connection.
       clearHiddenTeardownTimer();
+      // Consume the hidden mark on this first resume edge, ahead of the
+      // dedup window below, so the suspect check runs once per background
+      // and cannot be skipped: the iOS double-fire's second resume finds
+      // it null and so can neither bypass nor re-run the bounce.
+      const hiddenSince = hiddenAt;
+      hiddenAt = null;
       const now = Date.now();
+      if (
+        current !== null &&
+        hiddenSince !== null &&
+        now - hiddenSince > SUSPECT_SOCKET_AFTER_MS
+      ) {
+        // Long background: JS was frozen, so the grace teardown never got
+        // to run and the socket `current` names was almost certainly
+        // killed by the OS behind our back. Drop it so the reopen paths
+        // below treat this as a down connection rather than trusting a
+        // handle that will never deliver another frame.
+        teardown();
+      }
       if (now - lastAppResumeAt < RESUME_DEDUP_WINDOW_MS) {
         // Inside the dedup window. This collapses the iOS double-fire
         // (visibilitychange + Capacitor appStateChange deliver two
@@ -279,10 +337,11 @@ export const sseService: SseService = {
       if (hiddenTeardownTimer !== null) {
         return;
       }
+      hiddenAt = Date.now();
       hiddenTeardownTimer = setTimeout(() => {
         hiddenTeardownTimer = null;
         teardownIfOpen();
-      }, hiddenTeardownGraceMs);
+      }, resolveHiddenTeardownGraceMs());
     };
 
     // System-level resume (Electron host): bounce the connection

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -27,7 +27,7 @@
 import * as Sentry from "@sentry/react";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
-import { publish, subscribe } from "@/lib/event-bus";
+import { publish, subscribe, type AppResumeSignal } from "@/lib/event-bus";
 import { resetReconnectCursor } from "@/lib/streaming/reconnect-cursor";
 import {
   clearSseReconnectHandler,
@@ -261,24 +261,36 @@ export const sseService: SseService = {
 
     // App lifecycle (renderer-visibility): a hidden tab does NOT tear the
     // connection down immediately — see `handleAppHidden`, which debounces
-    // it behind the platform's grace window. On resume we cancel any
-    // pending grace teardown (so a brief tab-out keeps its live socket) and
-    // reopen only if the connection was torn down, or if the background ran
-    // long enough that the socket we still hold is suspect. The self-dedup
-    // window collapses double-fires from visibilitychange + Capacitor
-    // appStateChange (both arrive in close succession on foregrounding the
-    // iOS native shell).
-    const handleAppResume = () => {
-      // Resumed within the grace window → the socket was never torn down;
-      // cancel the pending teardown and keep it. Resumed after it fired →
-      // no-op here, and the reopen below handles the down connection.
-      clearHiddenTeardownTimer();
-      // Consume the hidden mark on this first resume edge, ahead of the
-      // dedup window below, so the suspect check runs once per background
-      // and cannot be skipped: the iOS double-fire's second resume finds
-      // it null and so can neither bypass nor re-run the bounce.
-      const hiddenSince = hiddenAt;
-      hiddenAt = null;
+    // it behind the platform's grace window. On a foreground resume we
+    // cancel any pending grace teardown (so a brief tab-out keeps its live
+    // socket) and reopen only if the connection was torn down, or if the
+    // background ran long enough that the socket we still hold is suspect.
+    // The self-dedup window collapses double-fires from visibilitychange +
+    // Capacitor appStateChange (both arrive in close succession on
+    // foregrounding the iOS native shell).
+    const handleAppResume = ({ signal }: { signal: AppResumeSignal }) => {
+      // Only a real foreground consumes the hidden state. `online` is a
+      // network transition that can arrive while the app is still
+      // backgrounded, so letting it clear the hidden mark and the pending
+      // grace teardown would defeat the suspect-socket reconnect: the
+      // visibility/app_state resume that eventually lands would find no
+      // background to measure and would keep a socket the OS killed during
+      // the freeze. `online` still reopens a connection that is already
+      // down, which is all it ever did here.
+      const isForegroundResume = signal !== "online";
+      let hiddenSince: number | null = null;
+      if (isForegroundResume) {
+        // Resumed within the grace window → the socket was never torn down;
+        // cancel the pending teardown and keep it. Resumed after it fired →
+        // no-op here, and the reopen below handles the down connection.
+        clearHiddenTeardownTimer();
+        // Consume the hidden mark on this first resume edge, ahead of the
+        // dedup window below, so the suspect check runs once per background
+        // and cannot be skipped: the iOS double-fire's second resume finds
+        // it null and so can neither bypass nor re-run the bounce.
+        hiddenSince = hiddenAt;
+        hiddenAt = null;
+      }
       const now = Date.now();
       if (
         current !== null &&


### PR DESCRIPTION
## Summary
- Native mobile keeps the SSE socket across backgrounds up to 60s (desktop unchanged at 5s), so quick app switches no longer pay teardown + reopen + the reconcile fan-out
- Long-away resumes treat the frozen socket as suspect and reconnect deliberately instead of leaving a dead connection for the 45s watchdog
- Manual dev check: short background = no sse_stream_opened diagnostic; long background = exactly one reopen

Part of plan: resume-storm-fixes.md (PR 2 of 3)