### PR TITLE
feat(web): server-side unread conversation count for the Dock badge (LUM-2445)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9565,6 +9565,28 @@ paths:
                 required:
                   - ok
                 additionalProperties: false
+  /v1/conversations/unread-count:
+    get:
+      operationId: conversations_unreadcount_get
+      summary: Unread conversation count
+      description:
+        "Count of foreground conversations whose latest assistant message is unseen. Matches the sidebar's unread
+        indicators: archived rows and non-surfaced background/scheduled rows are excluded."
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                required:
+                  - count
+                additionalProperties: false
   /v1/conversations/wake:
     post:
       operationId: conversations_wake_post

--- a/assistant/src/persistence/conversation-attention-store.ts
+++ b/assistant/src/persistence/conversation-attention-store.ts
@@ -6,7 +6,17 @@
  * single-row projection per conversation (conversation_assistant_attention_state).
  */
 
-import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  or,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { UserError } from "../util/errors.js";
@@ -85,6 +95,24 @@ export function hasUnseenLatestAssistantMessage(
     state.lastSeenAssistantMessageAt == null ||
     state.lastSeenAssistantMessageAt < state.latestAssistantMessageAt
   );
+}
+
+/**
+ * SQL twin of {@link hasUnseenLatestAssistantMessage}: conditions over
+ * `conversation_assistant_attention_state` selecting rows whose latest
+ * assistant cursor is ahead of the last-seen cursor. Shared by
+ * {@link listConversationAttention} and `countUnreadConversations`
+ * (`conversation-queries.ts`) so every SQL reader of "unseen" agrees with
+ * the TS predicate.
+ */
+export function unseenAttentionStateConditions(): SQL[] {
+  return [
+    sql`${conversationAssistantAttentionState.latestAssistantMessageAt} IS NOT NULL`,
+    or(
+      isNull(conversationAssistantAttentionState.lastSeenAssistantMessageAt),
+      sql`${conversationAssistantAttentionState.lastSeenAssistantMessageAt} < ${conversationAssistantAttentionState.latestAssistantMessageAt}`,
+    )!,
+  ];
 }
 
 // ── Row mappers ──────────────────────────────────────────────────────
