### PR TITLE
fix(auth): least-privilege speech_relay_v1 profile for the relay dial token (ATL-1033)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -67,8 +67,10 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | `actor_client_v1`    | `chat.{read,write}`, `approval.{read,write}`, `settings.{read,write}`, `attachments.{read,write}`, `calls.{read,write}`, `feature_flags.{read,write}` | Desktop, CLI clients                         |
 | `gateway_ingress_v1` | `ingress.write`, `internal.write`                                                                                                                     | Gateway channel inbound + webhook forwarding |
-| `gateway_service_v1` | `settings.read`, `settings.write`, `internal.write`                                                                                                   | Gateway service-to-daemon calls              |
-| `internal_v1`        | `internal.all`                                                                                                                                        | Internal service connections                 |
+| `gateway_service_v1` | `chat.{read,write}`, `settings.{read,write}`, `attachments.{read,write}`, `internal.write`                                                            | Gateway service-to-daemon calls              |
+| `local_v1`           | `local.all`                                                                                                                                           | Local (loopback) conversation sessions       |
+| `speech_relay_v1`    | `speech.relay`                                                                                                                                        | Daemon dial of the gateway speech relay only |
+| `ui_page_v1`         | `settings.read`                                                                                                                                       | Served UI pages                              |
 
 **Identity lifecycle:**
 

--- a/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
+++ b/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
@@ -59,7 +59,9 @@ export async function resolveSpeechRelayConnection(): Promise<SpeechRelayConnect
     mintToken({
       aud: "vellum-gateway",
       sub: DAEMON_SERVICE_SUB,
-      scope_profile: "gateway_service_v1",
+      // Least-privilege (ATL-1033): this token rides in the dial URL, so it
+      // must open nothing but the speech relay.
+      scope_profile: "speech_relay_v1",
       policy_epoch: CURRENT_POLICY_EPOCH,
       ttlSeconds: RELAY_TOKEN_TTL_SECONDS,
     });

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -276,6 +276,7 @@ describe("scope profile contract", () => {
       "internal.write",
     ],
     local_v1: ["local.all"],
+    speech_relay_v1: ["speech.relay"],
     ui_page_v1: ["settings.read"],
   };
 
@@ -299,6 +300,7 @@ describe("scope profile contract", () => {
       "gateway_ingress_v1",
       "gateway_service_v1",
       "local_v1",
+      "speech_relay_v1",
       "ui_page_v1",
     ];
 

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -70,6 +70,20 @@ describe("resolveScopeProfile", () => {
     expect(scopes.size).toBe(1);
   });
 
+  test("unknown profiles resolve to no scopes, including prototype keys", () => {
+    // Claims come from JSON, so the ScopeProfile type does not protect at
+    // runtime. Unknown names and Object.prototype keys must both fail closed.
+    for (const profile of [
+      "bogus_v1",
+      "toString",
+      "constructor",
+      "__proto__",
+    ]) {
+      const scopes = resolveScopeProfile(profile as never);
+      expect(scopes.size).toBe(0);
+    }
+  });
+
   test("local_v1 includes only local.all", () => {
     const scopes = resolveScopeProfile("local_v1");
     expect(scopes.has("local.all")).toBe(true);

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -64,6 +64,12 @@ describe("resolveScopeProfile", () => {
     expect(scopes.size).toBe(7);
   });
 
+  test("speech_relay_v1 includes only speech.relay (ATL-1033 least-privilege)", () => {
+    const scopes = resolveScopeProfile("speech_relay_v1");
+    expect(scopes.has("speech.relay")).toBe(true);
+    expect(scopes.size).toBe(1);
+  });
+
   test("local_v1 includes only local.all", () => {
     const scopes = resolveScopeProfile("local_v1");
     expect(scopes.has("local.all")).toBe(true);

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -38,8 +38,13 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "internal.write",
   ]),
   local_v1: new Set<Scope>(["local.all"]),
+  // Managed speech relay only (ATL-1033): the daemon's relay-dial token must
+  // not open any other edge-scoped route.
+  speech_relay_v1: new Set<Scope>(["speech.relay"]),
   ui_page_v1: new Set<Scope>(["settings.read"]),
 };
+
+const EMPTY_SCOPES: ReadonlySet<Scope> = new Set();
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -47,7 +52,11 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
 
 /** Resolve a scope profile name to its set of granted scopes. */
 export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
-  return PROFILE_SCOPES[profile];
+  // Claims come from JSON, so an unrecognized profile (e.g. minted by a newer
+  // peer) can reach this despite the type — resolve it to no scopes, not a
+  // TypeError in the caller.
+  const scopes: ReadonlySet<Scope> | undefined = PROFILE_SCOPES[profile];
+  return scopes ?? EMPTY_SCOPES;
 }
 
 /** Check whether the auth context includes a specific scope. */

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -53,10 +53,13 @@ const EMPTY_SCOPES: ReadonlySet<Scope> = new Set();
 /** Resolve a scope profile name to its set of granted scopes. */
 export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
   // Claims come from JSON, so an unrecognized profile (e.g. minted by a newer
-  // peer) can reach this despite the type — resolve it to no scopes, not a
-  // TypeError in the caller.
-  const scopes: ReadonlySet<Scope> | undefined = PROFILE_SCOPES[profile];
-  return scopes ?? EMPTY_SCOPES;
+  // peer) can reach this despite the type. Resolve it to no scopes, not a
+  // TypeError in the caller. The own-property check keeps inherited keys
+  // ("toString", "constructor") failing closed too.
+  if (!Object.prototype.hasOwnProperty.call(PROFILE_SCOPES, profile)) {
+    return EMPTY_SCOPES;
+  }
+  return PROFILE_SCOPES[profile];
 }
 
 /** Check whether the auth context includes a specific scope. */

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -14,6 +14,7 @@ export type ScopeProfile =
   | "gateway_ingress_v1"
   | "gateway_service_v1"
   | "local_v1"
