### PR TITLE
feat(web): surface conclusive HTTP rejection from the org store

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -214,6 +214,7 @@ beforeEach(() => {
   useOrganizationStore.setState({
     fetchOrganizations: async () => {
       fetchOrganizationsCalls += 1;
+      return { ok: true };
     },
   });
   upgradeRejects = false;

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -116,6 +116,23 @@ describe("fetch outcome classification", () => {
     expect(state.error).toBe("Platform session was rejected (HTTP 403).");
   });
 
+  test("a rejection clears the persisted org id so stale headers stop", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(getActiveOrganizationIdForRequests()).toBeNull();
+  });
+
   test("a thrown fetch concludes as unavailable with no HTTP status", async () => {
     listOrganizations = () => Promise.reject(new Error("network down"));
 
@@ -126,6 +143,19 @@ describe("fetch outcome classification", () => {
     expect(state.status).toBe("error");
     expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBe("network down");
+  });
+
+  test("a transport failure keeps the persisted org id for offline reloads", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () => Promise.reject(new Error("network down"));
+
+    await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBe(
+      ORG_A.id,
+    );
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
   });
 
   test("a 200 with no organizations concludes as unavailable", async () => {

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
     persistedOrganizationId: null,
     status: "idle",
     error: null,
+    lastErrorStatus: null,
   });
 });
 
@@ -94,5 +95,66 @@ describe("the organization requests are scoped to", () => {
 
     expect(getActiveOrganizationIdForRequests()).toBeNull();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("fetch outcome classification", () => {
+  test("a settled 403 concludes as a rejected session", async () => {
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBe(403);
+    expect(state.error).toBe("Platform session was rejected (HTTP 403).");
+  });
+
+  test("a thrown fetch concludes as unavailable with no HTTP status", async () => {
+    listOrganizations = () => Promise.reject(new Error("network down"));
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "unavailable" });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBe("network down");
+  });
+
+  test("a 200 with no organizations concludes as unavailable", async () => {
+    listOrganizations = () =>
+      Promise.resolve({
+        data: { results: [] },
+        response: new Response(null, { status: 200 }),
+      });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "unavailable" });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBe("No organization available for this user.");
+  });
+
+  test("a successful fetch resets lastErrorStatus", async () => {
+    useOrganizationStore.setState({ lastErrorStatus: 403, status: "error" });
+    listOrganizations = () =>
+      Promise.resolve({ data: { results: [ORG_A] } });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: true });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("ready");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBeNull();
   });
 });

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -171,11 +171,22 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
             : "No organization available for this user.";
       }
 
+      // A settled rejection means the platform no longer honors the session
+      // this org id came from, so the persisted fallback must not keep
+      // stamping requests with a stale Vellum-Organization-Id. Transport and
+      // other failures keep the fallback (offline reloads still need it).
+      if (rejectionStatus !== null) {
+        clearStoredOrganizationId();
+      }
+      const persistedOrganizationId =
+        rejectionStatus !== null
+          ? null
+          : (currentOrganizationId ?? get().persistedOrganizationId);
+
       set({
         organizations,
         currentOrganizationId,
-        persistedOrganizationId:
-          currentOrganizationId ?? get().persistedOrganizationId,
+        persistedOrganizationId,
         status: currentOrganizationId ? "ready" : "error",
         error,
         lastErrorStatus: failureStatus,

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -23,11 +23,25 @@ import { organizationsList } from "@/generated/api/sdk.gen";
 import type { OrganizationRead } from "@/generated/api/types.gen";
 import { subscribe } from "@/lib/event-bus";
 import { useAuthStore } from "@/stores/auth-store";
-import { hasLivePlatformSession } from "@/stores/session-status";
+import {
+  hasLivePlatformSession,
+  isSettledSessionRejection,
+} from "@/stores/session-status";
 
 const ACTIVE_ORGANIZATION_STORAGE_KEY = "vellum_active_organization_id";
 
 export type OrganizationStatus = "idle" | "loading" | "ready" | "error";
+
+/**
+ * How a fetch concluded. `"rejected"` is a settled session rejection from the
+ * platform (401/403/410): the request completed and the server refused the
+ * credentials. `"unavailable"` covers everything else that lands in the error
+ * path: transport failures, 5xx, and a user with no organizations.
+ */
+export type OrgFetchOutcome =
+  | { ok: true }
+  | { ok: false; kind: "rejected"; status: number }
+  | { ok: false; kind: "unavailable" };
 
 interface OrganizationState {
   organizations: OrganizationRead[];
@@ -42,10 +56,16 @@ interface OrganizationState {
   persistedOrganizationId: string | null;
   status: OrganizationStatus;
   error: string | null;
+  /**
+   * HTTP status of the last fetch that concluded with an error response;
+   * null while loading, after a success, and for failures with no
+   * completed response (transport errors).
+   */
+  lastErrorStatus: number | null;
 }
 
 interface OrganizationActions {
-  fetchOrganizations: () => Promise<void>;
+  fetchOrganizations: () => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
   clearOrganization: () => void;
 }
@@ -114,9 +134,10 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   persistedOrganizationId: getStoredOrganizationId(),
   status: "idle",
   error: null,
+  lastErrorStatus: null,
 
   fetchOrganizations: async () => {
-    set({ status: "loading", error: null });
+    set({ status: "loading", error: null, lastErrorStatus: null });
 
     try {
       const result = await organizationsList();
@@ -132,22 +153,48 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         setStoredOrganizationId(currentOrganizationId);
       }
 
+      // throwOnError is false, so an HTTP error surfaces as data-undefined
+      // with the completed Response alongside.
+      const failureStatus =
+        result.data === undefined ? (result.response?.status ?? null) : null;
+      const rejectionStatus =
+        failureStatus !== null &&
+        isSettledSessionRejection({ ok: false, status: failureStatus })
+          ? failureStatus
+          : null;
+
+      let error: string | null = null;
+      if (!currentOrganizationId) {
+        error =
+          rejectionStatus !== null
+            ? `Platform session was rejected (HTTP ${rejectionStatus}).`
+            : "No organization available for this user.";
+      }
+
       set({
         organizations,
         currentOrganizationId,
         persistedOrganizationId:
           currentOrganizationId ?? get().persistedOrganizationId,
         status: currentOrganizationId ? "ready" : "error",
-        error: currentOrganizationId
-          ? null
-          : "No organization available for this user.",
+        error,
+        lastErrorStatus: failureStatus,
       });
+
+      if (currentOrganizationId) {
+        return { ok: true };
+      }
+      if (rejectionStatus !== null) {
+        return { ok: false, kind: "rejected", status: rejectionStatus };
+      }
+      return { ok: false, kind: "unavailable" };
     } catch (err) {
       const message =
         err instanceof Error && err.message
           ? err.message
           : "Failed to load organizations.";
       set({ status: "error", error: message });
+      return { ok: false, kind: "unavailable" };
     }
   },
 
@@ -173,6 +220,7 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
       persistedOrganizationId: null,
       status: "idle",
       error: null,
+      lastErrorStatus: null,
     });
   },
 }));


### PR DESCRIPTION
## Summary
- fetchOrganizations returns a typed outcome (ok / rejected+status / unavailable) and records lastErrorStatus
- A settled 401/403/410 gets an accurate error message instead of the no-organization copy

Part of plan: half-dead-platform-session.md (PR 1 of 3)