### PR TITLE
feat(assistant): tag live-voice endpoint decisions with their source

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -338,6 +338,70 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(completed).not.toHaveProperty("ackSpoken");
   });
 
+  test("decisions without a source are attributed to the front door", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-src-default",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-src-default");
+    collector.markEndpointDecision("turn-src-default", {
+      action: "hold",
+      latencyMs: 900,
+    });
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({
+      endpointHoldCount: 1,
+      endpointDecisionMaxLatencyMs: 900,
+      endpointDecisionSource: "front-door",
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(
+        collector.getSnapshot(),
+        "turn-src-default",
+      ),
+    ).toMatchObject({ endpointDecisionSource: "front-door" });
+  });
+
+  test("flux decisions report their source with unchanged latency accounting", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-src-flux",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-src-flux");
+    collector.markEndpointDecision("turn-src-flux", {
+      action: "hold",
+      latencyMs: 40,
+      source: "flux",
+    });
+    collector.markEndpointDecision("turn-src-flux", {
+      action: "release",
+      latencyMs: 120,
+      source: "flux",
+    });
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({
+      endpointHoldCount: 1,
+      endpointDecisionMaxLatencyMs: 120,
+      endpointDecisionSource: "flux",
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(
+        collector.getSnapshot(),
+        "turn-src-flux",
+      ),
+    ).toMatchObject({
+      endpointHoldCount: 1,
+      endpointDecisionMaxLatencyMs: 120,
+      endpointDecisionSource: "flux",
+    });
+  });
+
   test("accumulates spoken progress updates on the turn and aggregate fields", () => {
     const clock = makeClock(0);
     const collector = new LiveVoiceMetricsCollector({
@@ -375,6 +439,7 @@ describe("LiveVoiceMetricsCollector", () => {
 
     expect(completed).not.toHaveProperty("endpointHoldCount");
     expect(completed).not.toHaveProperty("endpointDecisionMaxLatencyMs");
+    expect(completed).not.toHaveProperty("endpointDecisionSource");
     expect(completed).not.toHaveProperty("ackSpoken");
     expect(completed).not.toHaveProperty("progressUpdatesSpoken");
 
@@ -384,6 +449,7 @@ describe("LiveVoiceMetricsCollector", () => {
     );
     expect(aggregateFields).not.toHaveProperty("endpointHoldCount");
     expect(aggregateFields).not.toHaveProperty("endpointDecisionMaxLatencyMs");
+    expect(aggregateFields).not.toHaveProperty("endpointDecisionSource");
     expect(aggregateFields).not.toHaveProperty("ackSpoken");
     expect(aggregateFields).not.toHaveProperty("progressUpdatesSpoken");
   });

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -29,10 +29,17 @@ export type LiveVoiceMetricsEvent =
 // front-door leg either holds the utterance open or releases it to the turn.
 export type VoiceEndpointAction = "release" | "hold";
 
+// Which decider produced the endpoint outcome: the speculative front-door
+// leg, or the Flux turn-detection stream.
+export type VoiceEndpointSource = "front-door" | "flux";
+
+const DEFAULT_ENDPOINT_SOURCE: VoiceEndpointSource = "front-door";
+
 // Semantic-endpointing decision on a silence boundary.
 interface LiveVoiceEndpointDecisionMark {
   action: VoiceEndpointAction;
   latencyMs: number;
+  source?: VoiceEndpointSource;
 }
 
 // Which floor-holding ack actually spoke during a turn.
@@ -122,6 +129,7 @@ interface LiveVoiceTurnMetrics {
   // turns that never touch the features carry no trace of them.
   endpointHoldCount?: number;
   endpointDecisionMaxLatencyMs?: number;
+  endpointDecisionSource?: VoiceEndpointSource;
   ackSpoken?: LiveVoiceSpokenAckKind;
   progressUpdatesSpoken?: number;
 }
@@ -169,6 +177,7 @@ interface LiveVoiceMetricsAggregateFields {
   // features never engaged (see the matching fields on LiveVoiceTurnMetrics).
   endpointHoldCount?: number;
   endpointDecisionMaxLatencyMs?: number;
+  endpointDecisionSource?: VoiceEndpointSource;
   ackSpoken?: LiveVoiceSpokenAckKind;
   progressUpdatesSpoken?: number;
 }
@@ -191,6 +200,8 @@ interface MutableTurn {
   // Doubles as the "decider was consulted" latch: null means no endpoint
   // decision was ever recorded for the turn.
   endpointDecisionMaxLatencyMs: number | null;
+  // The decider behind the turn's most recent endpoint decision.
+  endpointDecisionSource: VoiceEndpointSource | null;
   ackSpoken: LiveVoiceSpokenAckKind | null;
   progressUpdatesSpoken: number;
 }
@@ -257,6 +268,7 @@ export class LiveVoiceMetricsCollector {
       },
       endpointHoldCount: 0,
       endpointDecisionMaxLatencyMs: null,
+      endpointDecisionSource: null,
       ackSpoken: null,
       progressUpdatesSpoken: 0,
     };
@@ -347,6 +359,7 @@ export class LiveVoiceMetricsCollector {
       turn.endpointDecisionMaxLatencyMs ?? 0,
       latencyMs,
     );
+    turn.endpointDecisionSource = decision.source ?? DEFAULT_ENDPOINT_SOURCE;
     return this.emit("endpoint_decision", turn.turnId);
   }
 
@@ -587,6 +600,7 @@ function frontModelFields(
   turn: {
     endpointHoldCount?: number | null;
     endpointDecisionMaxLatencyMs?: number | null;
+    endpointDecisionSource?: VoiceEndpointSource | null;
     ackSpoken?: LiveVoiceSpokenAckKind | null;
     progressUpdatesSpoken?: number | null;
   },
@@ -594,6 +608,7 @@ function frontModelFields(
   LiveVoiceTurnMetrics,
   | "endpointHoldCount"
   | "endpointDecisionMaxLatencyMs"
+  | "endpointDecisionSource"
   | "ackSpoken"
   | "progressUpdatesSpoken"
 > {
@@ -603,6 +618,8 @@ function frontModelFields(
       ? {
           endpointHoldCount: turn.endpointHoldCount ?? 0,
           endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
+          endpointDecisionSource:
+            turn.endpointDecisionSource ?? DEFAULT_ENDPOINT_SOURCE,
         }
       : {}),
     ...(turn.ackSpoken != null ? { ackSpoken: turn.ackSpoken } : {}),
@@ -651,6 +668,7 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     timestamps: { ...turn.timestamps },
     endpointHoldCount: turn.endpointHoldCount,
     endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
+    endpointDecisionSource: turn.endpointDecisionSource,
     ackSpoken: turn.ackSpoken,
     progressUpdatesSpoken: turn.progressUpdatesSpoken,
   };


### PR DESCRIPTION
## Summary

- Add `VoiceEndpointSource` (`front-door` | `flux`) and an optional `source` on the endpoint decision mark, defaulting to `front-door` so the existing caller is unchanged.
- Surface `endpointDecisionSource` on per-turn metrics and on the aggregate metrics frame fields, gated by the same "decider was consulted" latch as `endpointDecisionMaxLatencyMs` so turns that never endpoint stay byte-identical.
- Cover the default-source, explicit `flux` source, and field-absent cases in the live-voice metrics tests.

Part of plan: flux-turn-detection.md (PR 3 of 8)