### PR TITLE
fix(web): truthful resume-dedup comments and lifecycle-edge test isolation

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -596,7 +596,7 @@ describe("sseService.attach: background grace policy", () => {
     expect(cancelMock).toHaveBeenCalledTimes(1);
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
 
-    // AND the iOS double-fire's second resume neither bounces the fresh
+    // AND a redundant second resume neither bounces the fresh
     // connection nor re-runs the check: the hidden mark was consumed on
     // the first resume edge, ahead of the dedup window
     eventBus.publish("app.resume", { signal: "visibility" });
@@ -619,7 +619,7 @@ describe("sseService.attach: background grace policy", () => {
     eventBus.publish("app.resume", { signal: "app_state" });
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
 
-    // THEN the iOS double-fire's second resume leaves the seconds-old socket
+    // THEN a redundant second resume leaves the seconds-old socket
     // alone: the mark is consumed on the first edge, so an old `hiddenAt`
     // cannot make a freshly opened connection look suspect
     eventBus.publish("app.resume", { signal: "visibility" });

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -265,9 +265,12 @@ export const sseService: SseService = {
     // cancel any pending grace teardown (so a brief tab-out keeps its live
     // socket) and reopen only if the connection was torn down, or if the
     // background ran long enough that the socket we still hold is suspect.
-    // The self-dedup window collapses double-fires from visibilitychange +
-    // Capacitor appStateChange (both arrive in close succession on
-    // foregrounding the iOS native shell).
+    // `runtime/event-sources/lifecycle-edge.ts` is the primary collapse: the
+    // visibilitychange + Capacitor appStateChange pair for one physical edge
+    // reaches the bus as a single `app.resume`. The self-dedup window below
+    // covers the redundant resumes that still arrive: an
+    // `app.resume{signal:"online"}` landing next to a foreground resume, and a
+    // visibility/app_state pair spread further apart than the edge window.
     const handleAppResume = ({ signal }: { signal: AppResumeSignal }) => {
       // Only a real foreground consumes the hidden state. `online` is a
       // network transition that can arrive while the app is still
@@ -286,8 +289,8 @@ export const sseService: SseService = {
         clearHiddenTeardownTimer();
         // Consume the hidden mark on this first resume edge, ahead of the
         // dedup window below, so the suspect check runs once per background
-        // and cannot be skipped: the iOS double-fire's second resume finds
-        // it null and so can neither bypass nor re-run the bounce.
+        // and cannot be skipped: a redundant second resume finds it null and
+        // so can neither bypass nor re-run the bounce.
         hiddenSince = hiddenAt;
         hiddenAt = null;
       }
@@ -305,15 +308,15 @@ export const sseService: SseService = {
         teardown();
       }
       if (now - lastAppResumeAt < RESUME_DEDUP_WINDOW_MS) {
-        // Inside the dedup window. This collapses the iOS double-fire
-        // (visibilitychange + Capacitor appStateChange deliver two
-        // resumes ms apart for a single foreground) so the health check
-        // below runs once. But the window must NOT suppress a genuine
-        // reopen: an `app.hidden` can land *between* two resumes and (once
-        // its grace elapses) tear the socket down (`current === null`),
-        // and a blanket early-return would then strand the connection
-        // torn-down until the next foreground — the user sees a frozen
-        // transcript and has to refresh to get streaming back. Reopen
+        // Inside the dedup window. This collapses a redundant second resume
+        // (an `online` edge landing next to a foreground one, or a
+        // visibility/app_state pair spread further apart than the
+        // lifecycle-edge window) so the health check below runs once. But the
+        // window must NOT suppress a genuine reopen: an `app.hidden` can land
+        // *between* two resumes and (once its grace elapses) tear the socket
+        // down (`current === null`), and a blanket early-return would then
+        // strand the connection torn-down until the next foreground, leaving
+        // the user a frozen transcript that only a refresh recovers. Reopen
         // whenever the connection is down; only the redundant health check
         // is skipped here.
         if (!current) {

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -208,11 +208,14 @@ export function installResumeRequestCounter(): void {
 
   subscribe("app.resume", ({ signal }) => {
     if (resumeWindow) {
-      // iOS publishes both a visibility and an app_state resume for a single
-      // foreground; the first edge wins so the burst is counted once. A window
-      // older than its own span is one whose timer was frozen while the app was
-      // suspended: its counts belong to an earlier foreground, so drop it and
-      // start a fresh window for this resume.
+      // The bus collapses the visibility + app_state pair for one physical
+      // edge at the source (`runtime/event-sources/lifecycle-edge.ts`).
+      // First-edge-wins here keeps the burst counted once for the redundant
+      // resumes that still reach subscribers: an `online` edge landing next to
+      // a foreground one, or a pair spread further apart than that window.
+      // A window older than its own span is one whose timer was frozen while
+      // the app was suspended: its counts belong to an earlier foreground, so
+      // drop it and start a fresh window for this resume.
       if (performance.now() - resumeWindow.openedAt < WINDOW_MS) {
         return;
       }

--- a/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
+++ b/clients/web/src/runtime/event-sources/capacitor-app-state.test.ts
@@ -31,6 +31,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 import * as eventBus from "@/lib/event-bus";
+import { __resetLifecycleEdgeForTests } from "@/runtime/event-sources/lifecycle-edge";
 
 const publishSpy = spyOn(eventBus, "publish");
 
@@ -47,6 +48,10 @@ const flushMicrotasks = async (rounds = 4) => {
 };
 
 beforeEach(() => {
+  // The edge window is module state shared with every other source that
+  // publishes through it, so a case in another suite can otherwise swallow
+  // this one's first edge.
+  __resetLifecycleEdgeForTests();
   activeHandler = null;
   addListenerMock.mockClear();
   captureErrorMock.mockClear();

--- a/clients/web/src/runtime/event-sources/dom-visibility.test.ts
+++ b/clients/web/src/runtime/event-sources/dom-visibility.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import * as eventBus from "@/lib/event-bus";
 import { publishVisibilitySource } from "@/runtime/event-sources/dom-visibility";
+import { __resetLifecycleEdgeForTests } from "@/runtime/event-sources/lifecycle-edge";
 
 const publishSpy = spyOn(eventBus, "publish");
 
@@ -15,6 +16,10 @@ const trackedSubscribe = (): void => {
 };
 
 beforeEach(() => {
+  // The edge window is module state shared with every other source that
+  // publishes through it, so a case in another suite can otherwise swallow
+  // this one's first edge.
+  __resetLifecycleEdgeForTests();
   publishSpy.mockClear();
 });
 


### PR DESCRIPTION
## Summary
- Resume-dedup comments now name the real remaining redundant-resume cases and point at lifecycle-edge as the primary collapse (the visibility+app_state pair no longer reaches consumers)
- The two event-source test suites reset the shared lifecycle-edge window so the directory runs green in one process

Fixes gaps found during plan self-review for resume-storm-fixes.md