### PR TITLE
feat(assistant): add turn-detection events and deepgram-flux id to the STT contract

### DIFF
--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -510,6 +510,17 @@ export class MediaStreamSttSession {
     switch (event.type) {
       case "partial":
         return;
+      case "finalized":
+        return;
+      case "turn-start":
+      case "eager-turn-end":
+      case "turn-resumed":
+      case "turn-end":
+        // The local VAD and the provider's boundary finals own turn
+        // taking. Listed case-by-case rather than under `default` so the
+        // exhaustiveness check flags this site when turn detection is
+        // wired in.
+        return;
       case "final": {
         const durationMs = Math.round(this.utteranceAudioMs);
         this.utteranceAudioMs = 0;
@@ -536,6 +547,10 @@ export class MediaStreamSttSession {
           this.enterBatchMode();
         }
         return;
+      default: {
+        const _exhaustive: never = event;
+        return;
+      }
     }
   }
 

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -216,6 +216,20 @@ describe("LiveVoiceSession STT", () => {
     ]);
   });
 
+  test("ignores model-integrated turn-detection events", async () => {
+    const { frames, session, transcriber } = createSessionWithTranscriber();
+
+    await session.start();
+    transcriber.emit({ type: "turn-start" });
+    transcriber.emit({ type: "eager-turn-end", text: "eager" });
+    transcriber.emit({ type: "turn-resumed" });
+    transcriber.emit({ type: "turn-end", text: "committed", confidence: 0.9 });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(frames.map((frame) => frame.type)).toEqual(["ready"]);
+    expect(session.finalTranscriptText).toBe("");
+  });
+
   test("marks transient transcriber errors recoverable while the session continues", async () => {
     const { frames, session, transcriber } = createSessionWithTranscriber();
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -3161,6 +3161,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // Per-cycle transcribers are torn down with stop(); the finalize
         // completion signal has no cycle to advance here.
         return;
+      case "turn-start":
+      case "eager-turn-end":
+      case "turn-resumed":
+      case "turn-end":
+        // The silence boundary owns turn commits. Listed case-by-case
+        // rather than under `default` so the exhaustiveness check flags
+        // this site when turn detection is wired in.
+        return;
       case "error":
         await this.sendTranscriberErrorFrame(event);
         return;
@@ -3182,6 +3190,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }
         await this.startAssistantTurnIfReady();
         return;
+      default: {
+        const _exhaustive: never = event;
+        return;
+      }
     }
   }
 
@@ -3280,6 +3292,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.startAssistantTurnIfReady();
         return;
       }
+      case "turn-start":
+      case "eager-turn-end":
+      case "turn-resumed":
+      case "turn-end":
+        // The silence boundary owns turn commits. Listed case-by-case
+        // rather than under `default` so the exhaustiveness check flags
+        // this site when turn detection is wired in.
+        return;
       case "error":
         await this.sendTranscriberErrorFrame(event);
         return;
@@ -3317,6 +3337,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
         }
         await this.startAssistantTurnIfReady();
+        return;
+      }
+      default: {
+        const _exhaustive: never = event;
         return;
       }
     }

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -632,6 +632,10 @@ async function createStreamingTranscriber(
           : {}),
       });
     }
