### PR TITLE
fix(android): limit app haptics to pull-to-refresh

### DIFF
--- a/clients/web/src/domains/chat/transcript/use-pull-to-refresh.ts
+++ b/clients/web/src/domains/chat/transcript/use-pull-to-refresh.ts
@@ -230,7 +230,7 @@ export function usePullToRefresh({
         })
       ) {
         drag.hasFiredThresholdHaptic = true;
-        void haptic.light();
+        void haptic.refreshThreshold();
       }
       setPullDistance(visualPullHeight(pullExtent));
       setIsAtThreshold(cls.atThreshold);

--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let nativePlatform: "ios" | "android" | null = "ios";
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => nativePlatform === "ios",
+  isNativeMobile: () => nativePlatform !== null,
 }));
 
 // ── @capacitor/haptics (lazy-imported plugin Proxy) ──────────────────────────
@@ -82,15 +83,17 @@ describe("haptic on iOS", () => {
 });
 
 describe("haptic on Android", () => {
-  test("never touches the plugin", async () => {
+  test("only fires the pull-to-refresh threshold impact", async () => {
     nativePlatform = "android";
 
     await haptic.light();
     await haptic.medium();
     await haptic.success();
     await haptic.error();
+    await haptic.refreshThreshold();
 
-    expect(impactMock).not.toHaveBeenCalled();
+    expect(impactMock).toHaveBeenCalledTimes(1);
+    expect(impactMock).toHaveBeenCalledWith({ style: "LIGHT" });
     expect(notificationMock).not.toHaveBeenCalled();
   });
 });
@@ -103,6 +106,7 @@ describe("haptic on web", () => {
     await haptic.medium();
     await haptic.success();
     await haptic.error();
+    await haptic.refreshThreshold();
 
     expect(impactMock).not.toHaveBeenCalled();
     expect(notificationMock).not.toHaveBeenCalled();

--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -2,13 +2,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── platform guard ───────────────────────────────────────────────────────────
 //
-// `native-auth` is mocked rather than loaded because its module-load
-// `registerPlugin("NativeAuth")` would fail outside a Capacitor runtime
-// (mirrors push-registration.test.ts).
+// Platform detection is mocked so each native shell can be exercised without
+// loading the Capacitor runtime.
 
-let isNative = true;
-mock.module("@/runtime/native-auth", () => ({
-  isNativePlatform: () => isNative,
+let nativePlatform: "ios" | "android" | null = "ios";
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => nativePlatform === "ios",
 }));
 
 // ── @capacitor/haptics (lazy-imported plugin Proxy) ──────────────────────────
@@ -46,13 +45,13 @@ mock.module("@capacitor/haptics", () => ({
 const { haptic } = await import("@/utils/haptics");
 
 beforeEach(() => {
-  isNative = true;
+  nativePlatform = "ios";
   pluginError = null;
   impactMock.mockClear();
   notificationMock.mockClear();
 });
 
-describe("haptic on native", () => {
+describe("haptic on iOS", () => {
   test("light() fires a Light impact", async () => {
     await haptic.light();
 
@@ -82,9 +81,23 @@ describe("haptic on native", () => {
   });
 });
 
+describe("haptic on Android", () => {
+  test("never touches the plugin", async () => {
+    nativePlatform = "android";
+
+    await haptic.light();
+    await haptic.medium();
+    await haptic.success();
+    await haptic.error();
+
+    expect(impactMock).not.toHaveBeenCalled();
+    expect(notificationMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("haptic on web", () => {
   test("never touches the plugin", async () => {
-    isNative = false;
+    nativePlatform = null;
 
     await haptic.light();
     await haptic.medium();

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -1,7 +1,13 @@
-import { isNativeIOS } from "@/runtime/platform-detection";
+import {
+  isNativeIOS,
+  isNativeMobile,
+} from "@/runtime/platform-detection";
 
-const runIOS = async (fire: () => Promise<void>): Promise<void> => {
-  if (!isNativeIOS()) {
+const runWhen = async (
+  enabled: boolean,
+  fire: () => Promise<void>,
+): Promise<void> => {
+  if (!enabled) {
     return;
   }
   try {
@@ -11,30 +17,33 @@ const runIOS = async (fire: () => Promise<void>): Promise<void> => {
   }
 };
 
+const lightImpact = (enabled: boolean): Promise<void> =>
+  runWhen(enabled, async () => {
+    const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
+    await Haptics.impact({ style: ImpactStyle.Light });
+  });
+
 /**
- * Thin haptic-feedback wrapper. On native Capacitor iOS this delegates to
- * `@capacitor/haptics`; on Android and web it's a no-op. The lazy import keeps
- * the plugin out of plain browser contexts.
+ * Thin haptic-feedback wrapper. Standard effects run only on native iOS. The
+ * pull-to-refresh threshold also runs on Android. The lazy imports keep the
+ * plugin out of plain browser contexts.
  */
 export const haptic = {
-  light: () =>
-    runIOS(async () => {
-      const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
-      await Haptics.impact({ style: ImpactStyle.Light });
-    }),
+  light: () => lightImpact(isNativeIOS()),
   medium: () =>
-    runIOS(async () => {
+    runWhen(isNativeIOS(), async () => {
       const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
       await Haptics.impact({ style: ImpactStyle.Medium });
     }),
   success: () =>
-    runIOS(async () => {
+    runWhen(isNativeIOS(), async () => {
       const { Haptics, NotificationType } = await import("@capacitor/haptics");
       await Haptics.notification({ type: NotificationType.Success });
     }),
   error: () =>
-    runIOS(async () => {
+    runWhen(isNativeIOS(), async () => {
       const { Haptics, NotificationType } = await import("@capacitor/haptics");
       await Haptics.notification({ type: NotificationType.Error });
     }),
+  refreshThreshold: () => lightImpact(isNativeMobile()),
 };

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -1,7 +1,7 @@
-import { isNativePlatform } from "@/runtime/native-auth";
+import { isNativeIOS } from "@/runtime/platform-detection";
 
-const runNative = async (fire: () => Promise<void>): Promise<void> => {
-  if (!isNativePlatform()) {
+const runIOS = async (fire: () => Promise<void>): Promise<void> => {
+  if (!isNativeIOS()) {
     return;
   }
   try {
@@ -12,29 +12,28 @@ const runNative = async (fire: () => Promise<void>): Promise<void> => {
 };
 
 /**
- * Thin haptic-feedback wrapper. On native Capacitor platforms this delegates
- * to `@capacitor/haptics`; on web it's a no-op. The lazy import ensures the
- * Capacitor plugin's `registerPlugin()` call (which throws without the full
- * runtime) never runs in a plain browser context.
+ * Thin haptic-feedback wrapper. On native Capacitor iOS this delegates to
+ * `@capacitor/haptics`; on Android and web it's a no-op. The lazy import keeps
+ * the plugin out of plain browser contexts.
  */
 export const haptic = {
   light: () =>
-    runNative(async () => {
+    runIOS(async () => {
       const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
       await Haptics.impact({ style: ImpactStyle.Light });
     }),
   medium: () =>
-    runNative(async () => {
+    runIOS(async () => {
       const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
       await Haptics.impact({ style: ImpactStyle.Medium });
     }),
   success: () =>
-    runNative(async () => {
+    runIOS(async () => {
       const { Haptics, NotificationType } = await import("@capacitor/haptics");
       await Haptics.notification({ type: NotificationType.Success });
     }),
   error: () =>
-    runNative(async () => {
+    runIOS(async () => {
       const { Haptics, NotificationType } = await import("@capacitor/haptics");
       await Haptics.notification({ type: NotificationType.Error });
     }),


### PR DESCRIPTION
## Summary

- disable routine Android haptics for navigation, chat actions, and gestures
- preserve one light Android haptic when pull-to-refresh crosses its release threshold
- preserve the existing iOS feedback behavior

## Original prompt

The Android app was vibrating during routine navigation, chat actions, and gestures. The audit found that Android inherited the iOS-oriented Capacitor haptic wrapper, so this change disables those effects centrally for Android. A follow-up clarified that pull-to-refresh should retain useful feedback, so Android receives one threshold pulse without the later result patterns.