### PR TITLE
fix(assistant): self-heal SSE dev-bypass actor principal on cold guardian cache

### DIFF
--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -16,12 +16,16 @@
  * principalId at registration time so both sides agree. This keeps targeted
  * host proxy execution working on Docker / platform-managed deployments.
  */
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Module mocks (must be set up before importing the route) ──────────────
 
 let fakeHttpAuthDisabled = false;
 let fakeGuardianPrincipalId: string | undefined = undefined;
+
+// Manually-resolvable async resolutions, in call order, so tests control
+// exactly when the SSE self-heal lookup completes.
+const pendingAsyncResolutions: Array<(value: string | undefined) => void> = [];
 
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => fakeHttpAuthDisabled,
@@ -38,7 +42,20 @@ mock.module("../runtime/local-actor-identity.js", () => ({
     }
     return fakeGuardianPrincipalId;
   },
+  resolveActorPrincipalIdForLocalGuardian: (rawHeader: string | undefined) => {
+    if (rawHeader !== "dev-bypass" || !fakeHttpAuthDisabled) {
+      return Promise.resolve(rawHeader);
+    }
+    return new Promise<string | undefined>((resolve) => {
+      pendingAsyncResolutions.push(resolve);
+    });
+  },
 }));
+
+/** Let the fire-and-forget heal promise chain settle. */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 // ── Real imports (after mocks) ────────────────────────────────────────────
 
@@ -50,6 +67,10 @@ afterAll(() => {
 });
 
 describe("events SSE registration — dev-bypass actor translation", () => {
+  beforeEach(() => {
+    pendingAsyncResolutions.length = 0;
+  });
+
   test("translates 'dev-bypass' to the real guardian principalId when auth is disabled", () => {
     fakeHttpAuthDisabled = true;
     fakeGuardianPrincipalId = "guardian-real-id";
@@ -102,6 +123,167 @@ describe("events SSE registration — dev-bypass actor translation", () => {
     expect(entry?.actorPrincipalId).toBeUndefined();
 
     ac.abort();
+  });
+
+  test("self-heals a cold-cache registration once the async guardian lookup resolves", async () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined; // cold cache: sync resolution misses
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "heal-client-001",
+          "x-vellum-interface-id": "chrome-extension",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    // Registered without a principal, heal lookup in flight.
+    expect(hub.getActorPrincipalIdForClient("heal-client-001")).toBeUndefined();
+    expect(pendingAsyncResolutions).toHaveLength(1);
+
+    pendingAsyncResolutions.shift()!("guardian-real-id");
+    await flushMicrotasks();
+
+    // Hub record patched — a host-proxy request registered now snapshots the
+    // real principal, so the result-route same-actor check passes.
+    expect(hub.getActorPrincipalIdForClient("heal-client-001")).toBe(
+      "guardian-real-id",
+    );
+
+    ac.abort();
+  });
+
+  test("does not start the heal lookup when the sync resolution already succeeded", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = "guardian-real-id"; // warm cache
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "warm-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    expect(pendingAsyncResolutions).toHaveLength(0);
+
+    ac.abort();
+  });
+
+  test("does not start the heal lookup for connections without a dev-bypass principal", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined;
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    // Legacy connection with no actor-principal header at all: it registers
+    // without a principal and must stay that way (no dev-bypass translation).
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "legacy-client-001",
+          "x-vellum-interface-id": "macos",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    expect(pendingAsyncResolutions).toHaveLength(0);
+    expect(
+      hub.getActorPrincipalIdForClient("legacy-client-001"),
+    ).toBeUndefined();
+
+    ac.abort();
+  });
+
+  test("a stale heal cannot patch the subscription that replaced it (reconnect race)", async () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined; // cold cache for the first connect
+
+    const ac1 = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "race-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac1.signal,
+      },
+      { hub },
+    );
+    expect(pendingAsyncResolutions).toHaveLength(1);
+    const staleHeal = pendingAsyncResolutions.shift()!;
+
+    // Client reconnects before the first heal resolves; cache is warm now.
+    fakeGuardianPrincipalId = "guardian-current";
+    const ac2 = new AbortController();
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "race-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac2.signal,
+      },
+      { hub },
+    );
+
+    // The stale heal resolves late with a different value — it is keyed to
+    // the disposed connection, so the live record must be untouched.
+    staleHeal("guardian-stale");
+    await flushMicrotasks();
+
+    expect(hub.getActorPrincipalIdForClient("race-client-001")).toBe(
+      "guardian-current",
+    );
+
+    ac1.abort();
+    ac2.abort();
+  });
+
+  test("fillClientActorPrincipalId never overwrites a present principal", () => {
+    const hub = new AssistantEventHub();
+    const sub = hub.subscribe({
+      type: "client",
+      clientId: "direct-client-001",
+      interfaceId: "macos",
+      capabilities: [],
+      actorPrincipalId: "existing-principal",
+      callback: () => {},
+    });
+
+    hub.fillClientActorPrincipalId(sub.connectionId, "other-principal");
+    expect(hub.getActorPrincipalIdForClient("direct-client-001")).toBe(
+      "existing-principal",
+    );
+
+    // Unknown connection id is a no-op.
+    hub.fillClientActorPrincipalId("conn-does-not-exist", "other-principal");
+    expect(hub.getActorPrincipalIdForClient("direct-client-001")).toBe(
+      "existing-principal",
+    );
+
+    sub.dispose();
   });
 
   test("does NOT translate when auth is enabled (production mode)", () => {

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -312,6 +312,73 @@ describe("handleHostBashResult", () => {
     });
   });
 
