### PR TITLE
Bake Stripe publishable key into macOS Electron builds

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1660,6 +1660,9 @@ jobs:
     needs: [compute-version]
     runs-on: macos-26
     timeout-minutes: 30
+    # Resolves the environment-scoped STRIPE_PUBLISHABLE_KEY secret baked into
+    # the renderer below.
+    environment: dev
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -1746,6 +1749,11 @@ jobs:
           VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: dev
           VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
+          # Environment-scoped secret (pk_test_ on dev); requires the job's
+          # `environment: dev` above, else it resolves empty and the
+          # payment-method modal can't mount Stripe Elements. Publishable keys
+          # are public, so embedding them is expected.
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           # Sentry release tracking for the Electron renderer (mirrors release.yml).
           # VITE_APP_VERSION tags renderer events with the release (read in
           # clients/web/src/lib/sentry/sentry-init.ts) and names the registered

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2124,6 +2124,9 @@ jobs:
     needs: [extract-version]
     runs-on: macos-26
     timeout-minutes: 30
+    # Resolves the environment-scoped STRIPE_PUBLISHABLE_KEY secret baked into
+    # the renderer below (same environment expression as upload-electron-updates).
+    environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
     strategy:
       # Let both arches finish so a failure reports which arch(es) broke; any
       # failed leg fails the job (and therefore the release).
@@ -2209,6 +2212,11 @@ jobs:
           VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
+          # Environment-scoped secret (pk_test_ on staging, pk_live_ on prod);
+          # requires the job's `environment:` above, else it resolves empty and
+          # the payment-method modal can't mount Stripe Elements. Publishable
+          # keys are public, so embedding them is expected.
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           # Sentry release tracking for the Electron renderer. VITE_APP_VERSION
           # tags renderer events with the release (read in
           # clients/web/src/lib/sentry/sentry-init.ts) and names the registered


### PR DESCRIPTION
## Summary
- Attach `environment:` to the `build-electron` jobs in `release.yml` (staging/production via the existing `is_staging` expression, mirroring `upload-electron-updates`) and `dev-release.yaml` (`dev`) so the environment-scoped `STRIPE_PUBLISHABLE_KEY` secret resolves there.
- Pass `VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}` in both Electron renderer build env blocks, matching what `deploy-platform-web-spa.yaml` already bakes into the browser SPA.

## Why
Adding a payment method in the macOS app fails: the modal reads `import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY` at build time, and the Electron builds never set it, so `STRIPE_PK` is empty and the modal renders the `MissingStripeKeyNotice` fallback ('Payment method setup is currently unavailable'). All three GitHub environments already have `STRIPE_PUBLISHABLE_KEY` configured — no new secrets needed. Publishable keys are public by design, so baking them into the DMG is expected (same rationale as the SPA deploy).

Verified before choosing this approach: none of the three environments have required reviewers or wait timers (branch policies only, already satisfied by `main`/`release/*`), and deployment records are already generated constantly by other environment-attached jobs, so attaching the environment adds no gating and negligible noise.

Rollout: the fix reaches users with the next macOS release via auto-update; existing installs keep showing the fallback notice until they update.

## Original prompt
Adding a payment method doesn't work in the macOS app — the Stripe publishable key is missing from the Electron builds. After confirming publishable keys are not sensitive and comparing options (repo-level vars/secrets, hardcoding in the environments seeds table, GitHub environments), the user chose reusing the already-configured environment-scoped `STRIPE_PUBLISHABLE_KEY` secrets by attaching `environment:` to the Electron build jobs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->