### PR TITLE
Use the native mobile composer peek on Android

### DIFF
--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -7,11 +7,11 @@
  *   from the top edge of the screen, eyes half cut off by the edge with
  *   the rest of the body exposed, breathing and blinking over the
  *   chrome.
- * - **Resting, Capacitor iOS**: no top perch. The native shell draws
- *   under the Dynamic Island, which sits exactly where that avatar's
- *   eyes would be, so instead the avatar says hello once from behind
- *   the input's bottom edge, off toward the right and hanging upside
- *   down off the rim, then tucks back up and stays behind the card.
+ * - **Resting, native mobile**: no top perch. Native shells draw under
+ *   the system status area, which can cover that avatar's eyes, so the
+ *   avatar says hello once from behind the input's bottom edge, off
+ *   toward the right and hanging upside down off the rim, then tucks
+ *   back up and stays behind the card.
  * - **Focused** (the input is active): on both shells the avatar
  *   surfaces over the input's top edge, its lower half hidden behind
  *   the rim, while the input casts a soft unoffset shadow over it so
@@ -33,7 +33,7 @@ import { motion, useReducedMotion } from "motion/react";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
 import { recordUpdate } from "@/lib/commit-pressure";
-import { useIsNativeIOS } from "@/runtime/platform-detection";
+import { useIsNativeMobile } from "@/runtime/platform-detection";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { avatarPeekMetrics } from "@/utils/avatar-peek-metrics";
@@ -113,11 +113,9 @@ export function ComposerPeek({
   const reduce = useReducedMotion();
   // The onboarding tour floods the composer itself — never compete with it.
   const navTourActive = useInChatOnboardingStore.use.navTourActive();
-  // The top perch hangs its eyes off the screen's top edge, which is where
-  // the Dynamic Island sits once a Capacitor shell draws under the status
-  // bar. Browsers (including mobile Safari, where the Island is above the
-  // page) keep it; the native shell gets the bottom-edge hello instead.
-  const nativeIOS = useIsNativeIOS();
+  // Native shells can place the system status area over the top perch.
+  // Browsers keep it; native mobile gets the bottom-edge hello instead.
+  const nativeMobile = useIsNativeMobile();
   const [rect, setRect] = useState<TargetRect | null>(null);
   const [mode, setMode] = useState<Mode>("rest");
   const [introRisen, setIntroRisen] = useState(false);
@@ -238,10 +236,10 @@ export function ComposerPeek({
     };
   }, [runnable]);
 
-  // The iOS hello runs off the first rect, since that's when the avatar
-  // first has an edge to peek over. It always runs to completion: a fresh
-  // chat autofocuses its composer, so gating it on focus would skip it.
-  const introReady = nativeIOS && rect !== null;
+  // The native mobile hello runs off the first rect, when the avatar first
+  // has an edge to peek over. It always runs to completion: a fresh chat
+  // autofocuses its composer, so gating it on focus would skip it.
+  const introReady = nativeMobile && rect !== null;
   useEffect(() => {
     if (!introReady) {
       return;
@@ -266,7 +264,7 @@ export function ComposerPeek({
   const focused = mode === "focus";
   // The hello owns the avatar until it has ducked away, so the focus peek
   // stays out of the way rather than putting a second one on screen.
-  const introActive = nativeIOS && !introDone;
+  const introActive = nativeMobile && !introDone;
 
   // Input peek geometry: expose down to just below the eye ink, capped —
   // low-faced bodies scale down rather than exposing a taller slab.
@@ -334,7 +332,7 @@ export function ComposerPeek({
 
   return createPortal(
     <div aria-hidden="true" className="pointer-events-none fixed inset-0 z-30">
-      {!nativeIOS && (
+      {!nativeMobile && (
         /* Top-of-screen dude, shown while the input is idle. */
         <motion.div
           className="absolute"
@@ -365,8 +363,8 @@ export function ComposerPeek({
         </motion.div>
       )}
       {introActive && (
-        /* The iOS hello: a mirror column below the input, clipped at its
-           bottom rim, so the avatar comes out of the other edge.
+        /* The native mobile hello: a mirror column below the input, clipped
+           at its bottom rim, so the avatar comes out of the other edge.
 
            Keyed apart from the focus peek below so React remounts rather
            than reconciling the two into one element. Without the keys a


### PR DESCRIPTION
## Summary
- Use the shared native mobile detector for the empty-chat avatar perch.
- Keep the top avatar out of both iOS and Android system status areas.

## Original prompt
Audit iOS-specific behavior and apply it to Android where the same native mobile constraint exists. This PR addresses the composer peek parity gap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->