### PR TITLE
fix(memory): cancel timed-out consolidation and fail closed on its lock (LUM-3018)

### DIFF
--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
@@ -71,6 +71,7 @@ let runnerImpl: () => Promise<{
   errorKind?: string;
   failureCode?: string;
   skipReason?: string;
+  workStopped?: boolean;
 }> = runnerTrimsBuffer;
 
 mock.module("../../../../../runtime/background-job-runner.js", () => ({
@@ -745,6 +746,71 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     // Lock must still be released on the failure path so the next
     // scheduled consolidation can re-attempt.
     expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("timeout whose turn stopped cooperatively releases the lock", async () => {
+    // The runner cancelled the turn and it settled, so nothing is writing
+    // `memory/**` any more and the next run may proceed normally.
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: true,
+    });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("run_failed");
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("timeout whose turn is STILL RUNNING keeps the lock held (fail closed)", async () => {
+    // The abandoned turn may still be writing memory files, so the lock must
+    // outlive this handler. Reclamation is the pre-existing stale-lock path
+    // (holder PID death, or the stale TTL), deliberately NOT a late release
+    // from here, which could unlink a lock a successor already took over.
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: false,
+    });
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    // Truthful terminal outcome: the row still reports the failure, which
+    // `resolveConsolidationOutcome` dead-letters at the queue seam.
+    expect(result.kind).toBe("run_failed");
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  test("a retained lock excludes the next consolidation while the abandoned turn is alive", async () => {
+    // The exclusion this fix exists for: no second bulk writer may start
+    // while the timed-out turn may still be writing.
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("Background job 'memory-consolidation' timed out"),
+      errorKind: "timeout",
+      workStopped: false,
+    });
+
+    expect((await memoryV2ConsolidateJob(makeJob(), CONFIG)).kind).toBe(
+      "run_failed",
+    );
+    expect(existsSync(lockPath())).toBe(true);
+
+    // A second consolidation attempt is refused by the retained lock, and
+    // never reaches the runner.
+    const runnerCallsBefore = runnerCalls;
+    const second = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(second.kind).toBe("locked");
+    expect(runnerCalls).toBe(runnerCallsBefore);
   });
 
   test("does NOT emit a notification signal when the runner fails (suppression honored)", async () => {

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/ingest.test.ts
@@ -25,6 +25,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -277,6 +278,31 @@ describe("ingestPages", () => {
     expect(enqueuedJobs).toEqual([]);
     // The pre-existing lock is left in place for its holder.
     expect(existsSync(path)).toBe(true);
+  });
+
+  test("a lock retained by a timed-out consolidation excludes daemon-side ingest (LUM-3018)", async () => {
+    // Ingest runs in the daemon while consolidation runs in the jobs worker,
+    // and they share this lock precisely so their `memory/**` writes cannot
+    // interleave. When a consolidation times out and its turn refuses to
+    // stop, the handler deliberately leaves the lock held; this asserts the
+    // other writer is genuinely excluded for as long as that abandoned turn
+    // may still be writing, rather than merely being expected to be.
+    const path = lockPath();
+    mkdirSync(dirname(path), { recursive: true });
+    const retained = `${process.pid} ${Date.now()} consolidation`;
+    writeFileSync(path, `${retained}\n`);
+
+    await expect(
+      ingestPages(workspace, [
+        { slug: "people/alice", content: validPage("Alice likes hiking.") },
+      ]),
+    ).rejects.toBeInstanceOf(IngestLockedError);
+
+    expect(await listPages(workspace)).toEqual([]);
+    expect(enqueuedJobs).toEqual([]);
+    // Ingest must not reclaim the abandoned writer's lock: only the
+    // pre-existing stale path (PID death, or the stale TTL) may.
+    expect(readFileSync(path, "utf-8").trim()).toBe(retained);
   });
 
   test("batch over the cap throws RangeError before any validation", async () => {

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
@@ -320,6 +320,15 @@ export async function memoryV2ConsolidateJob(
     return { kind: "locked", holder };
   }
 
+  // Set when the run timed out and the underlying turn did NOT stop within
+  // the abort grace window: that turn can still be writing `memory/**`, so
+  // releasing the lock would let a second bulk writer (the next scheduled
+  // consolidation, or a page ingest, which shares this lock) run
+  // concurrently with it. Fail closed and leave the lock held; the
+  // pre-existing stale-lock recovery (holder PID death, or the stale TTL)
+  // reclaims it.
+  let abandonedRunStillWriting = false;
+
   try {
     // Step 2: bail on empty buffer. Nothing for the agent to consolidate.
     // The lock is released in finally below.
@@ -458,6 +467,16 @@ export async function memoryV2ConsolidateJob(
     });
 
     if (!runResult.ok) {
+      // A timed-out run is cooperatively aborted by the runner, which reports
+      // whether the turn actually stopped. A turn that refused to stop may
+      // still be writing memory files, so the lock must outlive this handler
+      // (see `abandonedRunStillWriting` above).
+      if (
+        runResult.errorKind === "timeout" &&
+        runResult.workStopped === false
+      ) {
+        abandonedRunStillWriting = true;
+      }
       // Billing turn failures (`PROVIDER_BILLING` covers both exhausted
       // managed credits and BYOK provider-account credits) are
       // non-retryable and select the scheduler's long backoff curve;
@@ -471,6 +490,7 @@ export async function memoryV2ConsolidateJob(
           errorKind: runResult.errorKind,
           failureCode: runResult.failureCode,
           failureKind,
+          abandonedRunStillWriting,
           err: runResult.error?.message,
         },
         "consolidation run failed; follow-ups skipped",
@@ -576,7 +596,21 @@ export async function memoryV2ConsolidateJob(
       noProgress: false,
     };
   } finally {
-    releaseLock(lockPath);
+    if (abandonedRunStillWriting) {
+      // Fail closed: the timed-out turn is still executing, so keep the lock
+      // to exclude every other bulk `memory/**` writer, including the page
+      // ingest path that shares it (ingest returns 409 while held).
+      // Reclamation is the pre-existing stale-lock path: the holder PID
+      // dying, or the stale TTL elapsing. The availability cost is bounded
+      // and deliberate, and strictly safer than releasing a lock whose
+      // writer is still running.
+      log.warn(
+        { lockPath },
+        "consolidation: leaving lock held for a timed-out run that has not stopped",
+      );
+    } else {
+      releaseLock(lockPath);
+    }
   }
 }
 

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -68,6 +68,22 @@ mock.module("../../daemon/process-message.js", () => ({
   },
 }));
 
+// The timeout path cancels the turn on the conversation's abort rail. The
+// stub records each signal and lets a test drive whether the turn actually
+// unwinds in response (`onAbort`), which is what separates a cooperative
+// stop from a turn that ignores the abort.
+const abortCalls: Array<{ conversationId: string; reasonKind?: string }> = [];
+let onAbort: (() => void) | undefined;
+
+mock.module("../../daemon/conversation-registry.js", () => ({
+  findConversation: (conversationId: string) => ({
+    abort: (reason?: { kind?: string }) => {
+      abortCalls.push({ conversationId, reasonKind: reason?.kind });
+      onAbort?.();
+    },
+  }),
+}));
+
 const emitCalls: Array<Record<string, unknown>> = [];
 let emitImpl: (
   params: Record<string, unknown>,
@@ -123,6 +139,8 @@ beforeEach(() => {
   processMessageCalls.length = 0;
   emitCalls.length = 0;
   addMessageCalls.length = 0;
+  abortCalls.length = 0;
+  onAbort = undefined;
   preFirstMessageGateOpen = true;
   processMessageImpl = async () => ({ messageId: "msg-1" });
   emitImpl = async () => ({
@@ -288,10 +306,14 @@ describe("runBackgroundJob", () => {
   });
 
   test("timeout: returns ok=false with errorKind=timeout and emits activity.failed", async () => {
-    // Never resolve — force timeout to win the race.
+    // Never resolve: force timeout to win the race. The short grace override
+    // keeps the test fast; the turn ignores the abort, so the runner waits
+    // the full window before reporting.
     processMessageImpl = () => new Promise(() => {});
 
-    const result = await runBackgroundJob(baseOpts({ timeoutMs: 50 }));
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 20 }),
+    );
 
     expect(result.ok).toBe(false);
     expect(result.errorKind).toBe("timeout");
@@ -301,6 +323,57 @@ describe("runBackgroundJob", () => {
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("timeout");
+  });
+
+  test("timeout signals the conversation's abort rail and reports workStopped=true when the turn settles", async () => {
+    // Cooperative stop: the turn observes the abort and unwinds, so its
+    // resources (the consolidation lock) are free.
+    let settle: (() => void) | undefined;
+    processMessageImpl = () =>
+      new Promise((resolve) => {
+        settle = () => resolve({ messageId: "msg-aborted" });
+      });
+    onAbort = () => settle?.();
+
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 500 }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("timeout");
+    expect(result.workStopped).toBe(true);
+    // Cancellation rode the existing abort rail with a truthful reason.
+    expect(abortCalls).toHaveLength(1);
+    expect(abortCalls[0].conversationId).toBe(STUB_CONVERSATION_ID);
+    expect(abortCalls[0].reasonKind).toBe("background_job_timeout");
+  });
+
+  test("timeout: a turn that ignores the abort reports workStopped=false", async () => {
+    // The turn never settles, so after the grace window the runner reports
+    // the work as still running. Callers guarding a shared resource must
+    // fail closed on this.
+    processMessageImpl = () => new Promise(() => {});
+
+    const result = await runBackgroundJob(
+      baseOpts({ timeoutMs: 50, timeoutAbortGraceMs: 20 }),
+    );
+
+    expect(result.errorKind).toBe("timeout");
+    expect(result.workStopped).toBe(false);
+    expect(abortCalls).toHaveLength(1);
+  });
+
+  test("workStopped is absent for non-timeout outcomes", async () => {
+    processMessageImpl = async () => {
+      throw new Error("kaboom");
+    };
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("exception");
+    expect(result.workStopped).toBeUndefined();
+    expect(abortCalls).toHaveLength(0);
   });
 
   test("suppressFailureNotifications: failure returns ok=false but emits nothing", async () => {

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -19,6 +19,7 @@
  */
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import { findConversation } from "../daemon/conversation-registry.js";
 import { processMessage } from "../daemon/process-message.js";
 import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
@@ -27,6 +28,7 @@ import type { AttentionHints } from "../notifications/signal.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import type { TitleOrigin } from "../persistence/conversation-title-service.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { hasReceivedUserMessage } from "./pre-first-message-gate.js";
 
@@ -97,6 +99,13 @@ export interface RunBackgroundJobOptions {
   cronRunId?: string | null;
   /** Hard timeout for `processMessage` in milliseconds. */
   timeoutMs: number;
+  /**
+   * How long to wait, after signalling the timed-out turn's abort, for that
+   * turn to actually settle before reporting `workStopped: false`. Defaults
+   * to {@link TIMEOUT_ABORT_GRACE_MS}. Exposed for tests; production callers
+   * take the default.
+   */
+  timeoutAbortGraceMs?: number;
   /**
    * When true, failures do NOT emit an `activity.failed` notification.
    * Use for jobs that own their own failure UX (e.g. heartbeat's alerter)
@@ -215,6 +224,92 @@ export interface RunBackgroundJobResult {
    *   was bootstrapped; `conversationId` is the empty string.
    */
   skipReason?: "pre_first_user_message";
+  /**
+   * Timeout results only: whether the underlying turn actually stopped.
+   *
+   * A timeout used to be a pure race: the timer won, the caller reported
+   * failure, and the losing `processMessage` kept running and kept writing.
+   * The runner now cancels the turn on the conversation's abort rail and
+   * waits a bounded grace window, so callers that guard a shared resource
+   * (the memory consolidation lock) can act on what actually happened
+   * instead of assuming the abandoned turn is gone:
+   *
+   * - `true`: the turn observed the abort and settled. Its resources are
+   *   free.
+   * - `false`: the turn ignored the abort for the whole grace window and may
+   *   still be executing and writing. Callers must treat its resources as
+   *   still in use (fail closed).
+   *
+   * Absent for every non-timeout outcome.
+   */
+  workStopped?: boolean;
+}
+
+/**
+ * Default grace window between signalling a timed-out turn's abort and
+ * declaring that it did not stop. Long enough for a cooperative unwind (the
+ * agent loop observes the signal at its next await, tears down, and settles)
+ * and short enough that a caller guarding a shared resource is not blocked
+ * behind an uncooperative turn.
+ */
+export const TIMEOUT_ABORT_GRACE_MS = 5_000;
+
+/**
+ * Cancel the turn a timed-out job owns and report whether it actually
+ * stopped within `graceMs`.
+ *
+ * Cancellation rides the conversation's existing abort rail (the same
+ * controller user Stop signals), so it reaches the in-flight provider call
+ * and the tool loop rather than being a second, parallel cancellation
+ * mechanism. Failing to signal is not fatal: the caller still learns the
+ * turn did not stop and fails closed on that.
+ */
+async function cancelTimedOutWork(
+  conversationId: string | undefined,
+  work: Promise<unknown> | undefined,
+  jobName: string,
+  graceMs: number,
+): Promise<boolean> {
+  if (conversationId) {
+    try {
+      findConversation(conversationId)?.abort(
+        createAbortReason(
+          "background_job_timeout",
+          `backgroundJobTimeout:${jobName}`,
+          conversationId,
+        ),
+      );
+    } catch (abortErr) {
+      log.warn(
+        {
+          err: abortErr instanceof Error ? abortErr.message : String(abortErr),
+          jobName,
+          conversationId,
+        },
+        "Failed to signal abort for timed-out background job",
+      );
+    }
+  }
+  if (!work) {
+    return true;
+  }
+  let graceTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Settled either way counts as stopped: the turn is no longer executing.
+    return await Promise.race([
+      work.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        graceTimer = setTimeout(() => resolve(false), graceMs);
+      }),
+    ]);
+  } finally {
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+    }
+  }
 }
 
 function classifyError(err: unknown): BackgroundJobErrorKind {
@@ -280,6 +375,9 @@ export async function runBackgroundJob(
     | Awaited<ReturnType<typeof bootstrapConversation>>
     | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  // Hoisted so the timeout path in `catch` can cancel the turn still holding
+  // this promise and observe whether it settles.
+  let work: ReturnType<typeof processMessage> | undefined;
   try {
     // Bootstrap inside the try so that a `createConversation` /
     // `queueGenerateConversationTitle` failure is caught and surfaced as a
@@ -339,7 +437,7 @@ export async function runBackgroundJob(
       );
     }
 
-    const work = processMessage(conversation.id, opts.prompt, {
+    work = processMessage(conversation.id, opts.prompt, {
       trustContext: opts.trustContext,
       callSite: opts.callSite,
       ...(opts.overrideProfile
@@ -393,6 +491,26 @@ export async function runBackgroundJob(
     // so the structured failure result still flows to the caller.
     const conversationId = conversation?.id ?? "";
 
+    // A timeout must not silently abandon a still-running turn. Signal the
+    // conversation's abort rail and wait a bounded grace window, so the
+    // reported outcome describes what actually happened to the work rather
+    // than only who won the race.
+    let workStopped: boolean | undefined;
+    if (err instanceof BackgroundJobTimeoutError) {
+      workStopped = await cancelTimedOutWork(
+        conversation?.id,
+        work,
+        opts.jobName,
+        opts.timeoutAbortGraceMs ?? TIMEOUT_ABORT_GRACE_MS,
+      );
+      log.warn(
+        { jobName: opts.jobName, conversationId, workStopped },
+        workStopped
+          ? "Timed-out background job cancelled cooperatively"
+          : "Timed-out background job did NOT stop within the abort grace window; treating its resources as still in use",
+      );
+    }
+
     log.error(
       {
         err: error.message,
@@ -445,6 +563,7 @@ export async function runBackgroundJob(
       error,
       errorKind,
       ...(failureCode !== undefined ? { failureCode } : {}),
+      ...(workStopped !== undefined ? { workStopped } : {}),
     };
   } finally {
     if (timer) {

--- a/assistant/src/util/abort-reasons.ts
+++ b/assistant/src/util/abort-reasons.ts
@@ -21,7 +21,9 @@ export type AbortReasonKind =
   /** A signal-file cancel was written by an out-of-process caller (CLI, hook). */
   | "signal_cancel"
   /** Voice session bridge aborted the conversation (turn supersession, call end). */
-  | "voice_session_aborted";
+  | "voice_session_aborted"
+  /** A background job's hard timeout elapsed and the runner is cancelling the turn it owns. */
+  | "background_job_timeout";
 
 const ABORT_REASON_TAG = "__vellumAbortReason" as const;
 


### PR DESCRIPTION
## TL;DR

A background-job timeout now cancels the turn it abandoned on the conversation's existing abort rail, waits a bounded grace window, and reports truthfully whether the turn stopped. Consolidation releases its lock only when the writer actually stopped; when the turn ignores the abort, it fails closed and leaves the lock held for the pre-existing stale-recovery path. **No change to the lock file format, acquire/release API, or stale-takeover implementation.**

Replaces #39915, which accumulated a broader lock-protocol redesign (inode-bound release, empty-file release semantics, rename quarantine, quarantine sweeping, per-process contender registry). That work is deliberately **not** carried over; see "Left for follow-up". Part of LUM-3018.

## Why this is needed

Verified on a live workspace (the Aug 3 oversized consolidation attempt): `runBackgroundJob`'s timeout was a pure race. The timer won, the caller reported failure, released the consolidation lock, and moved on, while the losing `processMessage` turn **kept running and kept writing `memory/**`**. Two consequences:

- **Overlapping bulk writers.** The next scheduled consolidation, or a daemon-side page ingest (which shares this lock precisely so their writes cannot interleave, #39523/#39554), could start while the abandoned turn was still mutating the same files. That is the invariant #28420 established.
- **A queue outcome that described the wrong execution.** The row and failure checkpoint reported a terminal result for work that had not stopped.

Frequency, stated honestly: on the largest workspace we have (10 GB, the box that produced the incident), consolidation ran **178 times since Jun 24 with exactly one timeout day**. This is a rare, high-consequence failure, not a common one, which is exactly why the repair is scoped to fail-closed behavior rather than a lock redesign.

## What changes

- **`runBackgroundJob`**: on timeout, signal the conversation's abort controller (the same rail user Stop uses, so cancellation reaches the in-flight provider call and the tool loop), then wait `timeoutAbortGraceMs` (default 5s) for the turn to settle. The result gains `workStopped`, present only for timeouts: `true` = the turn settled and its resources are free; `false` = it ignored the abort and may still be executing.
- **A truthful abort reason**: new `background_job_timeout` kind, rather than reusing `signal_cancel` (which means a user interrupt and makes `isUserInterruptAbort` return true).
- **`memoryV2ConsolidateJob`**: when `errorKind === "timeout" && workStopped === false`, skip the release in `finally` and log the retention. Every other path releases exactly as before.
- **Queue outcome is unchanged and already correct**: the run still returns `run_failed`, which the merged #39914 seam (`resolveConsolidationOutcome` → `applyQueueResolution`) dead-letters with an honest `last_error`. Timeout, cancellation, lock ownership, and job status now describe the same execution.

## Accepted tradeoff

An ignored-abort turn that later settles leaves the lock held until the holder PID dies or the existing stale TTL elapses. Consolidation and ingest are excluded for that window. This is a bounded availability cost, and it is deliberately preferred over releasing a lock whose writer is still running, or over redesigning the shared lock protocol inside an incident fix.

## Why this is safe

The lock primitive is untouched: same file format, same `tryAcquireLock`/`releaseLock` signatures, same stale-takeover code (`consolidation-lock.ts` has **zero** diff, and its suite passes unmodified). The only behavioral change on the success and non-timeout failure paths is none: `workStopped` is absent for every non-timeout outcome and the release path is identical. Cancellation reuses the existing abort rail rather than adding a second mechanism.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| Consolidation exceeds its timeout, turn stops when asked | Turn kept running invisibly; lock released under it | Turn is cancelled and settles; lock released normally |
| Consolidation times out, turn ignores the abort | Lock released while the turn kept writing; next run could overlap | Lock held; no consolidation or ingest can overlap the abandoned writer |
| Page ingest during an abandoned consolidation | Could write `memory/**` concurrently | Refused (409) until PID death or the stale TTL |
| Job status after a timeout | Terminal status while work possibly continued | Status, cancellation, and lock ownership describe the same execution |

## Coverage

Runner 20/20 (abort rail signalled with the `background_job_timeout` reason and `workStopped: true` on cooperative stop; `workStopped: false` when the turn ignores the abort; absent for non-timeout outcomes), consolidation job 57/57 (cooperative timeout releases the lock; ignored-abort timeout retains it with a truthful `run_failed`; a retained lock refuses the next consolidation without reaching the runner), ingest 15/15 (a lock retained by a timed-out consolidation excludes daemon-side ingest and is not reclaimed by it), consolidation lock 9/9 **unmodified**, queue outcome-contract 8/8. Typecheck, prettier, lint clean.

## Left for follow-up (not in this PR)

The generalized cross-process stale-lock protocol: concurrent stale reclaimers can still race such that one deletes a successor's lock. That is a real gap, it is **pre-existing on main** and untouched here, and it needs its own design (the process model is daemon + worker, and worker startup is probe-then-spawn with generations overlapping until PID-file eviction, so a two-process assumption is not safe to build on). Tracked separately from this incident fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->