### PR TITLE
feat(assistant): parse Deepgram Flux v2 frames into STT stream events

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildFluxQueryParams,
+  parseFluxFrame,
+} from "../deepgram-flux-frames.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures: one frame per documented Flux type
+// ---------------------------------------------------------------------------
+
+const CONNECTED = {
+  type: "Connected",
+  request_id: "req-123",
+  sequence_id: 0,
+};
+
+const START_OF_TURN = {
+  type: "TurnInfo",
+  event: "StartOfTurn",
+  request_id: "req-123",
+  turn_index: 0,
+  audio_window_start: 0,
+  audio_window_end: 0.32,
+  transcript: "",
+  words: [],
+};
+
+const UPDATE = {
+  type: "TurnInfo",
+  event: "Update",
+  turn_index: 0,
+  transcript: "what is the",
+  words: [
+    { word: "what", confidence: 0.99, start: 0.1, end: 0.28 },
+    { word: "is", confidence: 0.98, start: 0.28, end: 0.4 },
+    { word: "the", confidence: 0.97, start: 0.4, end: 0.55 },
+  ],
+};
+
+const EAGER_END_OF_TURN = {
+  type: "TurnInfo",
+  event: "EagerEndOfTurn",
+  turn_index: 0,
+  transcript: "what is the weather",
+  end_of_turn_confidence: 0.42,
+};
+
+const TURN_RESUMED = {
+  type: "TurnInfo",
+  event: "TurnResumed",
+  turn_index: 0,
+};
+
+const END_OF_TURN = {
+  type: "TurnInfo",
+  event: "EndOfTurn",
+  turn_index: 0,
+  transcript: "what is the weather today",
+  end_of_turn_confidence: 0.88,
+  words: [{ word: "today", confidence: 0.95, start: 1.1, end: 1.4 }],
+};
+
+// ---------------------------------------------------------------------------
+// parseFluxFrame
+// ---------------------------------------------------------------------------
+
+describe("parseFluxFrame", () => {
+  test("Connected emits no events", () => {
+    expect(parseFluxFrame(CONNECTED)).toEqual([]);
+  });
+
+  test("StartOfTurn emits turn-start", () => {
+    expect(parseFluxFrame(START_OF_TURN)).toEqual([{ type: "turn-start" }]);
+  });
+
+  test("Update emits a partial with the interim transcript", () => {
+    expect(parseFluxFrame(UPDATE)).toEqual([
+      { type: "partial", text: "what is the" },
+    ]);
+  });
+
+  test("a bare TurnInfo frame emits a partial transcript refresh", () => {
+    expect(
+      parseFluxFrame({ type: "TurnInfo", transcript: "partial text" }),
+    ).toEqual([{ type: "partial", text: "partial text" }]);
+  });
+
+  test("EagerEndOfTurn emits eager-turn-end with the speculated text", () => {
+    expect(parseFluxFrame(EAGER_END_OF_TURN)).toEqual([
+      { type: "eager-turn-end", text: "what is the weather" },
+    ]);
+  });
+
+  test("TurnResumed emits turn-resumed", () => {
+    expect(parseFluxFrame(TURN_RESUMED)).toEqual([{ type: "turn-resumed" }]);
+  });
+
+  test("EndOfTurn emits final before turn-end", () => {
+    const events = parseFluxFrame(END_OF_TURN);
+    expect(events).toEqual([
+      { type: "final", text: "what is the weather today" },
+      {
+        type: "turn-end",
+        text: "what is the weather today",
+        confidence: 0.88,
+      },
+    ]);
+    // Consumers that ignore turn events must still see the commit first.
+    expect(events[0]?.type).toBe("final");
+    expect(events[1]?.type).toBe("turn-end");
+  });
+
+  test("EndOfTurn omits confidence when Deepgram sends none", () => {
+    expect(parseFluxFrame({ type: "EndOfTurn", transcript: "done" })).toEqual([
+      { type: "final", text: "done" },
+      { type: "turn-end", text: "done" },
+    ]);
+  });
+
+  test("flat frames without a nested event field are accepted", () => {
+    expect(parseFluxFrame({ type: "StartOfTurn" })).toEqual([
+      { type: "turn-start" },
+    ]);
+    expect(parseFluxFrame({ type: "Update", transcript: "hi" })).toEqual([
+      { type: "partial", text: "hi" },
+    ]);
+    expect(parseFluxFrame({ type: "TurnResumed" })).toEqual([
+      { type: "turn-resumed" },
+    ]);
+  });
+
+  test("JSON string payloads are parsed", () => {
+    expect(parseFluxFrame(JSON.stringify(END_OF_TURN))).toEqual([
+      { type: "final", text: "what is the weather today" },
+      {
+        type: "turn-end",
+        text: "what is the weather today",
+        confidence: 0.88,
+      },
+    ]);
+  });
+
+  test("transcripts are trimmed and missing ones become empty strings", () => {
+    expect(
+      parseFluxFrame({ type: "Update", transcript: "  spaced  " }),
+    ).toEqual([{ type: "partial", text: "spaced" }]);
+    expect(parseFluxFrame({ type: "Update" })).toEqual([
+      { type: "partial", text: "" },
+    ]);
+  });
+
+  test("unknown frame types emit nothing", () => {
+    expect(parseFluxFrame({ type: "SomeFutureFrame", data: 1 })).toEqual([]);
+    expect(
+      parseFluxFrame({ type: "TurnInfo", event: "FutureTurnState" }),
+    ).toEqual([]);
+  });
+
+  test("malformed and arbitrary input never throws and emits nothing", () => {
+    const garbage: unknown[] = [
+      undefined,
+      null,
+      0,
+      1,
+      Number.NaN,
+      true,
+      "",
+      "not json",
+      "{ broken json",
+      "[]",
+      "null",
+      "42",
+      [],
+      [{ type: "EndOfTurn" }],
+      {},
+      { type: 7 },
+      { type: null },
+      { event: 7, type: 7 },
+      new Date(),
+      () => undefined,
+      Symbol("x"),
+      10n,
+    ];
+    for (const value of garbage) {
+      expect(() => parseFluxFrame(value)).not.toThrow();
+      expect(parseFluxFrame(value)).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFluxQueryParams
+// ---------------------------------------------------------------------------
+
+describe("buildFluxQueryParams", () => {
+  test("builds the raw-audio parameter set", () => {
+    const query = buildFluxQueryParams({
+      model: "flux-general-en",
+      encoding: "linear16",
+      sampleRate: 16_000,
+      eotThreshold: 0.7,
+      eotTimeoutMs: 5_000,
+    });
+    const params = new URLSearchParams(query);
+    expect(params.get("model")).toBe("flux-general-en");
+    expect(params.get("encoding")).toBe("linear16");
+    expect(params.get("sample_rate")).toBe("16000");
+    expect(params.get("eot_threshold")).toBe("0.7");
+    expect(params.get("eot_timeout_ms")).toBe("5000");
+  });
+
+  test("omits eager_eot_threshold when unset", () => {
+    const query = buildFluxQueryParams({
+      model: "flux-general-en",
+      eotThreshold: 0.7,
+      eotTimeoutMs: 5_000,
+    });
+    expect(query).not.toContain("eager_eot_threshold");
+    expect(new URLSearchParams(query).has("eager_eot_threshold")).toBe(false);
+  });
+
+  test("passes eager_eot_threshold through when set", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eagerEotThreshold: 0.5,
+      }),
+    );
+    expect(params.get("eager_eot_threshold")).toBe("0.5");
+  });
+
+  test("omits encoding and sample_rate for containerized audio", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({ model: "flux-general-en" }),
+    );
+    expect(params.has("encoding")).toBe(false);
+    expect(params.has("sample_rate")).toBe(false);
+  });
+
+  test("clamps thresholds and the timeout to the ranges Deepgram accepts", () => {
+    const low = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eotThreshold: 0.1,
+        eagerEotThreshold: 0.05,
+        eotTimeoutMs: 10,
+      }),
+    );
+    expect(low.get("eot_threshold")).toBe("0.5");
+    expect(low.get("eager_eot_threshold")).toBe("0.3");
+    expect(low.get("eot_timeout_ms")).toBe("500");
+
+    const high = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eotThreshold: 5,
+        eagerEotThreshold: 5,
+        eotTimeoutMs: 999_999,
+      }),
+    );
+    expect(high.get("eot_threshold")).toBe("0.9");
+    expect(high.get("eager_eot_threshold")).toBe("0.9");
+    expect(high.get("eot_timeout_ms")).toBe("60000");
+  });
+
+  test("repeats language_hint once per hint", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-multi",
+        languageHint: ["en", "es"],
+      }),
+    );
+    expect(params.getAll("language_hint")).toEqual(["en", "es"]);
+
+    const single = new URLSearchParams(
+      buildFluxQueryParams({ model: "flux-general-multi", languageHint: "fr" }),
+    );
+    expect(single.getAll("language_hint")).toEqual(["fr"]);
+  });
+});

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
@@ -61,6 +61,13 @@ const END_OF_TURN = {
   words: [{ word: "today", confidence: 0.95, start: 1.1, end: 1.4 }],
 };
 
