### PR TITLE
fix: currency-guard the org clear in the assistants-rejection branch

### DIFF
--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1857,6 +1857,43 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
     expect(useAuthStore.getState().user?.kind).toBe("platform");
   });
 
+  test("a rejection landing after the race timeout does not clear org state", async () => {
+    arrangeLocalProbe();
+    // Hold the org fetch past the (shrunken) timeout, then resolve it OK and
+    // let the assistants call report a settled rejection. The probe already
+    // settled "present" from cached data, so the dangling call must not
+    // strip the org header out from under that session.
+    let releaseOrgFetch: (value: unknown) => void = () => {};
+    mockOrgFetchOutcome = new Promise((resolve) => {
+      releaseOrgFetch = resolve;
+    });
+    mockListAssistantsResult = { ok: false, status: 403, error: {} };
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    setTimeoutSpy.mockImplementation(((
+      handler: () => void,
+      timeout?: number,
+    ) =>
+      originalSetTimeout(
+        handler,
+        timeout === 3_000 ? 0 : timeout,
+      )) as typeof setTimeout);
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+      expect(useAuthStore.getState().platformSession).toBe("present");
+
+      releaseOrgFetch({ ok: true });
+      await new Promise((resolve) => originalSetTimeout(resolve, 0));
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(clearOrganizationMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+
   test("the probe clears its sync race timer once it settles", async () => {
     arrangeLocalProbe();
     const setTimeoutSpy = spyOn(globalThis, "setTimeout");

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -596,8 +596,13 @@ async function reconcilePlatformAssistants(
     if (isSettledSessionRejection(apiAssistants)) {
       // The org fetch self-clears on its own rejection; an assistants-only
       // rejection must clear the org state too, or the request interceptor
-      // keeps stamping the rejected account's Vellum-Organization-Id.
-      useOrganizationStore.getState().clearOrganization();
+      // keeps stamping the rejected account's Vellum-Organization-Id. The
+      // currency guard matches the sync below: a timed-out or superseded
+      // probe settled "present" from cached data, and its dangling call must
+      // not strip the org header out from under that session.
+      if (syncIsCurrent?.() ?? true) {
+        useOrganizationStore.getState().clearOrganization();
+      }
       return true;
     }
     if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {


### PR DESCRIPTION
## Summary
Closes the open Codex P2 on #40136: the assistants-rejection org clear in reconcilePlatformAssistants now carries the same syncIsCurrent guard as the adjacent lockfile sync, so a timed-out or superseded probe's dangling call cannot clear org state under a present-settled session. Test pins the late-rejection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)