### PR TITLE
style: replace em dashes in comments added by #40169

### DIFF
--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -151,7 +151,7 @@ describe("events SSE registration — dev-bypass actor translation", () => {
     pendingAsyncResolutions.shift()!("guardian-real-id");
     await flushMicrotasks();
 
-    // Hub record patched — a host-proxy request registered now snapshots the
+    // Hub record patched: a host-proxy request registered now snapshots the
     // real principal, so the result-route same-actor check passes.
     expect(hub.getActorPrincipalIdForClient("heal-client-001")).toBe(
       "guardian-real-id",
@@ -248,7 +248,7 @@ describe("events SSE registration — dev-bypass actor translation", () => {
       { hub },
     );
 
-    // The stale heal resolves late with a different value — it is keyed to
+    // The stale heal resolves late with a different value; it is keyed to
     // the disposed connection, so the live record must be untouched.
     staleHeal("guardian-stale");
     await flushMicrotasks();

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -316,10 +316,10 @@ describe("handleHostBashResult", () => {
   //
   // A request registered while the target's SSE record had no principal
   // persists `targetActorPrincipalId: undefined`. Once the SSE self-heal
-  // fills the hub record, the result route re-reads the live record —
+  // fills the hub record, the result route re-reads the live record,
   // but ONLY when the persisted value is missing.
 
-  describe("targeted request — missing persisted target principal fills from the live hub record", () => {
+  describe("targeted request - missing persisted target principal fills from the live hub record", () => {
     test("accepts a matching submitter when the hub record was healed after registration", async () => {
       const requestId = "req-healed-target";
       // Registered pre-heal: hub had no principal, so nothing was persisted.

--- a/assistant/src/contacts/guardian-delivery-reader.ts
+++ b/assistant/src/contacts/guardian-delivery-reader.ts
@@ -152,7 +152,7 @@ export async function getGuardianDelivery(input?: {
  * when the cache is cold or expired. Used by sync hot paths (SSE subscribe)
  * that cannot await {@link getGuardianDelivery} but must resolve the SAME
  * gateway-owned principal the async paths land on. There is no fallback
- * fetch — on a cold/expired cache the caller proceeds without a principal.
+ * fetch: on a cold/expired cache the caller proceeds without a principal.
  */
 export function peekCachedGuardianDelivery(input?: {
   channelTypes?: string[];

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -443,7 +443,7 @@ export class AssistantEventHub {
    * route resolves it async and patches the record here. Keyed by
    * `connectionId` (not clientId) so a reconnect race cannot patch the
    * subscription that replaced the one being healed. No-op when the
-   * connection is gone or already carries a principal — this only fills a
+   * connection is gone or already carries a principal: this only fills a
    * missing value, never overwrites one. The value must come from the
    * daemon's own server-side guardian lookup, never from client input.
    */

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -80,7 +80,7 @@ export interface SameActorPersistedArgs {
    * target principal is absent (the request was registered before the SSE
    * self-heal filled the target client's hub record), re-read the live hub
    * record. Only consulted when `targetActorPrincipalId` is nullish AND HTTP
-   * auth is disabled — a present persisted value always wins, so a
+   * auth is disabled. A present persisted value always wins, so a
    * present-but-mismatched principal still rejects, and JWT-auth deployments
    * are unaffected. The hub value is set server-side at SSE registration (or
    * by the self-heal), never from client input.

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -104,7 +104,7 @@ export async function warmLocalGuardianPrincipalCache(): Promise<void> {
  * Reads the same gateway-owned binding as the async path via a sync, IO-free
  * snapshot of the guardian-delivery cache, so SSE registers the SAME
  * principal the send/result routes resolve. Returns `undefined` on a cold or
- * expired cache — there is no fallback fetch; the SSE route compensates by
+ * expired cache (there is no fallback fetch); the SSE route compensates by
  * resolving async after subscribe and filling the hub record
  * (`fillClientActorPrincipalId`).
  */

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -456,8 +456,8 @@ export function handleSubscribeAssistantEvents(
   }
 
   // Self-heal for dev-bypass connections: the sync resolution above reads
-  // only the guardian-delivery cache, which can be cold at connect time —
-  // without this, the subscription would carry no principal for its whole
+  // only the guardian-delivery cache, which can be cold at connect time.
+  // Without this, the subscription would carry no principal for its whole
   // lifetime and every host-proxy result would 403. Fire-and-forget so the
   // stream is not delayed; keyed by connectionId so a reconnect race cannot
   // patch the subscription that replaced this one.


### PR DESCRIPTION
## Summary
- Follow-up to #40169, which was merged while its Codex review cycle was still running: Codex flagged (P2) that the comments and docstrings added there use em dashes, which the repo rule (AGENTS.md, Em Dashes) forbids in changed text.
- Replaces every em dash on lines added by #40169 with allowed punctuation (periods, colons, semicolons, parentheses, plain hyphens). Comment-only change, no behavior difference.

## Original prompt
Part of the /do run that shipped the SSE dev-bypass actor-principal self-heal (#40169). The review feedback loop surfaced this style rule violation after the PR had already been merged, so the fix lands as this follow-up instead of a push to the original branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)