### PR TITLE
feat(assistant): register the deepgram-flux STT provider

### DIFF
--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
  */
 export const VALID_STT_PROVIDERS = [
   "deepgram",
+  "deepgram-flux",
   "google-gemini",
   "openai-whisper",
   "xai",

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -23,6 +23,7 @@ describe("STT provider catalog", () => {
     const ids = listProviderIds();
     expect(ids).toContain("openai-whisper");
     expect(ids).toContain("deepgram");
+    expect(ids).toContain("deepgram-flux");
     expect(ids).toContain("google-gemini");
   });
 
@@ -101,6 +102,13 @@ describe("STT provider catalog", () => {
     expect(supportsBoundary("openai-whisper", "daemon-streaming")).toBe(true);
   });
 
+  test("deepgram-flux is streaming-only", () => {
+    // Flux has no batch endpoint; the batch transcriber factory rejects it
+    // explicitly rather than silently falling through.
+    expect(supportsBoundary("deepgram-flux", "daemon-streaming")).toBe(true);
+    expect(supportsBoundary("deepgram-flux", "daemon-batch")).toBe(false);
+  });
+
   test("supportsBoundary returns false for unknown provider IDs", () => {
     // Cast to bypass type checking for the test
     expect(supportsBoundary("nonexistent" as never, "daemon-batch")).toBe(
@@ -148,6 +156,7 @@ describe("STT provider catalog", () => {
 
   const expectedLanguageSelection = [
     ["deepgram", "manual"],
+    ["deepgram-flux", "manual"],
     ["vellum", "manual"],
     ["xai", "manual"],
     ["google-gemini", "auto"],
@@ -169,6 +178,15 @@ describe("STT provider catalog", () => {
     expect(getCredentialProvider("openai-whisper")).toBe("openai");
     expect(getCredentialProvider("deepgram")).toBe("deepgram");
     expect(getCredentialProvider("google-gemini")).toBe("gemini");
+  });
+
+  test("deepgram-flux shares the deepgram credential", () => {
+    expect(getCredentialProvider("deepgram-flux")).toBe("deepgram");
+    // Sharing must not duplicate the key in the API-key provider list.
+    const deepgramEntries = listCredentialProviderNames().filter(
+      (name) => name === "deepgram",
+    );
+    expect(deepgramEntries).toEqual(["deepgram"]);
   });
 
   test("getCredentialProvider returns undefined for unknown ID", () => {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -491,6 +491,7 @@ describe("resolveTelephonySttCapability", () => {
 // Tests — telephony capability alignment with provider catalog
 // ---------------------------------------------------------------------------
 
+import type { SttProviderId } from "../../../stt/types.js";
 import { getProviderEntry, listProviderIds } from "../provider-catalog.js";
 
 describe("telephony capability catalog alignment", () => {
@@ -501,6 +502,15 @@ describe("telephony capability catalog alignment", () => {
    * telephonyMode or a new provider is added, these tests will catch
    * misalignment early.
    */
+
+  /**
+   * Providers that deliberately sit out telephony (`telephonyMode: "none"`).
+   * `deepgram-flux` is a streaming-only spike: phone calls stay on the
+   * `deepgram` provider until Flux proves itself in live voice.
+   */
+  const TELEPHONY_OPT_OUT: ReadonlySet<SttProviderId> = new Set([
+    "deepgram-flux",
+  ]);
 
   test("deepgram catalog entry has realtime-ws telephonyMode", () => {
     const entry = getProviderEntry("deepgram");
@@ -535,15 +545,31 @@ describe("telephony capability catalog alignment", () => {
     expect(entry!.credentialProvider).toBe("openai");
   });
 
-  test("every catalog provider has a non-none telephonyMode", () => {
-    // The telephony capability resolver assumes all known providers
-    // participate in telephony over the media-stream transport. If a
-    // provider with telephonyMode: "none" is added, the resolver reports
-    // it as unsupported.
+  test("every catalog provider has a non-none telephonyMode unless it opts out", () => {
+    // The telephony capability resolver assumes known providers participate
+    // in telephony over the media-stream transport. A provider with
+    // telephonyMode: "none" is reported as unsupported, so opting out has to
+    // be a deliberate, listed choice rather than an oversight.
     for (const id of listProviderIds()) {
       const entry = getProviderEntry(id);
       expect(entry).toBeDefined();
+      if (TELEPHONY_OPT_OUT.has(id)) {
+        expect(entry!.telephonyMode).toBe("none");
+        continue;
+      }
       expect(entry!.telephonyMode).not.toBe("none");
+    }
+  });
+
+  test("telephony opt-out providers resolve as unsupported", async () => {
+    for (const id of TELEPHONY_OPT_OUT) {
+      const entry = getProviderEntry(id);
+      mockVellumAvailable = false;
+      mockProviderKeys = { [entry!.credentialProvider]: `test-key-${id}` };
+      applyConfig({ provider: id });
+
+      const result = await resolveTelephonySttCapability();
+      expect(result.status).toBe("unsupported");
     }
   });
 
@@ -574,6 +600,9 @@ describe("telephony capability catalog alignment", () => {
     };
 
     for (const id of listProviderIds()) {
+      if (TELEPHONY_OPT_OUT.has(id)) {
+        continue;
+      }
       const credKey = credentialMap[id];
       expect(credKey).toBeDefined();
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -118,6 +118,17 @@ interface SttProviderEntry {
 // ---------------------------------------------------------------------------
 
 /**
+ * Shared by every provider that authenticates against a Deepgram account —
+ * the key is the same one, so the instructions must not drift apart.
+ */
+const DEEPGRAM_CREDENTIALS_GUIDE: SttCredentialsGuide = {
+  description:
+    "Sign in to the Deepgram console, navigate to API Keys, and create a new key.",
+  url: "https://console.deepgram.com/",
+  linkLabel: "Open Deepgram Console",
+};
+
+/**
  * Provider catalog entries, keyed by provider ID.
  *
  * To add a new STT provider:
@@ -148,12 +159,30 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: true,
       languageSelection: "manual",
-      credentialsGuide: {
-        description:
-          "Sign in to the Deepgram console, navigate to API Keys, and create a new key.",
-        url: "https://console.deepgram.com/",
-        linkLabel: "Open Deepgram Console",
-      },
+      credentialsGuide: DEEPGRAM_CREDENTIALS_GUIDE,
+    },
+  ],
+  [
+    "deepgram-flux",
+    {
+      id: "deepgram-flux",
+      displayName: "Deepgram Flux",
+      subtitle:
+        "Conversational speech-to-text with model-native turn detection. Uses your Deepgram API key.",
+      setupMode: "api-key",
+      setupHint:
+        "Enter your Deepgram API key — Flux shares the same key as Deepgram.",
+      // Shared with the `deepgram` provider: Flux is a model on the same
+      // account, not a separate credential.
+      credentialProvider: "deepgram",
+      // Streaming only — Flux has no batch endpoint.
+      supportedBoundaries: new Set<SttBoundaryId>(["daemon-streaming"]),
+      // Phone calls stay on the `deepgram` provider while Flux is a spike.
+      telephonyMode: "none",
+      conversationStreamingMode: "realtime-ws",
+      supportsDiarization: false,
+      languageSelection: "manual",
+      credentialsGuide: DEEPGRAM_CREDENTIALS_GUIDE,
     },
   ],
   [


### PR DESCRIPTION
## Summary

- Adds a `deepgram-flux` entry to the STT provider catalog: shared `deepgram` credential, `daemon-streaming` only, `telephonyMode: "none"`, `realtime-ws` conversation streaming, manual language selection.
- Appends `"deepgram-flux"` to `VALID_STT_PROVIDERS` so `services.stt.provider: "deepgram-flux"` passes config validation and the provider is selectable end-to-end.
- Updates the catalog and telephony-parity tests for the new entry (shared-key dedupe, streaming-only boundary, deliberate telephony opt-out).

Part of plan: flux-turn-detection.md (PR 4 of 8)