### PR TITLE
fix(web): flush the pending reconnect sweep as stale-marking when leaving an assistant

### DIFF
--- a/clients/web/src/domains/intelligence/memory-graph/invalidate-memory-queries.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/invalidate-memory-queries.ts
@@ -18,15 +18,22 @@ import { memoryStatsOptions } from "./get-memory-stats";
  * Called from the `assistantConfig` sync tag (a config write on any client) and
  * on mount of the unavailable-graph surface, which is where a stale answer is
  * most actively misleading.
+ *
+ * `refetchType` defaults to TanStack's own default: observed queries refetch
+ * now, unobserved ones only go stale. Pass `"none"` to mark stale without
+ * issuing any request.
  */
 export function invalidateMemoryQueries(
   queryClient: QueryClient,
   assistantId: string,
+  refetchType: "active" | "none" = "active",
 ): void {
   void queryClient.invalidateQueries({
     queryKey: memoryGraphOptions(assistantId).queryKey,
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: memoryStatsOptions(assistantId).queryKey,
+    refetchType,
   });
 }

--- a/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
+++ b/clients/web/src/domains/intelligence/plugins/invalidate-plugin-queries.ts
@@ -14,30 +14,39 @@ import {
  * just that plugin's; omitting `name` (a broad, name-agnostic `plugins:list`
  * sync or a reconnect reconcile) invalidates every open plugin detail for the
  * assistant, since any of them may have changed on another client.
+ *
+ * `refetchType` defaults to TanStack's own default: observed queries refetch
+ * now, unobserved ones only go stale. Pass `"none"` to mark stale without
+ * issuing any request.
  */
 export function invalidatePluginQueries(
   queryClient: QueryClient,
   assistantId: string,
   name?: string,
+  refetchType: "active" | "none" = "active",
 ): void {
   void queryClient.invalidateQueries({
     queryKey: pluginsGetQueryKey({ path: { assistant_id: assistantId } }),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: pluginsSearchGetQueryKey({
       path: { assistant_id: assistantId },
     }),
+    refetchType,
   });
   if (name) {
     void queryClient.invalidateQueries({
       queryKey: pluginsByNameGetQueryKey({
         path: { assistant_id: assistantId, name },
       }),
+      refetchType,
     });
     void queryClient.invalidateQueries({
       queryKey: pluginsByNameInspectGetQueryKey({
         path: { assistant_id: assistantId, name },
       }),
+      refetchType,
     });
     return;
   }
@@ -48,10 +57,12 @@ export function invalidatePluginQueries(
     queryKey: [
       { _id: "pluginsByNameGet", path: { assistant_id: assistantId } },
     ],
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: [
       { _id: "pluginsByNameInspectGet", path: { assistant_id: assistantId } },
     ],
+    refetchType,
   });
 }

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -74,6 +74,27 @@ function keyId(queryKey: readonly unknown[] | undefined): string | undefined {
   return queryKey === undefined ? undefined : hashKey(queryKey);
 }
 
+type InvalidateCall = {
+  queryKey?: readonly unknown[];
+  refetchType?: string;
+};
+
+/** Stand-in for `queryClient.invalidateQueries` that records every call. */
+function recordInvalidations(sink: InvalidateCall[]) {
+  return (arg: unknown) => {
+    sink.push(arg as InvalidateCall);
+    return Promise.resolve();
+  };
+}
+
+/** The recorded invalidations that targeted one exact query key. */
+function sweepsFor(
+  calls: InvalidateCall[],
+  queryKey: readonly unknown[],
+): InvalidateCall[] {
+  return calls.filter((call) => keyId(call.queryKey) === keyId(queryKey));
+}
+
 beforeEach(() => {
   __resetForTesting();
 });
@@ -467,10 +488,15 @@ describe("useAssistantResourceSync", () => {
     expect(avatarSweeps.length).toBe(1);
   });
 