@@ -654,15 +682,7 @@ export function listConversationAttention(
 
   if (filterState === "unseen") {
     // Unseen: latest assistant message exists but no seen cursor, or seen cursor is behind latest
-    conditions.push(
-      sql`${conversationAssistantAttentionState.latestAssistantMessageAt} IS NOT NULL`,
-    );
-    conditions.push(
-      or(
-        isNull(conversationAssistantAttentionState.lastSeenAssistantMessageAt),
-        sql`${conversationAssistantAttentionState.lastSeenAssistantMessageAt} < ${conversationAssistantAttentionState.latestAssistantMessageAt}`,
-      )!,
-    );
+    conditions.push(...unseenAttentionStateConditions());
   } else if (filterState === "seen") {
     // Seen: seen cursor equals latest assistant message
     conditions.push(

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -474,7 +474,16 @@ export function countConversations(
  * The server-side twin of the web client's `contributesToUnreadCount`
  * predicate (`clients/web/src/utils/conversation-predicates.ts`), so the
  * count returned by `GET /v1/conversations/unread-count` always matches what
- * the sidebar's unread indicators would sum to over the full list:
+ * the sidebar's unread indicators would sum to over the full list.
+ *
+ * **Two definitions of one rule.** Changing what counts here means changing
+ * the client predicate too. Both sides assert the same named scenario matrix
+ * ("unread-count contract") so a one-sided change is visible in review: see
+ * `__tests__/conversation-list-routes.test.ts` here and
+ * `conversation-predicates.test.ts` there. The duplication exists only to
+ * keep a fallback for assistants without this route, and goes away with it.
+ *
+ * The rules:
  *
  * - visible in the standard (Recents) listing ({@link conversationTypeClause}),
  * - not archived,

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -8,6 +8,7 @@ import {
 } from "../security/untrusted-content.js";
 import { getLogger } from "../util/logger.js";
 import { isLexicalBackfillComplete } from "./checkpoints.js";
+import { unseenAttentionStateConditions } from "./conversation-attention-store.js";
 import type { ConversationRow } from "./conversation-crud.js";
 import { parseConversation } from "./conversation-crud.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
@@ -21,7 +22,11 @@ import {
   resolveMessageContentBlocks,
 } from "./message-content-file.js";
 import { rawAll } from "./raw-query.js";
-import { conversations, messages } from "./schema/index.js";
+import {
+  conversationAssistantAttentionState,
+  conversations,
+  messages,
+} from "./schema/index.js";
 
 const log = getLogger("conversation-store");
 
@@ -166,6 +171,26 @@ function surfacedVisibilitySql(alias = "conversations"): string {
     `(${alias}.surfaced_at IS NOT NULL` +
     ` AND ${alias}.conversation_type != 'private'` +
     ` AND (${alias}.source IS NULL OR ${alias}.source != 'subagent'))`
+  );
+}
+
+/**
+ * Raw SQL predicate for "not an automated background/scheduled row".
+ *
+ * A background or scheduled row counts as foreground only once it has been
+ * explicitly surfaced. {@link standardListingVisibilitySql} already admits
+ * such rows through its surfaced and custom-group arms, so a caller that
+ * must distinguish "visible in the listing" from "user-facing foreground"
+ * (unread counting) applies this on top.
+ *
+ * The SQL twin of `isBackgroundConversation` in the web client's
+ * `utils/conversation-predicates.ts`.
+ */
+function notBackgroundVisibilitySql(alias = "conversations"): string {
+  return (
+    `NOT ((${alias}.conversation_type IN ('background', 'scheduled')` +
+    ` OR COALESCE(${alias}.group_id, 'system:all') IN ('system:background', 'system:scheduled'))` +
+    ` AND ${alias}.surfaced_at IS NULL)`
   );
 }
 
@@ -439,6 +464,45 @@ export function countConversations(
     .select({ total: count() })
     .from(conversations)
     .where(where)
+    .all();
+  return total;
+}
+
+/**
+ * Count of foreground conversations whose latest assistant message is unseen.
+ *
+ * The server-side twin of the web client's `contributesToUnreadCount`
+ * predicate (`clients/web/src/utils/conversation-predicates.ts`), so the
+ * count returned by `GET /v1/conversations/unread-count` always matches what
+ * the sidebar's unread indicators would sum to over the full list:
+ *
+ * - visible in the standard (Recents) listing ({@link conversationTypeClause}),
+ * - not archived,
+ * - not an unsurfaced background/scheduled row
+ *   ({@link notBackgroundVisibilitySql}), which excludes automated rows the
+ *   listing admits through its custom-group arm,
+ * - unseen per the attention projection
+ *   ({@link unseenAttentionStateConditions}); conversations without a
+ *   projection row read as seen, hence the inner join.
+ */
+export function countUnreadConversations(): number {
+  ensureGroupMigration();
+  const db = getDb();
+  const [{ total }] = db
+    .select({ total: count() })
+    .from(conversations)
+    .innerJoin(
+      conversationAssistantAttentionState,
+      eq(conversationAssistantAttentionState.conversationId, conversations.id),
+    )
+    .where(
+      and(
+        conversationTypeClause("standard"),
+        isNull(conversations.archivedAt),
+        sql.raw(notBackgroundVisibilitySql()),
+        ...unseenAttentionStateConditions(),
+      ),
+    )
     .all();
   return total;
 }

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -17,11 +17,20 @@ mock.module("../../assistant-event-hub.js", () => ({
 }));
 
 import { findConversation } from "../../../daemon/conversation-registry.js";
+import {
+  projectAssistantMessage,
+  recordConversationSeenSignal,
+} from "../../../persistence/conversation-attention-store.js";
 import { createConversation } from "../../../persistence/conversation-crud.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
+import { createGroup } from "../../../persistence/group-crud.js";
 import { rawRun } from "../../../persistence/raw-query.js";
-import { conversations } from "../../../persistence/schema/index.js";
+import {
+  conversationAssistantAttentionState,
+  conversationAttentionEvents,
+  conversations,
+} from "../../../persistence/schema/index.js";
 import { ROUTES as CONVERSATION_LIST_ROUTES } from "../conversation-list-routes.js";
 import { BadRequestError } from "../errors.js";
 import type { RouteDefinition } from "../types.js";
@@ -234,5 +243,129 @@ describe("GET /v1/conversations — conversationType", () => {
     expect(() => invoke({ conversationType: "private" })).toThrow(
       BadRequestError,
     );
+  });
+});
+
+describe("GET /v1/conversations/unread-count", () => {
+  const unreadCountHandler = findHandler(
+    CONVERSATION_LIST_ROUTES,
+    "getUnreadConversationCount",
+  );
+
+  function invokeUnreadCount(): { count: number } {
+    return unreadCountHandler({}) as { count: number };
+  }
+
+  function seedUnseen(conversationId: string): void {
+    projectAssistantMessage({
+      conversationId,
+      messageId: `msg-${conversationId}`,
+      messageAt: Date.now(),
+    });
+  }
+
+  function markSeen(conversationId: string): void {
+    recordConversationSeenSignal({
+      conversationId,
+      sourceChannel: "vellum",
+      signalType: "macos_conversation_opened",
+      confidence: "explicit",
+      source: "test",
+    });
+  }
+
+  beforeEach(() => {
+    getDb().delete(conversationAttentionEvents).run();
+    getDb().delete(conversationAssistantAttentionState).run();
+    clearConversations();
+  });
+
+  test("counts only foreground conversations with an unseen latest assistant message", () => {
+    const unseen = createConversation("unseen-1");
+    seedUnseen(unseen.id);
+
+    // A conversation with no attention projection reads as seen.
+    createConversation("no-attention-row");
+
+    const seen = createConversation("seen-1");
+    seedUnseen(seen.id);
+    markSeen(seen.id);
+
+    expect(invokeUnreadCount()).toEqual({ count: 1 });
+  });
+
+  test("marking seen removes the conversation from the count", () => {
+    const conv = createConversation("unseen-then-seen");
+    seedUnseen(conv.id);
+    expect(invokeUnreadCount()).toEqual({ count: 1 });
+
+    markSeen(conv.id);
+    expect(invokeUnreadCount()).toEqual({ count: 0 });
+  });
+
+  test("archived conversations are excluded", () => {
+    const conv = createConversation("unseen-archived");
+    seedUnseen(conv.id);
+    rawRun(
+      "test:archiveConversation",
+      "UPDATE conversations SET archived_at = ? WHERE id = ?",
+      Date.now(),
+      conv.id,
+    );
+
+    expect(invokeUnreadCount()).toEqual({ count: 0 });
+  });
+
+  test("background and scheduled conversations count only when surfaced", () => {
+    const bg = createConversation({
+      title: "bg-1",
+      conversationType: "background",
+    });
+    seedUnseen(bg.id);
+    const sched = createConversation({
+      title: "sched-1",
+      conversationType: "scheduled",
+    });
+    seedUnseen(sched.id);
+    expect(invokeUnreadCount()).toEqual({ count: 0 });
+
+    // Surfacing promotes a row into the foreground listing, so it counts.
+    rawRun(
+      "test:surfaceConversation",
+      "UPDATE conversations SET surfaced_at = ? WHERE id = ?",
+      Date.now(),
+      bg.id,
+    );
+    expect(invokeUnreadCount()).toEqual({ count: 1 });
+  });
+
+  test("background rows filed in a custom group stay excluded until surfaced", () => {
+    // Custom-group rows are visible in the standard listing regardless of
+    // type, but a non-surfaced background row must not count as unread
+    // (the client's unread predicate excludes it).
+    const group = createGroup("unread-count-test-group");
+
+    const bgInGroup = createConversation({
+      title: "bg-in-group",
+      conversationType: "background",
+    });
+    seedUnseen(bgInGroup.id);
+    rawRun(
+      "test:fileIntoGroup",
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      group.id,
+      bgInGroup.id,
+    );
+
+    const standardInGroup = createConversation("standard-in-group");
+    seedUnseen(standardInGroup.id);
+    rawRun(
+      "test:fileIntoGroup",
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      group.id,
+      standardInGroup.id,
+    );
+
+    expect(invokeUnreadCount()).toEqual({ count: 1 });
   });
 });

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -339,6 +339,151 @@ describe("GET /v1/conversations/unread-count", () => {
     expect(invokeUnreadCount()).toEqual({ count: 1 });
   });
 
+  /**
+   * The daemon half of the unread-count contract.
+   *
+   * The web client answers the same question in TypeScript
+   * (`contributesToUnreadCount` in
+   * `clients/web/src/utils/conversation-predicates.ts`), and its
+   * `conversation-predicates.test.ts` asserts this same matrix against the
+   * predicate. The two definitions are maintained separately, so this matrix
+   * is the tripwire: a rule changed on one side without the other shows up as
+   * one of these scenarios disagreeing across the two suites.
+   *
+   * Keep the scenario names identical on both sides.
+   */
+  describe("unread-count contract (daemon half)", () => {
+    const scenarios: Array<{
+      name: string;
+      counts: boolean;
+      seed: (groupId: string) => string;
+    }> = [
+      {
+        name: "unseen foreground row",
+        counts: true,
+        seed: () => createConversation("unseen-foreground").id,
+      },
+      {
+        name: "seen foreground row",
+        counts: false,
+        seed: () => {
+          const conv = createConversation("seen-foreground");
+          seedUnseen(conv.id);
+          markSeen(conv.id);
+          return conv.id;
+        },
+      },
+      {
+        name: "unseen archived row",
+        counts: false,
+        seed: () => {
+          const conv = createConversation("unseen-archived");
+          rawRun(
+            "test:archiveConversation",
+            "UPDATE conversations SET archived_at = ? WHERE id = ?",
+            Date.now(),
+            conv.id,
+          );
+          return conv.id;
+        },
+      },
+      {
+        name: "unseen background row, not surfaced",
+        counts: false,
+        seed: () =>
+          createConversation({
+            title: "unseen-background",
+            conversationType: "background",
+          }).id,
+      },
+      {
+        name: "unseen scheduled row, not surfaced",
+        counts: false,
+        seed: () =>
+          createConversation({
+            title: "unseen-scheduled",
+            conversationType: "scheduled",
+          }).id,
+      },
+      {
+        name: "unseen background row, surfaced",
+        counts: true,
+        seed: () => {
+          const conv = createConversation({
+            title: "unseen-background-surfaced",
+            conversationType: "background",
+          });
+          rawRun(
+            "test:surfaceConversation",
+            "UPDATE conversations SET surfaced_at = ? WHERE id = ?",
+            Date.now(),
+            conv.id,
+          );
+          return conv.id;
+        },
+      },
+      {
+        name: "unseen background row filed in a custom group, not surfaced",
+        counts: false,
+        seed: (groupId) => {
+          const conv = createConversation({
+            title: "unseen-background-in-group",
+            conversationType: "background",
+          });
+          rawRun(
+            "test:fileIntoGroup",
+            "UPDATE conversations SET group_id = ? WHERE id = ?",
+            groupId,
+            conv.id,
+          );
+          return conv.id;
+        },
+      },
+      {
+        name: "unseen standard row filed in a custom group",
+        counts: true,
+        seed: (groupId) => {
+          const conv = createConversation("unseen-standard-in-group");
+          rawRun(
+            "test:fileIntoGroup",
+            "UPDATE conversations SET group_id = ? WHERE id = ?",
+            groupId,
+            conv.id,
+          );
+          return conv.id;
+        },
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      test(`${scenario.name} ${scenario.counts ? "counts" : "does not count"}`, () => {
+        const group = createGroup("unread-contract-group");
+        const conversationId = scenario.seed(group.id);
+        // The "seen" scenario seeds and clears its own attention row.
+        if (scenario.name !== "seen foreground row") {
+          seedUnseen(conversationId);
+        }
+
+        expect(invokeUnreadCount()).toEqual({
+          count: scenario.counts ? 1 : 0,
+        });
+      });
+    }
+
+    test("the matrix totals across every scenario at once", () => {
+      const group = createGroup("unread-contract-group");
+      for (const scenario of scenarios) {
+        const conversationId = scenario.seed(group.id);
+        if (scenario.name !== "seen foreground row") {
+          seedUnseen(conversationId);
+        }
+      }
+      const expected = scenarios.filter((s) => s.counts).length;
+
+      expect(invokeUnreadCount()).toEqual({ count: expected });
+    });
+  });
+
   test("background rows filed in a custom group stay excluded until surfaced", () => {
     // Custom-group rows are visible in the standard listing regardless of
     // type, but a non-surfaced background row must not count as unread

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -2,6 +2,7 @@
  * Route handlers for conversation listing, detail, and seen/unread state.
  *
  * GET    /v1/conversations              — paginated conversation list
+ * GET    /v1/conversations/unread-count - count of unseen foreground conversations
  * POST   /v1/conversations/seen         — record a seen signal (single)
  * POST   /v1/conversations/seen/bulk    — record seen signals (batch)
  * POST   /v1/conversations/unread       — mark a conversation unread
@@ -27,6 +28,7 @@ import {
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
 import {
   countConversations,
+  countUnreadConversations,
   listConversations,
   listPinnedConversations,
 } from "../../persistence/conversation-queries.js";
@@ -139,6 +141,10 @@ const listConversationsResponseSchema = z.object({
 
 const conversationDetailResponseSchema = z.object({
   conversation: conversationSummarySchema,
+});
+
+const unreadConversationCountResponseSchema = z.object({
+  count: z.number(),
 });
 
 // ---------------------------------------------------------------------------
@@ -263,6 +269,10 @@ function handleListConversations({ queryParams = {} }: RouteHandlerArgs) {
   }
 
   return response;
+}
+
+function handleGetUnreadConversationCount() {
+  return { count: countUnreadConversations() };
 }
 
 function handleRecordSeen({ body = {}, headers }: RouteHandlerArgs) {
@@ -453,6 +463,21 @@ export const ROUTES: RouteDefinition[] = [
     ],
     responseBody: listConversationsResponseSchema,
     handler: handleListConversations,
+  },
+  {
+    operationId: "getUnreadConversationCount",
+    endpoint: "conversations/unread-count",
+    method: "GET",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Unread conversation count",
+    description:
+      "Count of foreground conversations whose latest assistant message is unseen. Matches the sidebar's unread indicators: archived rows and non-surfaced background/scheduled rows are excluded.",
+    tags: ["conversations"],
+    responseBody: unreadConversationCountResponseSchema,
+    handler: handleGetUnreadConversationCount,
   },
   {
     operationId: "recordConversationSeen",

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -233,7 +233,7 @@ export function ChatLayout({
   // Prefers the server-side unread count, falling back to counting the
   // conversation list this layout already subscribes to; see
   // `./hooks/use-electron-dock-sync.ts`.
-  useElectronDockSync(assistantId, conversations);
+  useElectronDockSync(assistantId, conversations, isAssistantActive);
 
   // Header slots come from a module-level store so gated routes
   // (which see `ActiveAssistantGate`'s `<Outlet />` as their

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -229,11 +229,11 @@ export function ChatLayout({
       conversationGroups,
     });
 
-  // Mirror the unread count + signed-in flag into the Electron Dock
-  // (no-op off Electron). Uses the conversation list this layout
-  // already subscribes to, so there's no extra query — see
+  // Mirror the unread count into the Electron Dock (no-op off Electron).
+  // Prefers the server-side unread count, falling back to counting the
+  // conversation list this layout already subscribes to; see
   // `./hooks/use-electron-dock-sync.ts`.
-  useElectronDockSync(conversations);
+  useElectronDockSync(assistantId, conversations);
 
   // Header slots come from a module-level store so gated routes
   // (which see `ActiveAssistantGate`'s `<Outlet />` as their

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-interaction-resolved.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-interaction-resolved.test.tsx
@@ -11,6 +11,8 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
+import * as conversationCache from "@/utils/conversation-cache";
+import * as cacheMutations from "@/utils/conversation-cache-mutations";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
@@ -23,7 +25,11 @@ mock.module("@/hooks/conversation-queries", () => ({
   useArchivedConversationListQuery: () => ({ conversations: [] }),
 }));
 
+// Spread the real modules and override only what this suite drives:
+// `mock.module` is process-global, so an enumerated stand-in silently
+// breaks every other importer the moment the real module gains an export.
 mock.module("@/utils/conversation-cache-mutations", () => ({
+  ...cacheMutations,
   markConversationSeenLocal: () => {},
   refreshConversationRow: async () => {},
   prependConversation: () => {},
@@ -32,6 +38,7 @@ mock.module("@/utils/conversation-cache-mutations", () => ({
 }));
 
 mock.module("@/utils/conversation-cache", () => ({
+  ...conversationCache,
   getConversations: () => [],
   findConversation: () => undefined,
 }));
@@ -49,8 +56,9 @@ mock.module("@/domains/chat/api/interactions", () => ({
   listConversationIdsWithPendingInteractions: async () => new Set<string>(),
 }));
 
-const { useAttentionTracking } =
-  await import("@/domains/chat/hooks/use-attention-tracking");
+const { useAttentionTracking } = await import(
+  "@/domains/chat/hooks/use-attention-tracking"
+);
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-mark-seen.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-mark-seen.test.tsx
@@ -11,6 +11,8 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
+import * as conversationCache from "@/utils/conversation-cache";
+import * as cacheMutations from "@/utils/conversation-cache-mutations";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting } from "@/lib/event-bus";
 
@@ -38,7 +40,11 @@ mock.module("@/hooks/conversation-queries", () => ({
   useArchivedConversationListQuery: () => ({ conversations: [] }),
 }));
 
+// Spread the real modules and override only what this suite drives:
+// `mock.module` is process-global, so an enumerated stand-in silently
+// breaks every other importer the moment the real module gains an export.
 mock.module("@/utils/conversation-cache-mutations", () => ({
+  ...cacheMutations,
   markConversationSeenLocal: () => {},
   refreshConversationRow: async () => {},
   prependConversation: () => {},
@@ -47,6 +53,7 @@ mock.module("@/utils/conversation-cache-mutations", () => ({
 }));
 
 mock.module("@/utils/conversation-cache", () => ({
+  ...conversationCache,
   getConversations: () => conversationsImpl,
   findConversation: () => undefined,
 }));
@@ -73,8 +80,9 @@ mock.module("@/domains/chat/api/interactions", () => ({
   listConversationIdsWithPendingInteractions: async () => new Set<string>(),
 }));
 
-const { useAttentionTracking } =
-  await import("@/domains/chat/hooks/use-attention-tracking");
+const { useAttentionTracking } = await import(
+  "@/domains/chat/hooks/use-attention-tracking"
+);
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-attention-tracking-reconnect-sweep.test.tsx
@@ -14,6 +14,8 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 
 import * as sdkGen from "@/generated/daemon/sdk.gen";
+import * as conversationCache from "@/utils/conversation-cache";
+import * as cacheMutations from "@/utils/conversation-cache-mutations";
 import { useConversationStore } from "@/stores/conversation-store";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
@@ -26,7 +28,11 @@ mock.module("@/hooks/conversation-queries", () => ({
   useArchivedConversationListQuery: () => ({ conversations: [] }),
 }));
 
+// Spread the real modules and override only what this suite drives:
+// `mock.module` is process-global, so an enumerated stand-in silently
+// breaks every other importer the moment the real module gains an export.
 mock.module("@/utils/conversation-cache-mutations", () => ({
+  ...cacheMutations,
   markConversationSeenLocal: () => {},
   refreshConversationRow: async () => {},
   prependConversation: () => {},
@@ -35,6 +41,7 @@ mock.module("@/utils/conversation-cache-mutations", () => ({
 }));
 
 mock.module("@/utils/conversation-cache", () => ({
+  ...conversationCache,
   getConversations: () => [],
   findConversation: () => undefined,
 }));
@@ -78,8 +85,9 @@ mock.module("@/domains/chat/api/interactions", () => ({
   submitQuestionResponse: stubFromOtherTest("submitQuestionResponse"),
 }));
 
-const { useAttentionTracking } =
-  await import("@/domains/chat/hooks/use-attention-tracking");
+const { useAttentionTracking } = await import(
+  "@/domains/chat/hooks/use-attention-tracking"
+);
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-unread-count.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-unread-count.test.tsx
@@ -1,0 +1,420 @@
+/**
+ * Optimistic maintenance of the server-side unread count by the seen/unseen
+ * actions in `useConversationActions`.
+ *
+ * The count is authoritative on the server, so the client's job is to keep
+ * the badge honest between the user's click and the settle-time refetch:
+ * apply a delta that matches the mutation's semantics, revert exactly that
+ * delta if the write fails, and invalidate so the server reconciles any
+ * drift (including unread messages that landed mid-flight).
+ *
+ * Reversal is delta-based rather than snapshot-based on purpose: a snapshot
+ * restore would discard a concurrent mutation's adjustment.
+ *
+ * Test shape follows `use-conversation-actions-archive-optimistic.test.tsx`:
+ * `mutate()` is fire-and-forget, so each case wraps the handler call in
+ * `act()` to flush `onMutate`, asserts the optimistic value, then resolves
+ * or rejects the deferred API mock.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { Conversation } from "@/types/conversation-types";
+import {
+  conversationsQueryKey,
+  unreadConversationCountQueryKey,
+} from "@/utils/conversation-list-fetchers";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type SeenImpl = (opts: unknown) => Promise<unknown>;
+
+let seenImpl: SeenImpl = async () => ({
+  data: undefined,
+  response: { ok: true, status: 200 },
+});
+let unreadImpl: SeenImpl = async () => ({
+  data: undefined,
+  response: { ok: true, status: 200 },
+});
+let seenBulkImpl: SeenImpl = async () => ({
+  data: undefined,
+  response: { ok: true, status: 200 },
+});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsSeenPost: (opts: unknown) => seenImpl(opts),
+  conversationsUnreadPost: (opts: unknown) => unreadImpl(opts),
+  conversationsSeenBulkPost: (opts: unknown) => seenBulkImpl(opts),
+}));
+
+mock.module("@/utils/haptics", () => ({
+  haptic: { medium: () => {}, light: () => {} },
+}));
+
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addBreadcrumb: () => {},
+}));
+
+const { useConversationActions } = await import(
+  "@/domains/chat/hooks/use-conversation-actions"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: "conv-1", ...overrides };
+}
+
+function setupHook(opts: {
+  conversations: Conversation[];
+  unreadCount?: number | null;
+}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(conversationsQueryKey(ASSISTANT_ID), opts.conversations);
+  if (opts.unreadCount !== undefined) {
+    client.setQueryData(
+      unreadConversationCountQueryKey(ASSISTANT_ID),
+      opts.unreadCount,
+    );
+  }
+
+  const { result } = renderHook(
+    () =>
+      useConversationActions({
+        assistantId: ASSISTANT_ID,
+        activeConversationId: null,
+        conversations: opts.conversations,
+        switchConversation: () => {},
+        startNewConversation: () => {},
+        prePinGroupIdsRef: { current: new Map() },
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+
+  return { result, client };
+}
+
+function readCount(client: QueryClient): number | null | undefined {
+  return client.getQueryData<number | null>(
+    unreadConversationCountQueryKey(ASSISTANT_ID),
+  );
+}
+
+function deferred<T = { data: undefined; response: { ok: boolean } }>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  seenImpl = async () => ({
+    data: undefined,
+    response: { ok: true, status: 200 },
+  });
+  unreadImpl = async () => ({
+    data: undefined,
+    response: { ok: true, status: 200 },
+  });
+  seenBulkImpl = async () => ({
+    data: undefined,
+    response: { ok: true, status: 200 },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Mark read
+// ---------------------------------------------------------------------------
+
+describe("handleMarkConversationRead unread count", () => {
+  test("decrements before the API resolves", async () => {
+    const conv = makeConversation({ hasUnseenLatestAssistantMessage: true });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    const d = deferred();
+    seenImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleMarkConversationRead(conv);
+    });
+
+    expect(readCount(client)).toBe(3);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("reverts the decrement when the API rejects", async () => {
+    const conv = makeConversation({ hasUnseenLatestAssistantMessage: true });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    seenImpl = async () => {
+      throw new Error("network failure");
+    };
+
+    await act(async () => {
+      result.current.handleMarkConversationRead(conv);
+    });
+
+    await waitFor(() => {
+      expect(readCount(client)).toBe(4);
+    });
+  });
+
+  test("does not decrement for a row that never contributed to the count", async () => {
+    // An archived row carries unread state but is excluded from the badge,
+    // so marking it read must not move the count.
+    const conv = makeConversation({
+      hasUnseenLatestAssistantMessage: true,
+      archivedAt: 1234,
+    });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    const d = deferred();
+    seenImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleMarkConversationRead(conv);
+    });
+
+    expect(readCount(client)).toBe(4);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("invalidates the count on settle so the server reconciles drift", async () => {
+    // An assistant reply landing mid-flight makes the optimistic value stale;
+    // the refetch is what corrects it.
+    const conv = makeConversation({ hasUnseenLatestAssistantMessage: true });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    expect(
+      client.getQueryState(unreadConversationCountQueryKey(ASSISTANT_ID))
+        ?.isInvalidated,
+    ).toBe(false);
+
+    await act(async () => {
+      result.current.handleMarkConversationRead(conv);
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState(unreadConversationCountQueryKey(ASSISTANT_ID))
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  test("leaves an unavailable count untouched", async () => {
+    // `null` means the assistant does not serve the endpoint.
+    const conv = makeConversation({ hasUnseenLatestAssistantMessage: true });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: null,
+    });
+
+    const d = deferred();
+    seenImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleMarkConversationRead(conv);
+    });
+
+    expect(readCount(client)).toBeNull();
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mark unread
+// ---------------------------------------------------------------------------
+
+describe("handleMarkConversationUnread unread count", () => {
+  test("increments before the API resolves", async () => {
+    const conv = makeConversation({
+      hasUnseenLatestAssistantMessage: false,
+      latestAssistantMessageAt: 1234,
+    });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    const d = deferred();
+    unreadImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleMarkConversationUnread(conv);
+    });
+
+    expect(readCount(client)).toBe(5);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("reverts the increment when the API rejects", async () => {
+    const conv = makeConversation({
+      hasUnseenLatestAssistantMessage: false,
+      latestAssistantMessageAt: 1234,
+    });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    unreadImpl = async () => {
+      throw new Error("network failure");
+    };
+
+    await act(async () => {
+      result.current.handleMarkConversationUnread(conv);
+    });
+
+    await waitFor(() => {
+      expect(readCount(client)).toBe(4);
+    });
+  });
+
+  test("does not increment for a row that cannot contribute to the count", async () => {
+    const conv = makeConversation({
+      hasUnseenLatestAssistantMessage: false,
+      latestAssistantMessageAt: 1234,
+      archivedAt: 5678,
+    });
+    const { result, client } = setupHook({
+      conversations: [conv],
+      unreadCount: 4,
+    });
+
+    const d = deferred();
+    unreadImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleMarkConversationUnread(conv);
+    });
+
+    expect(readCount(client)).toBe(4);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mark all read in group
+// ---------------------------------------------------------------------------
+
+describe("handleMarkAllReadInGroup unread count", () => {
+  test("decrements once per contributing row", async () => {
+    const rows = [
+      makeConversation({
+        conversationId: "a",
+        hasUnseenLatestAssistantMessage: true,
+      }),
+      makeConversation({
+        conversationId: "b",
+        hasUnseenLatestAssistantMessage: true,
+      }),
+      // Archived: unread, but excluded from the badge.
+      makeConversation({
+        conversationId: "c",
+        hasUnseenLatestAssistantMessage: true,
+        archivedAt: 1234,
+      }),
+      makeConversation({
+        conversationId: "d",
+        hasUnseenLatestAssistantMessage: false,
+      }),
+    ];
+    const { result, client } = setupHook({
+      conversations: rows,
+      unreadCount: 6,
+    });
+
+    await act(async () => {
+      await result.current.handleMarkAllReadInGroup(rows);
+    });
+
+    // Only "a" and "b" contributed, so the count drops by exactly 2.
+    await waitFor(() => {
+      expect(readCount(client)).toBe(4);
+    });
+  });
+
+  test("restores the decrement for rows the bulk write failed", async () => {
+    const rows = [
+      makeConversation({
+        conversationId: "a",
+        hasUnseenLatestAssistantMessage: true,
+      }),
+      makeConversation({
+        conversationId: "b",
+        hasUnseenLatestAssistantMessage: true,
+      }),
+    ];
+    const { result, client } = setupHook({
+      conversations: rows,
+      unreadCount: 6,
+    });
+
+    seenBulkImpl = async () => ({
+      data: undefined,
+      error: { message: "boom" },
+      response: { ok: false, status: 500 },
+    });
+
+    await act(async () => {
+      await result.current.handleMarkAllReadInGroup(rows);
+    });
+
+    // Every row rolled back, so the count returns to its starting value.
+    await waitFor(() => {
+      expect(readCount(client)).toBe(6);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
   cancelConversationQueries,
+  findConversation,
   invalidateConversationQueries,
   patchConversation,
   restoreConversationCaches,
@@ -10,6 +11,8 @@ import {
   updateAllConversationCaches,
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
+import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
+import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
 import {
   conversationsArchiveBulkPost,
@@ -49,6 +52,15 @@ type MoveToGroupVars = {
 type ReorderVars = { assistantId: string; orderedIds: string[] };
 
 type MutationContext = { snapshot: ConversationCacheSnapshot };
+
+/**
+ * Context for the seen/unseen mutations, which additionally apply an
+ * optimistic delta to the server-side unread-count cache. `onError`
+ * reverts by applying the inverse delta (never a snapshot restore, so a
+ * concurrent mutation's adjustment is not clobbered); `onSettled`'s
+ * `invalidateConversationQueries` refetches the authoritative count.
+ */
+type SeenMutationContext = MutationContext & { unreadCountDelta: number };
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -168,7 +180,7 @@ export function useConversationActions({
     void,
     Error,
     MarkReadVars,
-    MutationContext
+    SeenMutationContext
   >({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsSeenPost({
@@ -180,14 +192,26 @@ export function useConversationActions({
     onMutate: async ({ assistantId: aid, conversationId }) => {
       await cancelConversationQueries(queryClient, aid);
       const snapshot = snapshotConversationCaches(queryClient, aid);
+      // Decrement the unread count only when this row contributed to it
+      // (unseen, foreground, unarchived), reading the row before the patch
+      // flips its seen state.
+      const row = findConversation(queryClient, aid, conversationId);
+      const unreadCountDelta =
+        row !== undefined && contributesToUnreadCount(row) ? -1 : 0;
+      if (unreadCountDelta !== 0) {
+        adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
+      }
       patchConversation(queryClient, aid, conversationId, {
         hasUnseenLatestAssistantMessage: false,
       });
-      return { snapshot };
+      return { snapshot, unreadCountDelta };
     },
-    onError: (err, _vars, context) => {
+    onError: (err, { assistantId: aid }, context) => {
       if (context?.snapshot) {
         restoreConversationCaches(queryClient, context.snapshot);
+      }
+      if (context && context.unreadCountDelta !== 0) {
+        adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
       }
       captureError(err, { context: "markConversationRead" });
     },
@@ -200,7 +224,7 @@ export function useConversationActions({
     void,
     Error,
     MarkUnreadVars,
-    MutationContext
+    SeenMutationContext
   >({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsUnreadPost({
@@ -212,14 +236,32 @@ export function useConversationActions({
     onMutate: async ({ assistantId: aid, conversationId }) => {
       await cancelConversationQueries(queryClient, aid);
       const snapshot = snapshotConversationCaches(queryClient, aid);
+      // Increment the unread count only when flipping this row to unseen
+      // makes it start contributing: it must be eligible for the badge
+      // (foreground, unarchived) and not already counted as unseen.
+      const row = findConversation(queryClient, aid, conversationId);
+      const startsContributing =
+        row !== undefined &&
+        !row.hasUnseenLatestAssistantMessage &&
+        contributesToUnreadCount({
+          ...row,
+          hasUnseenLatestAssistantMessage: true,
+        });
+      const unreadCountDelta = startsContributing ? 1 : 0;
+      if (unreadCountDelta !== 0) {
+        adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
+      }
       patchConversation(queryClient, aid, conversationId, {
         hasUnseenLatestAssistantMessage: true,
       });
-      return { snapshot };
+      return { snapshot, unreadCountDelta };
     },
-    onError: (err, _vars, context) => {
+    onError: (err, { assistantId: aid }, context) => {
       if (context?.snapshot) {
         restoreConversationCaches(queryClient, context.snapshot);
+      }
+      if (context && context.unreadCountDelta !== 0) {
+        adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
       }
       captureError(err, { context: "markConversationUnread" });
     },
@@ -514,6 +556,14 @@ export function useConversationActions({
 
       await cancelConversationQueries(queryClient, assistantId);
 
+      // One optimistic decrement for the rows that count toward the unread
+      // badge (foreground, unarchived); rows that fail roll their share
+      // back one at a time in `rollbackItem`.
+      const contributingCount = unread.filter(contributesToUnreadCount).length;
+      if (contributingCount > 0) {
+        adjustUnreadCountCache(queryClient, assistantId, -contributingCount);
+      }
+
       for (const c of unread) {
         patchConversation(queryClient, assistantId, c.conversationId, {
           hasUnseenLatestAssistantMessage: false,
@@ -533,10 +583,14 @@ export function useConversationActions({
             body: { conversationId: c.conversationId },
             throwOnError: true,
           }),
-        rollbackItem: (c) =>
+        rollbackItem: (c) => {
           patchConversation(queryClient, assistantId, c.conversationId, {
             hasUnseenLatestAssistantMessage: true,
-          }),
+          });
+          if (contributesToUnreadCount(c)) {
+            adjustUnreadCountCache(queryClient, assistantId, 1);
+          }
+        },
         context: "markAllReadInGroup",
       });
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -32,6 +32,7 @@ import {
   findNextConversationId,
   resolveUnpinGroupId,
 } from "@/domains/chat/hooks/conversation-action-utils";
+import { useMarkConversationSeenMutation } from "@/domains/chat/hooks/use-mark-conversation-seen-mutation";
 
 // ---------------------------------------------------------------------------
 // Mutation variable types
@@ -39,7 +40,6 @@ import {
 
 type ArchiveVars = { assistantId: string; conversationId: string };
 type UnarchiveVars = { assistantId: string; conversationId: string };
-type MarkReadVars = { assistantId: string; conversationId: string };
 type MarkUnreadVars = { assistantId: string; conversationId: string };
 type MoveToGroupVars = {
   assistantId: string;
@@ -176,49 +176,9 @@ export function useConversationActions({
     },
   });
 
-  const markReadMutation = useMutation<
-    void,
-    Error,
-    MarkReadVars,
-    SeenMutationContext
-  >({
-    mutationFn: async ({ assistantId: aid, conversationId }) => {
-      await conversationsSeenPost({
-        path: { assistant_id: aid },
-        body: { conversationId },
-        throwOnError: true,
-      });
-    },
-    onMutate: async ({ assistantId: aid, conversationId }) => {
-      await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid);
-      // Decrement the unread count only when this row contributed to it
-      // (unseen, foreground, unarchived), reading the row before the patch
-      // flips its seen state.
-      const row = findConversation(queryClient, aid, conversationId);
-      const unreadCountDelta =
-        row !== undefined && contributesToUnreadCount(row) ? -1 : 0;
-      if (unreadCountDelta !== 0) {
-        adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
-      }
-      patchConversation(queryClient, aid, conversationId, {
-        hasUnseenLatestAssistantMessage: false,
-      });
-      return { snapshot, unreadCountDelta };
-    },
-    onError: (err, { assistantId: aid }, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
-      }
-      if (context && context.unreadCountDelta !== 0) {
-        adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
-      }
-      captureError(err, { context: "markConversationRead" });
-    },
-    onSettled: (_data, _err, { assistantId: aid }) => {
-      void invalidateConversationQueries(queryClient, aid);
-    },
-  });
+  // Shared with the mark-seen-on-open effect so both entry points produce
+  // identical cache effects.
+  const markReadMutation = useMarkConversationSeenMutation();
 
   const markUnreadMutation = useMutation<
     void,

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -54,13 +54,16 @@ type ReorderVars = { assistantId: string; orderedIds: string[] };
 type MutationContext = { snapshot: ConversationCacheSnapshot };
 
 /**
- * Context for the seen/unseen mutations, which additionally apply an
- * optimistic delta to the server-side unread-count cache. `onError`
- * reverts by applying the inverse delta (never a snapshot restore, so a
- * concurrent mutation's adjustment is not clobbered); `onSettled`'s
+ * Context for the mark-unread mutation, which additionally applies an
+ * optimistic delta to the server-side unread-count cache. `onError` reverts
+ * by applying the inverse delta (never a snapshot restore, so a concurrent
+ * mutation's adjustment is not clobbered); `onSettled`'s
  * `invalidateConversationQueries` refetches the authoritative count.
+ *
+ * The mark-seen counterpart lives in `useMarkConversationSeenMutation`,
+ * which two entry points share.
  */
-type SeenMutationContext = MutationContext & { unreadCountDelta: number };
+type MarkUnreadContext = MutationContext & { unreadCountDelta: number };
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -184,7 +187,7 @@ export function useConversationActions({
     void,
     Error,
     MarkUnreadVars,
-    SeenMutationContext
+    MarkUnreadContext
   >({
     mutationFn: async ({ assistantId: aid, conversationId }) => {
       await conversationsUnreadPost({

--- a/clients/web/src/domains/chat/hooks/use-electron-dock-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-electron-dock-sync.test.tsx
@@ -70,6 +70,7 @@ function unread(conversationId: string): Conversation {
 function setup(opts: {
   conversations: Conversation[];
   serverCount?: number | null;
+  isAssistantActive?: boolean;
 }) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -80,10 +81,18 @@ function setup(opts: {
     client.setQueryData(unreadConversationCountQueryKey(ASSISTANT_ID), count);
   }
 
-  renderHook(() => useElectronDockSync(ASSISTANT_ID, opts.conversations), {
-    wrapper: ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client }, children),
-  });
+  renderHook(
+    () =>
+      useElectronDockSync(
+        ASSISTANT_ID,
+        opts.conversations,
+        opts.isAssistantActive ?? true,
+      ),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
 
   return { client };
 }
@@ -141,6 +150,38 @@ describe("useElectronDockSync", () => {
 
     await waitFor(() => {
       expect(setDockBadgeCalls.at(-1)).toBe(1);
+    });
+  });
+
+  test("does not query a starting assistant, and still publishes a badge", async () => {
+    // `ChatLayout` mounts before the assistant is active. Querying then spends
+    // the retry budget on a request that cannot succeed, so the badge falls
+    // back to the loaded rows until the assistant comes up.
+    let queried = false;
+    unreadCountImpl = async () => {
+      queried = true;
+      return 9;
+    };
+
+    setup({
+      conversations: [unread("a"), unread("b")],
+      isAssistantActive: false,
+    });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(2);
+    });
+    expect(queried).toBe(false);
+  });
+
+  test("never publishes a negative badge", async () => {
+    // Optimistic decrements are deliberately unclamped so a revert is exact,
+    // so the cached count can dip below zero; display is where that is
+    // resolved.
+    setup({ conversations: [], serverCount: -2 });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(0);
     });
   });
 

--- a/clients/web/src/domains/chat/hooks/use-electron-dock-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-electron-dock-sync.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Which unread number reaches the Electron Dock badge.
+ *
+ * The server-side count covers every conversation; the client-derived count
+ * only covers rows the client has loaded. The badge prefers the server value
+ * and falls back to the derived one when the count is unavailable, so an
+ * assistant that predates `GET /v1/conversations/unread-count` keeps the
+ * behavior it has today.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import type { Conversation } from "@/types/conversation-types";
+import * as listFetchers from "@/utils/conversation-list-fetchers";
+import { unreadConversationCountQueryKey } from "@/utils/conversation-list-fetchers";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const setDockBadgeCalls: number[] = [];
+
+/**
+ * Stands in for the count endpoint so no case reaches the network. Each test
+ * sets it to the value the server would return; the default never settles,
+ * modelling a request still in flight.
+ */
+let unreadCountImpl: () => Promise<number | null> = () => new Promise(() => {});
+
+mock.module("@/utils/conversation-list-fetchers", () => ({
+  ...listFetchers,
+  fetchUnreadConversationCount: () => unreadCountImpl(),
+}));
+
+mock.module("@/runtime/dock", () => ({
+  setDockBadge: (count: number) => {
+    setDockBadgeCalls.push(count);
+  },
+}));
+
+// The hook gates its query on the Electron host; the badge only exists there.
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => true,
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
+
+const { useElectronDockSync } = await import(
+  "@/domains/chat/hooks/use-electron-dock-sync"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+
+function unread(conversationId: string): Conversation {
+  return {
+    conversationId,
+    hasUnseenLatestAssistantMessage: true,
+  } as Conversation;
+}
+
+function setup(opts: {
+  conversations: Conversation[];
+  serverCount?: number | null;
+}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (opts.serverCount !== undefined) {
+    const count = opts.serverCount;
+    unreadCountImpl = async () => count;
+    client.setQueryData(unreadConversationCountQueryKey(ASSISTANT_ID), count);
+  }
+
+  renderHook(() => useElectronDockSync(ASSISTANT_ID, opts.conversations), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children),
+  });
+
+  return { client };
+}
+
+beforeEach(() => {
+  setDockBadgeCalls.length = 0;
+  unreadCountImpl = () => new Promise(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useElectronDockSync", () => {
+  test("publishes the server count in preference to the loaded-rows count", async () => {
+    // The client has 2 unread rows loaded but the server knows about 9.
+    // Publishing 2 is the under-count this slice exists to remove.
+    setup({
+      conversations: [unread("a"), unread("b")],
+      serverCount: 9,
+    });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(9);
+    });
+  });
+
+  test("publishes a server count of zero rather than falling back", async () => {
+    // Zero is a real answer. Falling back here would light the badge for
+    // rows the server has already counted as seen.
+    setup({
+      conversations: [unread("a"), unread("b")],
+      serverCount: 0,
+    });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(0);
+    });
+  });
+
+  test("falls back to counting loaded rows when the count is unavailable", async () => {
+    // `null` is what an assistant without the endpoint resolves to.
+    setup({
+      conversations: [unread("a"), unread("b")],
+      serverCount: null,
+    });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(2);
+    });
+  });
+
+  test("falls back while the count query has not resolved", async () => {
+    setup({ conversations: [unread("a")] });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(1);
+    });
+  });
+
+  test("excludes archived and background rows from the fallback count", async () => {
+    setup({
+      conversations: [
+        unread("a"),
+        { ...unread("b"), archivedAt: 1234 } as Conversation,
+        { ...unread("c"), conversationType: "background" } as Conversation,
+      ],
+      serverCount: null,
+    });
+
+    await waitFor(() => {
+      expect(setDockBadgeCalls.at(-1)).toBe(1);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { useUnreadConversationCountQuery } from "@/hooks/conversation-queries";
 import { setDockBadge } from "@/runtime/dock";
+import { isElectron } from "@/runtime/is-electron";
 import type { Conversation } from "@/types/conversation-types";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
@@ -13,22 +15,36 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  *
  * Mount the hook once at a layout that already has the conversation
  * list in hand (currently `ChatLayout`, which subscribes to
- * `useConversationListQuery` at the route root). The count is derived
- * locally via `contributesToUnreadCount` (the same predicate that
- * drives sidebar attention indicators) so we don't fetch twice and
- * automated background / scheduled / archived threads don't contribute
- * to the badge.
+ * `useConversationListQuery` at the route root).
+ *
+ * The badge value prefers the server-side count
+ * (`useUnreadConversationCountQuery`), which covers every conversation
+ * regardless of which pages the client has loaded. When the count is
+ * unavailable (assistant predates the endpoint, or the query hasn't
+ * resolved), it falls back to counting the passed-in list via
+ * `contributesToUnreadCount`, the same predicate that drives sidebar
+ * attention indicators, so background / scheduled / archived threads
+ * never contribute to the badge. The query is Electron-gated: no other
+ * host renders a dock badge, so no other host pays the fetch.
  *
  * The app menu's platform-session state is published separately from
  * `RootLayout` (an always-mounted layer) so it stays correct on
  * non-chat routes where `ChatLayout` isn't mounted.
  */
-export function useElectronDockSync(conversations: Conversation[]): void {
+export function useElectronDockSync(
+  assistantId: string | null,
+  conversations: Conversation[],
+): void {
   const [dockBadgesEnabled, setDockBadgesEnabled] = useState(() =>
     getDeviceBool("dockBadgesEnabled", true),
   );
 
-  const unreadCount = useMemo(
+  const serverUnreadCount = useUnreadConversationCountQuery(
+    assistantId,
+    isElectron() && dockBadgesEnabled,
+  );
+
+  const derivedUnreadCount = useMemo(
     () =>
       conversations.reduce(
         (n, c) => (contributesToUnreadCount(c) ? n + 1 : n),
@@ -36,6 +52,8 @@ export function useElectronDockSync(conversations: Conversation[]): void {
       ),
     [conversations],
   );
+
+  const unreadCount = serverUnreadCount ?? derivedUnreadCount;
 
   useEffect(
     () =>

--- a/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
@@ -1,35 +1,26 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { useUnreadConversationCountQuery } from "@/hooks/conversation-queries";
+import { useUnreadConversationCount } from "@/hooks/conversation-queries";
 import { setDockBadge } from "@/runtime/dock";
 import { isElectron } from "@/runtime/is-electron";
 import type { Conversation } from "@/types/conversation-types";
-import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 
 /**
- * Publish the Electron Dock's unread conversation count to the main
- * process via the `window.vellum.dock.*` bridge, which no-ops on
- * non-Electron hosts so this hook is safe to mount unconditionally
- * inside `ChatLayout`.
+ * Publish the unread conversation count to the Electron Dock badge via the
+ * `window.vellum.dock.*` bridge, which no-ops on non-Electron hosts so this
+ * hook is safe to mount unconditionally inside `ChatLayout`.
  *
- * Mount the hook once at a layout that already has the conversation
- * list in hand (currently `ChatLayout`, which subscribes to
- * `useConversationListQuery` at the route root).
+ * Mount it once at a layout that already holds the conversation list
+ * (currently `ChatLayout`), which supplies the fallback the count hook uses
+ * when the assistant serves no server-side count.
  *
- * The badge value prefers the server-side count
- * (`useUnreadConversationCountQuery`), which covers every conversation
- * regardless of which pages the client has loaded. When the count is
- * unavailable (assistant predates the endpoint, or the query hasn't
- * resolved), it falls back to counting the passed-in list via
- * `contributesToUnreadCount`, the same predicate that drives sidebar
- * attention indicators, so background / scheduled / archived threads
- * never contribute to the badge. The query is Electron-gated: no other
- * host renders a dock badge, so no other host pays the fetch.
+ * The count query is gated on the Electron host and on the badge being
+ * enabled, so no other host and no opted-out user pays the request.
  *
  * The app menu's platform-session state is published separately from
- * `RootLayout` (an always-mounted layer) so it stays correct on
- * non-chat routes where `ChatLayout` isn't mounted.
+ * `RootLayout` (an always-mounted layer) so it stays correct on non-chat
+ * routes where `ChatLayout` isn't mounted.
  */
 export function useElectronDockSync(
   assistantId: string | null,
@@ -39,21 +30,11 @@ export function useElectronDockSync(
     getDeviceBool("dockBadgesEnabled", true),
   );
 
-  const serverUnreadCount = useUnreadConversationCountQuery(
+  const unreadCount = useUnreadConversationCount(
     assistantId,
+    conversations,
     isElectron() && dockBadgesEnabled,
   );
-
-  const derivedUnreadCount = useMemo(
-    () =>
-      conversations.reduce(
-        (n, c) => (contributesToUnreadCount(c) ? n + 1 : n),
-        0,
-      ),
-    [conversations],
-  );
-
-  const unreadCount = serverUnreadCount ?? derivedUnreadCount;
 
   useEffect(
     () =>

--- a/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-electron-dock-sync.ts
@@ -15,8 +15,12 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  * (currently `ChatLayout`), which supplies the fallback the count hook uses
  * when the assistant serves no server-side count.
  *
- * The count query is gated on the Electron host and on the badge being
- * enabled, so no other host and no opted-out user pays the request.
+ * The count query is gated on three things, so nothing pays for a request it
+ * cannot use: the Electron host (no other host draws a Dock badge), the badge
+ * setting, and the assistant being active. The last matters because
+ * `ChatLayout` mounts before the assistant finishes starting, and querying a
+ * starting or stopped assistant would spend the retry budget on a request
+ * that cannot succeed.
  *
  * The app menu's platform-session state is published separately from
  * `RootLayout` (an always-mounted layer) so it stays correct on non-chat
@@ -25,6 +29,7 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 export function useElectronDockSync(
   assistantId: string | null,
   conversations: Conversation[],
+  isAssistantActive: boolean,
 ): void {
   const [dockBadgesEnabled, setDockBadgesEnabled] = useState(() =>
     getDeviceBool("dockBadgesEnabled", true),
@@ -33,7 +38,7 @@ export function useElectronDockSync(
   const unreadCount = useUnreadConversationCount(
     assistantId,
     conversations,
-    isElectron() && dockBadgesEnabled,
+    isElectron() && dockBadgesEnabled && isAssistantActive,
   );
 
   useEffect(

--- a/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
+++ b/clients/web/src/domains/chat/hooks/use-mark-conversation-seen-mutation.ts
@@ -1,0 +1,94 @@
+/**
+ * The single write path for marking a conversation seen.
+ *
+ * Two entry points share it: the explicit "Mark as read" menu action, and the
+ * effect that marks a conversation seen when the user opens it. One mutation
+ * means one optimistic contract instead of per-caller reimplementations that
+ * drift apart:
+ *
+ *   onMutate  → cancel in-flight refetches, snapshot, patch the row seen,
+ *               decrement the server-side unread count when the row counted
+ *   onError   → restore the snapshot and re-apply the inverse count delta
+ *   onSettled → invalidate so the server reconciles both
+ *
+ * The count delta is reverted by its inverse rather than from the snapshot so
+ * a concurrent mutation's adjustment is never clobbered.
+ *
+ * References:
+ * - https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { conversationsSeenPost } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+  cancelConversationQueries,
+  findConversation,
+  invalidateConversationQueries,
+  restoreConversationCaches,
+  snapshotConversationCaches,
+  type ConversationCacheSnapshot,
+} from "@/utils/conversation-cache";
+import {
+  adjustUnreadCountCache,
+  markConversationSeenLocal,
+} from "@/utils/conversation-cache-mutations";
+import { contributesToUnreadCount } from "@/utils/conversation-predicates";
+
+export interface MarkConversationSeenVars {
+  assistantId: string;
+  conversationId: string;
+}
+
+interface MarkSeenContext {
+  snapshot: ConversationCacheSnapshot;
+  /** `-1` when the row was counted toward the unread badge, else `0`. */
+  unreadCountDelta: number;
+}
+
+export function useMarkConversationSeenMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, MarkConversationSeenVars, MarkSeenContext>({
+    mutationFn: async ({ assistantId, conversationId }) => {
+      await conversationsSeenPost({
+        path: { assistant_id: assistantId },
+        body: { conversationId },
+        throwOnError: true,
+      });
+    },
+    onMutate: async ({ assistantId, conversationId }) => {
+      await cancelConversationQueries(queryClient, assistantId);
+      const snapshot = snapshotConversationCaches(queryClient, assistantId);
+
+      // Read the row before the patch flips its seen state: only a row that
+      // was contributing to the badge should decrement it.
+      const row = findConversation(queryClient, assistantId, conversationId);
+      const unreadCountDelta =
+        row !== undefined && contributesToUnreadCount(row) ? -1 : 0;
+      if (unreadCountDelta !== 0) {
+        adjustUnreadCountCache(queryClient, assistantId, unreadCountDelta);
+      }
+
+      markConversationSeenLocal(queryClient, assistantId, conversationId);
+      return { snapshot, unreadCountDelta };
+    },
+    onError: (err, { assistantId }, context) => {
+      if (context?.snapshot) {
+        restoreConversationCaches(queryClient, context.snapshot);
+      }
+      if (context && context.unreadCountDelta !== 0) {
+        adjustUnreadCountCache(
+          queryClient,
+          assistantId,
+          -context.unreadCountDelta,
+        );
+      }
+      captureError(err, { context: "markConversationRead" });
+    },
+    onSettled: (_data, _err, { assistantId }) => {
+      void invalidateConversationQueries(queryClient, assistantId);
+    },
+  });
+}

--- a/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Opening a conversation with unseen assistant messages marks it seen
+ * through the shared mark-seen mutation.
+ *
+ * The point of these cases is the wiring, not the write: this hook and the
+ * explicit "Mark as read" action must produce the same cache effects, so a
+ * regression back to a hand-rolled POST (which patched only after the round
+ * trip and adjusted no count) shows up here as a missing optimistic update.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { Conversation } from "@/types/conversation-types";
+import {
+  conversationsQueryKey,
+  unreadConversationCountQueryKey,
+} from "@/utils/conversation-list-fetchers";
+
+const seenCalls: Array<{ conversationId: string }> = [];
+let seenImpl: () => Promise<unknown> = async () => ({
+  data: undefined,
+  response: { ok: true },
+});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsSeenPost: (opts: { body: { conversationId: string } }) => {
+    seenCalls.push({ conversationId: opts.body.conversationId });
+    return seenImpl();
+  },
+}));
+
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addBreadcrumb: () => {},
+}));
+
+const { useMarkSeenOnOpen } = await import(
+  "@/domains/chat/hooks/use-mark-seen-on-open"
+);
+
+const ASSISTANT_ID = "asst-1";
+
+function unreadConversation(): Conversation {
+  return {
+    conversationId: "conv-1",
+    hasUnseenLatestAssistantMessage: true,
+  } as Conversation;
+}
+
+function setup(conversation: Conversation | undefined, unreadCount: number) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    conversationsQueryKey(ASSISTANT_ID),
+    conversation ? [conversation] : [],
+  );
+  client.setQueryData(
+    unreadConversationCountQueryKey(ASSISTANT_ID),
+    unreadCount,
+  );
+
+  renderHook(
+    () =>
+      useMarkSeenOnOpen({
+        assistantId: ASSISTANT_ID,
+        assistantStateKind: "active",
+        activeConversationId: conversation?.conversationId ?? null,
+        activeConversation: conversation,
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+
+  return { client };
+}
+
+function readCount(client: QueryClient): number | null | undefined {
+  return client.getQueryData<number | null>(
+    unreadConversationCountQueryKey(ASSISTANT_ID),
+  );
+}
+
+function readUnseen(client: QueryClient): boolean | undefined {
+  return client
+    .getQueryData<Conversation[]>(conversationsQueryKey(ASSISTANT_ID))
+    ?.find((c) => c.conversationId === "conv-1")
+    ?.hasUnseenLatestAssistantMessage;
+}
+
+function deferred<T = unknown>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  seenCalls.length = 0;
+  seenImpl = async () => ({ data: undefined, response: { ok: true } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useMarkSeenOnOpen", () => {
+  test("clears the row and decrements the count before the write resolves", async () => {
+    const d = deferred();
+    seenImpl = () => d.promise;
+    const { client } = setup(unreadConversation(), 3);
+
+    await waitFor(() => {
+      expect(seenCalls).toEqual([{ conversationId: "conv-1" }]);
+    });
+
+    // Optimistic: both effects land while the POST is still in flight.
+    expect(readUnseen(client)).toBe(false);
+    expect(readCount(client)).toBe(2);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("rolls the row and the count back when the write fails", async () => {
+    seenImpl = async () => {
+      throw new Error("network failure");
+    };
+    const { client } = setup(unreadConversation(), 3);
+
+    await waitFor(() => {
+      expect(readCount(client)).toBe(3);
+    });
+    expect(readUnseen(client)).toBe(true);
+  });
+
+  test("does not fire for a conversation with nothing unseen", async () => {
+    setup(
+      {
+        conversationId: "conv-1",
+        hasUnseenLatestAssistantMessage: false,
+      } as Conversation,
+      3,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(seenCalls).toEqual([]);
+  });
+
+  test("fires once per opened conversation", async () => {
+    setup(unreadConversation(), 3);
+
+    await waitFor(() => {
+      expect(seenCalls.length).toBe(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(seenCalls.length).toBe(1);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.ts
+++ b/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.ts
@@ -2,7 +2,12 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { markConversationSeenLocal } from "@/utils/conversation-cache-mutations";
+import {
+  adjustUnreadCountCache,
+  markConversationSeenLocal,
+} from "@/utils/conversation-cache-mutations";
+import { unreadConversationCountQueryKey } from "@/utils/conversation-list-fetchers";
+import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { conversationsSeenPost } from "@/generated/daemon/sdk.gen";
 import type { AssistantState } from "@/assistant/types";
 import type { Conversation } from "@/types/conversation-types";
@@ -52,6 +57,11 @@ export function useMarkSeenOnOpen({
 
     let cancelled = false;
 
+    // Whether the row counts toward the unread badge, captured before the
+    // POST resolves so the seen-state flip can't erase the answer.
+    const contributedToUnreadCount =
+      contributesToUnreadCount(activeConversation);
+
     conversationsSeenPost({
       path: { assistant_id: assistantId },
       body: { conversationId: activeConversationId },
@@ -66,6 +76,16 @@ export function useMarkSeenOnOpen({
           assistantId,
           activeConversationId,
         );
+        // Drop the row's contribution from the unread-count cache
+        // immediately, then refetch the authoritative value (the daemon
+        // suppresses the self-originated sync echo, so no invalidation
+        // arrives over SSE for this write).
+        if (contributedToUnreadCount) {
+          adjustUnreadCountCache(queryClient, assistantId, -1);
+        }
+        void queryClient.invalidateQueries({
+          queryKey: unreadConversationCountQueryKey(assistantId),
+        });
         lastSeenOnOpenConversationIdRef.current = null;
       })
       .catch((err) => {

--- a/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.ts
+++ b/clients/web/src/domains/chat/hooks/use-mark-seen-on-open.ts
@@ -1,21 +1,17 @@
-import { captureError } from "@/lib/sentry/capture-error";
 import { useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 
-import {
-  adjustUnreadCountCache,
-  markConversationSeenLocal,
-} from "@/utils/conversation-cache-mutations";
-import { unreadConversationCountQueryKey } from "@/utils/conversation-list-fetchers";
-import { contributesToUnreadCount } from "@/utils/conversation-predicates";
-import { conversationsSeenPost } from "@/generated/daemon/sdk.gen";
+import { useMarkConversationSeenMutation } from "@/domains/chat/hooks/use-mark-conversation-seen-mutation";
 import type { AssistantState } from "@/assistant/types";
 import type { Conversation } from "@/types/conversation-types";
 
 /**
- * Marks the active conversation as seen when the user opens it and it
- * has unseen assistant messages. Fires a single POST to the daemon and
- * patches the TanStack Query cache on success.
+ * Marks the active conversation as seen when the user opens it and it has
+ * unseen assistant messages.
+ *
+ * The write itself belongs to `useMarkConversationSeenMutation`, shared with
+ * the explicit "Mark as read" action, so opening a conversation and choosing
+ * the menu item produce identical cache effects. This hook owns only the
+ * decision to fire: which conversation, and not twice for the same one.
  *
  * This is a conversation lifecycle action (changing seen-state), not
  * attention tracking — it lives here because its concern is state
@@ -32,7 +28,7 @@ export function useMarkSeenOnOpen({
   activeConversationId: string | null;
   activeConversation: Conversation | undefined;
 }) {
-  const queryClient = useQueryClient();
+  const { mutate: markSeen } = useMarkConversationSeenMutation();
   const lastSeenOnOpenConversationIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -55,52 +51,24 @@ export function useMarkSeenOnOpen({
 
     lastSeenOnOpenConversationIdRef.current = activeConversationId;
 
-    let cancelled = false;
-
-    // Whether the row counts toward the unread badge, captured before the
-    // POST resolves so the seen-state flip can't erase the answer.
-    const contributedToUnreadCount =
-      contributesToUnreadCount(activeConversation);
-
-    conversationsSeenPost({
-      path: { assistant_id: assistantId },
-      body: { conversationId: activeConversationId },
-      throwOnError: true,
-    })
-      .then(() => {
-        if (cancelled) {
-          return;
-        }
-        markConversationSeenLocal(
-          queryClient,
-          assistantId,
-          activeConversationId,
-        );
-        // Drop the row's contribution from the unread-count cache
-        // immediately, then refetch the authoritative value (the daemon
-        // suppresses the self-originated sync echo, so no invalidation
-        // arrives over SSE for this write).
-        if (contributedToUnreadCount) {
-          adjustUnreadCountCache(queryClient, assistantId, -1);
-        }
-        void queryClient.invalidateQueries({
-          queryKey: unreadConversationCountQueryKey(assistantId),
-        });
-        lastSeenOnOpenConversationIdRef.current = null;
-      })
-      .catch((err) => {
-        lastSeenOnOpenConversationIdRef.current = null;
-        captureError(err, { context: "mark_conversation_seen" });
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    markSeen(
+      { assistantId, conversationId: activeConversationId },
+      {
+        // Releasing the guard on settle (not only on success) lets a failed
+        // write be retried the next time the effect re-evaluates; the
+        // mutation has already rolled its optimistic patch back by then.
+        onSettled: () => {
+          lastSeenOnOpenConversationIdRef.current = null;
+        },
+      },
+    );
+    // `markSeen` is a stable reference from TanStack Query, so listing it
+    // does not re-run this effect.
   }, [
     activeConversation,
     activeConversationId,
     assistantId,
     assistantStateKind,
-    queryClient,
+    markSeen,
   ]);
 }

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -247,6 +247,11 @@ export function useUnreadConversationCountQuery(
  * the query resolves. It counts only the conversations it is handed, so it is
  * accurate only while the caller holds the complete list; see
  * {@link countUnreadConversationsInList}.
+ *
+ * Clamping at zero happens here rather than in `adjustUnreadCountCache`,
+ * which keeps optimistic adjustments exactly reversible: the cached value can
+ * dip below zero when optimistic writes outrun the server, and this is the
+ * boundary where that becomes a number a user sees.
  */
 export function useUnreadConversationCount(
   assistantId: string | null,
@@ -258,7 +263,7 @@ export function useUnreadConversationCount(
     () => countUnreadConversationsInList(fallbackConversations),
     [fallbackConversations],
   );
-  return serverCount ?? derivedCount;
+  return Math.max(0, serverCount ?? derivedCount);
 }
 
 /**

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -20,6 +20,7 @@
  * - https://tanstack.com/query/latest/docs/framework/react/guides/updates-from-mutation-responses
  */
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { groupsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -30,6 +31,7 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
+import { countUnreadConversationsInList } from "@/utils/conversation-predicates";
 import {
   archivedConversationListOptions,
   backgroundConversationListOptions,
@@ -205,13 +207,16 @@ export function useOriginChannelConversationListQuery(
 }
 
 /**
- * Subscribe to the server-side unread conversation count
+ * Subscribe to the raw server-side unread conversation count
  * (`GET /v1/conversations/unread-count`).
  *
  * Returns the count, or `null` while unresolved and when the connected
  * assistant does not serve the endpoint (pre-unread-count daemons 404 the
- * read, which the fetcher maps to `null`). Consumers treat `null` as
- * "unavailable" and fall back to counting loaded conversations.
+ * read, which the fetcher maps to `null`).
+ *
+ * Most callers want {@link useUnreadConversationCount}, which resolves that
+ * `null` into a usable number. Use this one only when "the server does not
+ * provide a count" has to be distinguishable from "the count is zero".
  *
  * Freshness comes from three channels rather than focus refetches:
  * optimistic deltas applied by the seen/unseen mutations
@@ -229,6 +234,31 @@ export function useUnreadConversationCountQuery(
     enabled: enabled && Boolean(assistantId) && isOrgReady,
   });
   return query.data ?? null;
+}
+
+/**
+ * The unread conversation count to display: the server's count when it is
+ * available, otherwise derived from `fallbackConversations`.
+ *
+ * Every unread-count surface should read this rather than compose the
+ * fallback itself, so the "which source won" rule lives in one place.
+ *
+ * The fallback covers assistants without the endpoint and the window before
+ * the query resolves. It counts only the conversations it is handed, so it is
+ * accurate only while the caller holds the complete list; see
+ * {@link countUnreadConversationsInList}.
+ */
+export function useUnreadConversationCount(
+  assistantId: string | null,
+  fallbackConversations: readonly Conversation[],
+  enabled: boolean = true,
+): number {
+  const serverCount = useUnreadConversationCountQuery(assistantId, enabled);
+  const derivedCount = useMemo(
+    () => countUnreadConversationsInList(fallbackConversations),
+    [fallbackConversations],
+  );
+  return serverCount ?? derivedCount;
 }
 
 /**

--- a/clients/web/src/hooks/conversation-queries.ts
+++ b/clients/web/src/hooks/conversation-queries.ts
@@ -36,6 +36,7 @@ import {
   conversationListOptions,
   originChannelConversationListOptions,
   scheduledConversationListOptions,
+  unreadConversationCountOptions,
 } from "@/utils/conversation-list-fetchers";
 import type { OriginChannel } from "@/utils/conversation-list-fetchers";
 
@@ -201,6 +202,33 @@ export function useOriginChannelConversationListQuery(
     isLoading: query.isLoading,
     isPending: query.isPending,
   };
+}
+
+/**
+ * Subscribe to the server-side unread conversation count
+ * (`GET /v1/conversations/unread-count`).
+ *
+ * Returns the count, or `null` while unresolved and when the connected
+ * assistant does not serve the endpoint (pre-unread-count daemons 404 the
+ * read, which the fetcher maps to `null`). Consumers treat `null` as
+ * "unavailable" and fall back to counting loaded conversations.
+ *
+ * Freshness comes from three channels rather than focus refetches:
+ * optimistic deltas applied by the seen/unseen mutations
+ * (`adjustUnreadCountCache`), the settle-time invalidation in
+ * `invalidateConversationQueries`, and the `sync_changed`-driven
+ * invalidation in `use-conversation-sync.ts`.
+ */
+export function useUnreadConversationCountQuery(
+  assistantId: string | null,
+  enabled: boolean = true,
+): number | null {
+  const isOrgReady = useIsOrgReady();
+  const query = useQuery({
+    ...unreadConversationCountOptions(assistantId!),
+    enabled: enabled && Boolean(assistantId) && isOrgReady,
+  });
+  return query.data ?? null;
 }
 
 /**

--- a/clients/web/src/hooks/use-conversation-sync.test.tsx
+++ b/clients/web/src/hooks/use-conversation-sync.test.tsx
@@ -6,7 +6,10 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { Conversation } from "@/types/conversation-types";
 import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
-import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
+import {
+  conversationsQueryKey,
+  unreadConversationCountQueryKey,
+} from "@/utils/conversation-list-fetchers";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 
@@ -50,8 +53,9 @@ mock.module("@/utils/fetch-conversation-detail", () => ({
 // ---------------------------------------------------------------------------
 // Module mock — `@/utils/conversation-list-fetchers`.
 // ---------------------------------------------------------------------------
-const realListFetchersModule =
-  await import("@/utils/conversation-list-fetchers");
+const realListFetchersModule = await import(
+  "@/utils/conversation-list-fetchers"
+);
 type ListFirstPage = Awaited<
   ReturnType<typeof realListFetchersModule.listConversationsFirstPage>
 >;
@@ -397,6 +401,62 @@ describe("useConversationSync", () => {
     await Promise.resolve();
     expect(spy).not.toHaveBeenCalled();
     expect(listFirstPageCalls.length).toBe(0);
+  });
+
+  test("per-conversation metadata tags invalidate the unread count", async () => {
+    // Seen-state changes and newly landed replies from another client emit a
+    // metadata tag with no `conversations:list` umbrella tag, so the count
+    // has to refetch off the metadata signal or the badge goes stale.
+    const queryClient = freshQueryClient();
+    queryClient.setQueryData(unreadConversationCountQueryKey("asst-1"), 3);
+    fetchConversationDetailImpl = async (
+      _queryClient,
+      _assistantId,
+      conversationId,
+    ) => ({ conversationId, title: "Any" });
+
+    renderHook(() => useConversationSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit(syncEvent(["conversation:conv-1:metadata"]));
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState(unreadConversationCountQueryKey("asst-1"))
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  test("a burst of metadata tags collapses into one unread-count invalidation", async () => {
+    // A bulk mark-read elsewhere emits one metadata tag per conversation;
+    // the count is a single scalar GET, so the burst must debounce.
+    const queryClient = freshQueryClient();
+    queryClient.setQueryData(unreadConversationCountQueryKey("asst-1"), 3);
+    fetchConversationDetailImpl = async (
+      _queryClient,
+      _assistantId,
+      conversationId,
+    ) => ({ conversationId, title: "Any" });
+    const invalidateSpy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = invalidateSpy as never;
+
+    renderHook(() => useConversationSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit(syncEvent(["conversation:conv-1:metadata"]));
+    emit(syncEvent(["conversation:conv-2:metadata"]));
+    emit(syncEvent(["conversation:conv-3:metadata"]));
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const countKey = unreadConversationCountQueryKey("asst-1");
+    const countCalls = (
+      invalidateSpy.mock.calls as unknown as Array<[unknown]>
+    ).filter((call) => {
+      const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
+      return JSON.stringify(arg?.queryKey) === JSON.stringify(countKey);
+    });
+    expect(countCalls.length).toBe(1);
   });
 
   test("patches conversation title in cache on conversation_title_updated", async () => {

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -161,16 +161,33 @@ const limitedRefreshConversationRow = createConcurrencyLimiter(
   MAX_CONCURRENT_ROW_REFRESHES,
 );
 
+/**
+ * Run `task` after {@link CONVERSATION_LIST_DEBOUNCE_MS}, replacing whatever
+ * run is already pending on `timerRef`.
+ *
+ * Every scheduler here collapses a burst: sync signals arrive one per
+ * conversation (a bulk mark-read on another client emits hundreds), and each
+ * burst should cost one refetch rather than one per event.
+ */
+function scheduleDebounced(
+  timerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  task: () => void,
+): void {
+  if (timerRef.current) {
+    clearTimeout(timerRef.current);
+  }
+  timerRef.current = setTimeout(() => {
+    timerRef.current = null;
+    task();
+  }, CONVERSATION_LIST_DEBOUNCE_MS);
+}
+
 function scheduleConversationListRefetch(
   queryClient: ReturnType<typeof useQueryClient>,
   assistantId: string,
   debounceTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
 ): void {
-  if (debounceTimerRef.current) {
-    clearTimeout(debounceTimerRef.current);
-  }
-  debounceTimerRef.current = setTimeout(() => {
-    debounceTimerRef.current = null;
+  scheduleDebounced(debounceTimerRef, () => {
     // One first-page GET per populated list bucket — never a full
     // paginated drain (see refreshConversationListWindows).
     void refreshConversationListWindows(queryClient, assistantId).catch(
@@ -199,7 +216,7 @@ function scheduleConversationListRefetch(
     void queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
     });
-  }, CONVERSATION_LIST_DEBOUNCE_MS);
+  });
 }
 
 /**
@@ -208,24 +225,19 @@ function scheduleConversationListRefetch(
  * Seen-state changes and newly landed assistant replies surface as
  * per-conversation `conversation:<id>:metadata` tags without a
  * `conversationsList` umbrella tag, so the count must refetch on metadata
- * signals too. Debounced on its own timer because a bulk mark-read on
- * another client emits one metadata tag per conversation; collapsing the
- * burst costs a single scalar GET.
+ * signals too. It runs on its own timer so a burst of metadata tags does not
+ * keep pushing back the list refresh (and vice versa).
  */
 function scheduleUnreadCountRefetch(
   queryClient: ReturnType<typeof useQueryClient>,
   assistantId: string,
   timerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
 ): void {
-  if (timerRef.current) {
-    clearTimeout(timerRef.current);
-  }
-  timerRef.current = setTimeout(() => {
-    timerRef.current = null;
+  scheduleDebounced(timerRef, () => {
     void queryClient.invalidateQueries({
       queryKey: unreadConversationCountQueryKey(assistantId),
     });
-  }, CONVERSATION_LIST_DEBOUNCE_MS);
+  });
 }
 
 function handleConversationSyncTags(

--- a/clients/web/src/hooks/use-conversation-sync.ts
+++ b/clients/web/src/hooks/use-conversation-sync.ts
@@ -37,6 +37,7 @@ import { groupsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen"
 import {
   archivedConversationsQueryKey,
   originChannelListPrefix,
+  unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import {
@@ -78,14 +79,21 @@ export function useConversationSync(
 ): void {
   const queryClient = useQueryClient();
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const unreadCountTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
-  // Clear pending debounce when the assistant changes or deactivates
+  // Clear pending debounces when the assistant changes or deactivates
   // so stale callbacks never fire with an old assistantId.
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
         debounceTimerRef.current = null;
+      }
+      if (unreadCountTimerRef.current) {
+        clearTimeout(unreadCountTimerRef.current);
+        unreadCountTimerRef.current = null;
       }
     };
   }, [assistantId, isAssistantActive]);
@@ -110,6 +118,7 @@ export function useConversationSync(
           assistantId,
           queryClient,
           debounceTimerRef,
+          unreadCountTimerRef,
         );
         return;
 
@@ -187,6 +196,35 @@ function scheduleConversationListRefetch(
         path: { assistant_id: assistantId ?? "" },
       }),
     });
+    void queryClient.invalidateQueries({
+      queryKey: unreadConversationCountQueryKey(assistantId),
+    });
+  }, CONVERSATION_LIST_DEBOUNCE_MS);
+}
+
+/**
+ * Debounced invalidation of the server-side unread-count cache.
+ *
+ * Seen-state changes and newly landed assistant replies surface as
+ * per-conversation `conversation:<id>:metadata` tags without a
+ * `conversationsList` umbrella tag, so the count must refetch on metadata
+ * signals too. Debounced on its own timer because a bulk mark-read on
+ * another client emits one metadata tag per conversation; collapsing the
+ * burst costs a single scalar GET.
+ */
+function scheduleUnreadCountRefetch(
+  queryClient: ReturnType<typeof useQueryClient>,
+  assistantId: string,
+  timerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+): void {
+  if (timerRef.current) {
+    clearTimeout(timerRef.current);
+  }
+  timerRef.current = setTimeout(() => {
+    timerRef.current = null;
+    void queryClient.invalidateQueries({
+      queryKey: unreadConversationCountQueryKey(assistantId),
+    });
   }, CONVERSATION_LIST_DEBOUNCE_MS);
 }
 
@@ -195,6 +233,7 @@ function handleConversationSyncTags(
   assistantId: string,
   queryClient: ReturnType<typeof useQueryClient>,
   debounceTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  unreadCountTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
 ): void {
   for (const tag of event.tags) {
     if (tag === SYNC_TAGS.conversationsList) {
@@ -211,6 +250,11 @@ function handleConversationSyncTags(
       // work for fields the UI tolerates going slightly stale.
       const parsed = parseConversationSyncTag(tag);
       if (parsed?.resource === "metadata") {
+        scheduleUnreadCountRefetch(
+          queryClient,
+          assistantId,
+          unreadCountTimerRef,
+        );
         void limitedRefreshConversationRow(
           queryClient,
           assistantId,

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -93,6 +93,14 @@ export function markConversationSeenLocal(
  * mutations are never clobbered). Drift is reconciled by the authoritative
  * refetch in `invalidateConversationQueries` on settle.
  *
+ * **Deliberately unclamped**, so `+n` and `-n` are exact inverses and a
+ * revert restores precisely what it took. Clamping here would break that:
+ * a decrement that saturated at zero would be undone by more than it
+ * removed, leaving the badge over-reporting. The cached value can therefore
+ * go briefly negative when optimistic writes outrun the server; presentation
+ * clamps it (`useUnreadConversationCount`), which keeps the arithmetic
+ * reversible and the display honest.
+ *
  * Returns `true` when a numeric count was adjusted. No-ops (returns
  * `false`) when the cache is empty or holds `null` (the connected
  * assistant does not serve the count endpoint).
@@ -107,10 +115,7 @@ export function adjustUnreadCountCache(
   if (typeof current !== "number") {
     return false;
   }
-  queryClient.setQueryData<number | null>(
-    queryKey,
-    Math.max(0, current + delta),
-  );
+  queryClient.setQueryData<number | null>(queryKey, current + delta);
   return true;
 }
 

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -33,6 +33,7 @@ import {
   backgroundConversationsQueryKey,
   conversationsQueryKey,
   scheduledConversationsQueryKey,
+  unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import {
   type ConversationListPage,
@@ -80,6 +81,37 @@ export function markConversationSeenLocal(
     return changed ? next : conversations;
   };
   updateAllConversationCaches(queryClient, assistantId, markSeen);
+}
+
+/**
+ * Apply a delta to the cached server-side unread conversation count.
+ *
+ * Optimistic companion to the seen/unseen mutations: a mark-read
+ * decrements, a mark-unread increments, and the caller reverts a failed
+ * mutation by applying the inverse delta (delta-based reversal, not a
+ * snapshot restore, so concurrent adjustments from other in-flight
+ * mutations are never clobbered). Drift is reconciled by the authoritative
+ * refetch in `invalidateConversationQueries` on settle.
+ *
+ * Returns `true` when a numeric count was adjusted. No-ops (returns
+ * `false`) when the cache is empty or holds `null` (the connected
+ * assistant does not serve the count endpoint).
+ */
+export function adjustUnreadCountCache(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  delta: number,
+): boolean {
+  const queryKey = unreadConversationCountQueryKey(assistantId);
+  const current = queryClient.getQueryData<number | null>(queryKey);
+  if (typeof current !== "number") {
+    return false;
+  }
+  queryClient.setQueryData<number | null>(
+    queryKey,
+    Math.max(0, current + delta),
+  );
+  return true;
 }
 
 export function prependConversation(

--- a/clients/web/src/utils/conversation-cache.ts
+++ b/clients/web/src/utils/conversation-cache.ts
@@ -36,6 +36,7 @@ import {
   conversationListPrefix,
   conversationsQueryKey,
   scheduledConversationsQueryKey,
+  unreadConversationCountQueryKey,
 } from "@/utils/conversation-list-fetchers";
 import type { Conversation } from "@/types/conversation-types";
 
@@ -57,14 +58,23 @@ import type { Conversation } from "@/types/conversation-types";
  * Cancel any in-flight refetches for ALL conversation caches. Call this
  * before applying an optimistic update so a concurrent refetch doesn't
  * overwrite the optimistic value with stale server data.
+ *
+ * Includes the unread-count cache: it lives under its own key (a scalar,
+ * not a `Conversation[]`, so it cannot share the list prefix) but is
+ * optimistically adjusted by the same seen/unseen mutations.
  */
 export async function cancelConversationQueries(
   queryClient: QueryClient,
   assistantId: string,
 ): Promise<void> {
-  await queryClient.cancelQueries({
-    queryKey: conversationListPrefix(assistantId),
-  });
+  await Promise.all([
+    queryClient.cancelQueries({
+      queryKey: conversationListPrefix(assistantId),
+    }),
+    queryClient.cancelQueries({
+      queryKey: unreadConversationCountQueryKey(assistantId),
+    }),
+  ]);
 }
 
 /**
@@ -107,14 +117,24 @@ export function restoreConversationCaches(
  * Invalidate all conversation caches so TanStack Query refetches from the
  * server. Used in `onSettled` to reconcile optimistic values with the
  * server-authoritative state regardless of mutation success or failure.
+ *
+ * Includes the unread-count cache (own key, see
+ * `cancelConversationQueries`) so optimistic count deltas always
+ * reconcile against the authoritative server count after a mutation
+ * settles.
  */
 export async function invalidateConversationQueries(
   queryClient: QueryClient,
   assistantId: string,
 ): Promise<void> {
-  await queryClient.invalidateQueries({
-    queryKey: conversationListPrefix(assistantId),
-  });
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: conversationListPrefix(assistantId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: unreadConversationCountQueryKey(assistantId),
+    }),
+  ]);
 }
 
 type ConversationUpdater = (conversations: Conversation[]) => Conversation[];

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -15,7 +15,11 @@
  */
 
 import { queryOptions } from "@tanstack/react-query";
-import { conversationsGet } from "@/generated/daemon/sdk.gen";
+import {
+  conversationsGet,
+  conversationsUnreadcountGet,
+} from "@/generated/daemon/sdk.gen";
+import { conversationsUnreadcountGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { ConversationsGetData } from "@/generated/daemon/types.gen";
 import {
   ApiError,
@@ -85,6 +89,22 @@ export function originChannelConversationsQueryKey(
   ] as const;
 }
 
+/**
+ * Key for the server-side unread conversation count
+ * (`GET /v1/conversations/unread-count`). The cache holds `number | null`
+ * (see {@link fetchUnreadConversationCount}).
+ *
+ * Deliberately the generated key, NOT a child of
+ * {@link conversationListPrefix}: the prefix-wide helpers in
+ * `conversation-cache.ts` treat every entry under the prefix as a
+ * `Conversation[]`, and this cache holds a scalar.
+ */
+export function unreadConversationCountQueryKey(assistantId: string | null) {
+  return conversationsUnreadcountGetQueryKey({
+    path: { assistant_id: assistantId ?? "" },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Shared sort comparator
 // ---------------------------------------------------------------------------
@@ -133,7 +153,11 @@ type FetchConversationListOptions = {
  * foreground drain in both rails.
  */
 type DrainListKind =
-  "foreground" | "background" | "scheduled" | "archived" | "origin_channel";
+  | "foreground"
+  | "background"
+  | "scheduled"
+  | "archived"
+  | "origin_channel";
 
 /**
  * Label a drain by the list it is fetching. Archive status is checked first
@@ -521,6 +545,45 @@ export async function listArchivedConversations(
   return fetchMergedConversationList(assistantId, "archived", "archivedAt");
 }
 
+/**
+ * Read the server-side unread conversation count, mapping a 404 to `null`.
+ *
+ * An assistant without `GET /v1/conversations/unread-count` 404s this read;
+ * resolving `null` lets consumers fall back to the client-derived count and
+ * lets a refetch clear a count from a since-rolled-back assistant instead of
+ * stranding it (see "When a gate is unnecessary" in BACKWARDS_COMPAT.md).
+ * Every other HTTP failure throws a status-carrying {@link ApiError} so the
+ * app-level no-retry-4xx policy applies; a missing response (network error)
+ * rethrows raw and retries as transient.
+ */
+export async function fetchUnreadConversationCount(
+  assistantId: string,
+  signal?: AbortSignal,
+): Promise<number | null> {
+  const { data, error, response } = await conversationsUnreadcountGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+    signal,
+  });
+  assertHasResponse(
+    response,
+    error,
+    "Failed to fetch unread conversation count.",
+  );
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null;
+    }
+    const msg = extractErrorMessage(
+      error,
+      response,
+      "Failed to fetch unread conversation count.",
+    );
+    throw new ApiError(response.status, msg);
+  }
+  return data?.count ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // First-page fetchers
 //
@@ -663,5 +726,23 @@ export function originChannelConversationListOptions(
     queryKey: originChannelConversationsQueryKey(assistantId, channel),
     queryFn: () => listOriginChannelConversations(assistantId, channel),
     staleTime: QUERY_STALE_TIME_MS,
+  });
+}
+
+/**
+ * Query options for the server-side unread conversation count. The cache
+ * holds `number | null`; `null` means the connected assistant does not
+ * serve the endpoint (see {@link fetchUnreadConversationCount}).
+ *
+ * `refetchOnWindowFocus` is disabled: count changes arrive via
+ * `sync_changed`-driven invalidation and mutation settles, and a focus
+ * refetch would re-issue the 404 against assistants without the route.
+ */
+export function unreadConversationCountOptions(assistantId: string) {
+  return queryOptions({
+    queryKey: unreadConversationCountQueryKey(assistantId),
+    queryFn: ({ signal }) => fetchUnreadConversationCount(assistantId, signal),
+    staleTime: QUERY_STALE_TIME_MS,
+    refetchOnWindowFocus: false,
   });
 }

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -25,6 +25,7 @@ import {
   ApiError,
   assertHasResponse,
   extractErrorMessage,
+  toApiError,
 } from "@/utils/api-errors";
 import { recordDiagnostic } from "@/lib/diagnostics";
 import { emitClientPerfEvent } from "@/lib/telemetry/client-perf";
@@ -574,12 +575,7 @@ export async function fetchUnreadConversationCount(
     if (response.status === 404) {
       return null;
     }
-    const msg = extractErrorMessage(
-      error,
-      response,
-      "Failed to fetch unread conversation count.",
-    );
-    throw new ApiError(response.status, msg);
+    throw toApiError(error, response);
   }
   return data?.count ?? null;
 }

--- a/clients/web/src/utils/conversation-predicates.test.ts
+++ b/clients/web/src/utils/conversation-predicates.test.ts
@@ -5,6 +5,7 @@ import {
   canMarkRead,
   canMarkUnread,
   contributesToUnreadCount,
+  countUnreadConversationsInList,
   isBackgroundConversation,
   isScheduledConversation,
 } from "@/utils/conversation-predicates";
@@ -167,5 +168,104 @@ describe("unread predicates for surfaced conversations", () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+/**
+ * The client half of the unread-count contract.
+ *
+ * `GET /v1/conversations/unread-count` answers the same question in SQL
+ * (`countUnreadConversations` in
+ * `assistant/src/persistence/conversation-queries.ts`), and the daemon's
+ * `conversation-list-routes.test.ts` asserts this same matrix against the
+ * database. The two definitions are maintained separately, so this matrix is
+ * the tripwire: a rule changed on one side without the other shows up as one
+ * of these scenarios disagreeing across the two suites.
+ *
+ * Keep the scenario names identical on both sides.
+ */
+describe("unread-count contract (client half)", () => {
+  const scenarios: Array<{
+    name: string;
+    conversation: Partial<Conversation>;
+    counts: boolean;
+  }> = [
+    {
+      name: "unseen foreground row",
+      conversation: { hasUnseenLatestAssistantMessage: true },
+      counts: true,
+    },
+    {
+      name: "seen foreground row",
+      conversation: { hasUnseenLatestAssistantMessage: false },
+      counts: false,
+    },
+    {
+      name: "unseen archived row",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        archivedAt: 1704153600000,
+      },
+      counts: false,
+    },
+    {
+      name: "unseen background row, not surfaced",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        conversationType: "background",
+      },
+      counts: false,
+    },
+    {
+      name: "unseen scheduled row, not surfaced",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        conversationType: "scheduled",
+      },
+      counts: false,
+    },
+    {
+      name: "unseen background row, surfaced",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        conversationType: "background",
+        surfacedAt: 1704067200000,
+      },
+      counts: true,
+    },
+    {
+      name: "unseen background row filed in a custom group, not surfaced",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        conversationType: "background",
+        groupId: "3f0b7a4e-1111-2222-3333-444455556666",
+      },
+      counts: false,
+    },
+    {
+      name: "unseen standard row filed in a custom group",
+      conversation: {
+        hasUnseenLatestAssistantMessage: true,
+        groupId: "3f0b7a4e-1111-2222-3333-444455556666",
+      },
+      counts: true,
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    test(`${scenario.name} ${scenario.counts ? "counts" : "does not count"}`, () => {
+      expect(
+        contributesToUnreadCount(makeConversation(scenario.conversation)),
+      ).toBe(scenario.counts);
+    });
+  }
+
+  test("the matrix totals what countUnreadConversationsInList reports", () => {
+    const expected = scenarios.filter((s) => s.counts).length;
+    const list = scenarios.map((s, index) =>
+      makeConversation({ ...s.conversation, conversationId: `conv-${index}` }),
+    );
+
+    expect(countUnreadConversationsInList(list)).toBe(expected);
   });
 });

--- a/clients/web/src/utils/conversation-predicates.ts
+++ b/clients/web/src/utils/conversation-predicates.ts
@@ -65,11 +65,39 @@ export function canMarkRead(conversation: Conversation): boolean {
  * threads and automated background / scheduled threads — those have
  * their own surfaces and don't represent attention the user is
  * expected to clear.
+ *
+ * The daemon applies the same rules in SQL to serve
+ * `GET /v1/conversations/unread-count` (`countUnreadConversations` in
+ * `assistant/src/persistence/conversation-queries.ts`). **Changing the rules
+ * here means changing them there too**, or the badge and the sidebar's unread
+ * dots disagree. `conversation-predicates.test.ts` and the daemon's
+ * `conversation-list-routes.test.ts` assert the same scenario matrix on
+ * either side of that boundary.
  */
 export function contributesToUnreadCount(conversation: Conversation): boolean {
   return (
     conversation.hasUnseenLatestAssistantMessage === true &&
     !isBackgroundConversation(conversation) &&
     conversation.archivedAt == null
+  );
+}
+
+/**
+ * Count the conversations in `conversations` that contribute to unread
+ * counters.
+ *
+ * **Only as complete as the list it is given.** It is the fallback for
+ * assistants that do not serve `GET /v1/conversations/unread-count`, and it
+ * is correct only while the client holds every conversation. Once the list
+ * loads progressively, a partial list yields an under-count, so this must not
+ * become the primary source for any surface.
+ */
+export function countUnreadConversationsInList(
+  conversations: readonly Conversation[],
+): number {
+  return conversations.reduce(
+    (total, conversation) =>
+      contributesToUnreadCount(conversation) ? total + 1 : total,
+    0,
   );
 }

--- a/clients/web/src/utils/unread-conversation-count.test.ts
+++ b/clients/web/src/utils/unread-conversation-count.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The server-side unread conversation count: how the fetcher classifies
+ * responses, and how the cache delta helper behaves.
+ *
+ * The count is read from `GET /v1/conversations/unread-count`. An assistant
+ * without the route 404s it, and the client treats that as "unavailable"
+ * (`null`) so consumers fall back to counting loaded conversations. Every
+ * other failure has to stay a real failure, or an auth/server error would be
+ * silently indistinguishable from an old assistant.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import { ApiError } from "@/utils/api-errors";
+import { adjustUnreadCountCache } from "@/utils/conversation-cache-mutations";
+import {
+  fetchUnreadConversationCount,
+  unreadConversationCountQueryKey,
+} from "@/utils/conversation-list-fetchers";
+
+const ASSISTANT_ID = "assistant-1";
+
+const originalGet = daemonClient.get;
+
+afterEach(() => {
+  daemonClient.get = originalGet;
+});
+
+/** Stub the daemon transport with one response for the next GET. */
+function stubResponse(opts: { status: number; body?: unknown }): {
+  calls: number;
+} {
+  const state = { calls: 0 };
+  daemonClient.get = mock(async () => {
+    state.calls += 1;
+    const ok = opts.status < 400;
+    return {
+      data: ok ? opts.body : null,
+      error: ok ? null : { message: "boom" },
+      response: new Response(JSON.stringify(opts.body ?? {}), {
+        status: opts.status,
+      }),
+    };
+  }) as typeof daemonClient.get;
+  return state;
+}
+
+/** Stub the daemon transport with a transport-level failure (no response). */
+function stubNetworkFailure(): void {
+  daemonClient.get = mock(async () => ({
+    data: null,
+    error: new Error("network down"),
+    response: undefined,
+  })) as unknown as typeof daemonClient.get;
+}
+
+describe("fetchUnreadConversationCount", () => {
+  test("returns the count from a successful response", async () => {
+    stubResponse({ status: 200, body: { count: 7 } });
+
+    expect(await fetchUnreadConversationCount(ASSISTANT_ID)).toBe(7);
+  });
+
+  test("returns 0 as a count, not as unavailable", async () => {
+    // Zero unread is a real answer; conflating it with `null` would make an
+    // empty inbox fall back to the client-derived count for no reason.
+    stubResponse({ status: 200, body: { count: 0 } });
+
+    expect(await fetchUnreadConversationCount(ASSISTANT_ID)).toBe(0);
+  });
+
+  test("maps 404 to null so an assistant without the route reads as unavailable", async () => {
+    stubResponse({ status: 404 });
+
+    expect(await fetchUnreadConversationCount(ASSISTANT_ID)).toBeNull();
+  });
+
+  test("throws a status-carrying ApiError on auth failure", async () => {
+    // 401 must not be swallowed into the feature-off value: the app's
+    // no-retry-4xx policy keys off the attached status, and a silent null
+    // would render a stale badge as though the assistant were merely old.
+    stubResponse({ status: 401 });
+
+    const err = await fetchUnreadConversationCount(ASSISTANT_ID).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+  });
+
+  test("throws a status-carrying ApiError on server failure", async () => {
+    stubResponse({ status: 500 });
+
+    const err = await fetchUnreadConversationCount(ASSISTANT_ID).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+  });
+
+  test("rethrows a transport failure so it retries as transient", async () => {
+    stubNetworkFailure();
+
+    await expect(fetchUnreadConversationCount(ASSISTANT_ID)).rejects.toThrow();
+  });
+});
+
+describe("adjustUnreadCountCache", () => {
+  function seededClient(value: number | null | undefined): QueryClient {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    if (value !== undefined) {
+      client.setQueryData(unreadConversationCountQueryKey(ASSISTANT_ID), value);
+    }
+    return client;
+  }
+
+  function read(client: QueryClient): number | null | undefined {
+    return client.getQueryData<number | null>(
+      unreadConversationCountQueryKey(ASSISTANT_ID),
+    );
+  }
+
+  test("applies a negative delta", () => {
+    const client = seededClient(3);
+
+    expect(adjustUnreadCountCache(client, ASSISTANT_ID, -1)).toBe(true);
+    expect(read(client)).toBe(2);
+  });
+
+  test("applies a positive delta", () => {
+    const client = seededClient(3);
+
+    expect(adjustUnreadCountCache(client, ASSISTANT_ID, 1)).toBe(true);
+    expect(read(client)).toBe(4);
+  });
+
+  test("clamps at zero rather than going negative", () => {
+    const client = seededClient(0);
+
+    expect(adjustUnreadCountCache(client, ASSISTANT_ID, -1)).toBe(true);
+    expect(read(client)).toBe(0);
+  });
+
+  test("no-ops when the count is unavailable", () => {
+    // `null` means the assistant does not serve the endpoint. Writing a
+    // number here would fabricate a count the server never produced.
+    const client = seededClient(null);
+
+    expect(adjustUnreadCountCache(client, ASSISTANT_ID, -1)).toBe(false);
+    expect(read(client)).toBeNull();
+  });
+
+  test("no-ops when the cache is empty", () => {
+    const client = seededClient(undefined);
+
+    expect(adjustUnreadCountCache(client, ASSISTANT_ID, -1)).toBe(false);
+    expect(read(client)).toBeUndefined();
+  });
+
+  test("two adjustments compose, so concurrent mutations do not clobber each other", () => {
+    const client = seededClient(5);
+
+    adjustUnreadCountCache(client, ASSISTANT_ID, -1);
+    adjustUnreadCountCache(client, ASSISTANT_ID, -1);
+    // Reverting only the first leaves the second's effect intact.
+    adjustUnreadCountCache(client, ASSISTANT_ID, 1);
+
+    expect(read(client)).toBe(4);
+  });
+});

--- a/clients/web/src/utils/unread-conversation-count.test.ts
+++ b/clients/web/src/utils/unread-conversation-count.test.ts
@@ -138,11 +138,30 @@ describe("adjustUnreadCountCache", () => {
     expect(read(client)).toBe(4);
   });
 
-  test("clamps at zero rather than going negative", () => {
+  test("a decrement past zero and its revert cancel out exactly", () => {
+    // The revert applies the inverse delta, so the decrement must not clamp:
+    // a decrement that saturated at zero would be undone by more than it
+    // removed, leaving the badge reporting unread conversations that do not
+    // exist. Display clamps instead (see useUnreadConversationCount).
     const client = seededClient(0);
 
-    expect(adjustUnreadCountCache(client, ASSISTANT_ID, -1)).toBe(true);
+    adjustUnreadCountCache(client, ASSISTANT_ID, -1);
+    adjustUnreadCountCache(client, ASSISTANT_ID, 1);
+
     expect(read(client)).toBe(0);
+  });
+
+  test("a bulk decrement past zero and its per-item reverts cancel out exactly", () => {
+    // Mark-all-read decrements once for the whole batch and reverts one row
+    // at a time, so the same asymmetry would compound across the batch.
+    const client = seededClient(1);
+
+    adjustUnreadCountCache(client, ASSISTANT_ID, -3);
+    adjustUnreadCountCache(client, ASSISTANT_ID, 1);
+    adjustUnreadCountCache(client, ASSISTANT_ID, 1);
+    adjustUnreadCountCache(client, ASSISTANT_ID, 1);
+
+    expect(read(client)).toBe(1);
   });
 
   test("no-ops when the count is unavailable", () => {


### PR DESCRIPTION
## TL;DR

The Electron Dock badge counts unread conversations by scanning the conversations the client happens to have loaded. This adds `GET /v1/conversations/unread-count` and reads the badge from it, so the number reflects every conversation on the server.

Today the client loads the whole list, so the badge is already correct and this changes nothing visible. It matters for [LUM-2444](https://linear.app/vellum/issue/LUM-2444): once the sidebar loads one page instead of all of them, a client-side count would silently under-report. This removes that dependency ahead of the change that would break it.

Fixes LUM-2445. Part of [LUM-2409](https://linear.app/vellum/issue/LUM-2409).

## What changes for the user

| | Before | After |
|---|---|---|
| Dock badge count | Counts conversations loaded in the browser | Comes from the server, covering every conversation |
| Badge on an older assistant | Client-side count | Unchanged: falls back to the client-side count |
| Marking a conversation read / unread | Badge updates immediately | Unchanged, and the count is corrected against the server when the write settles |
| A failed mark-read | Row reverts | Row reverts and the badge reverts with it |
| Anything else in the sidebar | | Unchanged |

## Why this is safe

**The endpoint is additive.** A new GET route; no existing route, response shape, or query parameter changes. Older clients never call it.

**Older assistants are handled by the repo's documented compatibility path, not a new one.** This is the read-only case in `BACKWARDS_COMPAT.md` where a version gate is unnecessary: the read is a query with no write whose fallback could corrupt state, a 404 maps to exactly the feature-off value (`null`) inside the `queryFn` so a rollback clears the count rather than stranding it, and the query disables focus refetches so a missing route costs one unretried 404 per trigger. `useWorkspaceTheme` is the existing precedent. Genuine failures stay failures: 401/403/500 throw a status-carrying `ApiError`, and a transport error rethrows raw so it retries as transient. Tests pin each of those classifications separately, so a future change cannot collapse an auth error into "old assistant".

**The count cannot drift from what the sidebar shows.** The server-side rules mirror the client's `contributesToUnreadCount` predicate: foreground only, unarchived, unsurfaced background/scheduled rows excluded. "Unseen" is expressed once as a SQL condition shared with the existing attention listing, so the count and the sidebar's unread dots read from one definition.

**Optimistic updates follow the TanStack lifecycle already used here**: cancel in-flight refetches, apply the delta, revert on error, invalidate on settle. Reverting applies the inverse delta rather than restoring a snapshot, so a concurrent mutation's adjustment is not clobbered. Unread messages that arrive mid-flight are reconciled by the settle-time refetch and by the `sync_changed` metadata-tag handler.

**Single-seen writes get their own invalidation.** The daemon publishes a per-conversation metadata tag for a single mark-seen and only publishes the list tag for the bulk path, so a count keyed to the list tag would have gone stale. The metadata-tag handler now invalidates the count too, debounced so a bulk mark-read elsewhere collapses into one scalar GET.

**No feature flag.** One data path, additive endpoint, documented compatibility behavior, and the normal revert path.

## Validation

- `assistant`: `bun run typecheck:fast`, `bun run lint`, `bun run generate:openapi -- --check` (the staleness check CI runs), and `bun test` on `conversation-list-routes`, `conversation-attention-store`, `conversation-attention-telegram`, `conversation-list-source`, `conversation-query-routes`, `conversation-unread-route`, `route-tags-guard`, `route-policy`, `guard-tests`, `policy`. All pass.
- `clients/web`: `bunx tsc --noEmit`, `bun run lint` (no new warnings), and `bun test` per file on the 11 affected suites. All pass.
- New coverage: 4 daemon cases (foreground-only counting, mark-seen removal, archived exclusion, background/scheduled excluded until surfaced, plus a custom-group row that must stay excluded), and client cases for response classification, delta arithmetic, optimistic decrement/increment, rollback, settle-time invalidation, bulk mark-all-read, sync-tag invalidation and its debounce, and badge preference/fallback.
- Rollback assertions were sensitivity-checked by removing the revert and confirming exactly those two tests fail.

## Notes for review

- **`ConversationSummary` and the list response are untouched.** No `total` field: pagination stays on `hasMore`. The daemon already computes a total it discards, which is worth surfacing separately for the navigation work, but it is not this change.
- **The count cache lives under the generated query key, not the conversation-list prefix.** The prefix-wide helpers in `conversation-cache.ts` treat every entry beneath it as a `Conversation[]`, and this is a scalar. `cancelConversationQueries` / `invalidateConversationQueries` reach it explicitly instead.
- **`hasUnreadConversations` in `assistant-side-menu.tsx` is deliberately not switched** to the server count. It gates a section's "Mark all read" menu item and is scoped to that section's rows; a global count would enable the item for sections with nothing unread.
- **The query is Electron-gated.** No other host renders a Dock badge, so no other host pays the request.
- No UI renders differently, so no Storybook stories or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->