### PR TITLE
fix(macos): lockfile watcher falls back to readable candidates so legacy-only installs keep their paired allowlist

### DIFF
--- a/clients/macos/src/main/lockfile-watcher.test.ts
+++ b/clients/macos/src/main/lockfile-watcher.test.ts
@@ -265,5 +265,107 @@ describe("lockfile-watcher", () => {
 
       teardown();
     });
+
+    test("keeps serving the legacy lockfile across polls when the canonical file never appears", async () => {
+      /**
+       * Tests the legacy-only install regression: the first poll finds the
+       * canonical file missing and must fall back to the legacy candidate
+       * instead of clearing the seeded cache to empty.
+       */
+
+      // GIVEN a legacy-only install
+      mockPaths = [CANONICAL_PATH, LEGACY_PATH];
+      writeLockfile(SAMPLE_LOCKFILE, LEGACY_PATH);
+      const teardown = installLockfileWatcher();
+
+      // WHEN several poll intervals elapse with no canonical file
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      // THEN the cache still serves the legacy data
+      const cached = getWatchedLockfile();
+      expect(cached.assistants).toHaveLength(2);
+      expect(cached.activeAssistant).toBe("ast-1");
+
+      teardown();
+    });
+
+    test("does not clear a previously-good cache when the canonical file goes transiently missing", async () => {
+      /**
+       * Tests that a transient canonical-file gap falls back to a readable
+       * candidate instead of clearing the cache to empty. Identical content
+       * in the fallback also produces no spurious change notification.
+       */
+
+      // GIVEN canonical and legacy files with the same content
+      mockPaths = [CANONICAL_PATH, LEGACY_PATH];
+      writeLockfile(SAMPLE_LOCKFILE, CANONICAL_PATH);
+      writeLockfile(SAMPLE_LOCKFILE, LEGACY_PATH);
+      const teardown = installLockfileWatcher();
+
+      const listener = mock((_lockfile: Lockfile) => undefined);
+      onLockfileChange(listener);
+
+      // WHEN the canonical file disappears while the legacy file remains
+      fs.unlinkSync(CANONICAL_PATH);
+      await new Promise((resolve) => setTimeout(resolve, 750));
+
+      // THEN the cache still holds the data and no notification fired
+      expect(getWatchedLockfile().assistants).toHaveLength(2);
+      expect(listener).not.toHaveBeenCalled();
+
+      teardown();
+    });
+
+    test("post-unpair canonical file is authoritative over a stale legacy fallback", async () => {
+      /**
+       * Tests unpair safety: a readable canonical file with the entry removed
+       * wins over a legacy file that still lists it, so a stale fallback can
+       * never resurrect an unpaired assistant.
+       */
+
+      // GIVEN a canonical file and a stale legacy file that still has entries
+      mockPaths = [CANONICAL_PATH, LEGACY_PATH];
+      writeLockfile(SAMPLE_LOCKFILE, CANONICAL_PATH);
+      writeLockfile(SAMPLE_LOCKFILE, LEGACY_PATH);
+      const teardown = installLockfileWatcher();
+
+      // WHEN an unpair rewrites the canonical file with the entries removed
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      writeLockfile({ assistants: [], activeAssistant: null }, CANONICAL_PATH);
+      const now = new Date();
+      fs.utimesSync(CANONICAL_PATH, now, new Date(now.getTime() + 1000));
+      await new Promise((resolve) => setTimeout(resolve, 750));
+
+      // THEN the empty canonical file wins despite the populated legacy file
+      const cached = getWatchedLockfile();
+      expect(cached.assistants).toHaveLength(0);
+      expect(cached.activeAssistant).toBeNull();
+
+      teardown();
+    });
+
+    test("clears to empty when no candidate is readable", async () => {
+      /**
+       * Tests that deleting every candidate still clears the cache, with a
+       * single change notification.
+       */
+
+      // GIVEN a canonical-only install with data
+      writeLockfile(SAMPLE_LOCKFILE);
+      const teardown = installLockfileWatcher();
+
+      const listener = mock((_lockfile: Lockfile) => undefined);
+      onLockfileChange(listener);
+
+      // WHEN the only lockfile is deleted
+      fs.unlinkSync(CANONICAL_PATH);
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+
+      // THEN the cache is cleared exactly once
+      expect(getWatchedLockfile().assistants).toHaveLength(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      teardown();
+    });
   });
 });

--- a/clients/macos/src/main/lockfile-watcher.ts
+++ b/clients/macos/src/main/lockfile-watcher.ts
@@ -25,7 +25,7 @@ const DEBOUNCE_MS = 100;
 
 const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 
