### PR TITLE
Custom plan configurator: cadence copy, docs links, baseline machine seed

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -259,8 +259,8 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
       creditChoice: NO_EXTRA_CREDITS,
     });
 
-    // Previously the baseline produced no machine row at all, so the recap
-    // silently omitted a spec the sub actually holds.
+    // The baseline earns a row like any other machine, so the recap accounts
+    // for every spec the sub holds.
     const machineRow = diff.rows.find((r) => r.key === "machine");
     expect(machineRow?.label).toBe(BASELINE_MACHINE_LABEL);
     expect(machineRow?.changed).toBe(false);

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -11,7 +11,12 @@ import { describe, expect, test } from "bun:test";
 
 import type { ProPlan } from "@/generated/api/types.gen";
 
-import { NO_EXTRA_CREDITS, computeCustomPlanDiff } from "./custom-plan-diff";
+import {
+  BASELINE_MACHINE,
+  BASELINE_MACHINE_LABEL,
+  NO_EXTRA_CREDITS,
+  computeCustomPlanDiff,
+} from "./custom-plan-diff";
 
 function proPlan(): ProPlan {
   return {
@@ -227,7 +232,7 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(creditRow?.label).toBe("$50 of bundled credits");
   });
 
-  test("a null baseline seed machine changes without a previous label", () => {
+  test("a baseline seed machine strikes through the baseline it left", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
       seed: { machineTier: null, storageTier: "xs", creditTier: null },
@@ -239,8 +244,36 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(diff.deltaCents).toBe(3500);
     const machineRow = diff.rows.find((r) => r.key === "machine");
     expect(machineRow?.changed).toBe(true);
-    expect(machineRow?.previousLabel).toBeUndefined();
+    // The baseline has no catalog entry, but it is still what the sub was on,
+    // so the row names it rather than appearing out of nowhere.
+    expect(machineRow?.previousLabel).toBe(BASELINE_MACHINE_LABEL);
     expect(machineRow?.label).toBe("Medium machine (2.5 vCPU, 5 GiB)");
+  });
+
+  test("an untouched baseline machine gets its own unchanged row", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: null, storageTier: "xs", creditTier: null },
+      machineTier: BASELINE_MACHINE,
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    // Previously the baseline produced no machine row at all, so the recap
+    // silently omitted a spec the sub actually holds.
+    const machineRow = diff.rows.find((r) => r.key === "machine");
+    expect(machineRow?.label).toBe(BASELINE_MACHINE_LABEL);
+    expect(machineRow?.changed).toBe(false);
+    expect(machineRow?.previousLabel).toBeUndefined();
+    // It is the floor, so it adds nothing and the config is a no-op.
+    expect(diff.deltaCents).toBe(0);
+    expect(diff.previousTotalCents).toBe(diff.totalCents);
+  });
+
+  test("the baseline label matches the catalog's own description shape", () => {
+    // Guards the hand-built label against drifting from the server-provided
+    // ones it sits beside in the same dropdown.
+    expect(BASELINE_MACHINE_LABEL).toBe("Small machine (2 vCPU, 3 GiB)");
   });
 
   test("a legacy seed storage tier resolves and contributes its real price", () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -15,6 +15,11 @@ import type {
   ProPlan,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import {
+  MACHINE_FLOOR_SIZE,
+  SIZE_DESCRIPTION,
+  SIZE_LABEL,
+} from "@/lib/billing/machine-sizes";
 
 /** Sentinel for the "No extra credits" dropdown entry (Dropdown is generic over string, cannot carry real null). */
 export const NO_EXTRA_CREDITS = "__none__";
@@ -24,10 +29,24 @@ export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 export const NO_CREDITS_LABEL = "No extra credits";
 
 /**
- * The current Pro tiers used to pre-fill the modal. Unlike a submitted
- * selection, `machineTier` may be `null` — a package with no paid machine tier
- * (baseline "Small" computer) has no `MachineTierEnum` to seed, so its machine
- * dropdown starts empty and the user picks a paid tier to continue.
+ * Sentinel for the baseline machine. `MachineTierEnum` names only the paid
+ * tiers, so the small machine a package with no tier runs on has no value to
+ * carry: it is `null` on the wire, which the Dropdown cannot hold either.
+ */
+export const BASELINE_MACHINE = "__baseline__";
+export type MachineChoice = MachineTierEnum | typeof BASELINE_MACHINE;
+
+/**
+ * Matches the shape of the catalog's own machine descriptions ("Medium machine
+ * (2.5 vCPU, 5 GiB)"), built from the shared size constants because the
+ * baseline has no catalog entry to read one from.
+ */
+export const BASELINE_MACHINE_LABEL = `${SIZE_LABEL[MACHINE_FLOOR_SIZE]} machine (${SIZE_DESCRIPTION[MACHINE_FLOOR_SIZE]})`;
+
+/**
+ * The current Pro tiers used to pre-fill the modal. `machineTier` is `null` for
+ * a package with no paid machine tier, which seeds the dropdown to the baseline
+ * sentinel rather than leaving it empty.
  */
 export interface CustomPlanSeed {
   machineTier: MachineTierEnum | null;
@@ -54,7 +73,7 @@ export interface CustomPlanDiff {
 export function computeCustomPlanDiff(input: {
   proPlan: ProPlan;
   seed: CustomPlanSeed | null;
-  machineTier: MachineTierEnum | "";
+  machineTier: MachineChoice | "";
   storageTier: StorageTierEnum | "";
   creditChoice: CreditChoice | "";
 }): CustomPlanDiff {
@@ -67,8 +86,15 @@ export function computeCustomPlanDiff(input: {
   const storageTiers = proPlan.storage_tiers;
   const creditTiers = proPlan.credit_tiers ?? [];
 
-  const selectedMachine =
-    machineTiers.find((t) => t.tier === machineTier) ?? null;
+  // The baseline names no catalog tier, so it resolves to a label with no
+  // priced entry behind it rather than to a `machineTiers` row.
+  const machineIsBaseline = machineTier === BASELINE_MACHINE;
+  const selectedMachine = machineIsBaseline
+    ? null
+    : (machineTiers.find((t) => t.tier === machineTier) ?? null);
+  const selectedMachineLabel = machineIsBaseline
+    ? BASELINE_MACHINE_LABEL
+    : (selectedMachine?.description ?? null);
   const selectedStorage =
     storageTiers.find((t) => t.tier === storageTier) ?? null;
   const selectedCredit =
@@ -77,9 +103,19 @@ export function computeCustomPlanDiff(input: {
       : null;
 
   const seedMachine =
-    seed != null
+    seed != null && seed.machineTier != null
       ? (machineTiers.find((t) => t.tier === seed.machineTier) ?? null)
       : null;
+  // Normalized so a baseline seed compares against the sentinel the picker
+  // holds rather than against the null it arrives as.
+  const seedMachineChoice: MachineChoice | null =
+    seed != null ? (seed.machineTier ?? BASELINE_MACHINE) : null;
+  const seedMachineLabel =
+    seed == null
+      ? undefined
+      : seed.machineTier == null
+        ? BASELINE_MACHINE_LABEL
+        : seedMachine?.description;
   const seedStorage =
     seed != null
       ? (storageTiers.find((t) => t.tier === seed.storageTier) ?? null)
@@ -103,16 +139,15 @@ export function computeCustomPlanDiff(input: {
     },
   ];
 
-  if (selectedMachine != null) {
+  if (selectedMachineLabel != null) {
     const changed =
       seed != null &&
       !seedMachineUnresolved &&
-      seedMachine?.tier !== selectedMachine.tier;
+      seedMachineChoice !== machineTier;
     rows.push({
       key: "machine",
-      label: selectedMachine.description,
-      previousLabel:
-        changed && seedMachine != null ? seedMachine.description : undefined,
+      label: selectedMachineLabel,
+      previousLabel: changed ? seedMachineLabel : undefined,
       changed,
     });
   }

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/domains/settings/billing/plans/docs-links";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
+import * as nativeAuth from "@/runtime/native-auth";
 import * as platformGate from "@/hooks/use-platform-gate";
 import {
   organizationsBillingPlansRetrieveQueryKey,
@@ -54,6 +55,8 @@ let machineTierCall: Captured | null = null;
 let storageTierCall: Captured | null = null;
 let creditTierCall: Captured | null = null;
 let openedUrl: string | null = null;
+// True puts the app in the iOS Capacitor shell for the anchor-routing tests.
+let nativePlatform = false;
 // When non-null, the change-machine-tier call rejects with this — drives the
 // error path (the hook toasts and the caller keeps the modal open).
 let machineTierError: unknown = null;
@@ -106,6 +109,13 @@ mock.module("@/runtime/browser", () => ({
     openedUrl = url;
     return Promise.resolve();
   },
+}));
+
+// Drives `handleNativeAnchorClick`: on iOS the docs anchors must route through
+// the native opener, since the WKWebView shell cannot open a `target="_blank"`.
+mock.module("@/runtime/native-auth", () => ({
+  ...nativeAuth,
+  isNativePlatform: () => nativePlatform,
 }));
 
 // Force the platform-hosted gate open so the page mounts its pricing body
@@ -386,6 +396,7 @@ beforeEach(() => {
   storageTierCall = null;
   creditTierCall = null;
   openedUrl = null;
+  nativePlatform = false;
   machineTierError = null;
   onboardingHangs = false;
   subscriptionFixture = null;
@@ -425,6 +436,16 @@ function recapRows(): string[] {
   return Array.from(dialog?.querySelectorAll("li") ?? []).map(
     (li) => li.textContent?.trim() ?? "",
   );
+}
+
+function docsLink(href: string): HTMLAnchorElement {
+  const link = document.querySelector<HTMLAnchorElement>(
+    `[role="dialog"] a[href="${href}"]`,
+  );
+  if (!link) {
+    throw new Error(`expected a docs link to ${href}`);
+  }
+  return link;
 }
 
 /** Struck-through (previous-value) recap labels. */
@@ -767,6 +788,31 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(hrefs).toContain(MACHINE_DOCS_URL);
     expect(hrefs).toContain(STORAGE_DOCS_URL);
     expect(hrefs).toContain(CREDIT_DOCS_URL);
+  });
+
+  test("on iOS the docs links open through the native opener", () => {
+    // The WKWebView shell cannot open a target="_blank" anchor, so an
+    // unhandled click would silently do nothing.
+    nativePlatform = true;
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    const link = docsLink(STORAGE_DOCS_URL);
+    const dispatched = fireEvent.click(link);
+
+    expect(openedUrl).toBe(STORAGE_DOCS_URL);
+    // Default prevented, so the shell never gets the dead new-tab navigation.
+    expect(dispatched).toBe(false);
+  });
+
+  test("off native the docs links keep their plain new-tab behavior", () => {
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    const dispatched = fireEvent.click(docsLink(STORAGE_DOCS_URL));
+
+    expect(openedUrl).toBeNull();
+    expect(dispatched).toBe(true);
   });
 
   test("a baseline Pro sub picking a machine dispatches the upgrade", async () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -24,6 +24,12 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
+import { BASELINE_MACHINE_LABEL } from "@/domains/settings/billing/plans/custom-plan-diff";
+import {
+  CREDIT_DOCS_URL,
+  MACHINE_DOCS_URL,
+  STORAGE_DOCS_URL,
+} from "@/domains/settings/billing/plans/docs-links";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
 import * as platformGate from "@/hooks/use-platform-gate";
@@ -697,10 +703,11 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(queryByTestId("resize-takeover")).toBeNull();
   });
 
-  test("a baseline (null machine) Pro sub can still open and reconfigure", () => {
+  test("a baseline (null machine) Pro sub opens seeded to the baseline machine", () => {
     // A package with no paid machine tier reports max_machine_tier: null. That
-    // sub must still reach the modal (not route to manage); storage/credit seed
-    // and the machine picker starts empty, so Continue waits for a machine pick.
+    // sub must still reach the modal (not route to manage), and every dimension
+    // seeds, the baseline included, so the picker states what they run on
+    // instead of reading as unset.
     const { getByRole, getByText } = renderPage(
       proMightySubscription(),
       onboarding({ max_machine_tier: null }),
@@ -708,12 +715,58 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
     getByText("Create a custom plan");
+    // The seeded config is a no-op, so Continue waits for a real change.
     expect(continueButton().disabled).toBe(true);
 
-    // Storage and credit are seeded even though the machine is unset.
     const rows = recapRows();
+    expect(rows).toContain(BASELINE_MACHINE_LABEL);
     expect(rows).toContain("10 GB storage");
     expect(rows).toContain("No extra credits");
+  });
+
+  test("the baseline machine is offered to nobody else", () => {
+    // A sub on a paid tier must not be able to drop to the baseline from here:
+    // the change-tier scoring would read a to-null move as an upgrade and open
+    // the resize takeover for what is really a downgrade.
+    const { getByRole } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Machine size");
+
+    expect(optionLabels()).not.toContain(BASELINE_MACHINE_LABEL);
+  });
+
+  test("the baseline machine is withheld from a base checkout", () => {
+    // No seed at all, so there is no held baseline to preserve.
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Machine size");
+
+    expect(optionLabels()).not.toContain(BASELINE_MACHINE_LABEL);
+  });
+
+  test("the recap states the billing cadence", () => {
+    // Moved here off the Custom Plan row, where it sat apart from any price.
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog?.textContent).toContain("Billed monthly");
+  });
+
+  test("each picker links to its own pricing docs section", () => {
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    const hrefs = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('[role="dialog"] a'),
+    ).map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain(MACHINE_DOCS_URL);
+    expect(hrefs).toContain(STORAGE_DOCS_URL);
+    expect(hrefs).toContain(CREDIT_DOCS_URL);
   });
 
   test("a baseline Pro sub picking a machine dispatches the upgrade", async () => {
@@ -724,6 +777,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
     selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+    // The baseline it is leaving is struck through, like any other seed value.
+    expect(strikethroughs()).toContain(BASELINE_MACHINE_LABEL);
     fireEvent.click(continueButton());
 
     await waitFor(() => expect(machineTierCall).not.toBeNull());

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -727,8 +727,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
   test("a baseline (null machine) Pro sub opens seeded to the baseline machine", () => {
     // A package with no paid machine tier reports max_machine_tier: null. That
     // sub must still reach the modal (not route to manage), and every dimension
-    // seeds, the baseline included, so the picker states what they run on
-    // instead of reading as unset.
+    // seeds, the baseline included, so the picker names the machine they run on
+    // rather than showing its placeholder.
     const { getByRole, getByText } = renderPage(
       proMightySubscription(),
       onboarding({ max_machine_tier: null }),
@@ -768,7 +768,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
   });
 
   test("the recap states the billing cadence", () => {
-    // Moved here off the Custom Plan row, where it sat apart from any price.
+    // The recap owns the cadence, so it reads beside the total it describes.
     const { getByRole } = renderPage(freeSubscription());
 
     fireEvent.click(getByRole("button", { name: "Configure" }));

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -20,6 +20,7 @@ import type {
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { Button } from "@vellumai/design-library/components/button";
 import {
   Dropdown,
@@ -91,6 +92,9 @@ function priceSuffix(cents: number) {
 /**
  * A picker's caption and its docs link. The three links read "Learn more"
  * alike, so each takes an `aria-label` naming the dimension it explains.
+ * The click routes through the native opener because the iOS WKWebView shell
+ * cannot open a `target="_blank"` anchor on its own; the `href` stays for
+ * web and Electron.
  */
 function PickerLabel({
   label,
@@ -111,6 +115,7 @@ function PickerLabel({
         target="_blank"
         rel="noopener noreferrer"
         aria-label={docsLabel}
+        onClick={(e) => handleNativeAnchorClick(e, docsUrl)}
         className="text-[11px] font-medium text-[var(--content-tertiary)] underline hover:text-[var(--content-default)]"
       >
         Learn more

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -28,17 +28,26 @@ import {
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import {
+  BASELINE_MACHINE,
+  BASELINE_MACHINE_LABEL,
   type CreditChoice,
   type CustomPlanSeed,
+  type MachineChoice,
   computeCustomPlanDiff,
   NO_CREDITS_LABEL,
   NO_EXTRA_CREDITS,
 } from "./custom-plan-diff";
+import {
+  CREDIT_DOCS_URL,
+  MACHINE_DOCS_URL,
+  STORAGE_DOCS_URL,
+} from "./docs-links";
 
 export type { CustomPlanSeed };
 
 export interface CustomPlanSelection {
-  machineTier: MachineTierEnum;
+  /** `null` is the baseline machine: the absence of a paid tier. */
+  machineTier: MachineTierEnum | null;
   storageTier: StorageTierEnum;
   /** `null` is the explicit "No extra credits" choice. */
   creditTier: CreditTierEnum | null;
@@ -62,9 +71,9 @@ export interface CustomPlanModalProps {
    * plan. Pre-fills every dimension; the seeded default is a no-op, so Continue
    * stays disabled until a dimension changes, and an unrelated edit can't force
    * re-picking — and dropping — a tier the user still holds. A null
-   * `machineTier` (baseline "Small") seeds storage/credit and leaves the machine
-   * picker empty. Leave null/undefined for base checkout, which starts every
-   * dimension empty.
+   * `machineTier` is the baseline machine, seeded as a disabled option so the
+   * picker states what the sub runs on rather than reading as unset. Leave
+   * null/undefined for base checkout, which starts every dimension empty.
    */
   initialSelection?: CustomPlanSeed | null;
   onClose: () => void;
@@ -76,6 +85,37 @@ function priceSuffix(cents: number) {
     <span className="text-[12px] font-medium text-[var(--content-disabled)]">
       +{formatMonthly(cents)}
     </span>
+  );
+}
+
+/**
+ * A picker's caption and its docs link. The three links read "Learn more"
+ * alike, so each takes an `aria-label` naming the dimension it explains.
+ */
+function PickerLabel({
+  label,
+  docsUrl,
+  docsLabel,
+}: {
+  label: string;
+  docsUrl: string;
+  docsLabel: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-[11px] font-medium text-[var(--content-secondary)]">
+        {label}
+      </span>
+      <a
+        href={docsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={docsLabel}
+        className="text-[11px] font-medium text-[var(--content-tertiary)] underline hover:text-[var(--content-default)]"
+      >
+        Learn more
+      </a>
+    </div>
   );
 }
 
@@ -99,10 +139,11 @@ export function CustomPlanModal({
 }: CustomPlanModalProps) {
   // A Pro reconfigure seeds the current tiers so the default is a no-op; base
   // checkout passes none and leaves every dimension empty. A baseline machine
-  // (null) has no tier to seed, so its picker starts empty.
+  // (null) seeds the sentinel, mirroring how a null credit tier seeds
+  // "No extra credits".
   const seed = open ? (initialSelection ?? null) : null;
-  const [machineTier, setMachineTier] = useState<MachineTierEnum | "">(
-    () => seed?.machineTier ?? "",
+  const [machineTier, setMachineTier] = useState<MachineChoice | "">(() =>
+    seed ? (seed.machineTier ?? BASELINE_MACHINE) : "",
   );
   const [storageTier, setStorageTier] = useState<StorageTierEnum | "">(
     () => seed?.storageTier ?? "",
@@ -120,7 +161,7 @@ export function CustomPlanModal({
     seededFrom.initialSelection !== initialSelection
   ) {
     setSeededFrom({ open, initialSelection });
-    setMachineTier(seed?.machineTier ?? "");
+    setMachineTier(seed ? (seed.machineTier ?? BASELINE_MACHINE) : "");
     setStorageTier(seed?.storageTier ?? "");
     setCreditChoice(seed ? (seed.creditTier ?? NO_EXTRA_CREDITS) : "");
   }
@@ -152,15 +193,28 @@ export function CustomPlanModal({
     (t.legacy && t.tier !== initialSelection?.storageTier) ||
     (currentStorageGib != null && t.storage_gib < currentStorageGib);
 
-  const machineOptions: DropdownOption<MachineTierEnum>[] = machineTiers.map(
-    (t) => ({
-      value: t.tier as MachineTierEnum,
+  // The baseline is not a tier the catalog offers, so it is listed only for the
+  // sub already on it: present so the picker can state what they run on, and
+  // disabled because moving back down to it is not a change this modal makes.
+  // It carries no price suffix, since it adds nothing to the total.
+  const seededBaselineMachine =
+    initialSelection != null && initialSelection.machineTier == null;
+  const baselineMachineOption: DropdownOption<MachineChoice> = {
+    value: BASELINE_MACHINE,
+    label: BASELINE_MACHINE_LABEL,
+    icon: <Computer className="h-4 w-4" aria-hidden />,
+    disabled: true,
+  };
+  const machineOptions: DropdownOption<MachineChoice>[] = [
+    ...(seededBaselineMachine ? [baselineMachineOption] : []),
+    ...machineTiers.map((t) => ({
+      value: t.tier as MachineChoice,
       label: t.description,
       icon: <Computer className="h-4 w-4" aria-hidden />,
       suffix: priceSuffix(t.price_cents),
       disabled: isTierDisabled(t),
-    }),
-  );
+    })),
+  ];
   const storageOptions: DropdownOption<StorageTierEnum>[] =
     offerableStorageTiers.map((t) => ({
       value: t.tier as StorageTierEnum,
@@ -204,8 +258,23 @@ export function CustomPlanModal({
       : []),
   ];
 
-  const selectedMachine =
-    machineTiers.find((t) => t.tier === machineTier) ?? null;
+  const machineIsBaseline = machineTier === BASELINE_MACHINE;
+  const selectedMachine = machineIsBaseline
+    ? null
+    : (machineTiers.find((t) => t.tier === machineTier) ?? null);
+  // The submittable machine, as the tier the API takes: `null` IS the baseline,
+  // so the choice is wrapped rather than reported as a bare tier. The baseline
+  // passes through only for the sub it was seeded from, matching the storage
+  // and credit guards below. The dropdown renders it disabled for anyone else,
+  // and a disabled choice must not be submittable.
+  const submittableMachine: { tier: MachineTierEnum | null } | null =
+    machineIsBaseline
+      ? seededBaselineMachine
+        ? { tier: null }
+        : null
+      : selectedMachine != null
+        ? { tier: selectedMachine.tier as MachineTierEnum }
+        : null;
 
   // A tier the dropdown renders disabled would be rejected server-side, and a
   // plans refetch can disable the standing selection mid-modal. The seeded
@@ -226,7 +295,7 @@ export function CustomPlanModal({
     creditChoice !== "" && creditIsSubmittable ? creditChoice : null;
 
   const complete =
-    selectedMachine != null &&
+    submittableMachine != null &&
     submittableStorage != null &&
     submittableCredit != null;
 
@@ -238,7 +307,7 @@ export function CustomPlanModal({
   // as changed once the user picks a live replacement.
   const matchesSeed =
     initialSelection != null &&
-    machineTier === (initialSelection.machineTier ?? "") &&
+    machineTier === (initialSelection.machineTier ?? BASELINE_MACHINE) &&
     storageTier === initialSelection.storageTier &&
     creditChoice === (initialSelection.creditTier ?? NO_EXTRA_CREDITS);
 
@@ -259,7 +328,7 @@ export function CustomPlanModal({
       return;
     }
     onContinue({
-      machineTier: selectedMachine.tier as MachineTierEnum,
+      machineTier: submittableMachine.tier,
       storageTier: submittableStorage.tier as StorageTierEnum,
       creditTier:
         submittableCredit === NO_EXTRA_CREDITS ? null : submittableCredit,
@@ -306,10 +375,12 @@ export function CustomPlanModal({
               </div>
 
               <div className="flex flex-col gap-1">
-                <span className="text-[11px] font-medium text-[var(--content-secondary)]">
-                  Select a machine size:
-                </span>
-                <Dropdown<MachineTierEnum>
+                <PickerLabel
+                  label="Select a machine size:"
+                  docsUrl={MACHINE_DOCS_URL}
+                  docsLabel="Learn more about machine sizes"
+                />
+                <Dropdown<MachineChoice>
                   aria-label="Machine size"
                   placeholder="Select a machine size"
                   value={machineTier}
@@ -319,9 +390,11 @@ export function CustomPlanModal({
               </div>
 
               <div className="flex flex-col gap-1">
-                <span className="text-[11px] font-medium text-[var(--content-secondary)]">
-                  Select storage:
-                </span>
+                <PickerLabel
+                  label="Select storage:"
+                  docsUrl={STORAGE_DOCS_URL}
+                  docsLabel="Learn more about storage"
+                />
                 <Dropdown<StorageTierEnum>
                   aria-label="Storage"
                   placeholder="Select storage"
@@ -332,9 +405,11 @@ export function CustomPlanModal({
               </div>
 
               <div className="flex flex-col gap-1">
-                <span className="text-[11px] font-medium text-[var(--content-secondary)]">
-                  Bundle some credits:
-                </span>
+                <PickerLabel
+                  label="Bundle some credits:"
+                  docsUrl={CREDIT_DOCS_URL}
+                  docsLabel="Learn more about credit bundles"
+                />
                 <Dropdown<CreditChoice>
                   aria-label="Credit bundle"
                   placeholder="Select a credit bundle"
@@ -366,7 +441,7 @@ export function CustomPlanModal({
                       </span>
                     )}
                   <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
-                    Total
+                    Total · Billed monthly
                   </span>
                 </div>
 

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -73,8 +73,9 @@ export interface CustomPlanModalProps {
    * stays disabled until a dimension changes, and an unrelated edit can't force
    * re-picking — and dropping — a tier the user still holds. A null
    * `machineTier` is the baseline machine, seeded as a disabled option so the
-   * picker states what the sub runs on rather than reading as unset. Leave
-   * null/undefined for base checkout, which starts every dimension empty.
+   * picker names the machine the sub runs on rather than showing its
+   * placeholder. Leave null/undefined for base checkout, which starts every
+   * dimension empty.
    */
   initialSelection?: CustomPlanSeed | null;
   onClose: () => void;

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
@@ -22,6 +22,11 @@ describe("CustomPlanRow", () => {
     expect(queryByText("Your Current Plan")).toBeNull();
   });
 
+  test("states no billing cadence, which belongs to the configurator", () => {
+    const { queryByText } = render(<CustomPlanRow onConfigure={() => {}} />);
+    expect(queryByText("Billed monthly")).toBeNull();
+  });
+
   test("renders the current-plan tag when isCurrent", () => {
     const { queryByText } = render(
       <CustomPlanRow onConfigure={() => {}} isCurrent />,

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -71,9 +71,6 @@ export function CustomPlanRow({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-3">
-          <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
-            Billed monthly
-          </span>
           <Button
             variant="outlined"
             onClick={onConfigure}

--- a/clients/web/src/domains/settings/billing/plans/docs-links.ts
+++ b/clients/web/src/domains/settings/billing/plans/docs-links.ts
@@ -1,0 +1,11 @@
+/**
+ * Pricing docs links used by the plans takeover and the custom-plan
+ * configurator. The per-dimension anchors point at the sections of the pricing
+ * page that explain each picker.
+ */
+
+export const PRICING_DOCS_URL = "https://www.vellum.ai/docs/pricing";
+
+export const MACHINE_DOCS_URL = `${PRICING_DOCS_URL}#machine-sizes`;
+export const STORAGE_DOCS_URL = `${PRICING_DOCS_URL}#storage`;
+export const CREDIT_DOCS_URL = `${PRICING_DOCS_URL}#credit-bundles`;

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -430,7 +430,6 @@ describe("PlansPage — full catalog render", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Custom Plan");
     expect(html).toContain("Configure");
-    expect(html).toContain("Billed monthly");
     expect(html).toContain("Read our Docs.");
   });
 });
@@ -643,9 +642,7 @@ afterEach(() => {
 describe("PlansPage on native Android", () => {
   test("redirects to billing without exposing plan actions", async () => {
     nativeAndroid = true;
-    const { getByTestId, queryByRole } = renderInteractive(
-      freeSubscription(),
-    );
+    const { getByTestId, queryByRole } = renderInteractive(freeSubscription());
 
     await waitFor(() =>
       expect(getByTestId("loc").textContent).toBe(

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -27,6 +27,7 @@ import {
   type CustomPlanSelection,
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { CustomPlanRow } from "@/domains/settings/billing/plans/custom-plan-row";
+import { PRICING_DOCS_URL } from "@/domains/settings/billing/plans/docs-links";
 import { FreeDowngradeConfirmModal } from "@/domains/settings/billing/plans/free-downgrade-confirm-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
@@ -87,10 +88,6 @@ import { toast } from "@vellumai/design-library/components/toast";
 // Near-black takeover canvas. No surface token holds this value — the darkest
 // dark-theme surface is `--surface-base` (#17191C) — so the raw hex stands.
 const PAGE_BACKGROUND = "#0A0A0B";
-
-// External pricing docs — the closest existing docs link in the web client
-// (also used by the AI settings pricing banner).
-const DOCS_URL = "https://www.vellum.ai/docs/pricing";
 
 // How long the `?package=` deep link waits for its forced re-read of the
 // billing data before deciding on whatever the cache already holds.
@@ -858,7 +855,7 @@ function PlansPageContent() {
         <p className="mt-6 text-center text-[12px] font-medium text-[var(--content-tertiary)] sm:mt-10">
           You can cancel or change your plan anytime you want. To learn more{" "}
           <a
-            href={DOCS_URL}
+            href={PRICING_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-[var(--content-default)] underline"

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -38,7 +38,12 @@ export interface CurrentTiers {
 
 /** A three-dimension custom selection to apply (mirrors `CustomPlanSelection`). */
 export interface ChangeTiersSelection {
-  machineTier: MachineTierEnum;
+  /**
+   * `null` is the baseline machine. Only a sub already on the baseline can
+   * submit it (the configurator offers it to no one else), so it always equals
+   * `current.machineTier` and dispatches nothing.
+   */
+  machineTier: MachineTierEnum | null;
   storageTier: StorageTierEnum;
   /** `null` is the explicit "No extra credits" choice. */
   creditTier: CreditTierEnum | null;


### PR DESCRIPTION
Three fixes to the Custom Plan flow on the plans takeover.

## 1. "Billed monthly" moves into the recap

It sat in the Custom Plan banner between the descriptor and the Configure button, apart from any price, where it read as a stray label. It now captions the total in the configurator's recap: `Total · Billed monthly`.

The named plan column cards keep their own `priceCaption`, so the custom row is deliberately the only one on the page without the copy.

## 2. Per-dimension docs links

The modal had none. The only pricing-docs link on this surface is the page footer, which the dialog covers while open, so the link was unreachable at exactly the moment the user was choosing between machine sizes, storage and credit bundles.

Each picker label row now carries a "Learn more" link to its own section:

| Picker | Anchor |
| --- | --- |
| Machine size | `/docs/pricing#machine-sizes` |
| Storage | `/docs/pricing#storage` |
| Credit bundle | `/docs/pricing#credit-bundles` |

All three read "Learn more", so each takes an `aria-label` naming its dimension. A new `billing/plans/docs-links.ts` holds the base URL and the anchors; `plans-page.tsx` now imports it instead of keeping a private copy.

## 3. The baseline machine seeds and displays

A Pro subscriber on the baseline machine opened the modal with an apparently-unset machine picker, and `computeCustomPlanDiff` omitted the machine row from the recap entirely. They saw no machine anywhere despite having one.

The cause: `MachineTierEnum` is `'medium' | 'large' | 'xl'`. The baseline is the *absence* of a paid tier (`null`), so there was nothing to seed. A `BASELINE_MACHINE` sentinel now carries it, mirroring how `NO_EXTRA_CREDITS` already carries "no credit bundle" in the same file.

It is display-only: offered solely to the sub already on it, and rendered disabled. Making it selectable would let a paid sub drop to the baseline, and `changeTiers` scores that wrong today (machine prices resolve to `null` for a to-null move, so `machineIsDowngrade` is false and `needsResize` comes back true), wrongly opening the resize takeover for a downgrade. Fixing that scoring is a separate change.

Because it is display-only, `selection.machineTier === null` can only come from a baseline sub who never touched the picker, so `machineChanged` is `null !== null` and no machine mutation is ever dispatched. That is why `use-change-tiers.ts` needs only a type widening.

A bonus fix falls out: a baseline-to-paid move now strikes through the baseline it left, which previously rendered nothing at all.

## Notes

- `BASELINE_MACHINE_LABEL` is built from the shared `SIZE_LABEL` / `SIZE_DESCRIPTION` constants rather than hardcoded, so it matches the catalog's own description shape ("Medium machine (2.5 vCPU, 5 GiB)"). A test pins the exact string, since it is the one machine label the client authors rather than reads from the server.
- `plans-page.test.tsx` loses a `toContain("Billed monthly")` assertion. It ran against the whole page, so the named column cards kept satisfying it: it would have gone on passing after the row lost the copy, proving nothing.

## Verification

- `tsc --noEmit`, eslint and prettier all clean.
- 184 tests pass across 7 suites (custom-plan-modal, custom-plan-diff, custom-plan-row, plans-page, plans-page-checkout, use-change-tiers, adjust-plan-modal), each run in isolation. A multi-file local run shows 2 failures that vanish when the files run separately, which is this repo's known cross-file mock leakage rather than a real break.

**Outstanding:** the baseline-machine path has not been browser-verified. It only triggers for a Pro sub on a machine-less package (e.g. Mighty) and needs a real platform session. Worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)