### PR TITLE
fix: refresh stale lockfile on switch, drain deep links before auto-skip, dedupe paired removal and labels

### DIFF
--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -1,6 +1,9 @@
 import { Menu, Tray, app, nativeTheme, shell } from "electron";
 
-import type { LockfileAssistant } from "@vellumai/local-mode/contract";
+import {
+  pairedHostLabel,
+  type LockfileAssistant,
+} from "@vellumai/local-mode/contract";
 
 import {
   MENU_ICON_CIRCLECHECK,
@@ -104,15 +107,7 @@ const assistantMenuLabel = (assistant: LockfileAssistant): string => {
   if (assistant.cloud !== "paired") {
     return title;
   }
-  let suffix = "Paired";
-  if (assistant.runtimeUrl) {
-    try {
-      suffix = `Paired \u00b7 ${new URL(assistant.runtimeUrl).hostname}`;
-    } catch {
-      // Unparseable runtimeUrl: plain "Paired".
-    }
-  }
-  return `${title} (${suffix})`;
+  return `${title} (${pairedHostLabel(assistant.runtimeUrl)})`;
 };
 
 /**

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -11,6 +11,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // --- mutable mock state (set per test) --- //
 
 let lockfileAssistants: Array<{ assistantId: string; cloud?: string }> = [];
+// Entries the next loadLockfile makes visible, standing in for a lockfile
+// change (e.g. `vellum connect import`) the renderer cache hasn't seen.
+let lockfileAssistantsAfterReload: Array<{
+  assistantId: string;
+  cloud?: string;
+}> | null = null;
 let selectedAssistant: { assistantId: string } | undefined = undefined;
 let removeFromLockfileResult: { ok: boolean; error?: string } = { ok: true };
 let connectPairedShouldThrow = false;
@@ -21,11 +27,19 @@ let activeAssistantId: string | null = null;
 const removePairedFromLockfileMock = mock(
   async (_id: string) => removeFromLockfileResult,
 );
+const loadLockfileMock = mock(async () => {
+  if (lockfileAssistantsAfterReload) {
+    lockfileAssistants = lockfileAssistantsAfterReload;
+    lockfileAssistantsAfterReload = null;
+  }
+  return { assistants: lockfileAssistants, activeAssistant: null };
+});
 mock.module("@/lib/local-mode", () => ({
   getLockfileAssistant: (id: string) =>
     lockfileAssistants.find((a) => a.assistantId === id),
   getSelectedAssistant: () => selectedAssistant,
   isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
+  loadLockfile: loadLockfileMock,
   removePairedAssistantFromLockfile: removePairedFromLockfileMock,
 }));
 
@@ -69,11 +83,13 @@ const { removePairedAssistant, switchToAssistant } = await import(
 
 beforeEach(() => {
   lockfileAssistants = [];
+  lockfileAssistantsAfterReload = null;
   selectedAssistant = undefined;
   removeFromLockfileResult = { ok: true };
   connectPairedShouldThrow = false;
   activeAssistantId = null;
   removePairedFromLockfileMock.mockClear();
+  loadLockfileMock.mockClear();
   connectPairedAssistantMock.mockClear();
   setSelectedAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
@@ -100,11 +116,33 @@ describe("switchToAssistant", () => {
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
   });
 
-  test("an id with no lockfile entry falls back to the selection write", async () => {
+  test("an id with no lockfile entry reloads the lockfile, then falls back to the selection write", async () => {
     const outcome = await switchToAssistant("ghost");
 
     expect(outcome.ok).toBe(true);
+    expect(loadLockfileMock).toHaveBeenCalledTimes(1);
     expect(setSelectedAssistantMock).toHaveBeenCalledWith("ghost");
+  });
+
+  test("a paired entry the cache hasn't loaded yet connects with credentials after the reload", async () => {
+    // A `vellum connect import` while the app was open: the tray (fed by
+    // main's watched lockfile) knows the entry, the renderer cache doesn't.
+    lockfileAssistantsAfterReload = [{ assistantId: "pr2", cloud: "paired" }];
+
+    const outcome = await switchToAssistant("pr2");
+
+    expect(outcome.ok).toBe(true);
+    expect(loadLockfileMock).toHaveBeenCalledTimes(1);
+    expect(connectPairedAssistantMock).toHaveBeenCalledWith("pr2");
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a cached entry never triggers a reload", async () => {
+    lockfileAssistants = [{ assistantId: "pr1", cloud: "paired" }];
+
+    await switchToAssistant("pr1");
+
+    expect(loadLockfileMock).not.toHaveBeenCalled();
   });
 
   test("a failed paired connect surfaces an error outcome", async () => {

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -3,6 +3,7 @@ import {
   getLockfileAssistant,
   getSelectedAssistant,
   isPairedAssistant,
+  loadLockfile,
   removePairedAssistantFromLockfile,
 } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
@@ -27,7 +28,15 @@ export type SwitchOutcome = { ok: true } | { ok: false; error: string };
 export async function switchToAssistant(
   assistantId: string,
 ): Promise<SwitchOutcome> {
-  const entry = getLockfileAssistant(assistantId);
+  let entry = getLockfileAssistant(assistantId);
+  if (!entry) {
+    // The renderer cache can trail main's watched lockfile (e.g. a
+    // `vellum connect import` while the app was open). Reload before
+    // treating the id as managed, or a fresh paired entry would be
+    // selected without credentials.
+    await loadLockfile();
+    entry = getLockfileAssistant(assistantId);
+  }
   if (entry && isPairedAssistant(entry)) {
     try {
       await useAuthStore.getState().connectPairedAssistant(assistantId);

--- a/clients/web/src/components/remove-from-device-dialog.tsx
+++ b/clients/web/src/components/remove-from-device-dialog.tsx
@@ -1,0 +1,61 @@
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+
+/**
+ * Shared "Remove from this device?" confirmation, mounted by both the
+ * assistant chooser and the tray-command handler in `RootLayout` so the copy
+ * cannot drift. A paired entry is a pairing record on this machine and a
+ * platform entry is a device-local listing; neither removal touches the
+ * assistant itself, which is what the per-kind copy explains.
+ */
+export function RemoveFromDeviceDialog({
+  open,
+  kind,
+  assistantName,
+  errorMessage,
+  isPending,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  /** Which removal copy applies: a pairing or a platform listing. */
+  kind: "paired" | "platform";
+  assistantName: string;
+  /** Inline failure line under the message when a removal attempt failed. */
+  errorMessage?: string;
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <ConfirmDialog
+      open={open}
+      title="Remove from this device?"
+      message={
+        <>
+          {kind === "paired" ? (
+            <>
+              This won&rsquo;t affect {assistantName} on its host machine. It
+              only forgets the pairing on this device. Pair again anytime with
+              vellum connect import.
+            </>
+          ) : (
+            <>
+              This won&rsquo;t delete {assistantName}. It only removes it from
+              this device. Logging in will make it available again.
+            </>
+          )}
+          {errorMessage && (
+            <span className="mt-2 block text-[var(--system-negative-strong)]">
+              {errorMessage}
+            </span>
+          )}
+        </>
+      }
+      confirmLabel="Remove"
+      destructive
+      isPending={isPending}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -9,7 +9,14 @@
  * run this file solo (`mock.module` leaks across a shared `bun test` run).
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ReactNode } from "react";
 
@@ -63,6 +70,9 @@ mock.module("react-router", () => ({
 
 mock.module("@/assistant/selection", () => ({
   resolveSelectedAssistantId: () => null,
+  // Imported by switch-service (pulled in for the paired-removal branch);
+  // never reached by these tests.
+  setSelectedAssistant: async () => {},
 }));
 
 mock.module("@/assistant/retire-service", () => ({
@@ -76,8 +86,14 @@ mock.module("@/lib/auth/gateway-session", () => ({
 
 class MockUnresolvedLocalGatewayError extends Error {}
 
+// Includes the surface `@/assistant/switch-service` (the real module, which
+// the chooser's paired-removal branch calls into) pulls from local-mode.
 mock.module("@/lib/local-mode", () => ({
+  getLockfileAssistant: () => undefined,
+  getSelectedAssistant: () => undefined,
   isCliWakeableAssistant: () => false,
+  isPairedAssistant: (a: { cloud?: string }) => a?.cloud === "paired",
+  loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
   removePairedAssistantFromLockfile: removePairedAssistantFromLockfileMock,
   removePlatformAssistantFromLockfile: removePlatformAssistantFromLockfileMock,
   UnresolvedLocalGatewayError: MockUnresolvedLocalGatewayError,
@@ -138,8 +154,9 @@ mock.module("@/hooks/use-onboarding-login", () => ({
   }),
 }));
 
+let isElectronValue = false;
 mock.module("@/runtime/is-electron", () => ({
-  isElectron: () => false,
+  isElectron: () => isElectronValue,
 }));
 
 mock.module("@/runtime/local-mode-host", () => ({
@@ -182,6 +199,7 @@ mock.module("@/stores/resolved-assistants-store", () => ({
 mock.module("@/utils/routes", () => ({
   routes: {
     assistant: "/assistant",
+    selectAssistant: "/select-assistant",
     welcome: "/welcome",
     onboarding: { hosting: "/onboarding/hosting" },
   },
@@ -297,6 +315,7 @@ describe("SelectAssistantScreen paired assistants", () => {
     hasPlatformSessionValue = false;
     assistantsValue = [];
     localModeHostAvailableValue = false;
+    isElectronValue = false;
     removePairedAssistantFromLockfileMock.mockClear();
     removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
       ok: true,
@@ -687,6 +706,48 @@ describe("SelectAssistantScreen paired assistants", () => {
     );
     expect(connectPairedAssistantMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("on Electron the sole-assistant auto-skip waits for the deep-link drain, so a buffered connect link wins", async () => {
+    isElectronValue = true;
+    localModeHostAvailableValue = true;
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+
+    // Drain not settled yet: the chooser holds instead of auto-connecting.
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+
+    // The buffered connect link publishes (parking the dialog), then the
+    // drain settles.
+    act(() => {
+      useConnectDialogStore
+        .getState()
+        .openConnectDialog({ initialBundle: "eyJnYXRld2F5" });
+      useConnectDialogStore.getState().markDeepLinkDrainSettled();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Connect dialog open")).toBeTruthy(),
+    );
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("on Electron an empty drain releases the sole-assistant auto-skip", async () => {
+    isElectronValue = true;
+    assistantsValue = [makePairedAssistant()];
+
+    render(<SelectAssistantScreen />);
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useConnectDialogStore.getState().markDeepLinkDrainSettled();
+    });
+
+    await waitFor(() =>
+      expect(connectPairedAssistantMock).toHaveBeenCalledWith(PAIRED_ID),
+    );
   });
 
   test("confirming a locked platform removal still calls removePlatformAssistantFromLockfile", async () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -11,13 +11,14 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
+import { removePairedAssistant } from "@/assistant/switch-service";
+import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
   clearGatewayToken,
   isRepairableGatewayTokenError,
 } from "@/lib/auth/gateway-session";
 import {
   isCliWakeableAssistant,
-  removePairedAssistantFromLockfile,
   removePlatformAssistantFromLockfile,
   UnresolvedLocalGatewayError,
 } from "@/lib/local-mode";
@@ -41,8 +42,8 @@ import {
   type ResolvedAssistant,
 } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
+import { pairedHostLabel } from "@vellumai/local-mode/contract";
 import { Button } from "@vellumai/design-library/components/button";
-import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Menu } from "@vellumai/design-library/components/menu";
 
 function assistantLabel(a: ResolvedAssistant): string {
@@ -55,20 +56,9 @@ function assistantLabel(a: ResolvedAssistant): string {
   return a.isLocal ? "Local Assistant" : "Cloud Assistant";
 }
 
-function pairedHostingLabel(runtimeUrl: string | undefined): string {
-  if (runtimeUrl) {
-    try {
-      return `Paired · ${new URL(runtimeUrl).hostname}`;
-    } catch {
-      // Unparseable runtimeUrl: fall through to the plain label.
-    }
-  }
-  return "Paired";
-}
-
 function assistantSubtitle(a: ResolvedAssistant): string {
   const hosting = a.isPaired
-    ? pairedHostingLabel(a.runtimeUrl)
+    ? pairedHostLabel(a.runtimeUrl)
     : a.isLocal
       ? "On this computer"
       : "Cloud-hosted";
@@ -100,17 +90,14 @@ export function SelectAssistantScreen() {
 
   const accessibleAssistants = assistants.filter(isAccessible);
 
+  // Unpairing and importing a pairing bundle both rewrite the lockfile
+  // through the local-mode host, and a pairing is device-local regardless of
+  // platform session: one gate covers the paired-removal and connect
+  // affordances (never shown in remote-gateway mode or hostless browsers).
+  const localModeHostAvailable = isLocalModeHostAvailable();
   // A locked platform entry can be forgotten on this device (dropped from the
-  // lockfile) only where a local-mode host can rewrite the lockfile.
-  const canRemoveLockedAssistants =
-    !hasPlatformSession && isLocalModeHostAvailable();
-  // A pairing is device-local regardless of platform session, so unpairing
-  // needs only the host, not a logged-out state.
-  const canRemovePairedAssistants = isLocalModeHostAvailable();
-  // Importing a pairing bundle rewrites the lockfile through the same host,
-  // so the connect affordance shares the unpair gate: never shown in
-  // remote-gateway mode or browsers without a local-mode host.
-  const canConnectRemoteAssistant = isLocalModeHostAvailable();
+  // lockfile) only where that same host is present and the user is logged out.
+  const canRemoveLockedAssistants = !hasPlatformSession && localModeHostAvailable;
 
   const [selected, setSelected] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -135,6 +122,10 @@ export function SelectAssistantScreen() {
   const connectDialogOpen = useConnectDialogStore.use.open();
   const connectInitialBundle = useConnectDialogStore.use.initialBundle();
   const connectGuidanceMessage = useConnectDialogStore.use.guidanceMessage();
+  // Electron buffers deep links that arrive before the renderer exists and
+  // drains them shortly after mount; the auto-skip below defers until that
+  // drain settles so a cold-start connect link opens the dialog first.
+  const deepLinkDrainSettled = useConnectDialogStore.use.deepLinkDrainSettled();
   // After a manual removal the user is mid-management on this screen: a
   // sudden auto-connect to the sole remaining assistant would be jarring, so
   // the auto-skip stands down for the rest of the visit.
@@ -284,10 +275,22 @@ export function SelectAssistantScreen() {
     }
     setRemovePending(true);
     setRemoveError(null);
+    if (removeTarget.isPaired) {
+      // The shared service owns the paired sequence (lockfile removal plus
+      // lifecycle active-id cleanup); its chooser-route outcome is ignored
+      // because this screen is already the chooser.
+      const outcome = await removePairedAssistant(removeTarget.id);
+      if (outcome.ok) {
+        removedThisVisitRef.current = true;
+        setRemoveTarget(null);
+      } else {
+        setRemoveError(outcome.error);
+      }
+      setRemovePending(false);
+      return;
+    }
     try {
-      const result = removeTarget.isPaired
-        ? await removePairedAssistantFromLockfile(removeTarget.id)
-        : await removePlatformAssistantFromLockfile(removeTarget.id);
+      const result = await removePlatformAssistantFromLockfile(removeTarget.id);
       if (result.ok) {
         // The lockfile subscription reconciles the list and the selection,
         // but not the lifecycle's active id: without this, navigating back
@@ -334,6 +337,12 @@ export function SelectAssistantScreen() {
     if (fromLogin || noAutoSkip || removedThisVisitRef.current) {
       return;
     }
+    // On a cold Electron start the buffered deep links publish after mount;
+    // hold the skip until the drain settles so a parked connect link wins
+    // (it opens the dialog, which stands the auto-skip down below).
+    if (electron && !deepLinkDrainSettled) {
+      return;
+    }
     if (connecting || autoSkipping || connectDialogOpen) {
       return;
     }
@@ -345,7 +354,7 @@ export function SelectAssistantScreen() {
       void handleConnect(accessibleAssistants[0]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assistants.length, accessibleAssistants.length]);
+  }, [assistants.length, accessibleAssistants.length, deepLinkDrainSettled]);
 
   const onContinue = () => {
     const assistant = assistants.find((a) => a.id === selected);
@@ -436,7 +445,7 @@ export function SelectAssistantScreen() {
                 }
                 onRemove={
                   (assistant.isPlatformHosted && canRemoveLockedAssistants) ||
-                  (assistant.isPaired && canRemovePairedAssistants)
+                  (assistant.isPaired && localModeHostAvailable)
                     ? () => setRemoveTarget(assistant)
                     : undefined
                 }
@@ -453,7 +462,7 @@ export function SelectAssistantScreen() {
               )
             }
           />
-          {canConnectRemoteAssistant && (
+          {localModeHostAvailable && (
             <DashedActionButton
               icon={<Link2 className="h-4 w-4" />}
               label="Connect a remote assistant"
@@ -516,34 +525,13 @@ export function SelectAssistantScreen() {
         onRepair={() => void handleRecoveryRepair()}
         onRetire={() => void handleRecoveryRetire()}
       />
-      <ConfirmDialog
+      <RemoveFromDeviceDialog
         open={removeTarget != null}
-        title="Remove from this device?"
-        message={
-          <>
-            {removeTarget?.isPaired ? (
-              <>
-                This won&rsquo;t affect {assistantLabel(removeTarget)} on its
-                host machine. It only forgets the pairing on this device. Pair
-                again anytime with vellum connect import.
-              </>
-            ) : (
-              <>
-                This won&rsquo;t delete{" "}
-                {removeTarget ? assistantLabel(removeTarget) : "the assistant"}.
-                It only removes it from this device. Logging in will make it
-                available again.
-              </>
-            )}
-            {removeError && (
-              <span className="mt-2 block text-[var(--system-negative-strong)]">
-                {removeError}
-              </span>
-            )}
-          </>
+        kind={removeTarget?.isPaired ? "paired" : "platform"}
+        assistantName={
+          removeTarget ? assistantLabel(removeTarget) : "the assistant"
         }
-        confirmLabel="Remove"
-        destructive
+        errorMessage={removeError ?? undefined}
         isPending={removePending}
         onConfirm={() => void handleRemoveConfirm()}
         onCancel={closeRemoveDialog}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -68,8 +68,8 @@ import {
   switchToAssistant,
 } from "@/assistant/switch-service";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
+import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
-import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { toast } from "@vellumai/design-library/components/toast";
 
 const ShareFeedbackModal = lazy(() =>
@@ -428,23 +428,16 @@ export function RootLayout() {
         onCancel={() => setRetireId(null)}
       />
 
-      {/* Confirmation for the tray "Remove from this Mac…" command. Same copy
-          as the chooser's remove dialog: forgetting the pairing on this device
+      {/* Confirmation for the tray "Remove from this Mac…" command. Shares
+          the chooser's remove dialog: forgetting the pairing on this device
           never touches the assistant on its host machine. */}
-      <ConfirmDialog
+      <RemoveFromDeviceDialog
         open={removePairedId !== null}
-        title="Remove from this device?"
-        message={
-          <>
-            This won&rsquo;t affect{" "}
-            {(removePairedId && getLockfileAssistant(removePairedId)?.name) ||
-              "the assistant"}{" "}
-            on its host machine. It only forgets the pairing on this device.
-            Pair again anytime with vellum connect import.
-          </>
+        kind="paired"
+        assistantName={
+          (removePairedId && getLockfileAssistant(removePairedId)?.name) ||
+          "the assistant"
         }
-        confirmLabel="Remove"
-        destructive
         isPending={removePairedPending}
         onConfirm={() => void handleConfirmRemovePaired()}
         onCancel={() => setRemovePairedId(null)}

--- a/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
@@ -50,11 +50,18 @@ mock.module("@sentry/react", () => ({
 }));
 
 import * as eventBus from "@/lib/event-bus";
+import {
+  __resetConnectDialogForTesting,
+  useConnectDialogStore,
+} from "@/stores/connect-dialog-store";
 
 const publishSpy = spyOn(eventBus, "publish");
 
 const { publishElectronDeepLinksSource } =
   await import("@/runtime/event-sources/electron-deep-links");
+
+/** Flush the drain promise chain (then/catch/finally). */
+const settleDrain = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 beforeEach(() => {
   activeCallback = null;
@@ -65,6 +72,7 @@ beforeEach(() => {
   unsubscribeMock.mockClear();
   captureExceptionMock.mockClear();
   publishSpy.mockClear();
+  __resetConnectDialogForTesting();
 });
 
 describe("publishElectronDeepLinksSource", () => {
@@ -149,6 +157,29 @@ describe("publishElectronDeepLinksSource", () => {
       level: "warning",
       tags: { context: "deep_link_drain" },
     });
+  });
+
+  test("latches the drain-settled flag only after the backlog has published", async () => {
+    pendingFixture = [{ kind: "connect", bundle: "eyJnYXRld2F5" }];
+
+    publishElectronDeepLinksSource();
+    expect(useConnectDialogStore.getState().deepLinkDrainSettled).toBe(false);
+
+    await settleDrain();
+
+    expect(publishSpy.mock.calls).toEqual([
+      ["deeplink.connect", { url: null, bundle: "eyJnYXRld2F5" }],
+    ]);
+    expect(useConnectDialogStore.getState().deepLinkDrainSettled).toBe(true);
+  });
+
+  test("a drain failure still latches the drain-settled flag", async () => {
+    drainError = new Error("ipc transport failed");
+
+    publishElectronDeepLinksSource();
+    await settleDrain();
+
+    expect(useConnectDialogStore.getState().deepLinkDrainSettled).toBe(true);
   });
 
   test("returns the subscribe-side unsubscribe so cleanup detaches the live bridge", () => {

--- a/clients/web/src/runtime/event-sources/electron-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/electron-deep-links.ts
@@ -6,6 +6,7 @@ import {
   subscribeToDeepLinks,
   type DeepLink,
 } from "@/runtime/deep-links";
+import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 
 /**
  * Electron `vellum://` deep-link bridge → typed bus events:
@@ -75,6 +76,11 @@ export function publishElectronDeepLinksSource(): () => void {
     })
     .catch((err) => {
       captureError(err, { context: "deep_link_drain", level: "warning" });
+    })
+    .finally(() => {
+      // Latch after the backlog publishes so a buffered connect link parks
+      // its dialog state before the chooser's auto-skip resumes.
+      useConnectDialogStore.getState().markDeepLinkDrainSettled();
     });
 
   return unsubscribe;

--- a/clients/web/src/stores/connect-dialog-store.ts
+++ b/clients/web/src/stores/connect-dialog-store.ts
@@ -15,6 +15,13 @@
  * flag, so a later manual open starts empty. Renderer reloads blow this
  * away because it's not persisted; deep links are transient signals.
  *
+ * The store also carries `deepLinkDrainSettled`: Electron buffers deep
+ * links that arrive before the renderer exists and drains them shortly
+ * after mount (see `runtime/event-sources/electron-deep-links.ts`, which
+ * marks the flag once the drain settles). The chooser's auto-skip defers
+ * to it so a cold-start connect link can open this dialog before a sole
+ * assistant auto-connects. It latches true for the renderer's lifetime.
+ *
  * @see {@link https://zustand.docs.pmnd.rs/}
  */
 
@@ -28,6 +35,8 @@ export interface ConnectDialogState {
   initialBundle: string | null;
   /** Guidance shown above the form (bundle-less deep-link entry), or `null`. */
   guidanceMessage: string | null;
+  /** Whether the Electron cold-start deep-link drain has settled. */
+  deepLinkDrainSettled: boolean;
 }
 
 export interface ConnectDialogActions {
@@ -41,6 +50,8 @@ export interface ConnectDialogActions {
   }) => void;
   /** Close the dialog and clear any parked deep-link payload. */
   closeConnectDialog: () => void;
+  /** Latch that the startup deep-link backlog has been published (or failed). */
+  markDeepLinkDrainSettled: () => void;
 }
 
 export type ConnectDialogStore = ConnectDialogState & ConnectDialogActions;
@@ -49,6 +60,7 @@ const useConnectDialogStoreBase = create<ConnectDialogStore>()((set) => ({
   open: false,
   initialBundle: null,
   guidanceMessage: null,
+  deepLinkDrainSettled: false,
   openConnectDialog: (options) =>
     set({
       open: true,
@@ -57,6 +69,7 @@ const useConnectDialogStoreBase = create<ConnectDialogStore>()((set) => ({
     }),
   closeConnectDialog: () =>
     set({ open: false, initialBundle: null, guidanceMessage: null }),
+  markDeepLinkDrainSettled: () => set({ deepLinkDrainSettled: true }),
 }));
 
 export const useConnectDialogStore = createSelectors(useConnectDialogStoreBase);
@@ -69,5 +82,6 @@ export function __resetConnectDialogForTesting(): void {
     open: false,
     initialBundle: null,
     guidanceMessage: null,
+    deepLinkDrainSettled: false,
   });
 }

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   KNOWN_CLOUDS,
+  pairedHostLabel,
   parseLockfile,
   resolveCloud,
   SENSITIVE_KEYS,
@@ -335,6 +336,23 @@ describe("resolveCloud", () => {
     expect(resolveCloud({ sshUser: "u" })).toBe("custom");
     expect(resolveCloud({})).toBe("local");
     expect(resolveCloud({ cloud: "" })).toBe("local");
+  });
+});
+
+describe("pairedHostLabel", () => {
+  test("names the remote host from a parseable runtimeUrl", () => {
+    expect(pairedHostLabel("https://tunnel.example.com")).toBe(
+      "Paired · tunnel.example.com",
+    );
+    expect(pairedHostLabel("https://remote-host.example:8443")).toBe(
+      "Paired · remote-host.example",
+    );
+  });
+
+  test("falls back to plain Paired for a missing or unparseable runtimeUrl", () => {
+    expect(pairedHostLabel(undefined)).toBe("Paired");
+    expect(pairedHostLabel("")).toBe("Paired");
+    expect(pairedHostLabel("not a url")).toBe("Paired");
   });
 });
 

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -94,6 +94,22 @@ export function isUsableRuntimeUrl(url: unknown): boolean {
 }
 
 /**
+ * User-facing hosting label for a paired entry: "Paired · <hostname>" when
+ * `runtimeUrl` names the remote host, plain "Paired" otherwise. Shared by the
+ * macOS tray switcher and the web chooser so their renderings cannot drift.
+ */
+export function pairedHostLabel(runtimeUrl: string | undefined): string {
+  if (runtimeUrl) {
+    try {
+      return `Paired · ${new URL(runtimeUrl).hostname}`;
+    } catch {
+      // Unparseable runtimeUrl: plain "Paired".
+    }
+  }
+  return "Paired";
+}
+
+/**
  * Clouds whose gateway listens on a loopback port of this machine: the
  * on-machine daemon ("local") and local Docker instances ("docker").
  */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-paired-assistants.md.
- switchToAssistant reloads the lockfile before falling back to bare selection, so fresh imports selected from the tray connect with credentials
- Chooser auto-skip waits for the Electron deep-link drain, so cold-start connect links cannot be clobbered in the single-assistant case
- Paired removal flow and confirm copy consolidated; shared pairedHostLabel helper feeds both tray and chooser