### PR TITLE
fix(queue): keep daemon-injected notifications out of the queue drawer

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -935,10 +935,20 @@ describe("Conversation message queue", () => {
       position: 1,
     });
 
-    // Drain so the conversation finishes cleanly.
+    // Suppressing the ack changes only what clients are told: the row is
+    // still queued, still drains, and still wakes the parent on the notification
+    // text (delivery is asserted end-to-end in "drained subagent-notification
+    // message persists and wakes the agent but emits no user_message_echo").
     await resolveRun(0);
     await p1;
+    await waitForPendingRun(2);
     await waitForCondition(() => conversation.getQueueDepth() === 0);
+    expect(
+      capturedAddMessages.some((m) =>
+        m.content.includes("hermes-local-review"),
+      ),
+    ).toBe(true);
+
     for (let i = 1; i < pendingRuns.length; i++) {
       await resolveRun(i);
     }

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -883,6 +883,68 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
+  test("subagent notifications are never acked with message_queued and don't shift visible positions", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const notificationEvents: AssistantEvent[] = [];
+    const visibleEvents: AssistantEvent[] = [];
+
+    const p1 = conversation.processMessage({
+      content: "msg-1",
+      attachments: [],
+      requestId: "req-1",
+    });
+    await waitForPendingRun(1);
+
+    // A subagent's completion summary injected into a busy parent is daemon
+    // scaffolding: the user follows that run through its inline card, so the
+    // row gets no queued ack and no queue-drawer bubble.
+    const notification = conversation.enqueueMessage({
+      content: '[Subagent "hermes-local-review" — important] review finished',
+      onEvent: (e) => notificationEvents.push(e),
+      requestId: "req-subagent",
+      metadata: {
+        subagentNotification: {
+          subagentId: "sub-1",
+          label: "hermes-local-review",
+          status: "completed",
+          conversationId: "conv-sub-1",
+          objective: "review the diff",
+        },
+      },
+    });
+    expect(notification.queued).toBe(true);
+    expect(
+      notificationEvents.filter((e) => e.type === "message_queued"),
+    ).toEqual([]);
+
+    // The user's own send queued behind it is position 1: the notification
+    // does not consume a visible slot, matching the cold-load snapshot.
+    const visible = conversation.enqueueMessage({
+      content: "visible-msg",
+      onEvent: (e) => visibleEvents.push(e),
+      requestId: "req-visible",
+    });
+    expect(visible.queued).toBe(true);
+    expect(conversation.getQueueDepth()).toBe(2);
+    expect(
+      visibleEvents.find((e) => e.type === "message_queued"),
+    ).toMatchObject({
+      requestId: "req-visible",
+      position: 1,
+    });
+
+    // Drain so the conversation finishes cleanly.
+    await resolveRun(0);
+    await p1;
+    await waitForCondition(() => conversation.getQueueDepth() === 0);
+    for (let i = 1; i < pendingRuns.length; i++) {
+      await resolveRun(i);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
   test("abort() clears the queue and closes out each queued message", async () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -192,6 +192,49 @@ describe("handleListMessages in-memory queue", () => {
     expect(body.messages[0].queuePosition).toBe(1);
   });
 
+  test("filters daemon-injected notifications from the snapshot, keeping positions contiguous", async () => {
+    // A subagent's completion summary injected into a busy parent queues like
+    // any other turn, but it is scaffolding the user follows through the
+    // subagent card — never a queued bubble they could steer or cancel. Same
+    // for ACP run outcomes and wake triggers.
+    const conv = createConversation();
+    registerLiveConversation(conv.id, [
+      makeQueued({
+        requestId: "req-subagent",
+        content: '[Subagent "hermes-local-review" — important] review finished',
+        metadata: {
+          subagentNotification: {
+            subagentId: "sub-1",
+            label: "hermes-local-review",
+            status: "completed",
+            conversationId: "conv-sub-1",
+            objective: "review the diff",
+          },
+        },
+      }),
+      makeQueued({
+        requestId: "req-acp",
+        content: "[ACP run finished]",
+        metadata: { acpNotification: { acpSessionId: "acp-1" } },
+      }),
+      makeQueued({
+        requestId: "req-wake",
+        content: '<background_event source="schedule">',
+        metadata: { backgroundEventSource: "schedule" },
+      }),
+      makeQueued({ requestId: "req-visible", content: "a real message" }),
+    ]);
+
+    const response = await handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].id).toBe("req-visible");
+    expect(body.messages[0].queuePosition).toBe(1);
+  });
+
   test("does not append queued messages to an older-history page", async () => {
     // GIVEN history requested with beforeTimestamp (older page)
     const conv = createConversation();

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -12,7 +12,7 @@ import { getConfig } from "../config/loader.js";
 import { usesConceptPageMemory } from "../config/memory-v3-gate.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
-import { isHiddenMessageMetadata } from "../persistence/conversation-types.js";
+import { isSuppressedQueuedMessage } from "../persistence/conversation-types.js";
 import {
   enqueueMemoryJob,
   isMemoryEnabled,
@@ -197,9 +197,11 @@ function preserveQueueAcrossInterrupt(
  * closes out the turn the message was waiting on; `message_queued_deleted` is
  * the terminal event for the queued row itself, the same one a user-issued
  * DELETE emits (`deleteQueuedMessage`). Without the second, a client holds the
- * pending indicator forever, since no `message_dequeued` is coming. Hidden
- * sends are suppressed for the same reason they get no queued ack: they have
- * no client row to close.
+ * pending indicator forever, since no `message_dequeued` is coming. Rows with
+ * no client-visible queued counterpart ({@link isSuppressedQueuedMessage} —
+ * hidden sends and daemon-injected subagent/ACP/wake notifications) are
+ * suppressed for the same reason they get no queued ack: they have no client
+ * row to close.
  */
 function discardQueueOnAbort(ctx: AbortContext): void {
   for (const queued of ctx.queue) {
@@ -207,7 +209,7 @@ function discardQueueOnAbort(ctx: AbortContext): void {
       type: "generation_cancelled",
       conversationId: ctx.conversationId,
     });
-    if (isHiddenMessageMetadata(queued.metadata)) {
+    if (isSuppressedQueuedMessage(queued.metadata)) {
       continue;
     }
     queued.onEvent({

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -48,7 +48,7 @@ import {
   extractAttachmentStoredPaths,
   extractImageSourcePaths,
   getConversation,
-  isHiddenMessageMetadata,
+  isSuppressedQueuedMessage,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
@@ -636,16 +636,17 @@ export function enqueueMessage(
   }
   // Ack the accepted enqueue on the sender's event sink. Emitting here,
   // rather than at each ingress call site, is what guarantees every path
-  // that queues (HTTP send, surface actions, agent wake, subagent
-  // notifications) surfaces the queued row live. Hidden sends are
-  // suppressed from the transcript at every stage, including this ack,
-  // and `position` counts visible items only: both mirror the
-  // list-messages queued-snapshot filter so a live ack and a cold reload
-  // render the same row at the same position.
-  if (!isHiddenMessageMetadata(metadata)) {
+  // that queues a person's prompt (HTTP send, surface actions, CLI signal)
+  // surfaces the queued row live. Rows with no client-visible counterpart —
+  // hidden sends and daemon-injected notifications (subagent/ACP/wake) — are
+  // suppressed from the transcript at every stage, including this ack, and
+  // `position` counts visible items only: both mirror the list-messages
+  // queued-snapshot filter so a live ack and a cold reload render the same
+  // row at the same position.
+  if (!isSuppressedQueuedMessage(metadata)) {
     const position = ctx.queue
       .snapshot()
-      .filter((item) => !isHiddenMessageMetadata(item.metadata)).length;
+      .filter((item) => !isSuppressedQueuedMessage(item.metadata)).length;
     onEvent?.({
       type: "message_queued",
       conversationId: ctx.conversationId,

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -26,6 +26,7 @@ import {
   addMessage,
   isEchoSuppressedUserMessage,
   isHiddenMessageMetadata,
+  isSuppressedQueuedMessage,
   provenanceFromTrustContext,
   recordConversationPersistedSeq,
   setConversationOriginChannelIfUnset,
@@ -440,7 +441,7 @@ function visibleQueuePosition(
 ): number | undefined {
   let position = 0;
   for (const item of conversation.queue.snapshot()) {
-    if (isHiddenMessageMetadata(item.metadata)) {
+    if (isSuppressedQueuedMessage(item.metadata)) {
       continue;
     }
     position += 1;
@@ -466,8 +467,10 @@ function visibleQueuePosition(
  * `message_dequeued` and would otherwise see the row vanish until a later
  * drain. Messages requeued before the announcement (the pre-flight
  * processing-lock checks) get nothing, because clients never stopped showing
- * them as queued and an event there would be noise. Hidden sends are suppressed
- * for the same reason they get no queued ack: they have no client row.
+ * them as queued and an event there would be noise. Rows with no client-visible
+ * queued counterpart ({@link isSuppressedQueuedMessage} — hidden sends and
+ * daemon-injected subagent/ACP/wake notifications) are suppressed for the same
+ * reason they get no queued ack: they have no client row.
  */
 function requeueDrainedMessages(
   conversation: Conversation,
@@ -494,7 +497,7 @@ function requeueDrainedMessages(
       continue;
     }
     message.dequeueAnnounced = false;
-    if (isHiddenMessageMetadata(message.metadata)) {
+    if (isSuppressedQueuedMessage(message.metadata)) {
       continue;
     }
     const position = visibleQueuePosition(conversation, message.requestId);

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -3,7 +3,7 @@ import { decideGuardianRequest } from "../../channels/gateway-guardian-requests.
 import {
   clearAll,
   getConversation,
-  isHiddenMessageMetadata,
+  isSuppressedQueuedMessage,
 } from "../../persistence/conversation-crud.js";
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -281,7 +281,9 @@ function mayCancelQueuedMessage(
  * `message_queued_deleted`. It is the counterpart to the `message_queued` ack
  * and the only signal that closes out a queued row that never runs: without it
  * a client that didn't originate the delete leaves the pending indicator up
- * forever, since no `message_dequeued` is ever coming. Hidden sends are
+ * forever, since no `message_dequeued` is ever coming. Rows with no
+ * client-visible queued counterpart ({@link isSuppressedQueuedMessage} —
+ * hidden sends and daemon-injected subagent/ACP/wake notifications) are
  * suppressed for the same reason they get no ack: they have no client row to
  * close.
  */
@@ -323,7 +325,7 @@ export function deleteQueuedMessage(
     return { removed: false, reason: "forbidden" };
   }
   conversation.removeQueuedMessage(requestId);
-  if (!isHiddenMessageMetadata(queued.metadata)) {
+  if (!isSuppressedQueuedMessage(queued.metadata)) {
     queued.onEvent({
       type: "message_queued_deleted",
       conversationId,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -393,6 +393,7 @@ export {
   isBackgroundEventMetadata,
   isEchoSuppressedUserMessage,
   isHiddenMessageMetadata,
+  isSuppressedQueuedMessage,
   isVoiceSessionUserMessage,
 } from "./conversation-types.js";
 

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -138,6 +138,29 @@ export function isEchoSuppressedUserMessage(
 }
 
 /**
+ * True when a queued message has no client-visible queued row, so every event
+ * and snapshot that describes the queue to clients must skip it.
+ *
+ * Same set as {@link isEchoSuppressedUserMessage}: a row that never renders as
+ * a user bubble must not render as a queued one either. A subagent's
+ * completion notification injected into a busy parent (`subagent/notify.ts`)
+ * is the common case — the user sees that run through its inline card, and a
+ * `[Subagent "…" — …]` row in the queue drawer is daemon scaffolding leaking
+ * into the transcript's place.
+ *
+ * Named separately from the echo predicate for the queue sites that must
+ * agree: the `message_queued` ack and its visible-position count, the
+ * corrective `message_requeued` position, the terminal
+ * `message_queued_deleted` on user delete and on abort discard, and the
+ * list-messages queued snapshot a cold reload reads.
+ */
+export function isSuppressedQueuedMessage(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return isEchoSuppressedUserMessage(metadata);
+}
+
+/**
  * True when a role-`"user"` row was persisted by the voice bridge for a live
  * phone call or in-app voice session (every row `startVoiceTurn` persists, see
  * `calls/voice-session-bridge.ts`).

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -116,6 +116,7 @@ import {
   isConversationProcessing,
   isHiddenMessageMetadata,
   isProviderErrorMetadata,
+  isSuppressedQueuedMessage,
   isSystemCardMetadata,
   type MessageRow,
   recordConversationPersistedSeq,
@@ -713,12 +714,17 @@ function buildQueuedMessagePayloads(
     return [];
   }
 
-  // Hidden sends are suppressed from the transcript at every stage — echo,
-  // persisted row, and here the in-memory queue window: a latest-page fetch
-  // while the item still awaits drain must not surface it as a queued bubble.
+  // Rows that never render as a user bubble are suppressed at every stage —
+  // echo, persisted row, and here the in-memory queue window: a latest-page
+  // fetch while the item still awaits drain must not surface it as a queued
+  // bubble. That covers hidden sends and the daemon's own injected
+  // notifications (a subagent's completion summary enqueued into a busy
+  // parent, an ACP run outcome, a wake trigger) — the user follows those
+  // through their inline cards, never as a queued message they could steer or
+  // cancel.
   return conversation
     .snapshotQueuedMessages()
-    .filter((item) => !isHiddenMessageMetadata(item.metadata))
+    .filter((item) => !isSuppressedQueuedMessage(item.metadata))
     .map((item, index) => {
       const text = item.displayContent ?? item.content;
       const attachments: RuntimeAttachmentMetadata[] = item.attachments.map(

--- a/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
@@ -142,6 +142,45 @@ describe("useMessageQueue", () => {
     expect(result.current.queuedMessages).toHaveLength(0);
   });
 
+  test("omits daemon-injected notification rows from the queue", () => {
+    // A subagent completion summary queued behind an in-flight turn is
+    // internal scaffolding: the transcript already drops it, and the queue
+    // drawer — steer/cancel over the user's own pending prompts — must too.
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [
+          {
+            ...queuedMessage("request-subagent", "client-subagent"),
+            isSubagentNotification: true,
+          },
+          {
+            ...queuedMessage("request-acp", "client-acp", 2),
+            isAcpNotification: true,
+          },
+          {
+            ...queuedMessage("request-wake", "client-wake", 3),
+            isBackgroundEventNotification: true,
+          },
+          queuedMessage("request-1", "client-1", 4),
+        ],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    expect(result.current.queuedMessages.map((message) => message.id)).toEqual([
+      "request-1",
+    ]);
+  });
+
   test("steers a snapshot-backed queued message by its request id", () => {
     useChatSessionStore.setState({
       snapshot: {

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -73,7 +73,21 @@ export function useMessageQueue({
   const queuedMessages = useMemo(
     () =>
       transcriptMessages
-        .filter((m) => m.role === "user" && m.queueStatus === "queued")
+        .filter(
+          (m) =>
+            m.role === "user" &&
+            m.queueStatus === "queued" &&
+            // Daemon-injected run lifecycle notifications are internal
+            // scaffolding, not something the user typed: the transcript already
+            // drops them (see `buildTranscriptItems`), and the queue drawer —
+            // which offers steer/cancel on a person's own pending prompts —
+            // must drop them for the same reason. The daemon keeps them out of
+            // its queued snapshot too; this is the client-side half of that
+            // invariant.
+            !m.isSubagentNotification &&
+            !m.isAcpNotification &&
+            !m.isBackgroundEventNotification,
+        )
         .sort((a, b) => (a.queuePosition ?? 0) - (b.queuePosition ?? 0)),
     [transcriptMessages],
   );


### PR DESCRIPTION
## Prompt / plan

Screenshot from the web client showed the queue drawer rendering `Queue · 1` with `#1 [Subagent "hermes-local-review" — impo…` and steer/edit/cancel buttons. Prompt: "We shouldn't see queued messages from subagents in the UI."

Root cause: a subagent's completion summary is injected into its parent conversation as a user-role turn (`subagent/notify.ts` → `Conversation.enqueueMessage`). When the parent is mid-turn that turn queues, and every surface that describes the queue to clients gated visibility on `hidden` metadata alone:

- the `message_queued` ack and its visible-position count (`conversation-messaging.ts`)
- the corrective `message_requeued` position (`conversation-process.ts`)
- the terminal `message_queued_deleted` on user delete (`handlers/conversations.ts`) and on abort discard (`conversation-lifecycle.ts`)
- the list-messages queued snapshot a cold reload reads (`conversation-routes.ts`) — the path in the screenshot

The transcript already drops these rows: `buildTranscriptItems` skips `isSubagentNotification` / `isAcpNotification` / `isBackgroundEventNotification`, because the run surfaces through its inline card. The queue drawer is the same concern — steer/cancel over a person's own pending prompts — so it gets the same set.

Approach: add `isSuppressedQueuedMessage` in `persistence/conversation-types.ts`, delegating to the existing `isEchoSuppressedUserMessage` (hidden + subagent/ACP/wake notifications) so the two can't drift, and key every queue-visibility site on it. Positions still count visible items only, so a live ack and a cold reload agree — a user's send queued behind a subagent notification is position 1, not 2.

Client-side, `useMessageQueue` also filters the three notification flags, so a notification row that reaches a client can't render as a queued bubble there either.

Not touched: the hidden-metadata checks in `conversation-process.ts` that drive preference extraction and `isHiddenPrompt` — those are about machine-signal turn semantics, not queue visibility.

## Test plan

- New: `conversation-queue.test.ts` — a subagent notification enqueued into a busy conversation gets no `message_queued` ack, and the user's send queued behind it is position 1.
- New: `list-messages-queued.test.ts` — subagent / ACP / wake rows are filtered from the queued snapshot, visible siblings keep contiguous 1-based positions.
- New: `use-message-queue.test.tsx` — notification-flagged rows are omitted from `queuedMessages`.
- `bun test` green on the queue-related daemon suites: `conversation-queue`, `list-messages-queued`, `conversation-routes-hidden-queue`, `conversation-slash-queue`, `conversation-surfaces-queued-emit`, `drain-requeue-on-contention`, `message-queue`, `message-queue-steer`, `queued-message-delete-contract`, `steer-on-enqueue-question`, `transport-hints-queue`, `conversation-abort-tool-results`, plus the subagent notify suites.
- Web: `bun scripts/run-tests.ts` over `domains/chat/{hooks,utils/stream-handlers,transcript}` — 79 files, all passing.
- `typecheck` + `lint` clean in both `assistant/` and `clients/web/`.
- One pre-existing failure (`send-endpoint-busy.test.ts` "publishes events to assistantEventHub when conversation is idle") reproduces identically on the unmodified base branch when those four suites share a process; it passes in isolation with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xic88sd2rJ2eCRLzohAFN

---
_Generated by [Claude Code](https://claude.ai/code/session_015xic88sd2rJ2eCRLzohAFN)_