### PR TITLE
feat(web): measure the onboarding research turn's duration (JARVIS-1458)

### DIFF
--- a/assistant/src/__tests__/telemetry-routes.test.ts
+++ b/assistant/src/__tests__/telemetry-routes.test.ts
@@ -103,6 +103,56 @@ describe("telemetry-routes: ingest", () => {
     );
   });
 
+  test("accepts the duration-metric start event", () => {
+    // The onboarding research duration metric is a PAIR of events — the start
+    // and the terminal report — with duration read as the gap between their
+    // daemon-stamped `recorded_at`s. The start half carries `status: "started"`
+    // and empty result fields, a shape nothing else exercises.
+    //
+    // This guards a silent failure mode: `status` is a free-form string on the
+    // wire today, and the client depends on that. Were the platform to tighten
+    // it to an enum of the terminal values, every start event would 400 and the
+    // metric would go quiet with no other signal. Then this test goes red on
+    // the wire-sync PR instead.
+    const result = call({
+      type: "onboarding_research",
+      daemon_event_id: "onboarding_research:started:conv-xyz",
+      fields: {
+        conversation_id: "conv-xyz",
+        status: "started",
+        self_reported_occupation: "engineer",
+        claims: [],
+        claim_count: 0,
+        claims_confident: 0,
+        claims_maybe: 0,
+        claims_guessing: 0,
+        suggestions: [],
+        suggestion_count: 0,
+        plugins: [],
+        installed_plugins: [],
+      },
+    });
+    expect(result).toEqual({ id: expect.any(String) });
+
+    const payloads = pendingPayloads();
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]).toMatchObject({
+      status: "started",
+      conversation_id: "conv-xyz",
+      claim_count: 0,
+    });
+    // The start's collapse key must differ from the terminal report's, or the
+    // pair dedups down to one event and the duration is unrecoverable.
+    expect(payloads[0]?.daemon_event_id).toBe(
+      "onboarding_research:started:conv-xyz",
+    );
+    expect(payloads[0]?.daemon_event_id).not.toBe(
+      "onboarding_research:conv-xyz",
+    );
+    // Daemon-stamped, so the subtraction never depends on the browser clock.
+    expect(payloads[0]?.recorded_at).toEqual(expect.any(Number));
+  });
+
   test("returns skipped and persists nothing under the analytics opt-out", () => {
     setShareAnalytics(false);
     expect(call(VALID_BODY)).toEqual({ skipped: true });

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -36,9 +36,18 @@ interface ArchiveCall {
   path: { assistant_id: string; id: string };
 }
 
+interface TelemetryCall {
+  body: {
+    type: string;
+    daemon_event_id?: string;
+    fields: Record<string, unknown>;
+  };
+}
+
 let postCalls: PostCall[] = [];
 let createCalls: CreateCall[] = [];
 let archiveCalls: ArchiveCall[] = [];
+let telemetryCalls: TelemetryCall[] = [];
 let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
 /** When set, the prompt POST fails, so the run gives up before the poll loop. */
@@ -57,7 +66,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   ...sdkGen,
   pluginsSearchGet: () => ok({ matches: [] }),
   pluginsInstallPost: () => ok({}),
-  telemetryIngestPost: () => ok({}),
+  telemetryIngestPost: (opts: TelemetryCall) => {
+    telemetryCalls.push(opts);
+    return ok({});
+  },
   conversationsPost: (opts: CreateCall) => {
     createCalls.push(opts);
     return ok({ id: "conv-fresh" });
@@ -100,6 +112,7 @@ afterEach(() => {
   postCalls = [];
   createCalls = [];
   archiveCalls = [];
+  telemetryCalls = [];
   getCalls = 0;
   listed = { messages: [] };
   failMessagePost = false;
@@ -224,6 +237,98 @@ describe("research prompt send", () => {
 
     await whenResumeDecided();
     expect(postCalls).toHaveLength(0);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+});
+
+/**
+ * The `status: "started"` event is one half of the duration metric — the other
+ * half is the terminal report, and duration is the gap between the two
+ * `recorded_at` stamps. These pin the properties that make that subtraction
+ * meaningful: it fires exactly when the turn really began, and its collapse key
+ * is stable so a refresh cannot move the start forward.
+ */
+describe("research turn duration telemetry", () => {
+  const started = () =>
+    telemetryCalls.filter((c) => c.body.fields.status === "started");
+
+  test("emits a started event once the prompt lands", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+      });
+    });
+
+    await waitFor(() => {
+      expect(started()).toHaveLength(1);
+    });
+    const event = started()[0];
+    expect(event?.body.type).toBe("onboarding_research");
+    expect(event?.body.fields.conversation_id).toBe("conv-fresh");
+    // Conversation-scoped so a re-post collapses onto the original start
+    // instead of stamping a later one and shortening the measured duration.
+    expect(event?.body.daemon_event_id).toBe(
+      "onboarding_research:started:conv-fresh",
+    );
+    // Results belong to the terminal event; summing the pair must not
+    // double-count them.
+    expect(event?.body.fields.claim_count).toBe(0);
+    expect(event?.body.fields.claims).toEqual([]);
+    expect(event?.body.fields.installed_plugins).toEqual([]);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  test("does not start the clock when the prompt fails to post", async () => {
+    // An interval opened here would never be closed — the run abandons before
+    // the poll loop, so no terminal event ever arrives to subtract from.
+    failMessagePost = true;
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+      });
+    });
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(archiveCalls).toHaveLength(1);
+    });
+    expect(started()).toHaveLength(0);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  test("does not restart the clock on a resume of an in-flight turn", async () => {
+    // The turn is already running, so its start was recorded before the
+    // refresh. Re-stamping it here would measure only the post-refresh tail.
+    listed = { processing: true, messages: [] };
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        resumeConversationId: "conv-resumed",
+      });
+    });
+
+    await whenResumeDecided();
+    expect(started()).toHaveLength(0);
 
     act(() => {
       result.current.reset();

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -298,6 +298,80 @@ async function sendOnboardingResearchTelemetry({
   }
 }
 
+/**
+ * Report that a research turn has just been kicked off, so how long it runs is
+ * measurable downstream.
+ *
+ * There is no duration field to write: the `onboarding_research` wire shape is
+ * generated from the platform's ingest serializers, and adding a field starts
+ * there rather than here (see `assistant/src/telemetry/AGENTS.md`). Timing
+ * therefore rides on a PAIR of events — duration is
+ * `recorded_at(terminal) − recorded_at(started)` grouped on `conversation_id`,
+ * the same two-event shape voice-mode session duration uses. `recorded_at` is
+ * stamped daemon-side on receipt, so neither end trusts the browser's clock.
+ *
+ * Consumers, two things. This doubles the raw `onboarding_research` count, so
+ * anything counting research runs must filter on `status`. And the terminal
+ * `status: "error"` is the runner's 120s poll ceiling firing — those are
+ * censored at the ceiling, not real durations, and inflate p95 if pooled with
+ * completions.
+ *
+ * The result fields are required by the wire schema but mean nothing before the
+ * turn has produced anything, so they go out empty (including
+ * `installed_plugins`, even though the deterministic floor is already
+ * installing by this point): read claims, suggestions and plugins off the
+ * terminal event, never by summing the pair.
+ *
+ * Fire-and-forget, like the terminal report — telemetry must never block the
+ * flow or surface to the user.
+ */
+async function sendOnboardingResearchStartedTelemetry({
+  assistantId,
+  conversationId,
+  subject,
+}: {
+  assistantId: string;
+  conversationId: string;
+  subject: ResearchSubject;
+}): Promise<void> {
+  try {
+    await telemetryIngestPost({
+      path: { assistant_id: assistantId },
+      body: {
+        type: "onboarding_research",
+        // Conversation-scoped like the terminal report's key, so a refresh that
+        // re-posts the prompt collapses onto the original start rather than
+        // stamping a second, later one and under-reporting the duration.
+        daemon_event_id: `onboarding_research:started:${conversationId}`,
+        fields: {
+          conversation_id: conversationId,
+          status: "started",
+          // Carried on both ends so duration can be segmented by who the turn
+          // ran for without joining back to the terminal event.
+          self_reported_occupation: subject.occupation,
+          self_reported_hobbies: (subject.hobbies ?? []).slice(
+            0,
+            MAX_REPORTED_HOBBIES,
+          ),
+          self_reported_timezone: subject.timezone,
+          claims: [],
+          claim_count: 0,
+          claims_confident: 0,
+          claims_maybe: 0,
+          claims_guessing: 0,
+          suggestions: [],
+          suggestion_count: 0,
+          plugins: [],
+          installed_plugins: [],
+        },
+      },
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, { context: "research_onboarding_started_telemetry" });
+  }
+}
+
 export type ResearchStatus = "idle" | "running" | "done" | "error";
 
 export interface ResearchRunnerState {
@@ -605,7 +679,20 @@ export function useResearchRunner(): UseResearchRunner {
               body,
               throwOnError: false,
             });
-            return Boolean(posted.response?.ok);
+            const ok = Boolean(posted.response?.ok);
+            if (ok) {
+              // Start the duration clock only once the prompt actually landed,
+              // so a failed POST never opens an interval nothing will close.
+              // Both call sites below route through here, and the resume path
+              // that finds the turn already running never calls it — its start
+              // was recorded before the refresh.
+              void sendOnboardingResearchStartedTelemetry({
+                assistantId,
+                conversationId: cid,
+                subject,
+              });
+            }
+            return ok;
           };
 
           // Mint a fresh research conversation + fire the prompt. Used for the


### PR DESCRIPTION
## Problem

The onboarding research pass reported only its outcome — a terminal `onboarding_research` event with `status: done | error`. We can see what it found, never how long it took. No median, no p95, and no way to tell whether #40160's parallel batching actually moved anything.

## Why a second event instead of a `duration_ms` field

There is no duration field to write, and adding one is not a change this repo can make. `telemetry-wire.generated.ts` is generated from the platform's ingest serializers, and `assistant/src/telemetry/AGENTS.md` is explicit that a contract change starts in `vellum-assistant-platform` and the daemon emitter is the **last** step. A field emitted ahead of its serializer is silently dropped at ingest.

So timing rides on a **pair** of events, the same shape the voice-mode session duration metric uses:

```
duration = recorded_at(terminal) − recorded_at(started)   grouped on conversation_id
```

This needs no platform work at all — `status` is already a free-form `z.string().max(32)` on the wire, and `conversation_id` is already carried. `recorded_at` is stamped daemon-side on receipt, so the subtraction never trusts the browser's clock.

## Where the start fires

From inside `postResearchPrompt`, which gets the three properties that make the interval trustworthy:

- **Only after the POST succeeded.** A failed post abandons the run before the poll loop, so a start emitted there would open an interval no terminal event ever closes.
- **Never on a resume of an in-flight turn.** That turn's start was recorded before the refresh; re-stamping it would measure only the post-refresh tail.
- **Collapse key is conversation-scoped and distinct** from the terminal report's (`onboarding_research:started:<cid>` vs `onboarding_research:<cid>`). A refresh that re-posts collapses onto the original start instead of moving it forward; a shared key would instead dedup the pair down to one event and lose the duration entirely.

Result fields are required by the wire schema but meaningless before the turn has produced anything, so they go out empty — including `installed_plugins`, even though the deterministic floor is already installing by then. Read results off the terminal event; never sum the pair.

## ⚠️ For whoever wires the dashboard

- This **doubles the raw `onboarding_research` event count.** Any existing query counting research runs without filtering on `status` will read 2× from the day this ships.
- Terminal `status: "error"` is the runner's 120s poll ceiling firing. Those are **censored at the ceiling, not durations** — pooling them with completions inflates p95 and understates the true tail.

## Testing

- `research-runner-send.test.ts` — 9 pass (3 new: emits on a landed prompt with the right collapse key and empty results; no start on a failed post; no restart on an in-flight resume)
- `telemetry-routes.test.ts` — 12 pass (1 new, driving the real route handler + outbox to prove the start shape survives ingest). It doubles as a drift guard: if the platform ever tightens `status` to an enum of the terminal values, every start event would 400 and the metric would go quiet with no other signal — this goes red on the wire-sync PR instead.
- `research-runner` 15, `research-onboarding-route` 30 green; client suites run one file at a time per the `mock.module` isolation constraint
- `bun run typecheck` (web) and `tsc --noEmit` (assistant) clean; prettier and eslint clean

Related: #40160 (the change this is meant to measure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)