### PR TITLE
fix: apply the session-rejection evidence rule at sibling confirmation sites

### DIFF
--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -152,9 +152,9 @@ const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 // unaffected; the reconciliation tests override it to a well-formed result.
 let mockListAssistantsResult: unknown = [];
 const listAssistantsMock = mock(async () => mockListAssistantsResult);
-// Controls the `OrgFetchOutcome` the probe's evidence check reads. A thrown
-// error simulates a transport failure; a never-resolving promise as the
-// outcome makes the fetch hang so the probe's sync race times out.
+// Controls the `OrgFetchOutcome` the session-rejection evidence checks read.
+// A thrown error simulates a transport failure; a never-resolving promise as
+// the outcome makes the fetch hang so the probe's sync race times out.
 let mockOrgFetchOutcome: unknown = { ok: true };
 let mockOrgFetchError: Error | null = null;
 const fetchOrganizationsMock = mock(async () => {
@@ -1575,6 +1575,9 @@ describe("auth store onboarding flag reconciliation", () => {
         },
       ],
       "org-test",
+      // The shared reconcile helper forwards its staleness predicate; the
+      // refresh path has none.
+      undefined,
     );
   });
 
@@ -1740,11 +1743,7 @@ describe("platform session probe resolution", () => {
 describe("platform probe conclusive rejection (half-dead session)", () => {
   // The half-dead state: allauth answers 200 with a user while the platform
   // API conclusively rejects the same credential. The probe consumes the
-  // org/assistants evidence it already gathers and settles the session
-  // "absent", which un-gates org-gated daemon queries on bearer-auth
-  // connections and surfaces the login affordances. The recovery
-  // interceptor's settled-absent gate then treats any residual platform 403
-  // as a no-op instead of looping.
+  // org/assistants evidence it already gathers and settles "absent".
   //
   // Every test drives the local-client init path (no gateway auth, no
   // platform assistants), where the probe runs with `setUserOnSuccess`.
@@ -1875,6 +1874,178 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
       setTimeoutSpy.mockRestore();
       clearTimeoutSpy.mockRestore();
     }
+  });
+});
+
+describe("session-rejection evidence at sibling confirmation sites", () => {
+  // The same half-dead evidence rule applies wherever an allauth 200 would
+  // otherwise confirm the session: refreshSession's resume path, initSession's
+  // platform-assistants path, and connectPlatformAssistant.
+
+  test("refreshSession settles a half-dead session absent instead of re-confirming it", async () => {
+    // A gateway client whose cached token expired while backgrounded lands in
+    // the non-gateway branch (isGatewayAuthMode() is false without a token).
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    // No snapshot may be re-persisted for the rejected session.
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshSession settles absent on an assistants-list rejection", async () => {
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockListAssistantsResult = { ok: false, status: 401, error: {} };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshSession ends a half-dead session whose assistants are platform-hosted", async () => {
+    // Same stands-alone exclusion as a settled getSession 401: a managed
+    // assistant is unreachable without a platform session, so login wins.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = false;
+    mockPlatformAssistants = [{ assistantId: "managed-1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("a resume refresh does not flip a probe-settled absent session back to present", async () => {
+    // Pin the oscillation regression: the probe settles absent on rejection,
+    // then the app-resume refresh runs against the same half-dead session.
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("a transport-failed sync on refresh keeps the platform confirmation", async () => {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).not.toBeNull();
+  });
+
+  test("a non-rejection org failure on refresh keeps the platform confirmation", async () => {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("initSession with platform assistants routes a rejected session to login", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    localStorage.setItem(
+      "vellum:auth:userSnapshot",
+      JSON.stringify({ id: "user-1", email: "user@example.com" }),
+    );
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("initSession with platform assistants routes an assistants-list rejection to login", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockListAssistantsResult = { ok: false, status: 410, error: {} };
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("initSession with platform assistants keeps the session on a transport-failed sync", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+
+  test("connectPlatformAssistant fails the connect on a rejected org fetch", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await expect(
+      useAuthStore.getState().connectPlatformAssistant("assistant-1"),
+    ).rejects.toThrow("Platform authentication required");
+
+    expect(useAuthStore.getState().platformSession).not.toBe("present");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("connectPlatformAssistant tolerates a non-rejection org failure", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await useAuthStore.getState().connectPlatformAssistant("assistant-1");
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().platformSession).toBe("present");
   });
 });
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -228,9 +228,9 @@ const sessionEnded = (): Partial<AuthState> => ({
  * non-auth reason (429 rate limiting, 5xx outages, the Electron proxy's
  * offline 502). Distinct from a settled "no session" answer (2xx without
  * user, or an explicit 401/403/410 rejection), which is the only thing
- * allowed to end the session. Callers check the 2xx-without-user case
- * themselves — by the time they consult this, `result.ok` means the user
- * field was missing, a settled negative.
+ * allowed to end the session. Callers handle the 2xx cases themselves;
+ * by the time they consult this, an ok result was already judged unusable
+ * (user missing, or platform-rejected evidence), a settled negative.
  */
 const isInconclusiveProbe = (
   result: Awaited<ReturnType<typeof getSession>> | null,
@@ -573,6 +573,36 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   store.setConsentHydrated(true);
 }
 
+/**
+ * Reconcile the lockfile's managed-assistant mirror and report whether the
+ * platform API conclusively rejected the session (a settled 401/403/410 from
+ * the org or assistants call). Only that settled evidence may end a platform
+ * session; transport failures and other errors prove nothing (LUM-2412) and
+ * leave cached lockfile data standing. Cloud mode loads assistants via
+ * `reloadPlatformAssistants` (platform-assistants-sync), which has no
+ * lockfile and stays outside this evidence rule.
+ */
+async function reconcilePlatformAssistants(
+  syncIsCurrent?: () => boolean,
+): Promise<{ sessionRejected: boolean }> {
+  const orgOutcome = await useOrganizationStore.getState().fetchOrganizations();
+  if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+    return { sessionRejected: true };
+  }
+  const apiAssistants = await listAssistants();
+  if (isSettledSessionRejection(apiAssistants)) {
+    return { sessionRejected: true };
+  }
+  if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
+    await syncPlatformAssistantsToLockfile(
+      apiAssistants.data,
+      useOrganizationStore.getState().currentOrganizationId ?? undefined,
+      syncIsCurrent,
+    );
+  }
+  return { sessionRejected: false };
+}
+
 // Monotonic id stamped on each platform-session probe. Probes can overlap
 // (an app-resume refresh firing while the initial probe is still in flight),
 // and a stale completion must not mutate session state — most importantly it
@@ -647,26 +677,8 @@ function probePlatformSession(
           try {
             await Promise.race([
               (async () => {
-                const orgOutcome = await useOrganizationStore
-                  .getState()
-                  .fetchOrganizations();
-                if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
-                  sessionRejected = true;
-                  return;
-                }
-                const apiAssistants = await listAssistants();
-                if (isSettledSessionRejection(apiAssistants)) {
-                  sessionRejected = true;
-                  return;
-                }
-                if (syncIsCurrent() && apiAssistants.ok) {
-                  await syncPlatformAssistantsToLockfile(
-                    apiAssistants.data,
-                    useOrganizationStore.getState().currentOrganizationId ??
-                      undefined,
-                    syncIsCurrent,
-                  );
-                }
+                ({ sessionRejected } =
+                  await reconcilePlatformAssistants(syncIsCurrent));
               })(),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {
@@ -685,17 +697,10 @@ function probePlatformSession(
           return;
         }
         if (sessionRejected) {
-          // The allauth cookie answered, but the platform API conclusively
-          // rejected the credential (a settled 401/403/410 on the org or
-          // assistants call), so this session is unusable for every consumer:
-          // settle it as absent, install no user, and skip the platform
-          // identity bootstrap. Transport failures and the race timeout
-          // deliberately never reach this branch (LUM-2412 offline restore).
-          // The persisted snapshot must go too, or `restoreOfflineSession`
-          // could resurrect the rejected account as "present" on a later
-          // offline boot; an already-authenticated local/gateway session
-          // demotes its user to the local shape, mirroring refreshSession's
-          // stands-alone demotion.
+          // The platform API conclusively rejected the allauth-confirmed
+          // credential: settle absent, install no user, and drop the snapshot
+          // so `restoreOfflineSession` cannot resurrect the account. Transport
+          // failures and the race timeout never reach here (LUM-2412).
           clearUserSnapshot();
           const demotion = isAuthenticated(
             useAuthStore.getState().sessionStatus,
@@ -868,21 +873,18 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             const user = toAuthUser(result.data.user);
             await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
+            let sessionRejected = false;
             try {
-              await useOrganizationStore.getState().fetchOrganizations();
-              const apiAssistants = await listAssistants();
-              if (apiAssistants.ok) {
-                await syncPlatformAssistantsToLockfile(
-                  apiAssistants.data,
-                  useOrganizationStore.getState().currentOrganizationId ??
-                    undefined,
-                );
-              }
+              ({ sessionRejected } = await reconcilePlatformAssistants());
             } catch {
-              // Sync failed — continue with cached data
+              // Sync failed; continue with cached data
             }
-            set(authenticatedPlatformUser(user));
-            return;
+            if (!sessionRejected) {
+              set(authenticatedPlatformUser(user));
+              return;
+            }
+            // A settled org/assistants rejection falls through to the
+            // settled-answer handling (login), never the offline restore.
           }
         } catch {
           // Thrown fetch — classified as a transport failure below.
@@ -1044,8 +1046,15 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
     const user = toAuthUser(result.data.user);
     await syncUserScopedState(user?.id ?? null);
-    // Hydrate the organizations to avoid race conditions from lazy fetch.
-    await useOrganizationStore.getState().fetchOrganizations();
+    // Hydrate the organizations to avoid race conditions from lazy fetch; a
+    // settled rejection fails the connect rather than installing a platform
+    // user the API refuses to serve.
+    const orgOutcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations();
+    if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+      throw new Error("Platform authentication required");
+    }
     set(authenticatedPlatformUser(user));
   },
 
@@ -1089,29 +1098,26 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
-        // Reconcile the lockfile mirror on refresh too — not just cold
-        // `initSession`. App resume, profile save, and the provider callback
-        // all route through here; without this the macOS tray and CLI keep a
-        // stale managed-assistant list until the next full boot. Best-effort
-        // and local-mode only (platform mode has no lockfile host); the
-        // refresh has already succeeded regardless of the sync outcome.
+        // Reconcile the lockfile mirror on refresh too, not just cold
+        // `initSession`: app resume, profile save, and the provider callback
+        // all route through here, and the macOS tray and CLI would otherwise
+        // keep a stale managed-assistant list until the next full boot.
+        // Local-mode only (platform mode has no lockfile host).
+        let sessionRejected = false;
         if (isLocalClient()) {
           try {
-            await useOrganizationStore.getState().fetchOrganizations();
-            const apiAssistants = await listAssistants();
-            if (apiAssistants.ok) {
-              await syncPlatformAssistantsToLockfile(
-                apiAssistants.data,
-                useOrganizationStore.getState().currentOrganizationId ??
-                  undefined,
-              );
-            }
+            ({ sessionRejected } = await reconcilePlatformAssistants());
           } catch {
-            // Sync failed — continue with cached lockfile data.
+            // Sync failed; continue with cached lockfile data.
           }
         }
-        set(authenticatedPlatformUser(user));
-        return true;
+        if (!sessionRejected) {
+          set(authenticatedPlatformUser(user));
+          return true;
+        }
+        // A settled org/assistants rejection is a rejected session even
+        // though allauth answered 200: fall through to the settled-rejection
+        // handling below, same as a settled getSession 401.
       }
     } catch (err) {
       console.warn("auth.refreshSession failed", err);

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     persistedOrganizationId: null,
     status: "idle",
     error: null,
-    lastErrorStatus: null,
   });
 });
 
@@ -112,7 +111,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBe(403);
     expect(state.error).toBe("Platform session was rejected (HTTP 403).");
   });
 
@@ -141,7 +139,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "unavailable" });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBe("network down");
   });
 
