### PR TITLE
fix(desktop): allow connecting a second Microsoft account

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -726,7 +726,15 @@ export const PROVIDER_SEED_DATA: Record<
     ],
     availableScopes:
       "https://learn.microsoft.com/en-us/graph/permissions-reference",
-    authorizeParams: { prompt: "consent" },
+    // `select_account`, not `consent`: the Microsoft identity platform accepts
+    // a single prompt value, and `consent` honours an existing session cookie —
+    // it re-asks for consent but never for *which* account, so a user who
+    // already signed in cannot connect a second mailbox. `select_account`
+    // always shows the account picker with its "Use another account" option.
+    // Consent is still collected for an account that has not granted it, and
+    // refresh tokens come from the `offline_access` scope above, so nothing is
+    // lost by dropping `consent`.
+    authorizeParams: { prompt: "select_account" },
     tokenEndpointAuthMethod: "client_secret_post",
     loopbackPort: 17334,
     managedServiceConfigKey: "outlook-oauth",

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import path from "node:path";
 
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
-import { trackAuthPopupSignInState } from "@vellumai/electron-utils/auth-popup-session";
+import { createAuthPopupSignInTracker } from "@vellumai/electron-utils/auth-popup-session";
 import {
   pairedGatewayTargetsFromLockfile,
   readAllowedGatewayPorts,
@@ -577,6 +577,18 @@ app.on("web-contents-created", (_event, contents) => {
     else log.info(line);
   });
 
+  // Sign-in isolation for the connect / OAuth popups below. Created per
+  // opener so the marked-window flag cannot cross windows.
+  const authPopups = createAuthPopupSignInTracker({
+    cookies: () => session.defaultSession.cookies,
+    onCleared: (hosts, removed) =>
+      log.info(
+        `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
+      ),
+    onError: (err) =>
+      log.warn("[auth-popup] failed to clear sign-in cookies:", err),
+  });
+
   contents.setWindowOpenHandler(({ url, disposition }) => {
     // Programmatic popups (`window.open(url, name, features)` with size
     // hints) come through as `new-window` disposition. The web app's OAuth /
@@ -587,6 +599,11 @@ app.on("web-contents-created", (_event, contents) => {
     // handle is returned to the renderer for the subsequent postMessage
     // callback chain.
     if (disposition === "new-window" && url === "about:blank") {
+      // That deferred-navigation shape is what identifies an authorization
+      // surface: a plain link popup always opens at its real URL. Only these
+      // get their third-party sign-in cookies swept on close, so closing a
+      // Slack / GitHub / Discord link window leaves those sessions intact.
+      authPopups.markNextChildAsAuthPopup();
       return {
         action: "allow",
         overrideBrowserWindowOptions: {
@@ -626,24 +643,15 @@ app.on("web-contents-created", (_event, contents) => {
     return { action: "deny" };
   });
 
-  // Every child window the renderer opens is a connect / OAuth surface, and an
-  // in-app one has no address bar, profile switcher, or provider sign-out page
-  // to fall back on. Left alone, the identity provider's SSO cookie sticks
-  // around in the app's session and every later authorization silently reuses
-  // the first account — Microsoft skips the account picker outright. Treat each
-  // popup as a throwaway sign-in surface: drop the third-party sign-in cookies
-  // it left behind once it closes, so the next connect starts signed out and
-  // the provider asks who you are. Vellum's own cookies are never touched.
+  // Sweep the sign-in cookies of the popups marked above once they close. An
+  // in-app authorization window has no address bar, profile switcher, or
+  // provider sign-out page to fall back on, so without this the identity
+  // provider's SSO cookie sticks around in the app's session and every later
+  // authorization silently reuses the first account — Microsoft skips the
+  // account picker outright. Unmarked child windows (plain link opens) keep
+  // their cookies, as do Vellum's own.
   contents.on("did-create-window", (window) => {
-    trackAuthPopupSignInState(window, {
-      cookies: () => session.defaultSession.cookies,
-      onCleared: (hosts, removed) =>
-        log.info(
-          `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
-        ),
-      onError: (err) =>
-        log.warn("[auth-popup] failed to clear sign-in cookies:", err),
-    });
+    authPopups.trackCreatedChild(window);
   });
 });
 

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -1,10 +1,11 @@
 import "./env-seed";
-import { app, net, protocol, shell } from "electron";
+import { app, net, protocol, session, shell } from "electron";
 import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
+import { trackAuthPopupSignInState } from "@vellumai/electron-utils/auth-popup-session";
 import {
   pairedGatewayTargetsFromLockfile,
   readAllowedGatewayPorts,
@@ -623,6 +624,26 @@ app.on("web-contents-created", (_event, contents) => {
     // Plain target=_blank link clicks → system browser.
     void shell.openExternal(url);
     return { action: "deny" };
+  });
+
+  // Every child window the renderer opens is a connect / OAuth surface, and an
+  // in-app one has no address bar, profile switcher, or provider sign-out page
+  // to fall back on. Left alone, the identity provider's SSO cookie sticks
+  // around in the app's session and every later authorization silently reuses
+  // the first account — Microsoft skips the account picker outright. Treat each
+  // popup as a throwaway sign-in surface: drop the third-party sign-in cookies
+  // it left behind once it closes, so the next connect starts signed out and
+  // the provider asks who you are. Vellum's own cookies are never touched.
+  contents.on("did-create-window", (window) => {
+    trackAuthPopupSignInState(window, {
+      cookies: () => session.defaultSession.cookies,
+      onCleared: (hosts, removed) =>
+        log.info(
+          `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
+        ),
+      onError: (err) =>
+        log.warn("[auth-popup] failed to clear sign-in cookies:", err),
+    });
   });
 });
 

--- a/clients/windows/package.json
+++ b/clients/windows/package.json
@@ -14,8 +14,8 @@
     "dev:electron": "wait-on --timeout 30000 http://localhost:5173 && electron-vite dev",
     "build": "electron-vite build",
     "typecheck": "bunx tsc --noEmit",
-    "test": "bun test ../../packages/electron-utils/src/app-protocol.test.ts",
-    "test:ci": "bun test ../../packages/electron-utils/src/app-protocol.test.ts",
+    "test": "bun test ../../packages/electron-utils/src",
+    "test:ci": "bun test ../../packages/electron-utils/src",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../windows && mkdir -p resources && rm -rf resources/web-dist && cp -R ../web/dist resources/web-dist",
     "pack": "bun run build && electron-builder --win --config electron-builder.config.cjs --publish never"
   },

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -1,11 +1,12 @@
 import "./env-seed";
 
-import { app, net, protocol, shell } from "electron";
+import { app, net, protocol, session, shell } from "electron";
 import fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
+import { trackAuthPopupSignInState } from "@vellumai/electron-utils/auth-popup-session";
 import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 import { z } from "zod";
 
@@ -269,6 +270,26 @@ app.on("web-contents-created", (_event, contents) => {
     // Plain target=_blank link clicks → system browser.
     void shell.openExternal(url);
     return { action: "deny" };
+  });
+
+  // Every child window the renderer opens is a connect / OAuth surface, and an
+  // in-app one has no address bar, profile switcher, or provider sign-out page
+  // to fall back on. Left alone, the identity provider's SSO cookie sticks
+  // around in the app's session and every later authorization silently reuses
+  // the first account - Microsoft skips the account picker outright. Treat each
+  // popup as a throwaway sign-in surface: drop the third-party sign-in cookies
+  // it left behind once it closes, so the next connect starts signed out and
+  // the provider asks who you are. Vellum's own cookies are never touched.
+  contents.on("did-create-window", (window) => {
+    trackAuthPopupSignInState(window, {
+      cookies: () => session.defaultSession.cookies,
+      onCleared: (hosts, removed) =>
+        log.info(
+          `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
+        ),
+      onError: (err) =>
+        log.warn("[auth-popup] failed to clear sign-in cookies:", err),
+    });
   });
 });
 

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import path from "node:path";
 
 import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
