### PR TITLE
fix(memory): raise consolidation run timeout to 30 minutes

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-lock.ts
@@ -31,11 +31,16 @@ const log = getLogger("memory-v2-consolidate");
 
 /**
  * Hard timeout for the consolidation run. Consolidation reads the buffer,
- * rewrites several files, and re-encodes essentials/threads: generous
- * upper bound so a slow run isn't killed mid-edit, but bounded so a stuck
- * provider can't pin the worker indefinitely.
+ * rewrites several files, and re-encodes essentials/threads: on a mature
+ * corpus a full pass legitimately runs ~20 minutes under cross-process write
+ * contention, so the bound leaves headroom above that while still keeping a
+ * stuck run from pinning the worker indefinitely. Matches the default
+ * `timeouts.backgroundTurnTimeoutSec` budget for heartbeat/background turns.
+ * Overrunning it marks the run failed and skips its follow-up jobs (reembeds,
+ * v3 maintenance) even though the agent's file edits land, so the bound must
+ * comfortably exceed a healthy run's duration.
  */
-export const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
+export const CONSOLIDATION_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Age past which a lock held by an apparently-live PID is taken over anyway.


### PR DESCRIPTION
## Summary

Raises \`CONSOLIDATION_TIMEOUT_MS\` from 15 to 30 minutes.

On a mature corpus a consolidation pass legitimately takes ~20 minutes under cross-process write contention (measured from production logs: agent loop start 01:05:09, completion 01:24:54, while the 15-minute timeout fired at 01:20:09). Every 4-hourly run had been timing out this way for 2+ days.

Because \`runBackgroundJob\` does not cancel the underlying turn on timeout, the agent's work completes and its file edits land anyway. The too-tight bound therefore does not protect anything; its only effects are:

- the run is recorded as failed and the scheduler stays on the transient-failure backoff curve,
- follow-up jobs (reembeds, v3 maintenance) are skipped on every pass, so the memory index silently drifts from the consolidated files,
- an \`activity.failed\`-class failure is logged for a run that actually succeeded.

30 minutes matches the default \`timeouts.backgroundTurnTimeoutSec\` (1800s) used for heartbeat and generic background turns. \`STALE_LOCK_TTL_MS\` is derived (4x the timeout, now 2h), which stays comfortably under the 4h scheduling cadence and preserves the documented lock-takeover invariant that the TTL exceeds any legitimate hold.

Considered and rejected: sourcing the timeout from \`timeouts.backgroundTurnTimeoutSec\` config directly. The stale-lock TTL derivation is computed at module load from the constant; a runtime-configurable timeout could be raised above the TTL, letting lock takeover fire against a legitimately in-flight run.

## Test plan

- [x] \`bun test src/plugins/defaults/memory/substrate/__tests__/consolidation-lock.test.ts\` (9 pass)
- [x] \`bun test src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts\` (54 pass)
- [x] \`bun run typecheck:fast\` clean
- [x] No test hardcodes the previous value

🤖 Generated with [Claude Code](https://claude.com/claude-code)