### PR TITLE
feat(providers): the chatgpt-subscription row carries its own identity

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14835,7 +14835,7 @@ paths:
             type: string
           description:
             "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, litellm, openai-compatible, minimax, atlascloud, baseten, poolside, vellum"
+            vercel-ai-gateway, litellm, openai-compatible, minimax, atlascloud, baseten, poolside, vellum, chatgpt"
       responses:
         "200":
           description: Successful response
@@ -34322,6 +34322,7 @@ components:
         - baseten
         - poolside
         - vellum
+        - chatgpt
     Auth:
       oneOf:
         - type: object

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -519,7 +519,7 @@ function attachLoginChatgptSubcommand(providers: Command): void {
             {
               body: {
                 name: connectionName,
-                provider: "openai",
+                provider: "chatgpt",
                 auth: authInput,
               },
             },

--- a/assistant/src/persistence/migrations/366-chatgpt-subscription-row-identity.test.ts
+++ b/assistant/src/persistence/migrations/366-chatgpt-subscription-row-identity.test.ts
@@ -1,0 +1,120 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateChatgptSubscriptionRowIdentity } from "./366-chatgpt-subscription-row-identity.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE provider_connections (
+      name        TEXT PRIMARY KEY,
+      provider    TEXT NOT NULL,
+      auth        TEXT NOT NULL,
+      label       TEXT,
+      base_url    TEXT,
+      models      TEXT,
+      created_at  INTEGER NOT NULL,
+      updated_at  INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function insertRow(
+  sqlite: Database,
+  name: string,
+  provider: string,
+  auth: string,
+): void {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at)
+       VALUES (?, ?, ?, 1, 1)`,
+    )
+    .run(name, provider, auth);
+}
+
+function readProvider(sqlite: Database, name: string): string | undefined {
+  const row = sqlite
+    .query(`SELECT provider FROM provider_connections WHERE name = ?`)
+    .get(name) as { provider: string } | null;
+  return row?.provider;
+}
+
+describe("migration 366: chatgpt-subscription row identity", () => {
+  test("flips the subscription row to provider chatgpt", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "chatgpt-subscription",
+      "openai",
+      '{"type":"oauth_subscription","credential":"credential/chatgpt/access_token"}',
+    );
+
+    migrateChatgptSubscriptionRowIdentity(db);
+
+    expect(readProvider(sqlite, "chatgpt-subscription")).toBe("chatgpt");
+  });
+
+  test("leaves a claiming row with key auth untouched", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "chatgpt-subscription",
+      "openai",
+      '{"type":"api_key","credential":"vault/openai"}',
+    );
+
+    migrateChatgptSubscriptionRowIdentity(db);
+
+    expect(readProvider(sqlite, "chatgpt-subscription")).toBe("openai");
+  });
+
+  test("leaves other rows untouched", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(sqlite, "openai-key", "openai", '{"type":"api_key"}');
+    insertRow(sqlite, "vellum", "vellum", '{"type":"platform"}');
+
+    migrateChatgptSubscriptionRowIdentity(db);
+
+    expect(readProvider(sqlite, "openai-key")).toBe("openai");
+    expect(readProvider(sqlite, "vellum")).toBe("vellum");
+  });
+
+  test("leaves unparseable auth untouched", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(sqlite, "chatgpt-subscription", "openai", "not json");
+
+    migrateChatgptSubscriptionRowIdentity(db);
+
+    expect(readProvider(sqlite, "chatgpt-subscription")).toBe("openai");
+  });
+
+  test("is idempotent", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "chatgpt-subscription",
+      "openai",
+      '{"type":"oauth_subscription"}',
+    );
+
+    migrateChatgptSubscriptionRowIdentity(db);
+    migrateChatgptSubscriptionRowIdentity(db);
+
+    expect(readProvider(sqlite, "chatgpt-subscription")).toBe("chatgpt");
+  });
+
+  test("no-ops without the table or the row", () => {
+    const bare = new Database(":memory:");
+    expect(() =>
+      migrateChatgptSubscriptionRowIdentity(drizzle(bare, { schema })),
+    ).not.toThrow();
+
+    const { db } = createTestDb();
+    expect(() => migrateChatgptSubscriptionRowIdentity(db)).not.toThrow();
+  });
+});

--- a/assistant/src/persistence/migrations/366-chatgpt-subscription-row-identity.ts
+++ b/assistant/src/persistence/migrations/366-chatgpt-subscription-row-identity.ts
@@ -1,0 +1,62 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Stamp the ChatGPT-subscription row with its own provider identity.
+ *
+ * The row is the subscription route by definition (auth modality = provider
+ * identity), but it historically stored `provider: "openai"` and was found
+ * by name, which left provider "openai" ambiguous on disk: a BYOK api_key
+ * row and the subscription row read identically at the provider column.
+ * With the row carrying `provider: "chatgpt"`, auth type is derivable from
+ * the provider for every row, and provider-keyed scans for "openai" no
+ * longer surface the subscription row.
+ *
+ * Scoped tightly: only the canonical row name with oauth_subscription auth
+ * is flipped. A claiming row under the same name with key auth is an
+ * ordinary connection and keeps its provider. Idempotent: a flipped row no
+ * longer matches, and the table-exists guard covers databases from before
+ * migration 243.
+ */
+export function migrateChatgptSubscriptionRowIdentity(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'provider_connections'`,
+    )
+    .get();
+  if (!tableExists) {
+    return;
+  }
+
+  const row = raw
+    .query(
+      `SELECT provider, auth FROM provider_connections WHERE name = 'chatgpt-subscription'`,
+    )
+    .get() as { provider: string; auth: string } | null;
+  if (!row || row.provider !== "openai") {
+    return;
+  }
+
+  let authType: unknown;
+  try {
+    const parsed: unknown = JSON.parse(row.auth);
+    authType =
+      parsed !== null && typeof parsed === "object"
+        ? (parsed as { type?: unknown }).type
+        : undefined;
+  } catch {
+    return;
+  }
+  if (authType !== "oauth_subscription") {
+    return;
+  }
+
+  raw
+    .prepare(
+      `UPDATE provider_connections SET provider = 'chatgpt', updated_at = ? WHERE name = 'chatgpt-subscription'`,
+    )
+    .run(Date.now());
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -473,6 +473,7 @@ import { migrateAddConversationSubagentKind } from "./migrations/362-add-convers
 import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfill-schedule-inference-profile.js";
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
 import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
