### PR TITLE
Half-dead platform session: settle it, and stop the 403-recovery loop

### DIFF
--- a/clients/web/docs/STATE_MANAGEMENT.md
+++ b/clients/web/docs/STATE_MANAGEMENT.md
@@ -518,6 +518,12 @@ Queries mounted inside `<ActiveAssistantGate>` typically don't race
 because the lifecycle resolves after org hydration, but the gate is
 cheap and safe to add defensively.
 
+A platform session whose API calls are conclusively rejected (a
+settled 401/403/410 from the org or assistants endpoints during the
+session probe) settles `platformSession: "absent"`, so bearer-auth
+(local/paired gateway) connections never stay org-gated behind a
+dead cookie.
+
 Reference: [TanStack Query — Dependent Queries](https://tanstack.com/query/latest/docs/framework/react/guides/dependent-queries)
 
 ### Canonical migration example

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -214,6 +214,7 @@ beforeEach(() => {
   useOrganizationStore.setState({
     fetchOrganizations: async () => {
       fetchOrganizationsCalls += 1;
+      return { ok: true };
     },
   });
   upgradeRejects = false;

--- a/clients/web/src/hooks/use-is-org-ready.test.tsx
+++ b/clients/web/src/hooks/use-is-org-ready.test.tsx
@@ -183,4 +183,19 @@ describe("useOrgHeaderReadiness", () => {
     render(<ReadinessProbe />);
     expect(latestReadiness).toBe("ready");
   });
+
+  test("a settled-absent session with a failed org fetch is ready", () => {
+    // The half-dead end state: the platform API conclusively rejected the
+    // session, so the probe settled `platformSession: "absent"` (no platform
+    // session) while the org fetch landed on "error". Readiness must be
+    // "ready" here; this is what un-gates the org-gated daemon queries
+    // (conversation skeletons) on bearer-auth connections.
+    hasPlatformSessionMock = false;
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Platform session was rejected (HTTP 403).",
+    });
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("ready");
+  });
 });

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1858,6 +1858,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
     );
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    // The refund also drops the remembered pathname; a leftover key would
+    // re-seed the outstanding flag after a reload and let a heal clear the
+    // retained cooldown.
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY)).toBeNull();
 
     // The cooldown survives the refund: an immediate rejection stays paced.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
@@ -1865,6 +1869,11 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(
       PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
     );
+
+    // With no remembered pathname, a later 2xx on that route cannot clear
+    // the cooldown the refund kept.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
   });
 
   test("a 2xx on the rejected route restores the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -1533,6 +1533,19 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     );
   }
 
+  /**
+   * refreshSession that never confirms the session live (the probe lands on
+   * "unknown"), so the claim it answers is not refunded.
+   */
+  function armUnrefundedRefresh() {
+    const refreshSession = mock(async () => {
+      mockAuthState.platformSession = "unknown";
+      return true;
+    });
+    mockAuthState.refreshSession = refreshSession;
+    return refreshSession;
+  }
+
   beforeEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
@@ -1780,9 +1793,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(hardNavigateMock).not.toHaveBeenCalled();
   });
 
-  test("an unsettled (unknown) platform session still recovers", async () => {
-    // "unknown" means the probe has not answered yet, so the rejection is
-    // still worth re-verifying; only a settled negative is conclusive.
+  test("an unsettled (unknown) platform session does not recover", async () => {
+    // While platformSession is "unknown" the boot probe is already evaluating
+    // this same rejection evidence, so spending a claim here would only nest
+    // a redundant refreshSession cycle on every dead-cookie boot.
     mockAuthState.platformSession = "unknown";
     const refreshSession = mock(async () => true);
     mockAuthState.refreshSession = refreshSession;
@@ -1790,7 +1804,8 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
 
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
   });
 
   test("a second rejection inside the cooldown window does not recover", async () => {
@@ -1808,25 +1823,18 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   });
 
   test("stops recovering once the attempt budget is spent", async () => {
-    // An unsettled probe never confirms the session live, so nothing refunds
-    // the count and the budget is the binding limit.
-    mockAuthState.platformSession = "unknown";
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+    // The cap's defended scenario: re-probes that repeatedly fail to confirm
+    // the session live never refund the count, so the budget binds. Each
+    // cycle claims while the session still reads "present".
+    const refreshSession = armUnrefundedRefresh();
 
     // Each round expires the cooldown so only the budget can stop it.
-    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS + 1; i++) {
+      mockAuthState.platformSession = "present";
       expireRecoveryCooldown();
       platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
       await flush();
     }
-    expect(refreshSession).toHaveBeenCalledTimes(
-      PLATFORM_RECOVERY_MAX_ATTEMPTS,
-    );
-
-    expireRecoveryCooldown();
-    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
-    await flush();
     expect(refreshSession).toHaveBeenCalledTimes(
       PLATFORM_RECOVERY_MAX_ATTEMPTS,
     );
@@ -1860,14 +1868,15 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
   });
 
   test("a 2xx on the rejected route restores the recovery budget", async () => {
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+    // Unrefunded claims keep the budget spent, so only the heal can clear it.
+    const refreshSession = armUnrefundedRefresh();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(1);
 
     // Inside the cooldown a rejection cannot recover.
+    mockAuthState.platformSession = "present";
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(1);
@@ -1883,9 +1892,8 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(2);
   });
 
-  test("an unrelated platform 2xx does not restore the budget", async () => {
-    const refreshSession = mock(async () => true);
-    mockAuthState.refreshSession = refreshSession;
+  test("an unrelated platform 2xx leaves an outstanding claim; the rejected route's clears it", async () => {
+    const refreshSession = armUnrefundedRefresh();
 
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
@@ -1897,11 +1905,26 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       makeResponse(200, "https://platform.test/v1/client-feature-flags/"),
     );
     expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe("1");
 
-    // Still inside the cooldown, so no second recovery.
+    // The rejected route healing clears the whole bound.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY)).toBeNull();
+  });
+
+  test("a refund resets the outstanding claim, so a later matching 2xx keeps the cooldown", async () => {
+    // Default refreshSession confirms the session live, so the claim is
+    // refunded and no heal is outstanding.
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+
+    // The matching 2xx must not clear the retained cooldown that paces
+    // re-probing while the permission 403 persists.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
   });
 
   test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {

--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -70,11 +70,20 @@ const mockAuthState: {
   refreshSession: async () => true,
 };
 
+// Controls the probe-settle wait the recovery path awaits after
+// `refreshSession`. Defaults to already-settled; a test swaps in a pending
+// promise to model the fire-and-forget probe still being in flight.
+let whenPlatformSessionSettledImpl: () => Promise<void> = async () => {};
+const whenPlatformSessionSettledMock = mock(() =>
+  whenPlatformSessionSettledImpl(),
+);
+
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     getState: () => mockAuthState,
     subscribe: () => () => {},
   },
+  whenPlatformSessionSettled: whenPlatformSessionSettledMock,
 }));
 
 const hardNavigateMock = mock((_url: string) => {});
@@ -1507,14 +1516,34 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
 
   const PLATFORM_AUTH_REDIRECT_KEY = "vellum:platform:auth-redirect-attempts";
   const PLATFORM_AUTH_MAX_REDIRECTS = 3;
+  const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
+  const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+  const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
+  const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
+
+  /**
+   * Backdate the recovery cooldown so the next rejection is outside the
+   * window. Tests that exercise the latch or the redirect budget across
+   * multiple cycles use this to keep the cooldown out of the picture.
+   */
+  function expireRecoveryCooldown(): void {
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_AT_KEY,
+      String(Date.now() - 700_000),
+    );
+  }
 
   beforeEach(() => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
     mockAuthState.sessionStatus = "authenticated";
     mockAuthState.platformSession = "present";
     mockAuthState.refreshSession = mock(async () => true);
+    whenPlatformSessionSettledImpl = async () => {};
     hardNavigateMock.mockClear();
   });
 
@@ -1522,6 +1551,10 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     resetPlatformAuthRecoveryFlag();
     setSelfHostedConnection(null);
     sessionStorage.removeItem(PLATFORM_AUTH_REDIRECT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
+    whenPlatformSessionSettledImpl = async () => {};
   });
 
   /** Drive one full rejection→recovery round trip against a dead session. */
@@ -1531,6 +1564,11 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
       mockAuthState.sessionStatus = "unauthenticated";
       return false;
     });
+    // Keep the recovery cooldown and budget out of redirect-budget tests:
+    // each round models a fresh, allowed recovery cycle.
+    expireRecoveryCooldown();
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
     platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
     await flush();
   };
@@ -1563,7 +1601,9 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(refreshSession).toHaveBeenCalledTimes(1);
     expect(hardNavigateMock).not.toHaveBeenCalled();
 
-    // Latch reopened → a later genuine rejection triggers another re-probe.
+    // Latch reopened → a later genuine rejection (outside the cooldown
+    // window) triggers another re-probe.
+    expireRecoveryCooldown();
     platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
     await flush();
     expect(refreshSession).toHaveBeenCalledTimes(2);
@@ -1693,6 +1733,217 @@ describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
     expect(sessionStorage.getItem(PLATFORM_AUTH_REDIRECT_KEY)).toBe(
       String(PLATFORM_AUTH_MAX_REDIRECTS),
     );