-import { trackAuthPopupSignInState } from "@vellumai/electron-utils/auth-popup-session";
+import { createAuthPopupSignInTracker } from "@vellumai/electron-utils/auth-popup-session";
 import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
 import { z } from "zod";
 
@@ -224,8 +224,27 @@ app.on("web-contents-created", (_event, contents) => {
     }
   });
 
+  // Sign-in isolation for the connect / OAuth popups below. Created per
+  // opener so the marked-window flag cannot cross windows.
+  const authPopups = createAuthPopupSignInTracker({
+    cookies: () => session.defaultSession.cookies,
+    onCleared: (hosts, removed) =>
+      log.info(
+        `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
+      ),
+    onError: (err) =>
+      log.warn("[auth-popup] failed to clear sign-in cookies:", err),
+  });
+
   contents.setWindowOpenHandler(({ url, disposition }) => {
     if (disposition === "new-window" && url === "about:blank") {
+      // The web app's connect / OAuth flows open a blank popup during the
+      // click handler and navigate it once the API call resolves. That
+      // deferred-navigation shape is what identifies an authorization
+      // surface: a plain link popup always opens at its real URL. Only these
+      // get their third-party sign-in cookies swept on close, so closing a
+      // Slack / GitHub / Discord link window leaves those sessions intact.
+      authPopups.markNextChildAsAuthPopup();
       return {
         action: "allow",
         overrideBrowserWindowOptions: {
@@ -272,24 +291,15 @@ app.on("web-contents-created", (_event, contents) => {
     return { action: "deny" };
   });
 
-  // Every child window the renderer opens is a connect / OAuth surface, and an
-  // in-app one has no address bar, profile switcher, or provider sign-out page
-  // to fall back on. Left alone, the identity provider's SSO cookie sticks
-  // around in the app's session and every later authorization silently reuses
-  // the first account - Microsoft skips the account picker outright. Treat each
-  // popup as a throwaway sign-in surface: drop the third-party sign-in cookies
-  // it left behind once it closes, so the next connect starts signed out and
-  // the provider asks who you are. Vellum's own cookies are never touched.
+  // Sweep the sign-in cookies of the popups marked above once they close. An
+  // in-app authorization window has no address bar, profile switcher, or
+  // provider sign-out page to fall back on, so without this the identity
+  // provider's SSO cookie sticks around in the app's session and every later
+  // authorization silently reuses the first account - Microsoft skips the
+  // account picker outright. Unmarked child windows (plain link opens) keep
+  // their cookies, as do Vellum's own.
   contents.on("did-create-window", (window) => {
-    trackAuthPopupSignInState(window, {
-      cookies: () => session.defaultSession.cookies,
-      onCleared: (hosts, removed) =>
-        log.info(
-          `[auth-popup] cleared ${removed} sign-in cookie(s) for ${hosts.join(", ")}`,
-        ),
-      onError: (err) =>
-        log.warn("[auth-popup] failed to clear sign-in cookies:", err),
-    });
+    authPopups.trackCreatedChild(window);
   });
 });
 

--- a/packages/electron-utils/package.json
+++ b/packages/electron-utils/package.json
@@ -5,11 +5,12 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "./app-protocol": "./src/app-protocol.ts"
+    "./app-protocol": "./src/app-protocol.ts",
+    "./auth-popup-session": "./src/auth-popup-session.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",
-    "test": "bun test src/app-protocol.test.ts"
+    "test": "bun test src"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/electron-utils/src/auth-popup-session.test.ts
+++ b/packages/electron-utils/src/auth-popup-session.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type AuthCookie,
+  type CookieJar,
+  clearSignInCookiesForHosts,
+  cookieDomainMatchesHost,
+  cookieRemovalUrl,
+  isFirstPartyAuthHost,
+  navigationUrlFromArgs,
+  selectSignInCookies,
+  thirdPartyAuthHostFromUrl,
+  trackAuthPopupSignInState,
+} from "./auth-popup-session";
+
+// A stand-in for `Session.cookies` that records what was removed.
+const fakeJar = (
+  cookies: AuthCookie[],
+  opts: { failOn?: string } = {},
+): CookieJar & { removed: Array<{ url: string; name: string }> } => {
+  const removed: Array<{ url: string; name: string }> = [];
+  return {
+    removed,
+    get: () => Promise.resolve(cookies),
+    remove: (url: string, name: string) => {
+      if (name === opts.failOn) {
+        return Promise.reject(new Error("remove failed"));
+      }
+      removed.push({ url, name });
+      return Promise.resolve();
+    },
+  };
+};
+
+// The close handler sweeps the jar asynchronously; let those turns settle.
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 5; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+// A stand-in for the popup BrowserWindow handed to `did-create-window`.
+const fakePopup = () => {
+  const navigationListeners: Array<(...args: unknown[]) => void> = [];
+  let closedListener: (() => void) | null = null;
+  return {
+    navigate: (...args: unknown[]) =>
+      navigationListeners.forEach((listener) => listener(...args)),
+    close: () => closedListener?.(),
+    window: {
+      webContents: {
+        on: (event: string, listener: (...args: unknown[]) => void) => {
+          if (event === "did-navigate" || event === "did-redirect-navigation") {
+            navigationListeners.push(listener);
+          }
+        },
+      },
+      once: (_event: "closed", listener: () => void) => {
+        closedListener = listener;
+      },
+    },
+  };
+};
+
+describe("isFirstPartyAuthHost", () => {
+  test("covers Vellum hosts and the loopback callback listener", () => {
+    expect(isFirstPartyAuthHost("vellum.ai")).toBe(true);
+    expect(isFirstPartyAuthHost("www.vellum.ai")).toBe(true);
+    expect(isFirstPartyAuthHost("staging-platform.vellum.ai")).toBe(true);
+    expect(isFirstPartyAuthHost("localhost")).toBe(true);
+    expect(isFirstPartyAuthHost("127.0.0.1")).toBe(true);
+  });
+
+  test("does not treat a lookalike suffix as first-party", () => {
+    expect(isFirstPartyAuthHost("notvellum.ai")).toBe(false);
+    expect(isFirstPartyAuthHost("vellum.ai.evil.com")).toBe(false);
+    expect(isFirstPartyAuthHost("login.microsoftonline.com")).toBe(false);
+  });
+});
+
+describe("thirdPartyAuthHostFromUrl", () => {
+  test("returns the host for third-party http(s) navigations", () => {
+    expect(
+      thirdPartyAuthHostFromUrl(
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?prompt=select_account",
+      ),
+    ).toBe("login.microsoftonline.com");
+  });
+
+  test("ignores first-party, non-web, and unparseable URLs", () => {
+    expect(thirdPartyAuthHostFromUrl("https://www.vellum.ai/connect/x")).toBe(
+      null,
+    );
+    expect(thirdPartyAuthHostFromUrl("app://vellum.ai/assistant")).toBe(null);
+    expect(thirdPartyAuthHostFromUrl("about:blank")).toBe(null);
+    expect(thirdPartyAuthHostFromUrl("not a url")).toBe(null);
+  });
+});
+
+describe("cookieDomainMatchesHost", () => {
+  test("matches the host itself and parent domains", () => {
+    expect(
+      cookieDomainMatchesHost(
+        "login.microsoftonline.com",
+        "login.microsoftonline.com",
+      ),
+    ).toBe(true);
+    expect(cookieDomainMatchesHost(".google.com", "accounts.google.com")).toBe(
+      true,
+    );
+  });
+
+  test("does not match a child domain or an unrelated one", () => {
+    expect(cookieDomainMatchesHost("accounts.google.com", "google.com")).toBe(
+      false,
+    );
+    expect(cookieDomainMatchesHost("evil-google.com", "google.com")).toBe(
+      false,
+    );
+  });
+});
+
+describe("selectSignInCookies", () => {
+  test("selects registrable-domain cookies a host-scoped lookup would miss", () => {
+    const selected = selectSignInCookies(
+      [
+        { name: "SID", domain: ".google.com", path: "/" },
+        { name: "ESTSAUTH", domain: "login.microsoftonline.com", path: "/" },
+      ],
+      ["accounts.google.com", "login.microsoftonline.com"],
+    );
+    expect(selected.map((c) => c.name).sort()).toEqual(["ESTSAUTH", "SID"]);
+  });
+
+  test("never selects a Vellum or loopback cookie", () => {
+    const selected = selectSignInCookies(
+      [
+        { name: "vellum_session", domain: ".vellum.ai", path: "/" },
+        { name: "dev", domain: "localhost", path: "/" },
+        { name: "ESTSAUTH", domain: "login.microsoftonline.com", path: "/" },
+      ],
+      ["login.microsoftonline.com", "www.vellum.ai", "localhost"],
+    );
+    expect(selected.map((c) => c.name)).toEqual(["ESTSAUTH"]);
+  });
+
+  test("leaves unrelated third-party cookies alone", () => {
+    const selected = selectSignInCookies(
+      [{ name: "sess", domain: "slack.com", path: "/" }],
+      ["login.microsoftonline.com"],
+    );
+    expect(selected).toEqual([]);
+  });
+});
+
+describe("cookieRemovalUrl", () => {
+  test("addresses the cookie by its own domain and path", () => {
+    expect(
+      cookieRemovalUrl({ name: "x", domain: ".google.com", path: "/accounts" }),
+    ).toBe("https://google.com/accounts");
+  });
+
+  test("falls back to the root path when none is set", () => {
+    expect(cookieRemovalUrl({ name: "x", domain: "login.live.com" })).toBe(
+      "https://login.live.com/",
+    );
+  });
+});
+
+describe("clearSignInCookiesForHosts", () => {
+  test("removes every matching cookie and reports the count", async () => {
+    const jar = fakeJar([
+      { name: "ESTSAUTH", domain: "login.microsoftonline.com", path: "/" },
+      {
+        name: "ESTSAUTHPERSISTENT",
+        domain: "login.microsoftonline.com",
+        path: "/",
+      },
+      { name: "vellum_session", domain: ".vellum.ai", path: "/" },
+    ]);
+
+    const removed = await clearSignInCookiesForHosts(jar, [
+      "login.microsoftonline.com",
+    ]);
+
+    expect(removed).toBe(2);
+    expect(jar.removed).toEqual([
+      { url: "https://login.microsoftonline.com/", name: "ESTSAUTH" },
+      {
+        url: "https://login.microsoftonline.com/",
+        name: "ESTSAUTHPERSISTENT",
+      },
+    ]);
+  });
+
+  test("keeps sweeping after a failed removal", async () => {
+    const jar = fakeJar(
+      [
+        { name: "a", domain: "login.microsoftonline.com", path: "/" },
+        { name: "b", domain: "login.microsoftonline.com", path: "/" },
+      ],
+      { failOn: "a" },
+    );
+    const errors: unknown[] = [];
+
+    const removed = await clearSignInCookiesForHosts(
+      jar,
+      ["login.microsoftonline.com"],
+      (err) => errors.push(err),
+    );
+
+    expect(removed).toBe(1);
+    expect(jar.removed.map((r) => r.name)).toEqual(["b"]);
+    expect(errors).toHaveLength(1);
+  });
+
+  test("does not touch the jar when no third-party host was visited", async () => {
+    const jar = fakeJar([{ name: "x", domain: "example.com", path: "/" }]);
+    expect(await clearSignInCookiesForHosts(jar, [])).toBe(0);
+    expect(jar.removed).toEqual([]);
+  });
+});
+
+describe("navigationUrlFromArgs", () => {
+  test("reads the positional (event, url) form", () => {
+    expect(navigationUrlFromArgs([{}, "https://example.com/a"])).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  test("reads the details-object form", () => {
+    expect(navigationUrlFromArgs([{ url: "https://example.com/b" }])).toBe(
+      "https://example.com/b",
+    );
+  });
+
+  test("returns null when no URL is present", () => {
+    expect(navigationUrlFromArgs([{}, 302])).toBe(null);
+  });
+});
+
+describe("trackAuthPopupSignInState", () => {
+  test("clears the sign-in cookies of every host the popup passed through", async () => {
+    const popup = fakePopup();
+    const jar = fakeJar([
+      { name: "ESTSAUTH", domain: "login.microsoftonline.com", path: "/" },
+      { name: "MSPAuth", domain: ".login.live.com", path: "/" },
+      { name: "vellum_session", domain: ".vellum.ai", path: "/" },
+    ]);
+    let clearedHosts: readonly string[] = [];
+
+    trackAuthPopupSignInState(popup.window, {
+      cookies: () => jar,
+      onCleared: (hosts) => (clearedHosts = hosts),
+    });
+
+    // The connect URL starts first-party, redirects into Microsoft, and lands
+    // back on the Vellum completion page.
+    popup.navigate({}, "https://www.vellum.ai/connect/abc");
+    popup.navigate(
+      {},
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    );
+    popup.navigate({ url: "https://login.live.com/oauth20_authorize.srf" });
+    popup.navigate({}, "https://www.vellum.ai/account/oauth/popup-complete");
+    popup.close();
+
+    await flush();
+
+    expect([...clearedHosts].sort()).toEqual([
+      "login.live.com",
+      "login.microsoftonline.com",
+    ]);
+    expect(jar.removed.map((r) => r.name).sort()).toEqual([
+      "ESTSAUTH",
+      "MSPAuth",
+    ]);
+  });
+
+  test("leaves the jar untouched for a popup that never left first-party hosts", async () => {
+    const popup = fakePopup();
+    const jar = fakeJar([
+      { name: "vellum_session", domain: ".vellum.ai", path: "/" },
+    ]);
+
+    trackAuthPopupSignInState(popup.window, { cookies: () => jar });
+
+    popup.navigate({}, "https://www.vellum.ai/account/settings");
+    popup.close();
+
+    await flush();
+
+    expect(jar.removed).toEqual([]);
+  });
+
+  test("reports a sweep failure instead of throwing at the close handler", async () => {
+    const popup = fakePopup();
+    const errors: unknown[] = [];
+
+    trackAuthPopupSignInState(popup.window, {
+      cookies: () => ({
+        get: () => Promise.reject(new Error("session gone")),
+        remove: () => Promise.resolve(),
+      }),
+      onError: (err) => errors.push(err),
+    });
+
+    popup.navigate({}, "https://login.microsoftonline.com/common");
+    popup.close();
+
+    await flush();
+
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/packages/electron-utils/src/auth-popup-session.test.ts
+++ b/packages/electron-utils/src/auth-popup-session.test.ts
@@ -6,8 +6,9 @@ import {
   clearSignInCookiesForHosts,
   cookieDomainMatchesHost,
   cookieRemovalUrl,
+  createAuthPopupSignInTracker,
   isFirstPartyAuthHost,
-  navigationUrlFromArgs,
+  navigationDetailsFromArgs,
   selectSignInCookies,
   thirdPartyAuthHostFromUrl,
   trackAuthPopupSignInState,
@@ -40,19 +41,31 @@ const flush = async (): Promise<void> => {
 };
 
 // A stand-in for the popup BrowserWindow handed to `did-create-window`.
+// Navigation events are kept apart so a test can reproduce a chain the way
+// Electron reports it: where a navigation *starts* versus where it lands.
 const fakePopup = () => {
-  const navigationListeners: Array<(...args: unknown[]) => void> = [];
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
   let closedListener: (() => void) | null = null;
+
+  const emit = (event: string, ...args: unknown[]) =>
+    listeners.get(event)?.forEach((listener) => listener(...args));
+
   return {
-    navigate: (...args: unknown[]) =>
-      navigationListeners.forEach((listener) => listener(...args)),
+    start: (...args: unknown[]) => emit("did-start-navigation", ...args),
+    redirect: (...args: unknown[]) => emit("did-redirect-navigation", ...args),
+    // The whole-chain shorthand most tests want: a navigation that starts and
+    // settles at the same URL.
+    navigate: (...args: unknown[]) => {
+      emit("did-start-navigation", ...args);
+      emit("did-navigate", ...args);
+    },
     close: () => closedListener?.(),
     window: {
       webContents: {
         on: (event: string, listener: (...args: unknown[]) => void) => {
-          if (event === "did-navigate" || event === "did-redirect-navigation") {
-            navigationListeners.push(listener);
-          }
+          const existing = listeners.get(event);
+          if (existing) existing.push(listener);
+          else listeners.set(event, [listener]);
         },
       },
       once: (_event: "closed", listener: () => void) => {
@@ -221,21 +234,42 @@ describe("clearSignInCookiesForHosts", () => {
   });
 });
 
-describe("navigationUrlFromArgs", () => {
+describe("navigationDetailsFromArgs", () => {
   test("reads the positional (event, url) form", () => {
-    expect(navigationUrlFromArgs([{}, "https://example.com/a"])).toBe(
-      "https://example.com/a",
-    );
+    expect(navigationDetailsFromArgs([{}, "https://example.com/a"])).toEqual({
+      url: "https://example.com/a",
+      isMainFrame: true,
+    });
   });
 
   test("reads the details-object form", () => {
-    expect(navigationUrlFromArgs([{ url: "https://example.com/b" }])).toBe(
-      "https://example.com/b",
-    );
+    expect(
+      navigationDetailsFromArgs([{ url: "https://example.com/b" }]),
+    ).toEqual({ url: "https://example.com/b", isMainFrame: true });
+  });
+
+  test("reads the frame flag from either shape", () => {
+    // (event, url, isInPlace, isMainFrame, …)
+    expect(
+      navigationDetailsFromArgs([{}, "https://example.com/c", false, false])
+        .isMainFrame,
+    ).toBe(false);
+    expect(
+      navigationDetailsFromArgs([
+        { url: "https://example.com/d", isMainFrame: false },
+      ]).isMainFrame,
+    ).toBe(false);
+  });
+
+  test("assumes the main frame when the event carries no flag", () => {
+    // `did-navigate`'s positional form is (event, url, statusCode, statusText).
+    expect(
+      navigationDetailsFromArgs([{}, "https://example.com/e", 200, "OK"]),
+    ).toEqual({ url: "https://example.com/e", isMainFrame: true });
   });
 
   test("returns null when no URL is present", () => {
-    expect(navigationUrlFromArgs([{}, 302])).toBe(null);
+    expect(navigationDetailsFromArgs([{}, 302]).url).toBe(null);
   });
 });
 
@@ -277,6 +311,51 @@ describe("trackAuthPopupSignInState", () => {
     ]);
   });
 
+  test("records a provider that only ever appears as a navigation's start", async () => {
+    const popup = fakePopup();
+    const jar = fakeJar([
+      { name: "ESTSAUTH", domain: "login.microsoftonline.com", path: "/" },
+    ]);
+
+    trackAuthPopupSignInState(popup.window, { cookies: () => jar });
+
+    // The stale-cookie case: a live SSO session bounces the authorize request
+    // straight back to the first-party callback. Microsoft is never a redirect
+    // target and never the final URL — only where the navigation began.
+    popup.start(
+      {},
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    );
+    popup.redirect(
+      {},
+      "https://www.vellum.ai/account/oauth/popup-complete?oauth_status=connected",
+    );
+    popup.navigate(
+      {},
+      "https://www.vellum.ai/account/oauth/popup-complete?oauth_status=connected",
+    );
+    popup.close();
+
+    await flush();
+
+    expect(jar.removed.map((r) => r.name)).toEqual(["ESTSAUTH"]);
+  });
+
+  test("ignores subframe navigations", async () => {
+    const popup = fakePopup();
+    const jar = fakeJar([{ name: "tracker", domain: "ads.example.com" }]);
+
+    trackAuthPopupSignInState(popup.window, { cookies: () => jar });
+
+    // (event, url, isInPlace, isMainFrame)
+    popup.start({}, "https://ads.example.com/pixel", false, false);
+    popup.close();
+
+    await flush();
+
+    expect(jar.removed).toEqual([]);
+  });
+
   test("leaves the jar untouched for a popup that never left first-party hosts", async () => {
     const popup = fakePopup();
     const jar = fakeJar([
@@ -311,5 +390,69 @@ describe("trackAuthPopupSignInState", () => {
     await flush();
 
     expect(errors).toHaveLength(1);
+  });
+});
+
+describe("createAuthPopupSignInTracker", () => {
+  const microsoftCookie = {
+    name: "ESTSAUTH",
+    domain: "login.microsoftonline.com",
+    path: "/",
+  };
+
+  test("sweeps a child window the window-open handler marked", async () => {
+    const popup = fakePopup();
+    const jar = fakeJar([microsoftCookie]);
+    const tracker = createAuthPopupSignInTracker({ cookies: () => jar });
+
+    tracker.markNextChildAsAuthPopup();
+    tracker.trackCreatedChild(popup.window);
+
+    popup.navigate({}, "https://login.microsoftonline.com/common");
+    popup.close();
+
+    await flush();
+
+    expect(jar.removed.map((r) => r.name)).toEqual(["ESTSAUTH"]);
+  });
+
+  test("leaves an unmarked child window alone", async () => {
+    // A plain link popup — a Slack app-setup page, a GitHub repo. Closing it
+    // must not sign the user out of a service they signed in to on purpose.
+    const popup = fakePopup();
+    const jar = fakeJar([{ name: "user_session", domain: ".github.com" }]);
+    const tracker = createAuthPopupSignInTracker({ cookies: () => jar });
+
+    tracker.trackCreatedChild(popup.window);
+
+    popup.navigate({}, "https://github.com/vellum-ai/vellum-assistant");
+    popup.close();
+
+    await flush();
+
+    expect(jar.removed).toEqual([]);
+  });
+
+  test("the mark applies to one child window only", async () => {
+    const authPopup = fakePopup();
+    const linkPopup = fakePopup();
+    const jar = fakeJar([
+      microsoftCookie,
+      { name: "user_session", domain: ".github.com" },
+    ]);
+    const tracker = createAuthPopupSignInTracker({ cookies: () => jar });
+
+    tracker.markNextChildAsAuthPopup();
+    tracker.trackCreatedChild(authPopup.window);
+    tracker.trackCreatedChild(linkPopup.window);
+
+    linkPopup.navigate({}, "https://github.com/vellum-ai/vellum-assistant");
+    linkPopup.close();
+    authPopup.navigate({}, "https://login.microsoftonline.com/common");
+    authPopup.close();
+
+    await flush();
+
+    expect(jar.removed.map((r) => r.name)).toEqual(["ESTSAUTH"]);
   });
 });

--- a/packages/electron-utils/src/auth-popup-session.ts
+++ b/packages/electron-utils/src/auth-popup-session.ts
@@ -167,31 +167,56 @@ export const clearSignInCookiesForHosts = async (
   return removed;
 };
 
+export interface NavigationDetails {
+  url: string | null;
+  isMainFrame: boolean;
+}
+
 /**
- * Pull the navigated URL out of a webContents navigation event's arguments.
+ * Pull the navigated URL and frame flag out of a webContents navigation
+ * event's arguments.
  *
  * Electron has moved several navigation events from the positional
- * `(event, url, …)` form to a single details object carrying `url`, and the
- * two forms coexist across versions. Reading whichever shape arrives keeps the
- * tracker correct either way instead of silently recording nothing.
+ * `(event, url, isInPlace, isMainFrame, …)` form to a single details object
+ * carrying the same fields, and the two forms coexist across versions. Reading
+ * whichever shape arrives keeps the tracker correct either way instead of
+ * silently recording nothing. `isMainFrame` defaults to true when the event
+ * does not carry it — `did-navigate` only ever fires for the main frame, and
+ * its positional slots hold a status code and text rather than frame flags.
  */
-export const navigationUrlFromArgs = (
+export const navigationDetailsFromArgs = (
   args: readonly unknown[],
-): string | null => {
-  for (const arg of args) {
-    if (typeof arg === "string") return arg;
-    if (arg && typeof arg === "object") {
-      const { url } = arg as { url?: unknown };
-      if (typeof url === "string") return url;
+): NavigationDetails => {
+  const [first, second] = args;
+
+  if (typeof second === "string") {
+    return {
+      url: second,
+      isMainFrame: typeof args[3] === "boolean" ? args[3] : true,
+    };
+  }
+
+  if (first && typeof first === "object") {
+    const details = first as { url?: unknown; isMainFrame?: unknown };
+    if (typeof details.url === "string") {
+      return {
+        url: details.url,
+        isMainFrame:
+          typeof details.isMainFrame === "boolean" ? details.isMainFrame : true,
+      };
     }
   }
-  return null;
+
+  return { url: null, isMainFrame: true };
 };
 
 /**
  * Watch an authorization popup and clear the sign-in state it accumulated once
- * it closes. Wire this from the main process's `did-create-window` handler so
- * every child window the renderer opens is covered.
+ * it closes.
+ *
+ * Prefer `createAuthPopupSignInTracker` at a call site that also owns the
+ * window-open handler: tracking every child window indiscriminately would sweep
+ * the cookies of plain link popups too.
  */
 export const trackAuthPopupSignInState = (
   popup: AuthPopupWindow,
@@ -200,16 +225,23 @@ export const trackAuthPopupSignInState = (
   const visited = new Set<string>();
 
   const record = (...args: unknown[]): void => {
-    const url = navigationUrlFromArgs(args);
-    if (!url) return;
+    const { url, isMainFrame } = navigationDetailsFromArgs(args);
+    if (!url || !isMainFrame) return;
     const host = thirdPartyAuthHostFromUrl(url);
     if (host) visited.add(host);
   };
 
-  // `did-redirect-navigation` catches the hosts a 302 chain passes through —
-  // the provider's authorize endpoint is often only ever an intermediate hop.
-  popup.webContents.on("did-navigate", record);
+  // All three events are needed to see the whole chain, because each reports a
+  // different point of it: `did-start-navigation` carries the URL a navigation
+  // begins at, `did-redirect-navigation` the target of each hop, and
+  // `did-navigate` the URL it settled on. The start event is what catches the
+  // case this whole module exists for — an authorize request that a live SSO
+  // cookie bounces straight back to the first-party callback, where the
+  // provider's host is *only* ever the initial request and never a redirect
+  // target or a final URL.
+  popup.webContents.on("did-start-navigation", record);
   popup.webContents.on("did-redirect-navigation", record);
+  popup.webContents.on("did-navigate", record);
 
   popup.once("closed", () => {
     if (visited.size === 0) return;
@@ -218,4 +250,46 @@ export const trackAuthPopupSignInState = (
       .then((removed) => deps.onCleared?.(hosts, removed))
       .catch((err: unknown) => deps.onError?.(err));
   });
+};
+
+export interface AuthPopupSignInTracker {
+  /**
+   * Call from the window-open handler when the window it is about to allow is
+   * an authorization surface. Applies to the next child window only.
+   */
+  markNextChildAsAuthPopup(): void;
+  /** Call from `did-create-window`. Tracks the window only if it was marked. */
+  trackCreatedChild(popup: AuthPopupWindow): void;
+}
+
+/**
+ * Pair a window-open handler with a `did-create-window` listener so only the
+ * child windows the handler identified as authorization surfaces get their
+ * sign-in cookies swept.
+ *
+ * The gate matters because a renderer opens child windows for ordinary links
+ * too — a Slack app-setup page, a GitHub repo, a Discord invite. Sweeping those
+ * would sign the user out of services they deliberately signed in to, which is
+ * the opposite of the fix. The two callbacks fire in order for the same window
+ * (handler first, then the event), so a single-slot flag correlates them; the
+ * flag is consumed on read, so an unmarked window is never tracked.
+ *
+ * Create one tracker per opener webContents, so the flag cannot cross windows.
+ */
+export const createAuthPopupSignInTracker = (
+  deps: AuthPopupTrackingDeps,
+): AuthPopupSignInTracker => {
+  let nextChildIsAuthPopup = false;
+
+  return {
+    markNextChildAsAuthPopup: () => {
+      nextChildIsAuthPopup = true;
+    },
+    trackCreatedChild: (popup) => {
+      const isAuthPopup = nextChildIsAuthPopup;
+      nextChildIsAuthPopup = false;
+      if (!isAuthPopup) return;
+      trackAuthPopupSignInState(popup, deps);
+    },
+  };
 };

--- a/packages/electron-utils/src/auth-popup-session.ts
+++ b/packages/electron-utils/src/auth-popup-session.ts
@@ -1,0 +1,221 @@
+/**
+ * Sign-in isolation for third-party OAuth popups.
+ *
+ * The desktop shells open the web app's connect flows (`window.open(...)` →
+ * the provider's authorize URL) as in-app child windows. Those windows share
+ * the app's persistent session, so the identity provider's SSO cookie — the
+ * Microsoft `ESTSAUTH*` pair, Google's `SID`, and their equivalents — is
+ * written into the app's cookie jar and survives for the life of the install.
+ *
+ * In a real browser that is fine: the user has an address bar, a profile
+ * switcher, and the provider's own sign-out page to fall back on. An in-app
+ * popup has none of that chrome, so the first account a user connects becomes
+ * the only account they can ever connect: every later authorization silently
+ * single-signs-on as that identity, and Microsoft in particular skips the
+ * account picker entirely when a live session cookie is present. That is the
+ * "can't register a second Outlook account from the desktop app" report.
+ *
+ * The fix is to treat each authorization window as a throwaway sign-in
+ * surface: track the third-party hosts it navigates through, and drop their
+ * cookies from the session once the window closes. The next connect therefore
+ * starts signed out and the provider asks who you are. First-party Vellum
+ * hosts (and loopback, used by the local OAuth callback listener) are never
+ * touched, so the app's own session is unaffected.
+ *
+ * Everything here is typed against minimal structural interfaces rather than
+ * Electron's classes so the package stays a dependency-free leaf and the logic
+ * is unit-testable without booting a browser process.
+ */
+
+/** The cookie fields this module reads. Structural subset of Electron's `Cookie`. */
+export interface AuthCookie {
+  name: string;
+  domain?: string;
+  path?: string;
+}
+
+/** Structural subset of Electron's `Session.cookies`. */
+export interface CookieJar {
+  get(filter: { domain?: string }): Promise<AuthCookie[]>;
+  remove(url: string, name: string): Promise<void>;
+}
+
+/** Structural subset of the `BrowserWindow` handed to `did-create-window`. */
+export interface AuthPopupWindow {
+  webContents: {
+    on(event: string, listener: (...args: unknown[]) => void): unknown;
+  };
+  once(event: "closed", listener: () => void): unknown;
+}
+
+export interface AuthPopupTrackingDeps {
+  /** Resolved lazily: the session outlives the popup, the popup does not. */
+  cookies: () => CookieJar;
+  /** Reported after a successful sweep, for the main-process log. */
+  onCleared?: (hosts: readonly string[], removed: number) => void;
+  onError?: (err: unknown) => void;
+}
+
+/**
+ * Hosts that belong to Vellum itself, or to the loopback listener the local
+ * OAuth callback binds. Their cookies carry the user's own session and must
+ * survive an authorization window.
+ */
+export const isFirstPartyAuthHost = (host: string): boolean => {
+  const normalized = host.toLowerCase();
+  return (
+    normalized === "vellum.ai" ||
+    normalized.endsWith(".vellum.ai") ||
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+};
+
+/**
+ * The third-party host of an http(s) navigation, or null when the URL is
+ * first-party, unparseable, or a non-web scheme (`about:blank` starts every
+ * popup; custom schemes are already blocked by the window-open handler).
+ */
+export const thirdPartyAuthHostFromUrl = (url: string): string | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!host || isFirstPartyAuthHost(host)) {
+    return null;
+  }
+  return host;
+};
+
+/**
+ * Standard cookie domain-match: a cookie is in scope for a host when the
+ * domains are equal or the cookie's domain is a parent of the host. Applied to
+ * the domain the browser already accepted, so no public-suffix check is needed
+ * here — `.microsoftonline.com` covers `login.microsoftonline.com`, while
+ * `login.microsoftonline.com` does not cover `microsoftonline.com`.
+ */
+export const cookieDomainMatchesHost = (
+  cookieDomain: string,
+  host: string,
+): boolean => {
+  const domain = cookieDomain.replace(/^\./, "").toLowerCase();
+  const target = host.toLowerCase();
+  if (!domain) return false;
+  return target === domain || target.endsWith(`.${domain}`);
+};
+
+/**
+ * The cookies to drop: every cookie whose domain covers one of the hosts the
+ * authorization window visited. Selecting from the full jar (rather than
+ * querying per host) is what catches registrable-domain cookies such as
+ * `.google.com`, which a host-scoped lookup for `accounts.google.com` misses.
+ */
+export const selectSignInCookies = (
+  cookies: readonly AuthCookie[],
+  hosts: readonly string[],
+): AuthCookie[] =>
+  cookies.filter((cookie) => {
+    const domain = cookie.domain;
+    if (!domain) return false;
+    const bare = domain.replace(/^\./, "").toLowerCase();
+    if (isFirstPartyAuthHost(bare)) return false;
+    return hosts.some((host) => cookieDomainMatchesHost(domain, host));
+  });
+
+/** The URL `cookies.remove` needs to address a cookie: its own domain and path. */
+export const cookieRemovalUrl = (cookie: AuthCookie): string => {
+  const domain = (cookie.domain ?? "").replace(/^\./, "");
+  const path = cookie.path && cookie.path.startsWith("/") ? cookie.path : "/";
+  return `https://${domain}${path}`;
+};
+
+/**
+ * Drop the sign-in cookies the given hosts left behind. Best-effort: a single
+ * failed removal must not abort the sweep, since a half-cleared jar is what
+ * leaves the next authorization stuck on the previous account.
+ *
+ * Returns the number of cookies removed.
+ */
+export const clearSignInCookiesForHosts = async (
+  jar: CookieJar,
+  hosts: readonly string[],
+  onError?: (err: unknown) => void,
+): Promise<number> => {
+  if (hosts.length === 0) return 0;
+
+  const all = await jar.get({});
+  const doomed = selectSignInCookies(all, hosts);
+
+  let removed = 0;
+  for (const cookie of doomed) {
+    try {
+      await jar.remove(cookieRemovalUrl(cookie), cookie.name);
+      removed += 1;
+    } catch (err) {
+      onError?.(err);
+    }
+  }
+  return removed;
+};
+
+/**
+ * Pull the navigated URL out of a webContents navigation event's arguments.
+ *
+ * Electron has moved several navigation events from the positional
+ * `(event, url, …)` form to a single details object carrying `url`, and the
+ * two forms coexist across versions. Reading whichever shape arrives keeps the
+ * tracker correct either way instead of silently recording nothing.
+ */
+export const navigationUrlFromArgs = (
+  args: readonly unknown[],
+): string | null => {
+  for (const arg of args) {
+    if (typeof arg === "string") return arg;
+    if (arg && typeof arg === "object") {
+      const { url } = arg as { url?: unknown };
+      if (typeof url === "string") return url;
+    }
+  }
+  return null;
+};
+
+/**
+ * Watch an authorization popup and clear the sign-in state it accumulated once
+ * it closes. Wire this from the main process's `did-create-window` handler so
+ * every child window the renderer opens is covered.
+ */
+export const trackAuthPopupSignInState = (
+  popup: AuthPopupWindow,
+  deps: AuthPopupTrackingDeps,
+): void => {
+  const visited = new Set<string>();
+
+  const record = (...args: unknown[]): void => {
+    const url = navigationUrlFromArgs(args);
+    if (!url) return;
+    const host = thirdPartyAuthHostFromUrl(url);
+    if (host) visited.add(host);
+  };
+
+  // `did-redirect-navigation` catches the hosts a 302 chain passes through —
+  // the provider's authorize endpoint is often only ever an intermediate hop.
+  popup.webContents.on("did-navigate", record);
+  popup.webContents.on("did-redirect-navigation", record);
+
+  popup.once("closed", () => {
+    if (visited.size === 0) return;
+    const hosts = [...visited];
+    void clearSignInCookiesForHosts(deps.cookies(), hosts, deps.onError)
+      .then((removed) => deps.onCleared?.(hosts, removed))
+      .catch((err: unknown) => deps.onError?.(err));
+  });
+};


### PR DESCRIPTION
## Prompt / plan

From a user report: *"you can not register multiple outlook accounts from the desktop app. it keeps you logged into current MS session and has no way to take you out of it to sign in as another. On the flip side, I was able to log in to vellum.ai on the web and connect multiple accounts without a problem."*

The desktop-only asymmetry is the tell. Both surfaces run the same `useOAuthConnect` popup flow against the same connect URL, so the difference is the popup's environment:

- **The session is shared and permanent.** `setWindowOpenHandler` allows connect popups as in-app child windows, which inherit the app's default persistent session. Microsoft's `ESTSAUTH*` cookies (and every other provider's SSO cookie) land in the app's cookie jar and stay for the life of the install. A real browser has an address bar, a profile switcher, and the provider's own sign-out page to escape that with; an in-app popup has none of them, so the first account connected is the only account that can ever be connected.
- **The authorize URL never asks.** The Outlook provider seed sends `prompt=consent`. The Microsoft identity platform accepts a single prompt value, and `consent` honours an existing session cookie — it re-asks for consent but never for *which* account, so the picker and its "Use another account" option never appear.

Two changes, one per cause:

1. **New shared helper `@vellumai/electron-utils/auth-popup-session`.** Wired into both Electron shells, it records the third-party hosts an authorization popup navigates through and drops their cookies from the session once the window closes. Each connect therefore starts signed out and the provider asks who you are. Three navigation events are needed to see the whole chain, because each reports a different point of it: `did-start-navigation` (where a navigation begins), `did-redirect-navigation` (the target of each hop), and `did-navigate` (where it settled) — recording is filtered to the main frame. Cookie selection walks the full jar and applies standard domain-matching, so registrable-domain cookies like `.google.com` are caught where a host-scoped lookup for `accounts.google.com` would miss them. Vellum hosts and loopback (where the local OAuth callback listens) are excluded, so the user's own session and the BYO callback flow are untouched. The sweep is best-effort per cookie: one failed removal doesn't abort the rest, since a half-cleared jar is exactly what leaves the next authorization stuck.

   The sweep is **gated to authorization surfaces**. The renderer opens child windows for ordinary links too — a Slack app-setup page, a GitHub repo, a Discord invite — and sweeping those would sign the user out of services they signed in to on purpose. `createAuthPopupSignInTracker` pairs the window-open handler with `did-create-window`, marking only popups that open as `about:blank`: a connect flow opens blank during the click handler and navigates once the API call resolves, while a link popup always opens at its real URL. The tracker is created per opener `webContents` and the mark is consumed on read, so it cannot leak to the next window.

2. **`prompt=select_account` for the Outlook provider seed.** Always shows the account picker. Consent is still collected for an account that hasn't granted it, and refresh tokens come from the `offline_access` scope already in `defaultScopes`, so dropping `consent` costs nothing. `seedProviders` updates `authorizeParams` on conflict, so existing installs pick this up on the next daemon start.

The helper is typed against minimal structural interfaces rather than Electron's classes, keeping `electron-utils` a dependency-free leaf and the logic unit-testable without booting a browser process. Reading both the positional `(event, url, …)` and details-object shapes of the navigation events keeps it correct across Electron's migration between the two.

Note on scope: the seed change covers bring-your-own-credential connections. Managed connections get their authorize URL from the platform, which this repo doesn't build — the session isolation is what fixes the managed path, and it fixes every provider rather than just Microsoft.

No client-side UI change was needed: `ManagedOAuthTab` already keeps "Connect account" available once connections exist, and lists each connected account separately.

## Test plan

- New `packages/electron-utils/src/auth-popup-session.test.ts` — 27 tests covering first-party host classification (including lookalike suffixes such as `vellum.ai.evil.com`), third-party host extraction from `about:blank` / `app://` / unparseable URLs, cookie domain-matching in both directions, selection of registrable-domain cookies, removal-URL construction, sweep resilience after a failed removal, both navigation-event argument shapes and their frame flags, the marked / unmarked / mark-applies-once gate, and an end-to-end popup walk through `vellum.ai → login.microsoftonline.com → login.live.com → vellum.ai` asserting only the Microsoft cookies are dropped.
- Regression test for the silent-SSO chain — an authorize request that a live cookie bounces straight back to the first-party callback, where the provider host is *only* ever the initial request. Verified it fails without the `did-start-navigation` listener and passes with it.
- `bun test src` in `packages/electron-utils` — 46 pass (also now the Windows client's `test` / `test:ci` target, widened from the single `app-protocol` file).
- `bunx tsc --noEmit` clean in `packages/electron-utils`, `clients/macos`, `clients/windows`.
- `bun run test:ci` in `clients/macos` — 66 test files, all pass.
- `bun test src/oauth`, `src/__tests__/oauth-store.test.ts`, `src/__tests__/oauth-apps-routes.test.ts`, `src/__tests__/oauth-connect-orchestrator.test.ts` in `assistant/` — all pass individually. (Running `src/oauth` together with those `src/__tests__` files in one process fails 79 tests, but it does so identically on an unmodified tree — a pre-existing cross-file isolation artifact, not this change.)
- Not verified by running the packaged desktop app end-to-end — the cookie sweep and the account picker both need a real Microsoft sign-in to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfXk1V6ayWm4KMZJqoctCg