### PR TITLE
JARVIS-1448: gate the tour's voice finale on capability, not the button

### DIFF
--- a/clients/web/src/domains/chat/in-chat-onboarding/avatar-tour.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/avatar-tour.tsx
@@ -10,6 +10,8 @@ import {
 import { createPortal } from "react-dom";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
+import { whenAssistantVersionKnown } from "@/lib/backwards-compat/utils";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
@@ -147,11 +149,16 @@ function measureComposerRect(): TourTargetRect | null {
   };
 }
 
-/** Viewport rect of the composer's live-voice button, or null when the
- *  assistant serves no live voice (the button is the entry point, so where it
- *  is absent the beat has nothing to land on and is dropped). Prefers the tour
- *  overlay's scenery composer over the app's, and is measured at beat entry,
- *  for the same reasons as {@link measureComposerRect}. */
+/** Viewport rect of the composer's live-voice button, or null when it is not
+ *  currently rendered. Prefers the tour overlay's scenery composer over the
+ *  app's, and is measured at beat entry, for the same reasons as
+ *  {@link measureComposerRect}.
+ *
+ *  A placement probe, not a capability check: the button leaves the DOM
+ *  whenever the composer's action row is busy or holds sendable content, so
+ *  null means "not on screen right now", never "this assistant serves no live
+ *  voice". Whether the finale exists at all is decided by
+ *  {@link supportsLiveVoice} in `start()`. */
 function measureVoiceRect(): TourTargetRect | null {
   const el =
     document.querySelector<HTMLElement>(
@@ -248,6 +255,14 @@ export function AvatarTour({
     "none" | "page" | "menu" | "row" | "composer" | "voice"
   >("none");
   const activeRef = useRef(false);
+  /** Read by the beat-building effect, which must not re-run (and so restart
+   *  the tour from its intro) when the bound assistant changes. A mid-tour
+   *  swap is handled at the finale's entry, which ends the tour when the
+   *  button it lands on is gone. */
+  const assistantIdRef = useRef(assistantId);
+  useEffect(() => {
+    assistantIdRef.current = assistantId;
+  }, [assistantId]);
 
   const accent =
     (components &&
@@ -429,7 +444,17 @@ export function AvatarTour({
       setBeatIndex(-1);
       setBeatCount(0);
       visualRef.current = "none";
-      await sleep(TOUR_LEAD_IN_MS);
+      // The lead-in doubles as the hydration window for the finale's
+      // capability gate below, so it reads a resolved version rather than the
+      // conservative `false`-on-unknown default. Bounded by the lead-in
+      // itself: the controller paints its input-blocking capture layer the
+      // moment the tour stage opens, so any wait past this point is an inert
+      // chat the user cannot touch. A hydrated version resolves
+      // synchronously, which is the common case on the onboarding hand-off.
+      await Promise.all([
+        sleep(TOUR_LEAD_IN_MS),
+        whenAssistantVersionKnown(TOUR_LEAD_IN_MS),
+      ]);
       if (!activeRef.current) {
         return;
       }
@@ -451,11 +476,14 @@ export function AvatarTour({
       if (measureComposerRect()) {
         beats.push({ kind: "composer" });
       }
-      // The finale, on the voice button inside that composer. Presence is
-      // probed here against the app's own composer (the scenery one is not
-      // mounted until the first beat lands), so an assistant without live
-      // voice never gets the beat and the tour ends on the chat beat.
-      if (measureVoiceRect()) {
+      // The finale, on the voice button inside that composer. Gated on the
+      // assistant's live-voice capability rather than the button's presence,
+      // because the beat list is frozen here while the composer is mid
+      // auto-greet: a busy composer swaps its whole action row, voice button
+      // included, for the stop button, so a DOM probe at this instant reads
+      // as "no live voice" for an assistant that serves it. The rect is
+      // measured at beat entry, which is what places the avatar.
+      if (supportsLiveVoice(assistantIdRef.current)) {
         beats.push({ kind: "voice" });
       }
       beatsRef.current = beats;


### PR DESCRIPTION
Follow-up to #40071. The closing voice beat shipped, but never appears for the users it was built for.

## What's wrong

`avatar-tour.tsx` freezes its beat list 350ms after the tour starts, and pushed the finale only if it could measure a rendered live-voice button at that instant:

```ts
await sleep(TOUR_LEAD_IN_MS);
...
if (measureVoiceRect()) {
  beats.push({ kind: "voice" });
}
```

The tour starts on the onboarding hand-off. The same effect that calls `startPrototype()` also drives the auto-greet (`use-onboarding-orchestrator.ts:86-115`), so at T+350ms the assistant is streaming, `isAssistantBusy` is true, and `chat-composer.tsx:988` takes the stop-button branch, which drops the entire action row. `chat-composer.test.tsx:652` already asserts this: *"isAssistantBusy=true on desktop renders only the Stop button (send/attach/voice hidden)"*.

The list is frozen right after, so the finale is gone for the whole run. The greeting then finishes, the button appears, and the user watches it sit there while the tour ends on the chat beat. `supportsLiveVoice` not having hydrated yet loses the same race independently.

The entry-time re-probe at `avatar-tour.tsx:393-402` cannot save it. That re-measures beats already in the list, and this one was never pushed.

## The fix

Presence was standing in for capability. They come apart exactly here, because the button's presence is time-varying and the capability is not. The gate now asks the question it means to ask:

```ts
await Promise.all([
  sleep(TOUR_LEAD_IN_MS),
  whenAssistantVersionKnown(TOUR_LEAD_IN_MS),
]);
...
if (supportsLiveVoice(assistantIdRef.current)) {
  beats.push({ kind: "voice" });
}
```

The lead-in doubles as the hydration window so the read lands on a resolved version instead of the conservative `false`-on-unknown default, and the wait is bounded by the lead-in itself. `in-chat-onboarding-controller.tsx:152-154` paints its input-blocking capture layer as soon as `stage === "tour"`, so any wait past that point would be an inert chat the user cannot touch. Startup cost stays at 350ms, and an already-hydrated version resolves synchronously (`when-store-state.ts:30`).

Residual: if the version has not hydrated within the lead-in, the finale is still dropped. That is strictly no worse than the behavior this replaces, and it is not the dominant cause. The busy composer is.

The rect is still measured at beat entry. That is what places the avatar, and it still ends the tour when the button is genuinely gone. That probe is reliable where the build-time one is not: by then the overlay's scenery composer is mounted, it hardcodes `isAssistantBusy={false}` (`tour-overlay.tsx:160`), and `measureVoiceRect` prefers it over the app's.

`assistantId` is read through a ref so the beat-building effect does not re-run and restart the tour from its intro on an assistant swap. That case is handled at the finale's entry, where it matters.

## Why it got through

The tour has no stories and no tests, and the only way to replay it by hand is `startPrototype()` from the console on a settled chat: an idle composer, where the race cannot happen. The one path that has the race is a real hatch, which is also the one path you cannot easily re-run. **This PR does not close that gap.** Worth a follow-up, but a meaningful test means driving the full beat sequence through fake timers.

## Testing

- `bunx tsc --noEmit` clean
- `bunx eslint` clean on the changed file
- Not yet verified against a live hatch. That needs a real onboarding run on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)