+  });
+
+  test("holds the latch until the platform probe settles", async () => {
+    // `refreshSession` in gateway-auth mode fire-and-forgets the platform
+    // probe, whose own requests 403 against a half-dead cookie. Those
+    // rejections arrive after `refreshSession` resolved; if the latch were
+    // already released, each would start the next recovery cycle.
+    let settleProbe: () => void = () => {};
+    whenPlatformSessionSettledImpl = () =>
+      new Promise((resolve) => {
+        settleProbe = resolve;
+      });
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // A probe-spawned 403 during the settle window must not recover again.
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Once the probe settles the latch reopens for a later genuine cycle.
+    whenPlatformSessionSettledImpl = async () => {};
+    settleProbe();
+    await flush();
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("a settled-absent platform session never triggers recovery", async () => {
+    mockAuthState.platformSession = "absent";
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+  });
+
+  test("an unsettled (unknown) platform session still recovers", async () => {
+    // "unknown" means the probe has not answered yet, so the rejection is
+    // still worth re-verifying; only a settled negative is conclusive.
+    mockAuthState.platformSession = "unknown";
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("a second rejection inside the cooldown window does not recover", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Latch is reopened, but the attempt timestamp is fresh.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops recovering once the attempt budget is spent", async () => {
+    // An unsettled probe never confirms the session live, so nothing refunds
+    // the count and the budget is the binding limit.
+    mockAuthState.platformSession = "unknown";
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    // Each round expires the cooldown so only the budget can stop it.
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS; i++) {
+      expireRecoveryCooldown();
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    }
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
+
+    expireRecoveryCooldown();
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS,
+    );
+  });
+
+  test("a live-confirmed recovery refunds the count but keeps the cooldown", async () => {
+    // platformSession stays "present" (beforeEach default): the probe keeps
+    // confirming the session is live, so a route-level permission 403 must
+    // not eat the budget a later real expiry needs.
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    for (let i = 0; i < PLATFORM_RECOVERY_MAX_ATTEMPTS + 2; i++) {
+      expireRecoveryCooldown();
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    }
+
+    // Every cycle recovered: the count was refunded each time.
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
+    );
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+
+    // The cooldown survives the refund: an immediate rejection stays paced.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(
+      PLATFORM_RECOVERY_MAX_ATTEMPTS + 2,
+    );
+  });
+
+  test("a 2xx on the rejected route restores the recovery budget", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // Inside the cooldown a rejection cannot recover.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // The same route succeeding is proof it healed; the cooldown clears and
+    // the next rejection may recover immediately.
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBeNull();
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).toBeNull();
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("an unrelated platform 2xx does not restore the budget", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    // A route the platform serves without the session (feature-flag polling)
+    // keeps succeeding; it must not clear the cooldown or the count.
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, "https://platform.test/v1/client-feature-flags/"),
+    );
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY)).not.toBeNull();
+
+    // Still inside the cooldown, so no second recovery.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("a self-hosted gateway 2xx does not restore the recovery budget", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_ATTEMPTS_KEY,
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+
+    platformAuthRecoveryInterceptor(
+      makeResponse(200, `${INGRESS}/v1/assistants/123/messages`),
+    );
+
+    expect(sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY)).toBe(
+      String(PLATFORM_RECOVERY_MAX_ATTEMPTS),
+    );
+  });
+
+  test("skips recovery when sessionStorage is unavailable", async () => {
+    // Without storage neither the cooldown nor the budget can be enforced,
+    // so recovery fails closed rather than looping uncountably.
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+    const originalGetItem = sessionStorage.getItem;
+    Object.defineProperty(sessionStorage, "getItem", {
+      configurable: true,
+      value: () => {
+        throw new DOMException("unavailable");
+      },
+    });
+
+    try {
+      platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+      await flush();
+    } finally {
+      Object.defineProperty(sessionStorage, "getItem", {
+        configurable: true,
+        value: originalGetItem,
+      });
+    }
+
+    expect(refreshSession).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -715,6 +715,10 @@ function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
 function refundPlatformRecoveryAttempt(): void {
   try {
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    // Drop the remembered pathname too: a leftover key would re-seed the
+    // outstanding flag after a reload, letting a heal clear the cooldown
+    // this refund deliberately keeps.
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
   } catch {
     // sessionStorage unavailable; the claim already fails closed.
   }
@@ -796,9 +800,6 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
           clearPlatformRecoveryBudgetIfHealed(pathname);
         }
       }
-      // The redirect budget stays gated on a confirmed session: the platform
-      // serves some routes anonymously, so a 2xx alone does not prove the
-      // session works.
       if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
         clearPlatformAuthRedirectBudget();
       }
@@ -821,8 +822,6 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (fromSelfHostedGateway) {
     return response;
   }
-  // Claim only for a session currently believed live: the boot probe owns
-  // unsettled ("unknown") evidence, and settled-absent has nothing to recover.
   if (!hasLivePlatformSession(platformSession)) {
     return response;
   }

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -58,10 +58,11 @@ import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
-import { useAuthStore } from "@/stores/auth-store";
+import { useAuthStore, whenPlatformSessionSettled } from "@/stores/auth-store";
 import {
   hasLivePlatformSession,
   isAuthenticated,
+  isPlatformSessionSettled,
   isSettledSessionRejection,
 } from "@/stores/session-status";
 import { routes } from "@/utils/routes";
@@ -632,6 +633,103 @@ function clearPlatformAuthRedirectBudget(): void {
   }
 }
 
