### PR TITLE
feat(web): count unattributed commits in the commit-pressure probe

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -504,9 +504,13 @@ export function ChatMainPanel({
 
   // Commit counter for the chat-route subtree. Deliberately dependency-less:
   // it has to run on every commit to measure how tightly they are packed,
-  // which is what `Maximum update depth exceeded` actually reacts to. Records
-  // nothing but two integers — see `lib/commit-pressure.ts`.
-  useEffect(() => {
+  // which is what `Maximum update depth exceeded` actually reacts to. A layout
+  // effect rather than a passive one, so the commit is recorded before
+  // ResizeObserver, rAF, and timer callbacks can fire: an instrumented update
+  // landing in that window would otherwise be consumed as attribution of the
+  // commit that just finished instead of the commit it causes. Records nothing
+  // but a few integers; see `lib/commit-pressure.ts`.
+  useLayoutEffect(() => {
     recordCommit();
   });
 

--- a/clients/web/src/lib/commit-pressure.test.ts
+++ b/clients/web/src/lib/commit-pressure.test.ts
@@ -105,4 +105,79 @@ describe("commit-pressure probe", () => {
     expect(Object.keys(snapshot?.sources ?? {}).length).toBeLessThanOrEqual(25);
     expect(snapshot?.sources.other).toBe(16);
   });
+
+  test("a commit preceded by a recorded update is attributed", () => {
+    recordUpdate("smooth-stream");
+    recordCommit();
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.commits).toBe(1);
+    expect(snapshot?.unattributedCommits).toBe(0);
+    expect(snapshot?.maxUnattributedCommits).toBe(0);
+  });
+
+  test("one update attributes only the next commit, not a cascade behind it", () => {
+    // The LUM-3062 shape: an instrumented update drives a commit, then an
+    // uninstrumented effect setState drives another. The cascade commit has
+    // no recorded update of its own and must count as unattributed.
+    recordUpdate("transcript-scroll");
+    recordCommit();
+    clock += 2;
+    recordCommit();
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.commits).toBe(2);
+    expect(snapshot?.unattributedCommits).toBe(1);
+    expect(snapshot?.maxUnattributedCommits).toBe(1);
+  });
+
+  test("tracks the longest unattributed run across interleaved attributed traffic", () => {
+    for (let i = 0; i < 5; i += 1) {
+      recordCommit();
+      clock += 2;
+    }
+    recordUpdate("smooth-stream");
+    recordCommit(); // attributed, breaks the run
+    clock += 2;
+    for (let i = 0; i < 3; i += 1) {
+      recordCommit();
+      clock += 2;
+    }
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.commits).toBe(9);
+    expect(snapshot?.unattributedCommits).toBe(8);
+    expect(snapshot?.maxUnattributedCommits).toBe(5);
+  });
+
+  test("unattributed run survives a bucket rollover", () => {
+    for (let i = 0; i < 4; i += 1) {
+      recordCommit();
+      clock += 2;
+    }
+    clock += 1100; // roll into the next bucket, no idle gap
+    for (let i = 0; i < 4; i += 1) {
+      recordCommit();
+      clock += 2;
+    }
+
+    // Rollover is not an update; the run keeps growing across it.
+    expect(snapshotCommitPressure()?.maxUnattributedCommits).toBe(8);
+  });
+
+  test("idle gap clears attribution state along with the tallies", () => {
+    recordUpdate("smooth-stream");
+    for (let i = 0; i < 4; i += 1) {
+      recordCommit();
+      clock += 2;
+    }
+    clock += 5000; // idle: everything on record is stale
+    recordCommit();
+
+    const snapshot = snapshotCommitPressure();
+    expect(snapshot?.commits).toBe(1);
+    // The pre-gap update must not attribute a post-gap commit.
+    expect(snapshot?.unattributedCommits).toBe(1);
+    expect(snapshot?.maxUnattributedCommits).toBe(1);
+  });
 });

