### PR TITLE
fix(web): settle a conclusively rejected platform session as absent

### DIFF
--- a/clients/web/docs/STATE_MANAGEMENT.md
+++ b/clients/web/docs/STATE_MANAGEMENT.md
@@ -518,6 +518,12 @@ Queries mounted inside `<ActiveAssistantGate>` typically don't race
 because the lifecycle resolves after org hydration, but the gate is
 cheap and safe to add defensively.
 
+A platform session whose API calls are conclusively rejected (a
+settled 401/403/410 from the org or assistants endpoints during the
+session probe) settles `platformSession: "absent"`, so bearer-auth
+(local/paired gateway) connections never stay org-gated behind a
+dead cookie.
+
 Reference: [TanStack Query — Dependent Queries](https://tanstack.com/query/latest/docs/framework/react/guides/dependent-queries)
 
 ### Canonical migration example

--- a/clients/web/src/hooks/use-is-org-ready.test.tsx
+++ b/clients/web/src/hooks/use-is-org-ready.test.tsx
@@ -183,4 +183,19 @@ describe("useOrgHeaderReadiness", () => {
     render(<ReadinessProbe />);
     expect(latestReadiness).toBe("ready");
   });
+
+  test("a settled-absent session with a failed org fetch is ready", () => {
+    // The half-dead end state: the platform API conclusively rejected the
+    // session, so the probe settled `platformSession: "absent"` (no platform
+    // session) while the org fetch landed on "error". Readiness must be
+    // "ready" here; this is what un-gates the org-gated daemon queries
+    // (conversation skeletons) on bearer-auth connections.
+    hasPlatformSessionMock = false;
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Platform session was rejected (HTTP 403).",
+    });
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("ready");
+  });
 });

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { cleanup } from "@testing-library/react";
 
 type MockSessionUser = {
@@ -144,6 +152,17 @@ const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 // unaffected; the reconciliation tests override it to a well-formed result.
 let mockListAssistantsResult: unknown = [];
 const listAssistantsMock = mock(async () => mockListAssistantsResult);
+// Controls the `OrgFetchOutcome` the probe's evidence check reads. A thrown
+// error simulates a transport failure; a never-resolving promise as the
+// outcome makes the fetch hang so the probe's sync race times out.
+let mockOrgFetchOutcome: unknown = { ok: true };
+let mockOrgFetchError: Error | null = null;
+const fetchOrganizationsMock = mock(async () => {
+  if (mockOrgFetchError) {
+    throw mockOrgFetchError;
+  }
+  return mockOrgFetchOutcome;
+});
 const syncPlatformAssistantsToLockfileMock = mock(
   async (_list: unknown, _orgId?: string) => {},
 );
@@ -314,7 +333,7 @@ mock.module("@/stores/organization-store", () => ({
   clearOrganization: clearOrganizationMock,
   useOrganizationStore: {
     getState: () => ({
-      fetchOrganizations: async () => {},
+      fetchOrganizations: fetchOrganizationsMock,
       currentOrganizationId: "org-test",
     }),
   },
@@ -344,8 +363,11 @@ mock.module("@/assistant/api", () => ({
   listAssistants: listAssistantsMock,
 }));
 
-const { useAuthStore, __resetConsentSyncUserForTesting } =
-  await import("@/stores/auth-store");
+const {
+  useAuthStore,
+  whenPlatformSessionSettled,
+  __resetConsentSyncUserForTesting,
+} = await import("@/stores/auth-store");
 const { useAssistantLifecycleStore } =
   await import("@/assistant/lifecycle-store");
 const { useResolvedAssistantsStore } =
@@ -438,6 +460,9 @@ beforeEach(() => {
   lifecycleCheckAssistantMock.mockClear();
   mockListAssistantsResult = [];
   listAssistantsMock.mockClear();
+  mockOrgFetchOutcome = { ok: true };
+  mockOrgFetchError = null;
+  fetchOrganizationsMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   bootstrapLocalAssistantPlatformIdentityMock.mockClear();
   resetAuthStore();
@@ -1709,6 +1734,129 @@ describe("platform session probe resolution", () => {
     gates[1]();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+});
+
+describe("platform probe conclusive rejection (half-dead session)", () => {
+  // The half-dead state: allauth answers 200 with a user while the platform
+  // API conclusively rejects the same credential. The probe consumes the
+  // org/assistants evidence it already gathers and settles the session
+  // "absent", which un-gates org-gated daemon queries on bearer-auth
+  // connections and surfaces the login affordances. The recovery
+  // interceptor's settled-absent gate then treats any residual platform 403
+  // as a no-op instead of looping.
+  //
+  // Every test drives the local-client init path (no gateway auth, no
+  // platform assistants), where the probe runs with `setUserOnSuccess`.
+  function arrangeLocalProbe(): void {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+  }
+
+  test("an org-fetch session rejection settles the session absent", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    // A rejected session must not install a platform user, persist a
+    // restorable snapshot, or bootstrap the platform identity.
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
+    // The evidence check short-circuits before the assistants call and sync.
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("an assistants-list session rejection settles the session absent", async () => {
+    arrangeLocalProbe();
+    mockListAssistantsResult = { ok: false, status: 403, error: {} };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("a transport-thrown org fetch keeps the present settle", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    // No evidence of rejection: the offline-restore contract (LUM-2412)
+    // keeps the session present.
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(bootstrapLocalAssistantPlatformIdentityMock).toHaveBeenCalled();
+  });
+
+  test("a non-rejection org failure keeps the present settle", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("a sync race timeout keeps the present settle", async () => {
+    arrangeLocalProbe();
+    // An org fetch that never resolves leaves the race with only the timeout
+    // arm; shrink the 3s timer to 0 so the test settles immediately.
+    mockOrgFetchOutcome = new Promise(() => {});
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    setTimeoutSpy.mockImplementation(((
+      handler: () => void,
+      timeout?: number,
+    ) =>
+      originalSetTimeout(
+        handler,
+        timeout === 3_000 ? 0 : timeout,
+      )) as typeof setTimeout);
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("the probe clears its sync race timer once it settles", async () => {
+    arrangeLocalProbe();
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+
+      const raceTimerIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === 3_000,
+      );
+      expect(raceTimerIndex).toBeGreaterThanOrEqual(0);
+      const raceTimerHandle = setTimeoutSpy.mock.results[raceTimerIndex]?.value;
+      expect(
+        clearTimeoutSpy.mock.calls.some((call) => call[0] === raceTimerHandle),
+      ).toBe(true);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1771,6 +1771,24 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
   });
 
+  test("a session rejection clears a previously persisted snapshot", async () => {
+    arrangeLocalProbe();
+    // A snapshot persisted by an earlier confirmed session must not survive
+    // the rejection: restoreOfflineSession would otherwise resurrect the
+    // rejected account as "present" on a later offline boot.
+    localStorage.setItem(
+      "vellum:auth:userSnapshot",
+      JSON.stringify({ id: "user-1", email: "user@example.com" }),
+    );
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
   test("an assistants-list session rejection settles the session absent", async () => {
     arrangeLocalProbe();
     mockListAssistantsResult = { ok: false, status: 403, error: {} };

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -627,33 +627,38 @@ function probePlatformSession(
       }
       if (result.ok && result.data.user) {
         const probedUser = toAuthUser(result.data.user);
-        const userUpdate = options.setUserOnSuccess ? { user: probedUser } : {};
-        // Adopting the probed user confirms a platform session outside the
-        // `authenticatedPlatformUser` transition — persist here too so the
-        // local-mode path feeds the offline restore (LUM-2412).
-        if (options.setUserOnSuccess) {
-          persistUserSnapshot(probedUser);
-        }
         // Sync platform assistants to the lockfile BEFORE setting
         // platformSession to "present". The auth middleware unblocks on
         // `platformSession !== "unknown"`, and hasAssistants() must
         // already reflect synced platform assistants at that point.
         // The whole sequence (org fetch, list, host replace) is bounded
-        // to 3s so a hanging call can't block the probe from settling —
+        // to 3s so a hanging call can't block the probe from settling;
         // the middleware's 5s timeout would loop indefinitely otherwise.
         // The race does not cancel the inner branch, so the guard also
         // checks `timedOut`: once the probe settles without the sync, a
         // late commit must not land after routing decisions were made on
         // the un-synced lockfile. `!isStale()` likewise keeps a
         // superseded probe from committing an out-of-date lockfile.
+        let sessionRejected = false;
         if (isLocalClient()) {
           let timedOut = false;
           const syncIsCurrent = (): boolean => !timedOut && !isStale();
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
           try {
             await Promise.race([
               (async () => {
-                await useOrganizationStore.getState().fetchOrganizations();
+                const orgOutcome = await useOrganizationStore
+                  .getState()
+                  .fetchOrganizations();
+                if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+                  sessionRejected = true;
+                  return;
+                }
                 const apiAssistants = await listAssistants();
+                if (isSettledSessionRejection(apiAssistants)) {
+                  sessionRejected = true;
+                  return;
+                }
                 if (syncIsCurrent() && apiAssistants.ok) {
                   await syncPlatformAssistantsToLockfile(
                     apiAssistants.data,
@@ -663,19 +668,41 @@ function probePlatformSession(
                   );
                 }
               })(),
-              new Promise<never>((_, reject) =>
-                setTimeout(() => {
+              new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(() => {
                   timedOut = true;
                   reject(new Error("sync timeout"));
-                }, 3_000),
-              ),
+                }, 3_000);
+              }),
             ]);
           } catch {
-            // Sync failed or timed out — continue with cached lockfile data
+            // Sync failed or timed out; continue with cached lockfile data
+          } finally {
+            clearTimeout(timeoutHandle);
           }
         }
         if (isStale()) {
           return;
+        }
+        if (sessionRejected) {
+          // The allauth cookie answered, but the platform API conclusively
+          // rejected the credential (a settled 401/403/410 on the org or
+          // assistants call), so this session is unusable for every consumer:
+          // settle it as absent, install no user, and skip the platform
+          // identity bootstrap. Transport failures and the race timeout
+          // deliberately never reach this branch (LUM-2412 offline restore).
+          set({
+            platformSession: "absent",
+            platformSessionRestoredOffline: false,
+          });
+          return;
+        }
+        const userUpdate = options.setUserOnSuccess ? { user: probedUser } : {};
+        // Adopting the probed user confirms a platform session outside the
+        // `authenticatedPlatformUser` transition, so persist here too to feed
+        // the local-mode offline restore (LUM-2412).
+        if (options.setUserOnSuccess) {
+          persistUserSnapshot(probedUser);
         }
         set({
           platformSession: "present",

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -691,7 +691,19 @@ function probePlatformSession(
           // settle it as absent, install no user, and skip the platform
           // identity bootstrap. Transport failures and the race timeout
           // deliberately never reach this branch (LUM-2412 offline restore).
+          // The persisted snapshot must go too, or `restoreOfflineSession`
+          // could resurrect the rejected account as "present" on a later
+          // offline boot; an already-authenticated local/gateway session
+          // demotes its user to the local shape, mirroring refreshSession's
+          // stands-alone demotion.
+          clearUserSnapshot();
+          const demotion = isAuthenticated(
+            useAuthStore.getState().sessionStatus,
+          )
+            ? authenticatedLocalUser()
+            : {};
           set({
+            ...demotion,
             platformSession: "absent",
             platformSessionRestoredOffline: false,
           });


### PR DESCRIPTION
## Summary
- The session probe now consumes the org/assistants evidence it already gathers: a settled 401/403/410 on either settles platformSession to absent instead of present
- Un-gates org-gated daemon queries on bearer-auth connections and surfaces the login affordances; transport failures keep the offline-restore behavior
- Clears the probe's leaked 3s race timer

Part of plan: half-dead-platform-session.md (PR 3 of 3)