### PR TITLE
fix: paired host-proxy hardening (poster 401 refresh, cloud-first classification, pending-guard dedup)

### DIFF
--- a/clients/macos/src/main/host-proxy-poster.test.ts
+++ b/clients/macos/src/main/host-proxy-poster.test.ts
@@ -45,15 +45,18 @@ interface CapturedRequest {
   rawBody: Buffer | null;
 }
 
+/** Status may be a list: one entry per call, with the last entry repeating. */
 function createMockFetch(
-  status = 200,
+  status: number | number[] = 200,
   responseBody: unknown = { accepted: true },
 ) {
+  const statuses = Array.isArray(status) ? status : [status];
   const captured: CapturedRequest[] = [];
   const fetchFn = async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
+    const callStatus = statuses[Math.min(captured.length, statuses.length - 1)];
     const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";
     const headers: Record<string, string> = {};
@@ -83,7 +86,7 @@ function createMockFetch(
         ? responseBody
         : JSON.stringify(responseBody);
     return new Response(resBody, {
-      status,
+      status: callStatus,
       headers: { "Content-Type": "application/json" },
     });
   };
@@ -430,6 +433,91 @@ describe("HostProxyPoster", () => {
       );
 
       expect(result).toBe(false);
+    });
+  });
+
+  // -- 401 refresh --------------------------------------------------------
+
+  describe("401 refresh", () => {
+    function makeRefreshingPoster(
+      fetchFn: typeof globalThis.fetch,
+      refresh: () => Promise<string | null>,
+    ) {
+      let token = "stale-token";
+      const poster = new HostProxyPoster({
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: `Bearer ${token}` }),
+        refreshAuth: async () => {
+          const fresh = await refresh();
+          if (fresh) {
+            token = fresh;
+          }
+          return fresh;
+        },
+        fetch: fetchFn,
+      });
+      return poster;
+    }
+
+    test("refreshes and retries once with the new bearer on 401", async () => {
+      const { fetchFn, captured } = createMockFetch([401, 200]);
+      const refresh = mock(async () => "fresh-token");
+      const poster = makeRefreshingPoster(fetchFn, refresh);
+
+      const result = await poster.postBashResult({ requestId: "r1", stdout: "" });
+
+      expect(result).toBe(true);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(captured).toHaveLength(2);
+      expect(captured[0].headers["Authorization"]).toBe("Bearer stale-token");
+      expect(captured[1].headers["Authorization"]).toBe("Bearer fresh-token");
+      expect(captured[1].body).toBe(captured[0].body);
+    });
+
+    test("returns false without retrying when refresh fails", async () => {
+      const { fetchFn, captured } = createMockFetch([401]);
+      const refresh = mock(async () => null);
+      const poster = makeRefreshingPoster(fetchFn, refresh);
+
+      const result = await poster.postBashResult({ requestId: "r2", stdout: "" });
+
+      expect(result).toBe(false);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(captured).toHaveLength(1);
+    });
+
+    test("returns false without retrying when refresh throws", async () => {
+      const { fetchFn, captured } = createMockFetch([401]);
+      const poster = makeRefreshingPoster(fetchFn, async () => {
+        throw new Error("refresh failed");
+      });
+
+      const result = await poster.postBashResult({ requestId: "r3", stdout: "" });
+
+      expect(result).toBe(false);
+      expect(captured).toHaveLength(1);
+    });
+
+    test("returns false after a second 401 without looping", async () => {
+      const { fetchFn, captured } = createMockFetch([401, 401]);
+      const refresh = mock(async () => "fresh-token");
+      const poster = makeRefreshingPoster(fetchFn, refresh);
+
+      const result = await poster.postBashResult({ requestId: "r4", stdout: "" });
+
+      expect(result).toBe(false);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(captured).toHaveLength(2);
+    });
+
+    test("401 without a refresh callback fails with a single request", async () => {
+      const { fetchFn, captured } = createMockFetch([401]);
+      const poster = makeLocalPoster(fetchFn);
+
+      const result = await poster.postBashResult({ requestId: "r5", stdout: "" });
+
+      expect(result).toBe(false);
+      expect(captured).toHaveLength(1);
     });
   });
 

--- a/clients/macos/src/main/host-proxy-poster.ts
+++ b/clients/macos/src/main/host-proxy-poster.ts
@@ -10,7 +10,8 @@
  * base and an auth-headers builder.
  *
  * Injectable fetch function for testability (mirrors the SSE client pattern).
