### PR TITLE
fix(memory): default memoryRetrospective to a vision-capable profile (ATL-1236)

### DIFF
--- a/assistant/src/__tests__/memory-retrospective-vision-default.test.ts
+++ b/assistant/src/__tests__/memory-retrospective-vision-default.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Guard: the `memoryRetrospective` call-site default must resolve to a
+ * vision-capable model on every provider that offers one.
+ *
+ * The retrospective forks the source conversation and preserves its image
+ * blocks, so a text-only model rejects every image-bearing window. Because the
+ * retrospective cursor advances only on usable output, such a window is never
+ * consumed: it is retried on every cooldown and can never succeed, so the
+ * conversation stops forming derived memory from its first image onward.
+ *
+ * The invariant is asserted rather than left to a source comment because two
+ * ordinary changes silently reintroduce it: flipping the default back to a
+ * cheaper profile, and a catalog edit that repoints the chosen profile's model.
+ *
+ * Resolution mirrors `materializeProfile`: a profile impl either pins a
+ * concrete `model` (the Vellum-managed impls) or carries an `intent` resolved
+ * per provider (the BYOK impls).
+ *
+ * Providers whose profile matrix has NO vision-capable model are exempt by
+ * construction rather than by allowlist: on those, every profile resolves to
+ * the same text-only model, so no default could satisfy the invariant. The
+ * exempt set is derived, so a provider that later gains a vision-capable model
+ * is covered automatically.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { CALL_SITE_DEFAULTS } from "../config/call-site-defaults.js";
+import { PROFILE_IMPLS } from "../config/default-profile-catalog.js";
+import { DEFAULT_PROFILE_KEYS } from "../config/default-profile-names.js";
+import { doesSupportVision } from "../plugin-api/vision-support.js";
+import { resolveModelIntent } from "../providers/model-intents.js";
+
+/** The profile key the retrospective call site ships with. */
+function retrospectiveProfileKey(): string {
+  const key = CALL_SITE_DEFAULTS.memoryRetrospective?.profile;
+  expect(key).toBeDefined();
+  return key!;
+}
+
+/**
+ * The concrete model a profile impl resolves to on a provider, mirroring
+ * `materializeProfile`: an explicit `model` wins, otherwise the impl's
+ * `intent` is resolved against that provider.
+ */
+function resolvedModel(
+  profileKey: string,
+  provider: string,
+): string | undefined {
+  const impl = (
+    PROFILE_IMPLS as Record<
+      string,
+      Record<string, { model?: string; intent?: string }>
+    >
+  )[profileKey]?.[provider];
+  if (impl == null) {
+    return undefined;
+  }
+  if (impl.model != null && impl.model !== "") {
+    return impl.model;
+  }
+  return impl.intent != null
+    ? resolveModelIntent(provider, impl.intent as never)
+    : undefined;
+}
+
+/** Providers appearing in the profile matrix. */
+function allProviders(): string[] {
+  return Object.keys(
+    (PROFILE_IMPLS as Record<string, Record<string, unknown>>)[
+      DEFAULT_PROFILE_KEYS[0]
+    ],
+  );
+}
+
+/** True when SOME shipped profile gives this provider a vision-capable model. */
+function providerHasAnyVisionModel(provider: string): boolean {
+  return DEFAULT_PROFILE_KEYS.some((key) => {
+    const model = resolvedModel(key, provider);
+    return model != null && model !== "" && doesSupportVision(model);
+  });
+}
+
+describe("memoryRetrospective default must be vision-capable", () => {
+  test("resolves to a vision-capable model on every provider that has one", () => {
+    const profileKey = retrospectiveProfileKey();
+    const offenders: string[] = [];
+
+    for (const provider of allProviders()) {
+      if (!providerHasAnyVisionModel(provider)) {
+        continue;
+      }
+      const model = resolvedModel(profileKey, provider);
+      if (model == null || model === "" || !doesSupportVision(model)) {
+        offenders.push(`${provider} -> ${model ?? "<unresolved>"}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("the Vellum-managed path specifically is vision-capable", () => {
+    // The managed catalog is where the original failure was observed: the
+    // shipped default resolved to a model that rejects images outright.
+    const model = resolvedModel(retrospectiveProfileKey(), "vellum");
+    expect(model).toBeDefined();
+    expect(doesSupportVision(model!)).toBe(true);
+  });
+
+  test("records why the cheapest profile cannot be the default", () => {
+    // Pins the reason this call site is not on the cheap profile. If a catalog
+    // change ever makes the cheap managed model vision-capable, this fails and
+    // the cost/correctness tradeoff can be revisited deliberately.
+    const cheap = resolvedModel("cost-optimized", "vellum");
+    expect(cheap).toBeDefined();
+    expect(doesSupportVision(cheap!)).toBe(false);
+  });
+});

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -67,7 +67,14 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   filingAgent: { profile: "cost-optimized" },
   memoryExtraction: { profile: "cost-optimized" },
   memoryRetrieval: { profile: "cost-optimized" },
-  memoryRetrospective: { profile: "cost-optimized" },
+  // Vision-capable by requirement, not by preference: the retrospective forks
+  // the source conversation and preserves its image blocks, so a text-only
+  // model rejects every image-bearing window. Because the retrospective
+  // cursor only advances on usable output, such a window is retried forever
+  // and the conversation stops forming derived memory from its first image
+  // onward. Matches the sibling background memory call site
+  // (`memoryV2Consolidation`). Keep this profile vision-capable.
+  memoryRetrospective: { profile: "balanced" },
   memoryV2Migration: { profile: "cost-optimized" },
   memoryV2Sweep: { profile: "cost-optimized" },
   memoryV2Consolidation: { profile: "balanced" },


### PR DESCRIPTION
## TL;DR

`memoryRetrospective` ships defaulting to `cost-optimized`, which resolves in the managed catalog to a model with **no vision support**. The retrospective forks the source conversation and preserves its image blocks, so every image-bearing window is rejected. This points the default at `balanced` (vision-capable), matching the sibling background memory call site.

One line changed, plus a comment recording why the profile must stay vision-capable.

## Why this needs your call rather than a quiet merge

The cheap managed model **is** the non-vision one, so this moves all retrospective traffic to a pricier model rather than only the image-bearing minority:

- `cost-optimized` → `accounts/fireworks/models/deepseek-v4-flash` (no vision)
- `balanced` / `latency-optimized` → `gpt-5.6-luna` (vision-capable)

On one heavy workspace, `memoryRetrospective` is the third-largest call site by spend: **3,660 calls / ~$232 over 7 days**, behind only `mainAgent` and `subagentSpawn`. This is a real cost increase, so it should be an explicit yes rather than a rubber stamp.

The cost-optimal alternative is to send only image-bearing windows to a vision-capable profile. That needs real routing logic rather than a default change; [ATL-1236](https://linear.app/vellum/issue/ATL-1236/memory-retrospective-ships-defaulting-to-a-non-vision-model-so-image) carries that option and the reasoning if the answer here is no.

## Why the impact is worse than "some memory is lost"

The retrospective cursor advances only when a run produces usable output. A rejected window is therefore never consumed: it is retried on every cooldown and can never succeed while the route stays text-only.

For an affected conversation that means it stops forming derived memory **permanently**, from its first image onward, not just for the window that contained the image. Each retry also runs another full retrospective fork whose input tokens are billed.

## Verified before making the change

- The default is still `cost-optimized` on current `main`, and the live managed catalog still maps it to the non-vision Fireworks model.
- `memory.retrospective.matchConversationProfile` **defaults to `false`**, so the call-site default is what actually resolves on a default workspace. This is the effective lever, not a no-op.
- `memoryV2Consolidation` is already on `balanced`, so `memoryRetrospective` was the lone outlier among the background memory call sites.
- No test or doc pinned the old value.

Originally reproduced as 39 explicit `vision_unsupported` retrospective failures across 8 source conversations in a single day on the dogfood box. The `balanced` pin was verified there with a PNG-bearing canary that produced durable `remember` writes.

## Before / after for the user

| Scenario | Before | After |
| --- | --- | --- |
| Conversation containing an image, default config | Retrospective rejected; conversation stops forming memory from that point on | Window processes normally |
| Retry behavior on an affected conversation | Re-runs a billed fork every cooldown, can never succeed | No retry loop |
| Text-only conversations | Unchanged | Same behavior, pricier model |

## Checks

`llm-catalog-parity` 20/20, `config-get-vision-flag` 4/4, `llm-resolver-override-or-default` 27/27; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
