### PR TITLE
Report Android feedback from the native app

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -6593,6 +6593,7 @@ components:
       enum:
       - macos
       - ios
+      - android
       - web
       - cli
       - electron
@@ -6600,6 +6601,7 @@ components:
       description: |-
         * `macos` - macOS
         * `ios` - iOS
+        * `android` - Android
         * `web` - Web
         * `cli` - CLI
         * `electron` - Electron

--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const feedbackRequests: unknown[] = [];
+let capacitorPlatform: "web" | "ios" | "android" = "web";
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   feedbackCreateMutation: () => ({
@@ -13,6 +14,13 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
       return { id: "feedback-1" };
     },
   }),
+}));
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => capacitorPlatform,
+    isNativePlatform: () => capacitorPlatform !== "web",
+  },
 }));
 
 mock.module("@/stores/auth-store", () => ({
@@ -29,6 +37,7 @@ const { ShareFeedbackModal, stripBulkBase64, dedupeAgainstClientMessages } =
 afterEach(() => {
   cleanup();
   feedbackRequests.length = 0;
+  capacitorPlatform = "web";
   delete (window as unknown as { _vellumDebug?: unknown })._vellumDebug;
 });
 
@@ -83,6 +92,32 @@ describe("ShareFeedbackModal", () => {
       (screen.getByLabelText("What's on your mind?") as HTMLTextAreaElement)
         .value,
     ).toBe("The app colors are ugly.");
+  });
+
+  test("reports Android shell feedback as android", async () => {
+    capacitorPlatform = "android";
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ShareFeedbackModal
+          open
+          onClose={() => {}}
+          initialReason="other"
+          initialMessage="The app colors are ugly."
+        />
+      </QueryClientProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(feedbackRequests).toHaveLength(1));
+    const request = feedbackRequests[0] as { body: { client?: string } };
+    expect(request.body.client).toBe("android");
   });
 
   test("submits Doctor session id and transcript diagnostics", async () => {

--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -21,6 +21,7 @@ mock.module("@capacitor/core", () => ({
     getPlatform: () => capacitorPlatform,
     isNativePlatform: () => capacitorPlatform !== "web",
   },
+  registerPlugin: () => ({}),
 }));
 
 mock.module("@/stores/auth-store", () => ({

--- a/clients/web/src/components/share-feedback-modal.test.tsx
+++ b/clients/web/src/components/share-feedback-modal.test.tsx
@@ -6,11 +6,18 @@ import userEvent from "@testing-library/user-event";
 
 const feedbackRequests: unknown[] = [];
 let capacitorPlatform: "web" | "ios" | "android" = "web";
+let rejectAndroidFeedbackClient = false;
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   feedbackCreateMutation: () => ({
     mutationFn: async (request: unknown) => {
       feedbackRequests.push(request);
+      if (
+        rejectAndroidFeedbackClient &&
+        (request as { body?: { client?: string } }).body?.client === "android"
+      ) {
+        throw { client: ["Unsupported client."] };
+      }
       return { id: "feedback-1" };
     },
   }),
@@ -39,6 +46,7 @@ afterEach(() => {
   cleanup();
   feedbackRequests.length = 0;
   capacitorPlatform = "web";
+  rejectAndroidFeedbackClient = false;
   delete (window as unknown as { _vellumDebug?: unknown })._vellumDebug;
 });
 
@@ -119,6 +127,36 @@ describe("ShareFeedbackModal", () => {
     await waitFor(() => expect(feedbackRequests).toHaveLength(1));
     const request = feedbackRequests[0] as { body: { client?: string } };
     expect(request.body.client).toBe("android");
+  });
+
+  test("falls back to web when the platform rejects Android", async () => {
+    capacitorPlatform = "android";
+    rejectAndroidFeedbackClient = true;
+    const client = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <ShareFeedbackModal
+          open
+          onClose={() => {}}
+          initialReason="other"
+          initialMessage="The app colors are ugly."
+        />
+      </QueryClientProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(feedbackRequests).toHaveLength(2));
+    expect(
+      feedbackRequests.map(
+        (request) => (request as { body: { client?: string } }).body.client,
+      ),
+    ).toEqual(["android", "web"]);
   });
 
   test("submits Doctor session id and transcript diagnostics", async () => {

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -136,19 +136,17 @@ const CLASSIFICATION_MAP: Record<FeedbackReason, ClassificationEnum> = {
  *
  * Typed as the API's own `ClientEnum` rather than a restated union, so a value
  * the platform stops accepting is a compile error here instead of a rejected
- * submission at runtime — which is exactly how `android` got here: it was
- * removed from the enum server-side, and nothing on this side noticed.
- *
- * Android reports as `web` deliberately. No native Capacitor Android shell
- * ships (see `runtime/push-registration.ts`), so an Android device reaching
- * this is in a browser and *is* a web client. This field is triage metadata,
- * and failing the whole submission over it would cost the report itself.
+ * submission at runtime.
  */
 function getFeedbackClient(): ClientEnum {
   if (isElectron()) {
     return "electron";
   }
-  return Capacitor.getPlatform() === "ios" ? "ios" : "web";
+  const platform = Capacitor.getPlatform();
+  if (platform === "ios" || platform === "android") {
+    return platform;
+  }
+  return "web";
 }
 
 type FeedbackDiagnosticsProvider = () => Record<string, unknown> | null;

--- a/clients/web/src/components/share-feedback-modal.tsx
+++ b/clients/web/src/components/share-feedback-modal.tsx
@@ -149,6 +149,10 @@ function getFeedbackClient(): ClientEnum {
   return "web";
 }
 
+function isFeedbackClientValidationError(error: unknown): boolean {
+  return error !== null && typeof error === "object" && "client" in error;
+}
+
 type FeedbackDiagnosticsProvider = () => Record<string, unknown> | null;
 
 interface ExtraLogFile {
@@ -867,43 +871,58 @@ export function ShareFeedbackModal({
               },
             )
           : null;
-      await mutation.mutateAsync({
-        headers: { "Content-Type": null },
-        body: {
-          message: message.trim(),
-          classification: CLASSIFICATION_MAP[selectedReason],
-          email: email.trim(),
-          client: getFeedbackClient(),
-          client_version: import.meta.env.VITE_APP_VERSION ?? undefined,
-          ...(assistantId ? { assistant_id: assistantId } : {}),
-          ...(assistantVersion ? { assistant_version: assistantVersion } : {}),
-          ...(doctorSessionId ? { doctor_session_id: doctorSessionId } : {}),
-          ...(logsFile ? { logs_file: logsFile } : {}),
-          ...(attachments.length ? { attachments } : {}),
-        },
-        bodySerializer: (body) => {
-          const form = new FormData();
-          for (const [key, value] of Object.entries(
-            body as Record<string, unknown>,
-          )) {
-            if (value == null) {
-              continue;
-            }
-            if (key === "attachments" && Array.isArray(value)) {
-              for (const file of value) {
-                form.append("attachments", file as Blob);
+      const feedbackClient = getFeedbackClient();
+      const submitFeedback = (client: ClientEnum) =>
+        mutation.mutateAsync({
+          headers: { "Content-Type": null },
+          body: {
+            message: message.trim(),
+            classification: CLASSIFICATION_MAP[selectedReason],
+            email: email.trim(),
+            client,
+            client_version: import.meta.env.VITE_APP_VERSION ?? undefined,
+            ...(assistantId ? { assistant_id: assistantId } : {}),
+            ...(assistantVersion
+              ? { assistant_version: assistantVersion }
+              : {}),
+            ...(doctorSessionId ? { doctor_session_id: doctorSessionId } : {}),
+            ...(logsFile ? { logs_file: logsFile } : {}),
+            ...(attachments.length ? { attachments } : {}),
+          },
+          bodySerializer: (body) => {
+            const form = new FormData();
+            for (const [key, value] of Object.entries(
+              body as Record<string, unknown>,
+            )) {
+              if (value == null) {
+                continue;
               }
-              continue;
+              if (key === "attachments" && Array.isArray(value)) {
+                for (const file of value) {
+                  form.append("attachments", file as Blob);
+                }
+                continue;
+              }
+              if (value instanceof Blob) {
+                form.append(key, value);
+              } else {
+                form.append(key, String(value));
+              }
             }
-            if (value instanceof Blob) {
-              form.append(key, value);
-            } else {
-              form.append(key, String(value));
-            }
-          }
-          return form;
-        },
-      });
+            return form;
+          },
+        });
+      try {
+        await submitFeedback(feedbackClient);
+      } catch (err) {
+        if (
+          feedbackClient !== "android" ||
+          !isFeedbackClientValidationError(err)
+        ) {
+          throw err;
+        }
+        await submitFeedback("web");
+      }
       onSubmitted?.();
       onClose();
     } catch (err) {


### PR DESCRIPTION
## Summary
- Report native Android feedback as android while preserving iOS, Electron, and web attribution.
- Update the platform schema snapshot and add a behavioral submission test for Android.
- Retry once as web when an older platform rejects the Android client value, preserving the report during rollout.
- Companion contract: https://github.com/vellum-ai/vellum-assistant-platform/pull/9796.

## Original prompt
Audit iOS-specific behavior and apply it to Android where the native clients need parity. Android feedback currently reaches triage labeled as web, so this PR sends the correct client attribution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->