### PR TITLE
feat(assistant): add liveVoice.flux config block for Flux turn detection

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -980,7 +980,7 @@ describe("AssistantConfigSchema", () => {
     // Unspecified vad fields still get defaults
     expect(result.liveVoice.vad.maxTurnDurationMs).toBe(30000);
     expect(result.liveVoice.maxSessionDurationSeconds).toBe(900);
-    // A config predating the flux block still parses, with Flux turn-end off.
+    // A partial liveVoice override leaves Flux turn-end disabled by default.
     expect(result.liveVoice.flux.turnEnd.enabled).toBe(false);
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -950,6 +950,12 @@ describe("AssistantConfigSchema", () => {
           generationTimeoutMs: 1500,
         },
       },
+      flux: {
+        turnEnd: { enabled: false },
+        model: "flux-general-en",
+        eotThreshold: 0.7,
+        eotTimeoutMs: 5000,
+      },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,
     });
@@ -974,6 +980,8 @@ describe("AssistantConfigSchema", () => {
     // Unspecified vad fields still get defaults
     expect(result.liveVoice.vad.maxTurnDurationMs).toBe(30000);
     expect(result.liveVoice.maxSessionDurationSeconds).toBe(900);
+    // A config predating the flux block still parses, with Flux turn-end off.
+    expect(result.liveVoice.flux.turnEnd.enabled).toBe(false);
   });
 
   test("accepts a liveVoice.vad.bargeInMinSpeechMs of 0 (guard disabled)", () => {

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   LiveVoiceConfigSchema,
+  LiveVoiceFluxConfigSchema,
   LiveVoiceFrontModelConfigSchema,
   LiveVoiceVadConfigSchema,
   VALID_LIVE_VOICE_MODES,
@@ -24,6 +25,15 @@ const FRONT_MODEL_DEFAULTS = {
   ackFirstDeltaTimeoutMs: 2500,
   ackGenerationTimeoutMs: 600,
   progress: PROGRESS_DEFAULTS,
+};
+
+// `eagerEotThreshold` is deliberately absent: it has no default, and leaving it
+// unset is what keeps Deepgram from emitting speculative turn events.
+const FLUX_DEFAULTS = {
+  turnEnd: { enabled: false },
+  model: "flux-general-en",
+  eotThreshold: 0.7,
+  eotTimeoutMs: 5_000,
 };
 
 describe("LiveVoiceVadConfigSchema", () => {
@@ -181,6 +191,87 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
   });
 });
 
