### PR TITLE
fix(web): bound the platform 403-recovery loop

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1808,6 +1808,9 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   });
 
   test("stops recovering once the attempt budget is spent", async () => {
+    // An unsettled probe never confirms the session live, so nothing refunds
+    // the count and the budget is the binding limit.
+    mockAuthState.platformSession = "unknown";
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
 
@@ -1829,64 +1832,76 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     );
   });
 
-  test("a 2xx on the rejected route restores the recovery budget", async () => {
+  test("a live-confirmed recovery refunds the count but keeps the cooldown", async () => {
+    // platformSession stays "present" (beforeEach default): the probe keeps
+    // confirming the session is live, so a route-level permission 403 must
+    // not eat the budget a later real expiry needs.
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
 
-    // Spend the whole budget with rejections on one route.
-    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS + 2; i++) {
       expireRecoveryCooldown();
       platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
       await flush();
     }
-    expireRecoveryCooldown();
+
+    // Every cycle recovered: the count was refunded each time.
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
+    );
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+
+    // The cooldown survives the refund: an immediate rejection stays paced.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+      PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
     );
+  });
 
-    // The same route succeeding is proof it healed.
+  test("a 2xx on the rejected route restores the recovery budget", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Inside the cooldown a rejection cannot recover.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // The same route succeeding is proof it healed; the cooldown clears and
+    // the next rejection may recover immediately.
     platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS + 1,
-    );
+    expect(refreshSession).toHaveBeenCalledTimes(2);
   });
 
   test("an unrelated platform 2xx does not restore the budget", async () => {
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
 
-    // Spend the whole budget with rejections on the session-sensitive route.
-    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
-      expireRecoveryCooldown();
-      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
-      await flush();
-    }
-    expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS,
-    );
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
 
     // A route the platform serves without the session (feature-flag polling)
-    // keeps succeeding; it must not re-arm the exhausted budget.
+    // keeps succeeding; it must not clear the cooldown or the count.
     platformAuthRecoveryInterceptor(
       makeResponse(200, "https://platform.test/v1/client-feature-flags/"),
     );
-    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe(
-      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
-    );
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
 
-    expireRecoveryCooldown();
+    // Still inside the cooldown, so no second recovery.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS,
-    );
+    expect(refreshSession).toHaveBeenCalledTimes(1);
   });
 
   test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1518,6 +1518,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   const PLATFORM_AUTH_MAX_REDIRECTS = 3;
   const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
   const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+  const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
   const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
 
   /**
@@ -1538,6 +1539,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
     mockAuthState.sessionStatus = "authenticated";
     mockAuthState.platformSession = "present";
     mockAuthState.refreshSession = mock(async () => true);
@@ -1551,6 +1553,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
     whenPlatformSessionSettledImpl = async () => {};
   });
 
@@ -1565,6 +1568,7 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     // each round models a fresh, allowed recovery cycle.
     expireRecoveryCooldown();
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
     platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
     await flush();
   };
@@ -1825,26 +1829,64 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     );
   });
 
-  test("a platform 2xx restores the recovery budget", async () => {
-    sessionStorage.setItem(
-      PLATFORM_RECOVERY_ATTEMPTS_KEY,
-      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
-    );
-    expireRecoveryCooldown();
+  test("a 2xx on the rejected route restores the recovery budget", async () => {
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
 
+    // Spend the whole budget with rejections on one route.
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+      expireRecoveryCooldown();
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    }
+    expireRecoveryCooldown();
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).not.toHaveBeenCalled();
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
 
+    // The same route succeeding is proof it healed.
     platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS + 1,
+    );
+  });
+
+  test("an unrelated platform 2xx does not restore the budget", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    // Spend the whole budget with rejections on the session-sensitive route.
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+      expireRecoveryCooldown();
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    }
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
+
+    // A route the platform serves without the session (feature-flag polling)
+    // keeps succeeding; it must not re-arm the exhausted budget.
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, "https://platform.test/v1/client-feature-flags/"),
+    );
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe(
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
   });
 
   test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -70,11 +70,20 @@ const mockAuthState: {
   refreshSession: async () => true,
 };
 
+// Controls the probe-settle wait the recovery path awaits after
+// `refreshSession`. Defaults to already-settled; a test swaps in a pending
+// promise to model the fire-and-forget probe still being in flight.
+let whenPlatformSessionSettledImpl: () => Promise<void> = async () => {};
+const whenPlatformSessionSettledMock = mock(() =>
+  whenPlatformSessionSettledImpl(),
+);
+
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     getState: () => mockAuthState,
     subscribe: () => () => {},
   },
+  whenPlatformSessionSettled: whenPlatformSessionSettledMock,
 }));
 
 const hardNavigateMock = mock((_url: string) => {});
@@ -1507,14 +1516,32 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
 
   const PLATFORM_AUTH_REDIRECT_KEY = "vellum:platform:auth-redirect-attempts";
   const PLATFORM_AUTH_MAX_REDIRECTS = 3;
+  const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
+  const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+  const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
+
+  /**
+   * Backdate the recovery cooldown so the next rejection is outside the
+   * window. Tests that exercise the latch or the redirect budget across
+   * multiple cycles use this to keep the cooldown out of the picture.
+   */
+  function expireRecoveryCooldown(): void {
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_AT_KEY,
+      String(Date.now() - 700_000),
+    );
+  }
 
   beforeEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
     mockAuthState.sessionStatus = "authenticated";
     mockAuthState.platformSession = "present";
     mockAuthState.refreshSession = mock(async () => true);
