### PR TITLE
feat(web): connect a remote assistant from the chooser by pasting a pair bundle

### DIFF
--- a/clients/web/src/domains/onboarding/components/connect-assistant-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-assistant-dialog.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Behavioral tests for the paste-a-bundle connect dialog: the host import op
+ * receives the trimmed bundle and optional name, host failures render their
+ * structured error copy verbatim, an access-only pairing interposes the expiry
+ * warning before `onImported`, and a refresh-capable pairing completes
+ * immediately. Self-contained mocks: run this file solo (`mock.module` leaks
+ * across a shared `bun test` run).
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ComponentProps, ReactNode } from "react";
+
+// --- Mutable per-test state, reset in beforeEach ------------------------------
+
+type ImportResult =
+  | { ok: true; assistantId: string; accessOnly: boolean }
+  | { ok: false; error: string };
+
+const importPairedAssistantBundleMock = mock(
+  async (_bundle: string, _name?: string): Promise<ImportResult> => ({
+    ok: true,
+    assistantId: "paired-new",
+    accessOnly: false,
+  }),
+);
+
+const onCloseMock = mock(() => {});
+const onImportedMock = mock((_assistantId: string) => {});
+
+// --- Mocks --------------------------------------------------------------------
+
+mock.module("@/lib/local-mode", () => ({
+  importPairedAssistantBundle: importPairedAssistantBundleMock,
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+mock.module("@vellumai/design-library/components/input", () => ({
+  Input: ({
+    fullWidth: _fullWidth,
+    ...props
+  }: ComponentProps<"input"> & { fullWidth?: boolean }) => <input {...props} />,
+  Textarea: ({
+    fullWidth: _fullWidth,
+    ...props
+  }: ComponentProps<"textarea"> & { fullWidth?: boolean }) => (
+    <textarea {...props} />
+  ),
+}));
+
+mock.module("@vellumai/design-library/components/modal", () => ({
+  Modal: {
+    Root: ({ open, children }: { open: boolean; children: ReactNode }) =>
+      open ? <div>{children}</div> : null,
+    Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Header: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Title: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+    Description: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+    Body: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Footer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+mock.module("@vellumai/design-library/components/notice", () => ({
+  Notice: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const { ConnectAssistantDialog } = await import(
+  "@/domains/onboarding/components/connect-assistant-dialog"
+);
+
+// --- Helpers ------------------------------------------------------------------
+
+function renderDialog(
+  overrides: Partial<
+    ComponentProps<typeof ConnectAssistantDialog>
+  > = {},
+) {
+  return render(
+    <ConnectAssistantDialog
+      open
+      onClose={onCloseMock}
+      onImported={onImportedMock}
+      {...overrides}
+    />,
+  );
+}
+
+function fillBundle(value: string): void {
+  fireEvent.change(screen.getByLabelText("Pairing bundle"), {
+    target: { value },
+  });
+}
+
+// --- Suite --------------------------------------------------------------------
+
+describe("ConnectAssistantDialog", () => {
+  beforeEach(() => {
+    importPairedAssistantBundleMock.mockClear();
+    importPairedAssistantBundleMock.mockImplementation(async () => ({
+      ok: true,
+      assistantId: "paired-new",
+      accessOnly: false,
+    }));
+    onCloseMock.mockClear();
+    onImportedMock.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  test("submits the trimmed bundle and name and completes via onImported", async () => {
+    renderDialog();
+
+    fillBundle("  eyJnYXRld2F5...  ");
+    fireEvent.change(screen.getByLabelText("Name (optional)"), {
+      target: { value: "  desk  " },
+    });
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() =>
+      expect(importPairedAssistantBundleMock).toHaveBeenCalledWith(
+        "eyJnYXRld2F5...",
+        "desk",
+      ),
+    );
+    await waitFor(() =>
+      expect(onImportedMock).toHaveBeenCalledWith("paired-new"),
+    );
+  });
+
+  test("a blank name is passed as undefined", async () => {
+    renderDialog();
+
+    fillBundle("eyJnYXRld2F5...");
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() =>
+      expect(importPairedAssistantBundleMock).toHaveBeenCalledWith(
+        "eyJnYXRld2F5...",
+        undefined,
+      ),
+    );
+  });
+
+  test("Connect stays disabled until a bundle is pasted", () => {
+    renderDialog();
+
+    expect(
+      (screen.getByText("Connect") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fillBundle("eyJnYXRld2F5...");
+
+    expect(
+      (screen.getByText("Connect") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  test.each([
+    "invalid pairing bundle. Paste the full base64 string printed by vellum pair.",
+    "an assistant named 'desk' already exists locally. Choose a different name to avoid overwriting it.",
+    "Connecting a paired assistant is not supported by this app version",
+  ])("a host failure renders its error copy verbatim: %s", async (error) => {
+    importPairedAssistantBundleMock.mockImplementation(async () => ({
+      ok: false,
+      error,
+    }));
+    renderDialog();
+
+    fillBundle("eyJnYXRld2F5...");
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() => expect(screen.getByText(error)).toBeTruthy());
+    expect(onImportedMock).not.toHaveBeenCalled();
+  });
+
+  test("an access-only pairing interposes the expiry warning before onImported", async () => {
+    importPairedAssistantBundleMock.mockImplementation(async () => ({
+      ok: true,
+      assistantId: "paired-new",
+      accessOnly: true,
+    }));
+    renderDialog();
+
+    fillBundle("eyJnYXRld2F5...");
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/access-only: its access expires and cannot renew/),
+      ).toBeTruthy(),
+    );
+    expect(onImportedMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(onImportedMock).toHaveBeenCalledWith("paired-new");
+  });
+
+  test("initialBundle prefills the paste field and guidanceMessage renders", () => {
+    renderDialog({
+      initialBundle: "eyJwcmVmaWxs...",
+      guidanceMessage: "Open this page from a pairing link to prefill it.",
+    });
+
+    expect(
+      (screen.getByLabelText("Pairing bundle") as HTMLTextAreaElement).value,
+    ).toBe("eyJwcmVmaWxs...");
+    expect(
+      screen.getByText("Open this page from a pairing link to prefill it."),
+    ).toBeTruthy();
+  });
+
+  test("Cancel closes without importing", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(onCloseMock).toHaveBeenCalled();
+    expect(importPairedAssistantBundleMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-assistant-dialog.tsx
@@ -1,0 +1,214 @@
+import { Link2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Input, Textarea } from "@vellumai/design-library/components/input";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { importPairedAssistantBundle } from "@/lib/local-mode";
+
+interface ConnectAssistantDialogProps {
+  open: boolean;
+  /** Prefills the bundle field when the dialog opens (deep-link entry). */
+  initialBundle?: string;
+  /** Extra guidance rendered above the form (deep-link entry with no bundle). */
+  guidanceMessage?: string;
+  onClose: () => void;
+  /**
+   * Fired once the pairing is imported and the lockfile refreshed, so the
+   * caller can select and connect the new assistant. When the pairing is
+   * access-only this fires only after the user acknowledges the expiry
+   * warning.
+   */
+  onImported: (assistantId: string) => void;
+}
+
+/**
+ * Paste-a-bundle dialog for connecting a remote assistant paired via
+ * `vellum pair` on another machine. Submitting registers the pairing through
+ * the local-mode host and refreshes the lockfile; host failures (malformed
+ * bundle, name collision, unsupported app version) render inline. An
+ * access-only pairing interposes an expiry warning before completing.
+ */
+function ConnectAssistantDialog({
+  open,
+  initialBundle,
+  guidanceMessage,
+  onClose,
+  onImported,
+}: ConnectAssistantDialogProps) {
+  const [bundle, setBundle] = useState("");
+  const [name, setName] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Set when an access-only pairing was imported: the dialog holds on the
+  // expiry warning until the user continues into the connect flow.
+  const [accessOnlyAssistantId, setAccessOnlyAssistantId] = useState<
+    string | null
+  >(null);
+
+  useEffect(() => {
+    if (open) {
+      setBundle(initialBundle ?? "");
+      setName("");
+      setPending(false);
+      setError(null);
+      setAccessOnlyAssistantId(null);
+    }
+  }, [open, initialBundle]);
+
+  const handleClose = () => {
+    if (!pending) {
+      onClose();
+    }
+  };
+
+  const handleSubmit = async () => {
+    const trimmedBundle = bundle.trim();
+    // pending also guards re-entry: a second click can land before React
+    // flushes the pending state into the disabled buttons.
+    if (!trimmedBundle || pending) {
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      const trimmedName = name.trim();
+      const result = await importPairedAssistantBundle(
+        trimmedBundle,
+        trimmedName || undefined,
+      );
+      if (!result.ok) {
+        setError(result.error);
+      } else if (result.accessOnly) {
+        setAccessOnlyAssistantId(result.assistantId);
+      } else {
+        onImported(result.assistantId);
+        return;
+      }
+    } catch (err) {
+      console.error("connectAssistantDialog.import failed", err);
+      setError("Failed to import the pairing bundle. Please try again.");
+    }
+    setPending(false);
+  };
+
+  if (accessOnlyAssistantId != null) {
+    return (
+      <Modal.Root
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) {
+            handleClose();
+          }
+        }}
+      >
+        <Modal.Content size="sm">
+          <Modal.Header>
+            <Modal.Title icon={Link2}>Pairing Imported</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Notice tone="warning">
+              This pairing is access-only: its access expires and cannot renew
+              itself. Re-run vellum pair on the assistant&rsquo;s machine and
+              import the new bundle when it expires.
+            </Notice>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              variant="primary"
+              onClick={() => onImported(accessOnlyAssistantId)}
+            >
+              Continue
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    );
+  }
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          handleClose();
+        }
+      }}
+    >
+      <Modal.Content size="md">
+        <Modal.Header>
+          <Modal.Title icon={Link2}>Connect a Remote Assistant</Modal.Title>
+          <Modal.Description>
+            On the assistant&rsquo;s machine, run{" "}
+            <code>vellum pair --url https://...</code> and paste the bundle
+            here.
+          </Modal.Description>
+        </Modal.Header>
+
+        <Modal.Body>
+          <div className="space-y-4">
+            {guidanceMessage && <Notice tone="info">{guidanceMessage}</Notice>}
+
+            <div className="space-y-1.5">
+              <label
+                className="text-body-small-default text-[var(--content-secondary)]"
+                htmlFor="connect-assistant-bundle"
+              >
+                Pairing bundle
+              </label>
+              <Textarea
+                id="connect-assistant-bundle"
+                value={bundle}
+                onChange={(e) => setBundle(e.target.value)}
+                placeholder="eyJnYXRld2F5..."
+                rows={4}
+                fullWidth
+                autoFocus
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                className="text-body-small-default text-[var(--content-secondary)]"
+                htmlFor="connect-assistant-name"
+              >
+                Name (optional)
+              </label>
+              <Input
+                id="connect-assistant-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="office-mac"
+                fullWidth
+              />
+            </div>
+
+            {error && (
+              <p className="text-body-small-default text-[var(--system-negative-strong)]">
+                {error}
+              </p>
+            )}
+          </div>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="ghost" onClick={handleClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void handleSubmit()}
+            disabled={!bundle.trim() || pending}
+          >
+            {pending ? "Connecting…" : "Connect"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export { ConnectAssistantDialog };

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -87,6 +87,26 @@ mock.module("@/domains/onboarding/components/connect-recovery-dialog", () => ({
   ConnectRecoveryDialog: () => null,
 }));
 
+// A stub that surfaces the open state and lets tests drive the imported
+// callback the way a successful paste-and-submit would.
+mock.module("@/domains/onboarding/components/connect-assistant-dialog", () => ({
+  ConnectAssistantDialog: ({
+    open,
+    onImported,
+  }: {
+    open: boolean;
+    onImported: (assistantId: string) => void;
+  }) =>
+    open ? (
+      <div>
+        Connect dialog open
+        <button onClick={() => onImported("paired-new")}>
+          Simulate import
+        </button>
+      </div>
+    ) : null,
+}));
+
 mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
   OnboardingLayout: ({ children }: { children: ReactNode }) => children,
 }));
@@ -142,6 +162,7 @@ mock.module("@/stores/resolved-assistants-store", () => ({
   useResolvedAssistantsStore: {
     use: { assistants: () => assistantsValue },
     getState: () => ({
+      assistants: assistantsValue,
       activeAssistantId: activeAssistantIdValue,
       setActiveAssistantId: setActiveAssistantIdMock,
     }),
@@ -510,6 +531,48 @@ describe("SelectAssistantScreen paired assistants", () => {
       radios.find((r) => r.textContent?.includes("Second Mac"))
         ?.getAttribute("aria-checked"),
     ).toBe("false");
+  });
+
+  test("the connect-a-remote-assistant affordance is hidden without a local-mode host", () => {
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Connect a remote assistant")).toBeNull();
+  });
+
+  test("the connect-a-remote-assistant affordance opens the dialog when a local-mode host is available", () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    expect(screen.queryByText("Connect dialog open")).toBeNull();
+
+    fireEvent.click(screen.getByText("Connect a remote assistant"));
+
+    expect(screen.getByText("Connect dialog open")).toBeTruthy();
+  });
+
+  test("a successful import connects the new pairing and navigates", async () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Connect a remote assistant"));
+    fireEvent.click(screen.getByText("Simulate import"));
+
+    await waitFor(() =>
+      expect(connectPairedAssistantMock).toHaveBeenCalledWith("paired-new"),
+    );
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/assistant", {
+        replace: true,
+      }),
+    );
+    // The dialog closes as the connect kicks off.
+    expect(screen.queryByText("Connect dialog open")).toBeNull();
   });
 
   test("confirming a locked platform removal still calls removePlatformAssistantFromLockfile", async () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -575,6 +575,26 @@ describe("SelectAssistantScreen paired assistants", () => {
     expect(screen.queryByText("Connect dialog open")).toBeNull();
   });
 
+  test("an open connect dialog suppresses the sole-assistant auto-skip", async () => {
+    localModeHostAvailableValue = true;
+    assistantsValue = [];
+
+    const { rerender } = render(<SelectAssistantScreen />);
+
+    fireEvent.click(screen.getByText("Connect a remote assistant"));
+
+    // The import's lockfile reload populates the store while the dialog is
+    // still open (e.g. the access-only warning step is showing).
+    assistantsValue = [makePairedAssistant()];
+    rerender(<SelectAssistantScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Connect dialog open")).toBeTruthy(),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
   test("confirming a locked platform removal still calls removePlatformAssistantFromLockfile", async () => {
     localModeHostAvailableValue = true;
     assistantsValue = [makePlatformAssistant()];

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -6,7 +6,7 @@ import {
   Link2,
   Plus,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
@@ -21,6 +21,7 @@ import {
   removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
+import { ConnectAssistantDialog } from "@/domains/onboarding/components/connect-assistant-dialog";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { handleRadioCardArrowNav } from "@/domains/onboarding/components/radio-card-nav";
@@ -105,6 +106,10 @@ export function SelectAssistantScreen() {
   // A pairing is device-local regardless of platform session, so unpairing
   // needs only the host, not a logged-out state.
   const canRemovePairedAssistants = isLocalModeHostAvailable();
+  // Importing a pairing bundle rewrites the lockfile through the same host,
+  // so the connect affordance shares the unpair gate: never shown in
+  // remote-gateway mode or browsers without a local-mode host.
+  const canConnectRemoteAssistant = isLocalModeHostAvailable();
 
   const [selected, setSelected] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -122,6 +127,8 @@ export function SelectAssistantScreen() {
   );
   const [removePending, setRemovePending] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  // The "Connect a remote assistant" paste-a-bundle dialog.
+  const [connectDialogOpen, setConnectDialogOpen] = useState(false);
   // After a manual removal the user is mid-management on this screen: a
   // sudden auto-connect to the sole remaining assistant would be jarring, so
   // the auto-skip stands down for the rest of the visit.
@@ -296,6 +303,23 @@ export function SelectAssistantScreen() {
     setRemovePending(false);
   };
 
+  const handleImported = (assistantId: string) => {
+    setConnectDialogOpen(false);
+    // The import refreshes the lockfile before resolving, so the store already
+    // lists the new entry; the fallback keeps the connect total if it lags.
+    const imported = useResolvedAssistantsStore
+      .getState()
+      .assistants.find((a) => a.id === assistantId);
+    void handleConnect(
+      imported ?? {
+        id: assistantId,
+        isLocal: false,
+        isPlatformHosted: false,
+        isPaired: true,
+      },
+    );
+  };
+
   // Auto-skip when there's exactly one assistant and it's accessible.
   // Don't skip when the user just logged in or navigated here deliberately
   // (e.g. from settings or the Developer menu): let them see the chooser.
@@ -413,31 +437,24 @@ export function SelectAssistantScreen() {
               />
             );
           })}
-          <button
-            type="button"
+          <DashedActionButton
+            icon={<Plus className="h-4 w-4" />}
+            label="Create a new assistant"
+            disabled={connecting || loginLoading}
             onClick={() =>
               void navigate(
                 `${routes.onboarding.hosting}?from=select-assistant`,
               )
             }
-            disabled={connecting || loginLoading}
-            className={[
-              "group flex w-full items-center justify-center gap-2 border border-dashed border-[var(--border-element)]/50 text-[var(--content-tertiary)]",
-              electron ? "rounded-lg px-3 py-2.5" : "rounded-xl px-5 py-3",
-              "cursor-pointer transition-all duration-200 ease-out",
-              "hover:border-[var(--border-element)] hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-            ].join(" ")}
-          >
-            <Plus className="h-4 w-4" />
-            <span
-              className={
-                electron ? "text-body-small-default" : "text-body-medium-default"
-              }
-            >
-              Create a new assistant
-            </span>
-          </button>
+          />
+          {canConnectRemoteAssistant && (
+            <DashedActionButton
+              icon={<Link2 className="h-4 w-4" />}
+              label="Connect a remote assistant"
+              disabled={connecting || loginLoading}
+              onClick={() => setConnectDialogOpen(true)}
+            />
+          )}
         </div>
 
         {accessibleAssistants.length > 0 && (
@@ -473,6 +490,11 @@ export function SelectAssistantScreen() {
         </div>
         </div>
       </div>
+      <ConnectAssistantDialog
+        open={connectDialogOpen}
+        onClose={() => setConnectDialogOpen(false)}
+        onImported={handleImported}
+      />
       <ConnectRecoveryDialog
         open={recoveryAssistant != null}
         assistantName={
@@ -517,6 +539,44 @@ export function SelectAssistantScreen() {
         onCancel={closeRemoveDialog}
       />
     </OnboardingLayout>
+  );
+}
+
+/** Dashed full-width secondary action below the assistant cards. */
+function DashedActionButton({
+  icon,
+  label,
+  disabled,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  const electron = isElectron();
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={[
+        "group flex w-full items-center justify-center gap-2 border border-dashed border-[var(--border-element)]/50 text-[var(--content-tertiary)]",
+        electron ? "rounded-lg px-3 py-2.5" : "rounded-xl px-5 py-3",
+        "cursor-pointer transition-all duration-200 ease-out",
+        "hover:border-[var(--border-element)] hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+      ].join(" ")}
+    >
+      {icon}
+      <span
+        className={
+          electron ? "text-body-small-default" : "text-body-medium-default"
+        }
+      >
+        {label}
+      </span>
+    </button>
   );
 }
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -328,7 +328,7 @@ export function SelectAssistantScreen() {
     if (fromLogin || noAutoSkip || removedThisVisitRef.current) {
       return;
     }
-    if (connecting || autoSkipping) {
+    if (connecting || autoSkipping || connectDialogOpen) {
       return;
     }
     if (assistants.length === 0) {

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -14,7 +14,7 @@ const replacePlatformAssistantsHost = mock(
   }),
 );
 
-const loadLockfileHost = mock(async () => {
+const loadLockfileHost = mock(async (): Promise<localModeHost.Lockfile> => {
   throw new Error("host down");
 });
 
@@ -34,6 +34,17 @@ const unpairAssistantHost = mock(
   }),
 );
 
+const connectImportHost = mock(
+  async (
+    _bundle: string,
+    _name?: string,
+  ): Promise<localModeHost.LocalConnectImportResult> => ({
+    ok: true as const,
+    assistantId: "paired-new",
+    accessOnly: false,
+  }),
+);
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
@@ -41,6 +52,7 @@ mock.module("@/runtime/local-mode-host", () => ({
   saveLockfileAssistantHost,
   fetchGuardianTokenHost,
   unpairAssistantHost,
+  connectImportHost,
 }));
 
 import {
@@ -53,6 +65,7 @@ import {
   getPlatformAssistants,
   getPlatformRuntimeUrl,
   getSelectedAssistant,
+  importPairedAssistantBundle,
   isCliWakeableAssistant,
   isLocalAssistant,
   isLocalGatewayAssistant,
@@ -131,9 +144,11 @@ afterEach(() => {
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
+  loadLockfileHost.mockClear();
   saveLockfileAssistantHost.mockClear();
   fetchGuardianTokenHost.mockClear();
   unpairAssistantHost.mockClear();
+  connectImportHost.mockClear();
   clearGatewayToken();
   setSelfHostedConnection(null);
 });
@@ -437,6 +452,60 @@ describe("removePairedAssistantFromLockfile", () => {
     );
     expect(getGatewayToken()).toBe("tok");
     expect(getSelfHostedIngressUrl()).toBe("http://localhost/x");
+  });
+});
+
+describe("importPairedAssistantBundle", () => {
+  test("registers the bundle through the host and reloads the lockfile", async () => {
+    loadLockfileHost.mockImplementationOnce(async () => ({
+      assistants: [pairedEntry],
+      activeAssistant: null,
+    }));
+
+    const result = await importPairedAssistantBundle("bundle-data", "desk");
+
+    expect(connectImportHost).toHaveBeenCalledWith("bundle-data", "desk");
+    expect(result).toEqual({
+      ok: true,
+      assistantId: "paired-new",
+      accessOnly: false,
+    });
+    expect(loadLockfileHost).toHaveBeenCalledTimes(1);
+    expect(
+      useLockfileStore.getState().lockfile?.assistants.map(
+        (a) => a.assistantId,
+      ),
+    ).toEqual(["paired-a"]);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("passes accessOnly through on an access-only pairing", async () => {
+    connectImportHost.mockResolvedValueOnce({
+      ok: true as const,
+      assistantId: "paired-new",
+      accessOnly: true,
+    });
+
+    const result = await importPairedAssistantBundle("bundle-data");
+
+    expect(connectImportHost).toHaveBeenCalledWith("bundle-data", undefined);
+    expect(result).toEqual({
+      ok: true,
+      assistantId: "paired-new",
+      accessOnly: true,
+    });
+  });
+
+  test("returns the host error without reloading on failure", async () => {
+    connectImportHost.mockResolvedValueOnce({
+      ok: false,
+      error: "invalid pairing bundle",
+    });
+
+    const result = await importPairedAssistantBundle("nope");
+
+    expect(result).toEqual({ ok: false, error: "invalid pairing bundle" });
+    expect(loadLockfileHost).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -21,6 +21,7 @@ import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import {
+  connectImportHost,
   fetchGuardianTokenHost,
   GuardianTokenError,
   loadLockfileHost,
@@ -419,6 +420,37 @@ export async function removePairedAssistantFromLockfile(
   }
   commitLockfile(result.lockfile);
   return { ok: true };
+}
+
+/**
+ * Register a pairing bundle printed by `vellum pair` on another machine: the
+ * host persists its guardian token and creates a `cloud: "paired"` lockfile
+ * entry, then the lockfile is reloaded so subscribers (the resolved-assistants
+ * store) pick up the new entry, the write counterpart of
+ * {@link removePairedAssistantFromLockfile}. `accessOnly` is true when the
+ * bundle carried no refresh credential, so the pairing's access expires and
+ * cannot renew itself.
+ */
+export async function importPairedAssistantBundle(
+  bundle: string,
+  name?: string,
+): Promise<
+  | { ok: true; assistantId: string; accessOnly: boolean }
+  | { ok: false; error: string }
+> {
+  const result = await connectImportHost(bundle, name);
+  if (!result.ok || result.assistantId == null) {
+    return {
+      ok: false,
+      error: result.error || "Failed to import the pairing bundle.",
+    };
+  }
+  await loadLockfile();
+  return {
+    ok: true,
+    assistantId: result.assistantId,
+    accessOnly: result.accessOnly === true,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New ConnectAssistantDialog: paste a vellum pair bundle (optional name), inline errors, access-only expiry warning
- Chooser affordance gated on isLocalModeHostAvailable(); success refreshes the lockfile, selects, and connects the new paired assistant
- importPairedAssistantBundle wrapper over the connectImport host op

Part of plan: macos-paired-assistants.md (PR 8 of 10)