+describe("LiveVoiceFluxConfigSchema", () => {
+  test("empty object parses to defaults, with turn-end off", () => {
+    expect(LiveVoiceFluxConfigSchema.parse({})).toEqual(FLUX_DEFAULTS);
+  });
+
+  test("an unset eagerEotThreshold is absent, not zero", () => {
+    expect("eagerEotThreshold" in LiveVoiceFluxConfigSchema.parse({})).toBe(
+      false,
+    );
+  });
+
+  test("accepts overrides", () => {
+    const parsed = LiveVoiceFluxConfigSchema.parse({
+      turnEnd: { enabled: true },
+      model: "flux-general-multi",
+      eotThreshold: 0.85,
+      eagerEotThreshold: 0.45,
+      eotTimeoutMs: 12_000,
+    });
+    expect(parsed.turnEnd.enabled).toBe(true);
+    expect(parsed.model).toBe("flux-general-multi");
+    expect(parsed.eotThreshold).toBe(0.85);
+    expect(parsed.eagerEotThreshold).toBe(0.45);
+    expect(parsed.eotTimeoutMs).toBe(12_000);
+  });
+
+  test("partial overrides merge with defaults", () => {
+    const parsed = LiveVoiceFluxConfigSchema.parse({ eotThreshold: 0.6 });
+    expect(parsed.eotThreshold).toBe(0.6);
+    expect(parsed.turnEnd.enabled).toBe(false);
+    expect(parsed.model).toBe("flux-general-en");
+    expect(parsed.eotTimeoutMs).toBe(5_000);
+  });
+
+  test("rejects an eotThreshold outside 0.5..0.9", () => {
+    const above = LiveVoiceFluxConfigSchema.safeParse({ eotThreshold: 0.95 });
+    expect(above.success).toBe(false);
+    expect(above.error?.issues.map((i) => i.message)).toEqual([
+      "liveVoice.flux.eotThreshold must be <= 0.9",
+    ]);
+
+    const below = LiveVoiceFluxConfigSchema.safeParse({ eotThreshold: 0.4 });
+    expect(below.success).toBe(false);
+    expect(below.error?.issues.map((i) => i.message)).toEqual([
+      "liveVoice.flux.eotThreshold must be >= 0.5",
+    ]);
+  });
+
+  test("rejects an eagerEotThreshold outside 0.3..0.9", () => {
+    expect(
+      LiveVoiceFluxConfigSchema.safeParse({ eagerEotThreshold: 0.2 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceFluxConfigSchema.safeParse({ eagerEotThreshold: 0.95 }).success,
+    ).toBe(false);
+  });
+
+  test("rejects an eotTimeoutMs outside 500..60000, and non-integers", () => {
+    expect(
+      LiveVoiceFluxConfigSchema.safeParse({ eotTimeoutMs: 499 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceFluxConfigSchema.safeParse({ eotTimeoutMs: 60_001 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceFluxConfigSchema.safeParse({ eotTimeoutMs: 1_500.5 }).success,
+    ).toBe(false);
+  });
+
+  test("rejects a non-boolean turnEnd.enabled", () => {
+    const result = LiveVoiceFluxConfigSchema.safeParse({
+      turnEnd: { enabled: "yes" },
+    });
+    expect(result.success).toBe(false);
+    const msgs = result.error?.issues.map((i) => i.message) ?? [];
+    expect(msgs.some((m) => m.includes("liveVoice.flux.turnEnd.enabled"))).toBe(
+      true,
+    );
+  });
+});
+
 describe("LiveVoiceConfigSchema", () => {
   test("empty object parses to defaults", () => {
     const parsed = LiveVoiceConfigSchema.parse({});
@@ -193,6 +284,9 @@ describe("LiveVoiceConfigSchema", () => {
         bargeInMinSpeechMs: 250,
       },
       frontModel: FRONT_MODEL_DEFAULTS,
+      // Off by default: Flux turn detection is opt-in, so the front-door hold
+      // verdict keeps committing turns until it is enabled.
+      flux: FLUX_DEFAULTS,
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio
       // artifacts on the conversation messages (JARVIS-1283).
@@ -220,6 +314,7 @@ describe("LiveVoiceConfigSchema", () => {
       mode: "ptt",
       vad: { silenceThresholdMs: 900 },
       frontModel: { endpointDecisionTimeoutMs: 300 },
+      flux: { turnEnd: { enabled: true } },
       maxSessionDurationSeconds: 600,
     });
     expect(parsed.mode).toBe("ptt");
@@ -230,6 +325,9 @@ describe("LiveVoiceConfigSchema", () => {
     // Partial frontModel overrides merge with defaults
     expect(parsed.frontModel.endpointDecisionTimeoutMs).toBe(300);
     expect(parsed.frontModel.endpointExtensionMs).toBe(1500);
+    // Partial flux overrides merge with defaults
+    expect(parsed.flux.turnEnd.enabled).toBe(true);
+    expect(parsed.flux.eotThreshold).toBe(0.7);
     expect(parsed.maxSessionDurationSeconds).toBe(600);
   });
 

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -212,6 +212,58 @@ export const LiveVoiceFrontModelConfigSchema = z
     "Front-model presence layer tuning for live voice sessions (semantic endpointing + spoken acks + progress narration)",
   );
 
+const LiveVoiceFluxTurnEndConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "liveVoice.flux.turnEnd.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Commit the live-voice turn on Flux's EndOfTurn instead of the front-door [0] hold verdict. Requires services.stt.provider to be deepgram-flux; ignored otherwise.",
+      ),
+  })
+  .describe(
+    "Which signal commits a live voice turn when Deepgram Flux is the STT provider",
+  );
+
+export const LiveVoiceFluxConfigSchema = z
+  .object({
+    turnEnd: LiveVoiceFluxTurnEndConfigSchema.default(
+      LiveVoiceFluxTurnEndConfigSchema.parse({}),
+    ),
+    model: z
+      .string({ error: "liveVoice.flux.model must be a string" })
+      .default("flux-general-en")
+      .describe("Deepgram Flux model requested when opening the STT stream"),
+    eotThreshold: z
+      .number({ error: "liveVoice.flux.eotThreshold must be a number" })
+      .min(0.5, "liveVoice.flux.eotThreshold must be >= 0.5")
+      .max(0.9, "liveVoice.flux.eotThreshold must be <= 0.9")
+      .default(0.7)
+      .describe(
+        "End-of-turn confidence Flux must reach before it emits EndOfTurn. Lower values commit sooner and cut speakers off more often; higher values wait longer and add end-of-turn latency.",
+      ),
+    eagerEotThreshold: z
+      .number({ error: "liveVoice.flux.eagerEotThreshold must be a number" })
+      .min(0.3, "liveVoice.flux.eagerEotThreshold must be >= 0.3")
+      .max(0.9, "liveVoice.flux.eagerEotThreshold must be <= 0.9")
+      .optional()
+      .describe(
+        "Confidence at which Flux starts speculating that the turn has ended. Leaving it unset disables Deepgram's EagerEndOfTurn / TurnResumed events; enabling it raises LLM calls 50-70% because speculative turns that resume are thrown away.",
+      ),
+    eotTimeoutMs: z
+      .number({ error: "liveVoice.flux.eotTimeoutMs must be a number" })
+      .int("liveVoice.flux.eotTimeoutMs must be an integer")
+      .min(500, "liveVoice.flux.eotTimeoutMs must be >= 500")
+      .max(60_000, "liveVoice.flux.eotTimeoutMs must be <= 60000")
+      .default(5_000)
+      .describe(
+        "Silence (ms) after which Flux force-ends the turn even though its end-of-turn confidence never reached eotThreshold",
+      ),
+  })
+  .describe(
+    "Deepgram Flux turn-detection tuning for live voice sessions (model-integrated end-of-turn)",
+  );
+
 export const LiveVoiceConfigSchema = z
   .object({
     mode: z
@@ -225,6 +277,9 @@ export const LiveVoiceConfigSchema = z
     vad: LiveVoiceVadConfigSchema.default(LiveVoiceVadConfigSchema.parse({})),
     frontModel: LiveVoiceFrontModelConfigSchema.default(
       LiveVoiceFrontModelConfigSchema.parse({}),
+    ),
+    flux: LiveVoiceFluxConfigSchema.default(
+      LiveVoiceFluxConfigSchema.parse({}),
     ),
     maxSessionDurationSeconds: z
       .number({
@@ -255,3 +310,4 @@ export type LiveVoiceFrontModelConfig = z.infer<
 export type LiveVoiceProgressConfig = z.infer<
   typeof LiveVoiceProgressConfigSchema
 >;
+export type LiveVoiceFluxConfig = z.infer<typeof LiveVoiceFluxConfigSchema>;


### PR DESCRIPTION
## Summary

- Add a fully-defaulted `liveVoice.flux` block (`turnEnd.enabled`, `model`, `eotThreshold`, `eagerEotThreshold`, `eotTimeoutMs`) as a sibling of `liveVoice.frontModel`, following the same zod conventions: an `error` message naming the full dotted config path on every rule, and a `.describe()` on every field.
- `turnEnd.enabled` defaults to `false` and is the feature flag for this spike (assistant-only config, not LaunchDarkly). Nothing reads it yet.
- `eagerEotThreshold` is optional with no default on purpose: leaving it unset is what disables Deepgram's speculative `EagerEndOfTurn` / `TurnResumed` events.
- No migration: the block is fully defaulted, so an existing workspace config with no `liveVoice.flux` key parses unchanged and yields `turnEnd.enabled === false`.

## Note on file placement

The plan named a new test file at `assistant/src/config/__tests__/live-voice-schema.test.ts`, but the canonical live-voice schema test already lives at `assistant/src/config/schemas/__tests__/live-voice.test.ts`. The Flux cases were added there instead of standing up a second test file for the same schema. `src/__tests__/config-schema.test.ts` asserts the full `liveVoice` defaults object, so it is updated in the same change.

Part of plan: flux-turn-detection.md (PR 2 of 8)