+    case "deepgram-flux":
+      // Flux has no streaming adapter in this factory; `null` is the
+      // documented "no streaming adapter" signal callers fall back on.
+      return null;
     default: {
       const _exhaustive: never = providerId;
       return null;

--- a/assistant/src/stt/__tests__/types.test.ts
+++ b/assistant/src/stt/__tests__/types.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import type {
   SttStreamServerClosedEvent,
+  SttStreamServerEagerTurnEndEvent,
   SttStreamServerErrorEvent,
   SttStreamServerEvent,
   SttStreamServerFinalEvent,
   SttStreamServerPartialEvent,
+  SttStreamServerTurnEndEvent,
+  SttStreamServerTurnResumedEvent,
+  SttStreamServerTurnStartEvent,
 } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -85,5 +89,95 @@ describe("SttStreamServerEvent types", () => {
     // @ts-expect-error — speakerLabel is not part of SttStreamServerClosedEvent.
     const _label: string | undefined = event.speakerLabel;
     expect(_label).toBeUndefined();
+  });
+});
+
+describe("turn-detection server events", () => {
+  test("turn-start event compiles and round-trips", () => {
+    const event: SttStreamServerTurnStartEvent = { type: "turn-start" };
+    const asUnion: SttStreamServerEvent = event;
+    expect(asUnion.type).toBe("turn-start");
+  });
+
+  test("eager-turn-end event carries the speculated transcript", () => {
+    const event: SttStreamServerEagerTurnEndEvent = {
+      type: "eager-turn-end",
+      text: "is this the end",
+    };
+    const asUnion: SttStreamServerEvent = event;
+    expect(asUnion.type).toBe("eager-turn-end");
+    expect(event.text).toBe("is this the end");
+  });
+
+  test("turn-resumed event compiles and round-trips", () => {
+    const event: SttStreamServerTurnResumedEvent = { type: "turn-resumed" };
+    const asUnion: SttStreamServerEvent = event;
+    expect(asUnion.type).toBe("turn-resumed");
+  });
+
+  test("turn-end event carries the committed transcript and optional confidence", () => {
+    const withoutConfidence: SttStreamServerTurnEndEvent = {
+      type: "turn-end",
+      text: "done speaking",
+    };
+    expect(withoutConfidence.confidence).toBeUndefined();
+
+    const event: SttStreamServerTurnEndEvent = {
+      type: "turn-end",
+      text: "done speaking",
+      confidence: 0.82,
+    };
+    const asUnion: SttStreamServerEvent = event;
+    expect(asUnion.type).toBe("turn-end");
+    expect(event.text).toBe("done speaking");
+    expect(event.confidence).toBe(0.82);
+  });
+
+  test("a consumer switch over every variant is exhaustive", () => {
+    // Fails to compile if a variant is added to SttStreamServerEvent
+    // without a case here, which is what forces consumers to be revisited.
+    const label = (event: SttStreamServerEvent): string => {
+      switch (event.type) {
+        case "partial":
+        case "final":
+        case "finalized":
+        case "error":
+        case "closed":
+          return "transcript";
+        case "turn-start":
+        case "eager-turn-end":
+        case "turn-resumed":
+        case "turn-end":
+          return "turn";
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
+    };
+
+    const events: SttStreamServerEvent[] = [
+      { type: "partial", text: "a" },
+      { type: "final", text: "a" },
+      { type: "finalized" },
+      { type: "error", category: "provider-error", message: "boom" },
+      { type: "closed" },
+      { type: "turn-start" },
+      { type: "eager-turn-end", text: "a" },
+      { type: "turn-resumed" },
+      { type: "turn-end", text: "a" },
+    ];
+
+    expect(events.map(label)).toEqual([
+      "transcript",
+      "transcript",
+      "transcript",
+      "transcript",
+      "transcript",
+      "turn",
+      "turn",
+      "turn",
+      "turn",
+    ]);
   });
 });

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -268,6 +268,11 @@ export function createDaemonBatchTranscriber(
       return new GoogleGeminiBatchTranscriber(apiKey);
     case "xai":
       return new XAIBatchTranscriber(apiKey, language);
+    case "deepgram-flux":
+      throw new SttError(
+        "provider-error",
+        "Flux is streaming-only; use the deepgram provider for batch transcription",
+      );
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -23,6 +23,11 @@
 export type SttProviderId =
   | "openai-whisper"
   | "deepgram"
+  /**
+   * Deepgram's Flux conversational speech model. Shares the `deepgram`
+   * credential and is streaming-only: Flux has no batch endpoint.
+   */
+  | "deepgram-flux"
   | "google-gemini"
   | "xai"
   | "vellum";
@@ -245,6 +250,10 @@ export type SttStreamServerEvent =
   | SttStreamServerPartialEvent
   | SttStreamServerFinalEvent
   | SttStreamServerFinalizedEvent
+  | SttStreamServerTurnStartEvent
+  | SttStreamServerEagerTurnEndEvent
+  | SttStreamServerTurnResumedEvent
+  | SttStreamServerTurnEndEvent
   | SttStreamServerErrorEvent
   | SttStreamServerClosedEvent;
 
@@ -296,6 +305,66 @@ export interface SttStreamServerFinalEvent {
  */
 export interface SttStreamServerFinalizedEvent {
   readonly type: "finalized";
+}
+
+// ---------------------------------------------------------------------------
+// Turn-detection events
+//
+// Consumers that ignore these keep committing transcripts from `final`
+// exactly as they do without a turn-detecting provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * The provider's turn model detected the start of a user turn.
+ *
+ * Emitted only by providers with model-integrated turn detection; providers
+ * without it never emit these.
+ */
+export interface SttStreamServerTurnStartEvent {
+  readonly type: "turn-start";
+}
+
+/**
+ * The provider's turn model speculates the user has finished, ahead of its
+ * committed end-of-turn decision. A {@link SttStreamServerTurnResumedEvent}
+ * retracts the speculation; a {@link SttStreamServerTurnEndEvent} confirms it.
+ *
+ * Emitted only by providers with model-integrated turn detection; providers
+ * without it never emit these.
+ */
+export interface SttStreamServerEagerTurnEndEvent {
+  readonly type: "eager-turn-end";
+  /** Transcript text as of the speculated turn end. */
+  readonly text: string;
+}
+
+/**
+ * The user kept speaking after an {@link SttStreamServerEagerTurnEndEvent},
+ * retracting the speculated turn end.
+ *
+ * Emitted only by providers with model-integrated turn detection; providers
+ * without it never emit these.
+ */
+export interface SttStreamServerTurnResumedEvent {
+  readonly type: "turn-resumed";
+}
+
+/**
+ * The provider's turn model committed an end of turn: the user has finished
+ * speaking and a reply can be dispatched.
+ *
+ * Emitted only by providers with model-integrated turn detection; providers
+ * without it never emit these.
+ */
+export interface SttStreamServerTurnEndEvent {
+  readonly type: "turn-end";
+  /** Committed transcript text for the completed turn. */
+  readonly text: string;
+  /**
+   * Provider-emitted end-of-turn confidence in [0, 1]. Undefined when the
+   * provider does not surface a score.
+   */
+  readonly confidence?: number;
 }
 
 /** An error occurred during streaming transcription. */


### PR DESCRIPTION
## Summary

- Adds four additive turn-detection variants to `SttStreamServerEvent` (`turn-start`, `eager-turn-end`, `turn-resumed`, `turn-end`) and a `deepgram-flux` `SttProviderId` that shares the `deepgram` credential and is streaming-only.
- Adds explicit no-op cases at every consumer switch (both live-voice event handlers, the media-stream STT session) plus `never` exhaustiveness guards, so the integration PR is forced to visit each site instead of a `default` branch hiding them.
- Pure contract change, no runtime behavior: a `turn-end` fed into the live-voice handler is a no-op, covered by a new test alongside per-variant and exhaustive-switch type tests.

Part of plan: flux-turn-detection.md (PR 1 of 8)