-let lockfilePath: string | null = null;
+let lockfileCandidates: string[] = [];
 let cachedLockfile: Lockfile = EMPTY_LOCKFILE;
 let lastMtimeMs = 0;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -33,34 +33,24 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 const listeners = new Set<LockfileChangeListener>();
 
 /**
- * Read and parse the lockfile from the watched path. Falls back to
- * EMPTY_LOCKFILE on any error (file missing, invalid JSON, etc.).
+ * Parse the first readable candidate lockfile, canonical first. The first
+ * readable file is authoritative even when its entry list is empty, matching
+ * `readPairedGatewayTargets` in @vellumai/local-mode: an unpair leaves a
+ * readable canonical file with the entry removed, so a stale legacy fallback
+ * can never resurrect it. The fallback keeps legacy-only installs (no
+ * canonical file yet) populated. Returns EMPTY_LOCKFILE when no candidate
+ * is readable.
  */
 const readAndParse = (): Lockfile => {
-  if (!lockfilePath) return EMPTY_LOCKFILE;
-  try {
-    const raw = fs.readFileSync(lockfilePath, "utf-8");
-    return parseLockfile(JSON.parse(raw));
-  } catch {
-    return EMPTY_LOCKFILE;
-  }
-};
-
-/**
- * Seed the cache from the first readable candidate. Used only during
- * initial install so that legacy-only installs still populate the cache
- * before the canonical file is created by the first write.
- */
-const seedFromExistingCandidate = (candidates: string[]): void => {
-  for (const candidate of candidates) {
+  for (const candidate of lockfileCandidates) {
     try {
       const raw = fs.readFileSync(candidate, "utf-8");
-      cachedLockfile = parseLockfile(JSON.parse(raw));
-      return;
+      return parseLockfile(JSON.parse(raw));
     } catch {
-      // continue
+      // Missing or corrupt, try the next candidate.
     }
   }
+  return EMPTY_LOCKFILE;
 };
 
 const notifyListeners = (): void => {
@@ -70,16 +60,20 @@ const notifyListeners = (): void => {
 };
 
 const checkForChanges = (): void => {
-  if (!lockfilePath) return;
+  const canonicalPath = lockfileCandidates[0];
+  if (!canonicalPath) return;
 
   let mtimeMs: number;
   try {
-    mtimeMs = fs.statSync(lockfilePath).mtimeMs;
+    mtimeMs = fs.statSync(canonicalPath).mtimeMs;
   } catch {
-    // File deleted or inaccessible — if we previously had data, clear it.
-    if (cachedLockfile !== EMPTY_LOCKFILE) {
-      cachedLockfile = EMPTY_LOCKFILE;
-      lastMtimeMs = 0;
+    // Canonical file missing or inaccessible. Fall back to the first
+    // readable candidate (legacy-only installs, transient gaps) and go
+    // empty only when nothing is readable.
+    lastMtimeMs = 0;
+    const next = readAndParse();
+    if (JSON.stringify(next) !== JSON.stringify(cachedLockfile)) {
+      cachedLockfile = next;
       notifyListeners();
     }
     return;
@@ -109,7 +103,7 @@ export const getWatchedLockfile = (): Lockfile => cachedLockfile;
  * window where the watcher is not installed yet.
  */
 export const getWatchedLockfileSnapshot = (): Lockfile | null =>
-  lockfilePath ? cachedLockfile : null;
+  lockfileCandidates.length > 0 ? cachedLockfile : null;
 
 /**
  * Re-read the watched lockfile immediately, bypassing the poll interval and
@@ -118,7 +112,8 @@ export const getWatchedLockfileSnapshot = (): Lockfile | null =>
  * than after the next poll. No-op before the watcher is installed.
  */
 export const refreshLockfileNow = (): void => {
-  if (!lockfilePath) {
+  const canonicalPath = lockfileCandidates[0];
+  if (!canonicalPath) {
     return;
   }
   if (debounceTimer) {
@@ -126,7 +121,7 @@ export const refreshLockfileNow = (): void => {
     debounceTimer = null;
   }
   try {
-    lastMtimeMs = fs.statSync(lockfilePath).mtimeMs;
+    lastMtimeMs = fs.statSync(canonicalPath).mtimeMs;
   } catch {
     lastMtimeMs = 0;
   }
@@ -149,22 +144,20 @@ export const onLockfileChange = (listener: LockfileChangeListener): (() => void)
  * has data). Returns a teardown function for `before-quit`.
  */
 export const installLockfileWatcher = (): (() => void) => {
-  const candidates = resolveLockfilePaths(process.env);
-
-  // Always poll the canonical (first) path — write helpers always target
+  // Poll only the canonical (first) path — write helpers always target
   // candidates[0], so watching a legacy candidate would miss updates once
   // the canonical file is created.
-  lockfilePath = candidates[0]!;
+  lockfileCandidates = resolveLockfilePaths(process.env);
 
   // Initial read — synchronous so the tray menu has data from frame one.
+  // readAndParse falls back to legacy candidates when the canonical file
+  // doesn't exist yet, so pre-migration installs still show data.
   try {
-    lastMtimeMs = fs.statSync(lockfilePath).mtimeMs;
-    cachedLockfile = readAndParse();
+    lastMtimeMs = fs.statSync(lockfileCandidates[0]!).mtimeMs;
   } catch {
-    // Canonical file doesn't exist yet — seed cache from any existing
-    // candidate (legacy path) so pre-migration installs still show data.
-    seedFromExistingCandidate(candidates);
+    lastMtimeMs = 0;
   }
+  cachedLockfile = readAndParse();
 
   pollTimer = setInterval(checkForChanges, POLL_INTERVAL_MS);
 
@@ -188,5 +181,5 @@ export const __resetForTesting = (): void => {
   listeners.clear();
   cachedLockfile = EMPTY_LOCKFILE;
   lastMtimeMs = 0;
-  lockfilePath = null;
+  lockfileCandidates = [];
 };


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for macos-paired-assistants.md (flagged by two review passes).
- checkForChanges seeds from the first readable candidate when the canonical lockfile is missing, clearing only when nothing is readable
- Restores the pre-watcher first-readable-candidate semantics on the paired forward path without reintroducing unpair resurrection