+  // ── Fill-if-missing: persisted target healed after registration ────
+  //
+  // A request registered while the target's SSE record had no principal
+  // persists `targetActorPrincipalId: undefined`. Once the SSE self-heal
+  // fills the hub record, the result route re-reads the live record —
+  // but ONLY when the persisted value is missing.
+
+  describe("targeted request — missing persisted target principal fills from the live hub record", () => {
+    test("accepts a matching submitter when the hub record was healed after registration", async () => {
+      const requestId = "req-healed-target";
+      // Registered pre-heal: hub had no principal, so nothing was persisted.
+      registerPending(requestId, { targetClientId: "client-abc" });
+      // SSE self-heal fills the hub record afterwards.
+      clientActorPrincipals.set("client-abc", "principal-shared");
+
+      const result = await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-actor-principal-id": "principal-shared",
+        },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolvedIds).toContain(requestId);
+    });
+
+    test("still throws ForbiddenError (403) for a submitter with a different principal than the healed target", () => {
+      const requestId = "req-healed-target-mismatch";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-victim");
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-abc",
+            "x-vellum-actor-principal-id": "principal-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+
+    test("a present persisted principal always wins over the live hub record", () => {
+      // The fill is missing-only: a persisted value captured at registration
+      // is never overridden, so a submitter matching only the (different)
+      // live record is still rejected.
+      const requestId = "req-persisted-wins";
+      registerPending(requestId, {
+        targetClientId: "client-abc",
+        targetActorPrincipalId: "principal-registration",
+      });
+      clientActorPrincipals.set("client-abc", "principal-live");
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-abc",
+            "x-vellum-actor-principal-id": "principal-live",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+  });
+
   // ── Untargeted-request behavior (regression for new check) ─────────
 
   describe("untargeted request — actor principal check is skipped", () => {

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -151,8 +151,8 @@ export async function getGuardianDelivery(input?: {
  * Returns the fresh cached list for the given channel filter, or `undefined`
  * when the cache is cold or expired. Used by sync hot paths (SSE subscribe)
  * that cannot await {@link getGuardianDelivery} but must resolve the SAME
- * gateway-owned principal the async paths land on. A cold/expired return lets
- * the caller fall back to the local store as before.
+ * gateway-owned principal the async paths land on. There is no fallback
+ * fetch — on a cold/expired cache the caller proceeds without a principal.
  */
 export function peekCachedGuardianDelivery(input?: {
   channelTypes?: string[];

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -436,6 +436,42 @@ export class AssistantEventHub {
   }
 
   /**
+   * Fill a missing `actorPrincipalId` on a live client subscription.
+   *
+   * Used by the SSE dev-bypass self-heal: when the guardian-delivery cache is
+   * cold at subscribe time, the registration lands without a principal; the
+   * route resolves it async and patches the record here. Keyed by
+   * `connectionId` (not clientId) so a reconnect race cannot patch the
+   * subscription that replaced the one being healed. No-op when the
+   * connection is gone or already carries a principal — this only fills a
+   * missing value, never overwrites one. The value must come from the
+   * daemon's own server-side guardian lookup, never from client input.
+   */
+  fillClientActorPrincipalId(
+    connectionId: string,
+    actorPrincipalId: string,
+  ): void {
+    for (const entry of this.subscribers) {
+      if (entry.connectionId !== connectionId) {
+        continue;
+      }
+      if (
+        !entry.active ||
+        entry.type !== "client" ||
+        entry.actorPrincipalId != null
+      ) {
+        return;
+      }
+      entry.actorPrincipalId = actorPrincipalId;
+      log.info(
+        { clientId: entry.clientId, connectionId },
+        "filled missing actorPrincipalId for client subscription",
+      );
+      return;
+    }
+  }
+
+  /**
    * Returns true when at least one active subscriber would receive the given
    * event based on the same conversation matching rules as publish().
    */

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -21,6 +21,7 @@
  * in the audit log.
  */
 import type { HostProxyCapability } from "../../channels/types.js";
+import { isHttpAuthDisabled } from "../../config/env.js";
 import { getLogger } from "../../util/logger.js";
 import type { AssistantEventHub } from "../assistant-event-hub.js";
 import { ForbiddenError } from "../routes/errors.js";
@@ -74,6 +75,17 @@ export interface SameActorPersistedArgs {
   targetActorPrincipalId: string | undefined;
   targetClientId: string;
   op: SameActorOp;
+  /**
+   * Fill-if-missing fallback for dev-bypass deployments: when the PERSISTED
+   * target principal is absent (the request was registered before the SSE
+   * self-heal filled the target client's hub record), re-read the live hub
+   * record. Only consulted when `targetActorPrincipalId` is nullish AND HTTP
+   * auth is disabled — a present persisted value always wins, so a
+   * present-but-mismatched principal still rejects, and JWT-auth deployments
+   * are unaffected. The hub value is set server-side at SSE registration (or
+   * by the self-heal), never from client input.
+   */
+  hubForMissingTarget?: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
 }
 
 export type SameActorArgs = SameActorLiveArgs;
@@ -97,7 +109,12 @@ function detectRejection(
   const { sourceActorPrincipalId, targetClientId, op } = args;
   const targetActorPrincipalId = isLive(args)
     ? args.hub.getActorPrincipalIdForClient(targetClientId)
-    : args.targetActorPrincipalId;
+    : (args.targetActorPrincipalId ??
+      (isHttpAuthDisabled()
+        ? args.hubForMissingTarget?.getActorPrincipalIdForClient(
+            targetClientId,
+          )
+        : undefined));
 
   let reason: RejectionReason | undefined;
   if (sourceActorPrincipalId == null) {

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -84,8 +84,8 @@ export async function resolveDecidableGuardianPrincipalId(
  * {@link findLocalGuardianPrincipalIdFromStore}, which reads only the IO-free
  * cache snapshot. On a cold cache (auth-disabled / local startup, before any
  * async `getGuardianDelivery` has run) it returns undefined, so the FIRST SSE
- * registration would carry no `actorPrincipalId` and host-proxy same-user
- * targeting would regress until a later reconnect warms the cache.
+ * registration would carry no `actorPrincipalId` until the route's async
+ * self-heal fills the hub record.
  *
  * Called during daemon startup (after the gateway IPC is reachable) so the
  * cache is populated before clients register. Best-effort: a cold gateway
@@ -102,9 +102,11 @@ export async function warmLocalGuardianPrincipalCache(): Promise<void> {
  * path (`events-routes`), which registers before the stream is created.
  *
  * Reads the same gateway-owned binding as the async path via a sync, IO-free
- * snapshot of the guardian-delivery cache (kept fresh by the async hot paths
- * and event-driven invalidation), so SSE registers the SAME principal the
- * send/result routes resolve.
+ * snapshot of the guardian-delivery cache, so SSE registers the SAME
+ * principal the send/result routes resolve. Returns `undefined` on a cold or
+ * expired cache — there is no fallback fetch; the SSE route compensates by
+ * resolving async after subscribe and filling the hub record
+ * (`fillClientActorPrincipalId`).
  */
 export function findLocalGuardianPrincipalIdFromStore(): string | undefined {
   const cached = peekCachedGuardianDelivery({ channelTypes: ["vellum"] });
@@ -157,10 +159,10 @@ export async function resolveActorPrincipalIdForLocalGuardian(
  * Synchronous variant of {@link resolveActorPrincipalIdForLocalGuardian} for
  * the SSE eager-subscribe path, which registers before the response stream is
  * created and cannot await. Resolves the guardian from the IO-free gateway
- * cache snapshot first (same source the async path reads), falling back to the
- * local store when the cache is cold — so SSE registers the SAME principal the
- * send/result routes resolve and host-proxy targeting matches the same-user
- * client even when the local contact row is stale.
+ * cache snapshot only (same source the async path reads), so SSE registers
+ * the SAME principal the send/result routes resolve. On a cold cache this
+ * returns `undefined`; the SSE route then self-heals the registration via the
+ * async resolver once it completes.
  */
 export function resolveActorPrincipalIdForLocalGuardianSync(
   rawHeader: string | undefined,

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -42,7 +42,10 @@ import type { ReplaySubscriber } from "../assistant-stream-state.js";
 import { getReplayWindow } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from "../client-health.js";
-import { resolveActorPrincipalIdForLocalGuardianSync } from "../local-actor-identity.js";
+import {
+  resolveActorPrincipalIdForLocalGuardian,
+  resolveActorPrincipalIdForLocalGuardianSync,
+} from "../local-actor-identity.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -450,6 +453,30 @@ export function handleSubscribeAssistantEvents(
       throw new ServiceUnavailableError("Too many concurrent connections");
     }
     throw err;
+  }
+
+  // Self-heal for dev-bypass connections: the sync resolution above reads
+  // only the guardian-delivery cache, which can be cold at connect time —
+  // without this, the subscription would carry no principal for its whole
+  // lifetime and every host-proxy result would 403. Fire-and-forget so the
+  // stream is not delayed; keyed by connectionId so a reconnect race cannot
+  // patch the subscription that replaced this one.
+  if (
+    clientId &&
+    interfaceId &&
+    actorPrincipalId == null &&
+    rawActorPrincipalId?.trim() === "dev-bypass"
+  ) {
+    void resolveActorPrincipalIdForLocalGuardian("dev-bypass")
+      .then((resolved) => {
+        if (resolved) {
+          hub.fillClientActorPrincipalId(sub.connectionId, resolved);
+        }
+      })
+      .catch(() => {
+        // Best-effort: an unreachable gateway leaves the record unhealed;
+        // the next reconnect retries.
+      });
   }
 
   const stream = new ReadableStream<Uint8Array>(

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -19,6 +19,7 @@ import type {
   HostAppControlResultPayload,
   HostAppControlState,
 } from "../../daemon/message-types/host-app-control.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -118,6 +119,7 @@ async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_app_control",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -99,6 +100,7 @@ async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId,
       op: "host_bash",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -11,6 +11,7 @@ import {
   publishCdpEvent,
 } from "../../browser-session/events.js";
 import { clearPinnedTabByTabId } from "../../tools/browser/pinned-tabs.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -137,6 +138,7 @@ export async function resolveHostBrowserResultByRequestId(
         targetActorPrincipalId: peeked.targetActorPrincipalId,
         targetClientId: peeked.targetClientId,
         op: "host_browser",
+        hubForMissingTarget: assistantEventHub,
       });
     } catch (err) {
       // enforceSameActorOrThrow throws ForbiddenError on rejection.

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-registry.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -107,6 +108,7 @@ async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_cu",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -97,6 +98,7 @@ async function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_file",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   enforceSameActorOrThrow,
@@ -83,6 +84,7 @@ async function handleTransferContentGet({
         match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
       targetClientId,
       op: "host_transfer",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 
@@ -168,6 +170,7 @@ async function handleTransferContentPut({
         match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
       targetClientId,
       op: "host_transfer",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 
@@ -240,6 +243,7 @@ async function handleTransferResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_transfer",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 

--- a/assistant/src/runtime/routes/ui-snapshot-routes.ts
+++ b/assistant/src/runtime/routes/ui-snapshot-routes.ts
@@ -206,6 +206,7 @@ async function handleHostUiSnapshotResult({ body, headers }: RouteHandlerArgs) {
       targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_ui_snapshot",
+      hubForMissingTarget: assistantEventHub,
     });
   }
 


### PR DESCRIPTION
## Summary
- **Self-heal the SSE registration (primary fix).** In platform-hosted pods (`DISABLE_HTTP_AUTH`), the SSE subscribe path resolves the dev-bypass actor principal via a sync peek of the guardian-delivery cache; on a cold cache the subscription was registered with `actorPrincipalId: undefined` permanently, so every host-proxy result POST 403'd (`missing_target`) and the proxy timed out 30s later — for all clients (chrome-extension, macOS) and all host-proxy capabilities. The route now resolves the guardian async after the eager subscribe (fire-and-forget, never delays the stream) and patches the live hub record via a new `AssistantEventHub.fillClientActorPrincipalId` — keyed by `connectionId` so a reconnect race cannot patch the replacing subscription, and fill-only so a present principal is never overwritten. The value comes from the daemon's own gateway lookup, never client input.
- **Fill-if-missing at result time.** A host-proxy request registered during the brief pre-heal window persists `targetActorPrincipalId: undefined`. The persisted same-actor check (`SameActorPersistedArgs`) now accepts `hubForMissingTarget`, consulted only when the persisted value is missing AND HTTP auth is disabled — a present-but-mismatched principal still 403s, and JWT-auth deployments are behaviorally unchanged. All nine result-route call sites (bash/file/cu/browser/app-control/transfer×3/ui-snapshot) pass it.
- **Docstring fixes.** `resolveActorPrincipalIdForLocalGuardianSync` / `findLocalGuardianPrincipalIdFromStore` / `peekCachedGuardianDelivery` claimed a local-store fallback on cold cache that the implementation doesn't have; they now describe the actual cache-only behavior and the new self-heal.

Tests: heal path (cold-cache registration patched after async resolve), no-heal when sync already resolved or connection is non-dev-bypass, reconnect-race safety (stale heal cannot patch the replacing subscription), fill-never-overwrites, and result-route fill-if-missing (matching submitter accepted after heal; mismatched submitter still 403; persisted value always wins over the live record). All existing host-proxy/SSE/same-actor suites green.

## Original prompt
Platform-hosted (cloud) assistants rejected Chrome extension / desktop host-proxy results with 403, making browser and host actions fail even though the client was connected. Root cause (pre-diagnosed, verified against the code): the SSE subscribe path cannot await and only sync-peeks the guardian-delivery cache to translate the dev-bypass principal; a cold cache at connect time left the hub registration principal-less for the connection's lifetime, so result submissions failed the same-actor gate with `missing_target`. Requested: self-heal the SSE registration via an async guardian resolve + hub record patch keyed by connection id, close the pre-heal window at result time with strict fill-if-missing semantics (never weaken the same-actor gate; JWT-auth path unchanged), and fix the stale docstrings claiming a store fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)