### PR TITLE
fix(web): draw one sidebar rule, never between two sections

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -55,6 +55,8 @@ import type {
 } from "@/types/conversation-types";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
 import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
+import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
+import type { PinnedAppEntry } from "@/utils/app-pin-storage";
 
 // Most of what follows describes the Grouped view's composition: the Chats
 // section, the per-channel sections, and the peer treatment they share with
@@ -1062,7 +1064,15 @@ describe("AssistantSideMenu · equal section treatment", () => {
       el.matches(ruleSelector) ? true : el.querySelector(ruleSelector) != null,
     );
 
-    expect(root.querySelectorAll(ruleSelector)).toHaveLength(1);
+    // Counts *every* horizontal rule in the list, not just the curated
+    // block's own: a `SideMenu.Separator` between two sections draws the
+    // same line, and this fixture puts Pinned directly above a custom group
+    // - the boundary a per-section divider would land on.
+    expect(
+      root.querySelectorAll(
+        `${ruleSelector}, [data-slot="side-menu-separator"]`,
+      ),
+    ).toHaveLength(1);
     // Pinned and Alpha above it, Chats and Slack below.
     expect(indexOfText("Pinned")).toBeLessThan(ruleIndex);
     expect(indexOfText("Alpha")).toBeLessThan(ruleIndex);
@@ -1088,6 +1098,43 @@ describe("AssistantSideMenu · equal section treatment", () => {
     expect(
       root.querySelectorAll('[data-slot="sidebar-section-rule"]'),
     ).toHaveLength(0);
+  });
+
+  // The built-in nav block above the list closes with a separator once the
+  // user pins an app; the collapsed rail adds its own to break the cluster
+  // off from the group icons. Only one of the two may render, or the rail
+  // shows two rules with nothing between them.
+  test("the collapsed rail's header carries one separator, pinned apps or not", () => {
+    for (const pinnedApps of [
+      [] as PinnedAppEntry[],
+      [{ appId: "app-1", pinnedOrder: 0, name: "Vex Ops" }],
+    ]) {
+      usePinnedAppsStore.setState({
+        pinnedApps,
+        pinnedAppIds: new Set(pinnedApps.map((a) => a.appId)),
+      });
+
+      const container = parse(
+        renderMenu({
+          conversations: LAYOUT_CONVERSATIONS,
+          conversationGroups: LAYOUT_GROUPS,
+          collapsed: true,
+        }),
+      );
+
+      const header = container.querySelector<HTMLElement>(
+        '[data-slot="side-menu-header"]',
+      );
+      if (!header) {
+        throw new Error("expected the rail's non-scrolling header");
+      }
+
+      expect(
+        header.querySelectorAll('[data-slot="side-menu-separator"]'),
+      ).toHaveLength(1);
+    }
+
+    usePinnedAppsStore.setState({ pinnedApps: [], pinnedAppIds: new Set() });
   });
 
   // Pinned is the one section that doesn't cap: it grows to fit its own

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,6 +1,5 @@
 import { Search, X } from "lucide-react";
 import {
-  Fragment,
   useCallback,
   useState,
   type CSSProperties,
@@ -159,8 +158,8 @@ function SearchButton() {
  *   Body · one section list, in the user's own order (default shown)
  *     • Pinned ▾       - when non-empty
  *     • Group ▾        - one collapsible section per custom group
- *     • ───────────────  - when anything is curated above it; drags to
- *       resize Pinned while that section is expanded
+ *     • ───────────────  - the list's one rule, when anything is curated
+ *       above it; never between two sections
  *     • Conversations  - the persistent header; its "…" menu carries the
  *       "Group by" dropdown (None | Channel)
  *     • Group by None: every remaining conversation as one headerless,
@@ -541,22 +540,12 @@ export function AssistantSideMenu({
                 onValueChange={sidebar.onOpenSectionsChange}
               >
                 {/* Pinned and the custom groups: the user's own curation,
-                    identical in both views. One divider under Pinned; the
-                    custom groups flow together with nothing between them,
-                    and the block's own rule below marks the boundary to
-                    Conversations. */}
+                    identical in both views. Nothing between them - they flow
+                    together as one curated block, and only the block's own
+                    rule below marks the boundary to Conversations. */}
                 {sidebar.sections
                   .slice(0, sidebar.curatedSectionCount)
-                  .map((section, index, curated) => (
-                    <Fragment key={section.key}>
-                      {index > 0 && curated[index - 1]?.type === "pinned" ? (
-                        // 2px closer to the section below than the
-                        // separator's own default my-1 (4px) gives.
-                        <SideMenu.Separator style={{ marginBottom: 2 }} />
-                      ) : null}
-                      {renderSection(section)}
-                    </Fragment>
-                  ))}
+                  .map(renderSection)}
                 {/* The list's one rule, marking where curation ends and the
                     conversations begin. Absent when nothing is curated yet, so
                     a fresh sidebar never opens on a stray line. Sits on the

--- a/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
+++ b/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
@@ -133,10 +133,13 @@ export function SideMenuBuiltInNav({
           <SideMenu.Separator />
         </>
       ) : null}
-      {/* The collapsed rail separates the cluster (or, when pinned apps
-          exist, the pinned-apps block above) from the group icons below it
-          (Figma 7257:135826). */}
-      {isCollapsedRail ? <SideMenu.Separator /> : null}
+      {/* The collapsed rail separates the cluster from the group icons below
+          it (Figma 7257:135826). Only when there are no pinned apps: that
+          block already closed with a separator, and a second one here would
+          stack two rules with nothing between them. */}
+      {isCollapsedRail && pinnedApps.length === 0 ? (
+        <SideMenu.Separator />
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
## TL;DR

The sidebar drew a divider under Pinned whenever another curated section followed it, so Pinned, the custom groups, and Conversations each read as a separately-walled block. This removes it: the list keeps exactly one rule — the one marking where the user's curation ends and the conversations begin. Also fixes a duplicate rule on the collapsed rail, where the pinned-apps separator and the rail's own separator stacked with nothing between them.

## What changes for the user

| | Before | After |
|---|---|---|
| Pinned, then a custom group | A divider between them | They flow together as one curated block |
| Pinned / groups → Conversations | One rule | Unchanged — still one rule |
| Nothing pinned, no custom groups | No rule (the Pinned Apps divider is the only line) | Unchanged |
| Collapsed rail with pinned apps | Two rules stacked back to back under the app tiles | One rule |
| Collapsed rail, no pinned apps | One rule under the assistant cluster | Unchanged |

## Why it's safe

- Pure presentation. No state, data shaping, or section-ordering logic is touched — the curated block still renders through `renderSection`, in the user's own stored order.
- The block-closing rule's guard is untouched: it renders only when `curatedSectionCount > 0`, and the Pinned section only exists when it has conversations, so an empty curated block still draws nothing. No new "stray line on a fresh sidebar" case is introduced.
- The change deletes a branch rather than adding one, which also drops the `Fragment` wrapper and lets the curated block use the same `.map(renderSection)` call the governed sections already use.
- Both behaviors are covered by DOM tests that assert exact rule counts, and both assertions were sensitivity-checked: reverted against the original source, each fails (2 rules found where 1 is expected).

## Test gap this closes

The existing "the only rule follows the curated sections" test counted only `[data-slot="sidebar-section-rule"]`. The per-section divider was a `SideMenu.Separator` — a different slot drawing the same line — so it passed while the sidebar showed two rules, on a fixture that already put Pinned directly above a custom group. The test now counts every horizontal rule in the list, so any future divider between two sections fails it.

## Nothing deferred

The one judgment call, flagged for confirmation rather than deferred: with custom groups but nothing pinned, the rule still renders between the groups and Conversations. Removing it there would leave the groups running straight into Conversations with no separation, and the redundant-divider concern only applies when the curated block is empty — which already draws nothing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->