+const FATAL_ERROR = {
+  type: "Error",
+  sequence_id: 5,
+  code: "INTERNAL_SERVER_ERROR",
+  description: "An internal server error occurred while processing the request",
+};
+
 // ---------------------------------------------------------------------------
 // parseFluxFrame
 // ---------------------------------------------------------------------------
@@ -150,11 +157,87 @@ describe("parseFluxFrame", () => {
     ]);
   });
 
+  test("a fatal Error frame emits exactly one error event", () => {
+    const events = parseFluxFrame(FATAL_ERROR);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "error",
+      category: "provider-error",
+      message:
+        "Deepgram Flux error (INTERNAL_SERVER_ERROR): An internal server error occurred while processing the request",
+    });
+  });
+
+  test("an Error frame preserves the provider description in the message", () => {
+    const [event] = parseFluxFrame(
+      JSON.stringify({
+        type: "Error",
+        code: "SOME_FUTURE_CODE",
+        description: "something specific went wrong upstream",
+      }),
+    );
+    expect(event?.type).toBe("error");
+    expect((event as { message: string }).message).toContain(
+      "something specific went wrong upstream",
+    );
+    expect((event as { message: string }).message).toContain(
+      "SOME_FUTURE_CODE",
+    );
+  });
+
+  test("Error frames are categorized from the provider code", () => {
+    const categoryOf = (frame: Record<string, unknown>) => {
+      const [event] = parseFluxFrame({ type: "Error", ...frame });
+      return (event as { category?: string } | undefined)?.category;
+    };
+
+    expect(categoryOf({ code: "INVALID_AUTH" })).toBe("auth");
+    expect(categoryOf({ code: "INSUFFICIENT_PERMISSIONS" })).toBe("auth");
+    expect(categoryOf({ code: "TOO_MANY_REQUESTS" })).toBe("rate-limit");
+    expect(categoryOf({ code: "REQUEST_TIMEOUT" })).toBe("timeout");
+    expect(categoryOf({ code: "ASR_UNPROCESSABLE_ENTITY" })).toBe(
+      "invalid-audio",
+    );
+    expect(categoryOf({ code: "INTERNAL_SERVER_ERROR" })).toBe(
+      "provider-error",
+    );
+    // Unrecognized and bare error frames still surface, as provider-error.
+    expect(categoryOf({ code: "SOMETHING_NEW" })).toBe("provider-error");
+    expect(categoryOf({})).toBe("provider-error");
+    // A complaint about eot_timeout_ms is a config error, not a transport
+    // timeout — the timeout matcher must not claim it.
+    expect(
+      categoryOf({
+        code: "INVALID_EOT_TIMEOUT_MS",
+        description: "eot_timeout_ms is out of range",
+      }),
+    ).toBe("provider-error");
+  });
+
+  test("an Error frame with no description still yields a usable message", () => {
+    expect(parseFluxFrame({ type: "Error" })).toEqual([
+      {
+        type: "error",
+        category: "provider-error",
+        message: "Deepgram Flux error: no description provided",
+      },
+    ]);
+  });
+
   test("unknown frame types emit nothing", () => {
     expect(parseFluxFrame({ type: "SomeFutureFrame", data: 1 })).toEqual([]);
     expect(
       parseFluxFrame({ type: "TurnInfo", event: "FutureTurnState" }),
     ).toEqual([]);
+    // Only the documented fatal `Error` frame becomes an error event: an
+    // unrecognized frame must never be reported as a stream failure, even
+    // when it carries error-shaped fields.
+    expect(
+      parseFluxFrame({ type: "ConfigureFailure", code: "INVALID_AUTH" }),
+    ).toEqual([]);
+    expect(parseFluxFrame({ type: "error", description: "lowercase" })).toEqual(
+      [],
+    );
   });
 
   test("malformed and arbitrary input never throws and emits nothing", () => {
@@ -262,6 +345,59 @@ describe("buildFluxQueryParams", () => {
     expect(high.get("eot_threshold")).toBe("0.9");
     expect(high.get("eager_eot_threshold")).toBe("0.9");
     expect(high.get("eot_timeout_ms")).toBe("60000");
+  });
+
+  test("clamps eager_eot_threshold down to eot_threshold", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eotThreshold: 0.5,
+        eagerEotThreshold: 0.9,
+      }),
+    );
+    // Deepgram rejects the handshake when eager exceeds the final threshold.
+    expect(Number(params.get("eager_eot_threshold"))).toBeLessThanOrEqual(
+      Number(params.get("eot_threshold")),
+    );
+    expect(params.get("eager_eot_threshold")).toBe("0.5");
+    expect(params.get("eot_threshold")).toBe("0.5");
+  });
+
+  test("clamps eager_eot_threshold against Deepgram's default when eot_threshold is unset", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eagerEotThreshold: 0.9,
+      }),
+    );
+    // No eot_threshold is sent, so the server default of 0.7 is in force.
+    expect(params.has("eot_threshold")).toBe(false);
+    expect(params.get("eager_eot_threshold")).toBe("0.7");
+  });
+
+  test("leaves an already-valid eager/eot pair untouched", () => {
+    const params = new URLSearchParams(
+      buildFluxQueryParams({
+        model: "flux-general-en",
+        eotThreshold: 0.9,
+        eagerEotThreshold: 0.6,
+      }),
+    );
+    expect(params.get("eot_threshold")).toBe("0.9");
+    expect(params.get("eager_eot_threshold")).toBe("0.6");
+  });
+
+  test("the eager clamp never invents an eager_eot_threshold", () => {
+    // Omitting the parameter is what disables eager turn-end speculation, so
+    // the cross-threshold clamp must not fire when it is unset.
+    for (const eotThreshold of [undefined, 0.5, 0.9]) {
+      const query = buildFluxQueryParams({
+        model: "flux-general-en",
+        ...(eotThreshold !== undefined ? { eotThreshold } : {}),
+      });
+      expect(query).not.toContain("eager_eot_threshold");
+      expect(new URLSearchParams(query).has("eager_eot_threshold")).toBe(false);
+    }
   });
 
   test("repeats language_hint once per hint", () => {

--- a/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
@@ -15,7 +15,11 @@
  * from `partial` / `final` exactly as it does with any other provider.
  */
 
-import type { SttStreamServerEvent } from "../../stt/types.js";
+import type {
+  SttErrorCategory,
+  SttStreamServerErrorEvent,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
 import { parseJsonSafe } from "../../util/json.js";
 import { getLogger } from "../../util/logger.js";
 import { isPlainObject } from "../../util/object.js";
@@ -30,7 +34,8 @@ const log = getLogger("deepgram-flux-frames");
  * Frame discriminators Deepgram emits on `/v2/listen`.
  *
  * `EagerEndOfTurn` and `TurnResumed` appear only when
- * `eager_eot_threshold` is set on the dialed URL.
+ * `eager_eot_threshold` is set on the dialed URL. `Error` is a fatal frame:
+ * Deepgram terminates the session after sending it.
  */
 export type FluxFrameKind =
   | "Connected"
@@ -39,7 +44,8 @@ export type FluxFrameKind =
   | "Update"
   | "EagerEndOfTurn"
   | "TurnResumed"
-  | "EndOfTurn";
+  | "EndOfTurn"
+  | "Error";
 
 /** A single word within a Flux turn frame, with timings and confidence. */
 export interface FluxWord {
@@ -88,7 +94,28 @@ export interface FluxTurnFrame {
   end_of_turn_confidence?: number;
 }
 
-export type FluxFrame = FluxConnectedFrame | FluxTurnFrame;
+/**
+ * Fatal error frame. Deepgram closes the session immediately after sending
+ * one, so it is the only diagnostic a caller ever gets for a provider-side
+ * failure.
+ */
+export interface FluxErrorFrame {
+  type: "Error";
+  sequence_id?: number;
+  /** Machine-readable identifier, e.g. `"INTERNAL_SERVER_ERROR"`. */
+  code?: string;
+  /** Prose explanation of the failure. */
+  description?: string;
+}
+
+export type FluxFrame = FluxConnectedFrame | FluxTurnFrame | FluxErrorFrame;
+
+/**
+ * A payload that has been confirmed to be an object but whose frame kind is
+ * not yet known: the union of every field any documented frame can carry.
+ */
+type InboundFluxFrame = Partial<FluxTurnFrame> &
+  Partial<Omit<FluxErrorFrame, "type">>;
 
 // ---------------------------------------------------------------------------
 // Frame parsing
@@ -114,6 +141,8 @@ export type FluxFrame = FluxConnectedFrame | FluxTurnFrame;
  * - `EndOfTurn` emits `final` followed by `turn-end`. The `final` comes first
  *   so a consumer that ignores turn events commits the transcript exactly as
  *   it does for a provider without turn detection.
+ * - `Error` emits `error`. This frame is fatal and is the only place the
+ *   provider's own diagnostic appears, so it is surfaced rather than dropped.
  */
 export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
   const frame = coerceFrame(raw);
@@ -146,6 +175,8 @@ export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
         },
       ];
     }
+    case "Error":
+      return [readErrorEvent(frame)];
     default:
       log.debug({ kind }, "Ignoring unrecognized Deepgram Flux frame");
       return [];
@@ -157,17 +188,17 @@ export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
  * one. JSON strings are parsed; anything that is not a plain object (null,
  * arrays, primitives, unparseable text) is rejected.
  */
-function coerceFrame(raw: unknown): Partial<FluxTurnFrame> | null {
+function coerceFrame(raw: unknown): InboundFluxFrame | null {
   const value = typeof raw === "string" ? parseJsonSafe(raw) : raw;
   if (!isPlainObject(value)) {
     log.debug("Dropped a Deepgram Flux payload that is not a frame object");
     return null;
   }
-  return value as Partial<FluxTurnFrame>;
+  return value as InboundFluxFrame;
 }
 
 /** The turn state a frame describes: `event` when present, else `type`. */
-function readFrameKind(frame: Partial<FluxTurnFrame>): string | undefined {
+function readFrameKind(frame: InboundFluxFrame): string | undefined {
   if (typeof frame.event === "string") {
     return frame.event;
   }
@@ -175,8 +206,63 @@ function readFrameKind(frame: Partial<FluxTurnFrame>): string | undefined {
 }
 
 /** Trimmed transcript text, empty when the frame carries none. */
-function readTranscript(frame: Partial<FluxTurnFrame>): string {
+function readTranscript(frame: InboundFluxFrame): string {
   return typeof frame.transcript === "string" ? frame.transcript.trim() : "";
+}
+
+/**
+ * Patterns that map a Flux error onto a normalized {@link SttErrorCategory},
+ * tried in order. Anything unmatched stays `provider-error`.
+ *
+ * Deepgram documents only `INTERNAL_SERVER_ERROR` for Flux itself, so these
+ * match the account-wide error vocabulary
+ * (https://developers.deepgram.com/docs/errors) and mirror how
+ * `DeepgramRealtimeTranscriber` separates auth and rate-limit failures from
+ * everything else.
+ *
+ * The timeout pattern deliberately requires a `_TIMEOUT` suffix at a word
+ * boundary so a configuration complaint about `eot_timeout_ms` is not
+ * mistaken for a transport timeout.
+ */
+const FLUX_ERROR_CATEGORY_PATTERNS: ReadonlyArray<
+  readonly [SttErrorCategory, RegExp]
+> = [
+  [
+    "auth",
+    /INVALID_AUTH|INSUFFICIENT_PERMISSIONS|UNAUTHORIZED|FORBIDDEN|INVALID CREDENTIALS|API KEY/,
+  ],
+  ["rate-limit", /TOO_MANY_REQUESTS|RATE[_ ]LIMIT|QUOTA/],
+  ["timeout", /^TIMEOUT|_TIMEOUT\b|TIMED[_ ]OUT/],
+  [
+    "invalid-audio",
+    /UNPROCESSABLE|CORRUPT|UNSUPPORTED|INVALID[_ ]AUDIO|BAD[_ ]AUDIO/,
+  ],
+];
+
+/**
+ * Turn a fatal `Error` frame into a stream `error` event, preserving the
+ * provider's own `code` and `description` so the diagnostic survives all the
+ * way to the caller. Deepgram closes the socket right after this frame, so
+ * dropping it would leave a bare close as the only signal.
+ */
+function readErrorEvent(frame: InboundFluxFrame): SttStreamServerErrorEvent {
+  const code = typeof frame.code === "string" ? frame.code.trim() : "";
+  const description =
+    typeof frame.description === "string" ? frame.description.trim() : "";
+
+  const haystack = `${code} ${description}`.toUpperCase();
+  const category =
+    FLUX_ERROR_CATEGORY_PATTERNS.find(([, pattern]) =>
+      pattern.test(haystack),
+    )?.[0] ?? "provider-error";
+
+  const detail = description || "no description provided";
+  const message = code
+    ? `Deepgram Flux error (${code}): ${detail}`
+    : `Deepgram Flux error: ${detail}`;
+
+  log.warn({ code, category }, "Deepgram Flux sent a fatal error frame");
+  return { type: "error", category, message };
 }
 
 /** A finite number, or undefined for anything else. */
@@ -204,6 +290,14 @@ export type FluxEncoding =
 
 /** Inclusive bounds Deepgram enforces on `eot_threshold`. */
 const EOT_THRESHOLD_RANGE = { min: 0.5, max: 0.9 } as const;
+
+/**
+ * Deepgram's server-side default for `eot_threshold`, applied when the
+ * parameter is omitted. It is the ceiling `eager_eot_threshold` must respect
+ * in that case, since the validation runs against the threshold actually in
+ * force rather than the one we sent.
+ */
+const DEFAULT_EOT_THRESHOLD = 0.7;
 
 /** Inclusive bounds Deepgram enforces on `eager_eot_threshold`. */
 const EAGER_EOT_THRESHOLD_RANGE = { min: 0.3, max: 0.9 } as const;
@@ -249,6 +343,15 @@ export interface FluxQueryParamOptions {
  * omitting `eager_eot_threshold` is what disables eager turn-end speculation.
  * Thresholds are clamped to the ranges Deepgram accepts so an out-of-range
  * value degrades to the nearest legal one instead of failing the handshake.
+ *
+ * Deepgram additionally rejects a request whose `eager_eot_threshold` exceeds
+ * its `eot_threshold`
+ * (https://developers.deepgram.com/docs/flux/configuration#validation-rules),
+ * so after each threshold is clamped to its own range the eager value is
+ * clamped down again to the EOT threshold in force — the one being sent, or
+ * Deepgram's {@link DEFAULT_EOT_THRESHOLD} when none is. Clamping keeps a
+ * misconfigured pair from failing the whole session; the adjustment is logged
+ * at debug when it fires.
  */
 export function buildFluxQueryParams(opts: FluxQueryParamOptions): string {
   const params = new URLSearchParams();
@@ -267,10 +370,23 @@ export function buildFluxQueryParams(opts: FluxQueryParamOptions): string {
     params.set("eot_threshold", String(eotThreshold));
   }
 
-  const eagerEotThreshold = clamp(
+  let eagerEotThreshold = clamp(
     opts.eagerEotThreshold,
     EAGER_EOT_THRESHOLD_RANGE,
   );
+  const eagerCeiling = eotThreshold ?? DEFAULT_EOT_THRESHOLD;
+  if (eagerEotThreshold !== undefined && eagerEotThreshold > eagerCeiling) {
+    log.debug(
+      {
+        requested: opts.eagerEotThreshold,
+        clampedTo: eagerCeiling,
+        eotThreshold: eagerCeiling,
+        usingDefaultEotThreshold: eotThreshold === undefined,
+      },
+      "Clamped Deepgram Flux eager_eot_threshold down to eot_threshold",
+    );
+    eagerEotThreshold = eagerCeiling;
+  }
   if (eagerEotThreshold !== undefined) {
     params.set("eager_eot_threshold", String(eagerEotThreshold));
   }

--- a/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
@@ -1,0 +1,303 @@
+/**
+ * Pure protocol helpers for Deepgram's Flux conversational speech API
+ * (`wss://api.deepgram.com/v2/listen`).
+ *
+ * This module holds only pure functions: frame parsing and URL query
+ * construction. It owns no socket, no timers, and no I/O, so the risky part
+ * of the protocol (the wire shapes Deepgram controls) can be exercised
+ * exhaustively in tests. The streaming transcriber wires these into a
+ * WebSocket session.
+ *
+ * Flux differs from Deepgram's v1 live API in that its turn model, not the
+ * caller's endpointing heuristics, decides when a turn ends. Frames are
+ * mapped onto the daemon's {@link SttStreamServerEvent} contract so that a
+ * consumer which ignores the turn-detection events still commits transcripts
+ * from `partial` / `final` exactly as it does with any other provider.
+ */
+
+import type { SttStreamServerEvent } from "../../stt/types.js";
+import { parseJsonSafe } from "../../util/json.js";
+import { getLogger } from "../../util/logger.js";
+import { isPlainObject } from "../../util/object.js";
+
+const log = getLogger("deepgram-flux-frames");
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/**
+ * Frame discriminators Deepgram emits on `/v2/listen`.
+ *
+ * `EagerEndOfTurn` and `TurnResumed` appear only when
+ * `eager_eot_threshold` is set on the dialed URL.
+ */
+export type FluxFrameKind =
+  | "Connected"
+  | "TurnInfo"
+  | "StartOfTurn"
+  | "Update"
+  | "EagerEndOfTurn"
+  | "TurnResumed"
+  | "EndOfTurn";
+
+/** A single word within a Flux turn frame, with timings and confidence. */
+export interface FluxWord {
+  /** The recognized word. */
+  word?: string;
+  /** Per-word recognition confidence in [0, 1]. */
+  confidence?: number;
+  /** Word start offset in seconds from the beginning of the stream. */
+  start?: number;
+  /** Word end offset in seconds from the beginning of the stream. */
+  end?: number;
+}
+
+/** Session-established frame, sent once after the socket opens. */
+export interface FluxConnectedFrame {
+  type: "Connected";
+  request_id?: string;
+  sequence_id?: number;
+}
+
+/**
+ * A turn-state frame.
+ *
+ * Deepgram nests the turn state under `event` on `TurnInfo` frames
+ * (`{ type: "TurnInfo", event: "EndOfTurn", ... }`) and also documents the
+ * states as frame types in their own right. Both shapes are accepted:
+ * `event` wins when present, otherwise `type` is the discriminator.
+ */
+export interface FluxTurnFrame {
+  type: FluxFrameKind;
+  /** Turn state carried by a `TurnInfo` frame. */
+  event?: FluxFrameKind;
+  request_id?: string;
+  sequence_id?: number;
+  /** Zero-based index of the turn within the session. */
+  turn_index?: number;
+  /** Start of the audio window this frame describes, in seconds. */
+  audio_window_start?: number;
+  /** End of the audio window this frame describes, in seconds. */
+  audio_window_end?: number;
+  /** Transcript for the turn so far. */
+  transcript?: string;
+  /** Per-word timings and confidences backing {@link transcript}. */
+  words?: FluxWord[];
+  /** Flux's end-of-turn confidence in [0, 1]. */
+  end_of_turn_confidence?: number;
+}
+
+export type FluxFrame = FluxConnectedFrame | FluxTurnFrame;
+
+// ---------------------------------------------------------------------------
+// Frame parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Map one Flux frame onto zero or more daemon streaming events.
+ *
+ * Accepts either a JSON string (as delivered by the WebSocket) or an
+ * already-parsed value. Unknown frame kinds, malformed JSON, and non-object
+ * payloads yield an empty array and a debug log: Deepgram can add frame types
+ * without breaking the session, so this never throws and never rejects a
+ * stream over an unrecognized frame.
+ *
+ * Mapping:
+ * - `Connected` emits nothing (session bookkeeping).
+ * - `StartOfTurn` emits `turn-start`.
+ * - `Update` and bare `TurnInfo` emit `partial`: an interim transcript
+ *   refresh, since the commit comes from `EndOfTurn`.
+ * - `EagerEndOfTurn` emits `eager-turn-end`, retracted by `TurnResumed` or
+ *   confirmed by `EndOfTurn`.
+ * - `TurnResumed` emits `turn-resumed`.
+ * - `EndOfTurn` emits `final` followed by `turn-end`. The `final` comes first
+ *   so a consumer that ignores turn events commits the transcript exactly as
+ *   it does for a provider without turn detection.
+ */
+export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
+  const frame = coerceFrame(raw);
+  if (!frame) {
+    return [];
+  }
+
+  const kind = readFrameKind(frame);
+  switch (kind) {
+    case "Connected":
+      return [];
+    case "StartOfTurn":
+      return [{ type: "turn-start" }];
+    case "Update":
+    case "TurnInfo":
+      return [{ type: "partial", text: readTranscript(frame) }];
+    case "EagerEndOfTurn":
+      return [{ type: "eager-turn-end", text: readTranscript(frame) }];
+    case "TurnResumed":
+      return [{ type: "turn-resumed" }];
+    case "EndOfTurn": {
+      const text = readTranscript(frame);
+      const confidence = readNumber(frame.end_of_turn_confidence);
+      return [
+        { type: "final", text },
+        {
+          type: "turn-end",
+          text,
+          ...(confidence !== undefined ? { confidence } : {}),
+        },
+      ];
+    }
+    default:
+      log.debug({ kind }, "Ignoring unrecognized Deepgram Flux frame");
+      return [];
+  }
+}
+
+/**
+ * Normalize an inbound payload into a frame object, or null when it is not
+ * one. JSON strings are parsed; anything that is not a plain object (null,
+ * arrays, primitives, unparseable text) is rejected.
+ */
+function coerceFrame(raw: unknown): Partial<FluxTurnFrame> | null {
+  const value = typeof raw === "string" ? parseJsonSafe(raw) : raw;
+  if (!isPlainObject(value)) {
+    log.debug("Dropped a Deepgram Flux payload that is not a frame object");
+    return null;
+  }
+  return value as Partial<FluxTurnFrame>;
+}
+
+/** The turn state a frame describes: `event` when present, else `type`. */
+function readFrameKind(frame: Partial<FluxTurnFrame>): string | undefined {
+  if (typeof frame.event === "string") {
+    return frame.event;
+  }
+  return typeof frame.type === "string" ? frame.type : undefined;
+}
+
+/** Trimmed transcript text, empty when the frame carries none. */
+function readTranscript(frame: Partial<FluxTurnFrame>): string {
+  return typeof frame.transcript === "string" ? frame.transcript.trim() : "";
+}
+
+/** A finite number, or undefined for anything else. */
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Query parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw audio encodings Flux accepts. Containerized audio (WAV, Ogg) is
+ * self-describing and needs neither `encoding` nor `sample_rate`.
+ */
+export type FluxEncoding =
+  | "linear16"
+  | "linear32"
+  | "mulaw"
+  | "alaw"
+  | "opus"
+  | "ogg-opus";
+
+/** Inclusive bounds Deepgram enforces on `eot_threshold`. */
+const EOT_THRESHOLD_RANGE = { min: 0.5, max: 0.9 } as const;
+
+/** Inclusive bounds Deepgram enforces on `eager_eot_threshold`. */
+const EAGER_EOT_THRESHOLD_RANGE = { min: 0.3, max: 0.9 } as const;
+
+/** Inclusive bounds Deepgram enforces on `eot_timeout_ms`. */
+const EOT_TIMEOUT_MS_RANGE = { min: 500, max: 60_000 } as const;
+
+export interface FluxQueryParamOptions {
+  /** Flux model to run, e.g. `"flux-general-en"`. Required by Deepgram. */
+  model: string;
+  /**
+   * Encoding of the raw audio being sent. Omit for containerized audio,
+   * which carries its own format header.
+   */
+  encoding?: FluxEncoding;
+  /**
+   * Sample rate (Hz) of the raw audio. Required whenever {@link encoding} is
+   * set. Flux accepts 8000, 16000, 24000, 44100, and 48000.
+   */
+  sampleRate?: number;
+  /** End-of-turn confidence Flux must reach before committing a turn. */
+  eotThreshold?: number;
+  /**
+   * Confidence at which Flux starts speculating a turn has ended. Leaving it
+   * undefined omits the parameter, which is what keeps Deepgram from emitting
+   * `EagerEndOfTurn` / `TurnResumed` frames at all.
+   */
+  eagerEotThreshold?: number;
+  /** Silence (ms) after which Flux force-ends a turn. */
+  eotTimeoutMs?: number;
+  /**
+   * Language hints for the multilingual model. Repeatable: each entry is sent
+   * as its own `language_hint` parameter. Ignored by monolingual models.
+   */
+  languageHint?: string | string[];
+}
+
+/**
+ * Build the query string for Flux's `/v2/listen` endpoint (no leading `?`).
+ *
+ * Every optional parameter is omitted when undefined rather than sent with a
+ * default, because Deepgram's own defaults are the intended behavior and
+ * omitting `eager_eot_threshold` is what disables eager turn-end speculation.
+ * Thresholds are clamped to the ranges Deepgram accepts so an out-of-range
+ * value degrades to the nearest legal one instead of failing the handshake.
+ */
+export function buildFluxQueryParams(opts: FluxQueryParamOptions): string {
+  const params = new URLSearchParams();
+  params.set("model", opts.model);
+
+  if (opts.encoding !== undefined) {
+    params.set("encoding", opts.encoding);
+  }
+  const sampleRate = readNumber(opts.sampleRate);
+  if (sampleRate !== undefined) {
+    params.set("sample_rate", String(Math.round(sampleRate)));
+  }
+
+  const eotThreshold = clamp(opts.eotThreshold, EOT_THRESHOLD_RANGE);
+  if (eotThreshold !== undefined) {
+    params.set("eot_threshold", String(eotThreshold));
+  }
+
+  const eagerEotThreshold = clamp(
+    opts.eagerEotThreshold,
+    EAGER_EOT_THRESHOLD_RANGE,
+  );
+  if (eagerEotThreshold !== undefined) {
+    params.set("eager_eot_threshold", String(eagerEotThreshold));
+  }
+
+  const eotTimeoutMs = clamp(opts.eotTimeoutMs, EOT_TIMEOUT_MS_RANGE);
+  if (eotTimeoutMs !== undefined) {
+    params.set("eot_timeout_ms", String(Math.round(eotTimeoutMs)));
+  }
+
+  const hints = opts.languageHint;
+  for (const hint of typeof hints === "string" ? [hints] : (hints ?? [])) {
+    if (hint) {
+      params.append("language_hint", hint);
+    }
+  }
+
+  return params.toString();
+}
+
+/** Clamp a finite number into an inclusive range; undefined passes through. */
+function clamp(
+  value: number | undefined,
+  range: { min: number; max: number },
+): number | undefined {
+  const numeric = readNumber(value);
+  if (numeric === undefined) {
+    return undefined;
+  }
+  return Math.min(Math.max(numeric, range.min), range.max);
+}


### PR DESCRIPTION
## Summary

- Adds `deepgram-flux-frames.ts`: pure `parseFluxFrame` + `buildFluxQueryParams` for Deepgram Flux's `/v2/listen` protocol, with no socket or I/O so PR 6 can build the transcriber on a tested seam.
- `EndOfTurn` emits `final` before `turn-end` so consumers that ignore turn events keep committing transcripts unchanged; unknown or malformed frames yield no events and never throw.
- `buildFluxQueryParams` omits `eager_eot_threshold` entirely when unset (that is what keeps eager turn-end speculation off) and clamps thresholds to Deepgram's accepted ranges.

Part of plan: flux-turn-detection.md (PR 5 of 8)