### PR TITLE
fix(web): stop AnimatedRightDrawer's per-commit effect setState (React error 185)

### DIFF
--- a/clients/web/src/domains/chat/components/animated-right-drawer.test.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Regression coverage for LUM-3062 (React error 185, "Maximum update depth
+ * exceeded").
+ *
+ * The drawer adjusts its `mounted` / `retainedRight` state DURING RENDER
+ * (guarded render-phase setState), not in effects keyed on the `open` /
+ * `right` props. `right` is a fresh element on every parent render, so an
+ * effect keyed on it queues a setState into every commit's passive phase
+ * while the drawer is open. Each commit then finishes with another update
+ * already queued, which is what React's nested-update counter tallies, and a
+ * busy stretch (streaming transcript + query invalidations) chains into one
+ * 51-commit run and throws. See `lib/commit-pressure.ts`.
+ *
+ * The Profiler test pins the invariant directly: one parent render of an
+ * open drawer produces exactly one commit, with no cascaded effect commit.
+ * The remaining tests pin the behavior the state adjustments exist for
+ * (synchronous mount on open, content retention through the close wipe), so
+ * the render-phase rewrite cannot silently regress them.
+ *
+ * `motion/react` is mocked with plain elements; the close animation's
+ * `onAnimationComplete` is captured and fired manually so retention during
+ * the close wipe is observable (see chat-route-content.test for the shared
+ * mock pattern).
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  createElement,
+  Profiler,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+// --- Mocks ----------------------------------------------------------------
+
+/** Props consumed by motion itself; everything else passes through to the DOM. */
+const MOTION_ONLY_PROPS = new Set([
+  "initial",
+  "animate",
+  "exit",
+  "transition",
+  "variants",
+  "whileHover",
+  "whileTap",
+  "layout",
+  "layoutId",
+  "custom",
+  "onAnimationStart",
+  "onAnimationComplete",
+]);
+
+/**
+ * Latest `onAnimationComplete` handed to the motion stub. Unlike the shared
+ * mock in chat-route-content.test, the stub never fires it on its own; tests
+ * invoke it to simulate the width animation finishing.
+ */
+let completeAnimation: (() => void) | undefined;
+
+mock.module("motion/react", () => ({
+  motion: new Proxy(
+    {} as Record<string, (props: Record<string, unknown>) => ReactElement>,
+    {
+      get: (_target, tag) => (props: Record<string, unknown>) => {
+        completeAnimation = props.onAnimationComplete as
+          | (() => void)
+          | undefined;
+        const domProps: Record<string, unknown> = {};
+        for (const key in props) {
+          if (!MOTION_ONLY_PROPS.has(key)) {
+            domProps[key] = props[key];
+          }
+        }
+        return createElement(String(tag), domProps);
+      },
+    },
+  ),
+  useReducedMotion: () => false,
+}));
+
+import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
+
+// --- Tests ----------------------------------------------------------------
+
+function drawer({
+  open,
+  right,
+  onCommit,
+}: {
+  open: boolean;
+  right: ReactNode;
+  onCommit?: () => void;
+}) {
+  const tree = (
+    <AnimatedRightDrawer open={open} left={<div>chat</div>} right={right} />
+  );
+  if (!onCommit) {
+    return tree;
+  }
+  return (
+    <Profiler id="animated-right-drawer" onRender={onCommit}>
+      {tree}
+    </Profiler>
+  );
+}
+
+describe("AnimatedRightDrawer", () => {
+  afterEach(() => {
+    cleanup();
+    completeAnimation = undefined;
+  });
+
+  test("re-rendering an open drawer with a fresh right element commits exactly once per render", () => {
+    // The failure shape behind LUM-3062: prop-keyed effects turn every parent
+    // render of an open drawer into TWO commits (the render itself, then the
+    // passive-effect setState). Count commits via Profiler and require the
+    // 1:1 ratio; an effect-based `retainedRight`/`mounted` adjustment doubles
+    // the count and fails this.
+    let commits = 0;
+    const onCommit = () => {
+      commits += 1;
+    };
+    const { rerender } = render(
+      drawer({ open: true, right: <div>panel v1</div>, onCommit }),
+    );
+    const afterMount = commits;
+
+    const parentRenders = 3;
+    for (let i = 0; i < parentRenders; i += 1) {
+      // A fresh element each time, exactly like a re-rendering parent.
+      rerender(
+        drawer({ open: true, right: <div>panel v{2 + i}</div>, onCommit }),
+      );
+    }
+    expect(commits - afterMount).toBe(parentRenders);
+  });
+
+  test("opening mounts the drawer content in the same render pass", () => {
+    const { rerender } = render(drawer({ open: false, right: null }));
+    expect(screen.queryByText("panel")).toBeNull();
+
+    rerender(drawer({ open: true, right: <div>panel</div> }));
+    expect(screen.getByText("panel")).toBeTruthy();
+  });
+
+  test("closing retains the last content through the wipe and unmounts once the animation completes", () => {
+    const { rerender } = render(
+      drawer({ open: true, right: <div>panel</div> }),
+    );
+    expect(screen.getByText("panel")).toBeTruthy();
+
+    // Close: `right` goes null in the same render, as in both production
+    // call sites. The retained copy must keep the content visible.
+    rerender(drawer({ open: false, right: null }));
+    expect(screen.getByText("panel")).toBeTruthy();
+
+    // Width animation reaches 0: content and drag handle tear down.
+    act(() => {
+      completeAnimation?.();
+    });
+    expect(screen.queryByText("panel")).toBeNull();
+    expect(screen.queryByRole("separator")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/animated-right-drawer.test.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.test.tsx
@@ -1,21 +1,16 @@
 /**
- * Regression coverage for LUM-3062 (React error 185, "Maximum update depth
- * exceeded").
+ * `AnimatedRightDrawer` adjusts its `mounted` / `retainedRight` state during
+ * render (guarded render-phase setState) rather than in effects keyed on the
+ * `open` / `right` props. `right` is a fresh element on every parent render,
+ * so a prop-keyed effect would fire a setState in every commit's passive
+ * phase while the drawer is open, and enough such commits back to back trip
+ * React's nested-update limit under streaming load (error 185, LUM-3062).
+ * See `lib/commit-pressure.ts`.
  *
- * The drawer adjusts its `mounted` / `retainedRight` state DURING RENDER
- * (guarded render-phase setState), not in effects keyed on the `open` /
- * `right` props. `right` is a fresh element on every parent render, so an
- * effect keyed on it queues a setState into every commit's passive phase
- * while the drawer is open. Each commit then finishes with another update
- * already queued, which is what React's nested-update counter tallies, and a
- * busy stretch (streaming transcript + query invalidations) chains into one
- * 51-commit run and throws. See `lib/commit-pressure.ts`.
- *
- * The Profiler test pins the invariant directly: one parent render of an
+ * The Profiler test pins that invariant directly: one parent render of an
  * open drawer produces exactly one commit, with no cascaded effect commit.
  * The remaining tests pin the behavior the state adjustments exist for
- * (synchronous mount on open, content retention through the close wipe), so
- * the render-phase rewrite cannot silently regress them.
+ * (synchronous mount on open, content retention through the close wipe).
  *
  * `motion/react` is mocked with plain elements; the close animation's
  * `onAnimationComplete` is captured and fired manually so retention during

--- a/clients/web/src/domains/chat/components/animated-right-drawer.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.tsx
@@ -107,16 +107,22 @@ export function AnimatedRightDrawer({
   // live `right` renders directly (below) so a streaming panel paints
   // immediately; this retained copy only backs the close wipe.
   const [retainedRight, setRetainedRight] = useState<ReactNode>(right);
-  useEffect(() => {
-    if (open) {
-      setMounted(true);
-    }
-  }, [open]);
-  useEffect(() => {
-    if (right != null) {
-      setRetainedRight(right);
-    }
-  }, [right]);
+  // Both adjustments happen DURING RENDER (guarded render-phase setState, the
+  // "adjusting state when a prop changes" pattern from react.dev), not in a
+  // `useEffect`. `right` is a fresh element on every parent render, so an
+  // effect keyed on it fires a setState in every commit's passive phase while
+  // the drawer is open. Each commit then finishes with another update already
+  // queued, which is precisely what React's nested-update counter tallies, and
+  // a busy stretch (streaming transcript + query invalidations) chains into
+  // one 51-commit run and throws error 185 (LUM-3062). A render-phase
+  // adjustment re-renders before commit and queues nothing into the commit
+  // stream. See `lib/commit-pressure.ts` for the accounting.
+  if (open && !mounted) {
+    setMounted(true);
+  }
+  if (right != null && right !== retainedRight) {
+    setRetainedRight(right);
+  }
 
   const clamp = useCallback(
     (next: number) => {

--- a/clients/web/src/domains/chat/components/animated-right-drawer.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.tsx
@@ -107,16 +107,14 @@ export function AnimatedRightDrawer({
   // live `right` renders directly (below) so a streaming panel paints
   // immediately; this retained copy only backs the close wipe.
   const [retainedRight, setRetainedRight] = useState<ReactNode>(right);
-  // Both adjustments happen DURING RENDER (guarded render-phase setState, the
-  // "adjusting state when a prop changes" pattern from react.dev), not in a
-  // `useEffect`. `right` is a fresh element on every parent render, so an
-  // effect keyed on it fires a setState in every commit's passive phase while
-  // the drawer is open. Each commit then finishes with another update already
-  // queued, which is precisely what React's nested-update counter tallies, and
-  // a busy stretch (streaming transcript + query invalidations) chains into
-  // one 51-commit run and throws error 185 (LUM-3062). A render-phase
-  // adjustment re-renders before commit and queues nothing into the commit
-  // stream. See `lib/commit-pressure.ts` for the accounting.
+  // Both adjustments are guarded render-phase setState (the "adjusting state
+  // when a prop changes" pattern from react.dev). `right` is a fresh element
+  // on every parent render, so an effect keyed on it would queue a setState
+  // into every commit's passive phase while the drawer is open, and enough
+  // such commits back to back trip React's nested-update limit under
+  // streaming load (error 185, LUM-3062). A render-phase adjustment
+  // re-renders before commit and adds nothing to the commit stream. See
+  // `lib/commit-pressure.ts` for the accounting.
   if (open && !mounted) {
     setMounted(true);
   }


### PR DESCRIPTION
## TL;DR

`AnimatedRightDrawer` retained its right-pane content via a `useEffect` keyed on the `right` prop. Since `right` is a fresh JSX element on every parent render, that effect fired a `setState` in **every commit's passive phase** while a side panel was open — so every commit finished with another update already queued, which is exactly what React's nested-update counter tallies. During a busy stretch (streaming transcript + query invalidations) the commits chained into one 51-commit run and React threw error 185, crashing the conversation route to the error boundary. The `mounted` and `retainedRight` adjustments now happen during render (guarded render-phase setState), which re-renders before commit and queues nothing into the commit stream.

Fixes [LUM-3062](https://linear.app/vellum/issue/LUM-3062/error-maximum-update-depth-exceeded-this-can-happen-when-a-component) / Sentry [VELLUM-ASSISTANT-WEB-7Z](https://vellum.sentry.io/issues/7654570707/).

## Diagnosis

The Sentry event's `commit_pressure` context (the probe added for LUM-2859, `lib/commit-pressure.ts`) recorded 107 commits in 1.7s with a max back-to-back run of 33, sourced from query invalidations (`conversation-history`, `chat`, operational status, billing) plus transcript scroll. React resets its nested-update counter on the first commit that finishes with nothing queued — the drawer's per-commit effect setState guaranteed that reset never happened while a panel was open, so independent update traffic fused into a single over-limit run. The stack frame at `animated-right-drawer.tsx:117` is both the victim and the amplifier here.

## The fix

Both prop-following state adjustments (`mounted` from `open`, `retainedRight` from `right`) use the react.dev ["adjusting state when a prop changes"](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern: a guarded setState during render. React re-renders synchronously before commit, so no update is ever queued into the commit phase. As a side benefit, the drawer content now mounts in the same commit as the open flip instead of one commit later.

## Why this is safe

- Behavior is pinned by tests: synchronous mount on open, content retention through the close wipe, teardown on animation complete — all pass, plus the existing `chat-route-content.test.tsx` suite over the real drawer.
- The new Profiler-based regression test asserts the invariant (one commit per parent render of an open drawer, no cascaded effect commit) and was sensitivity-checked: it fails against the previous effect-based implementation.
- The render-phase setState is the React-documented pattern, guarded (`right !== retainedRight`, `open && !mounted`) so it converges in one extra render pass; children bail out via element identity.
- Typecheck and lint clean.

## Before / after for the user

| | Before | After |
|---|---|---|
| Streaming conversation with a side panel open (tool detail, activity steps, suggestion detail, etc.) | Under heavy update traffic the route could crash to "Something went wrong" (React error 185) | No crash; the drawer adds zero commit pressure |
| Opening a side panel | Content mounted one commit after the width animation started | Content mounts in the same commit |
| Close animation, drag-to-resize, width persistence | unchanged | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->