### PR TITLE
Bound an unbounded file_read, and spool the reads that are not paging spooled content

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  DEFAULT_READ_LINE_LIMIT,
   FileSystemOps,
   type PathPolicy,
 } from "../tools/shared/filesystem/file-ops-service.js";
@@ -124,10 +125,80 @@ describe("FileSystemOps.readFileSafe", () => {
     if (!result.ok) {
       return;
     }
-    expect(result.value.content).toContain("b");
-    expect(result.value.content).toContain("c");
-    expect(result.value.content).not.toContain("     1");
-    expect(result.value.content).not.toContain("d");
+    // Assert on the numbered lines rather than bare letters: the truncation
+    // notice is prose, so a bare `toContain("d")` matches its wording.
+    const [body] = result.value.content.split("\n\n[Truncated:");
+    expect(body).toContain("     2  b");
+    expect(body).toContain("     3  c");
+    expect(body).not.toContain("     1  a");
+    expect(body).not.toContain("     4  d");
+  });
+
+  test("caps an unbounded read at the default line limit and says so", async () => {
+    const dir = makeTempDir();
+    const total = DEFAULT_READ_LINE_LIMIT + 500;
+    const lines = Array.from({ length: total }, (_, i) => `line${i + 1}`);
+    writeFileSync(join(dir, "big.txt"), lines.join("\n"));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({ path: "big.txt" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    const content = result.value.content;
+    expect(content).toContain(`  ${DEFAULT_READ_LINE_LIMIT}  line2000`);
+    expect(content).not.toContain("line2001");
+    expect(content).toContain(
+      `[Truncated: showing through line ${DEFAULT_READ_LINE_LIMIT} of ${total}. Read on with offset=${DEFAULT_READ_LINE_LIMIT + 1}`,
+    );
+  });
+
+  test("an explicit limit is honored rather than replaced by the default", async () => {
+    const dir = makeTempDir();
+    const lines = Array.from(
+      { length: DEFAULT_READ_LINE_LIMIT + 500 },
+      (_, i) => `line${i + 1}`,
+    );
+    writeFileSync(join(dir, "big.txt"), lines.join("\n"));
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({
+      path: "big.txt",
+      limit: DEFAULT_READ_LINE_LIMIT + 500,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.content).toContain("line2500");
+    expect(result.value.content).not.toContain("[Truncated:");
+  });
+
+  test("a read that reaches the last line carries no truncation notice", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "small.txt"), "a\nb\nc");
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({ path: "small.txt" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.content).not.toContain("[Truncated:");
+  });
+
+  test("paging past the end is not reported as truncation", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "small.txt"), "a\nb\nc");
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    const result = await ops.readFileSafe({ path: "small.txt", offset: 100 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.content).not.toContain("[Truncated:");
   });
 });
 

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -26,6 +26,7 @@ mock.module("../daemon/host-file-proxy.js", () => ({
   },
 }));
 
+import { DEFAULT_READ_LINE_LIMIT } from "../tools/shared/filesystem/file-ops-service.js";
 import { hostFileReadTool } from "../tools/host-filesystem/read.js";
 import type { ToolContext } from "../tools/types.js";
 
