### PR TITLE
fix(memory): carry memory.v3.live across quarantine-reseed + repair seed-pinned assistants

### DIFF
--- a/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
+++ b/assistant/src/__tests__/workspace-migration-139-clear-renamed-cost-profile-label.test.ts
@@ -51,15 +51,15 @@ afterEach(() => {
 });
 
 describe("139-clear-renamed-cost-profile-label migration", () => {
-  test("has correct migration id and is registered last", () => {
+  test("has correct migration id and is registered", () => {
     expect(clearRenamedCostProfileLabelMigration.id).toBe(
       "139-clear-renamed-cost-profile-label",
     );
-    // getLastWorkspaceMigrationId() reports the final entry as the registry
-    // ceiling, so the highest id must stay last.
-    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
-      "139-clear-renamed-cost-profile-label",
-    );
+    expect(
+      WORKSPACE_MIGRATIONS.some(
+        (migration) => migration.id === "139-clear-renamed-cost-profile-label",
+      ),
+    ).toBe(true);
   });
 
   test("clears the seeded label so the code catalog label applies", () => {

--- a/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
+++ b/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
@@ -22,6 +22,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { repairSeedPinnedMemoryV3LiveMigration } from "../workspace/migrations/140-repair-seed-pinned-memory-v3-live.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import type { MigrationRunContext } from "../workspace/migrations/types.js";
 
 const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
@@ -100,12 +101,17 @@ function writeSelectionRows(file: string): void {
 }
 
 describe("140-repair-seed-pinned-memory-v3-live migration", () => {
-  test("has correct id and description", () => {
+  test("has correct id and is registered last", () => {
     expect(repairSeedPinnedMemoryV3LiveMigration.id).toBe(
       "140-repair-seed-pinned-memory-v3-live",
     );
     expect(repairSeedPinnedMemoryV3LiveMigration.description).toContain(
       "memory.v3.live",
+    );
+    // getLastWorkspaceMigrationId() reports the final entry as the registry
+    // ceiling, so the highest id must stay last.
+    expect(WORKSPACE_MIGRATIONS[WORKSPACE_MIGRATIONS.length - 1]?.id).toBe(
+      "140-repair-seed-pinned-memory-v3-live",
     );
   });
 

--- a/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
+++ b/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
@@ -193,6 +193,28 @@ describe("140-repair-seed-pinned-memory-v3-live migration", () => {
     expect(readLive()).toBe(false);
   });
 
+  test("finds selection rows staged under the __relocating name mid-drain", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+    db.exec(`
+      CREATE TABLE memory_v3_selections__relocating (
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        slug TEXT NOT NULL,
+        source TEXT NOT NULL
+      );
+      INSERT INTO memory_v3_selections__relocating
+        (conversation_id, turn, slug, source)
+        VALUES ('conv-1', 1, 'some-page', 'needle');
+    `);
+    db.close();
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
   test("finds selection rows in the pre-relocation assistant.db too", () => {
     writeConfig({ memory: { v3: { live: false } } });
     writeCheckpoints(FIRST_BOOT_GAP_MS);

--- a/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
+++ b/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
@@ -183,6 +183,32 @@ describe("140-repair-seed-pinned-memory-v3-live migration", () => {
     expect(readLive()).toBe(false);
   });
 
+  test("respects a hatch-time opt-out recorded in the archived default overlay", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    writeFileSync(
+      join(workspaceDir, "default-config.json"),
+      JSON.stringify({ memory: { v3: { live: false } } }, null, 2),
+    );
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("an archived overlay without a memory.v3.live opt-out does not block repair", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    writeFileSync(
+      join(workspaceDir, "default-config.json"),
+      JSON.stringify({ llm: { activeProfile: "balanced" } }, null, 2),
+    );
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(true);
+  });
+
   test("respects a deliberate opt-out: v3 selection rows exist", () => {
     writeConfig({ memory: { v3: { live: false } } });
     writeCheckpoints(FIRST_BOOT_GAP_MS);

--- a/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
+++ b/assistant/src/__tests__/workspace-migration-140-repair-seed-pinned-memory-v3-live.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for workspace migration `140-repair-seed-pinned-memory-v3-live`.
+ *
+ * The pre-#39847 first-launch seed persisted `memory.v3.live = false` before
+ * migration 105 could record the real decision, stranding brand-new
+ * assistants on v2 and demoting existing v3 assistants whose config.json was
+ * quarantined and reseeded. The repair flips `live` back to true only for
+ * those two victim classes and never over a deliberate opt-out.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairSeedPinnedMemoryV3LiveMigration } from "../workspace/migrations/140-repair-seed-pinned-memory-v3-live.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+let workspaceDir: string;
+let configPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-140-test-"));
+  configPath = join(workspaceDir, "config.json");
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath, "utf-8"));
+}
+
+function readLive(): unknown {
+  const memory = (readConfig().memory ?? {}) as Record<string, unknown>;
+  const v3 = (memory.v3 ?? {}) as Record<string, unknown>;
+  return v3.live;
+}
+
+function writeConfig(config: Record<string, unknown>): void {
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+/** A checkpoint file whose 105 entry ran `gapMs` after the earliest entry. */
+function writeCheckpoints(gapMs: number): void {
+  const base = Date.parse("2026-06-20T12:00:00.000Z");
+  writeFileSync(
+    join(workspaceDir, "data", ".workspace-migrations.json"),
+    JSON.stringify(
+      {
+        applied: {
+          "001-avatar-rename": {
+            appliedAt: new Date(base).toISOString(),
+            status: "completed",
+          },
+          "105-enable-memory-v3-live-for-new-workspaces": {
+            appliedAt: new Date(base + gapMs).toISOString(),
+            status: "completed",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+const FIRST_BOOT_GAP_MS = 5_000;
+const UPGRADE_SWEEP_GAP_MS = 30 * 24 * 60 * 60 * 1000;
+
+function writeSelectionRows(file: string): void {
+  const db = new Database(join(workspaceDir, "data", "db", file));
+  db.exec(`
+    CREATE TABLE memory_v3_selections (
+      conversation_id TEXT NOT NULL,
+      turn INTEGER NOT NULL,
+      slug TEXT NOT NULL,
+      source TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0
+    );
+    INSERT INTO memory_v3_selections (conversation_id, turn, slug, source)
+      VALUES ('conv-1', 1, 'some-page', 'needle');
+  `);
+  db.close();
+}
+
+describe("140-repair-seed-pinned-memory-v3-live migration", () => {
+  test("has correct id and description", () => {
+    expect(repairSeedPinnedMemoryV3LiveMigration.id).toBe(
+      "140-repair-seed-pinned-memory-v3-live",
+    );
+    expect(repairSeedPinnedMemoryV3LiveMigration.description).toContain(
+      "memory.v3.live",
+    );
+  });
+
+  test("flips a seed-race victim: born in the 105 era, live=false, v3 never ran", () => {
+    writeConfig({
+      memory: { v2: { enabled: true }, v3: { live: false } },
+      llm: { activeProfile: "balanced" },
+    });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(true);
+    // The rest of the config is untouched.
+    const config = readConfig();
+    expect((config.llm as Record<string, unknown>).activeProfile).toBe(
+      "balanced",
+    );
+    expect(
+      ((config.memory as Record<string, unknown>).v2 as Record<string, unknown>)
+        .enabled,
+    ).toBe(true);
+  });
+
+  test("skips new workspaces so a hatch-time opt-out override wins", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("leaves an absent leaf alone: pre-105 assistants stay on the manual-upgrade path", () => {
+    writeConfig({ memory: { v2: { enabled: true } } });
+    writeCheckpoints(UPGRADE_SWEEP_GAP_MS);
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBeUndefined();
+  });
+
+  test("leaves live=true alone (idempotent after its own repair)", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+    expect(readLive()).toBe(true);
+    const afterFirstRun = readFileSync(configPath, "utf-8");
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+    expect(readFileSync(configPath, "utf-8")).toBe(afterFirstRun);
+  });
+
+  test("skips a live=false workspace that was NOT born in the 105 era", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(UPGRADE_SWEEP_GAP_MS);
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("skips when the checkpoint file is missing (no era evidence)", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("respects a deliberate opt-out: v3 selection rows exist", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    writeSelectionRows("assistant-memory.db");
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("finds selection rows in the pre-relocation assistant.db too", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    writeSelectionRows("assistant.db");
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("an empty selections table is not usage evidence", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(FIRST_BOOT_GAP_MS);
+    const db = new Database(
+      join(workspaceDir, "data", "db", "assistant-memory.db"),
+    );
+    db.exec(
+      `CREATE TABLE memory_v3_selections (conversation_id TEXT, turn INTEGER)`,
+    );
+    db.close();
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(true);
+  });
+
+  test("quarantine carry-forward flips a demoted v3 assistant even with usage rows and an old workspace", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(UPGRADE_SWEEP_GAP_MS);
+    writeSelectionRows("assistant-memory.db");
+    writeFileSync(
+      join(workspaceDir, "config.json.corrupt-2026-08-01T10-00-00.000Z.json"),
+      JSON.stringify({ memory: { v3: { live: true } } }, null, 2),
+    );
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(true);
+  });
+
+  test("salvages live=true from a truncated (unparseable) quarantined config", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(UPGRADE_SWEEP_GAP_MS);
+    writeFileSync(
+      join(workspaceDir, "config.json.corrupt-2026-08-01T10-00-00.000Z.json"),
+      `{\n  "memory": {\n    "v3": {\n      "live": true\n    }\n  },\n  "llm": {\n    "activeProf`,
+    );
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(true);
+  });
+
+  test("the NEWEST quarantined config wins", () => {
+    writeConfig({ memory: { v3: { live: false } } });
+    writeCheckpoints(UPGRADE_SWEEP_GAP_MS);
+    writeFileSync(
+      join(workspaceDir, "config.json.corrupt-2026-07-01T10-00-00.000Z.json"),
+      JSON.stringify({ memory: { v3: { live: true } } }),
+    );
+    writeFileSync(
+      join(workspaceDir, "config.json.corrupt-2026-08-01T10-00-00.000Z.json"),
+      JSON.stringify({ memory: { v3: { live: false } } }),
+    );
+
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(readLive()).toBe(false);
+  });
+
+  test("no-ops when config.json is missing or corrupt", () => {
+    // Missing.
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+    expect(existsSync(configPath)).toBe(false);
+
+    // Corrupt.
+    writeFileSync(configPath, "{ not json");
+    repairSeedPinnedMemoryV3LiveMigration.run(workspaceDir, UPGRADE_CTX);
+    expect(readFileSync(configPath, "utf-8")).toBe("{ not json");
+  });
+});

--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -1,6 +1,7 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -266,5 +267,77 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
       unknown
     >;
     expect(v3Raw.live).toBe(true);
+  });
+
+  describe("quarantine-reseed carries memory.v3.live forward", () => {
+    function removeQuarantineFiles(): void {
+      for (const name of readdirSync(WORKSPACE_DIR)) {
+        if (name.startsWith("config.json.corrupt-")) {
+          rmSync(join(WORKSPACE_DIR, name), { force: true });
+        }
+      }
+    }
+
+    function readV3Raw(): Record<string, unknown> {
+      const raw = readConfig();
+      return ((raw.memory as Record<string, unknown>).v3 ?? {}) as Record<
+        string,
+        unknown
+      >;
+    }
+
+    afterEach(() => {
+      removeQuarantineFiles();
+    });
+
+    test("a corrupt live-v3 config is quarantined and the reseed keeps live=true", () => {
+      // Truncated mid-write JSON from a memory-v3 assistant: unparseable,
+      // but the live flag survives in the raw text.
+      writeFileSync(
+        CONFIG_PATH,
+        `{\n  "memory": {\n    "v3": {\n      "live": true\n    }\n  },\n  "llm": {\n    "activeProf`,
+      );
+
+      const config = loadConfig();
+
+      // The corrupt file was quarantined and the reseeded config carries the
+      // tier forward, both in-memory (this boot runs v3) and on disk
+      // (migration 105 is checkpointed on existing workspaces and never
+      // re-runs, so the persisted value is the only durable record).
+      expect(config.memory.v3.live).toBe(true);
+      expect(readV3Raw()).toEqual({ live: true });
+    });
+
+    test("a corrupt config without live=true reseeds with the leaf absent", () => {
+      writeFileSync(
+        CONFIG_PATH,
+        `{\n  "memory": {\n    "v3": {\n      "live": false\n    }\n  },\n  "llm": {\n    "activeProf`,
+      );
+
+      const config = loadConfig();
+
+      // Never carry `false` forward: an absent leaf is the only way to keep
+      // "no decision recorded" representable for migration 105.
+      expect(config.memory.v3.live).toBe(false);
+      expect(readV3Raw()).toEqual({});
+    });
+
+    test("a deleted config with an earlier live-v3 quarantine still carries live=true", () => {
+      if (existsSync(CONFIG_PATH)) {
+        rmSync(CONFIG_PATH, { force: true });
+      }
+      writeFileSync(
+        join(
+          WORKSPACE_DIR,
+          "config.json.corrupt-2026-08-01T10-00-00.000Z.json",
+        ),
+        JSON.stringify({ memory: { v3: { live: true } } }, null, 2),
+      );
+
+      const config = loadConfig();
+
+      expect(config.memory.v3.live).toBe(true);
+      expect(readV3Raw()).toEqual({ live: true });
+    });
   });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -328,7 +328,7 @@ function writeQuarantineNotice(
  *
  * The first-launch seed asks this so a quarantine-reseed carries the memory
  * tier forward: without it, reseeding an existing memory-v3 assistant
- * silently demotes it to v2 — the reseeded file records no `live` decision,
+ * silently demotes it to v2: the reseeded file records no `live` decision,
  * migration 105 is already checkpointed on an existing workspace and never
  * re-runs, and the schema default is `false`. Only `true` is ever salvaged:
  * carrying `false` forward would re-pin a workspace to the schema default,
@@ -1188,7 +1188,7 @@ export function loadConfig(): AssistantConfig {
         // Exception: a quarantine-reseed carries the memory tier forward.
         // When the missing config.json is explained by a quarantined
         // predecessor that had `live: true`, this is an EXISTING memory-v3
-        // assistant being reseeded, not a first launch — migration 105 is
+        // assistant being reseeded, not a first launch: migration 105 is
         // already checkpointed here and never re-runs, so leaving the leaf
         // absent would silently demote the assistant to v2. Persist the
         // carried value and apply it to this load's effective config so the

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1196,6 +1196,12 @@ export function loadConfig(): AssistantConfig {
         if (quarantinedConfigSaidMemoryV3Live(configPath)) {
           seed.memory.v3 = { live: true } as (typeof seed.memory)["v3"];
           config.memory.v3.live = true;
+          // Refresh the last-known-good safety net (mirrors the
+          // deployment-context refresh above): its snapshot was taken before
+          // the carry, so a later in-process validation recovery would
+          // otherwise restore live=false and demote the assistant in memory
+          // despite the reseeded file on disk carrying true.
+          lastKnownGoodConfig = structuredClone(config);
           log.info(
             "Carried memory.v3.live=true forward from the quarantined config",
           );

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -1,12 +1,13 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { safeStatSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
@@ -316,6 +317,53 @@ function writeQuarantineNotice(
       `Failed to write config-quarantine notice; the quarantine event is ` +
         `still recorded in the assistant logs.`,
     );
+  }
+}
+
+/**
+ * Whether the newest quarantined config next to `configPath`
+ * (`config.json.corrupt-*.json`, written by {@link quarantineCorruptConfig})
+ * carried `memory.v3.live: true`. Quarantine filenames embed a
+ * filesystem-safe ISO timestamp, so a lexicographic sort is chronological.
+ *
+ * The first-launch seed asks this so a quarantine-reseed carries the memory
+ * tier forward: without it, reseeding an existing memory-v3 assistant
+ * silently demotes it to v2 — the reseeded file records no `live` decision,
+ * migration 105 is already checkpointed on an existing workspace and never
+ * re-runs, and the schema default is `false`. Only `true` is ever salvaged:
+ * carrying `false` forward would re-pin a workspace to the schema default,
+ * the exact bug the seed's absent-leaf contract exists to prevent.
+ *
+ * A quarantined file usually fails `JSON.parse` (that is why it was
+ * quarantined); every config writer serializes via
+ * `JSON.stringify(config, null, 2)` and `memory.v3.live` is the only config
+ * key named `"live"`, so a literal `"live": true` match on the raw text is
+ * an unambiguous fallback for truncated files.
+ */
+function quarantinedConfigSaidMemoryV3Live(configPath: string): boolean {
+  try {
+    const dir = dirname(configPath);
+    const prefix = `${basename(configPath)}.corrupt-`;
+    const quarantines = readdirSync(dir)
+      .filter((name) => name.startsWith(prefix) && name.endsWith(".json"))
+      .sort();
+    const newest = quarantines[quarantines.length - 1];
+    if (!newest) {
+      return false;
+    }
+    const raw = readFileSync(join(dir, newest), "utf-8");
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!isPlainObject(parsed) || !isPlainObject(parsed.memory)) {
+        return false;
+      }
+      const v3 = parsed.memory.v3;
+      return isPlainObject(v3) && v3.live === true;
+    } catch {
+      return /"live"\s*:\s*true/.test(raw);
+    }
+  } catch {
+    return false;
   }
 }
 
@@ -1137,6 +1185,21 @@ export function loadConfig(): AssistantConfig {
         // `memory.v3.live=false` override still wins by merging after
         // migrations.
         seed.memory.v3 = {} as (typeof seed.memory)["v3"];
+        // Exception: a quarantine-reseed carries the memory tier forward.
+        // When the missing config.json is explained by a quarantined
+        // predecessor that had `live: true`, this is an EXISTING memory-v3
+        // assistant being reseeded, not a first launch — migration 105 is
+        // already checkpointed here and never re-runs, so leaving the leaf
+        // absent would silently demote the assistant to v2. Persist the
+        // carried value and apply it to this load's effective config so the
+        // current boot already runs v3.
+        if (quarantinedConfigSaidMemoryV3Live(configPath)) {
+          seed.memory.v3 = { live: true } as (typeof seed.memory)["v3"];
+          config.memory.v3.live = true;
+          log.info(
+            "Carried memory.v3.live=true forward from the quarantined config",
+          );
+        }
         // Strip dataDir (runtime-derived) from the persisted config
         const { dataDir: _, ...persistable } = seed;
         writeFileSync(configPath, JSON.stringify(persistable, null, 2) + "\n");

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -196,7 +196,7 @@ interface TierKeyExemption {
  *   shape.
  * - `telemetry/config-setting-snapshot.ts` (both) — reports both tier keys
  *   as-is.
- * - the six named migrations — append-only history that rewrites or reads the
+ * - the named migrations — append-only history that rewrites or reads the
  *   historical tier keys it was written for. Listed per file, not per
  *   directory: a future migration reading a tier key is a new decision and
  *   gets challenged like any other.
@@ -256,6 +256,10 @@ const TIER_KEY_READ_ALLOWLIST: readonly TierKeyExemption[] = [
   {
     path: "src/workspace/migrations/135-copy-substrate-tunables.ts",
     keys: ["substrate", "v2"],
+  },
+  {
+    path: "src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts",
+    keys: ["v3"],
   },
 ];
 

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -196,7 +196,7 @@ interface TierKeyExemption {
  *   shape.
  * - `telemetry/config-setting-snapshot.ts` (both) — reports both tier keys
  *   as-is.
- * - the named migrations — append-only history that rewrites or reads the
+ * - the named migrations: append-only history that rewrites or reads the
  *   historical tier keys it was written for. Listed per file, not per
  *   directory: a future migration reading a tier key is a new decision and
  *   gets challenged like any other.

--- a/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
+++ b/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
@@ -24,15 +24,17 @@ import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
  *   reseed, so the current `false` is the seed's stamp.
  * - Seed-race repair: the workspace was created during the migration-105 era
  *   (105 completed in the first-boot sweep, i.e. at effectively the same
- *   time as the workspace's earliest checkpoint) AND memory-v3 never ran
- *   (no `memory_v3_selections` rows in either database). A deliberate
+ *   time as the workspace's earliest checkpoint), the archived hatch-time
+ *   overlay (`default-config.json`) records no `live: false` opt-out, AND
+ *   memory-v3 never ran (no `memory_v3_selections` rows in either database,
+ *   including the mid-drain `__relocating` staging name). A deliberate
  *   opt-out on such a workspace requires flipping v3 off before its first
  *   selection is logged; a workspace that DID run v3 and now reads `false`
  *   is treated as an opt-out and left alone.
  *
  * Everything else is skipped: `live` absent means a pre-105 assistant on the
- * deliberate manual-upgrade path (tier movement stays user-initiated), and
- * new workspaces are migration 105's job, and a post-#39847 hatch-time
+ * deliberate manual-upgrade path (tier movement stays user-initiated), while
+ * new workspaces are migration 105's job, where a post-#39847 hatch-time
  * `memory.v3.live=false` override merges after migrations and must win.
  */
 
@@ -137,6 +139,27 @@ function wasCreatedInMigration105Era(workspaceDir: string): boolean {
 }
 
 /**
+ * Whether a hatch-time default workspace overlay recorded a deliberate
+ * memory-v3 opt-out. `mergeDefaultWorkspaceConfig()` archives the consumed
+ * overlay to `default-config.json` next to config.json; an overlay carrying
+ * `memory.v3.live: false` merged AFTER workspace migrations, so the
+ * persisted `false` is the user's hatch-time choice, not the seed's stamp,
+ * even though the workspace otherwise fingerprints as a seed-race victim
+ * (born in the 105 era, no v3 selection rows).
+ */
+function hatchOverlayOptedOut(workspaceDir: string): boolean {
+  try {
+    const raw = readFileSync(
+      join(workspaceDir, "default-config.json"),
+      "utf-8",
+    );
+    return readMemoryV3Live(JSON.parse(raw)) === false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Whether memory-v3 ever ran a selection on this workspace. The
  * `memory_v3_selections` table lives in `assistant-memory.db` after DB
  * migration 338 and in `assistant.db` before it; both are checked, along
@@ -213,6 +236,9 @@ export const repairSeedPinnedMemoryV3LiveMigration: WorkspaceMigration = {
 
     if (!quarantinedConfigSaidLiveTrue(workspaceDir)) {
       if (!wasCreatedInMigration105Era(workspaceDir)) {
+        return;
+      }
+      if (hatchOverlayOptedOut(workspaceDir)) {
         return;
       }
       if (memoryV3EverRan(workspaceDir)) {

--- a/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
+++ b/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
@@ -8,7 +8,7 @@ import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
  * Repair assistants stuck on `memory.v3.live = false` by the first-launch
  * seed race fixed in #39847: the seed used to persist the schema default
  * (`false`) ~200ms before migration 105 ran, and 105's `"live" in v3Config`
- * guard then bailed — so a brand-new workspace that should have come up on
+ * guard then bailed: a brand-new workspace that should have come up on
  * memory-v3 ran v2 forever, with no signal to the user. 105 is checkpointed
  * as applied and never re-runs, so nothing self-heals the stamped value.
  *
@@ -20,7 +20,7 @@ import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
  * the seed, never over a deliberate opt-out:
  *
  * - Quarantine carry-forward: the newest quarantined config next to
- *   config.json says `live: true` — the assistant WAS on v3 before the
+ *   config.json says `live: true`, meaning the assistant WAS on v3 before the
  *   reseed, so the current `false` is the seed's stamp.
  * - Seed-race repair: the workspace was created during the migration-105 era
  *   (105 completed in the first-boot sweep, i.e. at effectively the same
@@ -32,7 +32,7 @@ import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
  *
  * Everything else is skipped: `live` absent means a pre-105 assistant on the
  * deliberate manual-upgrade path (tier movement stays user-initiated), and
- * new workspaces are migration 105's job — a post-#39847 hatch-time
+ * new workspaces are migration 105's job, and a post-#39847 hatch-time
  * `memory.v3.live=false` override merges after migrations and must win.
  */
 
@@ -96,7 +96,7 @@ function quarantinedConfigSaidLiveTrue(workspaceDir: string): boolean {
 }
 
 /**
- * Whether migration 105 completed in this workspace's first-boot sweep —
+ * Whether migration 105 completed in this workspace's first-boot sweep,
  * i.e. the workspace was CREATED in the era where 105 should have flipped it
  * to v3. On an older workspace 105 arrives in an upgrade sweep long after
  * the earliest checkpoint, so the gap exceeds the tolerance.

--- a/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
+++ b/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
@@ -1,0 +1,229 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair assistants stuck on `memory.v3.live = false` by the first-launch
+ * seed race fixed in #39847: the seed used to persist the schema default
+ * (`false`) ~200ms before migration 105 ran, and 105's `"live" in v3Config`
+ * guard then bailed — so a brand-new workspace that should have come up on
+ * memory-v3 ran v2 forever, with no signal to the user. 105 is checkpointed
+ * as applied and never re-runs, so nothing self-heals the stamped value.
+ *
+ * The same stamp lands on an EXISTING v3 assistant whose config.json is
+ * quarantined (corrupt JSON → renamed to `config.json.corrupt-<ts>.json`)
+ * and reseeded: the reseed silently demotes it to v2.
+ *
+ * Flips `live` to `true` only when the `false` on disk is attributable to
+ * the seed, never over a deliberate opt-out:
+ *
+ * - Quarantine carry-forward: the newest quarantined config next to
+ *   config.json says `live: true` — the assistant WAS on v3 before the
+ *   reseed, so the current `false` is the seed's stamp.
+ * - Seed-race repair: the workspace was created during the migration-105 era
+ *   (105 completed in the first-boot sweep, i.e. at effectively the same
+ *   time as the workspace's earliest checkpoint) AND memory-v3 never ran
+ *   (no `memory_v3_selections` rows in either database). A deliberate
+ *   opt-out on such a workspace requires flipping v3 off before its first
+ *   selection is logged; a workspace that DID run v3 and now reads `false`
+ *   is treated as an opt-out and left alone.
+ *
+ * Everything else is skipped: `live` absent means a pre-105 assistant on the
+ * deliberate manual-upgrade path (tier movement stays user-initiated), and
+ * new workspaces are migration 105's job — a post-#39847 hatch-time
+ * `memory.v3.live=false` override merges after migrations and must win.
+ */
+
+const MIGRATION_105_ID = "105-enable-memory-v3-live-for-new-workspaces";
+
+/** How close migration 105's checkpoint must be to the workspace's earliest
+ *  checkpoint to count as "completed in the first-boot sweep". The sweep
+ *  itself takes seconds; the margin absorbs a crash-restart mid-sweep. */
+const FIRST_BOOT_SWEEP_TOLERANCE_MS = 60 * 60 * 1000;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `memory.v3.live` from a parsed config-shaped value, or undefined. */
+function readMemoryV3Live(config: unknown): unknown {
+  if (!isPlainObject(config)) {
+    return undefined;
+  }
+  const memory = config.memory;
+  if (!isPlainObject(memory)) {
+    return undefined;
+  }
+  const v3 = memory.v3;
+  if (!isPlainObject(v3)) {
+    return undefined;
+  }
+  return v3.live;
+}
+
+/**
+ * Whether the newest quarantined config (`config.json.corrupt-*.json`)
+ * carried `memory.v3.live: true`. Quarantine filenames embed a
+ * filesystem-safe ISO timestamp, so a lexicographic sort is chronological.
+ * A quarantined file is usually truncated JSON; every config writer
+ * serializes via `JSON.stringify(config, null, 2)` and `memory.v3.live` is
+ * the only config key named `"live"`, so when parsing fails a literal
+ * `"live": true` match is unambiguous.
+ */
+function quarantinedConfigSaidLiveTrue(workspaceDir: string): boolean {
+  try {
+    const entries = readdirSync(workspaceDir)
+      .filter(
+        (name) =>
+          name.startsWith("config.json.corrupt-") && name.endsWith(".json"),
+      )
+      .sort();
+    const newest = entries[entries.length - 1];
+    if (!newest) {
+      return false;
+    }
+    const raw = readFileSync(join(workspaceDir, newest), "utf-8");
+    try {
+      return readMemoryV3Live(JSON.parse(raw)) === true;
+    } catch {
+      return /"live"\s*:\s*true/.test(raw);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether migration 105 completed in this workspace's first-boot sweep —
+ * i.e. the workspace was CREATED in the era where 105 should have flipped it
+ * to v3. On an older workspace 105 arrives in an upgrade sweep long after
+ * the earliest checkpoint, so the gap exceeds the tolerance.
+ */
+function wasCreatedInMigration105Era(workspaceDir: string): boolean {
+  try {
+    const raw = readFileSync(
+      join(workspaceDir, "data", ".workspace-migrations.json"),
+      "utf-8",
+    );
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed) || !isPlainObject(parsed.applied)) {
+      return false;
+    }
+    let earliest = Number.POSITIVE_INFINITY;
+    let applied105 = Number.NaN;
+    for (const [id, entry] of Object.entries(parsed.applied)) {
+      if (!isPlainObject(entry) || typeof entry.appliedAt !== "string") {
+        continue;
+      }
+      const at = Date.parse(entry.appliedAt);
+      if (!Number.isFinite(at)) {
+        continue;
+      }
+      earliest = Math.min(earliest, at);
+      if (id === MIGRATION_105_ID) {
+        applied105 = at;
+      }
+    }
+    return (
+      Number.isFinite(applied105) &&
+      Number.isFinite(earliest) &&
+      applied105 - earliest < FIRST_BOOT_SWEEP_TOLERANCE_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether memory-v3 ever ran a selection on this workspace. The
+ * `memory_v3_selections` table lives in `assistant-memory.db` after DB
+ * migration 338 and in `assistant.db` before it; both are checked. A
+ * database file that exists but cannot be read counts as "may have run v3"
+ * so an unreadable database never causes an opt-out to be overridden.
+ */
+function memoryV3EverRan(workspaceDir: string): boolean {
+  for (const file of ["assistant-memory.db", "assistant.db"]) {
+    const dbPath = join(workspaceDir, "data", "db", file);
+    if (!existsSync(dbPath)) {
+      continue;
+    }
+    let db: Database | null = null;
+    try {
+      db = new Database(dbPath, { readonly: true });
+      const table = db
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_v3_selections'`,
+        )
+        .get();
+      if (!table) {
+        continue;
+      }
+      const row = db.query(`SELECT 1 FROM memory_v3_selections LIMIT 1`).get();
+      if (row) {
+        return true;
+      }
+    } catch {
+      return true;
+    } finally {
+      db?.close();
+    }
+  }
+  return false;
+}
+
+export const repairSeedPinnedMemoryV3LiveMigration: WorkspaceMigration = {
+  id: "140-repair-seed-pinned-memory-v3-live",
+  description:
+    "Re-flip memory.v3.live=true for assistants the pre-#39847 first-launch seed pinned to false (seed-race and quarantine-reseed victims), leaving deliberate opt-outs alone",
+
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // New workspaces are migration 105's job, and a post-#39847 hatch-time
+    // memory.v3.live=false override (merged after migrations) must win.
+    if (ctx?.isNewWorkspace) {
+      return;
+    }
+
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+    let config: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      config = parsed;
+    } catch {
+      return;
+    }
+
+    // Only a persisted explicit `false` is repairable: `true` is healthy and
+    // an absent leaf is a pre-105 assistant on the manual-upgrade path.
+    if (readMemoryV3Live(config) !== false) {
+      return;
+    }
+
+    if (!quarantinedConfigSaidLiveTrue(workspaceDir)) {
+      if (!wasCreatedInMigration105Era(workspaceDir)) {
+        return;
+      }
+      if (memoryV3EverRan(workspaceDir)) {
+        return;
+      }
+    }
+
+    // Narrow-write: only the one leaf changes; the shape was validated above.
+    const memory = config.memory as Record<string, unknown>;
+    const v3 = memory.v3 as Record<string, unknown>;
+    v3.live = true;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: cannot distinguish this repair from a user's explicit
+    // choice after the fact (mirrors migration 105).
+  },
+};

--- a/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
+++ b/assistant/src/workspace/migrations/140-repair-seed-pinned-memory-v3-live.ts
@@ -139,11 +139,14 @@ function wasCreatedInMigration105Era(workspaceDir: string): boolean {
 /**
  * Whether memory-v3 ever ran a selection on this workspace. The
  * `memory_v3_selections` table lives in `assistant-memory.db` after DB
- * migration 338 and in `assistant.db` before it; both are checked. A
+ * migration 338 and in `assistant.db` before it; both are checked, along
+ * with the `__relocating` staging name the relocation renames the source to
+ * mid-drain (a crash there leaves the rows only under the staging name). A
  * database file that exists but cannot be read counts as "may have run v3"
  * so an unreadable database never causes an opt-out to be overridden.
  */
 function memoryV3EverRan(workspaceDir: string): boolean {
+  const tables = ["memory_v3_selections", "memory_v3_selections__relocating"];
   for (const file of ["assistant-memory.db", "assistant.db"]) {
     const dbPath = join(workspaceDir, "data", "db", file);
     if (!existsSync(dbPath)) {
@@ -152,17 +155,19 @@ function memoryV3EverRan(workspaceDir: string): boolean {
     let db: Database | null = null;
     try {
       db = new Database(dbPath, { readonly: true });
-      const table = db
-        .query(
-          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_v3_selections'`,
-        )
-        .get();
-      if (!table) {
-        continue;
-      }
-      const row = db.query(`SELECT 1 FROM memory_v3_selections LIMIT 1`).get();
-      if (row) {
-        return true;
+      for (const table of tables) {
+        const exists = db
+          .query(
+            `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+          )
+          .get(table);
+        if (!exists) {
+          continue;
+        }
+        const row = db.query(`SELECT 1 FROM "${table}" LIMIT 1`).get();
+        if (row) {
+          return true;
+        }
       }
     } catch {
       return true;

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -137,6 +137,7 @@ import { repairStaleFireworksKimiModelIdMigration } from "./136-repair-stale-fir
 import { repairRetiredFireworksMinimaxModelIdMigration } from "./137-repair-retired-fireworks-minimax-model-id.js";
 import { backfillHomeFeedTitlesMigration } from "./138-backfill-home-feed-titles.js";
 import { clearRenamedCostProfileLabelMigration } from "./139-clear-renamed-cost-profile-label.js";
+import { repairSeedPinnedMemoryV3LiveMigration } from "./140-repair-seed-pinned-memory-v3-live.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -289,4 +290,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairRetiredFireworksMinimaxModelIdMigration,
   backfillHomeFeedTitlesMigration,
   clearRenamedCostProfileLabelMigration,
+  repairSeedPinnedMemoryV3LiveMigration,
 ];


### PR DESCRIPTION
## Summary
- First-launch seed now carries `memory.v3.live=true` forward from the newest quarantined config (`config.json.corrupt-*.json`) when it reseeds an existing workspace, so a corrupt-config quarantine no longer silently demotes a memory-v3 assistant to v2 (migration 105 is checkpointed and never re-runs, so the demotion was permanent).
- New workspace migration `140-repair-seed-pinned-memory-v3-live` re-flips assistants already stuck at `live: false` by the pre-#39847 seed race or a quarantine-reseed: it flips when the quarantined predecessor said `live: true`, or when the workspace was born in the migration-105 era (105 completed in the first-boot sweep) and `memory_v3_selections` has no rows in either database. Deliberate opt-outs survive: absent leaf untouched, opted-out assistants that actually ran v3 untouched, new workspaces skipped so a hatch-time `memory.v3.live=false` override wins.
- Tests: per-file green for the new migration suite (14 tests) and the extended seed/carry-forward loader suite; existing migration-105 suite unaffected.

## Original prompt
Follow-up to #39847 (first-launch seed pinned `memory.v3.live=false` before migration 105 could flip new assistants to v3 — ~8% of new hatches, 100% of Docker hatches, 215 stuck). Investigating a Slack report showed a second victim class: an existing v3 assistant whose config.json got corrupted was quarantined and reseeded with the stamp, silently demoting it to v2 — undetected because v2 reads the same concept pages, with only the memory-graph upgrade card revealing the state. The ask: (1) carry `memory.v3.live` forward across quarantine-reseed so existing v3 assistants are never demoted, and (2) a repair migration for the already-stuck cohort that never overrides a deliberate user opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)