### PR TITLE
feat(design-library): add Skeleton primitive, migrate app skeletons to it

### DIFF
--- a/clients/web/src/components/profile-card.tsx
+++ b/clients/web/src/components/profile-card.tsx
@@ -29,6 +29,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 import { toast } from "@vellumai/design-library/components/toast";
 
 // Debounce window before firing the availability check. Tight enough that
@@ -544,21 +545,20 @@ function AssistantHandleSection({
 
 /**
  * Loading skeleton — mirrors the resolved layout so there is no
- * content-shift when fetchMe() returns. Uses the design-system pulse
- * pattern; no inline animation styles.
+ * content-shift when fetchMe() returns.
  */
 function ProfileCardSkeleton() {
   return (
     <div className="flex flex-col gap-4" aria-busy aria-live="polite">
       <div className="flex flex-col gap-2">
-        <div className="h-3 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <div className="h-9 w-full animate-pulse rounded-md bg-[var(--surface-muted)]" />
-        <div className="h-3 w-72 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-9 w-full rounded-md" />
+        <Skeleton className="h-3 w-72" />
       </div>
-      <div className="h-9 w-full animate-pulse rounded-md bg-[var(--surface-muted)]" />
+      <Skeleton className="h-9 w-full rounded-md" />
       <div className="flex items-center justify-between gap-3">
-        <div className="h-3 w-60 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <div className="h-7 w-16 animate-pulse rounded-md bg-[var(--surface-muted)]" />
+        <Skeleton className="h-3 w-60" />
+        <Skeleton className="h-7 w-16 rounded-md" />
       </div>
       <span className="sr-only">Loading your profile…</span>
     </div>

--- a/clients/web/src/domains/chat/components/chat-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/chat-skeleton.tsx
@@ -1,31 +1,29 @@
-export function SkeletonBar({ className }: { className?: string }) {
-  return <div className={`skeleton-shimmer rounded ${className ?? ""}`} />;
-}
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 export function ChatSkeleton() {
   return (
     <div className="mx-auto flex w-full max-w-[var(--chat-max-width)] flex-col gap-6 px-4 py-8 sm:px-6">
       {/* User message — right aligned */}
       <div className="flex justify-end">
-        <SkeletonBar className="h-4 w-32" />
+        <Skeleton className="h-4 w-32" />
       </div>
 
       {/* Assistant response — left aligned, multi-line */}
       <div className="flex flex-col gap-2">
-        <SkeletonBar className="h-4 w-3/4" />
-        <SkeletonBar className="h-4 w-1/2" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
       </div>
 
       {/* User message */}
       <div className="flex justify-end">
-        <SkeletonBar className="h-4 w-48" />
+        <Skeleton className="h-4 w-48" />
       </div>
 
       {/* Assistant response */}
       <div className="flex flex-col gap-2">
-        <SkeletonBar className="h-4 w-2/3" />
-        <SkeletonBar className="h-4 w-5/6" />
-        <SkeletonBar className="h-4 w-1/3" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-1/3" />
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/local-file/local-file-embed.tsx
+++ b/clients/web/src/domains/chat/components/local-file/local-file-embed.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { toast } from "@vellumai/design-library";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import { LocalFileCard } from "@/domains/chat/components/local-file/local-file-card";
 import { localFileKindFromFilename } from "@/domains/chat/components/local-file/local-file-icon";
@@ -144,10 +145,11 @@ export function LocalFileEmbed({
   );
 
   const placeholder = (
-    <span
+    <Skeleton
+      as="span"
       role="status"
       aria-label={`Loading ${mediaLabel}`}
-      className="my-2 inline-block h-7 w-40 animate-pulse rounded-lg bg-[var(--surface-lift)] align-middle"
+      className="my-2 inline-block h-7 w-40 rounded-lg align-middle"
     />
   );
 

--- a/clients/web/src/domains/chat/components/local-file/preview/preview-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/preview-skeleton.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+
 /** Relative widths of the placeholder lines, so the block reads as prose. */
 const LINE_WIDTHS = ["w-2/5", "w-full", "w-11/12", "w-4/5", "w-3/4"];
 
@@ -12,10 +14,7 @@ export function PreviewSkeleton(): ReactNode {
       className="flex flex-col gap-3 p-1"
     >
       {LINE_WIDTHS.map((width) => (
-        <span
-          key={width}
-          className={`h-4 animate-pulse rounded bg-[var(--surface-lift)] ${width}`}
-        />
+        <Skeleton as="span" key={width} className={`h-4 ${width}`} />
       ))}
     </div>
   );

--- a/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-conversation-skeleton.tsx
@@ -14,7 +14,7 @@
  * reflow between renders.
  */
 
-import { SkeletonBar } from "@/domains/chat/components/chat-skeleton";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 /**
  * Row widths, as Tailwind fraction utilities. Enough rows to fill the
@@ -50,7 +50,7 @@ export function SidebarConversationSkeleton() {
           className="flex h-[30px] items-center"
           style={{ paddingInline: 6 }}
         >
-          <SkeletonBar className={`h-3.5 ${width}`} />
+          <Skeleton className={`h-3.5 ${width}`} />
         </div>
       ))}
     </div>

--- a/clients/web/src/domains/chat/components/surfaces/visual-placeholder.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/visual-placeholder.tsx
@@ -1,3 +1,5 @@
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+
 /**
  * Stands in for an inline visual while the `ui_show` call that authors it is
  * still streaming.
@@ -10,13 +12,13 @@
  */
 export function VisualPlaceholder() {
   return (
-    <div
-      className="skeleton-shimmer flex h-[120px] w-full items-center justify-center rounded-lg"
+    <Skeleton
+      className="flex h-[120px] w-full items-center justify-center rounded-lg"
       role="status"
     >
       <span className="text-body-small-default text-[var(--content-quiet)]">
         Sketching a visual...
       </span>
-    </div>
+    </Skeleton>
   );
 }

--- a/clients/web/src/domains/home/home-page.tsx
+++ b/clients/web/src/domains/home/home-page.tsx
@@ -7,7 +7,7 @@ import { schedulesListQueryOptions } from "@/domains/settings/api/schedules";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useSupportsBulkFeedStatus } from "@/lib/backwards-compat/bulk-feed-status";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
-import { Button } from "@vellumai/design-library";
+import { Button, Skeleton } from "@vellumai/design-library";
 import { HomeDetailPanel } from "./detail-panel/home-detail-panel";
 import { HomeFeedList } from "./home-feed-list";
 import { HomeTopHeader } from "./home-top-header";
@@ -18,14 +18,11 @@ import { useHomeStateQuery } from "./hooks/use-home-state-query";
 function HomePageSkeleton() {
   return (
     <div className="flex flex-col gap-[var(--app-spacing-xl)]">
-      <div className="h-7 w-64 animate-pulse rounded-md bg-[var(--surface-lift)]" />
+      <Skeleton className="h-7 w-64 rounded-md" />
 
       <div className="flex flex-col gap-[var(--app-spacing-sm)]">
         {Array.from({ length: 4 }, (_, i) => (
-          <div
-            key={i}
-            className="h-16 animate-pulse rounded-md bg-[var(--surface-lift)]"
-          />
+          <Skeleton key={i} className="h-16 rounded-md" />
         ))}
       </div>
     </div>

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -32,7 +32,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { schedulesByIdRunsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
-import { Button, Typography, cn } from "@vellumai/design-library";
+import { Button, Skeleton, Typography, cn } from "@vellumai/design-library";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import type { Schedule, ScheduleRun } from "@/domains/settings/types/schedules";
@@ -93,10 +93,7 @@ function StatCards({ usage }: { usage: ScheduleRowUsage }) {
     return (
       <div className="grid grid-cols-2 gap-3 pt-2">
         {Array.from({ length: 2 }, (_, i) => (
-          <div
-            key={i}
-            className="h-[60px] animate-pulse rounded-lg bg-[var(--surface-muted)]"
-          />
+          <Skeleton key={i} className="h-[60px] rounded-lg" />
         ))}
       </div>
     );

--- a/clients/web/src/domains/schedules/components/schedule-row.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.tsx
@@ -8,6 +8,7 @@ import {
   formatTimestamp,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
@@ -16,8 +17,8 @@ function inlineUsage(usage: ScheduleRowUsage) {
   if (usage.status === "loading") {
     return (
       <>
-        <span className="h-4 w-12 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <span className="h-4 w-10 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <Skeleton as="span" className="h-4 w-12" />
+        <Skeleton as="span" className="h-4 w-10" />
       </>
     );
   }

--- a/clients/web/src/domains/schedules/components/schedule-summary-card.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-summary-card.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Maximize2, Minimize2 } from "lucide-react";
 
-import { Card } from "@vellumai/design-library";
+import { Card, Skeleton } from "@vellumai/design-library";
 
 export interface ScheduleSummaryCardProps {
   title: string;
@@ -82,9 +82,10 @@ function CostDisplay({
 }) {
   if (costStatus === "loading") {
     return (
-      <span
+      <Skeleton
+        as="span"
         aria-label="Loading cost"
-        className="h-7 w-44 animate-pulse rounded-md bg-[var(--surface-muted)]"
+        className="h-7 w-44 rounded-md"
       />
     );
   }

--- a/clients/web/src/domains/schedules/components/schedules-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedules-panel.tsx
@@ -6,6 +6,7 @@ import { ScheduleRow } from "@/domains/schedules/components/schedule-row";
 import { Button } from "@vellumai/design-library";
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
 import type { ScheduleRowUsage } from "@/domains/settings/utils/schedule-formatters";
@@ -106,10 +107,7 @@ export function SchedulesPanel({
       return (
         <div className="space-y-3">
           {Array.from({ length: 2 }, (_, i) => (
-            <div
-              key={i}
-              className="h-12 animate-pulse rounded-md bg-[var(--surface-muted)]"
-            />
+            <Skeleton key={i} className="h-12 rounded-md" />
           ))}
         </div>
       );

--- a/clients/web/src/domains/settings/ai/providers-section.tsx
+++ b/clients/web/src/domains/settings/ai/providers-section.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@vellumai/design-library/components/button";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { LanguageModelSection } from "@/domains/settings/ai/language-model-section";
@@ -95,10 +96,7 @@ export function ProvidersSection({
       {isLoading ? (
         <div className="space-y-2 py-2">
           {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="h-10 animate-pulse rounded-lg bg-[var(--surface-active)]"
-            />
+            <Skeleton key={i} className="h-10 rounded-lg" />
           ))}
         </div>
       ) : isError ? (

--- a/clients/web/src/domains/settings/components/schedule-shared-ui.tsx
+++ b/clients/web/src/domains/settings/components/schedule-shared-ui.tsx
@@ -1,3 +1,5 @@
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+
 import {
   formatScheduleCost,
   formatScheduleRunCount,
@@ -46,8 +48,8 @@ export function ScheduleUsageStats({
         aria-label="Loading schedule usage"
         className="flex w-[156px] shrink-0 items-center justify-end gap-3"
       >
-        <span className="h-5 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <span className="h-5 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <Skeleton as="span" className="h-5 w-16" />
+        <Skeleton as="span" className="h-5 w-16" />
       </div>
     );
   }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -172,46 +172,6 @@ body {
   }
 }
 
-/* Chat-loading skeleton shimmer — a soft gradient band sweeping left→right
- * over the placeholder bars while conversation history loads. The highlight
- * mixes the surface toward `--foreground` so it reads in every theme:
- * lighter band in dark/velvet, darker in light. */
-@keyframes skeleton-shimmer {
-  from { background-position: 150% 0; }
-  to { background-position: -50% 0; }
-}
-
-.skeleton-shimmer {
-  background-color: var(--surface-active);
-  /* Fallback band for engines without color-mix() (WKWebView before
-   * iOS 16.2, per the iOS 15.0 deployment target): a neutral translucent
-   * highlight over the surface color — no token expresses this without
-   * color-mix, hence the raw rgba. Engines that parse color-mix() take the
-   * declaration below instead. */
-  background-image: linear-gradient(
-    90deg,
-    transparent 35%,
-    rgba(128, 128, 128, 0.12) 50%,
-    transparent 65%
-  );
-  background-image: linear-gradient(
-    90deg,
-    var(--surface-active) 35%,
-    color-mix(in srgb, var(--surface-active), var(--foreground) 12%) 50%,
-    var(--surface-active) 65%
-  );
-  background-size: 200% 100%;
-  background-repeat: no-repeat;
-  animation: skeleton-shimmer 1.6s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .skeleton-shimmer {
-    animation: none;
-    background-image: none;
-  }
-}
-
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */
@@ -303,8 +263,8 @@ body {
   width: calc(var(--provision-avatar-size) * 0.8);
   margin-inline: auto;
   /* Fallback first for engines without color-mix(), see the skeleton-shimmer
-   * note above. The takeover is always dark-themed, so a translucent white
-   * stands in for the emphasised mix. */
+   * note in the design library's tokens.css. The takeover is always
+   * dark-themed, so a translucent white stands in for the emphasised mix. */
   background: radial-gradient(
     closest-side,
     rgba(255, 255, 255, 0.12),

--- a/packages/design-library/src/components/skeleton.stories.tsx
+++ b/packages/design-library/src/components/skeleton.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Skeleton } from "./skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+  args: {
+    className: "h-4 w-48",
+    as: "div",
+  },
+  argTypes: {
+    as: {
+      control: "inline-radio",
+      options: ["div", "span"],
+    },
+    className: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+/** Arg-driven: size and shape come from `className`. */
+export const Default: Story = {};
+
+/** A prose-shaped block: staggered line widths read as loading text. */
+export const Paragraph: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex w-80 flex-col gap-3">
+      <Skeleton className="h-4 w-2/5" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-11/12" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  ),
+};
+
+/** Common shapes: a list row, a card, and an inline chip-sized placeholder. */
+export const Shapes: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex w-80 flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-8 rounded-full" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+      <Skeleton className="h-16 w-full rounded-md" />
+      <p className="text-body-small-default">
+        Inline in text flow:{" "}
+        <Skeleton as="span" className="inline-block h-4 w-24 align-middle" />
+      </p>
+    </div>
+  ),
+};

--- a/packages/design-library/src/components/skeleton.tsx
+++ b/packages/design-library/src/components/skeleton.tsx
@@ -1,0 +1,34 @@
+import { createElement, type HTMLAttributes, type Ref } from "react";
+
+import { cn } from "../utils/cn";
+
+export type SkeletonAs = "div" | "span";
+
+export interface SkeletonProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Root element. Use `"span"` when the placeholder sits in phrasing
+   * content (e.g. inline in a paragraph), where a `div` is invalid HTML.
+   */
+  as?: SkeletonAs;
+  className?: string;
+  ref?: Ref<HTMLElement>;
+}
+
+/**
+ * Loading placeholder for content that is on its way. A soft gradient band
+ * sweeps across a surface-colored block; `prefers-reduced-motion` swaps the
+ * sweep for a static block. Size and shape come from the call site via
+ * `className` (`h-*`, `w-*`, `rounded-*`).
+ *
+ * Purely presentational by default. When a skeleton is the only signal that
+ * a region is loading, give the wrapper (or a standalone skeleton) the
+ * loading semantics: `role="status"` plus an `aria-label`.
+ */
+export function Skeleton({ as = "div", className, ref, ...rest }: SkeletonProps) {
+  return createElement(as, {
+    ...rest,
+    ref,
+    "data-slot": "skeleton",
+    className: cn("skeleton-shimmer rounded", className),
+  });
+}

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -194,6 +194,11 @@ export {
   type MarkdownLinkComponent,
 } from "./components/markdown-message";
 export {
+  Skeleton,
+  type SkeletonProps,
+  type SkeletonAs,
+} from "./components/skeleton";
+export {
   SideMenu,
   SideMenuBody,
   SideMenuFooter,

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -789,4 +789,46 @@
   animation: typing-dot-pulse 1s ease-in-out infinite;
 }
 
+/* ---------------------------------------------------------------------------
+ * Skeleton shimmer: a soft gradient band sweeping left→right over a
+ * placeholder block while content loads. Consumed by the `Skeleton`
+ * component. The highlight mixes the surface toward `--foreground` so it
+ * reads in every theme: lighter band in dark/velvet, darker in light.
+ * --------------------------------------------------------------------------- */
+@keyframes skeleton-shimmer {
+  from { background-position: 150% 0; }
+  to { background-position: -50% 0; }
+}
+
+.skeleton-shimmer {
+  background-color: var(--surface-active);
+  /* Fallback band for engines without color-mix() (WKWebView before
+   * iOS 16.2, per the iOS 15.0 deployment target): a neutral translucent
+   * highlight over the surface color (no token expresses this without
+   * color-mix, hence the raw rgba). Engines that parse color-mix() take the
+   * declaration below instead. */
+  background-image: linear-gradient(
+    90deg,
+    transparent 35%,
+    rgba(128, 128, 128, 0.12) 50%,
+    transparent 65%
+  );
+  background-image: linear-gradient(
+    90deg,
+    var(--surface-active) 35%,
+    color-mix(in srgb, var(--surface-active), var(--foreground) 12%) 50%,
+    var(--surface-active) 65%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer {
+    animation: none;
+    background-image: none;
+  }
+}
+
 


### PR DESCRIPTION
## TL;DR

Adds a `Skeleton` loading-placeholder primitive to `@vellumai/design-library` and migrates every skeleton in `clients/web` to it, collapsing the app's two competing hand-rolled idioms into one component. Fixes [LUM-3049](https://linear.app/vellum/issue/LUM-3049).

## What changed

- **New `Skeleton` component** (`packages/design-library/src/components/skeleton.tsx`): renders the shimmer treatment previously defined as `.skeleton-shimmer` in the app's `index.css`. Supports `as="span"` for placeholders in phrasing content (markdown flow, inside buttons). Size/shape come from `className`; `rounded` is the default and yields to caller overrides via tailwind-merge.
- **Shimmer CSS moved to the library's `tokens.css`**: the gradient sweep keyframes, the `color-mix()` highlight with the raw-rgba fallback for WKWebView before iOS 16.2, and the `prefers-reduced-motion` opt-out all travel with the component now. Storybook's preview already imports `tokens.css`, so the story renders without the app stylesheet (the gap PR #40020 fixed).
- **Story**: args-first `Default`, plus `Paragraph` and `Shapes` galleries. Verified rendering in the built Storybook (screenshots checked, including the inline-span case).
- **Idiom A migrated**: `ChatSkeleton`, `SidebarConversationSkeleton`, and `VisualPlaceholder` now use `Skeleton`; the chat-domain `SkeletonBar` export and the `index.css` copy are deleted, removing the layering wrinkle where non-chat surfaces had to reach into `domains/chat/`.
- **Idiom B migrated**: all ad-hoc `animate-pulse` + `bg-[var(--surface-*)]` skeletons (home page, providers section, schedules panel/row/detail/summary, profile card, local-file embed + preview, schedule shared UI) now render the same primitive, so every placeholder gets the reduced-motion opt-out and sits on the same surface token.

## Deliberately kept

Seven `animate-pulse` uses are live-status indicators, not loading placeholders: the voice recording light, thread/collapsed-group processing dots, the research-feed active-search icon, the name-editor typing caret, and terminal status pulses. The ticket's evidence list included four of these, but they signal ongoing activity rather than "content is on its way", so a skeleton primitive is the wrong replacement. The acceptance criterion ("no `animate-pulse`-based ad-hoc **skeletons**") is met.

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| Chat, sidebar, visual placeholders | Gradient shimmer | Unchanged |
| Home, settings, schedules, profile, file previews | Opacity pulse, per-page contrast (three different surface tokens) | Same shimmer as chat, uniform contrast |
| Reduced-motion users | Idiom-B placeholders kept pulsing | All placeholders render as static blocks |
| Status indicators (recording light, processing dots, caret) | Pulse | Unchanged |

## Why it's safe

- Idiom-A surfaces are pixel-identical: same class, same CSS, only its home moved. The existing transcript test asserting `skeleton-shimmer` on the visual placeholder still passes unchanged.
- Idiom-B surfaces keep their exact dimensions and radii; only the fill/animation changes, which is the point of the ticket.
- No API/data/behavioral changes; CSS is additive in the library and the deleted app block has no remaining references (`grep` clean for `SkeletonBar`; remaining `animate-pulse` hits are the indicators listed above).
- Verified: design-library + web typechecks clean, lint 0 errors, `transcript-message-body` / `chat-body` / `chat-scroll-area` / `tokens` tests pass, `build-storybook` succeeds and the new stories render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->