--- a/clients/web/src/lib/commit-pressure.ts
+++ b/clients/web/src/lib/commit-pressure.ts
@@ -161,8 +161,15 @@ export function recordUpdate(source: UpdateSource): void {
 }
 
 /**
- * Record a React commit. Called from a dependency-less effect in the chat
- * route, so it counts commits of that subtree — not every root commit.
+ * Record a React commit. Called from a dependency-less layout effect in the
+ * chat route, so it counts commits of that subtree, not every root commit.
+ * Layout-effect timing keeps attribution honest: the commit is recorded
+ * before ResizeObserver, rAF, and timer callbacks run, so an instrumented
+ * update firing in those callbacks attributes the commit it schedules, not
+ * the one that just finished. Updates scheduled inside the render or layout
+ * window itself are still consumed by the finishing commit, so an isolated
+ * `unattributedCommits` tick with a run of 1 is scheduling noise; the signal
+ * is counts rivaling `commits` and long runs.
  */
 export function recordCommit(): void {
   const ts = now();

--- a/clients/web/src/lib/commit-pressure.ts
+++ b/clients/web/src/lib/commit-pressure.ts
@@ -67,17 +67,37 @@ export interface CommitPressureSnapshot {
   commits: number;
   /** Longest run of commits separated by less than {@link BACK_TO_BACK_MS}. */
   maxBackToBackCommits: number;
+  /**
+   * Commits with no recorded update since the previous commit: traffic the
+   * per-source tallies cannot name. When this dwarfs `updates`, the driver is
+   * an uninstrumented updater and `sources` lists bystanders (LUM-3062).
+   */
+  unattributedCommits: number;
+  /**
+   * Longest consecutive run of unattributed commits. A long run fingerprints
+   * a per-commit updater outside the instrumented set, such as a setState in
+   * a passive effect; instrumented traffic interleaving every other commit
+   * caps the run at 1, so read it together with `unattributedCommits`.
+   */
+  maxUnattributedCommits: number;
 }
 
 interface Bucket {
   startedAt: number;
   updates: number;
   commits: number;
+  unattributed: number;
   sources: Map<string, number>;
 }
 
 function emptyBucket(startedAt: number): Bucket {
-  return { startedAt, updates: 0, commits: 0, sources: new Map() };
+  return {
+    startedAt,
+    updates: 0,
+    commits: 0,
+    unattributed: 0,
+    sources: new Map(),
+  };
 }
 
 let current: Bucket = emptyBucket(0);
@@ -88,6 +108,14 @@ let previous: Bucket = emptyBucket(0);
 let lastCommitAt = 0;
 let backToBackRun = 0;
 let maxBackToBackRun = 0;
+
+// Attribution tracking. A commit is attributed when at least one
+// `recordUpdate` landed since the previous commit; anything else is update
+// traffic the source tallies cannot see. Spans buckets like the back-to-back
+// run, for the same reason.
+let updateSinceLastCommit = false;
+let unattributedRun = 0;
+let maxUnattributedRun = 0;
 
 function now(): number {
   return typeof performance !== "undefined" && performance.now
@@ -106,6 +134,9 @@ function roll(ts: number): void {
     previous = emptyBucket(ts);
     maxBackToBackRun = 0;
     backToBackRun = 0;
+    updateSinceLastCommit = false;
+    unattributedRun = 0;
+    maxUnattributedRun = 0;
   } else {
     previous = current;
   }
@@ -120,6 +151,7 @@ function roll(ts: number): void {
 export function recordUpdate(source: UpdateSource): void {
   const ts = now();
   roll(ts);
+  updateSinceLastCommit = true;
   current.updates += 1;
   const key =
     current.sources.has(source) || current.sources.size < MAX_SOURCES
@@ -136,6 +168,16 @@ export function recordCommit(): void {
   const ts = now();
   roll(ts);
   current.commits += 1;
+  if (updateSinceLastCommit) {
+    unattributedRun = 0;
+  } else {
+    current.unattributed += 1;
+    unattributedRun += 1;
+    if (unattributedRun > maxUnattributedRun) {
+      maxUnattributedRun = unattributedRun;
+    }
+  }
+  updateSinceLastCommit = false;
   if (lastCommitAt !== 0 && ts - lastCommitAt < BACK_TO_BACK_MS) {
     backToBackRun += 1;
     if (backToBackRun > maxBackToBackRun) {
@@ -179,6 +221,8 @@ export function snapshotCommitPressure(): CommitPressureSnapshot | null {
     sources,
     commits,
     maxBackToBackCommits: maxBackToBackRun,
+    unattributedCommits: current.unattributed + previous.unattributed,
+    maxUnattributedCommits: maxUnattributedRun,
   };
 }
 
@@ -228,4 +272,7 @@ export function resetCommitPressure(): void {
   lastCommitAt = 0;
   backToBackRun = 0;
   maxBackToBackRun = 0;
+  updateSinceLastCommit = false;
+  unattributedRun = 0;
+  maxUnattributedRun = 0;
 }


### PR DESCRIPTION
## TL;DR

The commit-pressure probe attaches per-source update tallies to error-185 Sentry events, but it can only name sources that call `recordUpdate` — and both production incidents so far were driven by *uninstrumented* updaters, so `sources` listed bystanders. This PR makes the mismatch itself a first-class signal: the snapshot now reports `unattributedCommits` (commits with no recorded update since the previous commit) and `maxUnattributedCommits` (the longest consecutive run of them).

Fixes [LUM-3063](https://linear.app/vellum/issue/LUM-3063/commit-pressure-probe-count-unattributed-commits-and-cascade-runs) (sub-issue of the [LUM-2927](https://linear.app/vellum/issue/LUM-2927/keep-decorative-animation-out-of-the-react-commit-stream-root-cause-of) error-185 umbrella).

## Why

In the [LUM-3062](https://linear.app/vellum/issue/LUM-3062/error-maximum-update-depth-exceeded-this-can-happen-when-a-component) event the probe attributed 9 updates against 107 commits; the amplifier (a setState in a passive effect in `AnimatedRightDrawer`) was invisible to it, and diagnosing required reconstructing the cascade from the victim stack. Per-callsite instrumentation (LUM-2927 scope item 1) covers known writers; it structurally cannot cover the next unknown one. Counting what the probe *cannot* attribute closes that gap: a large `unattributedCommits` with long runs reads as "an uninstrumented per-commit updater is chained into the loop", pointing the investigation at effect-driven cascades before any archaeology.

## Why this is safe

- Additive only: two new snapshot fields; nothing existing changes shape or meaning. `sentry-init` attaches the whole snapshot object, so the fields flow to Sentry with no wiring change (its tests pass unchanged).
- Hot-path constraint preserved: one boolean and two integer writes per commit, no allocation.
- Attribution state follows the same lifecycle as the existing back-to-back tracking: it spans bucket rollovers and resets on the idle-gap branch, and both behaviors are pinned by tests (13 pass, including the LUM-3062 cascade shape: one update attributes only the next commit, not the cascade behind it).

## Before / after for the user

No user-facing behavior change; this is diagnostics.

| | Before | After |
|---|---|---|
| Error-185 Sentry event, instrumented updater at fault | `sources` names it | unchanged |
| Error-185 Sentry event, uninstrumented updater at fault | `sources` lists bystanders; cause requires manual reconstruction | `unattributedCommits` / `maxUnattributedCommits` flag the uninstrumented driver directly |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->