### PR TITLE
fix: recovery claims require a live-believed session; hot-path and comment polish

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1533,6 +1533,19 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     );
   }
 
+  /**
+   * refreshSession that never confirms the session live (the probe lands on
+   * "unknown"), so the claim it answers is not refunded.
+   */
+  function armUnrefundedRefresh() {
+    const refreshSession = mock(async () => {
+      mockAuthState.platformSession = "unknown";
+      return true;
+    });
+    mockAuthState.refreshSession = refreshSession;
+    return refreshSession;
+  }
+
   beforeEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
@@ -1780,9 +1793,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(hardNavigateMock).not.toHaveBeenCalled();
   });
 
-  test("an unsettled (unknown) platform session still recovers", async () => {
-    // "unknown" means the probe has not answered yet, so the rejection is
-    // still worth re-verifying; only a settled negative is conclusive.
+  test("an unsettled (unknown) platform session does not recover", async () => {
+    // While platformSession is "unknown" the boot probe is already evaluating
+    // this same rejection evidence, so spending a claim here would only nest
+    // a redundant refreshSession cycle on every dead-cookie boot.
     mockAuthState.platformSession = "unknown";
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
@@ -1790,7 +1804,8 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
 
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
   });
 
   test("a second rejection inside the cooldown window does not recover", async () => {
@@ -1808,25 +1823,18 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   });
 
   test("stops recovering once the attempt budget is spent", async () => {
-    // An unsettled probe never confirms the session live, so nothing refunds
-    // the count and the budget is the binding limit.
-    mockAuthState.platformSession = "unknown";
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+    // The cap's defended scenario: re-probes that repeatedly fail to confirm
+    // the session live never refund the count, so the budget binds. Each
+    // cycle claims while the session still reads "present".
+    const refreshSession = armUnrefundedRefresh();
 
     // Each round expires the cooldown so only the budget can stop it.
-    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS + 1; i++) {
+      mockAuthState.platformSession = "present";
       expireRecoveryCooldown();
       platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
       await flush();
     }
-    expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS,
-    );
-
-    expireRecoveryCooldown();
-    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
-    await flush();
     expect(refreshSession).toHaveBeenCalledTimes(
       PLATFORM_RECOVERY_MAX_ATTEMPTS,
     );
@@ -1860,14 +1868,15 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   });
 
   test("a 2xx on the rejected route restores the recovery budget", async () => {
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+    // Unrefunded claims keep the budget spent, so only the heal can clear it.
+    const refreshSession = armUnrefundedRefresh();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(1);
 
     // Inside the cooldown a rejection cannot recover.
+    mockAuthState.platformSession = "present";
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(1);
@@ -1883,9 +1892,8 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(2);
   });
 