- * Returns boolean success/failure without throwing.
+ * Returns boolean success/failure without throwing. Result POSTs that hit a
+ * 401 refresh the bearer via the optional refreshAuth callback and retry once.
  */
 
 import { getDeviceId } from "./device-id";
@@ -104,6 +105,13 @@ export interface HostProxyPosterOptions {
   endpointBase: string;
   /** Called on every request to build auth headers. */
   authHeaders: () => Record<string, string>;
+  /**
+   * Called when a result POST gets a 401. Resolves to a fresh token (which
+   * the authHeaders builder must observe) or null; on success the POST is
+   * retried once with rebuilt headers. A healthy SSE stream never reconnects,
+   * so this is the only refresh path once the captured bearer expires.
+   */
+  refreshAuth?: () => Promise<string | null>;
   /** Override fetch for testing. Defaults to globalThis.fetch. */
   fetch?: FetchFn;
 }
@@ -124,11 +132,13 @@ function computeTimeout(bodyBytes: number): number {
 export class HostProxyPoster {
   private readonly endpointBase: string;
   private readonly authHeaders: () => Record<string, string>;
+  private readonly refreshAuth: (() => Promise<string | null>) | null;
   private readonly fetchFn: FetchFn;
 
   constructor(opts: HostProxyPosterOptions) {
     this.endpointBase = opts.endpointBase;
     this.authHeaders = opts.authHeaders;
+    this.refreshAuth = opts.refreshAuth ?? null;
     this.fetchFn = opts.fetch ?? globalThis.fetch;
   }
 
@@ -245,8 +255,23 @@ export class HostProxyPoster {
     path: string,
     payload: object,
   ): Promise<boolean> {
+    const body = JSON.stringify(payload);
+    const first = await this.sendJson(path, body);
+    if (first !== "unauthorized" || !this.refreshAuth) {
+      return first === "ok";
+    }
+    const fresh = await this.refreshAuth().catch(() => null);
+    if (!fresh) {
+      return false;
+    }
+    return (await this.sendJson(path, body)) === "ok";
+  }
+
+  private async sendJson(
+    path: string,
+    body: string,
+  ): Promise<"ok" | "unauthorized" | "failed"> {
     try {
-      const body = JSON.stringify(payload);
       const timeout = computeTimeout(Buffer.byteLength(body, "utf-8"));
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeout);
@@ -259,12 +284,15 @@ export class HostProxyPoster {
           body,
           signal: controller.signal,
         });
-        return res.ok;
+        if (res.ok) {
+          return "ok";
+        }
+        return res.status === 401 ? "unauthorized" : "failed";
       } finally {
         clearTimeout(timer);
       }
     } catch {
-      return false;
+      return "failed";
     }
   }
 }

--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -446,6 +446,27 @@ describe("host-proxy-router", () => {
       expect(__testing.connections.has("custom-1")).toBe(false);
     });
 