+/**
+ * Cooldown + attempt budget for the recovery re-probe itself, mirroring the
+ * local-gateway 401 pattern above. The in-memory latch only serializes
+ * concurrent rejections within one cycle; against a platform that rejects
+ * every request, each released latch would otherwise start the next cycle
+ * immediately and without bound. The cooldown spaces cycles and the budget
+ * stops them; a 2xx on the route whose rejection last consumed an attempt
+ * restores both (proof the failing route healed), a re-probe that confirms
+ * the session live refunds the count while keeping the cooldown (a
+ * permission 403 must not starve a later real expiry), and quitting the app
+ * grants a fresh budget (sessionStorage).
+ */
+const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
+const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
+const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
+const PLATFORM_RECOVERY_COOLDOWN_MS = 600_000;
+const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
+
+/**
+ * Spend one recovery attempt for a rejection on `pathname`. False when the
+ * budget is exhausted, when the last attempt was inside the cooldown window,
+ * or when sessionStorage is unavailable so an uncountable environment fails
+ * closed (no recovery). The pathname is remembered so only that route's
+ * later success restores the budget.
+ */
+function claimPlatformRecoveryAttempt(pathname: string): boolean {
+  try {
+    const stored = Number(
+      sessionStorage.getItem(PLATFORM_RECOVERY_ATTEMPTS_KEY) ?? "0",
+    );
+    const attempts = Number.isFinite(stored) ? stored : 0;
+    if (attempts >= PLATFORM_RECOVERY_MAX_ATTEMPTS) {
+      return false;
+    }
+    const lastAttempt = sessionStorage.getItem(PLATFORM_RECOVERY_AT_KEY);
+    if (
+      lastAttempt &&
+      Date.now() - Number(lastAttempt) < PLATFORM_RECOVERY_COOLDOWN_MS
+    ) {
+      return false;
+    }
+    sessionStorage.setItem(PLATFORM_RECOVERY_AT_KEY, String(Date.now()));
+    sessionStorage.setItem(
+      PLATFORM_RECOVERY_ATTEMPTS_KEY,
+      String(attempts + 1),
+    );
+    sessionStorage.setItem(PLATFORM_RECOVERY_PATH_KEY, pathname);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restore the recovery budget when a success proves the previously rejected
+ * route is healthy again. Restoring on any platform 2xx would let routes the
+ * platform serves anonymously (client feature flags, for example) re-arm the
+ * budget every poll while the session-sensitive route keeps rejecting, which
+ * defeats the bound entirely.
+ */
+function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
+  try {
+    if (sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY) !== pathname) {
+      return;
+    }
+    sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+    sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
+  } catch {
+    // sessionStorage unavailable; the claim above already fails closed.
+  }
+}
+
+/**
+ * Refund the attempt count while keeping the cooldown timestamp. Used when
+ * the authoritative re-probe confirms the session is live: the rejection was
+ * a route-level permission denial, not session death, so it must not eat the
+ * budget a later real expiry needs. The retained cooldown still paces
+ * probing at one cycle per window while such a route keeps rejecting.
+ */
+function refundPlatformRecoveryAttempt(): void {
+  try {
+    sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
+  } catch {
+    // sessionStorage unavailable; the claim already fails closed.
+  }
+}
+
+/** The response URL's pathname, or null for an unparseable URL. */
+function responsePathname(response: Response): string | null {
+  try {
+    return new URL(response.url).pathname;
+  } catch {
+    return null;
+  }
+}
+
 async function recoverFromPlatformSessionRejection(): Promise<void> {
   try {
     // Authoritative re-probe. `refreshSession` calls `getSession()` and only
@@ -641,6 +739,14 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // and keeps `sessionStatus` authenticated, so the redirect below is
     // skipped there.
     await useAuthStore.getState().refreshSession();
+    // In gateway-auth mode `refreshSession` fire-and-forgets the
+    // platform-session probe and returns while the probe's own platform
+    // requests are still in flight. Hold the latch until the probe settles
+    // so those requests' rejections cannot each start a new recovery cycle.
+    await whenPlatformSessionSettled();
+    if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+      refundPlatformRecoveryAttempt();
+    }
     if (
       !isAuthenticated(useAuthStore.getState().sessionStatus) &&
       claimPlatformAuthRedirect()
@@ -669,10 +775,13 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * authenticated (excludes boot probes and the already-logged-out login flow,
  * and prevents a redirect loop), and the response did not come from the
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
- * {@link localGatewayAuthRecoveryInterceptor}.
+ * {@link localGatewayAuthRecoveryInterceptor}. A settled-absent platform
+ * session also no-ops (nothing to recover), and each re-probe cycle spends
+ * from the cooldown-spaced attempt budget above.
  *
- * A platform request that succeeds against a confirmed session restores the
- * redirect budget.
+ * A success on the route whose rejection last consumed a recovery attempt
+ * restores the recovery budget; a success against a confirmed session also
+ * restores the redirect budget.
  */
 export function platformAuthRecoveryInterceptor(response: Response): Response {
   const ingressUrl = getSelfHostedIngressUrl();
@@ -680,13 +789,18 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
     !!ingressUrl && response.url.startsWith(ingressUrl);
 
   if (response.ok) {
-    // A working self-hosted gateway says nothing about the platform session,
-    // and neither does a route the platform serves anonymously.
-    if (
-      !fromSelfHostedGateway &&
-      hasLivePlatformSession(useAuthStore.getState().platformSession)
-    ) {
-      clearPlatformAuthRedirectBudget();
+    // A working self-hosted gateway says nothing about the platform session.
+    if (!fromSelfHostedGateway) {
+      const pathname = responsePathname(response);
+      if (pathname !== null) {
+        clearPlatformRecoveryBudgetIfHealed(pathname);
+      }
+      // The redirect budget stays gated on a confirmed session: the platform
+      // serves some routes anonymously, so a 2xx alone does not prove the
+      // session works.
+      if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+        clearPlatformAuthRedirectBudget();
+      }
     }
     return response;
   }
@@ -699,10 +813,27 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (platformAuthRecoveryFired) {
     return response;
   }
-  if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
+  const { sessionStatus, platformSession } = useAuthStore.getState();
+  if (!isAuthenticated(sessionStatus)) {
     return response;
   }
   if (fromSelfHostedGateway) {
+    return response;
+  }
+  // A session already settled as not-live has nothing to recover; a re-probe
+  // would only repeat the answer. Keeps stray platform 403s after logout (or
+  // after the probe settled this rejection to "absent") inert.
+  if (
+    isPlatformSessionSettled(platformSession) &&
+    !hasLivePlatformSession(platformSession)
+  ) {
+    return response;
+  }
+  const rejectedPathname = responsePathname(response);
+  if (
+    rejectedPathname === null ||
+    !claimPlatformRecoveryAttempt(rejectedPathname)
+  ) {
     return response;
   }
 

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -62,7 +62,6 @@ import { useAuthStore, whenPlatformSessionSettled } from "@/stores/auth-store";
 import {
   hasLivePlatformSession,
   isAuthenticated,
-  isPlatformSessionSettled,
   isSettledSessionRejection,
 } from "@/stores/session-status";
 import { routes } from "@/utils/routes";
@@ -598,6 +597,7 @@ const PLATFORM_AUTH_MAX_REDIRECTS = 3;
 /** @internal Exposed for test teardown only. */
 export function resetPlatformAuthRecoveryFlag(): void {
   platformAuthRecoveryFired = false;
+  platformRecoveryOutstanding = false;
 }
 
 /**
@@ -634,16 +634,11 @@ function clearPlatformAuthRedirectBudget(): void {
 }
 
 /**
- * Cooldown + attempt budget for the recovery re-probe itself, mirroring the
- * local-gateway 401 pattern above. The in-memory latch only serializes
- * concurrent rejections within one cycle; against a platform that rejects
- * every request, each released latch would otherwise start the next cycle
- * immediately and without bound. The cooldown spaces cycles and the budget
- * stops them; a 2xx on the route whose rejection last consumed an attempt
- * restores both (proof the failing route healed), a re-probe that confirms
- * the session live refunds the count while keeping the cooldown (a
- * permission 403 must not starve a later real expiry), and quitting the app
- * grants a fresh budget (sessionStorage).
+ * Cooldown + attempt budget for the recovery re-probe, mirroring the
+ * local-gateway 401 pattern above. The cooldown spaces cycles and the budget
+ * stops them; with the refund below, the cap binds when re-probes repeatedly
+ * fail to settle (refreshSession throwing on a flaky network while the API
+ * keeps rejecting). Quitting the app grants a fresh budget (sessionStorage).
  */
 const PLATFORM_RECOVERY_AT_KEY = "vellum:platform:recovery-attempt-at";
 const PLATFORM_RECOVERY_ATTEMPTS_KEY = "vellum:platform:recovery-attempts";
@@ -651,12 +646,20 @@ const PLATFORM_RECOVERY_PATH_KEY = "vellum:platform:recovery-path";
 const PLATFORM_RECOVERY_COOLDOWN_MS = 600_000;
 const PLATFORM_RECOVERY_MAX_ATTEMPTS = 3;
 
+// Skips the ok-branch heal check until a claim is made. Seeded from storage:
+// a claim from this page's earlier life may still be awaiting its heal.
+let platformRecoveryOutstanding = (() => {
+  try {
+    return sessionStorage.getItem(PLATFORM_RECOVERY_PATH_KEY) !== null;
+  } catch {
+    return false;
+  }
+})();
+
 /**
- * Spend one recovery attempt for a rejection on `pathname`. False when the
- * budget is exhausted, when the last attempt was inside the cooldown window,
- * or when sessionStorage is unavailable so an uncountable environment fails
- * closed (no recovery). The pathname is remembered so only that route's
- * later success restores the budget.
+ * Spend one recovery attempt for a rejection on `pathname`; false when the
+ * budget or cooldown blocks it, or when sessionStorage is unavailable (fails
+ * closed). Only that pathname's later success restores the budget.
  */
 function claimPlatformRecoveryAttempt(pathname: string): boolean {
   try {
@@ -680,6 +683,7 @@ function claimPlatformRecoveryAttempt(pathname: string): boolean {
       String(attempts + 1),
     );
     sessionStorage.setItem(PLATFORM_RECOVERY_PATH_KEY, pathname);
+    platformRecoveryOutstanding = true;
     return true;
   } catch {
     return false;
@@ -687,11 +691,8 @@ function claimPlatformRecoveryAttempt(pathname: string): boolean {
 }
 
 /**
- * Restore the recovery budget when a success proves the previously rejected
- * route is healthy again. Restoring on any platform 2xx would let routes the
- * platform serves anonymously (client feature flags, for example) re-arm the
- * budget every poll while the session-sensitive route keeps rejecting, which
- * defeats the bound entirely.
+ * Restore the budget only when the last-rejected route succeeds: anonymously
+ * served routes (client feature flags) must not re-arm it every poll.
  */
 function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
   try {
@@ -701,17 +702,15 @@ function clearPlatformRecoveryBudgetIfHealed(pathname: string): void {
     sessionStorage.removeItem(PLATFORM_RECOVERY_AT_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_ATTEMPTS_KEY);
     sessionStorage.removeItem(PLATFORM_RECOVERY_PATH_KEY);
+    platformRecoveryOutstanding = false;
   } catch {
     // sessionStorage unavailable; the claim above already fails closed.
   }
 }
 
 /**
- * Refund the attempt count while keeping the cooldown timestamp. Used when
- * the authoritative re-probe confirms the session is live: the rejection was
- * a route-level permission denial, not session death, so it must not eat the
- * budget a later real expiry needs. The retained cooldown still paces
- * probing at one cycle per window while such a route keeps rejecting.
+ * Refund the attempt count but keep the cooldown: a permission 403 on a live
+ * session must not eat the budget a later real expiry needs.
  */
 function refundPlatformRecoveryAttempt(): void {
   try {
@@ -719,6 +718,7 @@ function refundPlatformRecoveryAttempt(): void {
   } catch {
     // sessionStorage unavailable; the claim already fails closed.
   }
+  platformRecoveryOutstanding = false;
 }
 
 /** The response URL's pathname, or null for an unparseable URL. */
@@ -739,10 +739,8 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
     // and keeps `sessionStatus` authenticated, so the redirect below is
     // skipped there.
     await useAuthStore.getState().refreshSession();
-    // In gateway-auth mode `refreshSession` fire-and-forgets the
-    // platform-session probe and returns while the probe's own platform
-    // requests are still in flight. Hold the latch until the probe settles
-    // so those requests' rejections cannot each start a new recovery cycle.
+    // refreshSession may fire-and-forget the platform probe; hold the latch
+    // until it settles so the probe's own rejections cannot re-enter.
     await whenPlatformSessionSettled();
     if (hasLivePlatformSession(useAuthStore.getState().platformSession)) {
       refundPlatformRecoveryAttempt();
@@ -775,9 +773,10 @@ async function recoverFromPlatformSessionRejection(): Promise<void> {
  * authenticated (excludes boot probes and the already-logged-out login flow,
  * and prevents a redirect loop), and the response did not come from the
  * self-hosted / remote-gateway bearer path — those 401s are recovered by
- * {@link localGatewayAuthRecoveryInterceptor}. A settled-absent platform
- * session also no-ops (nothing to recover), and each re-probe cycle spends
- * from the cooldown-spaced attempt budget above.
+ * {@link localGatewayAuthRecoveryInterceptor}. Recovery claims only for a
+ * platform session currently believed live: the boot probe owns unsettled
+ * evidence, and a settled-absent session has nothing to recover. Each cycle
+ * spends from the cooldown-spaced attempt budget above.
  *
  * A success on the route whose rejection last consumed a recovery attempt
  * restores the recovery budget; a success against a confirmed session also
@@ -791,9 +790,11 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (response.ok) {
     // A working self-hosted gateway says nothing about the platform session.
     if (!fromSelfHostedGateway) {
-      const pathname = responsePathname(response);
-      if (pathname !== null) {
-        clearPlatformRecoveryBudgetIfHealed(pathname);
+      if (platformRecoveryOutstanding) {
+        const pathname = responsePathname(response);
+        if (pathname !== null) {
+          clearPlatformRecoveryBudgetIfHealed(pathname);
+        }
       }
       // The redirect budget stays gated on a confirmed session: the platform
       // serves some routes anonymously, so a 2xx alone does not prove the
@@ -820,13 +821,9 @@ export function platformAuthRecoveryInterceptor(response: Response): Response {
   if (fromSelfHostedGateway) {
     return response;
   }
-  // A session already settled as not-live has nothing to recover; a re-probe
-  // would only repeat the answer. Keeps stray platform 403s after logout (or
-  // after the probe settled this rejection to "absent") inert.
-  if (
-    isPlatformSessionSettled(platformSession) &&
-    !hasLivePlatformSession(platformSession)
-  ) {
+  // Claim only for a session currently believed live: the boot probe owns
+  // unsettled ("unknown") evidence, and settled-absent has nothing to recover.
+  if (!hasLivePlatformSession(platformSession)) {
     return response;
   }
   const rejectedPathname = responsePathname(response);

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { cleanup } from "@testing-library/react";
 
 type MockSessionUser = {
@@ -144,6 +152,17 @@ const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 // unaffected; the reconciliation tests override it to a well-formed result.
 let mockListAssistantsResult: unknown = [];
 const listAssistantsMock = mock(async () => mockListAssistantsResult);
+// Controls the `OrgFetchOutcome` the probe's evidence check reads. A thrown
+// error simulates a transport failure; a never-resolving promise as the
+// outcome makes the fetch hang so the probe's sync race times out.
+let mockOrgFetchOutcome: unknown = { ok: true };
+let mockOrgFetchError: Error | null = null;
+const fetchOrganizationsMock = mock(async () => {
+  if (mockOrgFetchError) {
+    throw mockOrgFetchError;
+  }
+  return mockOrgFetchOutcome;
+});
 const syncPlatformAssistantsToLockfileMock = mock(
   async (_list: unknown, _orgId?: string) => {},
 );
@@ -314,7 +333,7 @@ mock.module("@/stores/organization-store", () => ({
   clearOrganization: clearOrganizationMock,
   useOrganizationStore: {
     getState: () => ({
-      fetchOrganizations: async () => {},
+      fetchOrganizations: fetchOrganizationsMock,
       currentOrganizationId: "org-test",
     }),
   },
@@ -344,8 +363,11 @@ mock.module("@/assistant/api", () => ({
   listAssistants: listAssistantsMock,
 }));
 
-const { useAuthStore, __resetConsentSyncUserForTesting } =
-  await import("@/stores/auth-store");
+const {
+  useAuthStore,
+  whenPlatformSessionSettled,
+  __resetConsentSyncUserForTesting,
+} = await import("@/stores/auth-store");
 const { useAssistantLifecycleStore } =
   await import("@/assistant/lifecycle-store");
 const { useResolvedAssistantsStore } =
@@ -438,6 +460,9 @@ beforeEach(() => {
   lifecycleCheckAssistantMock.mockClear();
   mockListAssistantsResult = [];
   listAssistantsMock.mockClear();
+  mockOrgFetchOutcome = { ok: true };
+  mockOrgFetchError = null;
+  fetchOrganizationsMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   bootstrapLocalAssistantPlatformIdentityMock.mockClear();
   resetAuthStore();
@@ -1709,6 +1734,147 @@ describe("platform session probe resolution", () => {
     gates[1]();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+});
+
+describe("platform probe conclusive rejection (half-dead session)", () => {
+  // The half-dead state: allauth answers 200 with a user while the platform
+  // API conclusively rejects the same credential. The probe consumes the
+  // org/assistants evidence it already gathers and settles the session
+  // "absent", which un-gates org-gated daemon queries on bearer-auth
+  // connections and surfaces the login affordances. The recovery
+  // interceptor's settled-absent gate then treats any residual platform 403
+  // as a no-op instead of looping.
+  //
+  // Every test drives the local-client init path (no gateway auth, no
+  // platform assistants), where the probe runs with `setUserOnSuccess`.
+  function arrangeLocalProbe(): void {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+  }
+
+  test("an org-fetch session rejection settles the session absent", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    // A rejected session must not install a platform user, persist a
+    // restorable snapshot, or bootstrap the platform identity.
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
+    // The evidence check short-circuits before the assistants call and sync.
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("a session rejection clears a previously persisted snapshot", async () => {
+    arrangeLocalProbe();
+    // A snapshot persisted by an earlier confirmed session must not survive
+    // the rejection: restoreOfflineSession would otherwise resurrect the
+    // rejected account as "present" on a later offline boot.
+    localStorage.setItem(
+      "vellum:auth:userSnapshot",
+      JSON.stringify({ id: "user-1", email: "user@example.com" }),
+    );
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("an assistants-list session rejection settles the session absent", async () => {
+    arrangeLocalProbe();
+    mockListAssistantsResult = { ok: false, status: 403, error: {} };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("a transport-thrown org fetch keeps the present settle", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    // No evidence of rejection: the offline-restore contract (LUM-2412)
+    // keeps the session present.
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(bootstrapLocalAssistantPlatformIdentityMock).toHaveBeenCalled();
+  });
+
+  test("a non-rejection org failure keeps the present settle", async () => {
+    arrangeLocalProbe();
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("a sync race timeout keeps the present settle", async () => {
+    arrangeLocalProbe();
+    // An org fetch that never resolves leaves the race with only the timeout
+    // arm; shrink the 3s timer to 0 so the test settles immediately.
+    mockOrgFetchOutcome = new Promise(() => {});
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    setTimeoutSpy.mockImplementation(((
+      handler: () => void,
+      timeout?: number,
+    ) =>
+      originalSetTimeout(
+        handler,
+        timeout === 3_000 ? 0 : timeout,
+      )) as typeof setTimeout);
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("the probe clears its sync race timer once it settles", async () => {
+    arrangeLocalProbe();
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+
+      const raceTimerIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === 3_000,
+      );
+      expect(raceTimerIndex).toBeGreaterThanOrEqual(0);
+      const raceTimerHandle = setTimeoutSpy.mock.results[raceTimerIndex]?.value;
+      expect(
+        clearTimeoutSpy.mock.calls.some((call) => call[0] === raceTimerHandle),
+      ).toBe(true);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -334,6 +334,7 @@ mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
     getState: () => ({
       fetchOrganizations: fetchOrganizationsMock,
+      clearOrganization: clearOrganizationMock,
       currentOrganizationId: "org-test",
     }),
   },
@@ -1799,6 +1800,9 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
     expect(useAuthStore.getState().user?.kind).toBe("local");
     expect(bootstrapLocalAssistantPlatformIdentityMock).not.toHaveBeenCalled();
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+    // The org fetch succeeded, so the rejected account's org state must be
+    // cleared here or its Vellum-Organization-Id keeps stamping requests.
+    expect(clearOrganizationMock).toHaveBeenCalled();
   });
 
   test("a transport-thrown org fetch keeps the present settle", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1857,6 +1857,43 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
     expect(useAuthStore.getState().user?.kind).toBe("platform");
   });
 
+  test("a rejection landing after the race timeout does not clear org state", async () => {
+    arrangeLocalProbe();
+    // Hold the org fetch past the (shrunken) timeout, then resolve it OK and
+    // let the assistants call report a settled rejection. The probe already
+    // settled "present" from cached data, so the dangling call must not
+    // strip the org header out from under that session.
+    let releaseOrgFetch: (value: unknown) => void = () => {};
+    mockOrgFetchOutcome = new Promise((resolve) => {
+      releaseOrgFetch = resolve;
+    });
+    mockListAssistantsResult = { ok: false, status: 403, error: {} };
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    setTimeoutSpy.mockImplementation(((
+      handler: () => void,
+      timeout?: number,
+    ) =>
+      originalSetTimeout(
+        handler,
+        timeout === 3_000 ? 0 : timeout,
+      )) as typeof setTimeout);
+
+    try {
+      await useAuthStore.getState().initSession();
+      await whenPlatformSessionSettled();
+      expect(useAuthStore.getState().platformSession).toBe("present");
+
+      releaseOrgFetch({ ok: true });
+      await new Promise((resolve) => originalSetTimeout(resolve, 0));
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(clearOrganizationMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+
   test("the probe clears its sync race timer once it settles", async () => {
     arrangeLocalProbe();
     const setTimeoutSpy = spyOn(globalThis, "setTimeout");

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1855,6 +1855,13 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
 
     expect(useAuthStore.getState().platformSession).toBe("present");
     expect(useAuthStore.getState().user?.kind).toBe("platform");
+    // Wiring pin: past the timeout the strict sync gate is closed but the
+    // same-session gate stays open (no newer probe), so a late org success
+    // may still commit and un-strand readiness.
+    const [isCurrent, isSameSession] = fetchOrganizationsMock.mock
+      .calls[0] as unknown as [() => boolean, () => boolean];
+    expect(isCurrent()).toBe(false);
+    expect(isSameSession()).toBe(true);
   });
 
   test("a rejection landing after the race timeout does not clear org state", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -2081,6 +2081,10 @@ describe("session-rejection evidence at sibling confirmation sites", () => {
 
     expect(useAuthStore.getState().platformSession).not.toBe("present");
     expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    // A failed connect leaves no side effects behind: the caller keeps its
+    // current selection and consent state, not the rejected account's.
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+    expect(fetchConsentMock).not.toHaveBeenCalled();
   });
 
   test("connectPlatformAssistant tolerates a non-rejection org failure", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1943,6 +1943,8 @@ describe("session-rejection evidence at sibling confirmation sites", () => {
     // No snapshot may be re-persisted for the rejected session.
     expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+    // Nor may the rejected account's user-scoped consent state be installed.
+    expect(fetchConsentMock).not.toHaveBeenCalled();
   });
 
   test("refreshSession settles absent on an assistants-list rejection", async () => {
@@ -2040,6 +2042,8 @@ describe("session-rejection evidence at sibling confirmation sites", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent");
     expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
     expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+    // Nor may the rejected account's user-scoped consent state be installed.
+    expect(fetchConsentMock).not.toHaveBeenCalled();
   });
 
   test("initSession with platform assistants routes an assistants-list rejection to login", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -152,9 +152,9 @@ const retrieveBiometricTokenMock = mock(async () => mockBiometricToken);
 // unaffected; the reconciliation tests override it to a well-formed result.
 let mockListAssistantsResult: unknown = [];
 const listAssistantsMock = mock(async () => mockListAssistantsResult);
-// Controls the `OrgFetchOutcome` the probe's evidence check reads. A thrown
-// error simulates a transport failure; a never-resolving promise as the
-// outcome makes the fetch hang so the probe's sync race times out.
+// Controls the `OrgFetchOutcome` the session-rejection evidence checks read.
+// A thrown error simulates a transport failure; a never-resolving promise as
+// the outcome makes the fetch hang so the probe's sync race times out.
 let mockOrgFetchOutcome: unknown = { ok: true };
 let mockOrgFetchError: Error | null = null;
 const fetchOrganizationsMock = mock(async () => {
@@ -1575,6 +1575,9 @@ describe("auth store onboarding flag reconciliation", () => {
         },
       ],
       "org-test",
+      // The shared reconcile helper forwards its staleness predicate; the
+      // refresh path has none.
+      undefined,
     );
   });
 
@@ -1740,11 +1743,7 @@ describe("platform session probe resolution", () => {
 describe("platform probe conclusive rejection (half-dead session)", () => {
   // The half-dead state: allauth answers 200 with a user while the platform
   // API conclusively rejects the same credential. The probe consumes the
-  // org/assistants evidence it already gathers and settles the session
-  // "absent", which un-gates org-gated daemon queries on bearer-auth
-  // connections and surfaces the login affordances. The recovery
-  // interceptor's settled-absent gate then treats any residual platform 403
-  // as a no-op instead of looping.
+  // org/assistants evidence it already gathers and settles "absent".
   //
   // Every test drives the local-client init path (no gateway auth, no
   // platform assistants), where the probe runs with `setUserOnSuccess`.
@@ -1875,6 +1874,178 @@ describe("platform probe conclusive rejection (half-dead session)", () => {
       setTimeoutSpy.mockRestore();
       clearTimeoutSpy.mockRestore();
     }
+  });
+});
+
+describe("session-rejection evidence at sibling confirmation sites", () => {
+  // The same half-dead evidence rule applies wherever an allauth 200 would
+  // otherwise confirm the session: refreshSession's resume path, initSession's
+  // platform-assistants path, and connectPlatformAssistant.
+
+  test("refreshSession settles a half-dead session absent instead of re-confirming it", async () => {
+    // A gateway client whose cached token expired while backgrounded lands in
+    // the non-gateway branch (isGatewayAuthMode() is false without a token).
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    // No snapshot may be re-persisted for the rejected session.
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshSession settles absent on an assistants-list rejection", async () => {
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockListAssistantsResult = { ok: false, status: 401, error: {} };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshSession ends a half-dead session whose assistants are platform-hosted", async () => {
+    // Same stands-alone exclusion as a settled getSession 401: a managed
+    // assistant is unreachable without a platform session, so login wins.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = false;
+    mockPlatformAssistants = [{ assistantId: "managed-1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("a resume refresh does not flip a probe-settled absent session back to present", async () => {
+    // Pin the oscillation regression: the probe settles absent on rejection,
+    // then the app-resume refresh runs against the same half-dead session.
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+    await whenPlatformSessionSettled();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(useAuthStore.getState().user?.kind).toBe("local");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("a transport-failed sync on refresh keeps the platform confirmation", async () => {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).not.toBeNull();
+  });
+
+  test("a non-rejection org failure on refresh keeps the platform confirmation", async () => {
+    mockIsLocalClient = true;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+  });
+
+  test("initSession with platform assistants routes a rejected session to login", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    localStorage.setItem(
+      "vellum:auth:userSnapshot",
+      JSON.stringify({ id: "user-1", email: "user@example.com" }),
+    );
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("initSession with platform assistants routes an assistants-list rejection to login", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockListAssistantsResult = { ok: false, status: 410, error: {} };
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(syncPlatformAssistantsToLockfileMock).not.toHaveBeenCalled();
+  });
+
+  test("initSession with platform assistants keeps the session on a transport-failed sync", async () => {
+    mockIsLocalClient = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchError = new TypeError("Failed to fetch");
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+
+  test("connectPlatformAssistant fails the connect on a rejected org fetch", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "rejected", status: 403 };
+
+    await expect(
+      useAuthStore.getState().connectPlatformAssistant("assistant-1"),
+    ).rejects.toThrow("Platform authentication required");
+
+    expect(useAuthStore.getState().platformSession).not.toBe("present");
+    expect(localStorage.getItem("vellum:auth:userSnapshot")).toBeNull();
+  });
+
+  test("connectPlatformAssistant tolerates a non-rejection org failure", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockOrgFetchOutcome = { ok: false, kind: "unavailable" };
+
+    await useAuthStore.getState().connectPlatformAssistant("assistant-1");
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().platformSession).toBe("present");
   });
 });
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -228,9 +228,9 @@ const sessionEnded = (): Partial<AuthState> => ({
  * non-auth reason (429 rate limiting, 5xx outages, the Electron proxy's
  * offline 502). Distinct from a settled "no session" answer (2xx without
  * user, or an explicit 401/403/410 rejection), which is the only thing
- * allowed to end the session. Callers check the 2xx-without-user case
- * themselves — by the time they consult this, `result.ok` means the user
- * field was missing, a settled negative.
+ * allowed to end the session. Callers handle the 2xx cases themselves;
+ * by the time they consult this, an ok result was already judged unusable
+ * (user missing, or platform-rejected evidence), a settled negative.
  */
 const isInconclusiveProbe = (
   result: Awaited<ReturnType<typeof getSession>> | null,
@@ -573,6 +573,36 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   store.setConsentHydrated(true);
 }
 
+/**
+ * Reconcile the lockfile's managed-assistant mirror and report whether the
+ * platform API conclusively rejected the session (a settled 401/403/410 from
+ * the org or assistants call). Only that settled evidence may end a platform
+ * session; transport failures and other errors prove nothing (LUM-2412) and
+ * leave cached lockfile data standing. Cloud mode loads assistants via
+ * `reloadPlatformAssistants` (platform-assistants-sync), which has no
+ * lockfile and stays outside this evidence rule.
+ */
+async function reconcilePlatformAssistants(
+  syncIsCurrent?: () => boolean,
+): Promise<{ sessionRejected: boolean }> {
+  const orgOutcome = await useOrganizationStore.getState().fetchOrganizations();
+  if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+    return { sessionRejected: true };
+  }
+  const apiAssistants = await listAssistants();
+  if (isSettledSessionRejection(apiAssistants)) {
+    return { sessionRejected: true };
+  }
+  if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
+    await syncPlatformAssistantsToLockfile(
+      apiAssistants.data,
+      useOrganizationStore.getState().currentOrganizationId ?? undefined,
+      syncIsCurrent,
+    );
+  }
+  return { sessionRejected: false };
+}
+
 // Monotonic id stamped on each platform-session probe. Probes can overlap
 // (an app-resume refresh firing while the initial probe is still in flight),
 // and a stale completion must not mutate session state — most importantly it
@@ -647,26 +677,8 @@ function probePlatformSession(
           try {
             await Promise.race([
               (async () => {
-                const orgOutcome = await useOrganizationStore
-                  .getState()
-                  .fetchOrganizations();
-                if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
-                  sessionRejected = true;
-                  return;
-                }
-                const apiAssistants = await listAssistants();
-                if (isSettledSessionRejection(apiAssistants)) {
-                  sessionRejected = true;
-                  return;
-                }
-                if (syncIsCurrent() && apiAssistants.ok) {
-                  await syncPlatformAssistantsToLockfile(
-                    apiAssistants.data,
-                    useOrganizationStore.getState().currentOrganizationId ??
-                      undefined,
-                    syncIsCurrent,
-                  );
-                }
+                ({ sessionRejected } =
+                  await reconcilePlatformAssistants(syncIsCurrent));
               })(),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {
@@ -685,17 +697,10 @@ function probePlatformSession(
           return;
         }
         if (sessionRejected) {
-          // The allauth cookie answered, but the platform API conclusively
-          // rejected the credential (a settled 401/403/410 on the org or
-          // assistants call), so this session is unusable for every consumer:
-          // settle it as absent, install no user, and skip the platform
-          // identity bootstrap. Transport failures and the race timeout
-          // deliberately never reach this branch (LUM-2412 offline restore).
-          // The persisted snapshot must go too, or `restoreOfflineSession`
-          // could resurrect the rejected account as "present" on a later
-          // offline boot; an already-authenticated local/gateway session
-          // demotes its user to the local shape, mirroring refreshSession's
-          // stands-alone demotion.
+          // The platform API conclusively rejected the allauth-confirmed
+          // credential: settle absent, install no user, and drop the snapshot
+          // so `restoreOfflineSession` cannot resurrect the account. Transport
+          // failures and the race timeout never reach here (LUM-2412).
           clearUserSnapshot();
           const demotion = isAuthenticated(
             useAuthStore.getState().sessionStatus,
@@ -868,21 +873,18 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             const user = toAuthUser(result.data.user);
             await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
+            let sessionRejected = false;
             try {
-              await useOrganizationStore.getState().fetchOrganizations();
-              const apiAssistants = await listAssistants();
-              if (apiAssistants.ok) {
-                await syncPlatformAssistantsToLockfile(
-                  apiAssistants.data,
-                  useOrganizationStore.getState().currentOrganizationId ??
-                    undefined,
-                );
-              }
+              ({ sessionRejected } = await reconcilePlatformAssistants());
             } catch {
-              // Sync failed — continue with cached data
+              // Sync failed; continue with cached data
             }
-            set(authenticatedPlatformUser(user));
-            return;
+            if (!sessionRejected) {
+              set(authenticatedPlatformUser(user));
+              return;
+            }
+            // A settled org/assistants rejection falls through to the
+            // settled-answer handling (login), never the offline restore.
           }
         } catch {
           // Thrown fetch — classified as a transport failure below.
@@ -1044,8 +1046,15 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
     const user = toAuthUser(result.data.user);
     await syncUserScopedState(user?.id ?? null);
-    // Hydrate the organizations to avoid race conditions from lazy fetch.
-    await useOrganizationStore.getState().fetchOrganizations();
+    // Hydrate the organizations to avoid race conditions from lazy fetch; a
+    // settled rejection fails the connect rather than installing a platform
+    // user the API refuses to serve.
+    const orgOutcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations();
+    if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+      throw new Error("Platform authentication required");
+    }
     set(authenticatedPlatformUser(user));
   },
 
@@ -1089,29 +1098,26 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
-        // Reconcile the lockfile mirror on refresh too — not just cold
-        // `initSession`. App resume, profile save, and the provider callback
-        // all route through here; without this the macOS tray and CLI keep a
-        // stale managed-assistant list until the next full boot. Best-effort
-        // and local-mode only (platform mode has no lockfile host); the
-        // refresh has already succeeded regardless of the sync outcome.
+        // Reconcile the lockfile mirror on refresh too, not just cold
+        // `initSession`: app resume, profile save, and the provider callback
+        // all route through here, and the macOS tray and CLI would otherwise
+        // keep a stale managed-assistant list until the next full boot.
+        // Local-mode only (platform mode has no lockfile host).
+        let sessionRejected = false;
         if (isLocalClient()) {
           try {
-            await useOrganizationStore.getState().fetchOrganizations();
-            const apiAssistants = await listAssistants();
-            if (apiAssistants.ok) {
-              await syncPlatformAssistantsToLockfile(
-                apiAssistants.data,
-                useOrganizationStore.getState().currentOrganizationId ??
-                  undefined,
-              );
-            }
+            ({ sessionRejected } = await reconcilePlatformAssistants());
           } catch {
-            // Sync failed — continue with cached lockfile data.
+            // Sync failed; continue with cached lockfile data.
           }
         }
-        set(authenticatedPlatformUser(user));
-        return true;
+        if (!sessionRejected) {
+          set(authenticatedPlatformUser(user));
+          return true;
+        }
+        // A settled org/assistants rejection is a rejected session even
+        // though allauth answered 200: fall through to the settled-rejection
+        // handling below, same as a settled getSession 401.
       }
     } catch (err) {
       console.warn("auth.refreshSession failed", err);

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -1051,22 +1051,24 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   },
 
   connectPlatformAssistant: async (assistantId: string) => {
-    await setSelectedAssistant(assistantId);
     const result = await getSession();
     if (!result.ok || !result.data.user) {
       throw new Error("Platform authentication required");
     }
     const user = toAuthUser(result.data.user);
-    await syncUserScopedState(user?.id ?? null);
     // Hydrate the organizations to avoid race conditions from lazy fetch; a
-    // settled rejection fails the connect rather than installing a platform
-    // user the API refuses to serve.
+    // settled rejection fails the connect before the assistant selection and
+    // user-scoped sync below, so a caller that catches the error keeps its
+    // current selection and consent state rather than the rejected
+    // account's.
     const orgOutcome = await useOrganizationStore
       .getState()
       .fetchOrganizations();
     if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
       throw new Error("Platform authentication required");
     }
+    await setSelectedAssistant(assistantId);
+    await syncUserScopedState(user?.id ?? null);
     set(authenticatedPlatformUser(user));
   },
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -584,11 +584,17 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
  */
 async function reconcilePlatformAssistants(
   syncIsCurrent?: () => boolean,
+  sessionIsCurrent?: () => boolean,
 ): Promise<boolean> {
   try {
+    // `sessionIsCurrent` is the looser gate: it stays true past the probe's
+    // race timeout as long as no newer probe superseded this one, letting a
+    // slow-but-successful org fetch for the still-active session commit
+    // instead of stranding readiness. Destructive writes stay on the strict
+    // `syncIsCurrent`.
     const orgOutcome = await useOrganizationStore
       .getState()
-      .fetchOrganizations(syncIsCurrent);
+      .fetchOrganizations(syncIsCurrent, sessionIsCurrent);
     if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
       return true;
     }
@@ -692,8 +698,10 @@ function probePlatformSession(
           try {
             await Promise.race([
               (async () => {
-                sessionRejected =
-                  await reconcilePlatformAssistants(syncIsCurrent);
+                sessionRejected = await reconcilePlatformAssistants(
+                  syncIsCurrent,
+                  () => !isStale(),
+                );
               })(),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -627,33 +627,38 @@ function probePlatformSession(
       }
       if (result.ok && result.data.user) {
         const probedUser = toAuthUser(result.data.user);
-        const userUpdate = options.setUserOnSuccess ? { user: probedUser } : {};
-        // Adopting the probed user confirms a platform session outside the
-        // `authenticatedPlatformUser` transition — persist here too so the
-        // local-mode path feeds the offline restore (LUM-2412).
-        if (options.setUserOnSuccess) {
-          persistUserSnapshot(probedUser);
-        }
         // Sync platform assistants to the lockfile BEFORE setting
         // platformSession to "present". The auth middleware unblocks on
         // `platformSession !== "unknown"`, and hasAssistants() must
         // already reflect synced platform assistants at that point.
         // The whole sequence (org fetch, list, host replace) is bounded
-        // to 3s so a hanging call can't block the probe from settling —
+        // to 3s so a hanging call can't block the probe from settling;
         // the middleware's 5s timeout would loop indefinitely otherwise.
         // The race does not cancel the inner branch, so the guard also
         // checks `timedOut`: once the probe settles without the sync, a
         // late commit must not land after routing decisions were made on
         // the un-synced lockfile. `!isStale()` likewise keeps a
         // superseded probe from committing an out-of-date lockfile.
+        let sessionRejected = false;
         if (isLocalClient()) {
           let timedOut = false;
           const syncIsCurrent = (): boolean => !timedOut && !isStale();
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
           try {
             await Promise.race([
               (async () => {
-                await useOrganizationStore.getState().fetchOrganizations();
+                const orgOutcome = await useOrganizationStore
+                  .getState()
+                  .fetchOrganizations();
+                if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+                  sessionRejected = true;
+                  return;
+                }
                 const apiAssistants = await listAssistants();
+                if (isSettledSessionRejection(apiAssistants)) {
+                  sessionRejected = true;
+                  return;
+                }
                 if (syncIsCurrent() && apiAssistants.ok) {
                   await syncPlatformAssistantsToLockfile(
                     apiAssistants.data,
@@ -663,19 +668,53 @@ function probePlatformSession(
                   );
                 }
               })(),
-              new Promise<never>((_, reject) =>
-                setTimeout(() => {
+              new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(() => {
                   timedOut = true;
                   reject(new Error("sync timeout"));
-                }, 3_000),
-              ),
+                }, 3_000);
+              }),
             ]);
           } catch {
-            // Sync failed or timed out — continue with cached lockfile data
+            // Sync failed or timed out; continue with cached lockfile data
+          } finally {
+            clearTimeout(timeoutHandle);
           }
         }
         if (isStale()) {
           return;
+        }
+        if (sessionRejected) {
+          // The allauth cookie answered, but the platform API conclusively
+          // rejected the credential (a settled 401/403/410 on the org or
+          // assistants call), so this session is unusable for every consumer:
+          // settle it as absent, install no user, and skip the platform
+          // identity bootstrap. Transport failures and the race timeout
+          // deliberately never reach this branch (LUM-2412 offline restore).
+          // The persisted snapshot must go too, or `restoreOfflineSession`
+          // could resurrect the rejected account as "present" on a later
+          // offline boot; an already-authenticated local/gateway session
+          // demotes its user to the local shape, mirroring refreshSession's
+          // stands-alone demotion.
+          clearUserSnapshot();
+          const demotion = isAuthenticated(
+            useAuthStore.getState().sessionStatus,
+          )
+            ? authenticatedLocalUser()
+            : {};
+          set({
+            ...demotion,
+            platformSession: "absent",
+            platformSessionRestoredOffline: false,
+          });
+          return;
+        }
+        const userUpdate = options.setUserOnSuccess ? { user: probedUser } : {};
+        // Adopting the probed user confirms a platform session outside the
+        // `authenticatedPlatformUser` transition, so persist here too to feed
+        // the local-mode offline restore (LUM-2412).
+        if (options.setUserOnSuccess) {
+          persistUserSnapshot(probedUser);
         }
         set({
           platformSession: "present",

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -596,8 +596,13 @@ async function reconcilePlatformAssistants(
     if (isSettledSessionRejection(apiAssistants)) {
       // The org fetch self-clears on its own rejection; an assistants-only
       // rejection must clear the org state too, or the request interceptor
-      // keeps stamping the rejected account's Vellum-Organization-Id.
-      useOrganizationStore.getState().clearOrganization();
+      // keeps stamping the rejected account's Vellum-Organization-Id. The
+      // currency guard matches the sync below: a timed-out or superseded
+      // probe settled "present" from cached data, and its dangling call must
+      // not strip the org header out from under that session.
+      if (syncIsCurrent?.() ?? true) {
+        useOrganizationStore.getState().clearOrganization();
+      }
       return true;
     }
     if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -584,23 +584,33 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
  */
 async function reconcilePlatformAssistants(
   syncIsCurrent?: () => boolean,
-): Promise<{ sessionRejected: boolean }> {
-  const orgOutcome = await useOrganizationStore.getState().fetchOrganizations();
-  if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
-    return { sessionRejected: true };
+): Promise<boolean> {
+  try {
+    const orgOutcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations();
+    if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
+      return true;
+    }
+    const apiAssistants = await listAssistants();
+    if (isSettledSessionRejection(apiAssistants)) {
+      // The org fetch self-clears on its own rejection; an assistants-only
+      // rejection must clear the org state too, or the request interceptor
+      // keeps stamping the rejected account's Vellum-Organization-Id.
+      useOrganizationStore.getState().clearOrganization();
+      return true;
+    }
+    if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
+      await syncPlatformAssistantsToLockfile(
+        apiAssistants.data,
+        useOrganizationStore.getState().currentOrganizationId ?? undefined,
+        syncIsCurrent,
+      );
+    }
+  } catch {
+    // A throw is non-settled evidence: continue with cached lockfile data.
   }
-  const apiAssistants = await listAssistants();
-  if (isSettledSessionRejection(apiAssistants)) {
-    return { sessionRejected: true };
-  }
-  if ((syncIsCurrent?.() ?? true) && apiAssistants.ok) {
-    await syncPlatformAssistantsToLockfile(
-      apiAssistants.data,
-      useOrganizationStore.getState().currentOrganizationId ?? undefined,
-      syncIsCurrent,
-    );
-  }
-  return { sessionRejected: false };
+  return false;
 }
 
 // Monotonic id stamped on each platform-session probe. Probes can overlap
@@ -677,8 +687,8 @@ function probePlatformSession(
           try {
             await Promise.race([
               (async () => {
-                ({ sessionRejected } =
-                  await reconcilePlatformAssistants(syncIsCurrent));
+                sessionRejected =
+                  await reconcilePlatformAssistants(syncIsCurrent);
               })(),
               new Promise<never>((_, reject) => {
                 timeoutHandle = setTimeout(() => {
@@ -873,12 +883,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             const user = toAuthUser(result.data.user);
             await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
-            let sessionRejected = false;
-            try {
-              ({ sessionRejected } = await reconcilePlatformAssistants());
-            } catch {
-              // Sync failed; continue with cached data
-            }
+            const sessionRejected = await reconcilePlatformAssistants();
             if (!sessionRejected) {
               set(authenticatedPlatformUser(user));
               return;
@@ -1103,14 +1108,9 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         // all route through here, and the macOS tray and CLI would otherwise
         // keep a stale managed-assistant list until the next full boot.
         // Local-mode only (platform mode has no lockfile host).
-        let sessionRejected = false;
-        if (isLocalClient()) {
-          try {
-            ({ sessionRejected } = await reconcilePlatformAssistants());
-          } catch {
-            // Sync failed; continue with cached lockfile data.
-          }
-        }
+        const sessionRejected = isLocalClient()
+          ? await reconcilePlatformAssistants()
+          : false;
         if (!sessionRejected) {
           set(authenticatedPlatformUser(user));
           return true;

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -588,7 +588,7 @@ async function reconcilePlatformAssistants(
   try {
     const orgOutcome = await useOrganizationStore
       .getState()
-      .fetchOrganizations();
+      .fetchOrganizations(syncIsCurrent);
     if (!orgOutcome.ok && orgOutcome.kind === "rejected") {
       return true;
     }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -886,10 +886,12 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
           result = await getSession();
           if (result.ok && result.data.user) {
             const user = toAuthUser(result.data.user);
-            await syncUserScopedState(user?.id ?? null);
             // Re-sync platform assistants to remove stale lockfile entries.
+            // The rejection evidence gates the user-scoped sync: a rejected
+            // account's consent and org state must not be (re)installed.
             const sessionRejected = await reconcilePlatformAssistants();
             if (!sessionRejected) {
+              await syncUserScopedState(user?.id ?? null);
               set(authenticatedPlatformUser(user));
               return;
             }
@@ -1107,16 +1109,18 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
-        await syncUserScopedState(user?.id ?? null);
         // Reconcile the lockfile mirror on refresh too, not just cold
         // `initSession`: app resume, profile save, and the provider callback
         // all route through here, and the macOS tray and CLI would otherwise
         // keep a stale managed-assistant list until the next full boot.
-        // Local-mode only (platform mode has no lockfile host).
+        // Local-mode only (platform mode has no lockfile host). The rejection
+        // evidence gates the user-scoped sync: a rejected account's consent
+        // and org state must not be (re)installed before the demotion below.
         const sessionRejected = isLocalClient()
           ? await reconcilePlatformAssistants()
           : false;
         if (!sessionRejected) {
+          await syncUserScopedState(user?.id ?? null);
           set(authenticatedPlatformUser(user));
           return true;
         }

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     persistedOrganizationId: null,
     status: "idle",
     error: null,
-    lastErrorStatus: null,
   });
 });
 
@@ -112,7 +111,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBe(403);
     expect(state.error).toBe("Platform session was rejected (HTTP 403).");
   });
 
@@ -141,7 +139,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "unavailable" });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBe("network down");
   });
 
@@ -170,12 +167,14 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: false, kind: "unavailable" });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("error");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBe("No organization available for this user.");
   });
 
-  test("a successful fetch resets lastErrorStatus", async () => {
-    useOrganizationStore.setState({ lastErrorStatus: 403, status: "error" });
+  test("a successful fetch resets the error state", async () => {
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Platform session was rejected (HTTP 403).",
+    });
     listOrganizations = () =>
       Promise.resolve({ data: { results: [ORG_A] } });
 
@@ -184,7 +183,6 @@ describe("fetch outcome classification", () => {
     expect(outcome).toEqual({ ok: true });
     const state = useOrganizationStore.getState();
     expect(state.status).toBe("ready");
-    expect(state.lastErrorStatus).toBeNull();
     expect(state.error).toBeNull();
   });
 });

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -129,19 +129,26 @@ describe("fetch outcome classification", () => {
     );
   });
 
-  test("a superseded successful fetch commits the fresh list", async () => {
-    listOrganizations = () =>
-      Promise.resolve({ data: { results: [ORG_A] } });
+  test("a superseded successful fetch settles status without committing the stale account's org", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_B.id);
+    useOrganizationStore.setState({
+      persistedOrganizationId: ORG_B.id,
+      status: "ready",
+    });
+    listOrganizations = () => Promise.resolve({ data: { results: [ORG_A] } });
 
     const outcome = await useOrganizationStore
       .getState()
       .fetchOrganizations(() => false);
 
+    // The stale fetch resolved an older session's org; committing it would
+    // stamp requests with the wrong Vellum-Organization-Id.
     expect(outcome).toEqual({ ok: true });
     const state = useOrganizationStore.getState();
-    expect(state.currentOrganizationId).toBe(ORG_A.id);
-    expect(state.status).toBe("ready");
-    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+    expect(state.currentOrganizationId).toBeNull();
+    expect(state.persistedOrganizationId).toBe(ORG_B.id);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_B.id);
+    expect(state.status).toBe("error");
   });
 
   test("a superseded thrown fetch still settles status", async () => {

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
     persistedOrganizationId: null,
     status: "idle",
     error: null,
+    lastErrorStatus: null,
   });
 });
 
@@ -94,5 +95,96 @@ describe("the organization requests are scoped to", () => {
 
     expect(getActiveOrganizationIdForRequests()).toBeNull();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("fetch outcome classification", () => {
+  test("a settled 403 concludes as a rejected session", async () => {
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBe(403);
+    expect(state.error).toBe("Platform session was rejected (HTTP 403).");
+  });
+
+  test("a rejection clears the persisted org id so stale headers stop", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(getActiveOrganizationIdForRequests()).toBeNull();
+  });
+
+  test("a thrown fetch concludes as unavailable with no HTTP status", async () => {
+    listOrganizations = () => Promise.reject(new Error("network down"));
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "unavailable" });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBe("network down");
+  });
+
+  test("a transport failure keeps the persisted org id for offline reloads", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () => Promise.reject(new Error("network down"));
+
+    await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBe(
+      ORG_A.id,
+    );
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+  });
+
+  test("a 200 with no organizations concludes as unavailable", async () => {
+    listOrganizations = () =>
+      Promise.resolve({
+        data: { results: [] },
+        response: new Response(null, { status: 200 }),
+      });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: false, kind: "unavailable" });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("error");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBe("No organization available for this user.");
+  });
+
+  test("a successful fetch resets lastErrorStatus", async () => {
+    useOrganizationStore.setState({ lastErrorStatus: 403, status: "error" });
+    listOrganizations = () =>
+      Promise.resolve({ data: { results: [ORG_A] } });
+
+    const outcome = await useOrganizationStore.getState().fetchOrganizations();
+
+    expect(outcome).toEqual({ ok: true });
+    const state = useOrganizationStore.getState();
+    expect(state.status).toBe("ready");
+    expect(state.lastErrorStatus).toBeNull();
+    expect(state.error).toBeNull();
   });
 });

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -151,6 +151,55 @@ describe("fetch outcome classification", () => {
     expect(state.status).toBe("error");
   });
 
+  test("a timed-out fetch from the still-active session commits a late success", async () => {
+    listOrganizations = () => Promise.resolve({ data: { results: [ORG_A] } });
+
+    // The probe's race timeout lapsed (isCurrent false) but no newer
+    // probe/session superseded the fetch (isSameSession true): the resolved
+    // org belongs to the active session, so discarding it would strand
+    // org-header readiness until the next resume.
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(
+        () => false,
+        () => true,
+      );
+
+    expect(outcome).toEqual({ ok: true });
+    const state = useOrganizationStore.getState();
+    expect(state.currentOrganizationId).toBe(ORG_A.id);
+    expect(state.status).toBe("ready");
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+  });
+
+  test("a timed-out rejection stays non-destructive even for the active session", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(
+        () => false,
+        () => true,
+      );
+
+    // Destructive writes ride only with a fully current sync: the probe
+    // already settled "present" past its timeout, so the late rejection must
+    // not strip the org header out from under that session.
+    expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBe(
+      ORG_A.id,
+    );
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+    expect(useOrganizationStore.getState().status).toBe("error");
+  });
+
   test("a superseded thrown fetch still settles status", async () => {
     useOrganizationStore.setState({ status: "ready" });
     listOrganizations = () => Promise.reject(new Error("network down"));

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -98,7 +98,7 @@ describe("the organization requests are scoped to", () => {
 });
 
 describe("fetch outcome classification", () => {
-  test("a superseded fetch reports its outcome but commits nothing", async () => {
+  test("a superseded failed fetch settles status but keeps the org fallback", async () => {
     sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
     useOrganizationStore.setState({
       persistedOrganizationId: ORG_A.id,
@@ -115,14 +115,46 @@ describe("fetch outcome classification", () => {
       .getState()
       .fetchOrganizations(() => false);
 
-    // The stale probe's rejection is reported to its caller, but the newer
-    // session's org fallback and store state stay untouched.
+    // The stale probe's rejection is reported to its caller and the store
+    // reaches a terminal status (never wedged at "loading"), but the newer
+    // session's org fallback stays untouched.
     expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
     expect(useOrganizationStore.getState().persistedOrganizationId).toBe(
       ORG_A.id,
     );
     expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
-    expect(useOrganizationStore.getState().error).toBeNull();
+    expect(useOrganizationStore.getState().status).toBe("error");
+    expect(useOrganizationStore.getState().error).toBe(
+      "Platform session was rejected (HTTP 403).",
+    );
+  });
+
+  test("a superseded successful fetch commits the fresh list", async () => {
+    listOrganizations = () =>
+      Promise.resolve({ data: { results: [ORG_A] } });
+
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(() => false);
+
+    expect(outcome).toEqual({ ok: true });
+    const state = useOrganizationStore.getState();
+    expect(state.currentOrganizationId).toBe(ORG_A.id);
+    expect(state.status).toBe("ready");
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+  });
+
+  test("a superseded thrown fetch still settles status", async () => {
+    useOrganizationStore.setState({ status: "ready" });
+    listOrganizations = () => Promise.reject(new Error("network down"));
+
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(() => false);
+
+    expect(outcome).toEqual({ ok: false, kind: "unavailable" });
+    expect(useOrganizationStore.getState().status).toBe("error");
+    expect(useOrganizationStore.getState().error).toBe("network down");
   });
 
   test("a current predicate commits normally", async () => {

--- a/clients/web/src/stores/organization-store.test.ts
+++ b/clients/web/src/stores/organization-store.test.ts
@@ -98,6 +98,52 @@ describe("the organization requests are scoped to", () => {
 });
 
 describe("fetch outcome classification", () => {
+  test("a superseded fetch reports its outcome but commits nothing", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({
+      persistedOrganizationId: ORG_A.id,
+      status: "ready",
+    });
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(() => false);
+
+    // The stale probe's rejection is reported to its caller, but the newer
+    // session's org fallback and store state stay untouched.
+    expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBe(
+      ORG_A.id,
+    );
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(ORG_A.id);
+    expect(useOrganizationStore.getState().error).toBeNull();
+  });
+
+  test("a current predicate commits normally", async () => {
+    sessionStorage.setItem(STORAGE_KEY, ORG_A.id);
+    useOrganizationStore.setState({ persistedOrganizationId: ORG_A.id });
+    listOrganizations = () =>
+      Promise.resolve({
+        data: undefined,
+        error: { detail: "Authentication credentials were not provided." },
+        response: new Response(null, { status: 403 }),
+      });
+
+    const outcome = await useOrganizationStore
+      .getState()
+      .fetchOrganizations(() => true);
+
+    expect(outcome).toEqual({ ok: false, kind: "rejected", status: 403 });
+    expect(useOrganizationStore.getState().persistedOrganizationId).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
   test("a settled 403 concludes as a rejected session", async () => {
     listOrganizations = () =>
       Promise.resolve({

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -59,7 +59,14 @@ interface OrganizationState {
 }
 
 interface OrganizationActions {
-  fetchOrganizations: () => Promise<OrgFetchOutcome>;
+  /**
+   * Load the org list and report how the fetch concluded. When `isCurrent`
+   * is provided and answers false at commit time (a raced caller superseded
+   * mid-flight), the outcome is still returned but no store or storage state
+   * is written, so a stale probe's rejection cannot strip the org fallback
+   * out from under a newer session.
+   */
+  fetchOrganizations: (isCurrent?: () => boolean) => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
   clearOrganization: () => void;
 }
@@ -129,23 +136,11 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   status: "idle",
   error: null,
 
-  fetchOrganizations: async () => {
+  fetchOrganizations: async (isCurrent?: () => boolean) => {
     set({ status: "loading", error: null });
 
     try {
       const result = await organizationsList();
-      const organizations = result.data?.results ?? [];
-      const candidateId =
-        get().currentOrganizationId ?? get().persistedOrganizationId;
-      const currentOrganizationId = resolveActiveOrganizationId(
-        organizations,
-        candidateId,
-      );
-
-      if (currentOrganizationId) {
-        setStoredOrganizationId(currentOrganizationId);
-      }
-
       // throwOnError is false, so an HTTP error surfaces as data-undefined
       // with the completed Response alongside.
       const failureStatus =
@@ -155,6 +150,29 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         isSettledSessionRejection({ ok: false, status: failureStatus })
           ? failureStatus
           : null;
+      const organizations = result.data?.results ?? [];
+      const candidateId =
+        get().currentOrganizationId ?? get().persistedOrganizationId;
+      const currentOrganizationId = resolveActiveOrganizationId(
+        organizations,
+        candidateId,
+      );
+      const outcome: OrgFetchOutcome = currentOrganizationId
+        ? { ok: true }
+        : rejectionStatus !== null
+          ? { ok: false, kind: "rejected", status: rejectionStatus }
+          : { ok: false, kind: "unavailable" };
+
+      // A superseded caller reports its outcome but commits nothing: a stale
+      // probe's rejection must not strip the org fallback out from under a
+      // newer session.
+      if (!(isCurrent?.() ?? true)) {
+        return outcome;
+      }
+
+      if (currentOrganizationId) {
+        setStoredOrganizationId(currentOrganizationId);
+      }
 
       let error: string | null = null;
       if (!currentOrganizationId) {
@@ -182,19 +200,15 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         error,
       });
 
-      if (currentOrganizationId) {
-        return { ok: true };
-      }
-      if (rejectionStatus !== null) {
-        return { ok: false, kind: "rejected", status: rejectionStatus };
-      }
-      return { ok: false, kind: "unavailable" };
+      return outcome;
     } catch (err) {
       const message =
         err instanceof Error && err.message
           ? err.message
           : "Failed to load organizations.";
-      set({ status: "error", error: message });
+      if (isCurrent?.() ?? true) {
+        set({ status: "error", error: message });
+      }
       return { ok: false, kind: "unavailable" };
     }
   },

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -23,11 +23,25 @@ import { organizationsList } from "@/generated/api/sdk.gen";
 import type { OrganizationRead } from "@/generated/api/types.gen";
 import { subscribe } from "@/lib/event-bus";
 import { useAuthStore } from "@/stores/auth-store";
-import { hasLivePlatformSession } from "@/stores/session-status";
+import {
+  hasLivePlatformSession,
+  isSettledSessionRejection,
+} from "@/stores/session-status";
 
 const ACTIVE_ORGANIZATION_STORAGE_KEY = "vellum_active_organization_id";
 
 export type OrganizationStatus = "idle" | "loading" | "ready" | "error";
+
+/**
+ * How a fetch concluded. `"rejected"` is a settled session rejection from the
+ * platform (401/403/410): the request completed and the server refused the
+ * credentials. `"unavailable"` covers everything else that lands in the error
+ * path: transport failures, 5xx, and a user with no organizations.
+ */
+export type OrgFetchOutcome =
+  | { ok: true }
+  | { ok: false; kind: "rejected"; status: number }
+  | { ok: false; kind: "unavailable" };
 
 interface OrganizationState {
   organizations: OrganizationRead[];
@@ -42,10 +56,16 @@ interface OrganizationState {
   persistedOrganizationId: string | null;
   status: OrganizationStatus;
   error: string | null;
+  /**
+   * HTTP status of the last fetch that concluded with an error response;
+   * null while loading, after a success, and for failures with no
+   * completed response (transport errors).
+   */
+  lastErrorStatus: number | null;
 }
 
 interface OrganizationActions {
-  fetchOrganizations: () => Promise<void>;
+  fetchOrganizations: () => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
   clearOrganization: () => void;
 }
@@ -114,9 +134,10 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   persistedOrganizationId: getStoredOrganizationId(),
   status: "idle",
   error: null,
+  lastErrorStatus: null,
 
   fetchOrganizations: async () => {
-    set({ status: "loading", error: null });
+    set({ status: "loading", error: null, lastErrorStatus: null });
 
     try {
       const result = await organizationsList();
@@ -132,22 +153,59 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         setStoredOrganizationId(currentOrganizationId);
       }
 
+      // throwOnError is false, so an HTTP error surfaces as data-undefined
+      // with the completed Response alongside.
+      const failureStatus =
+        result.data === undefined ? (result.response?.status ?? null) : null;
+      const rejectionStatus =
+        failureStatus !== null &&
+        isSettledSessionRejection({ ok: false, status: failureStatus })
+          ? failureStatus
+          : null;
+
+      let error: string | null = null;
+      if (!currentOrganizationId) {
+        error =
+          rejectionStatus !== null
+            ? `Platform session was rejected (HTTP ${rejectionStatus}).`
+            : "No organization available for this user.";
+      }
+
+      // A settled rejection means the platform no longer honors the session
+      // this org id came from, so the persisted fallback must not keep
+      // stamping requests with a stale Vellum-Organization-Id. Transport and
+      // other failures keep the fallback (offline reloads still need it).
+      if (rejectionStatus !== null) {
+        clearStoredOrganizationId();
+      }
+      const persistedOrganizationId =
+        rejectionStatus !== null
+          ? null
+          : (currentOrganizationId ?? get().persistedOrganizationId);
+
       set({
         organizations,
         currentOrganizationId,
-        persistedOrganizationId:
-          currentOrganizationId ?? get().persistedOrganizationId,
+        persistedOrganizationId,
         status: currentOrganizationId ? "ready" : "error",
-        error: currentOrganizationId
-          ? null
-          : "No organization available for this user.",
+        error,
+        lastErrorStatus: failureStatus,
       });
+
+      if (currentOrganizationId) {
+        return { ok: true };
+      }
+      if (rejectionStatus !== null) {
+        return { ok: false, kind: "rejected", status: rejectionStatus };
+      }
+      return { ok: false, kind: "unavailable" };
     } catch (err) {
       const message =
         err instanceof Error && err.message
           ? err.message
           : "Failed to load organizations.";
       set({ status: "error", error: message });
+      return { ok: false, kind: "unavailable" };
     }
   },
 
@@ -173,6 +231,7 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
       persistedOrganizationId: null,
       status: "idle",
       error: null,
+      lastErrorStatus: null,
     });
   },
 }));

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -62,9 +62,10 @@ interface OrganizationActions {
   /**
    * Load the org list and report how the fetch concluded. When `isCurrent`
    * is provided and answers false at commit time (a raced caller superseded
-   * mid-flight), the outcome is still returned but no store or storage state
-   * is written, so a stale probe's rejection cannot strip the org fallback
-   * out from under a newer session.
+   * mid-flight), a failed fetch settles status/error only: no org list, id,
+   * or storage writes, so a stale probe's rejection cannot strip the org
+   * fallback out from under a newer session, while readiness still reaches a
+   * terminal state. Successful data commits normally (fresh either way).
    */
   fetchOrganizations: (isCurrent?: () => boolean) => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
@@ -163,23 +164,27 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
           ? { ok: false, kind: "rejected", status: rejectionStatus }
           : { ok: false, kind: "unavailable" };
 
-      // A superseded caller reports its outcome but commits nothing: a stale
-      // probe's rejection must not strip the org fallback out from under a
-      // newer session.
-      if (!(isCurrent?.() ?? true)) {
-        return outcome;
-      }
-
-      if (currentOrganizationId) {
-        setStoredOrganizationId(currentOrganizationId);
-      }
-
       let error: string | null = null;
       if (!currentOrganizationId) {
         error =
           rejectionStatus !== null
             ? `Platform session was rejected (HTTP ${rejectionStatus}).`
             : "No organization available for this user.";
+      }
+
+      // A superseded caller must not strip the org fallback or the loaded
+      // list out from under a newer session, but leaving the store at
+      // "loading" would wedge org-header readiness at "resolving" when no
+      // newer fetch is coming (the probe's race timeout). Successful data is
+      // fresh regardless of the race, so it commits normally; failures
+      // settle status/error only.
+      if (!(isCurrent?.() ?? true) && !currentOrganizationId) {
+        set({ status: "error", error });
+        return outcome;
+      }
+
+      if (currentOrganizationId) {
+        setStoredOrganizationId(currentOrganizationId);
       }
 
       // A rejected session must stop stamping requests with its stale org
@@ -206,9 +211,9 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         err instanceof Error && err.message
           ? err.message
           : "Failed to load organizations.";
-      if (isCurrent?.() ?? true) {
-        set({ status: "error", error: message });
-      }
+      // Status-only settle even for superseded callers, or readiness wedges
+      // at "resolving" when no newer fetch is coming.
+      set({ status: "error", error: message });
       return { ok: false, kind: "unavailable" };
     }
   },

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -62,12 +62,19 @@ interface OrganizationActions {
   /**
    * Load the org list and report how the fetch concluded. When `isCurrent`
    * is provided and answers false at commit time (a raced caller superseded
-   * mid-flight), the fetch settles status/error only: no org list, id, or
-   * storage writes, so a stale rejection cannot strip the org fallback out
-   * from under a newer session and a stale success cannot install an older
-   * account's org id, while readiness still reaches a terminal state.
+   * mid-flight), a failed fetch settles status/error only: no org list, id,
+   * or storage writes, so a stale rejection cannot strip the org fallback
+   * out from under a newer session, while readiness still reaches a
+   * terminal state. A successful fetch consults `isSameSession` (defaulting
+   * to `isCurrent`): when the probed session is still the active one — the
+   * fetch merely outlived the probe's race timeout — the resolved org
+   * commits fully; a fetch superseded by a newer session/probe discards its
+   * success so an older account's org id cannot install itself.
    */
-  fetchOrganizations: (isCurrent?: () => boolean) => Promise<OrgFetchOutcome>;
+  fetchOrganizations: (
+    isCurrent?: () => boolean,
+    isSameSession?: () => boolean,
+  ) => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
   clearOrganization: () => void;
 }
@@ -137,7 +144,10 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   status: "idle",
   error: null,
 
-  fetchOrganizations: async (isCurrent?: () => boolean) => {
+  fetchOrganizations: async (
+    isCurrent?: () => boolean,
+    isSameSession?: () => boolean,
+  ) => {
     set({ status: "loading", error: null });
 
     try {
@@ -172,14 +182,21 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
             : "No organization available for this user.";
       }
 
-      // A superseded caller commits no data either way: a stale rejection
-      // must not strip the org fallback out from under a newer session, and
-      // a stale success must not overwrite the newer session's org id with
-      // an older account's (requests would carry the wrong
-      // Vellum-Organization-Id). But leaving the store at "loading" would
-      // wedge org-header readiness at "resolving" when no newer fetch is
-      // coming (the probe's race timeout), so it settles status/error only.
-      if (!(isCurrent?.() ?? true)) {
+      // A non-current caller commits no failure state beyond status/error: a
+      // stale rejection must not strip the org fallback out from under a
+      // newer session, but leaving the store at "loading" would wedge
+      // org-header readiness at "resolving" when no newer fetch is coming
+      // (the probe's race timeout). A SUCCESS is judged by `isSameSession`:
+      // when the fetch merely outlived the probe's race timeout but the
+      // probed session is still the active one, the resolved org belongs to
+      // that session and discarding it would strand readiness until the next
+      // resume — it commits fully. Only a fetch superseded by a newer
+      // session/probe discards its success, since an older account's org id
+      // must not overwrite the newer header source.
+      const current = isCurrent?.() ?? true;
+      const successCommits =
+        current || ((isSameSession ?? isCurrent)?.() ?? true);
+      if (currentOrganizationId ? !successCommits : !current) {
         set({
           status: "error",
           error: error ?? "Organization fetch superseded.",

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -62,10 +62,10 @@ interface OrganizationActions {
   /**
    * Load the org list and report how the fetch concluded. When `isCurrent`
    * is provided and answers false at commit time (a raced caller superseded
-   * mid-flight), a failed fetch settles status/error only: no org list, id,
-   * or storage writes, so a stale probe's rejection cannot strip the org
-   * fallback out from under a newer session, while readiness still reaches a
-   * terminal state. Successful data commits normally (fresh either way).
+   * mid-flight), the fetch settles status/error only: no org list, id, or
+   * storage writes, so a stale rejection cannot strip the org fallback out
+   * from under a newer session and a stale success cannot install an older
+   * account's org id, while readiness still reaches a terminal state.
    */
   fetchOrganizations: (isCurrent?: () => boolean) => Promise<OrgFetchOutcome>;
   setCurrentOrganizationId: (organizationId: string) => void;
@@ -172,14 +172,18 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
             : "No organization available for this user.";
       }
 
-      // A superseded caller must not strip the org fallback or the loaded
-      // list out from under a newer session, but leaving the store at
-      // "loading" would wedge org-header readiness at "resolving" when no
-      // newer fetch is coming (the probe's race timeout). Successful data is
-      // fresh regardless of the race, so it commits normally; failures
-      // settle status/error only.
-      if (!(isCurrent?.() ?? true) && !currentOrganizationId) {
-        set({ status: "error", error });
+      // A superseded caller commits no data either way: a stale rejection
+      // must not strip the org fallback out from under a newer session, and
+      // a stale success must not overwrite the newer session's org id with
+      // an older account's (requests would carry the wrong
+      // Vellum-Organization-Id). But leaving the store at "loading" would
+      // wedge org-header readiness at "resolving" when no newer fetch is
+      // coming (the probe's race timeout), so it settles status/error only.
+      if (!(isCurrent?.() ?? true)) {
+        set({
+          status: "error",
+          error: error ?? "Organization fetch superseded.",
+        });
         return outcome;
       }
 

--- a/clients/web/src/stores/organization-store.ts
+++ b/clients/web/src/stores/organization-store.ts
@@ -56,12 +56,6 @@ interface OrganizationState {
   persistedOrganizationId: string | null;
   status: OrganizationStatus;
   error: string | null;
-  /**
-   * HTTP status of the last fetch that concluded with an error response;
-   * null while loading, after a success, and for failures with no
-   * completed response (transport errors).
-   */
-  lastErrorStatus: number | null;
 }
 
 interface OrganizationActions {
@@ -134,10 +128,9 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
   persistedOrganizationId: getStoredOrganizationId(),
   status: "idle",
   error: null,
-  lastErrorStatus: null,
 
   fetchOrganizations: async () => {
-    set({ status: "loading", error: null, lastErrorStatus: null });
+    set({ status: "loading", error: null });
 
     try {
       const result = await organizationsList();
@@ -171,10 +164,8 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
             : "No organization available for this user.";
       }
 
-      // A settled rejection means the platform no longer honors the session
-      // this org id came from, so the persisted fallback must not keep
-      // stamping requests with a stale Vellum-Organization-Id. Transport and
-      // other failures keep the fallback (offline reloads still need it).
+      // A rejected session must stop stamping requests with its stale org
+      // id; transport failures keep the fallback for offline reloads.
       if (rejectionStatus !== null) {
         clearStoredOrganizationId();
       }
@@ -189,7 +180,6 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
         persistedOrganizationId,
         status: currentOrganizationId ? "ready" : "error",
         error,
-        lastErrorStatus: failureStatus,
       });
 
       if (currentOrganizationId) {
@@ -231,7 +221,6 @@ const useOrganizationStoreBase = create<OrganizationStore>()((set, get) => ({
       persistedOrganizationId: null,
       status: "idle",
       error: null,
-      lastErrorStatus: null,
     });
   },
 }));


### PR DESCRIPTION
## Summary
A stale platform cookie (allauth session 200+user, platform API 403) used to pin `platformSession: "present"` forever: org-readiness never resolved, every org-gated daemon query sat in permanent skeletons on bearer-auth (local/paired gateway) connections, and the platform 403-recovery interceptor looped unbounded (400+ requests in minutes). Now the session probe — and its sibling confirmation sites (`refreshSession`, `initSession`, `connectPlatformAssistant`) — consume the org/assistants rejection evidence they already gather: a settled 401/403/410 settles the session `"absent"` (clearing the user snapshot, org state, and persisted org id so nothing resurrects or keeps stamping the rejected account), which un-gates daemon queries and surfaces the login affordances through the existing paths. The recovery interceptor is bounded in depth: latch held until the probe settles, claims only for live-believed sessions, a 10-minute cooldown + 3-attempt budget (healed-route-only restore, live-confirmed refund), all failing closed without sessionStorage.

Design notes: 403 stays a session-rejection signal (the platform's DRF `SessionAuthentication` returns 403, not 401, for unauthenticated cookie requests, and the org endpoint has no other 403 path); transport failures and the probe's 3s race timeout keep the LUM-2412 offline-restore behavior byte-for-byte; `"absent"` is deliberately reused rather than adding a session-state union member.

## Self-review result
GAPS FOUND then fixed: 3 review rounds, 4 fix PRs. Round 1 (integration) caught the big one — the evidence rule applied only to the probe while `refreshSession`'s resume path could flip the settled session back to "present" and re-persist the snapshot — plus interceptor polish (live-only claims, hot-path flag, dead state). Rounds 2-3 converged to one-liners: assistants-only rejections clear org state (currency-guarded against the probe's race timeout), and the refund drops its remembered pathname so reloads can't bypass the retained cooldown.

## PRs merged into feature branch
- #40126: surface conclusive HTTP rejection from the org store
- #40127: bound the platform 403-recovery loop
- #40131: settle a conclusively rejected platform session as absent

### Fix PRs
- #40134: apply the session-rejection evidence rule at sibling confirmation sites
- #40133: recovery claims require a live-believed session; hot-path and comment polish
- #40136: round-3 review residue (org clear on assistants-only rejection; refund path key; helper cleanup)
- #40138: currency-guard the org clear in the assistants-rejection branch

## Declined review threads (recorded rationale on each)
- Dropping `OrgFetchOutcome`'s `status` payload: diagnostic, one field, churns ~10 test literals for zero behavior.
- Extracting a shared sessionStorage-budget factory and a settle-absent helper: touch pre-existing GW-401/redirect/demotion code; follow-ups.
- Cloud-SPA clients keep allauth-only confirmation by design (no lockfile to reconcile); the recovery bound still applies there.

Part of plan: half-dead-platform-session.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)