+    whenPlatformSessionSettledImpl = async () => {};
     hardNavigateMock.mockClear();
   });
 
@@ -1522,6 +1549,9 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    whenPlatformSessionSettledImpl = async () => {};
   });
 
   /** Drive one full rejection→recovery round trip against a dead session. */
@@ -1531,6 +1561,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       mockAuthState.sessionStatus = "unauthenticated";
       return false;
     });
+    // Keep the recovery cooldown and budget out of redirect-budget tests:
+    // each round models a fresh, allowed recovery cycle.
+    expireRecoveryCooldown();
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
     platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
     await flush();
   };
@@ -1563,7 +1597,9 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(1);
     expect(hardNavigateMock).not.toHaveBeenCalled();
 
-    // Latch reopened → a later genuine rejection triggers another re-probe.
+    // Latch reopened → a later genuine rejection (outside the cooldown
+    // window) triggers another re-probe.
+    expireRecoveryCooldown();
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(2);
@@ -1693,6 +1729,164 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBe(
       String(PLATFORM_AUTH_MAX_REDIRECTS),
     );
+  });
+
+  test("holds the latch until the platform probe settles", async () => {
+    // `refreshSession` in gateway-auth mode fire-and-forgets the platform
+    // probe, whose own requests 403 against a half-dead cookie. Those
+    // rejections arrive after `refreshSession` resolved; if the latch were
+    // already released, each would start the next recovery cycle.
+    let settleProbe: () => void = () => {};
+    whenPlatformSessionSettledImpl = () =>
+      new Promise((resolve) => {
+        settleProbe = resolve;
+      });
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // A probe-spawned 403 during the settle window must not recover again.
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Once the probe settles the latch reopens for a later genuine cycle.
+    whenPlatformSessionSettledImpl = async () => {};
+    settleProbe();
+    await flush();
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("a settled-absent platform session never triggers recovery", async () => {
+    mockAuthState.platformSession = "absent";
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+  });
+
+  test("an unsettled (unknown) platform session still recovers", async () => {
+    // "unknown" means the probe has not answered yet, so the rejection is
+    // still worth re-verifying; only a settled negative is conclusive.
+    mockAuthState.platformSession = "unknown";
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("a second rejection inside the cooldown window does not recover", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Latch is reopened, but the attempt timestamp is fresh.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops recovering once the attempt budget is spent", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    // Each round expires the cooldown so only the budget can stop it.
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+      expireRecoveryCooldown();
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    }
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
+
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
+  });
+
+  test("a platform 2xx restores the recovery budget", async () => {
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_ATTEMPTS_KEY,
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+    expireRecoveryCooldown();
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).not.toHaveBeenCalled();
+
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_ATTEMPTS_KEY,
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, `${INGRESS}/v1/assistants/123/messages`),
+    );
+
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe(
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+  });
+
+  test("skips recovery when sessionStorage is unavailable", async () => {
+    // Without storage neither the cooldown nor the budget can be enforced,
+    // so recovery fails closed rather than looping uncountably.
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+    const originalGetItem = sessionStorage.getItem;
+    Object.defineProperty(sessionStorage, "getItem", {
+      configurable: true,
+      value: () => {
+        throw new DOMException("unavailable");
+      },
+    });
+
+    try {
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    } finally {
+      Object.defineProperty(sessionStorage, "getItem", {
+        configurable: true,
+        value: originalGetItem,
+      });
+    }
+
+    expect(refreshSession).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -639,20 +639,24 @@ function clearPlatformAuthRedirectBudget(): void {
  * concurrent rejections within one cycle; against a platform that rejects
  * every request, each released latch would otherwise start the next cycle
  * immediately and without bound. The cooldown spaces cycles and the budget
- * stops them; a platform 2xx through this client restores both, and quitting
- * the app grants a fresh budget (sessionStorage).
+ * stops them; a 2xx on the route whose rejection last consumed an attempt
+ * restores both (proof the failing route healed), and quitting the app
+ * grants a fresh budget (sessionStorage).
  */
 const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
 const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
 const PLATFORM_RECOVERY_COOLDOWN_MS = 600_000;
 const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
 
 /**
- * Spend one recovery attempt. False when the budget is exhausted, when the
- * last attempt was inside the cooldown window, or when sessionStorage is
- * unavailable so an uncountable environment fails closed (no recovery).
+ * Spend one recovery attempt for a rejection on `pathname`. False when the
+ * budget is exhausted, when the last attempt was inside the cooldown window,
+ * or when sessionStorage is unavailable so an uncountable environment fails
+ * closed (no recovery). The pathname is remembered so only that route's
+ * later success restores the budget.
  */
-function claimPlatformRecoveryAttempt(): boolean {
+function claimPlatformRecoveryAttempt(pathname: string): boolean {
   try {
     const stored = Number(
       sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY) ?? "0",
@@ -673,6 +677,7 @@ function claimPlatformRecoveryAttempt(): boolean {
       PLATFORM_RECOVERY_ATTEMPTS_KEY,
       String(attempts + 1),
     );
+    sessionStorage.setItem(PLATFORM_RECOVERY_PATH_KEY, pathname);
     return true;
   } catch {
     return false;
@@ -680,17 +685,31 @@ function claimPlatformRecoveryAttempt(): boolean {
 }
 
 /**
- * Restore the recovery budget. Unlike the redirect budget this is not gated
- * on a confirmed session: the budget paces re-probes, not navigations, so the
- * worst an anonymous 2xx buys is one more cooldown-spaced probe cycle. The
- * loop's own requests are all rejections, so it can never refill itself.
+ * Restore the recovery budget when a success proves the previously rejected
+ * route is healthy again. Restoring on any platform 2xx would let routes the
+ * platform serves anonymously (client feature flags, for example) re-arm the
+ * budget every poll while the session-sensitive route keeps rejecting, which
+ * defeats the bound entirely.
  */
-function clearPlatformRecoveryBudget(): void {
+function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
   try {
+    if (sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY) !== pathname) {
+      return;
+    }
     sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
   } catch {
     // sessionStorage unavailable; the claim above already fails closed.
+  }
+}
+
+/** The response URL's pathname, or null for an unparseable URL. */
+function responsePathname(response: Response): string | null {
+  try {
+    return new URL(response.url).pathname;
+  } catch {
+    return null;
   }
 }
 
@@ -740,8 +759,9 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * session also no-ops (nothing to recover), and each re-probe cycle spends
  * from the cooldown-spaced attempt budget above.
  *
- * A platform request that succeeds restores the recovery budget; one that
- * succeeds against a confirmed session also restores the redirect budget.
+ * A success on the route whose rejection last consumed a recovery attempt
+ * restores the recovery budget; a success against a confirmed session also
+ * restores the redirect budget.
  */
 export function platformAuthRecoveryInterceptor(response: Response): Response {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -751,7 +771,10 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (response.ok) {
     // A working self-hosted gateway says nothing about the platform session.
     if (!fromSelfHostedGateway) {
-      clearPlatformRecoveryBudget();
+      const pathname = responsePathname(response);
+      if (pathname !== null) {
+        clearPlatformRecoveryBudgetIfHealed(pathname);
+      }
       // The redirect budget stays gated on a confirmed session: the platform
       // serves some routes anonymously, so a 2xx alone does not prove the
       // session works.
@@ -786,7 +809,11 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   ) {
     return response;
   }
-  if (!claimPlatformRecoveryAttempt()) {
+  const rejectedPathname = responsePathname(response);
+  if (
+    rejectedPathname === null ||
+    !claimPlatformRecoveryAttempt(rejectedPathname)
+  ) {
     return response;
   }
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -58,10 +58,11 @@ import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
-import { useAuthStore } from "@/stores/auth-store";
+import { useAuthStore, whenPlatformSessionSettled } from "@/stores/auth-store";
 import {
   hasLivePlatformSession,
   isAuthenticated,
+  isPlatformSessionSettled,
   isSettledSessionRejection,
 } from "@/stores/session-status";
 import { routes } from "@/utils/routes";
@@ -632,6 +633,67 @@ function clearPlatformAuthRedirectBudget(): void {
   }
 }
 
+/**
+ * Cooldown + attempt budget for the recovery re-probe itself, mirroring the
+ * local-gateway 401 pattern above. The in-memory latch only serializes
+ * concurrent rejections within one cycle; against a platform that rejects
+ * every request, each released latch would otherwise start the next cycle
+ * immediately and without bound. The cooldown spaces cycles and the budget
+ * stops them; a platform 2xx through this client restores both, and quitting
+ * the app grants a fresh budget (sessionStorage).
+ */
+const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
+const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+const PLATFORM_RECOVERY_COOLDOWN_MS = 600_000;
+const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
+
+/**
+ * Spend one recovery attempt. False when the budget is exhausted, when the
+ * last attempt was inside the cooldown window, or when sessionStorage is
+ * unavailable so an uncountable environment fails closed (no recovery).
+ */
+function claimPlatformRecoveryAttempt(): boolean {
+  try {
+    const stored = Number(
+      sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY) ?? "0",
+    );
+    const attempts = Number.isFinite(stored) ? stored : 0;
+    if (attempts >= PLATFORM_RECOVERY_MAX_ATTEMPTS) {
+      return false;
+    }
+    const lastAttempt = sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY);
+    if (
+      lastAttempt &&
+      Date.now() - Number(lastAttempt) < PLATFORM_RECOVERY_COOLDOWN_MS
+    ) {
+      return false;
+    }
+    sessionStorage.setItem(PLATFORM_RECOVERY_AT_KEY, String(Date.now()));
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_ATTEMPTS_KEY,
+      String(attempts + 1),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restore the recovery budget. Unlike the redirect budget this is not gated
+ * on a confirmed session: the budget paces re-probes, not navigations, so the
+ * worst an anonymous 2xx buys is one more cooldown-spaced probe cycle. The
+ * loop's own requests are all rejections, so it can never refill itself.
+ */
+function clearPlatformRecoveryBudget(): void {
+  try {
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+  } catch {
+    // sessionStorage unavailable; the claim above already fails closed.
+  }
+}
+
 async function recoverFromPlatformSessionRejection(): Promise<void> {
   try {
     // Authoritative re-probe. `refreshSession` calls `getSession()` and only
@@ -641,6 +703,11 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // and keeps `sessionStatus` authenticated, so the redirect below is
     // skipped there.
     await useAuthStore.getState().refreshSession();
+    // In gateway-auth mode `refreshSession` fire-and-forgets the
+    // platform-session probe and returns while the probe's own platform
+    // requests are still in flight. Hold the latch until the probe settles
+    // so those requests' rejections cannot each start a new recovery cycle.
+    await whenPlatformSessionSettled();
     if (
       !isAuthenticated(useAuthStore.getState().sessionStatus) &&
       claimPlatformAuthRedirect()
@@ -669,10 +736,12 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * authenticated (excludes boot probes and the already-logged-out login flow,
  * and prevents a redirect loop), and the response did not come from the
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
- * {@link localGatewayAuthRecoveryInterceptor}.
+ * {@link localGatewayAuthRecoveryInterceptor}. A settled-absent platform
+ * session also no-ops (nothing to recover), and each re-probe cycle spends
+ * from the cooldown-spaced attempt budget above.
  *
- * A platform request that succeeds against a confirmed session restores the
- * redirect budget.
+ * A platform request that succeeds restores the recovery budget; one that
+ * succeeds against a confirmed session also restores the redirect budget.
  */
 export function platformAuthRecoveryInterceptor(response: Response): Response {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -680,13 +749,15 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
     !!ingressUrl && response.url.startsWith(ingressUrl);
 
   if (response.ok) {
-    // A working self-hosted gateway says nothing about the platform session,
-    // and neither does a route the platform serves anonymously.
-    if (
-      !fromSelfHostedGateway &&
-      hasLivePlatformSession(useAuthStore.getState().platformSession)
-    ) {
-      clearPlatformAuthRedirectBudget();
+    // A working self-hosted gateway says nothing about the platform session.
+    if (!fromSelfHostedGateway) {
+      clearPlatformRecoveryBudget();
+      // The redirect budget stays gated on a confirmed session: the platform
+      // serves some routes anonymously, so a 2xx alone does not prove the
+      // session works.
+      if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+        clearPlatformAuthRedirectBudget();
+      }
     }
     return response;
   }
@@ -699,10 +770,23 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (platformAuthRecoveryFired) {
     return response;
   }
-  if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
+  const { sessionStatus, platformSession } = useAuthStore.getState();
+  if (!isAuthenticated(sessionStatus)) {
     return response;
   }
   if (fromSelfHostedGateway) {
+    return response;
+  }
+  // A session already settled as not-live has nothing to recover; a re-probe
+  // would only repeat the answer. Keeps stray platform 403s after logout (or
+  // after the probe settled this rejection to "absent") inert.
+  if (
+    isPlatformSessionSettled(platformSession) &&
+    !hasLivePlatformSession(platformSession)
+  ) {
+    return response;
+  }
+  if (!claimPlatformRecoveryAttempt()) {
     return response;
   }
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -640,7 +640,9 @@ function clearPlatformAuthRedirectBudget(): void {
  * every request, each released latch would otherwise start the next cycle
  * immediately and without bound. The cooldown spaces cycles and the budget
  * stops them; a 2xx on the route whose rejection last consumed an attempt
- * restores both (proof the failing route healed), and quitting the app
+ * restores both (proof the failing route healed), a re-probe that confirms
+ * the session live refunds the count while keeping the cooldown (a
+ * permission 403 must not starve a later real expiry), and quitting the app
  * grants a fresh budget (sessionStorage).
  */
 const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
@@ -704,6 +706,21 @@ function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
   }
 }
 
+/**
+ * Refund the attempt count while keeping the cooldown timestamp. Used when
+ * the authoritative re-probe confirms the session is live: the rejection was
+ * a route-level permission denial, not session death, so it must not eat the
+ * budget a later real expiry needs. The retained cooldown still paces
+ * probing at one cycle per window while such a route keeps rejecting.
+ */
+function refundPlatformRecoveryAttempt(): void {
+  try {
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+  } catch {
+    // sessionStorage unavailable; the claim already fails closed.
+  }
+}
+
 /** The response URL's pathname, or null for an unparseable URL. */
 function responsePathname(response: Response): string | null {
   try {
@@ -727,6 +744,9 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // requests are still in flight. Hold the latch until the probe settles
     // so those requests' rejections cannot each start a new recovery cycle.
     await whenPlatformSessionSettled();
+    if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+      refundPlatformRecoveryAttempt();
+    }
     if (
       !isAuthenticated(useAuthStore.getState().sessionStatus) &&
       claimPlatformAuthRedirect()


### PR DESCRIPTION
## Summary
- The recovery latch now stays closed until the platform probe settles, so probe-spawned 403s cannot each start a new cycle
- A settled-absent platform session skips recovery entirely
- Cooldown + attempt budget mirroring the gateway-401 pattern bound the worst case

Part of plan: half-dead-platform-session.md (PR 2 of 3)