### PR TITLE
refactor(local-mode): share the paired-entry classifier across guardian-token hosts

### DIFF
--- a/cli/src/__tests__/client-token.test.ts
+++ b/cli/src/__tests__/client-token.test.ts
@@ -10,7 +10,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,7 +27,7 @@ const testDir = mkdtempSync(join(tmpdir(), "client-token-test-"));
 const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
 const ORIGINAL_ARGV = [...process.argv];
 
-import { isPairedLockfileEntry, parseArgs } from "../commands/client.js";
+import { parseArgs } from "../commands/client.js";
 
 // A clearly non-local URL so maybeSwapToLocalhost won't rewrite it to 127.0.0.1.
 const REMOTE_URL = "http://192.0.2.50:7830";
@@ -110,36 +110,5 @@ describe("client --token (ephemeral)", () => {
       "--no-open",
     ];
     expect(parseArgs().openBrowser).toBe(false);
-  });
-});
-
-// The guardian-token route passes {paired} to getGuardianAccessToken so
-// expired pairings get re-pair guidance instead of hatch/wake; this pins the
-// classification the route derives from the lockfile.
-describe("isPairedLockfileEntry", () => {
-  test("only a lockfile entry with cloud=paired classifies as paired", () => {
-    const dir = mkdtempSync(join(tmpdir(), "client-paired-test-"));
-    try {
-      const lockfilePath = join(dir, ".vellum.lock.json");
-      writeFileSync(
-        lockfilePath,
-        JSON.stringify({
-          assistants: [
-            { assistantId: "paired-1", cloud: "paired" },
-            { assistantId: "local-1", cloud: "local" },
-          ],
-          activeAssistant: "local-1",
-        }),
-      );
-
-      expect(isPairedLockfileEntry([lockfilePath], "paired-1")).toBe(true);
-      expect(isPairedLockfileEntry([lockfilePath], "local-1")).toBe(false);
-      expect(isPairedLockfileEntry([lockfilePath], "missing")).toBe(false);
-      expect(
-        isPairedLockfileEntry([join(dir, "absent.json")], "paired-1"),
-      ).toBe(false);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
   });
 });

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -32,6 +32,7 @@ import {
   upsertLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
+  isPairedLockfileEntry,
   runHatch,
   runRetire,
   connectImport,
@@ -493,24 +494,6 @@ const _localEnv = getEnvRecord();
 const _lockfilePaths = resolveLockfilePaths(_localEnv);
 const _configDir = resolveConfigDir(_localEnv);
 const _baseDir = getBaseDir();
-
-/**
- * Whether the lockfile records this assistant as a paired entry. Paired
- * entries have no local daemon, so guardian-token failure guidance must say
- * re-pair rather than hatch/wake.
- */
-export function isPairedLockfileEntry(
-  lockfilePaths: string[],
-  assistantId: string,
-): boolean {
-  const lockfile = getLockfileData(lockfilePaths);
-  return (
-    lockfile.ok &&
-    lockfile.data.assistants.some(
-      (a) => a.assistantId === assistantId && a.cloud === "paired",
-    )
-  );
-}
 
 async function handleLocalEndpoints(
   req: Request,

--- a/clients/macos/src/main/bundle-flow.test.ts
+++ b/clients/macos/src/main/bundle-flow.test.ts
@@ -50,6 +50,7 @@ mock.module("@vellumai/local-mode", () => ({
   resolveConfigDir: resolveConfigDirMock,
   resolveEnvironmentName: mock((_env: NodeJS.ProcessEnv) => "production"),
   isActiveAssistant: mock(() => true),
+  isPairedLockfileEntry: mock(() => false),
   getGuardianAccessToken: getGuardianAccessTokenMock,
   replacePlatformAssistants: mock(() => ({ ok: false, error: "unused" })),
   upsertLockfileAssistant: mock(() => ({ ok: false, error: "unused" })),

--- a/clients/macos/src/main/local-mode.ts
+++ b/clients/macos/src/main/local-mode.ts
@@ -7,6 +7,7 @@ import {
   connectImport,
   getGuardianAccessToken,
   isActiveAssistant,
+  isPairedLockfileEntry,
   getLockfileData,
   getLocalAssistantStatus,
   replacePlatformAssistants,
@@ -401,21 +402,13 @@ export const installLocalMode = (): void => {
       } catch (err) {
         return { ok: false, status: 500, error: (err as Error).message };
       }
-      // Paired entries have no local daemon, so token-failure guidance must
-      // say re-pair rather than hatch/wake.
-      const lockfile = getLockfileData(lockfilePaths);
-      const paired =
-        lockfile.ok &&
-        lockfile.data.assistants.some(
-          (a) => a.assistantId === assistantId && a.cloud === "paired",
-        );
       return getGuardianAccessToken(
         assistantId,
         configDir,
         invocation,
         true,
         guardianTokenEnv,
-        { paired },
+        { paired: isPairedLockfileEntry(lockfilePaths, assistantId) },
       );
     },
   );

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -16,6 +16,7 @@ import {
   upsertLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
+  isPairedLockfileEntry,
   runHatch,
   runRetire,
   runSleep,
@@ -884,16 +885,8 @@ function guardianTokenMiddleware(
       return;
     }
 
-    // Paired entries have no local daemon, so token-failure guidance must
-    // say re-pair rather than hatch/wake.
-    const lockfile = getLockfileData(lockfilePaths);
-    const paired =
-      lockfile.ok &&
-      lockfile.data.assistants.some(
-        (a) => a.assistantId === assistantId && a.cloud === "paired",
-      );
     getGuardianAccessToken(assistantId, configDir, invocation, true, env, {
-      paired,
+      paired: isPairedLockfileEntry(lockfilePaths, assistantId),
     }).then(
       (result) => {
         if (result.ok) {

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -32,6 +32,7 @@ export {
   upsertLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
+  isPairedLockfileEntry,
 } from "./lockfile";
 export type { LockfileResult, WriteResult } from "./lockfile";
 export { parseLockfile } from "./lockfile-contract";

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import {
   getLockfileData,
+  isPairedLockfileEntry,
   replacePlatformAssistants,
   upsertLockfileAssistant,
 } from "./lockfile";
@@ -109,6 +110,30 @@ describe("getLockfileData", () => {
     fs.writeFileSync(lockfilePath, "{ not json");
     const result = getLockfileData([lockfilePath]);
     expect(result).toEqual({ ok: false, status: 500 });
+  });
+});
+
+// Hosts pass {paired} to getGuardianAccessToken so expired pairings get
+// re-pair guidance instead of hatch/wake; this pins the classification.
+describe("isPairedLockfileEntry", () => {
+  test("only a lockfile entry with cloud=paired classifies as paired", () => {
+    writeOnDisk({
+      assistants: [
+        { assistantId: "paired-1", cloud: "paired" },
+        { assistantId: "local-1", cloud: "local" },
+      ],
+      activeAssistant: "local-1",
+    });
+
+    expect(isPairedLockfileEntry([lockfilePath], "paired-1")).toBe(true);
+    expect(isPairedLockfileEntry([lockfilePath], "local-1")).toBe(false);
+    expect(isPairedLockfileEntry([lockfilePath], "missing")).toBe(false);
+  });
+
+  test("an absent lockfile never classifies as paired", () => {
+    expect(
+      isPairedLockfileEntry([path.join(dir, "absent.json")], "paired-1"),
+    ).toBe(false);
   });
 });
 

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -35,6 +35,24 @@ export function getLockfileData(lockfilePaths: string[]): LockfileResult {
   return { ok: true, data: parseLockfile(data) };
 }
 
+/**
+ * Whether the lockfile records this assistant as a paired entry. Paired
+ * entries have no local daemon, so guardian-token failure guidance must say
+ * re-pair rather than hatch/wake.
+ */
+export function isPairedLockfileEntry(
+  lockfilePaths: string[],
+  assistantId: string,
+): boolean {
+  const lockfile = getLockfileData(lockfilePaths);
+  return (
+    lockfile.ok &&
+    lockfile.data.assistants.some(
+      (a) => a.assistantId === assistantId && a.cloud === "paired",
+    )
+  );
+}
+
 export type WriteResult =
   | { ok: true; lockfile: Lockfile }
   | { ok: false; status: number; error: string };


### PR DESCRIPTION
## Summary
Fixes the remaining review gap for macos-paired-assistants.md (Codex P1 on #40141).
- isPairedLockfileEntry moves into packages/local-mode beside getLockfileData; CLI, Vite middleware, and macOS handler collapse to one-line calls
- Classification pinned once at the package; host tests keep their integration coverage