-  test("unmount cancels a pending reconnect sweep", async () => {
+  // The debounce window is the only place a scheduled catch-up could go
+  // missing: leaving inside it used to cancel the timer outright, and the
+  // return trip attaches fresh, which this hook ignores. Cleanup flushes
+  // instead, so the gap is always reconciled for the assistant it was
+  // scheduled for.
+  test("unmount flushes the pending reconnect sweep as stale-marking", async () => {
     const queryClient = freshQueryClient();
-    const spy = mock(() => Promise.resolve());
-    queryClient.invalidateQueries = spy as never;
+    const calls: InvalidateCall[] = [];
+    queryClient.invalidateQueries = recordInvalidations(calls) as never;
     const { unmount } = renderHook(
       () => useAssistantResourceSync("asst-1", true),
       { wrapper: createWrapper(queryClient) },
@@ -478,18 +504,23 @@ describe("useAssistantResourceSync", () => {
 
     publish("sse.opened", { assistantId: "asst-1", cause: "error" });
     unmount();
-    await flushReconnectSweep();
 
-    expect(spy).not.toHaveBeenCalled();
+    const avatarSweeps = sweepsFor(calls, avatarQueryKey("asst-1"));
+    expect(avatarSweeps.length).toBe(1);
+    expect(avatarSweeps[0]?.refetchType).toBe("none");
+
+    // The flush consumed the pending timer, so the debounce never fires again.
+    await flushReconnectSweep();
+    expect(sweepsFor(calls, avatarQueryKey("asst-1")).length).toBe(1);
   });
 
   // A queued sweep closes over the assistant that was active when it was
-  // scheduled, so switching assistants has to drop it rather than let it
-  // refresh caches for the assistant the user just left.
-  test("switching assistants cancels the pending reconnect sweep", async () => {
+  // scheduled, so switching assistants flushes it for that assistant rather
+  // than letting it run against the one the user just switched to.
+  test("switching assistants flushes the pending sweep for the assistant left behind", async () => {
     const queryClient = freshQueryClient();
-    const spy = mock(() => Promise.resolve());
-    queryClient.invalidateQueries = spy as never;
+    const calls: InvalidateCall[] = [];
+    queryClient.invalidateQueries = recordInvalidations(calls) as never;
     const { rerender } = renderHook(
       ({ id }: { id: string }) => useAssistantResourceSync(id, true),
       {
@@ -500,9 +531,123 @@ describe("useAssistantResourceSync", () => {
 
     publish("sse.opened", { assistantId: "asst-1", cause: "error" });
     rerender({ id: "asst-2" });
+
+    const avatarSweeps = sweepsFor(calls, avatarQueryKey("asst-1"));
+    expect(avatarSweeps.length).toBe(1);
+    expect(avatarSweeps[0]?.refetchType).toBe("none");
+    expect(sweepsFor(calls, avatarQueryKey("asst-2")).length).toBe(0);
+
+    await flushReconnectSweep();
+    expect(sweepsFor(calls, avatarQueryKey("asst-1")).length).toBe(1);
+  });
+
+  // The departing flush is the whole point of the invariant: the long
+  // staleTime families (memory reads at five minutes) would otherwise serve
+  // pre-gap data on the next visit, well past the 10s global staleTime that
+  // rescues everything else.
+  test("switching assistants stales the departing assistant's memory reads without fetching", async () => {
+    const queryClient = freshQueryClient();
+    const oldKey = memoryGraphOptions("asst-1").queryKey;
+    const newKey = memoryGraphOptions("asst-2").queryKey;
+    let oldFetches = 0;
+    let newFetches = 0;
+    const oldObserver = new QueryObserver(queryClient, {
+      queryKey: oldKey,
+      queryFn: () => {
+        oldFetches += 1;
+        return Promise.resolve({ ok: true });
+      },
+      staleTime: Infinity,
+    });
+    const newObserver = new QueryObserver(queryClient, {
+      queryKey: newKey,
+      queryFn: () => {
+        newFetches += 1;
+        return Promise.resolve({ ok: true });
+      },
+      staleTime: Infinity,
+    });
+    const unsubOld = oldObserver.subscribe(() => {});
+    const unsubNew = newObserver.subscribe(() => {});
+    try {
+      await waitFor(() => {
+        expect(oldFetches).toBe(1);
+        expect(newFetches).toBe(1);
+      });
+      const { rerender } = renderHook(
+        ({ id }: { id: string }) => useAssistantResourceSync(id, true),
+        {
+          wrapper: createWrapper(queryClient),
+          initialProps: { id: "asst-1" },
+        },
+      );
+
+      publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+      rerender({ id: "asst-2" });
+      await flushReconnectSweep();
+
+      expect(queryClient.getQueryState(oldKey)?.isInvalidated).toBe(true);
+      expect(oldFetches).toBe(1);
+      expect(queryClient.getQueryState(newKey)?.isInvalidated).toBe(false);
+      expect(newFetches).toBe(1);
+    } finally {
+      unsubOld();
+      unsubNew();
+    }
+  });
+
+  test("unmount stales the assistant's memory reads without fetching", async () => {
+    const queryClient = freshQueryClient();
+    const memoryKey = memoryGraphOptions("asst-1").queryKey;
+    let fetches = 0;
+    const observer = new QueryObserver(queryClient, {
+      queryKey: memoryKey,
+      queryFn: () => {
+        fetches += 1;
+        return Promise.resolve({ ok: true });
+      },
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    try {
+      await waitFor(() => {
+        expect(fetches).toBe(1);
+      });
+      const { unmount } = renderHook(
+        () => useAssistantResourceSync("asst-1", true),
+        { wrapper: createWrapper(queryClient) },
+      );
+
+      publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+      unmount();
+      await flushReconnectSweep();
+
+      expect(queryClient.getQueryState(memoryKey)?.isInvalidated).toBe(true);
+      expect(fetches).toBe(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // Cleanup only flushes what is still pending, so a sweep that already ran on
+  // its own timer is not run a second time when the hook later tears down.
+  test("cleanup after the debounce has fired does not sweep twice", async () => {
+    const queryClient = freshQueryClient();
+    const calls: InvalidateCall[] = [];
+    queryClient.invalidateQueries = recordInvalidations(calls) as never;
+    const { unmount } = renderHook(
+      () => useAssistantResourceSync("asst-1", true),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+    await flushReconnectSweep();
+    expect(sweepsFor(calls, avatarQueryKey("asst-1")).length).toBe(1);
+
+    unmount();
     await flushReconnectSweep();
 
-    expect(spy).not.toHaveBeenCalled();
+    expect(sweepsFor(calls, avatarQueryKey("asst-1")).length).toBe(1);
   });
 
   test("invalidates home-feed query on home_feed_updated", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -8,7 +8,8 @@
  *
  * Also handles `sse.opened` (non-fresh) to invalidate cached resources on
  * reconnect — the client may have missed `sync_changed` events during the
- * transport gap. That sweep is debounced; see `refreshAssistantResources`
+ * transport gap. That sweep is debounced, and a pending one is flushed rather
+ * than dropped when the assistant changes; see `refreshAssistantResources`
  * below.
  *
  * Focus-based refetching (tab visible, Capacitor foregrounding) is NOT
@@ -72,17 +73,27 @@ export function useAssistantResourceSync(
     null,
   );
 
-  // Drop a pending sweep on unmount and when the assistant changes or
-  // deactivates, so a queued callback never refreshes against an old
-  // assistantId.
+  // Invariant: a scheduled reconnect catch-up is never dropped. On unmount and
+  // when the assistant changes or deactivates, the pending sweep is flushed
+  // here rather than cancelled, so the transport gap is always reconciled for
+  // the assistant it was scheduled for. This closure captures the departing
+  // assistantId, and the flush marks stale without refetching, so at worst the
+  // catch-up degrades to stale-marking for an assistant nobody observes any
+  // more and the next visit reads through.
   useEffect(() => {
     return () => {
-      if (reconnectSweepTimerRef.current) {
-        clearTimeout(reconnectSweepTimerRef.current);
-        reconnectSweepTimerRef.current = null;
+      const pendingSweep = reconnectSweepTimerRef.current;
+      if (!pendingSweep) {
+        return;
       }
+      clearTimeout(pendingSweep);
+      reconnectSweepTimerRef.current = null;
+      if (!assistantId) {
+        return;
+      }
+      refreshAssistantResources(queryClient, assistantId, "none");
     };
-  }, [assistantId, isAssistantActive]);
+  }, [assistantId, isAssistantActive, queryClient]);
 
   useBusSubscription("sse.event", (envelope) => {
     if (!assistantId || !isAssistantActive) {
@@ -223,53 +234,69 @@ export function useAssistantResourceSync(
  * a view that is open refetches now, which is the only way it picks up the
  * `sync_changed` events it missed while the stream was down.
  *
+ * `refetchType: "none"` is the departure flush: the sweep still marks every
+ * family stale, but never issues a request. The caller uses it for an assistant
+ * the user has just left, whose views are unmounting in this same commit.
+ *
  * A flapping reconnect would run this fan-out once per `sse.opened`, so the
  * caller collapses a burst into a single trailing sweep.
  */
 function refreshAssistantResources(
   queryClient: QueryClient,
   assistantId: string,
+  refetchType: "active" | "none" = "active",
 ): void {
   const pathOpts = { path: { assistant_id: assistantId } };
 
   void queryClient.invalidateQueries({
     queryKey: identityGetQueryKey(pathOpts),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: configGetQueryKey(pathOpts),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: avatarQueryKey(assistantId),
+    refetchType,
   });
-  invalidateMemoryQueries(queryClient, assistantId);
+  invalidateMemoryQueries(queryClient, assistantId, refetchType);
   void queryClient.invalidateQueries({
     queryKey: soundsConfigGetQueryKey(pathOpts),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: soundsAvailableGetQueryKey(pathOpts),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: schedulesGetQueryKey(pathOpts),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: [
       { _id: "schedulesByIdRunsGet", path: { assistant_id: assistantId } },
     ],
+    refetchType,
   });
   void queryClient.invalidateQueries({
     queryKey: [
       { _id: "schedulesUsagesummaryGet", path: { assistant_id: assistantId } },
     ],
+    refetchType,
   });
   void queryClient.invalidateQueries({
     predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
+    refetchType,
   });
-  invalidatePluginQueries(queryClient, assistantId);
+  invalidatePluginQueries(queryClient, assistantId, undefined, refetchType);
   void queryClient.invalidateQueries({
     predicate: (query) => isGeneratedQueryKey(query.queryKey, "homeFeedGet"),
+    refetchType,
   });
   void queryClient.invalidateQueries({
     predicate: (query) => isGeneratedQueryKey(query.queryKey, "homeStateGet"),
+    refetchType,
   });
 }
 


### PR DESCRIPTION
## Summary
- A pending debounced reconnect sweep is no longer dropped by an assistant switch, deactivation, or unmount inside the 500ms window: cleanup flushes it as a zero-fetch stale-marking pass for the departing assistant, so long-staleTime families (memory, home) cannot serve pre-gap data on return
- The normal debounced path is unchanged

Addresses the post-merge Codex review on #40124 for resume-storm-fixes.md