@@ -170,12 +167,14 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "unavailable" });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBe("No organization available for this user.");
   });
 
-  test("a successful fetch resets lastErrorStatus", async () => {
-    useOrganizationStore.setState({ lastErrorStatus: 403, status: "error" });
+  test("a successful fetch resets the error state", async () => {
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Platform session was rejected (HTTP 403).",
+    });
     listOrganizations = () =>
       Promise.resolve({ data: { results: [ORG_A] } });
 
@@ -184,7 +183,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: true });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("ready");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBeNull();
   });
 });

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -56,12 +56,6 @@ interface OrganizationState {
   persistedOrganizationId: string | null;
   status: OrganizationStatus;
   error: string | null;
-  /**
-   * HTTP status of the last fetch that concluded with an error response;
-   * null while loading, after a success, and for failures with no
-   * completed response (transport errors).
-   */
-  lastErrorStatus: number | null;
 }
 
 interface OrganizationActions {
@@ -134,10 +128,9 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   persistedOrganizationId: getStoredOrganizationId(),
   status: "idle",
   error: null,
-  lastErrorStatus: null,
 
   fetchOrganizations: async () => {
-    set({ status: "loading", error: null, lastErrorStatus: null });
+    set({ status: "loading", error: null });
 
     try {
       const result = await organizationsList();
@@ -171,10 +164,8 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
             : "No organization available for this user.";
       }
 
-      // A settled rejection means the platform no longer honors the session
-      // this org id came from, so the persisted fallback must not keep
-      // stamping requests with a stale Vellum-Organization-Id. Transport and
-      // other failures keep the fallback (offline reloads still need it).
+      // A rejected session must stop stamping requests with its stale org
+      // id; transport failures keep the fallback for offline reloads.
       if (rejectionStatus !== null) {
         clearStoredOrganizationId();
       }
@@ -189,7 +180,6 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         persistedOrganizationId,
         status: currentOrganizationId ? "ready" : "error",
         error,
-        lastErrorStatus: failureStatus,
       });
 
       if (currentOrganizationId) {
@@ -231,7 +221,6 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
       persistedOrganizationId: null,
       status: "idle",
       error: null,
-      lastErrorStatus: null,
     });
   },
 }));


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for half-dead-platform-session.md.

**Gap:** refreshSession/initSession/connectPlatformAssistant confirmed the session from allauth alone, so a resume could flip a settled-absent half-dead session back to present (re-persisting the snapshot) and make the recovery refund untrustworthy.
**Fix:** the same org/assistants rejection evidence the probe consumes now routes those sites into the settled-rejection handling; dead lastErrorStatus state removed; branch comments tightened.