+    test("cloud entry with a stale gatewayPort is classified as cloud, not loopback", async () => {
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "cloud-1",
+            cloud: "vellum",
+            runtimeUrl: "https://platform.vellum.ai",
+            resources: { gatewayPort: 9001, daemonPort: 9002 },
+          },
+        ],
+        activeAssistant: "cloud-1",
+      });
+      await flush();
+
+      expect(__testing.connections.get("cloud-1")!.fingerprint).toBe(
+        "cloud:https://platform.vellum.ai:",
+      );
+    });
+
     test("does not duplicate cloud connections on repeated lockfile updates", async () => {
       installHostProxyBridge(fakeCliResolver);
 
@@ -581,6 +602,69 @@ describe("host-proxy-router", () => {
       await flush();
 
       expect(__testing.connections.size).toBe(0);
+    });
+
+    test("paired entry with a stale gatewayPort still connects via the runtimeUrl", async () => {
+      const requests = recordingFetch();
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          {
+            assistantId: "paired-1",
+            cloud: "paired",
+            runtimeUrl: "https://tunnel.example.com",
+            resources: { gatewayPort: 9001, daemonPort: 9002 },
+          },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      expect(__testing.connections.get("paired-1")!.fingerprint).toBe(
+        "paired:https://tunnel.example.com:paired-1",
+      );
+      // No loopback token exchange or loopback SSE against the stale port.
+      expect(requests.some((r) => r.url.includes("/auth/token"))).toBe(false);
+      expect(requests.some((r) => r.url.startsWith("http://127.0.0.1:9001"))).toBe(false);
+      expect(requests.some((r) => r.url === "https://tunnel.example.com/v1/events")).toBe(true);
+    });
+
+    test("paired poster refreshes the guardian bearer and retries once on 401", async () => {
+      const posts: { headers: Record<string, string> }[] = [];
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/host-bash-result")) {
+          posts.push({ headers: { ...((init?.headers ?? {}) as Record<string, string>) } });
+          return new Response("{}", { status: posts.length === 1 ? 401 : 200 });
+        }
+        return new Response("ok");
+      }) as typeof globalThis.fetch;
+      installHostProxyBridge(fakeCliResolver);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://tunnel.example.com" },
+        ],
+        activeAssistant: "paired-1",
+      });
+      await flush();
+
+      // The expired-bearer refresh path re-acquires the guardian token.
+      mockGetGuardianAccessToken.mockImplementation(
+        async () => ({ ok: true, accessToken: "fresh-token" }),
+      );
+
+      const ok = await __testing.connections
+        .get("paired-1")!
+        .poster.postBashResult({ requestId: "r1", stdout: "" });
+
+      expect(ok).toBe(true);
+      expect(posts).toHaveLength(2);
+      expect(posts[0].headers.Authorization).toBe("Bearer test-token");
+      expect(posts[1].headers.Authorization).toBe("Bearer fresh-token");
+      // The refresh keeps the paired flag so failures surface re-pair guidance.
+      expect(mockGetGuardianAccessToken.mock.calls.at(-1)?.[5]).toEqual({ paired: true });
     });
 
     test("unpairing during token acquisition aborts the stale connect", async () => {

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -19,7 +19,11 @@ import {
   type CliInvocation,
   type GuardianTokenOptions,
 } from "@vellumai/local-mode";
-import { isUsableRuntimeUrl, type Lockfile } from "@vellumai/local-mode/contract";
+import {
+  isLoopbackGatewayCloud,
+  isUsableRuntimeUrl,
+  type Lockfile,
+} from "@vellumai/local-mode/contract";
 
 import { HostProxySseClient, type HostProxySseMessage } from "./host-proxy-sse";
 import { HostProxyPoster } from "./host-proxy-poster";
@@ -293,6 +297,42 @@ const cloudFingerprint = (runtimeUrl: string, organizationId?: string): string =
 const pairedFingerprint = (runtimeUrl: string, assistantId: string): string =>
   `paired:${runtimeUrl}:${assistantId}`;
 
+// -- Pending-connect guard ---------------------------------------------------
+
+/**
+ * Run a connect attempt under the pending-connect guard: register the pending
+ * entry synchronously, acquire the token, abort if the reconcile pass cancels
+ * or replaces the attempt while the token await is in flight, then open the
+ * connection synchronously. Cleans up only its own pending entry.
+ */
+async function connectWithPendingGuard(
+  assistantId: string,
+  fingerprint: string,
+  acquireToken: () => Promise<string | null>,
+  open: (token: string) => void,
+): Promise<void> {
+  if (connections.has(assistantId)) return;
+  if (pendingConnects.get(assistantId)?.fingerprint === fingerprint) return;
+
+  const pending: PendingConnect = { fingerprint };
+  pendingConnects.set(assistantId, pending);
+  try {
+    const token = await acquireToken();
+    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
+      log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId, fingerprint });
+      return;
+    }
+    if (!token) {
+      log.warn("[host-proxy-router] could not acquire token, skipping connection", { assistantId, fingerprint });
+      return;
+    }
+
+    open(token);
+  } finally {
+    if (pendingConnects.get(assistantId) === pending) pendingConnects.delete(assistantId);
+  }
+}
+
 // -- Local assistant connection ---------------------------------------------
 
 async function connectLocalAssistant(
@@ -300,26 +340,12 @@ async function connectLocalAssistant(
   gatewayPort: number,
 ): Promise<void> {
   const fingerprint = localFingerprint(gatewayPort);
-  if (connections.has(assistantId)) return;
-  if (pendingConnects.get(assistantId)?.fingerprint === fingerprint) return;
-
-  const pending: PendingConnect = { fingerprint };
-  pendingConnects.set(assistantId, pending);
-  try {
-    const gatewayToken = await acquireGatewayToken(assistantId, gatewayPort);
-    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
-      log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId });
-      return;
-    }
-    if (!gatewayToken) {
-      log.warn("[host-proxy-router] could not acquire gateway token, skipping connection", { assistantId });
-      return;
-    }
-
-    openLocalConnection(assistantId, gatewayPort, gatewayToken, fingerprint);
-  } finally {
-    if (pendingConnects.get(assistantId) === pending) pendingConnects.delete(assistantId);
-  }
+  await connectWithPendingGuard(
+    assistantId,
+    fingerprint,
+    () => acquireGatewayToken(assistantId, gatewayPort),
+    (token) => openLocalConnection(assistantId, gatewayPort, token, fingerprint),
+  );
 }
 
 function openLocalConnection(
@@ -341,7 +367,7 @@ function openLocalConnection(
   const endpointBase = `http://127.0.0.1:${gatewayPort}/v1`;
 
   const sse = new HostProxySseClient({ eventsUrl, authHeaders, onRefreshToken });
-  const poster = new HostProxyPoster({ endpointBase, authHeaders });
+  const poster = new HostProxyPoster({ endpointBase, authHeaders, refreshAuth: onRefreshToken });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
@@ -357,26 +383,12 @@ async function connectPairedAssistant(
   runtimeUrl: string,
 ): Promise<void> {
   const fingerprint = pairedFingerprint(runtimeUrl, assistantId);
-  if (connections.has(assistantId)) return;
-  if (pendingConnects.get(assistantId)?.fingerprint === fingerprint) return;
-
-  const pending: PendingConnect = { fingerprint };
-  pendingConnects.set(assistantId, pending);
-  try {
-    const guardianToken = await acquireGuardianToken(assistantId, { paired: true });
-    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
-      log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId, runtimeUrl });
-      return;
-    }
-    if (!guardianToken) {
-      log.warn("[host-proxy-router] could not acquire guardian token, skipping paired connection", { assistantId });
-      return;
-    }
-
-    openPairedConnection(assistantId, runtimeUrl, guardianToken, fingerprint);
-  } finally {
-    if (pendingConnects.get(assistantId) === pending) pendingConnects.delete(assistantId);
-  }
+  await connectWithPendingGuard(
+    assistantId,
+    fingerprint,
+    () => acquireGuardianToken(assistantId, { paired: true }),
+    (token) => openPairedConnection(assistantId, runtimeUrl, token, fingerprint),
+  );
 }
 
 function openPairedConnection(
@@ -406,7 +418,7 @@ function openPairedConnection(
   const endpointBase = `${base}/v1`;
 
   const sse = new HostProxySseClient({ eventsUrl, authHeaders, onRefreshToken });
-  const poster = new HostProxyPoster({ endpointBase, authHeaders });
+  const poster = new HostProxyPoster({ endpointBase, authHeaders, refreshAuth: onRefreshToken });
 
   sse.setMessageCallback((msg) => dispatchMessage(msg, poster));
   sse.connect();
@@ -478,10 +490,15 @@ function handleLockfileChange(lockfile: Lockfile): void {
   const activeIds = new Set<string>();
 
   for (const assistant of lockfile.assistants) {
-    const port = assistant.resources?.gatewayPort;
-    const isCloud = !port && assistant.cloud === "vellum" && assistant.runtimeUrl;
+    // Cloud wins over resources: a merge can leave a stale gatewayPort on a
+    // non-loopback entry (paired, vellum), and such an entry must never be
+    // classified as a loopback connection.
+    const port = isLoopbackGatewayCloud(assistant.cloud)
+      ? assistant.resources?.gatewayPort
+      : undefined;
+    const isCloud = assistant.cloud === "vellum" && assistant.runtimeUrl;
     const isPaired =
-      !port && assistant.cloud === "paired" && isUsableRuntimeUrl(assistant.runtimeUrl);
+      assistant.cloud === "paired" && isUsableRuntimeUrl(assistant.runtimeUrl);
     if (!port && !isCloud && !isPaired) continue;
 
     activeIds.add(assistant.assistantId);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-paired-assistants.md.
- HostProxyPoster refreshes the guardian bearer and retries once on 401 (paired and cloud paths), so healthy long-lived streams survive token expiry
- Lockfile classification is cloud-first: paired/cloud entries with a stale gatewayPort never take the loopback path
- Pending-connect guard extracted into one helper shared by local and paired connects