### PR TITLE
refactor(web): extract the overrides draft model and call-site list

### DIFF
--- a/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
@@ -1,0 +1,123 @@
+import {
+  CUSTOM_SENTINEL,
+  isDraftActive,
+} from "@/domains/settings/ai/call-site-helpers";
+import { CallSiteOverrideRow } from "@/domains/settings/ai/call-site-overrides-row";
+import type { CallSiteDraftMap } from "@/domains/settings/ai/use-override-drafts";
+import type {
+  CallSiteOverrideDraft,
+  ConfigLlmCallsitesGetResponse,
+} from "@/generated/daemon/types.gen";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CallSiteCatalog = ConfigLlmCallsitesGetResponse;
+type CallSiteEntry = CallSiteCatalog["callSites"][number];
+type CallSiteDomain = CallSiteCatalog["domains"][number];
+
+interface ProfileOption {
+  value: string;
+  label: string;
+}
+
+/** The call sites of one catalog domain, rendered under a single label. */
+export interface CallSiteGroup {
+  domain: CallSiteDomain;
+  sites: CallSiteEntry[];
+}
+
+export interface OverridesCallSiteListProps {
+  groups: CallSiteGroup[];
+  drafts: CallSiteDraftMap;
+  buildProfileOptionsForRow: (
+    selectedProfile: string | null,
+  ) => ProfileOption[];
+  profileLabelFor: (name: string) => string;
+  advisorMatchesSearch: boolean;
+  onDraftChange: (id: string, draft: CallSiteOverrideDraft | null) => void;
+  onToggle: (id: string, on: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// OverridesCallSiteList
+// ---------------------------------------------------------------------------
+
+/**
+ * The Action Overrides body: one `CallSiteOverrideRow` per call site, grouped
+ * under its domain label, or the empty state when the search matches nothing.
+ */
+export function OverridesCallSiteList({
+  groups,
+  drafts,
+  buildProfileOptionsForRow,
+  profileLabelFor,
+  advisorMatchesSearch,
+  onDraftChange,
+  onToggle,
+}: OverridesCallSiteListProps) {
+  return (
+    <div className="space-y-4">
+      {groups.length === 0 ? (
+        // Suppressed when the Advisor row above already answered the
+        // search: "no matches" next to a visible match reads as a bug.
+        advisorMatchesSearch ? null : (
+          <p className="py-8 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
+            No actions match your search.
+          </p>
+        )
+      ) : (
+        groups.map(({ domain, sites }) => (
+          <div key={domain.id}>
+            {/* typography: off-scale. Domain section label uses semibold+tracking for visual grouping */}
+            <p className="mb-2 text-body-small-default font-semibold uppercase tracking-wider text-[var(--content-tertiary)]">
+              {domain.displayName}
+            </p>
+            <div className="space-y-1">
+              {sites.map((cs) => {
+                const profileVal = (() => {
+                  const d = drafts[cs.id] ?? null;
+                  if (!d || !isDraftActive(d)) {
+                    return "";
+                  }
+                  if (d.provider || d.model) {
+                    return CUSTOM_SENTINEL;
+                  }
+                  return d.profile ?? "";
+                })();
+                // The caption names the shipped tier (what the action
+                // falls back to when unpinned) when the daemon reports
+                // one; `defaultProfile` is the effective winner, pins
+                // included, so alone it would echo a pin back.
+                const defaultKey =
+                  cs.shippedDefaultProfile ?? cs.defaultProfile;
+                const defaultProfileLabel = defaultKey
+                  ? profileLabelFor(defaultKey)
+                  : null;
+
+                return (
+                  <CallSiteOverrideRow
+                    key={cs.id}
+                    id={cs.id}
+                    displayName={cs.displayName}
+                    description={cs.description}
+                    defaultProfileLabel={defaultProfileLabel}
+                    draft={drafts[cs.id] ?? null}
+                    profileOptions={buildProfileOptionsForRow(
+                      profileVal === "" || profileVal === CUSTOM_SENTINEL
+                        ? null
+                        : profileVal,
+                    )}
+                    onDraftChange={onDraftChange}
+                    onToggle={onToggle}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -10,14 +10,14 @@ import {
 } from "@/assistant/profile-pickers";
 import { getDefaultModelForProvider } from "@/assistant/llm-model-catalog";
 import { AdvisorProfileRow } from "@/domains/settings/ai/advisor-profile-row";
-import {
-  CUSTOM_SENTINEL,
-  draftsEqual,
-  isDraftActive,
-} from "@/domains/settings/ai/call-site-helpers";
-import { CallSiteOverrideRow } from "@/domains/settings/ai/call-site-overrides-row";
+import { CUSTOM_SENTINEL } from "@/domains/settings/ai/call-site-helpers";
 import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
+import {
+  type CallSiteGroup,
+  OverridesCallSiteList,
+} from "@/domains/settings/ai/overrides-call-site-list";
 import { useSelectableInferenceProviders } from "@/domains/settings/ai/provider-availability";
+import { useOverrideDrafts } from "@/domains/settings/ai/use-override-drafts";
 import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
 import {
   configGetOptions,
@@ -25,24 +25,12 @@ import {
   configLlmCallsitesGetOptions,
   useConfigPatchMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
-import type {
-  CallSiteOverrideDraft,
-  ConfigLlmCallsitesGetResponse,
-} from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { DetailShell } from "@/components/detail-shell";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type CallSiteCatalog = ConfigLlmCallsitesGetResponse;
-type CallSiteEntry = CallSiteCatalog["callSites"][number];
-type CallSiteDomain = CallSiteCatalog["domains"][number];
 
 export interface OverridesDetailPanelProps {
   assistantId: string;
@@ -96,12 +84,6 @@ export function OverridesDetailPanel({
   });
 
   const [search, setSearch] = useState("");
-  const [draftEdits, setDraftEdits] = useState<
-    Record<string, CallSiteOverrideDraft | null>
-  >({});
-  // `undefined` means "untouched this session": the row falls through to the
-  // persisted `llm.advisorProfile` rather than pinning a stale snapshot.
-  const [advisorEdit, setAdvisorEdit] = useState<string | undefined>(undefined);
   const [saving, setSaving] = useState(false);
   const [showResetConfirmation, setShowResetConfirmation] = useState(false);
 
@@ -133,24 +115,28 @@ export function OverridesDetailPanel({
     [gatedCallSites],
   );
 
-  // Derive the full draft map: persisted server values merged with any
-  // user edits made this session. When the user hasn't touched a row,
-  // it falls through to the persisted override (or empty).
-  const drafts = useMemo((): Record<string, CallSiteOverrideDraft | null> => {
-    if (!isSeeded) {
-      return {};
-    }
-    const merged: Record<string, CallSiteOverrideDraft | null> = {};
-    for (const id of catalogCallSiteIds) {
-      if (id in draftEdits) {
-        merged[id] = draftEdits[id];
-      } else {
-        const persisted = persistedOverrides[id];
-        merged[id] = persisted ? { ...persisted } : {};
-      }
-    }
-    return merged;
-  }, [isSeeded, catalogCallSiteIds, persistedOverrides, draftEdits]);
+  // The advisor is a top-level `llm.advisorProfile` selection, not a call-site
+  // override. It rides this panel's draft/Save cycle but never enters the
+  // `llm.callSites` patch or the Overrides count.
+  const persistedAdvisor = daemonConfig?.llm?.advisorProfile ?? "";
+
+  const {
+    drafts,
+    advisorProfile,
+    advisorDirty,
+    callSiteDraftsDirty,
+    hasUnsavedDrafts,
+    hasValidationError,
+    setDraft,
+    setAdvisor,
+    buildSavePatch,
+    buildResetPatch,
+  } = useOverrideDrafts({
+    catalogCallSiteIds,
+    persistedOverrides,
+    persistedAdvisor,
+    isSeeded,
+  });
 
   // ---------------------------------------------------------------------------
   // Derived state
@@ -166,13 +152,6 @@ export function OverridesDetailPanel({
       orderedProfiles.find((p) => p.name === name)?.label ?? name,
     [orderedProfiles],
   );
-
-  // The advisor is a top-level `llm.advisorProfile` selection, not a call-site
-  // override. It rides this panel's draft/Save cycle but never enters the
-  // `llm.callSites` patch or the Overrides count.
-  const persistedAdvisor = daemonConfig?.llm?.advisorProfile ?? "";
-  const advisorProfile = advisorEdit ?? persistedAdvisor;
-  const advisorDirty = advisorProfile !== persistedAdvisor;
 
   const advisorOptions = useMemo(
     () =>
@@ -200,28 +179,6 @@ export function OverridesDetailPanel({
           (s?.profile != null || s?.provider != null || s?.model != null),
       ),
     [persistedOverrides, gatedCallSiteIdSet],
-  );
-
-  const callSiteDraftsDirty = useMemo(() => {
-    if (!isSeeded) {
-      return false;
-    }
-    for (const id of Object.keys(drafts)) {
-      if (!draftsEqual(drafts[id], persistedOverrides[id])) {
-        return true;
-      }
-    }
-    return false;
-  }, [isSeeded, drafts, persistedOverrides]);
-
-  const hasUnsavedDrafts = advisorDirty || callSiteDraftsDirty;
-
-  const hasValidationError = useMemo(
-    () =>
-      Object.values(drafts).some(
-        (d) => isDraftActive(d) && !!d?.provider && !d?.model,
-      ),
-    [drafts],
   );
 
   const buildProfileOptionsForRow = useCallback(
@@ -259,7 +216,7 @@ export function OverridesDetailPanel({
     }
     const domainOrder = catalog.domains.map((d) => d.id);
     const domainMap = new Map(catalog.domains.map((d) => [d.id, d]));
-    const groups: { domain: CallSiteDomain; sites: CallSiteEntry[] }[] = [];
+    const groups: CallSiteGroup[] = [];
     for (const domainId of domainOrder) {
       const sites = filteredCallSites.filter((cs) => cs.domain === domainId);
       if (sites.length > 0) {
@@ -283,17 +240,10 @@ export function OverridesDetailPanel({
   // Row callbacks
   // ---------------------------------------------------------------------------
 
-  const handleDraftChange = useCallback(
-    (id: string, draft: CallSiteOverrideDraft | null) => {
-      setDraftEdits((prev) => ({ ...prev, [id]: draft }));
-    },
-    [],
-  );
-
   const handleToggle = useCallback(
     (id: string, on: boolean) => {
       if (!on) {
-        setDraftEdits((prev) => ({ ...prev, [id]: null }));
+        setDraft(id, null);
         return;
       }
       const cs = gatedCallSites.find((c) => c.id === id);
@@ -302,18 +252,15 @@ export function OverridesDetailPanel({
         cs?.defaultProfile,
       );
       if (seedProfile) {
-        setDraftEdits((prev) => ({ ...prev, [id]: { profile: seedProfile } }));
+        setDraft(id, { profile: seedProfile });
       } else {
         const defaultProvider =
           selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
         const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
-        setDraftEdits((prev) => ({
-          ...prev,
-          [id]: { provider: defaultProvider, model: defaultModel },
-        }));
+        setDraft(id, { provider: defaultProvider, model: defaultModel });
       }
     },
-    [gatedCallSites, orderedProfiles, selectableInferenceProviders],
+    [gatedCallSites, orderedProfiles, selectableInferenceProviders, setDraft],
   );
 
   // ---------------------------------------------------------------------------
@@ -323,32 +270,7 @@ export function OverridesDetailPanel({
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      // `PATCH /v1/config` deep-merges (`deepMergeOverwrite` in the daemon's
-      // config loader), so an omitted key keeps its persisted value and a
-      // `null` deletes the whole entry. Three cases follow from that:
-      //
-      //  - active draft: send the picker triple. Nulling provider/model
-      //    clears a stale pin; any tuning the entry carries is untouched
-      //    because it isn't mentioned.
-      //  - the user switched this row off: send `null` and delete it. That
-      //    is what off means.
-      //  - inactive and untouched: omit it. `isDraftActive` only reads the
-      //    picker triple, so an entry holding nothing but tuning reads as
-      //    off; sending `null` for it would delete settings the user never
-      //    asked to remove.
-      const patch: Record<string, CallSiteOverrideDraft | null> = {};
-      for (const id of Object.keys(drafts)) {
-        const d = drafts[id] ?? null;
-        if (isDraftActive(d)) {
-          patch[id] = {
-            profile: d?.profile ?? null,
-            provider: d?.provider ?? null,
-            model: d?.model ?? null,
-          };
-        } else if (id in draftEdits && draftEdits[id] === null) {
-          patch[id] = null;
-        }
-      }
+      const patch = buildSavePatch();
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: {
@@ -372,8 +294,7 @@ export function OverridesDetailPanel({
       setSaving(false);
     }
   }, [
-    drafts,
-    draftEdits,
+    buildSavePatch,
     callSiteDraftsDirty,
     advisorDirty,
     advisorProfile,
@@ -385,10 +306,7 @@ export function OverridesDetailPanel({
   const handleReset = useCallback(async () => {
     setSaving(true);
     try {
-      const resetPatch: Record<string, null> = {};
-      for (const id of Object.keys(drafts)) {
-        resetPatch[id] = null;
-      }
+      const resetPatch = buildResetPatch();
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: { llm: { callSites: resetPatch } },
@@ -401,7 +319,7 @@ export function OverridesDetailPanel({
     } finally {
       setSaving(false);
     }
-  }, [drafts, onClose, configMutation, assistantId]);
+  }, [buildResetPatch, onClose, configMutation, assistantId]);
 
   // ---------------------------------------------------------------------------
   // Render
@@ -470,7 +388,7 @@ export function OverridesDetailPanel({
               value={advisorProfile}
               profileOptions={advisorOptions}
               disabled={saving}
-              onChange={setAdvisorEdit}
+              onChange={setAdvisor}
             />
           </div>
         )}
@@ -503,67 +421,15 @@ export function OverridesDetailPanel({
 
         {/* Call site list grouped by domain */}
         {!isLoading && !isError && catalog && (
-          <div className="space-y-4">
-            {groupedCallSites.length === 0 ? (
-              // Suppressed when the Advisor row above already answered the
-              // search: "no matches" next to a visible match reads as a bug.
-              advisorMatchesSearch ? null : (
-                <p className="py-8 text-center text-body-medium-lighter text-[var(--content-tertiary)]">
-                  No actions match your search.
-                </p>
-              )
-            ) : (
-              groupedCallSites.map(({ domain, sites }) => (
-                <div key={domain.id}>
-                  {/* typography: off-scale — domain section label uses semibold+tracking for visual grouping */}
-                  <p className="mb-2 text-body-small-default font-semibold uppercase tracking-wider text-[var(--content-tertiary)]">
-                    {domain.displayName}
-                  </p>
-                  <div className="space-y-1">
-                    {sites.map((cs) => {
-                      const profileVal = (() => {
-                        const d = drafts[cs.id] ?? null;
-                        if (!d || !isDraftActive(d)) {
-                          return "";
-                        }
-                        if (d.provider || d.model) {
-                          return CUSTOM_SENTINEL;
-                        }
-                        return d.profile ?? "";
-                      })();
-                      // The caption names the shipped tier (what the action
-                      // falls back to when unpinned) when the daemon reports
-                      // one; `defaultProfile` is the effective winner, pins
-                      // included, so alone it would echo a pin back.
-                      const defaultKey =
-                        cs.shippedDefaultProfile ?? cs.defaultProfile;
-                      const defaultProfileLabel = defaultKey
-                        ? profileLabelFor(defaultKey)
-                        : null;
-
-                      return (
-                        <CallSiteOverrideRow
-                          key={cs.id}
-                          id={cs.id}
-                          displayName={cs.displayName}
-                          description={cs.description}
-                          defaultProfileLabel={defaultProfileLabel}
-                          draft={drafts[cs.id] ?? null}
-                          profileOptions={buildProfileOptionsForRow(
-                            profileVal === "" || profileVal === CUSTOM_SENTINEL
-                              ? null
-                              : profileVal,
-                          )}
-                          onDraftChange={handleDraftChange}
-                          onToggle={handleToggle}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
+          <OverridesCallSiteList
+            groups={groupedCallSites}
+            drafts={drafts}
+            buildProfileOptionsForRow={buildProfileOptionsForRow}
+            profileLabelFor={profileLabelFor}
+            advisorMatchesSearch={advisorMatchesSearch}
+            onDraftChange={setDraft}
+            onToggle={handleToggle}
+          />
         )}
       </div>
 

--- a/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the Action Overrides save/reset serializers.
+ *
+ * `PATCH /v1/config` deep-merges, so the difference between a `null` value
+ * and an absent key is the difference between deleting a call-site entry and
+ * leaving it alone. These tests pin which rows land in which case.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildCallSiteSavePatch,
+  buildResetPatch,
+  type CallSiteDraftMap,
+} from "@/domains/settings/ai/use-override-drafts";
+
+// ---------------------------------------------------------------------------
+// buildCallSiteSavePatch
+// ---------------------------------------------------------------------------
+
+describe("buildCallSiteSavePatch", () => {
+  test("an active profile draft sends the picker triple with explicit nulls", () => {
+    const drafts: CallSiteDraftMap = { workflowLeaf: { profile: "quality" } };
+    const patch = buildCallSiteSavePatch(drafts, {});
+    expect(patch.workflowLeaf).toEqual({
+      profile: "quality",
+      provider: null,
+      model: null,
+    });
+  });
+
+  test("an active custom draft sends provider and model with a null profile", () => {
+    const drafts: CallSiteDraftMap = {
+      workflowLeaf: { provider: "openai", model: "gpt-4o" },
+    };
+    const patch = buildCallSiteSavePatch(drafts, {});
+    expect(patch.workflowLeaf).toEqual({
+      profile: null,
+      provider: "openai",
+      model: "gpt-4o",
+    });
+  });
+
+  test("a row switched off this session serializes to null", () => {
+    const drafts: CallSiteDraftMap = { heartbeatAgent: null };
+    const draftEdits: CallSiteDraftMap = { heartbeatAgent: null };
+    const patch = buildCallSiteSavePatch(drafts, draftEdits);
+    expect("heartbeatAgent" in patch).toBe(true);
+    expect(patch.heartbeatAgent).toBe(null);
+  });
+
+  test("an inactive untouched row is absent from the patch", () => {
+    // A persisted entry holding nothing but tuning reads as inactive. It is
+    // omitted so the deep merge leaves the tuning in place; a `null` would
+    // delete settings the user never asked to remove.
+    const drafts: CallSiteDraftMap = {
+      heartbeatAgent: { effort: "low", thinking: { enabled: false } },
+      workflowLeaf: {},
+    };
+    const patch = buildCallSiteSavePatch(drafts, {});
+    expect("heartbeatAgent" in patch).toBe(false);
+    expect("workflowLeaf" in patch).toBe(false);
+    expect(Object.keys(patch)).toEqual([]);
+  });
+
+  test("an active row and a switched-off row coexist without touching an untouched one", () => {
+    const drafts: CallSiteDraftMap = {
+      workflowLeaf: { profile: "quality" },
+      heartbeatAgent: null,
+      titleGenerator: { effort: "low" },
+    };
+    const draftEdits: CallSiteDraftMap = { heartbeatAgent: null };
+    const patch = buildCallSiteSavePatch(drafts, draftEdits);
+    expect(Object.keys(patch).sort()).toEqual([
+      "heartbeatAgent",
+      "workflowLeaf",
+    ]);
+    expect("titleGenerator" in patch).toBe(false);
+  });
+
+  test("an inactive row edited to something still inactive is omitted", () => {
+    // `draftEdits[id]` is an empty draft rather than `null`, so it is not the
+    // explicit "switch this off" signal and must not delete the entry.
+    const drafts: CallSiteDraftMap = { heartbeatAgent: {} };
+    const draftEdits: CallSiteDraftMap = { heartbeatAgent: {} };
+    const patch = buildCallSiteSavePatch(drafts, draftEdits);
+    expect("heartbeatAgent" in patch).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildResetPatch
+// ---------------------------------------------------------------------------
+
+describe("buildResetPatch", () => {
+  test("nulls every draft key and nothing else", () => {
+    const drafts: CallSiteDraftMap = {
+      workflowLeaf: { profile: "quality" },
+      heartbeatAgent: { effort: "low" },
+      titleGenerator: null,
+    };
+    const patch = buildResetPatch(drafts);
+    expect(Object.keys(patch).sort()).toEqual([
+      "heartbeatAgent",
+      "titleGenerator",
+      "workflowLeaf",
+    ]);
+    expect(patch).toEqual({
+      workflowLeaf: null,
+      heartbeatAgent: null,
+      titleGenerator: null,
+    });
+  });
+
+  test("an empty draft map produces an empty patch", () => {
+    expect(buildResetPatch({})).toEqual({});
+  });
+});

--- a/clients/web/src/domains/settings/ai/use-override-drafts.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.ts
@@ -1,0 +1,207 @@
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  draftsEqual,
+  isDraftActive,
+} from "@/domains/settings/ai/call-site-helpers";
+import type { CallSiteOverrideDraft } from "@/generated/daemon/types.gen";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Call-site id to its draft override. `null` is an explicit "no override
+ * here"; an empty object is a row that carries nothing.
+ */
+export type CallSiteDraftMap = Record<string, CallSiteOverrideDraft | null>;
+
+export interface UseOverrideDraftsOptions {
+  /** Ids of every call site the panel enumerates, in catalog order. */
+  catalogCallSiteIds: string[];
+  /** `llm.callSites` as the daemon currently persists it. */
+  persistedOverrides: CallSiteDraftMap;
+  /** `llm.advisorProfile` as the daemon currently persists it. */
+  persistedAdvisor: string;
+  /** True once both the call-site catalog and the daemon config have loaded. */
+  isSeeded: boolean;
+}
+
+export interface OverrideDrafts {
+  /** Persisted overrides merged with this session's edits, keyed by id. */
+  drafts: CallSiteDraftMap;
+  advisorProfile: string;
+  advisorDirty: boolean;
+  callSiteDraftsDirty: boolean;
+  hasUnsavedDrafts: boolean;
+  hasValidationError: boolean;
+  setDraft: (id: string, draft: CallSiteOverrideDraft | null) => void;
+  setAdvisor: (profile: string) => void;
+  buildSavePatch: () => CallSiteDraftMap;
+  buildResetPatch: () => Record<string, null>;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Serializes the draft map into the `llm.callSites` body of a
+ * `PATCH /v1/config` request.
+ */
+export function buildCallSiteSavePatch(
+  drafts: CallSiteDraftMap,
+  draftEdits: CallSiteDraftMap,
+): CallSiteDraftMap {
+  // `PATCH /v1/config` deep-merges (`deepMergeOverwrite` in the daemon's
+  // config loader), so an omitted key keeps its persisted value and a
+  // `null` deletes the whole entry. Three cases follow from that:
+  //
+  //  - active draft: send the picker triple. Nulling provider/model
+  //    clears a stale pin; any tuning the entry carries is untouched
+  //    because it isn't mentioned.
+  //  - the user switched this row off: send `null` and delete it. That
+  //    is what off means.
+  //  - inactive and untouched: omit it. `isDraftActive` only reads the
+  //    picker triple, so an entry holding nothing but tuning reads as
+  //    off; sending `null` for it would delete settings the user never
+  //    asked to remove.
+  const patch: CallSiteDraftMap = {};
+  for (const id of Object.keys(drafts)) {
+    const d = drafts[id] ?? null;
+    if (isDraftActive(d)) {
+      patch[id] = {
+        profile: d?.profile ?? null,
+        provider: d?.provider ?? null,
+        model: d?.model ?? null,
+      };
+    } else if (id in draftEdits && draftEdits[id] === null) {
+      patch[id] = null;
+    }
+  }
+  return patch;
+}
+
+/**
+ * Serializes a "Reset to Defaults" request: every enumerated call site is
+ * nulled so the daemon deletes its entry and the action follows its default.
+ */
+export function buildResetPatch(
+  drafts: CallSiteDraftMap,
+): Record<string, null> {
+  const resetPatch: Record<string, null> = {};
+  for (const id of Object.keys(drafts)) {
+    resetPatch[id] = null;
+  }
+  return resetPatch;
+}
+
+// ---------------------------------------------------------------------------
+// useOverrideDrafts
+// ---------------------------------------------------------------------------
+
+/**
+ * Owns the Action Overrides panel's draft model: the per-call-site edits and
+ * the Advisor selection made this session, plus everything derived from them.
+ *
+ * A draft is the persisted value merged with this session's edit for that
+ * row; a row the user never touched falls through to the persisted override
+ * (or to an empty draft when there is none), so a config refetch is picked up
+ * rather than pinned to a stale snapshot. The same rule governs the Advisor:
+ * an untouched selection reads from `llm.advisorProfile`.
+ *
+ * `buildSavePatch` and `buildResetPatch` apply the serialization rules that
+ * protect tuning-only entries: a persisted entry holding only tuning fields
+ * reads as "off" and must be omitted from a save rather than nulled.
+ *
+ * Holds no side effects and issues no queries: the caller owns the mutation.
+ */
+export function useOverrideDrafts({
+  catalogCallSiteIds,
+  persistedOverrides,
+  persistedAdvisor,
+  isSeeded,
+}: UseOverrideDraftsOptions): OverrideDrafts {
+  const [draftEdits, setDraftEdits] = useState<CallSiteDraftMap>({});
+  // `undefined` means "untouched this session": the row falls through to the
+  // persisted `llm.advisorProfile` rather than pinning a stale snapshot.
+  const [advisorEdit, setAdvisorEdit] = useState<string | undefined>(undefined);
+
+  // Derive the full draft map: persisted server values merged with any
+  // user edits made this session. When the user hasn't touched a row,
+  // it falls through to the persisted override (or empty).
+  const drafts = useMemo((): CallSiteDraftMap => {
+    if (!isSeeded) {
+      return {};
+    }
+    const merged: CallSiteDraftMap = {};
+    for (const id of catalogCallSiteIds) {
+      if (id in draftEdits) {
+        merged[id] = draftEdits[id];
+      } else {
+        const persisted = persistedOverrides[id];
+        merged[id] = persisted ? { ...persisted } : {};
+      }
+    }
+    return merged;
+  }, [isSeeded, catalogCallSiteIds, persistedOverrides, draftEdits]);
+
+  const advisorProfile = advisorEdit ?? persistedAdvisor;
+  const advisorDirty = advisorProfile !== persistedAdvisor;
+
+  const callSiteDraftsDirty = useMemo(() => {
+    if (!isSeeded) {
+      return false;
+    }
+    for (const id of Object.keys(drafts)) {
+      if (!draftsEqual(drafts[id], persistedOverrides[id])) {
+        return true;
+      }
+    }
+    return false;
+  }, [isSeeded, drafts, persistedOverrides]);
+
+  const hasUnsavedDrafts = advisorDirty || callSiteDraftsDirty;
+
+  const hasValidationError = useMemo(
+    () =>
+      Object.values(drafts).some(
+        (d) => isDraftActive(d) && !!d?.provider && !d?.model,
+      ),
+    [drafts],
+  );
+
+  const setDraft = useCallback(
+    (id: string, draft: CallSiteOverrideDraft | null) => {
+      setDraftEdits((prev) => ({ ...prev, [id]: draft }));
+    },
+    [],
+  );
+
+  const setAdvisor = useCallback((profile: string) => {
+    setAdvisorEdit(profile);
+  }, []);
+
+  const savePatchBuilder = useCallback(
+    () => buildCallSiteSavePatch(drafts, draftEdits),
+    [drafts, draftEdits],
+  );
+
+  const resetPatchBuilder = useCallback(
+    () => buildResetPatch(drafts),
+    [drafts],
+  );
+
+  return {
+    drafts,
+    advisorProfile,
+    advisorDirty,
+    callSiteDraftsDirty,
+    hasUnsavedDrafts,
+    hasValidationError,
+    setDraft,
+    setAdvisor,
+    buildSavePatch: savePatchBuilder,
+    buildResetPatch: resetPatchBuilder,
+  };
+}


### PR DESCRIPTION
## TL;DR

Pure refactor of the Action Overrides sidepanel, no behavior change. The draft state and its save/reset serialization move into `use-override-drafts.ts`, with the tricky deep-merge rules as pure functions under direct unit test; the grouped call-site rendering moves into `overrides-call-site-list.tsx`. The panel drops from 584 to 450 lines and becomes an orchestrator: queries, search, advisor wiring, footer actions.

Groundwork for [LUM-2898](https://linear.app/vellum/issue/LUM-2898/bulk-profile-override-swap-override-this-profile-with-this-profile).

## What changes for the user

Nothing. No rendered copy, class name, or interaction changes.

## Why this is safe

The existing `overrides-detail-panel.test.tsx` is the behavior-preservation proof: it is **byte-identical to `main`** (absent from this diff entirely) and its 7 tests pass unmodified against the refactored panel.

## Why it is worth doing

The save serialization is the subtlest logic on this surface and the source of a past regression (LUM-2949, tuning-only entries being deleted). It was inline in a 584-line component, reachable only through full-component render tests. It is now `buildCallSiteSavePatch` / `buildResetPatch`, pure and directly tested, with the three deep-merge cases stated once next to the code that implements them:

- an active draft sends the picker triple with explicit `null`s, so a stale provider/model pin clears while tuning the entry carries is untouched;
- a row switched off this session sends `null`, deleting the entry;
- an inactive, untouched row is **omitted** so a persisted entry holding only tuning survives. The new test asserts absence (`"id" in patch === false`), not a falsy value, which is the invariant LUM-2949 needed.

## Verification

- `bunx tsc --noEmit`: clean
- `bunx eslint` on all touched files: clean
- `overrides-detail-panel.test.tsx`: 7 pass, 0 fail (unmodified)
- `use-override-drafts.test.ts`: 8 pass, 0 fail (new)
- `call-site-helpers.test.ts`: 13 pass, 0 fail

## Notes for review

- `groupedCallSites` stays in the panel because it depends on panel-owned catalog and search state; `OverridesCallSiteList` owns its own props shape, so the panel no longer imports `ConfigLlmCallsitesGetResponse`.
- One em dash was removed from a moved JSX comment to satisfy the repo rule. JSX comments are compiled away, so rendered output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->