### PR TITLE
Instrument live-voice sessions and attribute their turns (JARVIS-1456)

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -392,13 +392,15 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
 
     // `turn-events-store` projects `$.client` onto `TurnTelemetryEvent.client`,
     // so this bag is what makes a voice turn countable per client and joinable
-    // to its session's funnel rows.
+    // to its session's funnel rows. The platform goes in `os`, the same key
+    // the HTTP send path fills, so voice turns sit in the column existing turn
+    // analytics already read.
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
       client: {
         voice: true,
         voice_session_id: "session-123",
-        voice_client: "ios",
+        os: "ios",
       },
     });
   });

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -380,6 +380,54 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
       voiceSessionTurn: true,
     });
   });
+
+  test("a live-voice turn persists its session attribution under metadata.client", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      voiceTelemetry: { sessionId: "session-123", client: "ios" },
+    });
+
+    // `turn-events-store` projects `$.client` onto `TurnTelemetryEvent.client`,
+    // so this bag is what makes a voice turn countable per client and joinable
+    // to its session's funnel rows.
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+      client: {
+        voice: true,
+        voice_session_id: "session-123",
+        voice_client: "ios",
+      },
+    });
+  });
+
+  test("omits the client key when the session reported no originating client", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      voiceTelemetry: { sessionId: "session-123" },
+    });
+
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+      client: { voice: true, voice_session_id: "session-123" },
+    });
+  });
+
+  test("a phone turn carries no client bag", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions());
+
+    // Only live-voice sessions pass `voiceTelemetry`; a phone call has no
+    // live-voice session id to attribute a turn to.
+    expect(fake.lastPersistOpts()?.metadata).not.toHaveProperty("client");
+  });
 });
 
 describe("startVoiceTurn hiddenSyntheticPrompt", () => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -17,6 +17,7 @@ import type {
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import type {
   ChannelId,
+  ClientOs,
   InterfaceId,
   TurnChannelContext,
   TurnInterfaceContext,
@@ -265,6 +266,22 @@ export interface VoiceTurnOptions {
   userMessageInterface?: InterfaceId;
   /** Source interface for persisted assistant messages. Defaults to userMessageInterface. */
   assistantMessageInterface?: InterfaceId;
+  /**
+   * Analytics attribution for a live-voice turn: which client opened the
+   * session, and that session's id. Persisted into the user message's
+   * `metadata.client` bag, which `turn-events-store` projects onto
+   * `TurnTelemetryEvent.client` — so a live-voice turn is countable per client
+   * and joinable to its session's start/end funnel rows.
+   *
+   * Deliberately separate from {@link userMessageInterface}: that field feeds
+   * `resolveChannelCapabilities` and decides what the turn may do, so it is not
+   * free to carry attribution. Absent for phone calls and for clients that send
+   * no identity on the start frame.
+   */
+  voiceTelemetry?: {
+    sessionId: string;
+    client?: ClientOs;
+  };
   /** Per-turn control prompt. Undefined uses the phone prompt; null disables it. */
   voiceControlPrompt?: string | null;
   /** The transcribed caller utterance or synthetic marker. */
@@ -945,6 +962,22 @@ export async function startVoiceTurn(
         // `isVoiceSessionUserMessage` for why the channel fields cannot carry it.
         voiceSessionTurn: true,
         ...(isHiddenSyntheticPrompt ? { hidden: true } : {}),
+        ...(opts.voiceTelemetry
+          ? {
+              // Projected onto `TurnTelemetryEvent.client` by
+              // `turn-events-store`. `voice_session_id` is what joins these
+              // turn rows to the session's funnel rows, so a session's turn
+              // count is a count of rows carrying its id — the metric is never
+              // restated as a field anyone has to keep correct.
+              client: {
+                voice: true,
+                voice_session_id: opts.voiceTelemetry.sessionId,
+                ...(opts.voiceTelemetry.client
+                  ? { voice_client: opts.voiceTelemetry.client }
+                  : {}),
+              },
+            }
+          : {}),
       },
     });
     return persistResult.id;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -270,7 +270,7 @@ export interface VoiceTurnOptions {
    * Analytics attribution for a live-voice turn: which client opened the
    * session, and that session's id. Persisted into the user message's
    * `metadata.client` bag, which `turn-events-store` projects onto
-   * `TurnTelemetryEvent.client` — so a live-voice turn is countable per client
+   * `TurnTelemetryEvent.client`, so a live-voice turn is countable per client
    * and joinable to its session's start/end funnel rows.
    *
    * Deliberately separate from {@link userMessageInterface}: that field feeds
@@ -967,13 +967,18 @@ export async function startVoiceTurn(
               // Projected onto `TurnTelemetryEvent.client` by
               // `turn-events-store`. `voice_session_id` is what joins these
               // turn rows to the session's funnel rows, so a session's turn
-              // count is a count of rows carrying its id — the metric is never
-              // restated as a field anyone has to keep correct.
+              // count is a count of rows carrying its id, never a field
+              // anyone has to keep correct.
+              //
+              // `os` is the standard per-platform dimension the HTTP send
+              // path already fills from the same `detectClientOs()` value, so
+              // a voice turn reports its platform in the column existing turn
+              // analytics read rather than one only voice knows about.
               client: {
                 voice: true,
                 voice_session_id: opts.voiceTelemetry.sessionId,
                 ...(opts.voiceTelemetry.client
-                  ? { voice_client: opts.voiceTelemetry.client }
+                  ? { os: opts.voiceTelemetry.client }
                   : {}),
               },
             }

--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Live-voice session telemetry: the started/ended funnel rows a session
+ * records, and the attribution carried on its turns.
+ *
+ * The recorder is mocked — the outbox and its consent gate are covered by
+ * `telemetry-events-outbox.test.ts`. What these tests pin is the wiring that
+ * decides whether a row exists at all and what it says, which is where the
+ * measurement can silently go wrong: a session that fails before `ready` still
+ * has to count, a failed session still has to record an end, and a session's
+ * turns have to carry its id or the turn count has nothing to group on.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+
+const recordLiveVoiceSessionStarted = mock(() => null);
+const recordLiveVoiceSessionEnded = mock(() => null);
+
+// Spread the real module rather than replacing it: other importers pull
+// `recordActivationEvent` and friends out of it, and a bare replacement makes
+// those imports fail to resolve.
+const onboardingEventsStore =
+  await import("../../onboarding/onboarding-events-store.js");
+mock.module("../../onboarding/onboarding-events-store.js", () => ({
+  ...onboardingEventsStore,
+  recordLiveVoiceSessionStarted,
+  recordLiveVoiceSessionEnded,
+}));
+
+// Types are erased, so they import statically regardless of the mock ordering
+// the values below depend on.
+import type { LiveVoiceCredentialReadiness } from "../live-voice-credential-preflight.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceClientStartFrame,
+  LiveVoiceServerFrame,
+} from "../protocol.js";
+
+// Values load after `mock.module` so the session picks up the mocked recorder.
+const { LiveVoiceSession } = await import("../live-voice-session.js");
+const { LiveVoiceSessionStartupError } =
+  await import("../live-voice-session-manager.js");
+const { createLiveVoiceServerFrameSequencer } = await import("../protocol.js");
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+} as const satisfies LiveVoiceClientStartFrame;
+
+const NOT_READY: LiveVoiceCredentialReadiness = {
+  status: "not-ready",
+  missing: [
+    {
+      kind: "tts",
+      providerId: "fish-audio",
+      reason: 'TTS provider "fish-audio" is missing credentials',
+    },
+  ],
+  userMessage: "Live voice is unavailable because it requires an API key.",
+};
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(private readonly stopEvents: SttStreamServerEvent[] = []) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    for (const event of this.stopEvents) {
+      this.onEvent?.(event);
+    }
+  }
+}
+
+function createContext(
+  startFrame: LiveVoiceClientStartFrame = START_FRAME,
+): LiveVoiceSessionFactoryContext {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  return {
+    sessionId: "session-123",
+    startFrame,
+    sendFrame: mock(async (payload) => {
+      const frame = sequencer.next(payload);
+      frames.push(frame);
+      return frame;
+    }),
+  };
+}
+
+function readySession(startFrame?: LiveVoiceClientStartFrame) {
+  return new LiveVoiceSession(createContext(startFrame), {
+    resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+    resolveCredentialReadiness: mock(
+      async (): Promise<LiveVoiceCredentialReadiness> => ({ status: "ready" }),
+    ),
+  });
+}
+
+describe("live-voice session telemetry", () => {
+  beforeEach(() => {
+    recordLiveVoiceSessionStarted.mockClear();
+    recordLiveVoiceSessionEnded.mockClear();
+  });
+
+  test("records a started row for a session that reaches ready", async () => {
+    const session = readySession();
+
+    await session.start();
+
+    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith("session-123");
+
+    await session.close("client_end");
+  });
+
+  test("records a started row even when the preflight rejects the session", async () => {
+    const session = new LiveVoiceSession(createContext(), {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness: mock(async () => NOT_READY),
+    });
+
+    await expect(session.start()).rejects.toBeInstanceOf(
+      LiveVoiceSessionStartupError,
+    );
+
+    // The denominator of the failure rate: a session rejected before `ready`
+    // is exactly the one that must not go missing from the started count.
+    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith("session-123");
+  });
+
+  test("records the close reason and a completed outcome on a clean end", async () => {
+    const session = readySession();
+    await session.start();
+
+    await session.close("client_end");
+
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "ended_client_end",
+      outcome: "completed",
+    });
+  });
+
+  test("a dropped socket ends as completed, not failed", async () => {
+    const session = readySession();
+    await session.start();
+
+    await session.close("websocket_close");
+
+    // The session ran and then stopped; only an error makes it `failed`, and
+    // the reason on `screen` is what distinguishes a drop from a hangup.
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "ended_websocket_close",
+      outcome: "completed",
+    });
+  });
+
+  test("a failed session records an ended row carrying the failure code", async () => {
+    const session = new LiveVoiceSession(createContext(), {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness: mock(async () => NOT_READY),
+    });
+    await expect(session.start()).rejects.toBeInstanceOf(
+      LiveVoiceSessionStartupError,
+    );
+
+    // What the manager does after a startup failure.
+    await session.close("error");
+
+    // A failed session suppresses the client-facing `metrics` frame; the end
+    // row must not be suppressed with it.
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "ended_error:credentials_unavailable",
+      outcome: "failed",
+    });
+  });
+
+  test("records exactly one ended row when close is called twice", async () => {
+    const session = readySession();
+    await session.start();
+
+    await session.close("client_end");
+    await session.close("websocket_close");
+
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("live-voice turn attribution", () => {
+  /** Drives one push-to-talk turn and returns the options the bridge saw. */
+  async function captureTurnOptions(
+    startFrame: LiveVoiceClientStartFrame,
+  ): Promise<VoiceTurnOptions> {
+    let captured: VoiceTurnOptions | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      captured = options;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const session = new LiveVoiceSession(createContext(startFrame), {
+      resolveTranscriber: mock(
+        async () =>
+          new MockStreamingTranscriber([
+            { type: "final", text: "hello" },
+            { type: "closed" },
+          ]),
+      ),
+      startVoiceTurn,
+      emitMetrics: false,
+    });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    for (let attempt = 0; attempt < 40 && !captured; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    await session.close("client_end");
+
+    if (!captured) {
+      throw new Error("the live-voice session never started a bridge turn");
+    }
+    return captured;
+  }
+
+  test("carries the session id and originating client onto the turn", async () => {
+    const options = await captureTurnOptions({ ...START_FRAME, client: "ios" });
+
+    expect(options.voiceTelemetry).toEqual({
+      sessionId: "session-123",
+      client: "ios",
+    });
+  });
+
+  test("leaves the turn's interface id alone while attributing the client", async () => {
+    const options = await captureTurnOptions({ ...START_FRAME, client: "ios" });
+
+    // The load-bearing half of the attribution fix. `userMessageInterface`
+    // resolves the turn's channel capabilities, where `macos` is what grants a
+    // live-voice turn its dynamic surfaces; reporting the true client here
+    // would strip them from every iOS session. Attribution rides
+    // `voiceTelemetry` precisely so this can stay put.
+    expect(options.userMessageInterface).toBe("macos");
+    expect(options.assistantMessageInterface).toBe("macos");
+  });
+
+  test("omits the client when the start frame declares none", async () => {
+    const options = await captureTurnOptions(START_FRAME);
+
+    expect(options.voiceTelemetry).toEqual({ sessionId: "session-123" });
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -2,7 +2,7 @@
  * Live-voice session telemetry: the started/ended funnel rows a session
  * records, and the attribution carried on its turns.
  *
- * The recorder is mocked — the outbox and its consent gate are covered by
+ * The recorder is mocked: the outbox and its consent gate are covered by
  * `telemetry-events-outbox.test.ts`. What these tests pin is the wiring that
  * decides whether a row exists at all and what it says, which is where the
  * measurement can silently go wrong: a session that fails before `ready` still

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -305,6 +305,58 @@ describe("parseLiveVoiceClientTextFrame", () => {
     expect("turnDetection" in result.frame).toBe(false);
   });
 
+  test("parses the originating client from the start frame", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        client: "ios",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.frame).toMatchObject({ type: "start", client: "ios" });
+  });
+
+  test("omits client when absent from the start frame", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect("client" in result.frame).toBe(false);
+  });
+
+  test("drops an unrecognized client rather than rejecting the session", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        client: "commodore-64",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    // The field is an analytics dimension. Failing startup over it would
+    // trade a gap in a chart for a user who cannot talk to their assistant.
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect("client" in result.frame).toBe(false);
+  });
+
   test("returns typed protocol errors for invalid turnDetection values", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -38,6 +38,10 @@ import {
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import {
+  recordLiveVoiceSessionEnded,
+  recordLiveVoiceSessionStarted,
+} from "../onboarding/onboarding-events-store.js";
 import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
@@ -54,6 +58,7 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
+import { liveVoiceEndScreen } from "../telemetry/live-voice-funnel.js";
 import { getToolOwner } from "../tools/registry.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
@@ -972,6 +977,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private outboundFrames: Promise<void> = Promise.resolve();
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
   private sessionEndMetricsEmitted = false;
+  /**
+   * Protocol error code of the failure that killed the session, latched by
+   * {@link sendFrame} when an error frame goes out on an already-`failed`
+   * session. Both fatal paths (`failStartup` before `ready`, a failed
+   * utterance arm after it) set `state = "failed"` before sending, and no
+   * other error frame does — so this catches exactly the session-ending
+   * failures and ignores the recoverable mid-session ones. `null` on a
+   * session that never failed.
+   */
+  private failureCode: LiveVoiceProtocolErrorCode | null = null;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
   // Energy gate for server-VAD speech classification; undefined defers to
@@ -1184,6 +1199,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
+    // Before the preflight, not after: a session rejected for missing
+    // credentials is precisely the one the failure rate needs to count, and
+    // recording the start only once `ready` goes out would hide every such
+    // session from both the numerator and the denominator.
+    recordLiveVoiceSessionStarted(this.context.sessionId);
+
     if (this.resolveCredentialReadiness) {
       const readiness = await this.resolveCredentialReadiness();
       if (readiness.status === "not-ready") {
@@ -1261,10 +1282,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.handleAudio(Buffer.from(chunk));
   }
 
-  async close(_reason: LiveVoiceSessionCloseReason): Promise<void> {
+  async close(reason: LiveVoiceSessionCloseReason): Promise<void> {
     if (this.isClosed) {
       return;
     }
+
+    // Recorded first, and independently of `shouldEmitSessionEndMetrics`
+    // below: that flag governs the client-facing `metrics` frame, and a
+    // failed session — which suppresses the frame — is the one whose end
+    // telemetry matters most. Session duration downstream is this row's
+    // `recorded_at` minus the started row's, so it must be written before the
+    // teardown below, which awaits a pending continuation and can run long.
+    const failed = this.state === "failed";
+    recordLiveVoiceSessionEnded({
+      sessionId: this.context.sessionId,
+      screen: liveVoiceEndScreen(reason, failed ? this.failureCode : null),
+      outcome: failed ? "failed" : "completed",
+    });
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
@@ -3807,8 +3841,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         voiceSessionId: this.context.sessionId,
         userMessageChannel: "vellum",
         assistantMessageChannel: "vellum",
+        // Fixed, and NOT the originating client: this pair resolves the turn's
+        // channel capabilities, where `macos` is what grants a live-voice turn
+        // desktop UI and dynamic surfaces. Reporting the true client here would
+        // strip `supportsDynamicUi` from every iOS session — a behavior change
+        // wearing an attribution fix's clothes. The originating client travels
+        // as telemetry instead, on `voiceTelemetry` below.
         userMessageInterface: "macos",
         assistantMessageInterface: "macos",
+        voiceTelemetry: {
+          sessionId: this.context.sessionId,
+          ...(this.context.startFrame.client
+            ? { client: this.context.startFrame.client }
+            : {}),
+        },
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {
           ...(leg.frontDoor !== undefined ? { frontDoor: leg.frontDoor } : {}),
         }),
@@ -5506,6 +5552,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // method, and a per-call-site hook would drift from it on the first frame
     // anyone added. Fire-and-forget by contract — see the reporter.
     this.liveActivityReporter.report(frame);
+    // Latched here for the same reason: both fatal paths mark the session
+    // `failed` and then send their error frame through this method, so the
+    // code that ended the session is readable at close without either path
+    // having to remember to stash it.
+    if (frame.type === "error" && this.state === "failed") {
+      this.failureCode ??= frame.code;
+    }
     let sent = false;
     this.outboundFrames = this.outboundFrames
       .catch(() => {})

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -982,7 +982,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * {@link sendFrame} when an error frame goes out on an already-`failed`
    * session. Both fatal paths (`failStartup` before `ready`, a failed
    * utterance arm after it) set `state = "failed"` before sending, and no
-   * other error frame does — so this catches exactly the session-ending
+   * other error frame does, so this catches exactly the session-ending
    * failures and ignores the recoverable mid-session ones. `null` on a
    * session that never failed.
    */
@@ -1289,7 +1289,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     // Recorded first, and independently of `shouldEmitSessionEndMetrics`
     // below: that flag governs the client-facing `metrics` frame, and a
-    // failed session — which suppresses the frame — is the one whose end
+    // failed session (which suppresses the frame) is the one whose end
     // telemetry matters most. Session duration downstream is this row's
     // `recorded_at` minus the started row's, so it must be written before the
     // teardown below, which awaits a pending continuation and can run long.
@@ -3844,7 +3844,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // Fixed, and NOT the originating client: this pair resolves the turn's
         // channel capabilities, where `macos` is what grants a live-voice turn
         // desktop UI and dynamic surfaces. Reporting the true client here would
-        // strip `supportsDynamicUi` from every iOS session — a behavior change
+        // strip `supportsDynamicUi` from every iOS session: a behavior change
         // wearing an attribution fix's clothes. The originating client travels
         // as telemetry instead, on `voiceTelemetry` below.
         userMessageInterface: "macos",

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -1,3 +1,5 @@
+import { type ClientOs, parseClientOs } from "../channels/types.js";
+
 const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "start",
   "audio",
@@ -98,6 +100,21 @@ export interface LiveVoiceClientStartFrame {
    * [{@link MIN_BARGE_IN_MIN_SPEECH_MS}, {@link MAX_BARGE_IN_MIN_SPEECH_MS}].
    */
   readonly bargeInMinSpeechMs?: number;
+  /**
+   * Which client opened the session. Absent from clients that predate the
+   * field, in which case the originating client is simply unknown.
+   *
+   * A {@link ClientOs}, not an `InterfaceId`, and deliberately so: the iOS and
+   * macOS apps run the same web bundle over the same transport, so the thing
+   * that actually differs between them is the OS surface. `ClientOs` is also
+   * the vocabulary that is barred by contract from answering transport
+   * questions (see `channels/types.ts`), which is the invariant wanted here —
+   * this value is **analytics only**. It rides the voice turn's telemetry
+   * `client` bag (see `voice-session-bridge.ts`) and never reaches
+   * `userMessageInterface`, which feeds `resolveChannelCapabilities` and is
+   * load-bearing for what a voice turn may do.
+   */
+  readonly client?: ClientOs;
 }
 
 /**
@@ -642,6 +659,11 @@ function validateStartFrame(
     );
   }
 
+  // An unrecognized client is dropped rather than rejected: the field is an
+  // analytics dimension, and failing a session's startup over it would trade a
+  // gap in a chart for a user who cannot talk to their assistant.
+  const client = parseClientOs(value.client);
+
   return {
     ok: true,
     frame: {
@@ -649,6 +671,7 @@ function validateStartFrame(
       ...(typeof value.conversationId === "string"
         ? { conversationId: value.conversationId }
         : {}),
+      ...(client ? { client } : {}),
       audio: audioConfig.frame,
       ...(isLiveVoiceTurnDetectionMode(value.turnDetection)
         ? { turnDetection: value.turnDetection }

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -108,7 +108,7 @@ export interface LiveVoiceClientStartFrame {
    * macOS apps run the same web bundle over the same transport, so the thing
    * that actually differs between them is the OS surface. `ClientOs` is also
    * the vocabulary that is barred by contract from answering transport
-   * questions (see `channels/types.ts`), which is the invariant wanted here —
+   * questions (see `channels/types.ts`), which is the invariant wanted here:
    * this value is **analytics only**. It rides the voice turn's telemetry
    * `client` bag (see `voice-session-bridge.ts`) and never reaches
    * `userMessageInterface`, which feeds `resolveChannelCapabilities` and is

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -5,9 +5,18 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "../telemetry/activation-funnel.js";
+import {
+  LIVE_VOICE_FUNNEL_VERSION,
+  LIVE_VOICE_STEPS,
+  type LiveVoiceSessionOutcome,
+  type LiveVoiceStepName,
+} from "../telemetry/live-voice-funnel.js";
 import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
+import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
+
+const log = getLogger("onboarding-events-store");
 
 /** Identity of a recorded outbox row; the full payload lives in the outbox. */
 export interface OnboardingEvent {
@@ -28,6 +37,7 @@ export interface RecordOnboardingEventParams {
   stepIndex?: number | null;
   completedAt?: string | null;
   funnelVersion?: string | null;
+  outcome?: string | null;
 }
 
 /**
@@ -52,7 +62,7 @@ function buildOnboardingTelemetryEvent(
       params.sessionId && params.stepName && params.funnelVersion
         ? buildActivationDaemonEventId(
             params.sessionId,
-            params.stepName as ActivationStepName,
+            params.stepName,
             params.funnelVersion,
           )
         : id,
@@ -72,6 +82,7 @@ function buildOnboardingTelemetryEvent(
     ...(params.stepIndex != null ? { step_index: params.stepIndex } : {}),
     ...(params.completedAt ? { completed_at: params.completedAt } : {}),
     ...(params.funnelVersion ? { funnel_version: params.funnelVersion } : {}),
+    ...(params.outcome ? { outcome: params.outcome } : {}),
     assistant_version: APP_VERSION,
   };
 }
@@ -110,4 +121,83 @@ export function recordActivationEvent(params: {
       funnelVersion: ACTIVATION_FUNNEL_VERSION,
     }),
   );
+}
+
+/**
+ * Record a live-voice session milestone (started / ended). Reuses the same
+ * onboarding telemetry substrate as {@link recordActivationEvent}, keyed by the
+ * live-voice session id so the two events pair up downstream — see
+ * `telemetry/live-voice-funnel.ts` for why duration and turn count are derived
+ * from that pairing rather than carried as fields.
+ *
+ * `screen` carries the end reason on the ended event (the started event has no
+ * dimension beyond the step itself). Returns null when usage data collection is
+ * disabled or the telemetry database is unavailable.
+ *
+ * **Never throws.** These fire from `LiveVoiceSession.start()` and `.close()`,
+ * which are the user's call itself: the outbox insert raises on a telemetry DB
+ * that is missing, locked, or mid-migration, and an uncaught raise there would
+ * fail the session rather than the measurement. A dropped row costs a gap in a
+ * chart; a raised one costs the user their conversation.
+ */
+function recordLiveVoiceEventSafely(
+  record: () => OnboardingEvent | null,
+): OnboardingEvent | null {
+  try {
+    return record();
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to record live-voice session telemetry; continuing",
+    );
+    return null;
+  }
+}
+
+export function recordLiveVoiceSessionEvent(params: {
+  stepName: LiveVoiceStepName;
+  stepIndex: number;
+  sessionId: string;
+  screen?: string;
+  outcome?: LiveVoiceSessionOutcome;
+}): OnboardingEvent | null {
+  return recordLiveVoiceEventSafely(() =>
+    recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+      buildOnboardingTelemetryEvent(id, createdAt, {
+        screen: params.screen ?? params.stepName,
+        sessionId: params.sessionId,
+        stepName: params.stepName,
+        stepIndex: params.stepIndex,
+        completedAt: new Date(createdAt).toISOString(),
+        funnelVersion: LIVE_VOICE_FUNNEL_VERSION,
+        ...(params.outcome ? { outcome: params.outcome } : {}),
+      }),
+    ),
+  );
+}
+
+/** Record the "a live-voice session was attempted" milestone. */
+export function recordLiveVoiceSessionStarted(
+  sessionId: string,
+): OnboardingEvent | null {
+  return recordLiveVoiceSessionEvent({
+    stepName: LIVE_VOICE_STEPS.sessionStarted.stepName,
+    stepIndex: LIVE_VOICE_STEPS.sessionStarted.stepIndex,
+    sessionId,
+  });
+}
+
+/** Record the "a live-voice session ended" milestone, with how it ended. */
+export function recordLiveVoiceSessionEnded(params: {
+  sessionId: string;
+  screen: string;
+  outcome: LiveVoiceSessionOutcome;
+}): OnboardingEvent | null {
+  return recordLiveVoiceSessionEvent({
+    stepName: LIVE_VOICE_STEPS.sessionEnded.stepName,
+    stepIndex: LIVE_VOICE_STEPS.sessionEnded.stepIndex,
+    sessionId: params.sessionId,
+    screen: params.screen,
+    outcome: params.outcome,
+  });
 }

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -126,7 +126,7 @@ export function recordActivationEvent(params: {
 /**
  * Record a live-voice session milestone (started / ended). Reuses the same
  * onboarding telemetry substrate as {@link recordActivationEvent}, keyed by the
- * live-voice session id so the two events pair up downstream — see
+ * live-voice session id so the two events pair up downstream. See
  * `telemetry/live-voice-funnel.ts` for why duration and turn count are derived
  * from that pairing rather than carried as fields.
  *

--- a/assistant/src/telemetry/activation-funnel.ts
+++ b/assistant/src/telemetry/activation-funnel.ts
@@ -157,10 +157,15 @@ export function activationStepIndex(stepName: ActivationStepName): number {
  * `funnel_version` so the id stays stable across a version bump — otherwise
  * queued/offline v1 rows would be keyed with the new binary's version and
  * stop collapsing with already-ingested v1 rows from the same session.
+ *
+ * `stepName` is a plain string rather than an `ActivationStepName`: every
+ * funnel riding the onboarding substrate shares this keying (the live-voice
+ * session funnel is the other one today), and the dedup property depends only
+ * on the triple being stable per row, not on which funnel produced it.
  */
 export function buildActivationDaemonEventId(
   sessionId: string,
-  stepName: ActivationStepName,
+  stepName: string,
   funnelVersion: string = ACTIVATION_FUNNEL_VERSION,
 ): string {
   return `${funnelVersion}:${sessionId}:${stepName}`;

--- a/assistant/src/telemetry/live-voice-funnel.ts
+++ b/assistant/src/telemetry/live-voice-funnel.ts
@@ -1,5 +1,5 @@
 /**
- * Live-voice session telemetry vocabulary — the single source of truth for the
+ * Live-voice session telemetry vocabulary: the single source of truth for the
  * step names, funnel version, and end-reason values the live-voice session
  * emitter uses.
  *
@@ -35,9 +35,9 @@ export const LIVE_VOICE_FUNNEL_VERSION = "live_voice_v1_2026_08";
  * is the ordinal position.
  *
  * `sessionStarted` fires for every *attempted* session, before the credential
- * preflight that can reject it — a session that fails to connect is exactly
- * the one worth counting, and gating the start event on `ready` would hide it
- * from the failure rate entirely.
+ * preflight that can reject it. A session that fails to connect is exactly the
+ * one worth counting, and gating the start event on `ready` would hide it from
+ * the failure rate entirely.
  */
 export const LIVE_VOICE_STEPS = {
   sessionStarted: { stepName: "live_voice_session_started", stepIndex: 0 },
@@ -50,7 +50,7 @@ export type LiveVoiceStepName =
 /**
  * How a session ended, stamped as `outcome`.
  *
- * `failed` means the session died on an error — a credential preflight
+ * `failed` means the session died on an error: a credential preflight
  * rejection before `ready`, or an utterance-arm failure after it. Everything
  * else, including a dropped socket, is `completed`: the session ran and then
  * stopped, and the close reason on `screen` says how.

--- a/assistant/src/telemetry/live-voice-funnel.ts
+++ b/assistant/src/telemetry/live-voice-funnel.ts
@@ -1,0 +1,75 @@
+/**
+ * Live-voice session telemetry vocabulary — the single source of truth for the
+ * step names, funnel version, and end-reason values the live-voice session
+ * emitter uses.
+ *
+ * Rides the existing onboarding telemetry substrate (`type: "onboarding"`),
+ * exactly as `activation-funnel.ts` does: the backend stores `step_name` and
+ * `funnel_version` as open strings, so this funnel needs no platform serializer
+ * and no wire-contract change.
+ *
+ * **Duration is not a field.** The onboarding event shape carries no numeric
+ * slot for it, so the two events below are keyed by the live-voice `sessionId`
+ * in `session_id` and the warehouse subtracts their `recorded_at` stamps. That
+ * yields exact percentiles rather than the bucketed-string dimension the tips
+ * and tour funnels pack into `screen`.
+ *
+ * **Turn count is not a field either.** It comes from the `turn` telemetry
+ * events voice turns already produce, which carry this session's id in their
+ * `client` bag (see `voice-session-bridge.ts`), so a turn count is a count of
+ * those rows rather than a number restated here.
+ *
+ * A session that starts and never ends is **censored, not infinite**: a daemon
+ * crash or kill emits no end event, so downstream duration math must drop
+ * unmatched `started` rows instead of treating them as open-ended sessions.
+ */
+
+import type { LiveVoiceSessionCloseReason } from "../live-voice/live-voice-session-manager.js";
+import type { LiveVoiceProtocolErrorCode } from "../live-voice/protocol.js";
+
+/** Funnel version stamped on every live-voice session event. */
+export const LIVE_VOICE_FUNNEL_VERSION = "live_voice_v1_2026_08";
+
+/**
+ * Live-voice session funnel steps. `stepName` is the wire value; `stepIndex`
+ * is the ordinal position.
+ *
+ * `sessionStarted` fires for every *attempted* session, before the credential
+ * preflight that can reject it — a session that fails to connect is exactly
+ * the one worth counting, and gating the start event on `ready` would hide it
+ * from the failure rate entirely.
+ */
+export const LIVE_VOICE_STEPS = {
+  sessionStarted: { stepName: "live_voice_session_started", stepIndex: 0 },
+  sessionEnded: { stepName: "live_voice_session_ended", stepIndex: 1 },
+} as const;
+
+export type LiveVoiceStepName =
+  (typeof LIVE_VOICE_STEPS)[keyof typeof LIVE_VOICE_STEPS]["stepName"];
+
+/**
+ * How a session ended, stamped as `outcome`.
+ *
+ * `failed` means the session died on an error — a credential preflight
+ * rejection before `ready`, or an utterance-arm failure after it. Everything
+ * else, including a dropped socket, is `completed`: the session ran and then
+ * stopped, and the close reason on `screen` says how.
+ */
+export type LiveVoiceSessionOutcome = "completed" | "failed";
+
+/**
+ * The `screen` dimension for an ended session: how it closed, plus the
+ * protocol error code when a failure is what closed it.
+ *
+ * Both halves are the daemon's own vocabulary verbatim
+ * (`LiveVoiceSessionCloseReason`, `LiveVoiceProtocolErrorCode`) rather than a
+ * mapping, so a rename on either side surfaces here as a compile error instead
+ * of a silently-empty dashboard facet. The longest pair this can produce is
+ * well inside the wire field's 64-char bound.
+ */
+export function liveVoiceEndScreen(
+  reason: LiveVoiceSessionCloseReason,
+  failureCode?: LiveVoiceProtocolErrorCode | null,
+): string {
+  return failureCode ? `ended_${reason}:${failureCode}` : `ended_${reason}`;
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -199,6 +199,7 @@ describe("connect", () => {
     expect(ws.sentJson).toEqual([
       {
         type: "start",
+        client: "web",
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         conversationId: "conv-xyz",
       },
@@ -211,8 +212,21 @@ describe("connect", () => {
     ws.open();
     expect(ws.sentJson[0]).toEqual({
       type: "start",
+      client: "web",
       audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
     });
+  });
+
+  test("reports the detected OS surface as the start frame's client", async () => {
+    const ws = await connectAndGetSocket(makeClient());
+    ws.open();
+
+    // Attribution for the daemon's voice-turn telemetry. It has to be the
+    // detected surface rather than a literal: the iOS and macOS apps run this
+    // same bundle over this same transport, so a hardcoded "web" would report
+    // every native session as a browser one. Under the test DOM (no Electron,
+    // no Capacitor) the detected surface is "web".
+    expect(ws.sentJson[0]).toMatchObject({ client: "web" });
   });
 
   test("includes turnDetection in the start frame when provided", async () => {
@@ -224,6 +238,7 @@ describe("connect", () => {
     expect(ws.sentJson).toEqual([
       {
         type: "start",
+        client: "web",
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         turnDetection: "server_vad",
       },
@@ -241,6 +256,7 @@ describe("connect", () => {
     expect(ws.sentJson).toEqual([
       {
         type: "start",
+        client: "web",
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         turnDetection: "server_vad",
         silenceThresholdMs: 1500,
@@ -631,6 +647,7 @@ describe("sendAudio", () => {
     expect(ws.sentJson).toEqual([
       {
         type: "start",
+        client: "web",
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
       },
     ]);
@@ -690,6 +707,7 @@ describe("control frames", () => {
     expect(ws.sentJson).toEqual([
       {
         type: "start",
+        client: "web",
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
       },
     ]);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -43,6 +43,7 @@ import {
   type LiveVoiceUtteranceEndServerFrame,
   parseServerFrame,
 } from "@/domains/chat/voice/live-voice/protocol";
+import { detectClientOs } from "@/runtime/platform-detection";
 
 /** Fail the session if no `ready` frame arrives within this window. */
 const CONNECT_TIMEOUT_MS = 10_000;
@@ -381,6 +382,7 @@ export class LiveVoiceChannelClient {
     const startFrame: LiveVoiceClientStartFrame = {
       type: "start",
       audio: LIVE_VOICE_AUDIO_FORMAT,
+      client: detectClientOs(),
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
       ...(this.turnDetection ? { turnDetection: this.turnDetection } : {}),
       ...(this.silenceThresholdMs !== undefined

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -5,7 +5,8 @@
  * `assistant/src/live-voice/protocol.ts`. Field names and shapes mirror that
  * module exactly so the browser client and daemon agree on the wire format.
  *
- * Pure module: no DOM / WebSocket imports.
+ * Pure module: no DOM / WebSocket imports. The one import below is a `type`,
+ * so it is erased at build time and the module stays side-effect free.
  *
  * ## Framing
  *
@@ -16,6 +17,8 @@
  * - Every server frame ({@link LiveVoiceServerFrame}) is JSON text and carries a
  *   monotonically increasing `seq` number.
  */
+
+import type { ClientOs } from "@/runtime/platform-detection";
 
 // ---------------------------------------------------------------------------
 // Client frames (text/JSON control frames; audio goes over binary frames)
@@ -68,6 +71,17 @@ export interface LiveVoiceClientStartFrame {
    * daemon use its configured default.
    */
   readonly bargeInMinSpeechMs?: number;
+  /**
+   * Which client opened the session, as a `ClientOs` surface. The iOS and
+   * macOS apps run this same bundle over this same transport, so the OS
+   * surface is the only thing that actually distinguishes them — a literal
+   * here would report every native session as `web`.
+   *
+   * Analytics only: the daemon puts it on the voice turn's telemetry `client`
+   * bag so voice turns are countable per client, and never on the turn's
+   * interface id, which decides what the turn is allowed to do.
+   */
+  readonly client?: ClientOs;
 }
 
 export interface LiveVoiceClientPttReleaseFrame {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -74,7 +74,7 @@ export interface LiveVoiceClientStartFrame {
   /**
    * Which client opened the session, as a `ClientOs` surface. The iOS and
    * macOS apps run this same bundle over this same transport, so the OS
-   * surface is the only thing that actually distinguishes them — a literal
+   * surface is the only thing that actually distinguishes them, and a literal
    * here would report every native session as `web`.
    *
    * Analytics only: the daemon puts it on the voice turn's telemetry `client`


### PR DESCRIPTION
Adds the four voice-mode measures — session started, duration, turn count, and failures — plus the turn-attribution fix that was blocking any per-client read of voice usage.

Fixes JARVIS-1456.

## Daemon-side, not client-side

All three clients drive the same `LiveVoiceSession`, so one emitter covers web, iOS and macOS. A client-measured duration also dies on tab close, refresh, crash and network drop — exactly the sessions worth measuring — whereas `close(reason)` fires on every `LiveVoiceSessionCloseReason`. And the daemon owns a typed failure vocabulary; the web store's `fail(message)` is a copy-dependent string.

Session milestones ride the existing `onboarding` substrate with open-string `step_name`/`funnel_version`, exactly as `activation-funnel.ts` does, so **no platform serializer, wire-contract, or Terraform change is needed**.

## Duration and turn count are derived, not stored

The onboarding event shape has no numeric slot, so rather than bucketing into `screen`:

- **Duration** — `live_voice_session_started` and `_ended` share the live-voice session id in `session_id`; the warehouse subtracts their `recorded_at` stamps. Exact percentiles, no buckets.
- **Turn count** — a count of the `turn` rows carrying the same id in their `client` bag.

Neither is restated as a field anyone has to keep correct. Notably the session-end metrics summary is **not** used for the turn count: `summarizeTurns` covers only the retained 50-turn window, so any longer session would have silently undercounted.

## Turn attribution

Voice turns already emitted `turn` telemetry, but every one was labelled `macos` regardless of the originating client, and carried nothing on the wire to distinguish it from a macOS *text* turn. The start frame now declares the client, which travels to the turn's `metadata.client` bag (projected onto `TurnTelemetryEvent.client`) as `voice` / `voice_session_id` / `voice_client`.

**`userMessageInterface` deliberately stays `macos`.** It feeds `resolveChannelCapabilities`, where `iface === "macos"` is what grants a live-voice turn its dynamic surfaces — reporting the true client there would strip `supportsDynamicUi` from every iOS session mid-call. That is a behavior change, not an attribution fix, so attribution and capability are answered separately. The remaining honest-interface repoint is worth its own ticket with the capability matrix worked through.

The web client sends its *detected OS surface* rather than a literal, since the iOS and macOS apps run this same bundle over this same transport and a hardcoded `"web"` would report every native session as a browser one.

## Failure safety

Recording never throws. These fire from `start()` and `close()`, and the outbox insert raises on a telemetry DB that is missing, locked, or mid-migration. A dropped row costs a gap in a chart; a raised one would cost the user their conversation.

## Testing

- New `live-voice-session-telemetry.test.ts` (9 tests): a started row exists even when the preflight rejects the session, the close reason and outcome land, a dropped socket reads `completed` while a failure carries its protocol error code, the end row survives the failed-session metrics suppression, and a double close records once.
- New bridge tests pinning the `metadata.client` bag — including that `userMessageInterface` stays `macos` while attribution rides alongside.
- New protocol tests: the client field parses, omits cleanly, and an unrecognized value is dropped rather than failing startup.
- `bun test src/live-voice/` — 410 pass, 0 fail. Both repos typecheck and lint clean.

One caveat for whoever builds the dashboard: a daemon crash emits no end row, so **unmatched `started` rows are censored, not infinite** — duration math must drop them rather than treat them as open-ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)