+import { migrateChatgptSubscriptionRowIdentity } from "./migrations/366-chatgpt-subscription-row-identity.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1573,4 +1574,12 @@ export const migrationSteps: MigrationStep[] = [
   },
   migrateAddScheduleSourceKey,
   migrateAddConversationForkStrategy,
+  {
+    name: "migrateChatgptSubscriptionRowIdentity",
+    run: migrateChatgptSubscriptionRowIdentity,
+    // The table-exists guard treats a missing table as nothing-to-do, so the
+    // creating migration must be checkpointed first or a repair flow could
+    // permanently checkpoint the no-op.
+    dependsOn: ["migrateCreateProviderConnections"],
+  },
 ];

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -449,9 +449,41 @@ describe("routing identities", () => {
       },
     } as never);
     expect(resolveProviderCalls[0]?.name).toBe("chatgpt-subscription");
-    // No override needed: the subscription row itself carries provider
-    // "openai", so the adapter resolves from the row.
+    // A pre-migration row carries provider "openai": no override needed, the
+    // adapter resolves from the row.
     expect(resolveProviderCalls[0]?.provider).toBe("openai");
+  });
+
+  test("a chatgpt-identity subscription row dispatches with an openai override", async () => {
+    // Migration 366 stamps the row with the "chatgpt" identity; the identity
+    // must never reach adapter construction, so dispatch threads the openai
+    // upstream as providerOverride, mirroring the vellum sentinel.
+    fakeConnections.set("chatgpt-subscription", {
+      name: "chatgpt-subscription",
+      provider: "chatgpt",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    });
+    fakeProviders.set("conn:chatgpt-subscription", {
+      name: "openai",
+      tag: "subscription",
+    });
+
+    const provider = await tryResolveProviderForConnectionName(
+      "ignored",
+      { llm: {} } as never,
+      "chatgpt",
+      "gpt-5.5",
+    );
+
+    expect(provider?.routeAttribution).toEqual({
+      connectionName: "chatgpt-subscription",
+      isManagedRoute: false,
+    });
+    expect(resolveProviderCalls[0]?.name).toBe("chatgpt-subscription");
+    expect(resolveProviderOpts[0]?.providerOverride).toBe("openai");
   });
 
   // A second managed row is creatable under any non-reserved name: only the

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -220,6 +220,40 @@ describe("preflightResolvedConfig", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("a chatgpt-identity subscription row preflights the same way", async () => {
+    // Migration 366 stamps the row with provider "chatgpt"; preflight judges
+    // its subscription credential, not a provider equality with the openai
+    // upstream.
+    connectionsByName["chatgpt-subscription"] = {
+      name: "chatgpt-subscription",
+      provider: "chatgpt",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    };
+    const missing = await preflightError(
+      resolved({
+        provider: "chatgpt",
+        provider_connection: "",
+        model: "gpt-5.5",
+      }),
+    );
+    expect(missing?.reason).toBe("missing_credential");
+
+    secureKeys["credential/chatgpt/access_token"] = "tok";
+    await expect(
+      preflightResolvedConfig(
+        resolved({
+          provider: "chatgpt",
+          provider_connection: "",
+          model: "gpt-5.5",
+        }),
+        {},
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   test("a chatgpt identity with no subscription row throws not_found", async () => {
     const err = await preflightError(
       resolved({

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -162,8 +162,18 @@ export async function tryResolveProviderForConnectionName(
     isVellum &&
     !!expectedProvider &&
     MANAGED_ROUTABLE_PROVIDERS.has(expectedProvider);
+  // The ChatGPT-subscription row stores the "chatgpt" routing identity in
+  // its provider column, so the equality never holds for its openai
+  // upstream. The identity dispatches with the upstream threaded as
+  // `providerOverride`, mirroring the vellum sentinel; the upstream is
+  // always openai (`resolveRoutingIdentity`). Any other declared provider
+  // on a chatgpt row is a genuine mismatch and falls through below.
+  const isChatgptRoute =
+    connection.provider === "chatgpt" &&
+    (expectedProvider === undefined || expectedProvider === "openai");
   if (
     !isVellumRoute &&
+    !isChatgptRoute &&
     expectedProvider &&
     connection.provider !== expectedProvider
   ) {
@@ -225,7 +235,11 @@ export async function tryResolveProviderForConnectionName(
   try {
     const provider = await resolveProviderFromConnection(connection, config, {
       model,
-      providerOverride: isVellumRoute ? expectedProvider : undefined,
+      providerOverride: isVellumRoute
+        ? expectedProvider
+        : isChatgptRoute
+          ? "openai"
+          : undefined,
     });
     return attachProviderRoute(provider, connection);
   } catch (err) {
@@ -512,7 +526,12 @@ export async function preflightResolvedConfig(
     }
     return;
   }
-  if (connection.provider !== provider) {
+  // The ChatGPT-subscription row stores the "chatgpt" identity while its
+  // upstream is openai; the credential-presence switch below is the right
+  // preflight for it (the subscription token is its credential).
+  const isChatgptRow =
+    connection.provider === "chatgpt" && provider === "openai";
+  if (!isChatgptRow && connection.provider !== provider) {
     throw new ConnectionResolutionError(
       connectionName,
       "provider_mismatch",

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -126,6 +126,12 @@ export const VALID_CONNECTION_PROVIDERS: readonly string[] = [
   // persisted `vellum` rows — the routing threaded in via `providerOverride`
   // never runs on a row that fails to load.
   VELLUM_MANAGED_PROVIDER,
+  // The ChatGPT-subscription row stores the "chatgpt" routing identity in its
+  // `provider` column for the same reason: the row IS the subscription route
+  // (auth modality = provider identity), and dispatch derives the openai
+  // upstream per-request. Allowlisted explicitly or the DB loaders would drop
+  // the persisted row.
+  "chatgpt",
 ];
 
 export type ConnectionProvider = string;

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -161,7 +161,12 @@ export async function computeConnectionAvailability(
   if (resolvedConnectionName === VELLUM_MANAGED_CONNECTION_NAME) {
     return vellumConnectionAvailability();
   }
-  if (connection.provider !== provider) {
+  // The ChatGPT-subscription row stores the "chatgpt" identity while its
+  // upstream is openai; the credential switch below is the right check for
+  // it (the subscription token is its credential).
+  const isChatgptRow =
+    connection.provider === "chatgpt" && provider === "openai";
+  if (!isChatgptRow && connection.provider !== provider) {
     return {
       status: "provider_mismatch",
       message: `Connection "${resolvedConnectionName}" is for provider "${connection.provider}", but the requested provider is "${provider}". Pick a connection for "${provider}" ${SETTINGS_HINT}.`,

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -348,10 +348,12 @@ export function updateConnection(
     connection: {
       ...existing,
       auth,
+      provider: nextProvider,
       label: input.label !== undefined ? input.label : existing.label,
       baseUrl: nextBaseUrl,
       models: nextModels,
       updatedAt: now,
+      isManaged: isManagedRow({ name, provider: nextProvider, auth }),
     },
   };
 }

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -677,6 +677,52 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
 
   // The guard must not trap a legacy row in its mismatched state: an auth
   // change that repairs the pairing is exactly what should be allowed.
+  // The canonical subscription row owns the "chatgpt" identity: writing
+  // subscription auth to it stamps the provider (the CLI login-chatgpt path
+  // PATCHes auth through this route on a row the identity migration
+  // deliberately skipped).
+  test("stamps the chatgpt identity when subscription auth lands on the canonical row", async () => {
+    seedConnection({
+      name: "chatgpt-subscription",
+      provider: "openai",
+      auth: { type: "api_key", credential: "vault/openai/key" },
+    });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "chatgpt-subscription" },
+        body: {
+          auth: {
+            type: "oauth_subscription",
+            credential: "credential/chatgpt/access_token",
+          },
+        },
+      },
+    )) as { provider: string; auth: { type: string } };
+    expect(result.provider).toBe("chatgpt");
+    expect(result.auth.type).toBe("oauth_subscription");
+  });
+
+  test("does not stamp the identity for non-subscription auth on that name", async () => {
+    seedConnection({
+      name: "chatgpt-subscription",
+      provider: "openai",
+      auth: { type: "api_key", credential: "vault/openai/key" },
+    });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "chatgpt-subscription" },
+        body: {
+          auth: { type: "api_key", credential: "vault/openai/other-key" },
+        },
+      },
+    )) as { provider: string };
+    expect(result.provider).toBe("openai");
+  });
+
   test("allows repairing a legacy mismatched row with a valid auth change", async () => {
     seedConnection({
       name: "legacy-managed-anthropic",

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -232,6 +232,61 @@ describe("POST inference/provider-connections (create)", () => {
     expect((err as BadRequestError).message).toContain("vellum");
   });
 
+  test("rejects a chatgpt identity row under a non-canonical name", async () => {
+    const err = await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "my-chatgpt",
+          provider: "chatgpt",
+          auth: { type: "oauth_subscription", credential: "credential/x" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("chatgpt-subscription");
+  });
+
+  test("rejects key auth on the chatgpt provider, derived or explicit", async () => {
+    for (const body of [
+      {
+        name: "chatgpt-subscription",
+        provider: "chatgpt",
+        auth: { type: "api_key", credential: "vault/x" },
+      },
+      // No explicit auth: derivation would fall through to api_key.
+      {
+        name: "chatgpt-subscription",
+        provider: "chatgpt",
+        credential: "vault/x",
+      },
+    ]) {
+      const err = await call(
+        findHandler("inference_provider_connections_create"),
+        { body },
+      ).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(BadRequestError);
+      expect((err as BadRequestError).message).toContain("sign-in");
+    }
+  });
+
+  test("rejects subscription auth on a non-chatgpt provider", async () => {
+    const err = await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "keyed-oauth",
+          provider: "openai",
+          auth: { type: "oauth_subscription", credential: "credential/x" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("chatgpt");
+  });
+
   test("rejects key auth on the vellum provider", async () => {
     const err = await call(
       findHandler("inference_provider_connections_create"),

--- a/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
+++ b/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
@@ -159,13 +159,13 @@ async function handleExchange(args: RouteHandlerArgs) {
 
   const existing = getConnection(db, CONNECTION_NAME);
   if (existing) {
-    // Stamp the provider with the auth: this row is the subscription
-    // connection by name, and dispatch derives auth from the provider for
-    // managed rows, so a claiming row with e.g. provider "vellum" would
-    // otherwise strand the fresh token behind derived platform auth.
+    // Stamp the provider with the auth: this row IS the subscription route
+    // (auth modality = provider identity), and dispatch derives the openai
+    // upstream from the identity per-request. Stamping also heals a
+    // claiming row whose provider would otherwise misroute the fresh token.
     const updateResult = updateConnection(db, CONNECTION_NAME, {
       auth: authInput,
-      provider: "openai",
+      provider: "chatgpt",
     });
     if (!updateResult.ok) {
       log.error(
@@ -177,7 +177,7 @@ async function handleExchange(args: RouteHandlerArgs) {
   } else {
     const createResult = createConnection(db, {
       name: CONNECTION_NAME,
-      provider: "openai",
+      provider: "chatgpt",
       auth: authInput,
     });
     if (!createResult.ok) {

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -21,6 +21,7 @@ import { getDb } from "../../persistence/db-connection.js";
 import {
   type Auth,
   AuthSchema,
+  CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
   type ConnectionModel,
   ConnectionModelSchema,
   ConnectionProviderSchema,
@@ -434,15 +435,31 @@ async function handleUpdateConnection({
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
   }
+  // The canonical subscription row owns the "chatgpt" identity: writing
+  // subscription auth to it stamps the provider with the auth, mirroring
+  // the daemon's own sign-in exchange route. The CLI's login-chatgpt PATCHes
+  // auth through this route, and without the stamp a row the identity
+  // migration deliberately skipped (a claiming row with key auth) would end
+  // up as provider "openai" with subscription auth. Provider stays
+  // immutable for every other row.
+  const chatgptIdentityStamp =
+    name === CHATGPT_SUBSCRIPTION_CONNECTION_NAME &&
+    authResult.data.type === "oauth_subscription" &&
+    existing.provider !== "chatgpt";
+
   // The pairing is enforced on an actual auth change, not on the field being
   // present: the web editor and the CLI both resend the stored auth on every
   // edit, so a row whose columns already disagree stays relabelable and
-  // re-pointable.
+  // re-pointable. Judged against the stamped provider when the stamp
+  // applies, since that is the pair being written.
   if (
     body.auth !== undefined &&
     authFingerprint(authResult.data) !== authFingerprint(existing.auth)
   ) {
-    assertAuthMatchesProvider(existing.provider, authResult.data);
+    assertAuthMatchesProvider(
+      chatgptIdentityStamp ? "chatgpt" : existing.provider,
+      authResult.data,
+    );
   }
 
   const labelRaw = body.label;
@@ -473,6 +490,7 @@ async function handleUpdateConnection({
 
   const result = updateConnection(getDb(), name, {
     auth: authResult.data,
+    ...(chatgptIdentityStamp ? { provider: "chatgpt" } : {}),
     ...(labelRaw !== undefined ? { label: labelRaw as string | null } : {}),
     ...customFields,
   });

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -206,14 +206,26 @@ function deriveConnectionAuth(provider: string, credential: unknown): Auth {
 function assertAuthMatchesProvider(provider: string, auth: Auth): void {
   const managedAuth = auth.type === "platform";
   const managedProvider = provider === VELLUM_MANAGED_PROVIDER;
-  if (managedAuth === managedProvider) {
-    return;
+  if (managedAuth !== managedProvider) {
+    throw new BadRequestError(
+      managedAuth
+        ? `Auth type "platform" is only valid for provider "${VELLUM_MANAGED_PROVIDER}", not "${provider}". Vellum-managed routing is selected by the provider, so omit "auth" to derive it.`
+        : `Provider "${VELLUM_MANAGED_PROVIDER}" is always platform-authenticated; "${auth.type}" auth is not valid for it. Omit "auth" to derive it, or name a real provider for key-based auth.`,
+    );
   }
-  throw new BadRequestError(
-    managedAuth
-      ? `Auth type "platform" is only valid for provider "${VELLUM_MANAGED_PROVIDER}", not "${provider}". Vellum-managed routing is selected by the provider, so omit "auth" to derive it.`
-      : `Provider "${VELLUM_MANAGED_PROVIDER}" is always platform-authenticated; "${auth.type}" auth is not valid for it. Omit "auth" to derive it, or name a real provider for key-based auth.`,
-  );
+  // Same rule for the subscription identity: provider "chatgpt" and
+  // oauth_subscription auth record one fact and must pair, or a key-auth
+  // row under the identity would dispatch against the API while the user
+  // believes they are on subscription billing.
+  const subscriptionAuth = auth.type === "oauth_subscription";
+  const subscriptionProvider = provider === "chatgpt";
+  if (subscriptionAuth !== subscriptionProvider) {
+    throw new BadRequestError(
+      subscriptionAuth
+        ? `Auth type "oauth_subscription" is only valid for provider "chatgpt", not "${provider}". Run the ChatGPT sign-in flow to connect a subscription.`
+        : `Provider "chatgpt" is always subscription-authenticated; "${auth.type}" auth is not valid for it. Run the ChatGPT sign-in flow, or name a real provider for key-based auth.`,
+    );
+  }
 }
 
 /**
@@ -331,15 +343,27 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
       `Invalid provider "${String(provider)}". Valid: ${VALID_CONNECTION_PROVIDERS.join(", ")}`,
     );
   }
+  // The chatgpt identity lives on its canonical row: routing resolves the
+  // subscription by that name, so an identity row under any other name can
+  // never dispatch.
+  if (
+    providerResult.data === "chatgpt" &&
+    name !== CHATGPT_SUBSCRIPTION_CONNECTION_NAME
+  ) {
+    throw new BadRequestError(
+      `Provider "chatgpt" is reserved for the "${CHATGPT_SUBSCRIPTION_CONNECTION_NAME}" connection. Run the ChatGPT sign-in flow to connect a subscription.`,
+    );
+  }
   const authResult = AuthSchema.safeParse(
     auth ?? deriveConnectionAuth(providerResult.data, body.credential),
   );
   if (!authResult.success) {
     throw new BadRequestError(`Invalid auth: ${authResult.error.message}`);
   }
-  if (auth !== undefined) {
-    assertAuthMatchesProvider(providerResult.data, authResult.data);
-  }
+  // Asserted on derived auth as well: derivation pairs every provider
+  // correctly except the chatgpt identity, whose fallthrough would mint
+  // api_key auth from a bare credential.
+  assertAuthMatchesProvider(providerResult.data, authResult.data);
 
   const labelRaw = body.label;
   if (

--- a/clients/web/src/domains/settings/ai/chatgpt-oauth-section.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-oauth-section.tsx
@@ -104,9 +104,11 @@ export function ChatgptOAuthSection({
         throwOnError: true,
       });
       setOauthState("completed");
+      // Unfiltered: the subscription row is found by name, and its provider
+      // column differs across daemon versions ("chatgpt" on current daemons,
+      // "openai" on older ones), so a provider-filtered list can miss it.
       const { data } = await inferenceProviderconnectionsGet({
         path: { assistant_id: assistantId },
-        query: { provider: "openai" },
         throwOnError: true,
       });
       const conns = data.connections;
@@ -118,7 +120,7 @@ export function ChatgptOAuthSection({
       } else {
         onConnected({
           name: "chatgpt-subscription",
-          provider: "openai",
+          provider: "chatgpt",
           auth: {
             type: "oauth_subscription",
             credential: "credential/openai/chatgpt-subscription",


### PR DESCRIPTION
## Summary

Step 1 of the entries-model sequencing (`.private/plans/entries-model-13b.md` §5): the `chatgpt-subscription` row's provider column flips from `"openai"` to `"chatgpt"`, completing the "auth modality = provider identity" decision. Until now the row was found by name and stored a concrete upstream, which left provider `"openai"` ambiguous on disk (BYOK key row vs subscription row) and blocked deriving auth type from the provider column.

## Changes

- **`VALID_CONNECTION_PROVIDERS` gains `"chatgpt"`** with the same allowlist rationale as the vellum sentinel: without it, the DB loaders silently drop the flipped row.
- **DB migration 363** flips the stored row, scoped to the canonical name with `oauth_subscription` auth (a claiming row with key auth keeps its provider). `steps.ts` registration carries `dependsOn: ["migrateCreateProviderConnections"]`. Forward-only, idempotent.
- **Dispatch** (`tryResolveProviderForConnectionName`): the identity row passes the provider-equality check and threads `providerOverride: "openai"` into adapter resolution, mirroring the vellum sentinel — routing identities must never reach adapter construction. Pre-migration rows (provider `"openai"`) keep dispatching unchanged, so both shapes work across the upgrade window.
- **Preflight + availability** accept the identity row and judge its subscription credential, with the same pre-migration tolerance.
- **Sign-in flows** (web PKCE route and CLI `login-chatgpt`) stamp `provider: "chatgpt"` on upsert. CLI and daemon ship together, so no compat shim.
- **Web**: the OAuth section's post-sign-in fetch drops its `provider: "openai"` filter (the flipped row would be invisible to it) and finds the row by name, which works against both daemon versions. Display is keyed on `auth.type`, so rendering is unchanged. Regenerated `openapi.yaml` + the web client for the widened `ConnectionProvider` enum.

## Behavior change worth noting

Provider-keyed scans for `"openai"` (connection-less profile auto-resolve) no longer surface the subscription row. That is intentional: the `chatgpt` identity is the way to target the subscription, and a scan silently picking it was the same shape as the #38338 billing bug. A profile that wants Codex-on-subscription says `provider: "chatgpt"`.

## Testing

Migration fixtures (flip, claiming-row no-op, other rows untouched, unparseable auth, idempotency, missing table/row); dispatch + preflight tests for both row shapes; existing old-shape tests retained as transition coverage. Assistant `tsc` + eslint clean, web `tsc` clean; 154 tests across the inference/routes suites, all green. The 12 web settings failures are pre-existing environment noise (identical with the change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma7ZMzsQkJCG4t4uSGLoLT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->