@@ -226,13 +227,16 @@ describe("host_file_read image support", () => {
 
     expect(result.isError).toBe(false);
     expect(result.contentBlocks).toHaveLength(1);
+    // The proxied request carries the resolved default window, so a host read
+    // is bounded by the same limit as a local one rather than streaming a
+    // whole file across the bridge.
     expect(requests).toEqual([
       {
         input: {
           operation: "read",
           path: "/host/screenshot.png",
           offset: undefined,
-          limit: undefined,
+          limit: DEFAULT_READ_LINE_LIMIT,
         },
         conversationId: "test-conversation",
         signal: undefined,

--- a/assistant/src/__tests__/host-file-read-tool.test.ts
+++ b/assistant/src/__tests__/host-file-read-tool.test.ts
@@ -26,8 +26,8 @@ mock.module("../daemon/host-file-proxy.js", () => ({
   },
 }));
 
-import { DEFAULT_READ_LINE_LIMIT } from "../tools/shared/filesystem/file-ops-service.js";
 import { hostFileReadTool } from "../tools/host-filesystem/read.js";
+import { DEFAULT_READ_LINE_LIMIT } from "../tools/shared/filesystem/file-ops-service.js";
 import type { ToolContext } from "../tools/types.js";
 
 const testDirs: string[] = [];

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -49,7 +49,7 @@ const SHORT = "y".repeat(100);
 
 describe("spoolAndStubOversizedToolResults", () => {
   let convDir: string;
-  const noName = () => undefined;
+  const noCall = () => undefined;
 
   beforeEach(() => {
     convDir = mkdtempSync(join(tmpdir(), "tool-result-spool-"));
@@ -64,7 +64,7 @@ describe("spoolAndStubOversizedToolResults", () => {
 
     const count = spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
-      toolNameById: noName,
+      toolCallById: noCall,
     });
 
     expect(count).toBe(1);
@@ -81,7 +81,7 @@ describe("spoolAndStubOversizedToolResults", () => {
     const blocks = [makeToolResult(LONG, "tu_big")];
     spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
-      toolNameById: noName,
+      toolCallById: noCall,
     });
 
     const { messages: postTurn } = postTurnTruncateToolResults(
@@ -98,7 +98,7 @@ describe("spoolAndStubOversizedToolResults", () => {
     const blocks = [makeToolResult(LONG, "tu_big")];
     spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
-      toolNameById: noName,
+      toolCallById: noCall,
     });
 
     const history: Message[] = [{ role: "user", content: [...blocks] }];
@@ -110,13 +110,11 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(messages).toBe(history);
   });
 
-  test("skips below-threshold, error, exempt, file_read, host_file_read, web_fetch, marked, and ax-tree results", () => {
+  test("skips below-threshold, error, exempt, web_fetch, marked, and ax-tree results", () => {
     const blocks = [
       makeToolResult(SHORT, "tu_short"),
       makeToolResult(LONG, "tu_err", true),
       makeToolResult(LONG, "tu_skill"),
-      makeToolResult(LONG, "tu_read"),
-      makeToolResult(LONG, "tu_host_read"),
       makeToolResult(LONG, "tu_web_fetch"),
       makeToolResult(`${LONG}${TRUNCATION_MARKER}`, "tu_marked"),
       makeToolResult(`<ax-tree>${LONG}</ax-tree>`, "tu_ax"),
@@ -126,18 +124,12 @@ describe("spoolAndStubOversizedToolResults", () => {
 
     const count = spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
-      toolNameById: (id) => {
+      toolCallById: (id) => {
         if (id === "tu_skill") {
-          return "skill_load";
-        }
-        if (id === "tu_read") {
-          return "file_read";
-        }
-        if (id === "tu_host_read") {
-          return "host_file_read";
+          return { name: "skill_load", input: {} };
         }
         if (id === "tu_web_fetch") {
-          return "web_fetch";
+          return { name: "web_fetch", input: {} };
         }
         return undefined;
       },
@@ -146,6 +138,51 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(count).toBe(0);
     expect(blocks).toEqual(originals);
     expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
+  });
+
+  test("spools an oversized file read of an ordinary path", () => {
+    const blocks = [
+      makeToolResult(LONG, "tu_read"),
+      makeToolResult(LONG, "tu_host_read"),
+    ];
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolCallById: (id) =>
+        id === "tu_read"
+          ? { name: "file_read", input: { path: "/workspace/src/big.ts" } }
+          : { name: "host_file_read", input: { path: "/Users/me/notes.md" } },
+    });
+
+    expect(count).toBe(2);
+    expect((blocks[0] as { content: string }).content).toContain(
+      TRUNCATION_MARKER,
+    );
+    expect((blocks[1] as { content: string }).content).toContain(
+      TRUNCATION_MARKER,
+    );
+  });
+
+  test("leaves a file read of a spooled .tool-results path inline", () => {
+    // Stubbing this read would write a fresh copy and hand back another stub,
+    // so the spooled content could never be paged back into context.
+    const spooledPath = getToolResultFilePath(convDir, "tu_earlier");
+    const blocks = [
+      makeToolResult(LONG, "tu_read"),
+      makeToolResult(LONG, "tu_host_read"),
+    ];
+    const originals = blocks.map((b) => b);
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolCallById: (id) =>
+        id === "tu_read"
+          ? { name: "file_read", input: { path: spooledPath } }
+          : { name: "host_file_read", input: { file_path: spooledPath } },
+    });
+
+    expect(count).toBe(0);
+    expect(blocks).toEqual(originals);
   });
 
   test("spools each eligible block in a mixed batch", () => {
@@ -157,7 +194,7 @@ describe("spoolAndStubOversizedToolResults", () => {
 
     const count = spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
-      toolNameById: noName,
+      toolCallById: noCall,
     });
 
     expect(count).toBe(2);
@@ -184,7 +221,7 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(() =>
       spoolAndStubOversizedToolResults(blocks, {
         conversationDir: fileAsDir,
-        toolNameById: noName,
+        toolCallById: noCall,
       }),
     ).toThrow();
     expect((blocks[0] as { content: string }).content).toBe(LONG);

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -185,6 +185,25 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(blocks).toEqual(originals);
   });
 
+  test("recognizes a backslash-separated spooled path", () => {
+    // `getToolResultFilePath` builds the stub path with `join`, so on Windows
+    // it is backslash-separated. Missing that match would stub the read and
+    // put the saved content out of reach.
+    const blocks = [makeToolResult(LONG, "tu_read")];
+    const originals = blocks.map((b) => b);
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolCallById: () => ({
+        name: "file_read",
+        input: { path: `C:\\conv\\${TOOL_RESULT_DIR}\\abc123.txt` },
+      }),
+    });
+
+    expect(count).toBe(0);
+    expect(blocks).toEqual(originals);
+  });
+
   test("spools each eligible block in a mixed batch", () => {
     const blocks = [
       makeToolResult(LONG, "tu_a"),

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -2212,13 +2212,16 @@ export class AgentLoop {
         // message between calls would invalidate the prompt-cache prefix on
         // every iteration).
         if (conversationDir) {
-          const toolNameByUseId = new Map(
-            toolUseBlocks.map((tu) => [tu.id, tu.name]),
+          const toolCallByUseId = new Map(
+            toolUseBlocks.map((tu) => [
+              tu.id,
+              { name: tu.name, input: tu.input },
+            ]),
           );
           try {
             spoolAndStubOversizedToolResults(rawResultBlocks, {
               conversationDir,
-              toolNameById: (id) => toolNameByUseId.get(id),
+              toolCallById: (id) => toolCallByUseId.get(id),
             });
           } catch (err) {
             rlog.warn(

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -65,9 +65,13 @@ export function isSpooledToolResultRead(
     return false;
   }
   const filePath = input?.path ?? input?.file_path;
-  return (
-    typeof filePath === "string" && filePath.includes(`/${TOOL_RESULT_DIR}/`)
-  );
+  if (typeof filePath !== "string") {
+    return false;
+  }
+  // The path in the stub comes from `join`, so it is backslash-separated on
+  // Windows. Compare on a normalized form: a missed match would let the spool
+  // pass stub this read and put the saved content permanently out of reach.
+  return filePath.replace(/\\/g, "/").includes(`/${TOOL_RESULT_DIR}/`);
 }
 
 /**

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -37,10 +37,10 @@ export const TRUNCATION_MARKER = "\u2014 full result:";
 export const TRUNCATION_EXEMPT_TOOLS = new Set<string>(["skill_load"]);
 
 /**
- * File-read tools that page spooled `.tool-results/` content back into context.
- * `file_read` reads inside the workspace; `host_file_read` reads anywhere on the
- * host. Sharing one set keeps the passes that care about them from drifting if a
- * new file-read tool is added.
+ * File-read tools that can page spooled `.tool-results/` content back into
+ * context. `file_read` reads inside the workspace; `host_file_read` reads
+ * anywhere on the host. A new file-read tool belongs here so
+ * {@link isSpooledToolResultRead} recognizes it.
  */
 export const FILE_READ_TOOL_NAMES = new Set<string>([
   "file_read",
@@ -66,8 +66,7 @@ export function isSpooledToolResultRead(
   }
   const filePath = input?.path ?? input?.file_path;
   return (
-    typeof filePath === "string" &&
-    filePath.includes(`/${TOOL_RESULT_DIR}/`)
+    typeof filePath === "string" && filePath.includes(`/${TOOL_RESULT_DIR}/`)
   );
 }
 

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -39,17 +39,37 @@ export const TRUNCATION_EXEMPT_TOOLS = new Set<string>(["skill_load"]);
 /**
  * File-read tools that page spooled `.tool-results/` content back into context.
  * `file_read` reads inside the workspace; `host_file_read` reads anywhere on the
- * host. Both are (a) exempt from the result-time spool pass — re-stubbing a read
- * of a spooled file would hand back another stub, so the content could never be
- * paged back at all — and (b) recognized by {@link derefToolResultReReads}, so a
- * re-read of a spooled file collapses to a stub instead of duplicating content
- * already in context. Sharing one set keeps the two passes from drifting if a
+ * host. Sharing one set keeps the passes that care about them from drifting if a
  * new file-read tool is added.
  */
 export const FILE_READ_TOOL_NAMES = new Set<string>([
   "file_read",
   "host_file_read",
 ]);
+
+/**
+ * Whether a tool call is a file read aimed at a spooled `.tool-results/` file.
+ *
+ * Such a read is the model paging content back in, so both passes treat it
+ * specially: the result-time spool pass leaves it alone (re-stubbing it would
+ * write a fresh copy and hand back another stub, putting the content out of
+ * reach for good), and {@link derefToolResultReReads} collapses it at turn end
+ * (its prefix and suffix are already in context above). A file read aimed
+ * anywhere else is ordinary tool output and gets no such treatment.
+ */
+export function isSpooledToolResultRead(
+  toolName: string | undefined,
+  input: Record<string, unknown> | undefined,
+): boolean {
+  if (toolName === undefined || !FILE_READ_TOOL_NAMES.has(toolName)) {
+    return false;
+  }
+  const filePath = input?.path ?? input?.file_path;
+  return (
+    typeof filePath === "string" &&
+    filePath.includes(`/${TOOL_RESULT_DIR}/`)
+  );
+}
 
 /**
  * Build a map of tool_use_id -> originating tool name by walking the tool_use
@@ -329,14 +349,7 @@ export function derefToolResultReReads(messages: Message[]): {
         continue;
       }
       const tu = block as ToolUseContent;
-      if (!FILE_READ_TOOL_NAMES.has(tu.name)) {
-        continue;
-      }
-      const filePath = tu.input.path ?? tu.input.file_path;
-      if (typeof filePath !== "string") {
-        continue;
-      }
-      if (filePath.includes(`/${TOOL_RESULT_DIR}/`)) {
+      if (isSpooledToolResultRead(tu.name, tu.input)) {
         reReadToolUseIds.add(tu.id);
       }
     }

--- a/assistant/src/context/tool-result-spool.ts
+++ b/assistant/src/context/tool-result-spool.ts
@@ -102,7 +102,7 @@ export function spoolAndStubOversizedToolResults(
      */
     toolCallById: (
       toolUseId: string,
-    ) => { name: string; input: Record<string, unknown> } | undefined,
+    ) => { name: string; input: Record<string, unknown> } | undefined;
   },
 ): number {
   let stubbedCount = 0;

--- a/assistant/src/context/tool-result-spool.ts
+++ b/assistant/src/context/tool-result-spool.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import type { ContentBlock, ToolResultContent } from "../providers/types.js";
 import {
   buildTruncatedContent,
-  FILE_READ_TOOL_NAMES,
   getToolResultFilePath,
+  isSpooledToolResultRead,
   isTruncationEligible,
   TOOL_RESULT_DIR,
 } from "./post-turn-tool-result-truncation.js";
@@ -32,27 +32,32 @@ export const RESULT_TIME_SPOOL_EXEMPT_TOOLS = new Set<string>(["web_fetch"]);
 
 /**
  * Whether a tool result is eligible for the result-time spool/stub pass: the
- * post-turn pass's shared rules plus the AX-tree exemption, minus the file-read
- * tools ({@link FILE_READ_TOOL_NAMES}) and the explicit self-sized reads
- * ({@link RESULT_TIME_SPOOL_EXEMPT_TOOLS}). The file-read tools are the model's
- * only way to page spooled content back into context: stubbing a read of a
- * `.tool-results/` file would spool a fresh copy and hand back another stub, so
- * oversized content could never be read at all. Explicit reads are therefore
- * honored in full; the post-turn pass still truncates them at turn end, after
- * the model has consumed the content.
+ * post-turn pass's shared rules plus the AX-tree exemption, minus reads of
+ * already-spooled `.tool-results/` files ({@link isSpooledToolResultRead}) and
+ * the explicit self-sized reads ({@link RESULT_TIME_SPOOL_EXEMPT_TOOLS}).
+ *
+ * The spooled-read exemption is what keeps paging possible: a file read is the
+ * model's only way to pull spooled content back into context, so stubbing a
+ * read of a `.tool-results/` file would write a fresh copy and hand back
+ * another stub, putting that content out of reach for good. It is scoped by
+ * target path rather than by tool name, because a file read aimed anywhere
+ * else is ordinary oversized output with no such circularity, and exempting it
+ * keeps a whole file inline on every LLM call for the rest of the turn.
+ * Explicit self-sized reads are honored in full; the post-turn pass still
+ * truncates them at turn end, after the model has consumed the content.
  */
 function isSpoolEligible(
   tr: ToolResultContent,
   toolName: string | undefined,
+  toolInput: Record<string, unknown> | undefined,
 ): boolean {
   if (!isTruncationEligible(tr, toolName)) {
     return false;
   }
-  if (
-    toolName !== undefined &&
-    (FILE_READ_TOOL_NAMES.has(toolName) ||
-      RESULT_TIME_SPOOL_EXEMPT_TOOLS.has(toolName))
-  ) {
+  if (isSpooledToolResultRead(toolName, toolInput)) {
+    return false;
+  }
+  if (toolName !== undefined && RESULT_TIME_SPOOL_EXEMPT_TOOLS.has(toolName)) {
     return false;
   }
   if (tr.content.includes(AX_TREE_TAG)) {
@@ -72,8 +77,8 @@ function isSpoolEligible(
  * rewriting an earlier message between calls would invalidate the cache from
  * that point on every iteration. The model still gets the head/tail preview
  * plus the on-disk path, so it can page the full content back in with
- * `file_read` or `host_file_read` (whose results are exempt from this pass)
- * when it actually needs it.
+ * `file_read` or `host_file_read` (a read of a `.tool-results/` path is exempt
+ * from this pass) when it actually needs it.
  *
  * Uses the same file paths, stub bytes, and eligibility rules as
  * `postTurnTruncateToolResults`, whose `TRUNCATION_MARKER` guard then skips
@@ -89,7 +94,15 @@ export function spoolAndStubOversizedToolResults(
   blocks: ContentBlock[],
   options: {
     conversationDir: string;
-    toolNameById: (toolUseId: string) => string | undefined;
+    /**
+     * The originating call for a `tool_use_id`. A `tool_result` carries only
+     * the id, and eligibility turns on both the tool's name and the path it
+     * was pointed at, so the two travel together rather than as separate
+     * lookups that could disagree.
+     */
+    toolCallById: (
+      toolUseId: string,
+    ) => { name: string; input: Record<string, unknown> } | undefined,
   },
 ): number {
   let stubbedCount = 0;
@@ -98,7 +111,8 @@ export function spoolAndStubOversizedToolResults(
     if (block.type !== "tool_result") {
       continue;
     }
-    if (!isSpoolEligible(block, options.toolNameById(block.tool_use_id))) {
+    const toolCall = options.toolCallById(block.tool_use_id);
+    if (!isSpoolEligible(block, toolCall?.name, toolCall?.input)) {
       continue;
     }
 

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -43,7 +43,7 @@ export const fileReadInputSchema = z.looseObject({
     .catch(undefined),
   limit: z
     .number()
-    .describe("Maximum number of lines to read")
+    .describe("Maximum number of lines to read (defaults to 2000)")
     .optional()
     .catch(undefined),
   activity: z
@@ -58,7 +58,7 @@ export const fileReadInputSchema = z.looseObject({
 export const fileReadTool = {
   name: "file_read",
   description:
-    "Read the contents of a file on your own machine. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
+    "Read the contents of a file on your own machine. Text reads return the first 2000 lines unless you pass `limit`; when a read stops short the result says so, and `offset` pages on from there. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
   category: "filesystem",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -30,8 +30,8 @@ import type {
  * Model-input schema, the single source for both runtime validation (via
  * `TOOL_INPUT_SCHEMAS`) and the advertised `input_schema` below — mirrors
  * `filesystem/read.ts`. `offset`/`limit` catch to `undefined` so a
- * non-numeric value reads the whole file instead of failing the call;
- * `target_client_id` catches so a non-string (or empty) value means
+ * non-numeric value falls back to the default line window instead of failing
+ * the call; `target_client_id` catches so a non-string (or empty) value means
  * "untargeted".
  */
 export const hostFileReadInputSchema = z.looseObject({
@@ -43,7 +43,7 @@ export const hostFileReadInputSchema = z.looseObject({
     .catch(undefined),
   limit: z
     .number()
-    .describe("Maximum number of lines to read")
+    .describe("Maximum number of lines to read (defaults to 2000)")
     .optional()
     .catch(undefined),
   target_client_id: z
@@ -58,7 +58,7 @@ export const hostFileReadInputSchema = z.looseObject({
 export const hostFileReadTool = {
   name: "host_file_read",
   description:
-    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). For files on your own machine, use file_read instead.",
+    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). Text reads return the first 2000 lines unless you pass `limit`; when a read stops short the result says so, and `offset` pages on from there. For files on your own machine, use file_read instead.",
   category: "host-filesystem",
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -10,7 +10,10 @@ import {
   AUDIO_EXTENSIONS,
   readAudioFile,
 } from "../shared/filesystem/audio-read.js";
-import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
+import {
+  DEFAULT_READ_LINE_LIMIT,
+  FileSystemOps,
+} from "../shared/filesystem/file-ops-service.js";
 import {
   IMAGE_EXTENSIONS,
   readImageFile,
@@ -73,7 +76,12 @@ export const hostFileReadTool = {
     if (!parsed.success) {
       return invalidToolInputResult("host_file_read", parsed.error);
     }
-    const { path: rawPath, offset, limit } = parsed.data;
+    const { path: rawPath, offset } = parsed.data;
+    // Resolve the default here rather than leaving it to the read, so the
+    // proxied branch below is bounded by the same window as the local one. A
+    // proxied read that sent no limit would stream a whole host file across
+    // the bridge before anything could trim it.
+    const limit = parsed.data.limit ?? DEFAULT_READ_LINE_LIMIT;
 
     const targetClientId =
       parsed.data.target_client_id !== ""

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -77,6 +77,29 @@ function pathError(
   }
 }
 
+/**
+ * Lines returned by a read that names no `limit`. Without a default the read
+ * returns the whole file, and a file-read result is honored in full for the
+ * rest of the turn (see `isSpoolEligible` in `context/tool-result-spool.ts`),
+ * so one unbounded read of a large file rides every subsequent LLM call in
+ * that turn. The cap bounds that; `offset`/`limit` page past it, and
+ * {@link truncationNotice} tells the model when it is looking at a window
+ * rather than the whole file.
+ */
+export const DEFAULT_READ_LINE_LIMIT = 2000;
+
+/**
+ * Trailing marker appended when a read stops short of the last line. Silent
+ * truncation is the failure mode worth avoiding: a model that cannot tell a
+ * window from a whole file reasons about code it never saw.
+ */
+function truncationNotice(
+  lastLineReturned: number,
+  totalLines: number,
+): string {
+  return `\n\n[Truncated: showing through line ${lastLineReturned} of ${totalLines}. Read on with offset=${lastLineReturned + 1}, or pass an explicit limit.]`;
+}
+
 export class FileSystemOps {
   private policy: PathPolicy;
   private sizeLimit: number | undefined;
@@ -119,8 +142,9 @@ export class FileSystemOps {
       const lines = raw.split("\n");
 
       const offset = (input.offset ?? 1) - 1;
-      const limit = input.limit ?? lines.length;
-      const selected = lines.slice(Math.max(0, offset), offset + limit);
+      const start = Math.max(0, offset);
+      const limit = input.limit ?? DEFAULT_READ_LINE_LIMIT;
+      const selected = lines.slice(start, offset + limit);
 
       const numbered = selected
         .map((line, i) => {
@@ -129,7 +153,16 @@ export class FileSystemOps {
         })
         .join("\n");
 
-      return { ok: true, value: { content: numbered } };
+      // Only when the window stops before the last line. An empty window means
+      // the caller paged past the end or asked for nothing, which is not a
+      // truncated read.
+      const lastLineReturned = start + selected.length;
+      const content =
+        selected.length > 0 && lastLineReturned < lines.length
+          ? numbered + truncationNotice(lastLineReturned, lines.length)
+          : numbered;
+
+      return { ok: true, value: { content } };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { ok: false, error: Err.ioError(filePath, msg) };

--- a/clients/macos/src/main/executors/host-file-executor.test.ts
+++ b/clients/macos/src/main/executors/host-file-executor.test.ts
@@ -22,7 +22,14 @@ mock.module("electron-log/main", () => {
       error: noop,
       debug: noop,
       initialize: noop,
-      transports: { file: { maxSize: 0, fileName: "", format: "", getFile: () => ({ path: "" }) } },
+      transports: {
+        file: {
+          maxSize: 0,
+          fileName: "",
+          format: "",
+          getFile: () => ({ path: "" }),
+        },
+      },
     },
   };
 });
@@ -113,35 +120,47 @@ describe("host-file-executor", () => {
   describe("detectAudioByMagicBytes", () => {
     test("detects MP3 with ID3 tag", () => {
       const buf = Buffer.from([0x49, 0x44, 0x33, 0x00]);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/mpeg",
+      });
     });
 
     test("detects MP3 sync word", () => {
       const buf = Buffer.from([0xff, 0xfb, 0x90, 0x00]);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mpeg" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/mpeg",
+      });
     });
 
     test("detects OGG", () => {
       const buf = Buffer.from([0x4f, 0x67, 0x67, 0x53]);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/ogg" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/ogg",
+      });
     });
 
     test("detects FLAC", () => {
       const buf = Buffer.from([0x66, 0x4c, 0x61, 0x43]);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/flac" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/flac",
+      });
     });
 
     test("detects WAV", () => {
       const buf = Buffer.alloc(12);
       buf.write("RIFF", 0);
       buf.write("WAVE", 8);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/wav" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/wav",
+      });
     });
 
     test("detects M4A", () => {
       const buf = Buffer.alloc(8);
       buf.write("ftyp", 4);
-      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({ mimeType: "audio/mp4" });
+      expect(__testing.detectAudioByMagicBytes(buf)).toEqual({
+        mimeType: "audio/mp4",
+      });
     });
 
     test("returns null for text", () => {
@@ -192,6 +211,36 @@ describe("host-file-executor", () => {
       expect(result.content).toContain("exceeds the 100.0 MB limit");
     });
 
+    test("caps an unbounded read at the default line limit and says so", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "big.txt");
+      const total = 2500;
+      fs.writeFileSync(
+        filePath,
+        Array.from({ length: total }, (_, i) => `line${i + 1}`).join("\n"),
+      );
+
+      const result = __testing.executeRead({ path: filePath });
+      expect(result.content).toContain("line2000");
+      expect(result.content).not.toContain("line2001");
+      expect(result.content).toContain(
+        `[Truncated: showing through line 2000 of ${total}. Read on with offset=2001`,
+      );
+    });
+
+    test("an explicit limit is honored rather than replaced by the default", () => {
+      const dir = freshTmpDir();
+      const filePath = path.join(dir, "big.txt");
+      fs.writeFileSync(
+        filePath,
+        Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join("\n"),
+      );
+
+      const result = __testing.executeRead({ path: filePath, limit: 2500 });
+      expect(result.content).toContain("line2500");
+      expect(result.content).not.toContain("[Truncated:");
+    });
+
     test("reads text file and returns content", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "hello.txt");
@@ -207,14 +256,21 @@ describe("host-file-executor", () => {
       const filePath = path.join(dir, "lines.txt");
       fs.writeFileSync(filePath, "a\nb\nc\nd\ne");
 
-      const result = __testing.executeRead({ path: filePath, offset: 2, limit: 2 });
-      expect(result.content).toBe("b\nc");
+      const result = __testing.executeRead({
+        path: filePath,
+        offset: 2,
+        limit: 2,
+      });
+      const [body] = result.content!.split("\n\n[Truncated:");
+      expect(body).toBe("b\nc");
     });
 
     test("returns base64 imageData for PNG file", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "img.png");
-      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const pngHeader = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
       fs.writeFileSync(filePath, pngHeader);
 
       const result = __testing.executeRead({ path: filePath });
@@ -245,7 +301,10 @@ describe("host-file-executor", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "backup.key");
 
-      const result = __testing.executeWrite({ path: filePath, content: "secret" });
+      const result = __testing.executeWrite({
+        path: filePath,
+        content: "secret",
+      });
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Access to "backup.key" is denied');
       expect(fs.existsSync(filePath)).toBe(false);
@@ -254,7 +313,10 @@ describe("host-file-executor", () => {
     test("rejects oversized content before writing", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "large.txt");
-      const result = __testing.validateContentSize("x".repeat(100 * 1024 * 1024 + 1), filePath);
+      const result = __testing.validateContentSize(
+        "x".repeat(100 * 1024 * 1024 + 1),
+        filePath,
+      );
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -270,7 +332,10 @@ describe("host-file-executor", () => {
       fs.writeFileSync(target, "original");
       fs.symlinkSync(target, link);
 
-      const result = __testing.executeWrite({ path: link, content: "overwritten" });
+      const result = __testing.executeWrite({
+        path: link,
+        content: "overwritten",
+      });
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Access to ".backup.key" is denied');
       expect(fs.readFileSync(target, "utf-8")).toBe("original");
@@ -298,14 +363,20 @@ describe("host-file-executor", () => {
       fs.symlinkSync(target, mid);
       fs.symlinkSync(mid, link);
 
-      const result = __testing.executeWrite({ path: link, content: "overwritten" });
+      const result = __testing.executeWrite({
+        path: link,
+        content: "overwritten",
+      });
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Access to ".backup.key" is denied');
       expect(fs.readFileSync(target, "utf-8")).toBe("original");
     });
 
     test("rejects writing to existing non-regular file", () => {
-      const result = __testing.executeWrite({ path: "/dev/null", content: "data" });
+      const result = __testing.executeWrite({
+        path: "/dev/null",
+        content: "data",
+      });
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Not a regular file");
     });
@@ -314,7 +385,10 @@ describe("host-file-executor", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "out.txt");
 
-      const result = __testing.executeWrite({ path: filePath, content: "hello" });
+      const result = __testing.executeWrite({
+        path: filePath,
+        content: "hello",
+      });
       expect(result.isError).toBeUndefined();
       expect(fs.readFileSync(filePath, "utf-8")).toBe("hello");
     });
@@ -445,7 +519,12 @@ describe("host-file-executor", () => {
 
       const { poster, body } = capturingPoster();
       hostFileExecutor.handleRequest(
-        { type: "host_file_request", requestId: "r1", operation: "read", path: filePath },
+        {
+          type: "host_file_request",
+          requestId: "r1",
+          operation: "read",
+          path: filePath,
+        },
         poster,
       );
       await flush();
@@ -469,7 +548,12 @@ describe("host-file-executor", () => {
     test("posts error for fs failure", async () => {
       const { poster, body } = capturingPoster();
       hostFileExecutor.handleRequest(
-        { type: "host_file_request", requestId: "r3", operation: "read", path: "/nonexistent/path/file.txt" },
+        {
+          type: "host_file_request",
+          requestId: "r3",
+          operation: "read",
+          path: "/nonexistent/path/file.txt",
+        },
         poster,
       );
       await flush();

--- a/clients/macos/src/main/executors/host-file-executor.ts
+++ b/clients/macos/src/main/executors/host-file-executor.ts
@@ -22,40 +22,72 @@ import log from "../logger";
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
 
+/**
+ * Lines returned by a read that names no `limit`. The daemon resolves this
+ * same default before proxying, so this covers a client driven by an older
+ * daemon that still sends none. Mirrors `DEFAULT_READ_LINE_LIMIT` in the
+ * assistant's `tools/shared/filesystem/file-ops-service.ts`, which owns the
+ * value and the wording of the notice below.
+ */
+const DEFAULT_READ_LINE_LIMIT = 2000;
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function validateHostPath(rawPath: string): { ok: true; path: string } | { ok: false; content: string; isError: true } {
+function validateHostPath(
+  rawPath: string,
+): { ok: true; path: string } | { ok: false; content: string; isError: true } {
   if (!path.isAbsolute(rawPath)) {
-    return { content: `path must be absolute for host file access: ${rawPath}`, isError: true, ok: false };
+    return {
+      content: `path must be absolute for host file access: ${rawPath}`,
+      isError: true,
+      ok: false,
+    };
   }
 
   const basename = path.basename(rawPath);
   if (DENIED_BASENAMES.has(basename)) {
-    return { content: `Access to "${basename}" is denied`, isError: true, ok: false };
+    return {
+      content: `Access to "${basename}" is denied`,
+      isError: true,
+      ok: false,
+    };
   }
 
   return { ok: true, path: rawPath };
 }
 
-function validateRegularFile(filePath: string): { ok: true; stat: Stats } | { ok: false; content: string; isError: true } {
+function validateRegularFile(
+  filePath: string,
+): { ok: true; stat: Stats } | { ok: false; content: string; isError: true } {
   const resolved = fs.realpathSync(filePath);
   const resolvedBasename = path.basename(resolved);
   if (DENIED_BASENAMES.has(resolvedBasename)) {
-    return { content: `Access to "${resolvedBasename}" is denied`, isError: true, ok: false };
+    return {
+      content: `Access to "${resolvedBasename}" is denied`,
+      isError: true,
+      ok: false,
+    };
   }
 
   const stat = fs.statSync(filePath);
   if (!stat.isFile()) {
-    return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+    return {
+      content: `Not a regular file: ${filePath}`,
+      isError: true,
+      ok: false,
+    };
   }
   return { ok: true, stat };
 }
 
-function validateFileSize(filePath: string, size: number): { ok: true } | { ok: false; content: string; isError: true } {
+function validateFileSize(
+  filePath: string,
+  size: number,
+): { ok: true } | { ok: false; content: string; isError: true } {
   if (size > MAX_FILE_SIZE_BYTES) {
     return {
       content: `File size (${formatBytes(size)}) exceeds the ${formatBytes(MAX_FILE_SIZE_BYTES)} limit: ${filePath}`,
@@ -66,7 +98,10 @@ function validateFileSize(filePath: string, size: number): { ok: true } | { ok: 
   return { ok: true };
 }
 
-function validateContentSize(content: string, filePath: string): { ok: true } | { ok: false; content: string; isError: true } {
+function validateContentSize(
+  content: string,
+  filePath: string,
+): { ok: true } | { ok: false; content: string; isError: true } {
   const size = Buffer.byteLength(content, "utf-8");
   if (size > MAX_FILE_SIZE_BYTES) {
     return {
@@ -92,11 +127,15 @@ function resolveSymlinkChain(startPath: string): string {
     }
     if (!st.isSymbolicLink()) return current;
     const target = fs.readlinkSync(current);
-    current = path.isAbsolute(target) ? target : path.resolve(path.dirname(current), target);
+    current = path.isAbsolute(target)
+      ? target
+      : path.resolve(path.dirname(current), target);
   }
 }
 
-function validateWriteTarget(filePath: string): { ok: true } | { ok: false; content: string; isError: true } {
+function validateWriteTarget(
+  filePath: string,
+): { ok: true } | { ok: false; content: string; isError: true } {
   let lstat: Stats;
   try {
     lstat = fs.lstatSync(filePath);
@@ -107,18 +146,30 @@ function validateWriteTarget(filePath: string): { ok: true } | { ok: false; cont
   if (lstat.isSymbolicLink()) {
     const resolved = resolveSymlinkChain(filePath);
     if (DENIED_BASENAMES.has(path.basename(resolved))) {
-      return { content: `Access to "${path.basename(resolved)}" is denied`, isError: true, ok: false };
+      return {
+        content: `Access to "${path.basename(resolved)}" is denied`,
+        isError: true,
+        ok: false,
+      };
     }
     try {
       const targetStat = fs.statSync(filePath);
       if (!targetStat.isFile()) {
-        return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+        return {
+          content: `Not a regular file: ${filePath}`,
+          isError: true,
+          ok: false,
+        };
       }
     } catch {
       // Dangling symlink with allowed target basename — write will create regular file
     }
   } else if (!lstat.isFile()) {
-    return { content: `Not a regular file: ${filePath}`, isError: true, ok: false };
+    return {
+      content: `Not a regular file: ${filePath}`,
+      isError: true,
+      ok: false,
+    };
   }
 
   return { ok: true };
@@ -132,7 +183,8 @@ function validateWriteTarget(filePath: string): { ok: true } | { ok: false; cont
 function isImageByMagicBytes(buf: Buffer): boolean {
   if (buf.length < 4) return false;
   // PNG
-  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return true;
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47)
+    return true;
   // JPEG
   if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return true;
   // GIF
@@ -142,9 +194,16 @@ function isImageByMagicBytes(buf: Buffer): boolean {
   // WebP: RIFF....WEBP
   if (
     buf.length >= 12 &&
-    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
-    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
-  ) return true;
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  )
+    return true;
   return false;
 }
 
@@ -156,24 +215,39 @@ interface AudioDetection {
 function detectAudioByMagicBytes(buf: Buffer): AudioDetection | null {
   if (buf.length < 4) return null;
   // MP3 — ID3 tag
-  if (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33) return { mimeType: "audio/mpeg" };
+  if (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33)
+    return { mimeType: "audio/mpeg" };
   // MP3 — sync word 0xFF 0xFB (or 0xFF 0xEx)
-  if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) return { mimeType: "audio/mpeg" };
+  if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0)
+    return { mimeType: "audio/mpeg" };
   // OGG
-  if (buf[0] === 0x4f && buf[1] === 0x67 && buf[2] === 0x67 && buf[3] === 0x53) return { mimeType: "audio/ogg" };
+  if (buf[0] === 0x4f && buf[1] === 0x67 && buf[2] === 0x67 && buf[3] === 0x53)
+    return { mimeType: "audio/ogg" };
   // FLAC
-  if (buf[0] === 0x66 && buf[1] === 0x4c && buf[2] === 0x61 && buf[3] === 0x43) return { mimeType: "audio/flac" };
+  if (buf[0] === 0x66 && buf[1] === 0x4c && buf[2] === 0x61 && buf[3] === 0x43)
+    return { mimeType: "audio/flac" };
   // WAV: RIFF....WAVE
   if (
     buf.length >= 12 &&
-    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
-    buf[8] === 0x57 && buf[9] === 0x41 && buf[10] === 0x56 && buf[11] === 0x45
-  ) return { mimeType: "audio/wav" };
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x41 &&
+    buf[10] === 0x56 &&
+    buf[11] === 0x45
+  )
+    return { mimeType: "audio/wav" };
   // M4A: bytes 4-7 contain "ftyp"
   if (
     buf.length >= 8 &&
-    buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70
-  ) return { mimeType: "audio/mp4" };
+    buf[4] === 0x66 &&
+    buf[5] === 0x74 &&
+    buf[6] === 0x79 &&
+    buf[7] === 0x70
+  )
+    return { mimeType: "audio/mp4" };
   return null;
 }
 
@@ -221,9 +295,17 @@ function executeRead(fields: ReadFields): {
   const text = raw.toString("utf-8");
   const lines = text.split("\n");
   const offset = (fields.offset ?? 1) - 1;
-  const limit = fields.limit ?? lines.length;
-  const sliced = lines.slice(offset, offset + limit);
-  return { content: sliced.join("\n") };
+  const start = Math.max(0, offset);
+  const limit = fields.limit ?? DEFAULT_READ_LINE_LIMIT;
+  const sliced = lines.slice(start, offset + limit);
+  const lastLineReturned = start + sliced.length;
+  const content = sliced.join("\n");
+  if (sliced.length > 0 && lastLineReturned < lines.length) {
+    return {
+      content: `${content}\n\n[Truncated: showing through line ${lastLineReturned} of ${lines.length}. Read on with offset=${lastLineReturned + 1}, or pass an explicit limit.]`,
+    };
+  }
+  return { content };
 }
 
 // ---------------------------------------------------------------------------
@@ -235,7 +317,10 @@ interface WriteFields {
   content: string;
 }
 
-function executeWrite(fields: WriteFields): { content?: string; isError?: boolean } {
+function executeWrite(fields: WriteFields): {
+  content?: string;
+  isError?: boolean;
+} {
   const pathCheck = validateHostPath(fields.path);
   if (!pathCheck.ok) return pathCheck;
 
@@ -249,7 +334,9 @@ function executeWrite(fields: WriteFields): { content?: string; isError?: boolea
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(filePath, fields.content, "utf-8");
-  return { content: `Wrote ${Buffer.byteLength(fields.content, "utf-8")} bytes to ${filePath}` };
+  return {
+    content: `Wrote ${Buffer.byteLength(fields.content, "utf-8")} bytes to ${filePath}`,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -263,7 +350,10 @@ interface EditFields {
   replace_all?: boolean;
 }
 
-function executeEdit(fields: EditFields): { content?: string; isError?: boolean } {
+function executeEdit(fields: EditFields): {
+  content?: string;
+  isError?: boolean;
+} {
   const pathCheck = validateHostPath(fields.path);
   if (!pathCheck.ok) return pathCheck;
 
@@ -286,9 +376,15 @@ function executeEdit(fields: EditFields): { content?: string; isError?: boolean 
   if (!replace_all) {
     const secondIdx = existing.indexOf(old_string, firstIdx + 1);
     if (secondIdx !== -1) {
-      return { content: `old_string is not unique in ${filePath} (use replace_all to replace all occurrences)`, isError: true };
+      return {
+        content: `old_string is not unique in ${filePath} (use replace_all to replace all occurrences)`,
+        isError: true,
+      };
     }
-    updated = existing.slice(0, firstIdx) + new_string + existing.slice(firstIdx + old_string.length);
+    updated =
+      existing.slice(0, firstIdx) +
+      new_string +
+      existing.slice(firstIdx + old_string.length);
   } else {
     updated = existing.split(old_string).join(new_string);
   }
@@ -307,7 +403,10 @@ function executeEdit(fields: EditFields): { content?: string; isError?: boolean 
 
 const pendingRequests = new Set<string>();
 
-function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): void {
+function handleRequest(
+  message: HostProxySseMessage,
+  poster: HostProxyPoster,
+): void {
   const requestId = message.requestId as string | undefined;
   if (!requestId) {
     log.warn("[host-file-executor] message missing requestId");
@@ -318,14 +417,24 @@ function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): v
   const filePath = message.path as string | undefined;
 
   if (!operation || !filePath) {
-    void poster.postFileResult({ requestId, content: "Missing operation or path", isError: true });
+    void poster.postFileResult({
+      requestId,
+      content: "Missing operation or path",
+      isError: true,
+    });
     return;
   }
 
   pendingRequests.add(requestId);
 
   try {
-    let result: { content?: string; imageData?: string; audioData?: string; audioMimeType?: string; isError?: boolean };
+    let result: {
+      content?: string;
+      imageData?: string;
+      audioData?: string;
+      audioMimeType?: string;
+      isError?: boolean;
+    };
 
     switch (operation) {
       case "read":
@@ -338,14 +447,14 @@ function handleRequest(message: HostProxySseMessage, poster: HostProxyPoster): v
       case "write":
         result = executeWrite({
           path: filePath,
-          content: message.content as string ?? "",
+          content: (message.content as string) ?? "",
         });
         break;
       case "edit":
         result = executeEdit({
           path: filePath,
-          old_string: message.old_string as string ?? "",
-          new_string: message.new_string as string ?? "",
+          old_string: (message.old_string as string) ?? "",
+          new_string: (message.new_string as string) ?? "",
           replace_all: message.replace_all as boolean | undefined,
         });
         break;


### PR DESCRIPTION
## Summary

Two independent defects made a single `file_read` amplify context for the rest of a turn. This is the cost half of ATL-1188.

- **No default line limit.** `readFileSafe` fell back to `input.limit ?? lines.length`, so a read that named no `limit` returned the whole file, with only the 100 MB on-disk guard behind it (which never trips on source files). Reads now default to 2000 lines and append a notice naming the last line returned, the total, and the offset to resume from. `file_read` and `host_file_read` are the only two production callers, so the default lands in the shared service and both tool descriptions now advertise it.
- **The spool exemption was keyed on tool name, not target path.** A file read is how the model pages spooled content back in, so stubbing a read of a `.tool-results/` file would write a fresh copy and hand back another stub, putting that content out of reach for good. That reasoning only covers reads *aimed at* `.tool-results/`. Keyed on the name, it covered every file read: any result over `THRESHOLD_CHARS` (25,000) stayed inline in full on every LLM call until turn end, while `code_search` output spooled promptly. The check is now scoped by path, reusing what `derefToolResultReReads` already applies, and `spoolAndStubOversizedToolResults` resolves a `tool_use_id` to its name and input together since eligibility turns on both.

One deliberate call worth a look: the truncation notice fires for explicit limits too, not only for the default. A caller that guesses `limit` still cannot tell a window from a whole file, which is the failure this is meant to bound. Easy to scope to the default path instead if you would rather.

## Original prompt

An audit of the subagent cost lead in #prod-harness turned up two `file_read` defects that survived both merged pieces of ATL-1188 work. #39996 fixed the latency half by converting `code_search`'s synchronous walk to async, and #39990 removed the researcher preamble's instruction to read whole files, which reduces how often this triggers but does not bound it. These two changes are the remaining cost half. They touch files neither merged PR lists, so they were split out rather than folded in.

## Test plan

- `assistant/src/__tests__/file-ops-service.test.ts` (25 pass): default cap applied with the notice present, explicit limit honored and not replaced, a read reaching the last line carries no notice, paging past the end is not reported as truncation.
- `assistant/src/__tests__/tool-result-spool.test.ts` (13 pass): an oversized file read of an ordinary path now spools; a read of a `.tool-results/` path still does not, for both `file_read` and `host_file_read` (the regression that would make paging impossible).
- Also green per-file: `post-turn-tool-result-truncation` (23), `filesystem-tools` (41), `file-read-tool` (14), `conversation-agent-loop` (74).
- `tsc --noEmit` clean over the touched files; `eslint` and pinned `prettier` (3.8.1) clean over the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