+  | "speech_relay_v1"
   | "ui_page_v1";
 
 // ---------------------------------------------------------------------------
@@ -35,6 +36,7 @@ export type Scope =
   | "internal.write"
   | "feature_flags.read"
   | "feature_flags.write"
+  | "speech.relay"
   | "local.all";
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/__tests__/scopes.test.ts
+++ b/gateway/src/__tests__/scopes.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveScopeProfile } from "../auth/scopes.js";
+
+describe("resolveScopeProfile", () => {
+  test("known profiles resolve to their scopes", () => {
+    expect(resolveScopeProfile("speech_relay_v1").has("speech.relay")).toBe(
+      true,
+    );
+    expect(resolveScopeProfile("speech_relay_v1").size).toBe(1);
+    expect(
+      resolveScopeProfile("gateway_service_v1").has("settings.write"),
+    ).toBe(true);
+  });
+
+  test("unknown profiles resolve to no scopes, including prototype keys", () => {
+    // Claims come from JSON, so the ScopeProfile type does not protect at
+    // runtime. Unknown names and Object.prototype keys must both fail closed
+    // rather than throwing in validateScopedEdgeBearer.
+    for (const profile of [
+      "bogus_v1",
+      "toString",
+      "constructor",
+      "__proto__",
+    ]) {
+      const scopes = resolveScopeProfile(profile as never);
+      expect(scopes.size).toBe(0);
+    }
+  });
+});

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -19,6 +19,21 @@ function mintDaemonServiceToken(): string {
   return mintToken({
     aud: "vellum-gateway",
     sub: "svc:daemon:self",
+    scope_profile: "speech_relay_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/**
+ * A daemon-sub token with the broad service profile — the over-scoped shape
+ * ATL-1033 removed. The relay must reject it: only speech_relay_v1 carries
+ * the speech.relay scope.
+ */
+function mintOverScopedDaemonToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:daemon:self",
     scope_profile: "gateway_service_v1",
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: 300,
@@ -281,6 +296,20 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     });
     const req = new Request(
       `http://127.0.0.1:7830/v1/speech/stt/stream?key=${mintActorToken()}`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(401);
+    expect((await bodyOf(res)).code).toBe("invalid_token");
+  });
+
+  test("rejects a daemon token with the broad gateway_service_v1 profile (ATL-1033)", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${mintOverScopedDaemonToken()}`,
       { headers: { upgrade: "websocket" } },
     );
 

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -26,7 +26,7 @@ function mintDaemonServiceToken(): string {
 }
 
 /**
- * A daemon-sub token with the broad service profile — the over-scoped shape
+ * A daemon-sub token with the broad service profile, the over-scoped shape
  * ATL-1033 removed. The relay must reject it: only speech_relay_v1 carries
  * the speech.relay scope.
  */

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -39,8 +39,13 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "internal.write",
   ]),
   local_v1: new Set<Scope>(["local.all"]),
+  // Managed speech relay only (ATL-1033): the daemon's relay-dial token must
+  // not open any other edge-scoped route.
+  speech_relay_v1: new Set<Scope>(["speech.relay"]),
   ui_page_v1: new Set<Scope>(["settings.read"]),
 };
+
+const EMPTY_SCOPES: ReadonlySet<Scope> = new Set();
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -48,5 +53,9 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
 
 /** Resolve a scope profile name to its set of granted scopes. */
 export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
-  return PROFILE_SCOPES[profile];
+  // Claims come from JSON, so an unrecognized profile (e.g. minted by a newer
+  // peer) can reach this despite the type — resolve it to no scopes, not a
+  // TypeError in the caller.
+  const scopes: ReadonlySet<Scope> | undefined = PROFILE_SCOPES[profile];
+  return scopes ?? EMPTY_SCOPES;
 }

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -54,8 +54,11 @@ const EMPTY_SCOPES: ReadonlySet<Scope> = new Set();
 /** Resolve a scope profile name to its set of granted scopes. */
 export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
   // Claims come from JSON, so an unrecognized profile (e.g. minted by a newer
-  // peer) can reach this despite the type — resolve it to no scopes, not a
-  // TypeError in the caller.
-  const scopes: ReadonlySet<Scope> | undefined = PROFILE_SCOPES[profile];
-  return scopes ?? EMPTY_SCOPES;
+  // peer) can reach this despite the type. Resolve it to no scopes, not a
+  // TypeError in the caller. The own-property check keeps inherited keys
+  // ("toString", "constructor") failing closed too.
+  if (!Object.prototype.hasOwnProperty.call(PROFILE_SCOPES, profile)) {
+    return EMPTY_SCOPES;
+  }
+  return PROFILE_SCOPES[profile];
 }

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -14,6 +14,7 @@ export type ScopeProfile =
   | "gateway_ingress_v1"
   | "gateway_service_v1"
   | "local_v1"
+  | "speech_relay_v1"
   | "ui_page_v1";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,7 @@ export type Scope =
   | "admin.write"
   | "feature_flags.read"
   | "feature_flags.write"
+  | "speech.relay"
   | "local.all";
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -24,6 +24,7 @@ import type { OutgoingHttpHeaders } from "node:http";
 
 import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
 
+import { resolveScopeProfile } from "../../auth/scopes.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -252,9 +253,19 @@ export function createSpeechRelayUpgradeHandler(
       return jsonError(401, "invalid_token", "missing service token");
     }
     const result = validateEdgeToken(rawToken);
-    if (!result.ok || result.claims.sub !== DAEMON_SERVICE_SUB) {
+    if (
+      !result.ok ||
+      result.claims.sub !== DAEMON_SERVICE_SUB ||
+      !resolveScopeProfile(result.claims.scope_profile).has("speech.relay")
+    ) {
       log.warn(
-        { reason: result.ok ? "wrong_sub" : result.reason },
+        {
+          reason: !result.ok
+            ? result.reason
+            : result.claims.sub !== DAEMON_SERVICE_SUB
+              ? "wrong_sub"
+              : "missing_speech_scope",
+        },
         "Speech relay: authentication failed",
       );
       return jsonError(401, "invalid_token", "service token rejected");


### PR DESCRIPTION
Fixes [ATL-1033](https://linear.app/vellum/issue/ATL-1033/security-over-scoped-speech-relay-jwt-is-exposed-in-websocket-url).

## Problem

The daemon's managed-speech relay dial token was minted with the broad `gateway_service_v1` scope profile (`chat.*`, `settings.*`, `attachments.*`, `internal.write`) and is serialized into the WebSocket URL as `?key=`. Gateway scoped-route auth checks only signature/audience/scope-profile — not principal — so a captured token could be replayed as a `Authorization: Bearer` against any edge-scoped route (e.g. `settings.write`) within its 5-minute TTL.

## Fix

- New `speech_relay_v1` scope profile containing a single new `speech.relay` scope, added to **both** auth modules (`gateway/src/auth/` and `assistant/src/runtime/auth/` deliberately don't share constants; the existing guard test enforces the contract and caught the addition).
- The relay dial token (`vellum-speech-relay-connection.ts`) now mints `speech_relay_v1`.
- The gateway relay route now requires the `speech.relay` scope in addition to the existing `sub === "svc:daemon:self"` check — a broad `gateway_service_v1` token is rejected there (new regression test).
- `resolveScopeProfile` in both packages now resolves an *unknown* profile to an empty scope set instead of returning `undefined` and throwing a TypeError in `validateScopedEdgeBearer` (claims come from JSON; the union type doesn't protect at runtime).

## Compatibility

Daemon and gateway ship in the same release (one pod image on platform, one bundle self-hosted), so no transition window accepting both profiles is needed. Under theoretical skew: new daemon + old gateway works (old gateway checks only `sub`, and token validation doesn't enum-check the profile); old daemon + new gateway would 401 on speech until both restart — acceptable for co-deployed processes.

## Not in scope (follow-ups)

- Moving the token from `?key=` to an `Authorization` header on the dial (the query carrier was inherited from the Deepgram client's query-auth mode; Bun's server-side WS client supports headers).
- Principal-aware scoped-route auth: the gateway's own `svc:gateway:self` exchange tokens still carry `gateway_service_v1`, so the general class (leaked broad service token passes scoped routes) remains and deserves its own ticket.

## Checks

- `bunx tsc --noEmit` clean in `gateway/` and `assistant/`
- `bun test` — gateway speech-relay suite 25/25 (incl. new over-scoped-token rejection); assistant auth/guard/relay-connection suites 30/30
- `bun run lint` — no new issues (5 pre-existing unused-directive warnings in unrelated test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->