### PR TITLE
fix: half-dead-session round-3 review residue

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1858,6 +1858,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
     );
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    // The refund also drops the remembered pathname; a leftover key would
+    // re-seed the outstanding flag after a reload and let a heal clear the
+    // retained cooldown.
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY)).toBeNull();
 
     // The cooldown survives the refund: an immediate rejection stays paced.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
@@ -1865,6 +1869,11 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(
       PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
     );
+
+    // With no remembered pathname, a later 2xx on that route cannot clear
+    // the cooldown the refund kept.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
   });
 
   test("a 2xx on the rejected route restores the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -715,6 +715,10 @@ function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
 function refundPlatformRecoveryAttempt(): void {
   try {
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    // Drop the remembered pathname too: a leftover key would re-seed the
+    // outstanding flag after a reload, letting a heal clear the cooldown
+    // this refund deliberately keeps.
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
   } catch {
     // sessionStorage unavailable; the claim already fails closed.
   }
@@ -796,9 +800,6 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
           clearPlatformRecoveryBudgetIfHealed(pathname);
         }
       }
-      // The redirect budget stays gated on a confirmed session: the platform
-      // serves some routes anonymously, so a 2xx alone does not prove the
-      // session works.
       if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
         clearPlatformAuthRedirectBudget();
       }
@@ -821,8 +822,6 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (fromSelfHostedGateway) {
     return response;
   }
-  // Claim only for a session currently believed live: the boot probe owns
-  // unsettled ("unknown") evidence, and settled-absent has nothing to recover.
   if (!hasLivePlatformSession(platformSession)) {
     return response;
   }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -334,6 +334,7 @@ mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
     getState: () => ({
       fetchOrganizations: fetchOrganizationsMock,
+      clearOrganization: clearOrganizationMock,
       currentOrganizationId: "org-test",
     }),
   },
@@ -1799,6 +1800,9 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
     expect(useAuthStore.getState().user?.kind).toBe("local");
     expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+    // The org fetch succeeded, so the rejected account's org state must be
+    // cleared here or its Vellum-Organization-Id keeps stamping requests.
+    expect(clearOrganizationMock).toHaveBeenCalled();
   });
 
   test("a transport-thrown org fetch keeps the present settle", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -584,23 +584,33 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
  */
 async function reconcilePlatformAssistants(
   syncIsCurrent?: () => boolean,
-): Promise<{ sessionRejected: boolean }> {
-  const orgOutcome = await useOrganizationStore.getState().fetchOrganizations();
-  if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
-    return { sessionRejected: true };
+): Promise<boolean> {
+  try {
+    const orgOutcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations();
+    if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+      return true;
+    }
+    const apiAssistants = await listAssistants();
+    if (isSettledSessionRejection(apiAssistants)) {
+      // The org fetch self-clears on its own rejection; an assistants-only
+      // rejection must clear the org state too, or the request interceptor
+      // keeps stamping the rejected account's Vellum-Organization-Id.
+      useOrganizationStore.getState().clearOrganization();
+      return true;
+    }
+    if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
+      await syncPlatformAssistantsToLockfile(
+        apiAssistants.data,
+        useOrganizationStore.getState().currentOrganizationId ?? undefined,
+        syncIsCurrent,
+      );
+    }
+  } catch {
+    // A throw is non-settled evidence: continue with cached lockfile data.
   }
-  const apiAssistants = await listAssistants();
-  if (isSettledSessionRejection(apiAssistants)) {
-    return { sessionRejected: true };
-  }
-  if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
-    await syncPlatformAssistantsToLockfile(
-      apiAssistants.data,
-      useOrganizationStore.getState().currentOrganizationId ?? undefined,
-      syncIsCurrent,
-    );
-  }
-  return { sessionRejected: false };
+  return false;
 }
 
 // Monotonic id stamped on each platform-session probe. Probes can overlap
@@ -677,8 +687,8 @@ function probePlatformSession(
           try {
             await Promise.race([
               (async () => {
-                ({ sessionRejected } =
-                  await reconcilePlatformAssistants(syncIsCurrent));
+                sessionRejected =
+                  await reconcilePlatformAssistants(syncIsCurrent);
               })(),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {
@@ -873,12 +883,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             const user = toAuthUser(result.data.user);
             await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
-            let sessionRejected = false;
-            try {
-              ({ sessionRejected } = await reconcilePlatformAssistants());
-            } catch {
-              // Sync failed; continue with cached data
-            }
+            const sessionRejected = await reconcilePlatformAssistants();
             if (!sessionRejected) {
               set(authenticatedPlatformUser(user));
               return;
@@ -1103,14 +1108,9 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         // all route through here, and the macOS tray and CLI would otherwise
         // keep a stale managed-assistant list until the next full boot.
         // Local-mode only (platform mode has no lockfile host).
-        let sessionRejected = false;
-        if (isLocalClient()) {
-          try {
-            ({ sessionRejected } = await reconcilePlatformAssistants());
-          } catch {
-            // Sync failed; continue with cached lockfile data.
-          }
-        }
+        const sessionRejected = isLocalClient()
+          ? await reconcilePlatformAssistants()
+          : false;
         if (!sessionRejected) {
           set(authenticatedPlatformUser(user));
           return true;


### PR DESCRIPTION
## Summary
Fixes gaps from plan-review round 2 for half-dead-platform-session.md:
- Assistants-only rejection clears org state (Codex P2 on #40134): the interceptor otherwise keeps stamping the rejected account's Vellum-Organization-Id
- Refund drops the remembered recovery pathname (Codex P2 on #40133): a reload could re-seed the outstanding flag and let a heal clear the retained cooldown
- Slop: reconcilePlatformAssistants returns a plain boolean and owns its throw handling (three duplicate catch wrappers deleted); docstring-echo comments removed
- Declined with rationale: dropping OrgFetchOutcome's status payload (diagnostic, one field, churns ~10 test literals for zero behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)