### PR TITLE
perf(web): batch the onboarding research searches in parallel (JARVIS-1457)

### DIFF
--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -136,6 +136,57 @@ describe("buildResearchPrompt — suggestions toggle", () => {
   });
 });
 
+describe("buildResearchPrompt — parallel search batching", () => {
+  test("asks for parallel tool calls in two batches", () => {
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain("SEARCH IN PARALLEL");
+    expect(prompt).toContain("AS PARALLEL TOOL CALLS IN ONE STEP");
+    expect(prompt).toContain("Batch 1 — discovery.");
+    expect(prompt).toContain("Batch 2 — corroboration.");
+    // A cap keeps the discovery fan-out from turning into a search storm.
+    expect(prompt).toContain("at most 5 total");
+  });
+
+  test("bans subagent delegation", () => {
+    // Not a style preference: a subagent result is injected into the parent as
+    // a user message that starts a new turn, and a partial-but-complete payload
+    // from one of those turns settles the runner's poll on a half-researched
+    // card. See the module docstring.
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain("Do NOT delegate this to subagents");
+  });
+
+  test("gates the discovery batch on the placeholder rule", () => {
+    // The placeholder escape hatch lives in the identity gate, which is stated
+    // AFTER the batches — without this forward reference a model reading in
+    // order fires five searches for junk input before reaching it.
+    const prompt = buildResearchPrompt(SUBJECT);
+
+    expect(prompt).toContain("First check the placeholder rule");
+    expect(prompt.indexOf("First check the placeholder rule")).toBeLessThan(
+      prompt.indexOf("placeholder or joke input"),
+    );
+  });
+
+  test("batching does not displace the identity gate or the JSON contract", () => {
+    const prompt = buildResearchPrompt(SUBJECT, [
+      { name: "marketing-expert", description: "Full-stack marketing." },
+    ]);
+
+    // Ordering is load-bearing: batches are described before the gate that
+    // judges their output, which is before the shape the gate feeds.
+    expect(prompt.indexOf("SEARCH IN PARALLEL")).toBeLessThan(
+      prompt.indexOf("IDENTITY GATE"),
+    );
+    expect(prompt.indexOf("IDENTITY GATE")).toBeLessThan(
+      prompt.indexOf('"plugins"'),
+    );
+    expect(prompt).toContain("run the identity gate below");
+  });
+});
+
 describe("buildResearchPrompt — identity gate & confidence calibration", () => {
   test("states the identity gate and the honest no-match fallback", () => {
     const prompt = buildResearchPrompt(SUBJECT);

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -15,6 +15,16 @@
  * The output contract here MUST stay in sync with the parser in
  * `@/domains/chat/onboarding-research/research-facts.ts`.
  *
+ * The pass is latency-sensitive — the user is watching a spinner behind the
+ * gcal step, and `research-runner.ts` gives up at `MAX_POLL_MS` (120s) — so the
+ * prompt asks for the searches in two PARALLEL BATCHES (discovery, then
+ * corroboration) rather than a query-at-a-time walk. It also explicitly bans
+ * `subagent_spawn`, which is not a latency win here and is actively unsafe for
+ * this flow: a subagent's result is injected into the parent as a user message
+ * that starts a NEW parent turn (`subagent/notify.ts`), so N researchers cost N
+ * extra turns, and an early turn that emits a well-formed-but-partial payload
+ * satisfies `shouldSettleResearchPoll` and freezes a half-researched card.
+ *
  * NOTE(alex): the wording / claim count / confidence rubric / suggestion
  * guidance are all tunable — only the trailing JSON contract (`claims` +
  * `suggestions` shape) is load-bearing for the UI.
@@ -177,6 +187,15 @@ Keep each SHORT and skimmable: under 10 words, ONE clause, ONE artifact, no list
   return `${identity}
 
 Get to know me. Search the web for what's publicly known about me, and infer a handful of things about who I am: what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Prefer sources people author about themselves — LinkedIn, a personal site, GitHub, an employer's team page, published work, public social profiles. Never fetch or cite people-search or background-check aggregators (Instant Checkmate, Spokeo, BeenVerified, TruePeopleSearch, Whitepages, and similar); data-broker directories (ZoomInfo, RocketReach, Apollo) may corroborate another source but must never be a claim's only basis.
+
+SEARCH IN PARALLEL — I am waiting on this, so latency is part of the job. Work in two batches, and issue every call within a batch AS PARALLEL TOOL CALLS IN ONE STEP, never one at a time:
+
+Batch 1 — discovery. First check the placeholder rule in the identity gate below; if my details are junk input, skip both batches entirely. Otherwise: one search per source class, at most 5 total, all fired together — professional profile (LinkedIn), code and published work (GitHub, papers, talks), personal site or blog, employer team page, and public social. Vary the query per class rather than repeating my name five times.
+Batch 2 — corroboration. From batch 1's hits, fetch the promising candidate pages together in a single parallel step. Do not fetch them one by one to see how each turns out first.
+
+Then run the identity gate below over everything you have and write the JSON. A third small batch is fine if batch 2 leaves a specific claim one source short of its tier; more than that means the footprint isn't there, and an honest thinner card beats another round of searching.
+
+Do NOT delegate this to subagents. It is slower here, and it risks showing me a half-finished card — parallel tool calls in your own turn are what I want.
 
 IDENTITY GATE — decide who a page is about before you use it: a name match alone is NEVER enough to attribute a page to me. Attribute it to me only when it also corroborates something I stated — my role, my hobby, or a location consistent with my timezone if I gave one. If several people share my name and none clears that bar, or you find no verifiable match at all, then I have no public profile you can use: return ONLY inferences from what I stated above, each labeled "guessing" with "sources": []. An honest near-empty card beats a stranger's biography. If my details above read as placeholder or joke input rather than a real identity, skip the web search and return an empty claims array.
 


### PR DESCRIPTION
## Problem

The onboarding "research me" turn told the model to search the web and left query count and sequencing entirely to its discretion. Combined with an identity gate that is serial by construction — fetch a page, decide whether it is even the right person, and require 2+ independent corroborating sources for a `confident` claim — the pass walks its sources one at a time. It runs on `balanced` (`effort: high`, thinking on) against the runner's 120s poll ceiling, while the user waits behind the gcal step.

## Change

Scoped to `research-prompt.ts` and its tests.

- **Two explicitly parallel batches.** Discovery fires one search per source class (LinkedIn / GitHub + published work / personal site / employer page / social), capped at 5, all in one step. Corroboration then fetches the candidates together. The identity gate runs locally over the result, with one optional small third batch when a claim is a single source short of its tier.
- **Ban on subagent delegation** — see below.
- **Forward reference to the placeholder rule** at the top of batch 1. The "joke input → skip the search" escape hatch lives in the identity gate, which is stated *after* the batches, so without it a model reading in order fires five searches for junk input before reaching the rule.

The trailing `plugins`/`claims`/`suggestions` JSON contract that `research-facts.ts` parses is byte-identical.

## Why not subagents

The obvious reading of "parallelize this" is one `researcher` subagent per source class. That is the wrong mechanism here, and the prompt now rules it out explicitly:

- A subagent's result does not return inline. `injectMessageIntoParent` (`assistant/src/subagent/notify.ts:47-56`) persists the terminal message as a **user-role** message and calls `runAgentLoop`, so each completion starts a **new parent turn**. N researchers cost N extra `effort: high` reasoning turns the serial version never pays.
- It is also a correctness hazard, not just a latency one. `shouldSettleResearchPoll` (`research-runner.ts:63-71`) settles the poll on the first **complete** payload seen twice. A parent turn woken by researcher 2 of 4 that emits a well-formed JSON object with 3 claims settles it — freezing a half-researched card while the rest are still running.

Batched parallel tool calls inside the single turn get the concurrency with none of that: one turn, one final JSON, no wake-ups.

## Caveats

This is a prompt instruction, so compliance is probabilistic and this PR ships **no measurement**. Time-to-first-claim before/after is unknown. Follow-up work adds timing telemetry to the research turn so the effect is observable rather than assumed.

## Testing

- `research-prompt.test.ts` — 19 pass (4 new, covering the batches, the subagent ban, the placeholder forward reference, and that neither displaces the identity gate or the JSON contract)
- Dependent suites green, run one file at a time per the `mock.module` isolation constraint: `research-runner` 15, `research-runner-send` 6, `research-onboarding-route` 30
- `bun run typecheck`, prettier, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)