### PR TITLE
fix: paired-aware guardian guidance on the CLI web host and Vite dev host

### DIFF
--- a/cli/src/__tests__/client-token.test.ts
+++ b/cli/src/__tests__/client-token.test.ts
@@ -10,7 +10,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,7 +27,7 @@ const testDir = mkdtempSync(join(tmpdir(), "client-token-test-"));
 const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
 const ORIGINAL_ARGV = [...process.argv];
 
-import { parseArgs } from "../commands/client.js";
+import { isPairedLockfileEntry, parseArgs } from "../commands/client.js";
 
 // A clearly non-local URL so maybeSwapToLocalhost won't rewrite it to 127.0.0.1.
 const REMOTE_URL = "http://192.0.2.50:7830";
@@ -110,5 +110,36 @@ describe("client --token (ephemeral)", () => {
       "--no-open",
     ];
     expect(parseArgs().openBrowser).toBe(false);
+  });
+});
+
+// The guardian-token route passes {paired} to getGuardianAccessToken so
+// expired pairings get re-pair guidance instead of hatch/wake; this pins the
+// classification the route derives from the lockfile.
+describe("isPairedLockfileEntry", () => {
+  test("only a lockfile entry with cloud=paired classifies as paired", () => {
+    const dir = mkdtempSync(join(tmpdir(), "client-paired-test-"));
+    try {
+      const lockfilePath = join(dir, ".vellum.lock.json");
+      writeFileSync(
+        lockfilePath,
+        JSON.stringify({
+          assistants: [
+            { assistantId: "paired-1", cloud: "paired" },
+            { assistantId: "local-1", cloud: "local" },
+          ],
+          activeAssistant: "local-1",
+        }),
+      );
+
+      expect(isPairedLockfileEntry([lockfilePath], "paired-1")).toBe(true);
+      expect(isPairedLockfileEntry([lockfilePath], "local-1")).toBe(false);
+      expect(isPairedLockfileEntry([lockfilePath], "missing")).toBe(false);
+      expect(
+        isPairedLockfileEntry([join(dir, "absent.json")], "paired-1"),
+      ).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -494,6 +494,24 @@ const _lockfilePaths = resolveLockfilePaths(_localEnv);
 const _configDir = resolveConfigDir(_localEnv);
 const _baseDir = getBaseDir();
 
+/**
+ * Whether the lockfile records this assistant as a paired entry. Paired
+ * entries have no local daemon, so guardian-token failure guidance must say
+ * re-pair rather than hatch/wake.
+ */
+export function isPairedLockfileEntry(
+  lockfilePaths: string[],
+  assistantId: string,
+): boolean {
+  const lockfile = getLockfileData(lockfilePaths);
+  return (
+    lockfile.ok &&
+    lockfile.data.assistants.some(
+      (a) => a.assistantId === assistantId && a.cloud === "paired",
+    )
+  );
+}
+
 async function handleLocalEndpoints(
   req: Request,
   url: URL,
@@ -782,6 +800,7 @@ async function handleLocalEndpoints(
       invocation,
       true,
       _localEnv,
+      { paired: isPairedLockfileEntry(lockfilePaths, assistantId) },
     );
     if (result.ok) {
       return Response.json({ accessToken: result.accessToken });

--- a/clients/macos/src/main/local-mode.test.ts
+++ b/clients/macos/src/main/local-mode.test.ts
@@ -104,8 +104,6 @@ const lockfilePath = path.join(lockfileDir, ".vellum.lock.json");
 // Matches the module's `resolveConfigDir(process.env)` under the
 // production + XDG_CONFIG_HOME environment pinned above.
 const configDir = path.join(configHomeDir, "vellum");
-const guardianTokenPath = (assistantId: string): string =>
-  path.join(configDir, "assistants", assistantId, "guardian-token.json");
 
 let mockSessionToken: string | null = null;
 mock.module("./session-token-store", () => ({
@@ -122,6 +120,7 @@ mock.module("./lockfile-watcher", () => ({
 
 const { installLocalMode } = await import("./local-mode");
 const { resolveAllowedOrigin } = await import("./app-origin");
+const { guardianTokenPath } = await import("@vellumai/local-mode");
 
 // The IPC wrappers reject any sender whose frame origin isn't the build's
 // renderer origin. Tests drive the registered handlers directly, so they
@@ -633,10 +632,10 @@ describe("vellum:localMode:unpair handler", () => {
       { assistantId: "paired-1", cloud: "paired", runtimeUrl: "https://h" },
       "paired-1",
     );
-    fs.mkdirSync(path.dirname(guardianTokenPath("paired-1")), {
+    fs.mkdirSync(path.dirname(guardianTokenPath(configDir, "paired-1")), {
       recursive: true,
     });
-    fs.writeFileSync(guardianTokenPath("paired-1"), "{}");
+    fs.writeFileSync(guardianTokenPath(configDir, "paired-1"), "{}");
 
     const result = unpair("paired-1");
 
@@ -646,7 +645,7 @@ describe("vellum:localMode:unpair handler", () => {
     }
     expect(result.lockfile.activeAssistant).toBeNull();
     expect(result.lockfile.assistants).toEqual([]);
-    expect(fs.existsSync(guardianTokenPath("paired-1"))).toBe(false);
+    expect(fs.existsSync(guardianTokenPath(configDir, "paired-1"))).toBe(false);
     expect(spawnArgs).toHaveLength(0);
   });
 
@@ -740,7 +739,7 @@ describe("vellum:localMode:connectImport handler", () => {
 
     expect(result).toEqual({ ok: true, assistantId: "desk", accessOnly: true });
     expect(refreshLockfileNowMock).toHaveBeenCalledTimes(1);
-    expect(fs.existsSync(guardianTokenPath("desk"))).toBe(true);
+    expect(fs.existsSync(guardianTokenPath(configDir, "desk"))).toBe(true);
     const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
       assistants: Array<Record<string, unknown>>;
     };
@@ -775,7 +774,7 @@ describe("vellum:localMode:connectImport handler", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain("already exists");
-    expect(fs.existsSync(guardianTokenPath("local-1"))).toBe(false);
+    expect(fs.existsSync(guardianTokenPath(configDir, "local-1"))).toBe(false);
   });
 
   test("rejects a missing or oversized bundle with a structured error", () => {
@@ -899,11 +898,11 @@ describe("vellum:localMode:guardianToken handler", () => {
     assistantId: string,
     over: Record<string, unknown>,
   ): void => {
-    fs.mkdirSync(path.dirname(guardianTokenPath(assistantId)), {
+    fs.mkdirSync(path.dirname(guardianTokenPath(configDir, assistantId)), {
       recursive: true,
     });
     fs.writeFileSync(
-      guardianTokenPath(assistantId),
+      guardianTokenPath(configDir, assistantId),
       JSON.stringify({
         guardianPrincipalId: "principal",
         accessToken: "stored-token",
@@ -962,6 +961,8 @@ describe("vellum:localMode:guardianToken handler", () => {
     expect(await pending).toEqual({ ok: true, accessToken: "refreshed-token" });
   });
 
+  // The exact guidance copy is pinned in the package's guardian-token tests;
+  // here a distinguishing marker proves the handler routed the paired flag.
   test("expired refresh token resolves a structured 401 with hatch/wake guidance", async () => {
     writeToken("asst-g", {
       accessTokenExpiresAt: PAST,
@@ -977,7 +978,7 @@ describe("vellum:localMode:guardianToken handler", () => {
     expect(result.ok).toBe(false);
     expect(result.status).toBe(401);
     expect(result.error).toContain("vellum hatch");
-    expect(result.error).toContain("vellum wake");
+    expect(result.error).not.toContain("vellum pair");
     expect(spawnArgs).toHaveLength(0);
   });
 
@@ -1000,7 +1001,6 @@ describe("vellum:localMode:guardianToken handler", () => {
     expect(result.ok).toBe(false);
     expect(result.status).toBe(401);
     expect(result.error).toContain("vellum pair");
-    expect(result.error).toContain("vellum connect import");
     expect(result.error).not.toContain("vellum hatch");
     expect(spawnArgs).toHaveLength(0);
   });

--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the dev-server guardian-token route: the middleware classifies the
+ * assistant from the lockfile and passes {paired} to getGuardianAccessToken,
+ * so expired pairings get re-pair guidance instead of hatch/wake. The exact
+ * guidance copy is pinned in the package's guardian-token tests; here a
+ * distinguishing marker proves the route passed the paired flag.
+ */
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ViteDevServer, Connect } from "vite";
+
+import { guardianTokenPath } from "@vellumai/local-mode";
+
+import { localModePlugin } from "./vite-plugin-local-mode";
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vite-local-mode-"));
+const env = {
+  VELLUM_ENVIRONMENT: "production",
+  VELLUM_LOCKFILE_DIR: tempDir,
+  XDG_CONFIG_HOME: tempDir,
+};
+const configDir = path.join(tempDir, "vellum");
+const lockfilePath = path.join(tempDir, ".vellum.lock.json");
+
+// Capture the plugin's middleware chain from a fake dev server so requests
+// can be dispatched through it without booting Vite.
+const middlewares: Connect.NextHandleFunction[] = [];
+const plugin = localModePlugin(env);
+const configureServer = plugin.configureServer as (server: unknown) => void;
+configureServer({
+  middlewares: {
+    use: (handler: Connect.NextHandleFunction) => {
+      middlewares.push(handler);
+    },
+  },
+  config: { root: tempDir },
+} as unknown as ViteDevServer);
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+interface DispatchResult {
+  status: number;
+  body: string;
+}
+
+/** Drive a loopback GET through the captured connect chain. */
+function dispatch(url: string): Promise<DispatchResult> {
+  return new Promise((resolve, reject) => {
+    const req = Object.assign(new EventEmitter(), {
+      url,
+      method: "GET",
+      headers: { host: "127.0.0.1:5173" },
+      socket: { remoteAddress: "127.0.0.1" },
+    }) as unknown as Connect.IncomingMessage;
+    const res = {
+      statusCode: 200,
+      setHeader: () => {},
+      end: (body?: unknown) => {
+        resolve({ status: res.statusCode, body: String(body ?? "") });
+      },
+    };
+    let index = 0;
+    const next = (err?: unknown): void => {
+      if (err) {
+        reject(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      const middleware = middlewares[index++];
+      if (!middleware) {
+        resolve({ status: 404, body: "" });
+        return;
+      }
+      middleware(req, res as unknown as Parameters<typeof middleware>[1], next);
+    };
+    next();
+  });
+}
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const PAST = new Date(Date.now() - 60_000).toISOString();
+
+function writeToken(assistantId: string, over: Record<string, unknown>): void {
+  const tokenPath = guardianTokenPath(configDir, assistantId);
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+  fs.writeFileSync(
+    tokenPath,
+    JSON.stringify({
+      guardianPrincipalId: "principal",
+      accessToken: "stored-token",
+      accessTokenExpiresAt: FUTURE,
+      refreshToken: "refresh",
+      refreshTokenExpiresAt: FUTURE,
+      refreshAfter: FUTURE,
+      isNew: false,
+      deviceId: "device",
+      leasedAt: new Date().toISOString(),
+      ...over,
+    }),
+  );
+}
+
+function writeLockfile(assistants: Array<Record<string, unknown>>): void {
+  fs.writeFileSync(
+    lockfilePath,
+    JSON.stringify({ assistants, activeAssistant: null }),
+  );
+}
+
+describe("guardian-token middleware", () => {
+  beforeEach(() => {
+    fs.rmSync(lockfilePath, { force: true });
+    fs.rmSync(path.join(configDir, "assistants"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("returns a fresh token from the file", async () => {
+    writeLockfile([{ assistantId: "asst-g", cloud: "local" }]);
+    writeToken("asst-g", {});
+
+    const result = await dispatch("/__local/guardian-token/asst-g");
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ accessToken: "stored-token" });
+  });
+
+  test("expired refresh token for a local entry yields hatch/wake guidance", async () => {
+    writeLockfile([{ assistantId: "asst-g", cloud: "local" }]);
+    writeToken("asst-g", {
+      accessTokenExpiresAt: PAST,
+      refreshTokenExpiresAt: PAST,
+    });
+
+    const result = await dispatch("/__local/guardian-token/asst-g");
+
+    expect(result.status).toBe(401);
+    const { error } = JSON.parse(result.body) as { error: string };
+    expect(error).toContain("vellum hatch");
+    expect(error).not.toContain("vellum pair");
+  });
+
+  test("expired refresh token for a paired entry yields re-pair guidance", async () => {
+    writeLockfile([{ assistantId: "paired-g", cloud: "paired" }]);
+    writeToken("paired-g", {
+      accessTokenExpiresAt: PAST,
+      refreshTokenExpiresAt: PAST,
+    });
+
+    const result = await dispatch("/__local/guardian-token/paired-g");
+
+    expect(result.status).toBe(401);
+    const { error } = JSON.parse(result.body) as { error: string };
+    expect(error).toContain("vellum pair");
+    expect(error).not.toContain("vellum hatch");
+  });
+});

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -110,7 +110,12 @@ export function localModePlugin(env: Record<string, string>): Plugin {
         statusMiddleware(config.lockfilePaths, upgradingLocalAssistantIds),
       );
       server.middlewares.use(
-        guardianTokenMiddleware(config.configDir, baseDir, env),
+        guardianTokenMiddleware(
+          config.lockfilePaths,
+          config.configDir,
+          baseDir,
+          env,
+        ),
       );
       server.middlewares.use(gatewayProxyMiddleware(config.lockfilePaths));
       server.middlewares.use(pairedGatewayProxyMiddleware(config.lockfilePaths));
@@ -842,6 +847,7 @@ function statusMiddleware(
 }
 
 function guardianTokenMiddleware(
+  lockfilePaths: string[],
   configDir: string,
   baseDir: string,
   env: Record<string, string>,
@@ -878,7 +884,17 @@ function guardianTokenMiddleware(
       return;
     }
 
-    getGuardianAccessToken(assistantId, configDir, invocation, true, env).then(
+    // Paired entries have no local daemon, so token-failure guidance must
+    // say re-pair rather than hatch/wake.
+    const lockfile = getLockfileData(lockfilePaths);
+    const paired =
+      lockfile.ok &&
+      lockfile.data.assistants.some(
+        (a) => a.assistantId === assistantId && a.cloud === "paired",
+      );
+    getGuardianAccessToken(assistantId, configDir, invocation, true, env, {
+      paired,
+    }).then(
       (result) => {
         if (result.ok) {
           res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-paired-assistants.md.
- vellum client and the Vite dev host now classify paired entries and pass {paired} to getGuardianAccessToken, so expired pairings get re-pair guidance everywhere
- macOS local-mode tests import guardianTokenPath from the package and assert handler routing instead of re-pinning package copy