### PR TITLE
fix(gateway): register memory v3 gate-stats in bash risk registry

### DIFF
--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -198,6 +198,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v3 backfill-sections",
   "memory v3 eval",
   "memory v3 eval-tally",
+  "memory v3 gate-stats",
   "memory retrospective",
   "memory retrospective run",
   "memory retrospective list",
@@ -717,6 +718,12 @@ const riskOverrides: AssistantRiskOverride[] = [
     risk: "medium",
     reason:
       "Daemon handler is read-only, but the CLI writes the tally result to a user-supplied path when --out is provided; classifying medium so file-write invocations are not auto-approved as read-only",
+  },
+  {
+    path: "memory v3 gate-stats",
+    risk: "low",
+    reason:
+      "Read-only telemetry diagnostic: queries the local SQLite telemetry outbox and prints gate pass-rate stats; no writes, no daemon required",
   },
   {
     path: "memory retrospective run",


### PR DESCRIPTION
Add "memory v3 gate-stats" to ASSISTANT_SUPPORTED_COMMAND_PATHS and classify it as low risk — the command is read-only (queries local SQLite telemetry outbox, no writes, no daemon required).

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
