### PR TITLE
fix(velay): stop the hourly tunnel cycling from killing phone calls; make tunnel-loss closes readable

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -406,6 +406,8 @@ mock.module("../calls/access-request-wait.js", () => ({
 // Now import the module under test.
 // ---------------------------------------------------------------------------
 
+import { GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE } from "@vellumai/service-contracts/ingress";
+
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import { CallController } from "../calls/call-controller.js";
 import { postPointerMessageSafe } from "../calls/call-pointer-messages.js";
@@ -743,6 +745,40 @@ describe("MediaStreamCallSession", () => {
         "failed",
         "+15551234567",
         expect.objectContaining({ reason: expect.any(String) }),
+      );
+    });
+
+    test("tunnel-lost close code decodes to a readable failure detail", () => {
+      const mock = createMockWs();
+      mockSessions.set("call-1", {
+        id: "call-1",
+        conversationId: "conv-1",
+        status: "in_progress",
+        startedAt: Date.now() - 60000,
+        toNumber: "+16175550142",
+        initiatedFromConversationId: "conv-origin",
+      });
+
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      // The gateway's close reason is dropped in relay, so only the code
+      // arrives — it must decode to something a human can act on.
+      session.handleTransportClosed(GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE);
+
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError:
+            "Media stream WebSocket closed unexpectedly: public ingress tunnel disconnected",
+        }),
+      );
+      expect(postPointerMessageSafe).toHaveBeenCalledWith(
+        "conv-origin",
+        "failed",
+        "+16175550142",
+        expect.objectContaining({
+          reason: "public ingress tunnel disconnected",
+        }),
       );
     });
 

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -761,7 +761,7 @@ describe("MediaStreamCallSession", () => {
 
       const session = new MediaStreamCallSession(mock.ws, "call-1");
       // The gateway's close reason is dropped in relay, so only the code
-      // arrives — it must decode to something a human can act on.
+      // arrives; it must decode to something a human can act on.
       session.handleTransportClosed(GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE);
 
       expect(updateCallSession).toHaveBeenCalledWith(

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -38,6 +38,7 @@
  * - Media stream `stop` event / WebSocket close -> finalize call.
  */
 
+import { GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE } from "@vellumai/service-contracts/ingress";
 import type { ServerWebSocket } from "bun";
 
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
@@ -344,9 +345,16 @@ export class MediaStreamCallSession {
         );
       }
     } else {
+      // The gateway's close reason does not survive the relay (Bun's
+      // WebSocket client drops it), so tunnel loss is decoded from the
+      // dedicated close code.
       const detail =
         reason ||
-        (code ? `media_stream_closed_${code}` : "media_stream_closed_abnormal");
+        (code === GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE
+          ? "public ingress tunnel disconnected"
+          : code
+            ? `media_stream_closed_${code}`
+            : "media_stream_closed_abnormal");
       updateCallSession(this.callSessionId, {
         status: "failed",
         endedAt: Date.now(),

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -153,10 +153,14 @@ function makeClient(
     ) => Promise<VelayHttpResponseFrame>;
     websocketFrames?: VelayWebSocketInboundFrame[];
     reconnectDelays?: number[];
+    refresh?: { afterMs?: number; busyRetryMs?: number };
+    timerCallbacks?: Array<() => void>;
+    bridgeConnections?: { count: number };
   } = {},
 ) {
   const sockets = overrides.sockets ?? [];
   const reconnectDelays = overrides.reconnectDelays ?? [];
+  const bridgeConnections = overrides.bridgeConnections;
   return new VelayTunnelClient({
     velayBaseUrl: "http://velay.example.test",
     gatewayLoopbackBaseUrl: "http://127.0.0.1:7830",
@@ -170,7 +174,7 @@ function makeClient(
     webSocketConstructor: makeFakeWebSocketConstructor(sockets),
     httpBridge: overrides.httpBridge,
     webSocketBridgeFactory:
-      overrides.websocketFrames === undefined
+      overrides.websocketFrames === undefined && bridgeConnections === undefined
         ? undefined
         : () =>
             ({
@@ -178,10 +182,16 @@ function makeClient(
                 overrides.websocketFrames?.push(frame);
               },
               closeAll: () => {},
+              getConnectionCount: () => bridgeConnections?.count ?? 0,
             }) as never,
     reconnect: { baseDelayMs: 10, maxDelayMs: 10, jitterRatio: 0 },
     heartbeat: { intervalMs: 0, readTimeoutMs: 0 },
-    timerApi: makeTimerApi(reconnectDelays),
+    // Disabled by default so the strict reconnect-delay assertions above
+    // don't see the refresh timer; the refresh suite enables it explicitly.
+    refresh: overrides.refresh ?? { afterMs: 0 },
+    timerApi: overrides.timerCallbacks
+      ? makeManualTimerApi(reconnectDelays, overrides.timerCallbacks)
+      : makeTimerApi(reconnectDelays),
   });
 }
 
@@ -538,6 +548,7 @@ describe("VelayTunnelClient", () => {
       webSocketConstructor: makeFakeWebSocketConstructor(sockets),
       reconnect: { baseDelayMs: 10, maxDelayMs: 80, jitterRatio: 0 },
       heartbeat: { intervalMs: 0, readTimeoutMs: 0 },
+      refresh: { afterMs: 0 },
       timerApi: makeManualTimerApi(reconnectDelays, reconnectCallbacks),
     });
 
@@ -591,6 +602,7 @@ describe("VelayTunnelClient", () => {
       webSocketConstructor: makeFakeWebSocketConstructor(sockets),
       reconnect: { baseDelayMs: 10, maxDelayMs: 80, jitterRatio: 0 },
       heartbeat: { intervalMs: 0, readTimeoutMs: 0 },
+      refresh: { afterMs: 0 },
       timerApi: makeManualTimerApi(reconnectDelays, reconnectCallbacks),
     });
 
@@ -1254,5 +1266,168 @@ describe("VelayTunnelClient", () => {
       { code: 1000, reason: "heartbeat read timeout" },
     ]);
     expect(delays).toEqual([100, 1000, 100, 10]);
+  });
+});
+
+describe("proactive tunnel refresh", () => {
+  async function registerTunnel(sockets: FakeWebSocket[]): Promise<void> {
+    sockets[0].readyState = WS_OPEN;
+    sockets[0].emit("open");
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+  }
+
+  test("refreshes an idle tunnel before the LB deadline and reconnects", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      refresh: { afterMs: 5000, busyRetryMs: 500 },
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    expect(delays).toEqual([5000]);
+
+    // Idle at the deadline: close cleanly and reconnect immediately.
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    expect(delays).toEqual([5000, 10]);
+
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(2);
+    await client.stop();
+  });
+
+  test("defers refresh while connections are proxied, then refreshes once idle", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const bridgeConnections = { count: 1 };
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      bridgeConnections,
+      refresh: { afterMs: 5000, busyRetryMs: 500 },
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    expect(delays).toEqual([5000]);
+
+    // Busy (a call is proxied): no close, re-check scheduled.
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+    expect(delays).toEqual([5000, 500]);
+
+    // Still busy on the re-check.
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+    expect(delays).toEqual([5000, 500, 500]);
+
+    // Call ended: the next re-check refreshes.
+    bridgeConnections.count = 0;
+    callbacks[2]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    await client.stop();
+  });
+
+  test("defers refresh while an HTTP request is in flight through the tunnel", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    let releaseHttp: (() => void) | undefined;
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      httpBridge: () =>
+        new Promise((resolve) => {
+          releaseHttp = () =>
+            resolve({
+              type: VELAY_FRAME_TYPES.httpResponse,
+              request_id: "req-1",
+              status_code: 200,
+              headers: {},
+            });
+        }),
+      refresh: { afterMs: 5000, busyRetryMs: 500 },
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.httpRequest,
+      request_id: "req-1",
+      method: "GET",
+      path: "/webhooks/twilio/voice",
+      headers: {},
+    });
+    await flushPromises();
+
+    // Busy (webhook in flight): no close, re-check scheduled.
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+    expect(delays).toEqual([5000, 500]);
+
+    releaseHttp?.();
+    await flushPromises();
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    await client.stop();
+  });
+
+  test("a stale refresh timer fires harmlessly after the tunnel already closed", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      refresh: { afterMs: 5000, busyRetryMs: 500 },
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    sockets[0].readyState = WS_CLOSED;
+    sockets[0].emit("close", { code: 1006, reason: "" });
+    await flushPromises();
+
+    // The manual timer API cannot cancel, so the refresh callback still
+    // fires — the ws-identity guard must make it a no-op.
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+    await client.stop();
   });
 });

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -156,6 +156,7 @@ function makeClient(
     refresh?: { afterMs?: number; busyRetryMs?: number };
     timerCallbacks?: Array<() => void>;
     bridgeConnections?: { count: number };
+    bridgeIdle?: { fire: () => void };
   } = {},
 ) {
   const sockets = overrides.sockets ?? [];
@@ -176,14 +177,18 @@ function makeClient(
     webSocketBridgeFactory:
       overrides.websocketFrames === undefined && bridgeConnections === undefined
         ? undefined
-        : () =>
-            ({
+        : (_gatewayLoopbackBaseUrl, _sendFrame, onIdle) => {
+            if (overrides.bridgeIdle && onIdle) {
+              overrides.bridgeIdle.fire = onIdle;
+            }
+            return {
               handleFrame: (frame: VelayWebSocketInboundFrame) => {
                 overrides.websocketFrames?.push(frame);
               },
               closeAll: () => {},
               getConnectionCount: () => bridgeConnections?.count ?? 0,
-            }) as never,
+            } as never;
+          },
     reconnect: { baseDelayMs: 10, maxDelayMs: 10, jitterRatio: 0 },
     heartbeat: { intervalMs: 0, readTimeoutMs: 0 },
     // Disabled by default so the strict reconnect-delay assertions above
@@ -1353,6 +1358,42 @@ describe("proactive tunnel refresh", () => {
     await client.stop();
   });
 
+  test("refreshes the moment the tunnel drains once the deadline has passed", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const bridgeConnections = { count: 1 };
+    const bridgeIdle = { fire: () => {} };
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      bridgeConnections,
+      bridgeIdle,
+      refresh: { afterMs: 5000, busyRetryMs: 500 },
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    // Deadline passes while a call is proxied: refresh becomes due.
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+
+    // The call ends: the bridge idle hook refreshes immediately, without
+    // waiting for the busy-retry poll (which would leave a stale tunnel
+    // accepting new streams right before the LB chop).
+    bridgeConnections.count = 0;
+    bridgeIdle.fire();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    await client.stop();
+  });
+
   test("defers refresh while an HTTP request is in flight through the tunnel", async () => {
     const sockets: FakeWebSocket[] = [];
     const delays: number[] = [];
@@ -1394,9 +1435,9 @@ describe("proactive tunnel refresh", () => {
     expect(sockets[0].closes).toEqual([]);
     expect(delays).toEqual([5000, 500]);
 
+    // The request completes: the due refresh fires immediately from the
+    // in-flight counter reaching zero, without waiting for the poll.
     releaseHttp?.();
-    await flushPromises();
-    callbacks[1]();
     await flushPromises();
     expect(sockets[0].closes).toEqual([
       { code: 1000, reason: "proactive tunnel refresh" },
@@ -1424,7 +1465,7 @@ describe("proactive tunnel refresh", () => {
     await flushPromises();
 
     // The manual timer API cannot cancel, so the refresh callback still
-    // fires — the ws-identity guard must make it a no-op.
+    // fires; the ws-identity guard must make it a no-op.
     callbacks[0]();
     await flushPromises();
     expect(sockets[0].closes).toEqual([]);

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -35,8 +35,8 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_READ_TIMEOUT_MS = 60_000;
 // Velay's production load balancer terminates every tunnel connection at
 // exactly 3600s (BackendConfig timeoutSec), killing any proxied call
-// mid-stream. Refresh the tunnel ourselves before that deadline — but only
-// while nothing is proxied through it — so the LB's clock resets without
+// mid-stream. Refresh the tunnel ourselves before that deadline (but only
+// while nothing is proxied through it) so the LB's clock resets without
 // ever chopping an established call.
 const TUNNEL_REFRESH_AFTER_MS = 3_300_000;
 const TUNNEL_REFRESH_BUSY_RETRY_MS = 30_000;
@@ -61,6 +61,7 @@ export type VelayTunnelClientOptions = {
   webSocketBridgeFactory?: (
     gatewayLoopbackBaseUrl: string,
     sendFrame: (frame: VelayFrame) => void,
+    onIdle?: () => void,
   ) => VelayWebSocketBridge;
   reconnect?: {
     baseDelayMs?: number;
@@ -101,6 +102,12 @@ export class VelayTunnelClient {
   private heartbeatTimer: unknown = null;
   private readTimeoutTimer: unknown = null;
   private refreshTimer: unknown = null;
+  // Set when the refresh deadline passed while the tunnel was busy: the
+  // refresh then fires as soon as the tunnel drains (last bridged
+  // connection or in-flight HTTP request completes) instead of waiting for
+  // the next busy-retry poll, which could leave a stale tunnel accepting
+  // new streams right before the LB chops it.
+  private refreshDue = false;
   private inFlightHttpRequests = 0;
   private peerHeartbeatConfirmed = false;
   private publishedPublicBaseUrl: string | undefined;
@@ -117,7 +124,11 @@ export class VelayTunnelClient {
     this.httpBridge = options.httpBridge ?? bridgeVelayHttpRequest;
     this.webSocketBridge = (
       options.webSocketBridgeFactory ?? defaultWebSocketBridgeFactory
-    )(options.gatewayLoopbackBaseUrl, (frame) => this.sendFrame(frame));
+    )(
+      options.gatewayLoopbackBaseUrl,
+      (frame) => this.sendFrame(frame),
+      () => this.handleTunnelIdle(),
+    );
     this.backoff = new ExponentialBackoff({
       baseDelayMs: options.reconnect?.baseDelayMs ?? BASE_RECONNECT_DELAY_MS,
       maxDelayMs: options.reconnect?.maxDelayMs ?? MAX_RECONNECT_DELAY_MS,
@@ -468,10 +479,15 @@ export class VelayTunnelClient {
         frame,
         this.options.gatewayLoopbackBaseUrl,
       );
-      if (this.ws !== originWs || !this.running) return;
+      if (this.ws !== originWs || !this.running) {
+        return;
+      }
       this.sendFrame(response);
     } finally {
       this.inFlightHttpRequests--;
+      if (this.inFlightHttpRequests === 0) {
+        this.handleTunnelIdle();
+      }
     }
   }
 
@@ -508,33 +524,61 @@ export class VelayTunnelClient {
    * Restart the tunnel before velay's load balancer terminates it (see
    * TUNNEL_REFRESH_AFTER_MS), so proxied calls stop dying at the hourly
    * boundary. Only fires while nothing is proxied through the tunnel; while
-   * busy it re-checks every refreshBusyRetryMs — if the LB chops first, the
+   * busy it marks the refresh due, so the tunnel refreshes the moment it
+   * drains, with a busy-retry poll as backstop. If the LB chops first, the
    * close handler clears the timer and the normal reconnect takes over.
    */
   private scheduleTunnelRefresh(ws: WebSocket, delayMs: number): void {
-    if (this.refreshAfterMs <= 0) return;
+    if (this.refreshAfterMs <= 0) {
+      return;
+    }
     this.clearTunnelRefresh();
     this.refreshTimer = this.timerApi.setTimeout(() => {
       this.refreshTimer = null;
-      if (this.ws !== ws || !this.running) return;
-      const busy =
-        this.webSocketBridge.getConnectionCount() > 0 ||
-        this.inFlightHttpRequests > 0;
-      if (busy) {
-        this.scheduleTunnelRefresh(ws, this.refreshBusyRetryMs);
+      if (this.ws !== ws || !this.running) {
         return;
       }
-      log.info("Refreshing idle Velay tunnel before the load balancer timeout");
-      this.backoff.reset();
-      this.disconnectActiveWebSocket(ws, 1000, "proactive tunnel refresh");
+      if (this.isTunnelBusy()) {
+        this.scheduleTunnelRefresh(ws, this.refreshBusyRetryMs);
+        // Set after the reschedule: clearTunnelRefresh resets the flag.
+        this.refreshDue = true;
+        return;
+      }
+      this.performTunnelRefresh(ws);
     }, delayMs);
   }
 
   private clearTunnelRefresh(): void {
+    this.refreshDue = false;
     if (this.refreshTimer) {
       this.timerApi.clearTimeout(this.refreshTimer);
       this.refreshTimer = null;
     }
+  }
+
+  private isTunnelBusy(): boolean {
+    return (
+      this.webSocketBridge.getConnectionCount() > 0 ||
+      this.inFlightHttpRequests > 0
+    );
+  }
+
+  /** Overdue-refresh path: the tunnel just drained (see refreshDue). */
+  private handleTunnelIdle(): void {
+    if (!this.refreshDue || !this.running) {
+      return;
+    }
+    const ws = this.ws;
+    if (!ws || this.isTunnelBusy()) {
+      return;
+    }
+    this.performTunnelRefresh(ws);
+  }
+
+  private performTunnelRefresh(ws: WebSocket): void {
+    log.info("Refreshing idle Velay tunnel before the load balancer timeout");
+    this.backoff.reset();
+    this.disconnectActiveWebSocket(ws, 1000, "proactive tunnel refresh");
   }
 
   private async clearPublishedPublicBaseUrl(): Promise<void> {
@@ -722,8 +766,9 @@ const defaultTimerApi: TimerApi = {
 function defaultWebSocketBridgeFactory(
   gatewayLoopbackBaseUrl: string,
   sendFrame: (frame: VelayFrame) => void,
+  onIdle?: () => void,
 ): VelayWebSocketBridge {
-  return new VelayWebSocketBridge(gatewayLoopbackBaseUrl, sendFrame);
+  return new VelayWebSocketBridge(gatewayLoopbackBaseUrl, sendFrame, onIdle);
 }
 
 async function mutateGatewayConfigFile(

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -33,6 +33,13 @@ const RECONNECT_JITTER_RATIO = 0.5;
 const VELAY_POLICY_CLOSE_CODE = 4008;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_READ_TIMEOUT_MS = 60_000;
+// Velay's production load balancer terminates every tunnel connection at
+// exactly 3600s (BackendConfig timeoutSec), killing any proxied call
+// mid-stream. Refresh the tunnel ourselves before that deadline — but only
+// while nothing is proxied through it — so the LB's clock resets without
+// ever chopping an established call.
+const TUNNEL_REFRESH_AFTER_MS = 3_300_000;
+const TUNNEL_REFRESH_BUSY_RETRY_MS = 30_000;
 
 export type WebSocketConstructorWithOptions = {
   new (
@@ -65,6 +72,10 @@ export type VelayTunnelClientOptions = {
     intervalMs?: number;
     readTimeoutMs?: number;
   };
+  refresh?: {
+    afterMs?: number;
+    busyRetryMs?: number;
+  };
   timerApi?: TimerApi;
 };
 
@@ -80,6 +91,8 @@ export class VelayTunnelClient {
   private readonly backoff: ExponentialBackoff;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatReadTimeoutMs: number;
+  private readonly refreshAfterMs: number;
+  private readonly refreshBusyRetryMs: number;
   private readonly timerApi: TimerApi;
   private ws: WebSocket | null = null;
   private running = false;
@@ -87,6 +100,8 @@ export class VelayTunnelClient {
   private reconnectTimer: unknown = null;
   private heartbeatTimer: unknown = null;
   private readTimeoutTimer: unknown = null;
+  private refreshTimer: unknown = null;
+  private inFlightHttpRequests = 0;
   private peerHeartbeatConfirmed = false;
   private publishedPublicBaseUrl: string | undefined;
   private credentialRefreshPending = false;
@@ -116,6 +131,9 @@ export class VelayTunnelClient {
       options.heartbeat?.intervalMs ?? HEARTBEAT_INTERVAL_MS;
     this.heartbeatReadTimeoutMs =
       options.heartbeat?.readTimeoutMs ?? HEARTBEAT_READ_TIMEOUT_MS;
+    this.refreshAfterMs = options.refresh?.afterMs ?? TUNNEL_REFRESH_AFTER_MS;
+    this.refreshBusyRetryMs =
+      options.refresh?.busyRetryMs ?? TUNNEL_REFRESH_BUSY_RETRY_MS;
     this.timerApi = options.timerApi ?? defaultTimerApi;
   }
 
@@ -188,6 +206,7 @@ export class VelayTunnelClient {
       this.reconnectTimer = null;
     }
     this.clearHeartbeat();
+    this.clearTunnelRefresh();
     const ws = this.ws;
     this.ws = null;
     this.webSocketBridge.closeAll();
@@ -436,18 +455,24 @@ export class VelayTunnelClient {
     this.publishedPublicBaseUrl = publicUrl;
     this.backoff.reset();
     log.info({ publicUrl }, "Velay tunnel registered");
+    this.scheduleTunnelRefresh(originWs, this.refreshAfterMs);
   }
 
   private async handleHttpRequestFrame(
     frame: VelayHttpRequestFrame,
     originWs: WebSocket,
   ): Promise<void> {
-    const response = await this.httpBridge(
-      frame,
-      this.options.gatewayLoopbackBaseUrl,
-    );
-    if (this.ws !== originWs || !this.running) return;
-    this.sendFrame(response);
+    this.inFlightHttpRequests++;
+    try {
+      const response = await this.httpBridge(
+        frame,
+        this.options.gatewayLoopbackBaseUrl,
+      );
+      if (this.ws !== originWs || !this.running) return;
+      this.sendFrame(response);
+    } finally {
+      this.inFlightHttpRequests--;
+    }
   }
 
   private handleClose(ws: WebSocket, event: CloseEvent): void {
@@ -455,6 +480,7 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.clearHeartbeat();
+    this.clearTunnelRefresh();
     this.webSocketBridge.closeAll();
     log.info(
       { code: event.code, reason: event.reason },
@@ -472,9 +498,43 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.clearHeartbeat();
+    this.clearTunnelRefresh();
     this.webSocketBridge.closeAll();
     closeWebSocket(ws, code, reason);
     this.clearPublishedPublicBaseUrlThenReconnect();
+  }
+
+  /**
+   * Restart the tunnel before velay's load balancer terminates it (see
+   * TUNNEL_REFRESH_AFTER_MS), so proxied calls stop dying at the hourly
+   * boundary. Only fires while nothing is proxied through the tunnel; while
+   * busy it re-checks every refreshBusyRetryMs — if the LB chops first, the
+   * close handler clears the timer and the normal reconnect takes over.
+   */
+  private scheduleTunnelRefresh(ws: WebSocket, delayMs: number): void {
+    if (this.refreshAfterMs <= 0) return;
+    this.clearTunnelRefresh();
+    this.refreshTimer = this.timerApi.setTimeout(() => {
+      this.refreshTimer = null;
+      if (this.ws !== ws || !this.running) return;
+      const busy =
+        this.webSocketBridge.getConnectionCount() > 0 ||
+        this.inFlightHttpRequests > 0;
+      if (busy) {
+        this.scheduleTunnelRefresh(ws, this.refreshBusyRetryMs);
+        return;
+      }
+      log.info("Refreshing idle Velay tunnel before the load balancer timeout");
+      this.backoff.reset();
+      this.disconnectActiveWebSocket(ws, 1000, "proactive tunnel refresh");
+    }, delayMs);
+  }
+
+  private clearTunnelRefresh(): void {
+    if (this.refreshTimer) {
+      this.timerApi.clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
   }
 
   private async clearPublishedPublicBaseUrl(): Promise<void> {

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -379,6 +379,26 @@ describe("VelayWebSocketBridge", () => {
     });
   });
 
+  test("invokes onIdle when the last connection goes away", () => {
+    let idleCalls = 0;
+    const idleBridge = new VelayWebSocketBridge(
+      "http://127.0.0.1:7830",
+      () => {},
+      () => {
+        idleCalls++;
+      },
+    );
+    idleBridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+    expect(idleCalls).toBe(0);
+
+    fakeSocket.emit("close", { code: 1000, reason: "" });
+
+    expect(idleCalls).toBe(1);
+    expect(idleBridge.getConnectionCount()).toBe(0);
+  });
+
   test("closeAll uses the dedicated tunnel-lost close code", () => {
     bridge.open(makeOpenFrame());
     fakeSocket.readyState = WS_OPEN;
@@ -386,8 +406,8 @@ describe("VelayWebSocketBridge", () => {
 
     bridge.closeAll();
 
-    // Not the remapped 1001→4001: the reason string does not survive the
-    // relay to the daemon, so the code alone must identify tunnel loss.
+    // Not the remapped 1001-to-4001 code: the reason string does not survive
+    // the relay to the daemon, so the code alone must identify tunnel loss.
     expect(fakeSocket.closes).toEqual([
       { code: GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE, reason: "Tunnel closed" },
     ]);

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -1,6 +1,8 @@
 import { Buffer } from "node:buffer";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE } from "@vellumai/service-contracts/ingress";
+
 import { VELAY_BRIDGE_AUTH_HEADER } from "./bridge-auth.js";
 import {
   VELAY_FRAME_TYPES,
@@ -377,15 +379,17 @@ describe("VelayWebSocketBridge", () => {
     });
   });
 
-  test("remaps closeAll going-away semantics to an application close code", () => {
+  test("closeAll uses the dedicated tunnel-lost close code", () => {
     bridge.open(makeOpenFrame());
     fakeSocket.readyState = WS_OPEN;
     fakeSocket.emit("open");
 
     bridge.closeAll();
 
+    // Not the remapped 1001→4001: the reason string does not survive the
+    // relay to the daemon, so the code alone must identify tunnel loss.
     expect(fakeSocket.closes).toEqual([
-      { code: 4001, reason: "Tunnel closed" },
+      { code: GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE, reason: "Tunnel closed" },
     ]);
     expect(bridge.getConnectionCount()).toBe(0);
   });

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -1,5 +1,7 @@
 import type { OutgoingHttpHeaders } from "node:http";
 
+import { GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE } from "@vellumai/service-contracts/ingress";
+
 import { addVelayBridgeAuthHeader } from "./bridge-auth.js";
 import {
   binaryLikeToBytes,
@@ -188,7 +190,10 @@ export class VelayWebSocketBridge {
     );
   }
 
-  closeAll(code = 1001, reason = "Tunnel closed"): void {
+  closeAll(
+    code = GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE,
+    reason = "Tunnel closed",
+  ): void {
     for (const [connectionId, connection] of this.connections) {
       connection.suppressNextCloseFrame = true;
       this.closeConnection(connectionId, connection, code, reason);

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -54,6 +54,8 @@ export class VelayWebSocketBridge {
   constructor(
     private readonly gatewayLoopbackBaseUrl: string,
     private readonly sendFrame: SendVelayFrame,
+    /** Invoked whenever the last bridged connection goes away. */
+    private readonly onIdle?: () => void,
   ) {}
 
   handleFrame(frame: VelayWebSocketInboundFrame): void {
@@ -231,16 +233,19 @@ export class VelayWebSocketBridge {
         connection,
         "WebSocket connection failed",
       );
+      this.notifyIfIdle();
       return;
     }
 
-    if (connection.suppressNextCloseFrame) return;
-    this.sendFrame({
-      type: VELAY_FRAME_TYPES.websocketClose,
-      connection_id: connectionId,
-      code: event.code,
-      reason: event.reason,
-    } satisfies VelayWebSocketCloseFrame);
+    if (!connection.suppressNextCloseFrame) {
+      this.sendFrame({
+        type: VELAY_FRAME_TYPES.websocketClose,
+        connection_id: connectionId,
+        code: event.code,
+        reason: event.reason,
+      } satisfies VelayWebSocketCloseFrame);
+    }
+    this.notifyIfIdle();
   }
 
   private failOpeningConnection(
@@ -254,6 +259,7 @@ export class VelayWebSocketBridge {
     connection.pendingMessages = [];
     this.sendOpenErrorOnce(connectionId, connection, reason);
     closeWebSocket(connection.ws);
+    this.notifyIfIdle();
   }
 
   private closeExisting(connectionId: string): void {
@@ -274,6 +280,13 @@ export class VelayWebSocketBridge {
     }
     connection.pendingMessages = [];
     closeWebSocket(connection.ws, code, reason);
+    this.notifyIfIdle();
+  }
+
+  private notifyIfIdle(): void {
+    if (this.connections.size === 0) {
+      this.onIdle?.();
+    }
   }
 
   private sendOpenError(connectionId: string, reason: string): void {

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -24,8 +24,8 @@ export function normalizePublicBaseUrl(value: unknown): string | undefined {
  * Application close code the gateway's velay bridge sends to proxied
  * WebSockets when the tunnel itself is lost (velay disconnect, gateway
  * shutdown). A dedicated code because the natural 1001 (going away) cannot
- * be sent through the JS `close()` API — the bridge would remap it to a
- * misleading 4001 — and Bun's WebSocket client drops close reasons, so the
+ * be sent through the JS `close()` API (the bridge would remap it to a
+ * misleading 4001), and Bun's WebSocket client drops close reasons, so the
  * code is the only signal that survives the relay to the daemon.
  */
 export const GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE = 4801;

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -20,6 +20,16 @@ export function normalizePublicBaseUrl(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+/**
+ * Application close code the gateway's velay bridge sends to proxied
+ * WebSockets when the tunnel itself is lost (velay disconnect, gateway
+ * shutdown). A dedicated code because the natural 1001 (going away) cannot
+ * be sent through the JS `close()` API — the bridge would remap it to a
+ * misleading 4001 — and Bun's WebSocket client drops close reasons, so the
+ * code is the only signal that survives the relay to the daemon.
+ */
+export const GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE = 4801;
+
 export function normalizeHttpPublicBaseUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();


### PR DESCRIPTION
## Summary
- Gateway proactively refreshes the velay tunnel at 55 min — before the LB's 3600s `BackendConfig timeoutSec` chops it — but only while idle (no proxied WebSockets, no in-flight HTTP bridge requests; re-checks every 30s while busy), so in-flight phone calls no longer die at the hourly boundary.
- Tunnel teardown now closes proxied sockets with a dedicated shared close code `GATEWAY_TUNNEL_LOST_WS_CLOSE_CODE = 4801` (in `@vellumai/service-contracts/ingress`) instead of 1001, and the daemon decodes it to `public ingress tunnel disconnected` in the call's `lastError`.
- Tests: idle/busy/stale refresh paths in `client.test.ts`, bridge close-code pin, daemon decode test.

## Production trace
A support case (assistant `019ef7fc…`, v0.10.8) reported calls failing after 10–28s with `Media stream WebSocket closed unexpectedly: media_stream_closed_4001`. Pod logs show the gateway's velay tunnel disconnecting at :56 past every hour (registration completions with `latency_ms ≈ 3600000`), and the failed call's media stream closing with code 4001 **1 ms** after the `Velay tunnel disconnected (1006)` line — every other call that week closed 1000 (normal hangup). The 4001 was our own artifact: `closeAll(1001, "Tunnel closed")` → `toSafeWebSocketCloseCode` remaps 1001 → 3000+1001 = 4001 (the JS `close()` API can't send 1001), and Bun's WebSocket client drops the reason string (verified empirically), so only the remapped bare code reached the daemon.

## Original prompt
Investigated a customer phone-call failure (`media_stream_closed_4001` drops 10–28s into calls on a managed velay instance) and traced it to velay's hourly LB tunnel termination killing in-flight media streams, obscured by the 1001→4001 close-code remap. Asked to fix both: keep the tunnel's LB clock from expiring mid-call via proactive idle refresh, and make tunnel-loss closes decode to a readable error. Velay-side graceful rollover (platform #9787 drain work) is a separate follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->