### PR TITLE
refactor: contract cleanup for paired-assistant surfaces (dead fields, type/schema drift, export trim)

### DIFF
--- a/clients/macos/src/main/command-palette-window.test.ts
+++ b/clients/macos/src/main/command-palette-window.test.ts
@@ -271,6 +271,7 @@ mock.module("./cli-path-flow", () => ({
 
 const {
   __resetForTesting,
+  commandPaletteDispatchCommandSchema,
   installCommandPaletteWindow,
   openCommandPaletteWindow,
   selectCommandPaletteCommand,
@@ -422,6 +423,35 @@ describe("selectCommandPaletteCommand", () => {
 
     expect(ensureVisibleMock).toHaveBeenCalledTimes(1);
     expect(dispatchToMainMock).toHaveBeenCalledWith({ kind: "shareFeedback" });
+  });
+});
+
+describe("commandPaletteDispatchCommandSchema", () => {
+  test("accepts palette-dispatchable commands, with and without payloads", () => {
+    expect(
+      commandPaletteDispatchCommandSchema.safeParse({ kind: "home" }).success,
+    ).toBe(true);
+    expect(
+      commandPaletteDispatchCommandSchema.safeParse({
+        kind: "selectAssistant",
+        assistantId: "ast-1",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects the kinds the palette never offers", () => {
+    // Pins the exclusion list in the dispatch type to the runtime schema:
+    // both reject the same kinds.
+    expect(
+      commandPaletteDispatchCommandSchema.safeParse({ kind: "commandPalette" })
+        .success,
+    ).toBe(false);
+    expect(
+      commandPaletteDispatchCommandSchema.safeParse({
+        kind: "removePairedAssistant",
+        assistantId: "paired-1",
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/clients/macos/src/main/command-palette-window.ts
+++ b/clients/macos/src/main/command-palette-window.ts
@@ -21,10 +21,16 @@ type PayloadCommandKind = Extract<
   { kind: "selectAssistant" | "retireAssistant" | "quickInputSubmit" }
 >["kind"];
 
+// Kinds the palette never dispatches. This list and the zod schema below
+// grow together: a new VellumCommand kind either gets a schema member or
+// joins this exclusion, otherwise palette code can type-check a dispatch
+// that main rejects at runtime.
+type ExcludedCommandKind = "commandPalette" | "removePairedAssistant";
+
 type CommandPaletteDispatchCommand =
   | Exclude<
       VellumCommand,
-      { kind: "commandPalette" } | { kind: PayloadCommandKind }
+      { kind: ExcludedCommandKind } | { kind: PayloadCommandKind }
     >
   | Extract<VellumCommand, { kind: PayloadCommandKind }>;
 
@@ -56,7 +62,8 @@ const payloadlessCommandKindSchema = z.enum([
   "openComponentGallery",
 ]);
 
-const commandPaletteDispatchCommandSchema: z.ZodType<CommandPaletteDispatchCommand> =
+// Exported for unit tests pinning the schema against the exclusion list.
+export const commandPaletteDispatchCommandSchema: z.ZodType<CommandPaletteDispatchCommand> =
   z.union([
     z.object({ kind: payloadlessCommandKindSchema }),
     z.object({ kind: z.literal("openConversation"), conversationId: z.string() }),

--- a/clients/macos/src/main/deep-links.test.ts
+++ b/clients/macos/src/main/deep-links.test.ts
@@ -303,7 +303,7 @@ describe("parseVellumUrl", () => {
     ).toEqual({ kind: "unknown", url: "vellum-assistant://auth/callback" });
   });
 
-  test("vellum-assistant://connect?url=…&code=… → connect with the validated base and code", () => {
+  test("vellum-assistant://connect?url=…&code=… → connect with the validated base; the code is never carried", () => {
     expect(
       parseVellumUrl(
         "vellum-assistant://connect?url=https%3A%2F%2Fassistant.example.com%2Fassistant-1&code=ABCD-1234",
@@ -311,7 +311,6 @@ describe("parseVellumUrl", () => {
     ).toEqual({
       kind: "connect",
       url: "https://assistant.example.com/assistant-1",
-      code: "ABCD-1234",
     });
   });
 
@@ -331,15 +330,15 @@ describe("parseVellumUrl", () => {
   test("connect drops a non-https url param but keeps the rest of the link", () => {
     expect(
       parseVellumUrl(
-        "vellum://connect?url=http%3A%2F%2Fevil.example&code=ABCD-1234",
+        "vellum://connect?url=http%3A%2F%2Fevil.example&bundle=eyJnYXRld2F5",
       ),
-    ).toEqual({ kind: "connect", code: "ABCD-1234" });
+    ).toEqual({ kind: "connect", bundle: "eyJnYXRld2F5" });
   });
 
   test("connect drops an unparseable url param", () => {
     expect(
-      parseVellumUrl("vellum://connect?url=not%20a%20url&code=ABCD-1234"),
-    ).toEqual({ kind: "connect", code: "ABCD-1234" });
+      parseVellumUrl("vellum://connect?url=not%20a%20url&bundle=eyJnYXRld2F5"),
+    ).toEqual({ kind: "connect", bundle: "eyJnYXRld2F5" });
   });
 
   test("connect drops a bundle that is not base64/base64url", () => {
@@ -359,9 +358,10 @@ describe("parseVellumUrl", () => {
   });
 
   test("connect secrets never surface in console output from the module", () => {
-    // The parser carries `code` and `bundle` on the typed link only. This
-    // guards the auth/callback precedent: nothing the module does with a
-    // connect URL may write the secret material to a log stream.
+    // The parser carries `bundle` on the typed link only and drops the
+    // device code entirely. This guards the auth/callback precedent:
+    // nothing the module does with a connect URL may write the raw URL's
+    // secret material to a log stream.
     const consoleSpies = (["log", "warn", "error", "info", "debug"] as const)
       .map((method) => spyOn(console, method));
     try {

--- a/clients/macos/src/main/deep-links.ts
+++ b/clients/macos/src/main/deep-links.ts
@@ -103,16 +103,19 @@ const ACCEPTED_SCHEMES = resolveAcceptedSchemes(currentEnv);
  *   - `vellum://thread/<id>` → `{ kind: "openThread", threadId }`.
  *     Trailing slashes / extra path segments are tolerated;
  *     `threadId` is the first non-empty path segment.
- *   - `vellum://connect?url=…&code=…` / `vellum://connect?bundle=…` →
+ *   - `vellum://connect?url=…` / `vellum://connect?bundle=…` →
  *     `{ kind: "connect", … }`. The pair page's "Open in the Vellum
  *     app" button and `vellum pair --qr --app` QR codes. `url` must
  *     parse as https (dropped otherwise); `bundle` must look like
- *     base64/base64url. Malformed variants still parse as `connect`
+ *     base64/base64url. A `code` query param (device code) is
+ *     accepted but never carried: the renderer cannot complete a
+ *     device-code exchange, so the secret stays out of the IPC
+ *     boundary entirely. Malformed variants still parse as `connect`
  *     with the fields absent rather than falling to `unknown`: the
  *     user clicked a connect link, so the renderer routes them to
- *     the connect flow with guidance. `code` and `bundle` are secret
- *     material: never logged, and never echoed on an `unknown` URL
- *     (which the renderer breadcrumbs to Sentry).
+ *     the connect flow with guidance. `bundle` is secret material:
+ *     never logged, and never echoed on an `unknown` URL (which the
+ *     renderer breadcrumbs to Sentry).
  *   - `vellum://billing/checkout-complete?status=…&session_id=…` →
  *     `{ kind: "billingCheckoutComplete", status, sessionId }`. The
  *     platform bounces a native-initiated Stripe Checkout here once
@@ -164,9 +167,10 @@ export const parseVellumUrl = (input: string): DeepLink => {
     return { kind: "unknown", url: withoutQuery };
   }
   if (url.host === "connect") {
-    // `code` and `bundle` are secret material (device code / pairing
-    // bundle): carried on the typed link only, never logged, and never
-    // routed through `unknown` (whose URL the renderer breadcrumbs).
+    // `bundle` is secret material (pairing bundle): carried on the typed
+    // link only, never logged, and never routed through `unknown` (whose
+    // URL the renderer breadcrumbs). A `code` query param is accepted but
+    // dropped here: it has no renderer consumer.
     const link: Extract<DeepLink, { kind: "connect" }> = { kind: "connect" };
     const base = url.searchParams.get("url");
     if (base) {
@@ -177,10 +181,6 @@ export const parseVellumUrl = (input: string): DeepLink => {
       } catch {
         // Unparseable server base: leave the field absent.
       }
-    }
-    const code = url.searchParams.get("code");
-    if (code) {
-      link.code = code;
     }
     const bundle = url.searchParams.get("bundle");
     if (bundle && BUNDLE_RE.test(bundle)) {

--- a/clients/macos/src/main/gateway-forward.ts
+++ b/clients/macos/src/main/gateway-forward.ts
@@ -163,10 +163,6 @@ export type GatewayForwardFetcher = (
   init: RequestInit & { duplex?: "half" },
 ) => Promise<Response>;
 
-export interface GatewayForwardBodySource {
-  body: ReadableStream | null;
-}
-
 /**
  * Turn a gateway forward plan into its effect: `null` on `pass` so the caller
  * serves the request as a static asset, otherwise the plan's rejection or a
@@ -182,7 +178,7 @@ export interface GatewayForwardBodySource {
  */
 export function executeGatewayForwardPlan(
   plan: GatewayForwardPlan,
-  request: GatewayForwardBodySource,
+  request: Pick<Request, "body">,
   fetcher: GatewayForwardFetcher,
   retryOptions: ForwardFetchRetryOptions = {},
 ): Promise<Response> | Response | null {

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -36,6 +36,7 @@ import type {
   Lockfile,
   LockfileAssistant,
   LocalAssistantResources,
+  LocalConnectImportResult,
   LocalRetireResult,
 } from "@/runtime/local-mode-host";
 
@@ -434,16 +435,16 @@ export async function removePairedAssistantFromLockfile(
 export async function importPairedAssistantBundle(
   bundle: string,
   name?: string,
-): Promise<
-  | { ok: true; assistantId: string; accessOnly: boolean }
-  | { ok: false; error: string }
-> {
+): Promise<LocalConnectImportResult> {
+  const fallbackError = "Failed to import the pairing bundle.";
   const result = await connectImportHost(bundle, name);
-  if (!result.ok || result.assistantId == null) {
-    return {
-      ok: false,
-      error: result.error || "Failed to import the pairing bundle.",
-    };
+  if (!result.ok) {
+    return { ok: false, error: result.error || fallbackError };
+  }
+  // Runtime guard: the dev-server host branch parses untyped JSON, so a
+  // malformed success degrades to a structured failure.
+  if (!result.assistantId) {
+    return { ok: false, error: fallbackError };
   }
   await loadLockfile();
   return {

--- a/clients/web/src/runtime/deep-links.ts
+++ b/clients/web/src/runtime/deep-links.ts
@@ -24,9 +24,9 @@ export type DeepLink =
   | { kind: "openThread"; threadId: string }
   | { kind: "billingCheckoutComplete"; status: "success"; sessionId: string }
   | { kind: "billingCheckoutComplete"; status: "cancel"; sessionId: null }
-  /** `<scheme>://connect` pairing hand-off. `code` and `bundle` are secret
-   *  material: never log or breadcrumb them. */
-  | { kind: "connect"; url?: string; code?: string; bundle?: string }
+  /** `<scheme>://connect` pairing hand-off. `bundle` is secret material:
+   *  never log or breadcrumb it. */
+  | { kind: "connect"; url?: string; bundle?: string }
   | { kind: "unknown"; url: string };
 
 export async function drainPendingDeepLinks(): Promise<DeepLink[]> {

--- a/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
+++ b/clients/web/src/runtime/event-sources/electron-deep-links.test.ts
@@ -5,7 +5,7 @@ type DeepLink =
   | { kind: "openThread"; threadId: string }
   | { kind: "billingCheckoutComplete"; status: "success"; sessionId: string }
   | { kind: "billingCheckoutComplete"; status: "cancel"; sessionId: null }
-  | { kind: "connect"; url?: string; code?: string; bundle?: string }
+  | { kind: "connect"; url?: string; bundle?: string }
   | { kind: "unknown"; url: string };
 
 let activeCallback: ((link: DeepLink) => void) | null = null;
@@ -87,7 +87,6 @@ describe("publishElectronDeepLinksSource", () => {
     activeCallback!({
       kind: "connect",
       url: "https://assistant.example.com",
-      code: "ABCD-1234",
     });
     activeCallback!({ kind: "unknown", url: "javascript:alert(1)" });
 
@@ -103,8 +102,6 @@ describe("publishElectronDeepLinksSource", () => {
         { status: "cancel", sessionId: null },
       ],
       ["deeplink.connect", { url: null, bundle: "eyJnYXRld2F5" }],
-      // The device code stays behind: it has no renderer consumer and is
-      // secret material.
       ["deeplink.connect", { url: "https://assistant.example.com", bundle: null }],
       ["deeplink.unknown", { url: "javascript:alert(1)" }],
     ]);

--- a/clients/web/src/runtime/event-sources/electron-deep-links.ts
+++ b/clients/web/src/runtime/event-sources/electron-deep-links.ts
@@ -51,9 +51,6 @@ export function publishElectronDeepLinksSource(): () => void {
         );
         break;
       case "connect":
-        // `code` stays behind: the renderer cannot complete a device-code
-        // exchange as a durable pairing, and the code is secret material
-        // with no consumer.
         publish("deeplink.connect", {
           url: link.url ?? null,
           bundle: link.bundle ?? null,

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -63,12 +63,9 @@ export interface LocalUpgradeOptions {
  * local id the pairing was registered under, and `accessOnly` is true when the
  * bundle carried no refresh credential (the token expires without renewal).
  */
-export interface LocalConnectImportResult {
-  ok: boolean;
-  assistantId?: string;
-  accessOnly?: boolean;
-  error?: string;
-}
+export type LocalConnectImportResult =
+  | { ok: true; assistantId: string; accessOnly: boolean }
+  | { ok: false; error: string };
 
 export interface VellumBridge {
   platform: "electron";

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -67,7 +67,6 @@ export const LOCAL_MODE_SAVE_ASSISTANT = "vellum:localMode:saveLockfileAssistant
 export const LOCAL_MODE_REPLACE_PLATFORM = "vellum:localMode:replacePlatformAssistants";
 export const LOCAL_MODE_RETIRE = "vellum:localMode:retire";
 export const LOCAL_MODE_UNPAIR = "vellum:localMode:unpair";
-export const LOCAL_MODE_CONNECT_IMPORT = "vellum:localMode:connectImport";
 export const LOCAL_MODE_SLEEP = "vellum:localMode:sleep";
 export const LOCAL_MODE_WAKE = "vellum:localMode:wake";
 export const LOCAL_MODE_UPGRADE = "vellum:localMode:upgrade";

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -203,11 +203,12 @@ export type DeepLink =
   /**
    * `<scheme>://connect`: the pair-page "Open in the Vellum app" hand-off
    * and `vellum pair --qr --app` QR codes. `url` is a validated https server
-   * base; `code` (device code) and `bundle` (pairing bundle) are secret
-   * material and must never be logged or breadcrumbed. Fields absent when
-   * their query params were missing or malformed.
+   * base; `bundle` (pairing bundle) is secret material and must never be
+   * logged or breadcrumbed. Fields absent when their query params were
+   * missing or malformed. The link never carries the `code` query param
+   * (device code): the renderer has no consumer for it.
    */
-  | { kind: "connect"; url?: string; code?: string; bundle?: string }
+  | { kind: "connect"; url?: string; bundle?: string }
   | { kind: "unknown"; url: string };
 
 // ---------------------------------------------------------------------------

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -46,20 +46,7 @@ export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireOptions, RetireResult } from "./retire";
 export { unpairAssistant } from "./unpair";
-export {
-  decodePairBundle,
-  pairAssistant,
-  connectImport,
-  MAX_PAIR_BUNDLE_LENGTH,
-} from "./pair";
-export type {
-  PairBundle,
-  DecodePairBundleResult,
-  PairOptions,
-  PairResult,
-  ConnectImportOptions,
-  ConnectImportResult,
-} from "./pair";
+export { decodePairBundle, pairAssistant, connectImport } from "./pair";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -6,7 +6,6 @@ import { nanoid } from "nanoid";
 import { guardianTokenPath } from "./config";
 import { saveGuardianToken } from "./guardian-token";
 import { readRawLockfile, upsertLockfileAssistant } from "./lockfile";
-import type { Lockfile } from "./lockfile-contract";
 
 /**
  * A decoded `vellum pair` bundle: base64(JSON.stringify({ gatewayUrl, token,
@@ -120,7 +119,6 @@ export interface PairOptions {
 export type PairResult =
   | {
       ok: true;
-      lockfile: Lockfile;
       /** The unique local id the pairing was registered under. */
       assistantId: string;
       /** True when an existing paired entry was updated in place. */
@@ -230,7 +228,7 @@ export function pairAssistant(
     };
   }
 
-  const result = upsertLockfileAssistant(
+  const writeResult = upsertLockfileAssistant(
     lockfilePaths,
     {
       assistantId: localId,
@@ -249,7 +247,7 @@ export function pairAssistant(
     },
     undefined,
   );
-  if (!result.ok) {
+  if (!writeResult.ok) {
     // The entry was not registered, so undo the token write (best-effort;
     // the write failure itself is what gets reported): restore the prior
     // token of a re-import, or delete the freshly written one.
@@ -263,12 +261,11 @@ export function pairAssistant(
     } catch {
       // Rollback failed; the reported write error already covers the outcome.
     }
-    return result;
+    return writeResult;
   }
 
   return {
     ok: true,
-    lockfile: result.lockfile,
     assistantId: localId,
     updated: existing !== undefined,
     accessOnly: !bundle.refreshToken,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for macos-paired-assistants.md.
- The connect deep link no longer carries the unused device code across the IPC boundary
- Command-palette dispatch type matches its zod schema again (removePairedAssistant excluded)
- Unused local-mode/ipc-contract exports trimmed; connect-import result is one discriminated union end to end