-  test("an unrelated platform 2xx does not restore the budget", async () => {
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+  test("an unrelated platform 2xx leaves an outstanding claim; the rejected route's clears it", async () => {
+    const refreshSession = armUnrefundedRefresh();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
@@ -1897,11 +1905,26 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       makeResponse(200, "https://platform.test/v1/client-feature-flags/"),
     );
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe("1");
 
-    // Still inside the cooldown, so no second recovery.
+    // The rejected route healing clears the whole bound.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY)).toBeNull();
+  });
+
+  test("a refund resets the outstanding claim, so a later matching 2xx keeps the cooldown", async () => {
+    // Default refreshSession confirms the session live, so the claim is
+    // refunded and no heal is outstanding.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+
+    // The matching 2xx must not clear the retained cooldown that paces
+    // re-probing while the permission 403 persists.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
   });
 
   test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -62,7 +62,6 @@ import { useAuthStore, whenPlatformSessionSettled } from "@/stores/auth-store";
 import {
   hasLivePlatformSession,
   isAuthenticated,
-  isPlatformSessionSettled,
   isSettledSessionRejection,
 } from "@/stores/session-status";
 import { routes } from "@/utils/routes";
@@ -598,6 +597,7 @@ const PLATFORM_AUTH_MAX_REDIRECTS = 3;
 /** @internal Exposed for test teardown only. */
 export function resetPlatformAuthRecoveryFlag(): void {
   platformAuthRecoveryFired = false;
+  platformRecoveryOutstanding = false;
 }
 
 /**
@@ -634,16 +634,11 @@ function clearPlatformAuthRedirectBudget(): void {
 }
 
 /**
- * Cooldown + attempt budget for the recovery re-probe itself, mirroring the
- * local-gateway 401 pattern above. The in-memory latch only serializes
- * concurrent rejections within one cycle; against a platform that rejects
- * every request, each released latch would otherwise start the next cycle
- * immediately and without bound. The cooldown spaces cycles and the budget
- * stops them; a 2xx on the route whose rejection last consumed an attempt
- * restores both (proof the failing route healed), a re-probe that confirms
- * the session live refunds the count while keeping the cooldown (a
- * permission 403 must not starve a later real expiry), and quitting the app
- * grants a fresh budget (sessionStorage).
+ * Cooldown + attempt budget for the recovery re-probe, mirroring the
+ * local-gateway 401 pattern above. The cooldown spaces cycles and the budget
+ * stops them; with the refund below, the cap binds when re-probes repeatedly
+ * fail to settle (refreshSession throwing on a flaky network while the API
+ * keeps rejecting). Quitting the app grants a fresh budget (sessionStorage).
  */
 const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
 const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
@@ -651,12 +646,20 @@ const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
 const PLATFORM_RECOVERY_COOLDOWN_MS = 600_000;
 const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
 
+// Skips the ok-branch heal check until a claim is made. Seeded from storage:
+// a claim from this page's earlier life may still be awaiting its heal.
+let platformRecoveryOutstanding = (() => {
+  try {
+    return sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY) !== null;
+  } catch {
+    return false;
+  }
+})();
+
 /**
- * Spend one recovery attempt for a rejection on `pathname`. False when the
- * budget is exhausted, when the last attempt was inside the cooldown window,
- * or when sessionStorage is unavailable so an uncountable environment fails
- * closed (no recovery). The pathname is remembered so only that route's
- * later success restores the budget.
+ * Spend one recovery attempt for a rejection on `pathname`; false when the
+ * budget or cooldown blocks it, or when sessionStorage is unavailable (fails
+ * closed). Only that pathname's later success restores the budget.
  */
 function claimPlatformRecoveryAttempt(pathname: string): boolean {
   try {
@@ -680,6 +683,7 @@ function claimPlatformRecoveryAttempt(pathname: string): boolean {
       String(attempts + 1),
     );
     sessionStorage.setItem(PLATFORM_RECOVERY_PATH_KEY, pathname);
+    platformRecoveryOutstanding = true;
     return true;
   } catch {
     return false;
@@ -687,11 +691,8 @@ function claimPlatformRecoveryAttempt(pathname: string): boolean {
 }
 
 /**
- * Restore the recovery budget when a success proves the previously rejected
- * route is healthy again. Restoring on any platform 2xx would let routes the
- * platform serves anonymously (client feature flags, for example) re-arm the
- * budget every poll while the session-sensitive route keeps rejecting, which
- * defeats the bound entirely.
+ * Restore the budget only when the last-rejected route succeeds: anonymously
+ * served routes (client feature flags) must not re-arm it every poll.
  */
 function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
   try {
@@ -701,17 +702,15 @@ function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
     sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
+    platformRecoveryOutstanding = false;
   } catch {
     // sessionStorage unavailable; the claim above already fails closed.
   }
 }
 
 /**
- * Refund the attempt count while keeping the cooldown timestamp. Used when
- * the authoritative re-probe confirms the session is live: the rejection was
- * a route-level permission denial, not session death, so it must not eat the
- * budget a later real expiry needs. The retained cooldown still paces
- * probing at one cycle per window while such a route keeps rejecting.
+ * Refund the attempt count but keep the cooldown: a permission 403 on a live
+ * session must not eat the budget a later real expiry needs.
  */
 function refundPlatformRecoveryAttempt(): void {
   try {
@@ -719,6 +718,7 @@ function refundPlatformRecoveryAttempt(): void {
   } catch {
     // sessionStorage unavailable; the claim already fails closed.
   }
+  platformRecoveryOutstanding = false;
 }
 
 /** The response URL's pathname, or null for an unparseable URL. */
@@ -739,10 +739,8 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // and keeps `sessionStatus` authenticated, so the redirect below is
     // skipped there.
     await useAuthStore.getState().refreshSession();
-    // In gateway-auth mode `refreshSession` fire-and-forgets the
-    // platform-session probe and returns while the probe's own platform
-    // requests are still in flight. Hold the latch until the probe settles
-    // so those requests' rejections cannot each start a new recovery cycle.
+    // refreshSession may fire-and-forget the platform probe; hold the latch
+    // until it settles so the probe's own rejections cannot re-enter.
     await whenPlatformSessionSettled();
     if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
       refundPlatformRecoveryAttempt();
@@ -775,9 +773,10 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * authenticated (excludes boot probes and the already-logged-out login flow,
  * and prevents a redirect loop), and the response did not come from the
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
- * {@link localGatewayAuthRecoveryInterceptor}. A settled-absent platform
- * session also no-ops (nothing to recover), and each re-probe cycle spends
- * from the cooldown-spaced attempt budget above.
+ * {@link localGatewayAuthRecoveryInterceptor}. Recovery claims only for a
+ * platform session currently believed live: the boot probe owns unsettled
+ * evidence, and a settled-absent session has nothing to recover. Each cycle
+ * spends from the cooldown-spaced attempt budget above.
  *
  * A success on the route whose rejection last consumed a recovery attempt
  * restores the recovery budget; a success against a confirmed session also
@@ -791,9 +790,11 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (response.ok) {
     // A working self-hosted gateway says nothing about the platform session.
     if (!fromSelfHostedGateway) {
-      const pathname = responsePathname(response);
-      if (pathname !== null) {
-        clearPlatformRecoveryBudgetIfHealed(pathname);
+      if (platformRecoveryOutstanding) {
+        const pathname = responsePathname(response);
+        if (pathname !== null) {
+          clearPlatformRecoveryBudgetIfHealed(pathname);
+        }
       }
       // The redirect budget stays gated on a confirmed session: the platform
       // serves some routes anonymously, so a 2xx alone does not prove the
@@ -820,13 +821,9 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (fromSelfHostedGateway) {
     return response;
   }
-  // A session already settled as not-live has nothing to recover; a re-probe
-  // would only repeat the answer. Keeps stray platform 403s after logout (or
-  // after the probe settled this rejection to "absent") inert.
-  if (
-    isPlatformSessionSettled(platformSession) &&
-    !hasLivePlatformSession(platformSession)
-  ) {
+  // Claim only for a session currently believed live: the boot probe owns
+  // unsettled ("unknown") evidence, and settled-absent has nothing to recover.
+  if (!hasLivePlatformSession(platformSession)) {
     return response;
   }
   const rejectedPathname = responsePathname(response);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for half-dead-platform-session.md.

**Gap:** the claim gate admitted the boot probe's own rejections (redundant nested cycle per dead-cookie boot); every 2xx paid URL/storage overhead; budget comments were essays.
**Fix:** claims now require hasLivePlatformSession; an outstanding-claim flag skips hot-path work; the attempts cap's defended scenario is named; comments halved per repo convention.