### PR TITLE
fix(web): open apps full-width from every entry point (LUM-2553)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -826,15 +826,9 @@ export function ChatLayout({
   // mutate the viewer store with no surface to display against. Navigate
   // to a chat route first when off-chat, then run the shared open flow.
   //
-  // See `use-open-app-from-chat.ts` for the loadApp → enterAppEditing flow
-  // shared with the transcript / assets-pill open path.
-  const openAppFromChat = useOpenAppFromChat({
-    // When the user is off a chat route (home, library, identity, …), do
-    // not bind the stale `activeConversationId` as the editing target —
-    // the store value persists across route changes for SSE / attention
-    // consumers and doesn't reflect the user's current intent (LUM-2691).
-    bindConversation: isConversationChatPath(location.pathname),
-  });
+  // See `use-open-app-from-chat.ts` for the full-width loadApp flow shared
+  // with the transcript / assets-pill open path.
+  const openAppFromChat = useOpenAppFromChat();
   const activeAppId = useViewerStore.use.activeAppId();
   const handleOpenAppFromSidebar = useCallback(
     async (appId: string) => {

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
@@ -95,9 +95,9 @@ describe("useOpenAppFromChat", () => {
   });
 
   // LUM-2553: opening an app is a view action, so the entry point must not
-  // decide the layout. An active conversation used to upgrade the desktop
-  // viewer to the `app-editing` split, which made the same app open
-  // narrower from chat than from Home / Library.
+  // decide the layout. A wide viewport with an active conversation is the
+  // one combination that could justify the `app-editing` split, and it
+  // still lands full-width, matching an open from Home / Library.
   test("stays full-width with an active conversation on a wide viewport", async () => {
     useConversationStore.setState({ activeConversationId: "conv-7" });
     const { result } = renderHook(() => useOpenAppFromChat());

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
@@ -18,7 +18,7 @@ import { useViewerStore } from "@/stores/viewer-store";
 import { useOpenAppFromChat } from "./use-open-app-from-chat";
 
 // We can't safely `mock.module(...)` core stores like viewer/conversation
-// because Bun module mocks are process-global — they leak into every
+// because Bun module mocks are process-global. They leak into every
 // other test file in the run (the message-reconciliation suite would
 // suddenly find `useConversationStore.setState` undefined). Instead we
 // drive the real stores via `setState` and `getState`, capturing pre-test
@@ -43,9 +43,11 @@ beforeEach(() => {
   setEditingConversationIdMock.mockReset();
 
   // Default: loadApp succeeds, leaving viewer state pointing at the
-  // requested app (mirrors the real `loadApp` action's contract).
+  // requested app in the full-width `"app"` view (mirrors the real
+  // `loadApp` action's contract, which sets `mainView` up front).
   loadAppMock.mockImplementation(async (_assistantId, appId) => {
     useViewerStore.setState({
+      mainView: "app",
       activeAppId: appId,
       openedAppState: {
         appId,
@@ -57,6 +59,9 @@ beforeEach(() => {
   });
 
   useViewerStore.setState({
+    // Start from the split view so each test proves the hook leaves the
+    // viewer full-width rather than merely never leaving `"app"`.
+    mainView: "app-editing",
     activeAppId: null,
     openedAppState: null,
     loadApp: loadAppMock as unknown as typeof viewerSnapshot.loadApp,
@@ -89,21 +94,23 @@ describe("useOpenAppFromChat", () => {
     expect(setEditingConversationIdMock).not.toHaveBeenCalled();
   });
 
-  test("enters app-editing when an active conversation is present and load succeeds", async () => {
+  // LUM-2553: opening an app is a view action, so the entry point must not
+  // decide the layout. An active conversation used to upgrade the desktop
+  // viewer to the `app-editing` split, which made the same app open
+  // narrower from chat than from Home / Library.
+  test("stays full-width with an active conversation on a wide viewport", async () => {
     useConversationStore.setState({ activeConversationId: "conv-7" });
     const { result } = renderHook(() => useOpenAppFromChat());
 
     await result.current("app-42");
 
     expect(loadAppMock).toHaveBeenCalledWith("asst-1", "app-42");
-    expect(setEditingConversationIdMock).toHaveBeenCalledWith("conv-7");
-    expect(enterAppEditingMock).toHaveBeenCalledTimes(1);
+    expect(useViewerStore.getState().mainView).toBe("app");
+    expect(enterAppEditingMock).not.toHaveBeenCalled();
+    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
   });
 
-  test("on a mobile viewport, loads + binds editing conversation but stays full-screen (no app-editing upgrade)", async () => {
-    // Split chat+app doesn't fit on a phone — `loadApp` already left
-    // `mainView` at `"app"` (full-screen), and we expect no upgrade to
-    // `"app-editing"` even with an active conversation.
+  test("stays full-width with an active conversation on a mobile viewport", async () => {
     mobileRef.current = true;
     useConversationStore.setState({ activeConversationId: "conv-7" });
     const { result } = renderHook(() => useOpenAppFromChat());
@@ -111,35 +118,30 @@ describe("useOpenAppFromChat", () => {
     await result.current("app-42");
 
     expect(loadAppMock).toHaveBeenCalledWith("asst-1", "app-42");
-    // The editing-conversation binding still happens — any later
-    // "edit this app" affordance from mobile threads back to the right
-    // conversation.
-    expect(setEditingConversationIdMock).toHaveBeenCalledWith("conv-7");
+    expect(useViewerStore.getState().mainView).toBe("app");
     expect(enterAppEditingMock).not.toHaveBeenCalled();
+    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
   });
 
-  test("loads the app but skips app-editing when no conversation is active", async () => {
+  test("stays full-width when no conversation is active", async () => {
     const { result } = renderHook(() => useOpenAppFromChat());
 
     await result.current("app-42");
 
     expect(loadAppMock).toHaveBeenCalledWith("asst-1", "app-42");
-    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
+    expect(useViewerStore.getState().mainView).toBe("app");
     expect(enterAppEditingMock).not.toHaveBeenCalled();
+    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
   });
 
-  test("skips app-editing when a newer open superseded this one (activeAppId mismatch)", async () => {
+  test("leaves the viewer alone when the load fails", async () => {
     useConversationStore.setState({ activeConversationId: "conv-7" });
+    // The real `loadApp` falls back to chat when the open request fails.
     loadAppMock.mockImplementationOnce(async () => {
-      // Simulate a newer call having already swapped the active app.
       useViewerStore.setState({
-        activeAppId: "different-app",
-        openedAppState: {
-          appId: "different-app",
-          dirName: "",
-          name: "",
-          html: "",
-        },
+        mainView: "chat",
+        activeAppId: null,
+        openedAppState: null,
       });
     });
 
@@ -147,49 +149,8 @@ describe("useOpenAppFromChat", () => {
 
     await result.current("app-42");
 
-    expect(loadAppMock).toHaveBeenCalledTimes(1);
+    expect(useViewerStore.getState().mainView).toBe("chat");
     expect(enterAppEditingMock).not.toHaveBeenCalled();
     expect(setEditingConversationIdMock).not.toHaveBeenCalled();
-  });
-
-  test("skips app-editing when loadApp returns without populating openedAppState (load failed)", async () => {
-    useConversationStore.setState({ activeConversationId: "conv-7" });
-    loadAppMock.mockImplementationOnce(async () => {
-      useViewerStore.setState({ activeAppId: null, openedAppState: null });
-    });
-
-    const { result } = renderHook(() => useOpenAppFromChat());
-
-    await result.current("app-42");
-
-    expect(enterAppEditingMock).not.toHaveBeenCalled();
-    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
-  });
-
-  test("with bindConversation: false, loads the app but never binds or enters editing", async () => {
-    useConversationStore.setState({ activeConversationId: "conv-7" });
-    const { result } = renderHook(() =>
-      useOpenAppFromChat({ bindConversation: false }),
-    );
-
-    await result.current("app-42");
-
-    expect(loadAppMock).toHaveBeenCalledWith("asst-1", "app-42");
-    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
-    expect(enterAppEditingMock).not.toHaveBeenCalled();
-  });
-
-  test("with bindConversation: false on mobile, loads the app but never binds", async () => {
-    mobileRef.current = true;
-    useConversationStore.setState({ activeConversationId: "conv-7" });
-    const { result } = renderHook(() =>
-      useOpenAppFromChat({ bindConversation: false }),
-    );
-
-    await result.current("app-42");
-
-    expect(loadAppMock).toHaveBeenCalledWith("asst-1", "app-42");
-    expect(setEditingConversationIdMock).not.toHaveBeenCalled();
-    expect(enterAppEditingMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -1,8 +1,6 @@
 import { useCallback } from "react";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
 
@@ -11,39 +9,31 @@ import { haptic } from "@/utils/haptics";
  * pinned-app click, transcript "Open App" affordance, conversation assets
  * pill.
  *
- * On a wide viewport (`md` and up), when there's an active conversation,
- * transition the viewer to `app-editing` (split view: chat on the left,
- * app on the right) and bind the chat as the editing target. On a mobile
- * viewport (`max-width: 767px`) the split layout doesn't fit horizontally,
- * so we leave the viewer in `app` mode (full-screen app) — the editing
- * conversation is still bound so any subsequent "edit this app" affordance
- * threads back to the correct conversation.
+ * Opening an app is a *view* action, so the app lands full-width:
+ * `loadApp` sets `mainView` to `"app"` and nothing here upgrades it. That
+ * holds on every viewport, with or without an active conversation, so the
+ * app opens the same way from chat as it does from Home / Library rather
+ * than the layout depending on the entry point (LUM-2553).
+ *
+ * Split view (`app-editing`: chat on the left, app on the right) is an
+ * explicit choice, never a side effect of opening:
+ * - the user picks it through the viewer's "Edit" affordance
+ *   (`use-edit-app.ts`), which binds a per-app edit conversation;
+ * - the app requests it through `set_view({ view: "split" })`
+ *   (`app-viewer-actions.ts`), which binds the active conversation.
+ *
+ * Both bind `editingConversationId` themselves, and that value is only read
+ * while `mainView` is `"app-editing"`, so this hook leaves it alone.
  *
  * Returns a stable async callback `(appId: string) => Promise<void>` safe
  * to drop into deps arrays.
  *
- * Single source of truth — used by `chat-layout.tsx` (sidebar) and
- * `chat-page.tsx` (transcript). Don't inline a copy.
+ * Single source of truth, used by `chat-layout.tsx` (sidebar),
+ * `chat-route-content.tsx` (transcript) and
+ * `use-chat-header-registration.tsx` (assets pill). Don't inline a copy.
  */
-export interface UseOpenAppFromChatOptions {
-  /**
-   * When `true` (default), bind the active conversation as the app-editing
-   * target and enter `app-editing` split view on wide viewports. When
-   * `false`, skip both — the app opens in full-screen `app` mode with no
-   * conversation bound. The sidebar caller sets this to `false` when the
-   * user is not on a chat route, so a pinned-app click from home / library
-   * / identity doesn't surface a stale conversation (LUM-2691).
-   */
-  bindConversation?: boolean;
-}
-
-export function useOpenAppFromChat(
-  options?: UseOpenAppFromChatOptions,
-): (appId: string) => Promise<void> {
+export function useOpenAppFromChat(): (appId: string) => Promise<void> {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const activeConversationId = useConversationStore.use.activeConversationId();
-  const isMobile = useIsMobile();
-  const bindConversation = options?.bindConversation ?? true;
 
   return useCallback(
     async (appId: string) => {
@@ -52,24 +42,7 @@ export function useOpenAppFromChat(
       }
       haptic.light();
       await useViewerStore.getState().loadApp(assistantId, appId);
-      const { activeAppId, openedAppState } = useViewerStore.getState();
-      if (
-        bindConversation &&
-        activeConversationId &&
-        openedAppState &&
-        activeAppId === appId
-      ) {
-        useConversationStore
-          .getState()
-          .setEditingConversationId(activeConversationId);
-        // Mobile viewports can't fit the split chat+app layout. `loadApp`
-        // already left `mainView` at `"app"` (full-screen), so we simply
-        // skip the upgrade to `"app-editing"`.
-        if (!isMobile) {
-          useViewerStore.getState().enterAppEditing();
-        }
-      }
     },
-    [assistantId, activeConversationId, isMobile, bindConversation],
+    [assistantId],
   );
 }


### PR DESCRIPTION
## TL;DR

Opening an app from chat put the desktop viewer into the narrow `app-editing` split whenever a conversation was active, while opening the same app from Home / Library gave the full-width view. The layout was decided by the entry point instead of by the action. `useOpenAppFromChat` now just loads the app and leaves it full-width, on every viewport and every entry point.

Fixes LUM-2553.

## Before / after

| Action | Before | After |
| --- | --- | --- |
| Click a pinned app in the sidebar while in a conversation (desktop) | Split view: chat on the left, app squeezed to the right | Full-width app |
| Click a pinned app from Home / Library / Identity | Full-width app | Full-width app (unchanged) |
| "Open App" in the transcript, or the conversation assets pill | Split view when a conversation was active | Full-width app |
| Open a pinned app on mobile | Full-screen app | Full-screen app (unchanged) |
| Click "Edit" on an open app | Split view, chat on the left | Split view, chat on the left (unchanged) |
| App calls `set_view({ view: "split" })` | Split view | Split view (unchanged) |

The one behavior worth calling out: from the chat entry point, the split you reached by *opening* was bound to the conversation you were already in. Reaching the split deliberately through "Edit" binds the per-app edit conversation instead. That is what the Library entry point already did, which is the point of the ticket: one path, one behavior.

## Why it's safe

- The only removed calls are `enterAppEditing()` and `setEditingConversationId()` inside `useOpenAppFromChat`. Nothing else in the hook changes, and `loadApp` already sets `mainView` to `"app"` up front, so the full-width result needs no new state handling.
- Split view keeps both of its explicit entry points, and both bind `editingConversationId` themselves: `useEditApp` (viewer "Edit" affordance, shared with the Library app view) and `set_view({ view: "split" })` in `app-viewer-actions.ts`. After this change every remaining `enterAppEditing()` caller binds the conversation, so `app-editing` can't render against a stale or missing binding.
- `editingConversationId` is only ever read alongside `mainView === "app-editing"` (`chat-content-layout.tsx:343`, `chat-route-content.tsx:1303`), so not pre-binding it has no other consumer.
- Two of the tests are genuine regression guards, verified by re-running the suite against the pre-fix hook: "stays full-width with an active conversation" fails on both the wide and mobile viewport paths before the fix and passes after.

## Dead code removed

The `bindConversation` option existed so a pinned-app click from off-chat wouldn't surface a stale conversation in the split (LUM-2691). With no automatic split there is nothing to surface, so the option had no remaining effect and is gone along with the hook's `useIsMobile` / `activeConversationId` subscriptions. The other half of the LUM-2691 fix stays put in `chat-layout.tsx`: off-chat clicks still navigate to a fresh silent draft first, because the viewer panel only renders on a chat route.

## Testing

- `bun test src/domains/chat/hooks/use-open-app-from-chat.test.ts` (5 pass)
- `bun test` on the neighbouring suites: `app-viewer-actions`, `use-chat-header-registration`, `chat-route-content`, `use-edit-app`
- `bunx tsc --noEmit`, `bun run lint` (0 errors)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->