### PR TITLE
fix(config): turn reasoning fully off on the latency-optimized profile

### DIFF
--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -135,7 +135,11 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     label: "Speed",
     description: "Fastest responses, with reasoning turned off",
     maxTokens: 8192,
-    effort: "low",
+    // Explicit reasoning opt-out, matching `cost-optimized` above: this
+    // profile advertises reasoning as off, and OpenAI-compat APIs default
+    // reasoning to "medium" when the field is omitted, so the opt-out has to
+    // be stated rather than implied.
+    effort: "none",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: {
       maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -194,7 +198,7 @@ const BYOK_PROFILE_IMPLS: Record<
     label: "Speed",
     description: "Fastest responses, with reasoning turned off",
     maxTokens: 8192,
-    effort: "low",
+    effort: "none",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },


### PR DESCRIPTION
## What

`latency-optimized` (user-facing label **Speed**, description *"Fastest responses, with reasoning turned off"*) shipped with `effort: "low"` alongside `thinking: { enabled: false }`. `"low"` is a reduced reasoning tier, not an opt-out — the profile was still paying for reasoning tokens it advertises as off.

Changed to `effort: "none"` in both columns of the catalog in `assistant/src/config/default-profile-catalog.ts`:

- `VELLUM_PROFILE_IMPLS["latency-optimized"]` — the managed implementation (`gpt-5.6-luna`)
- `BYOK_PROFILE_IMPLS["latency-optimized"]` — the shared BYOK implementation resolved per provider through the `latency-optimized` intent

This matches what `cost-optimized` already does, and the accompanying comment there.

## Why `"none"` and not omission

`"none"` is the Vellum-specific opt-out value, and each provider encodes it however actually disables reasoning on that wire:

- OpenAI Responses → `reasoning.effort: "none"`
- Chat Completions → `reasoning_effort: "none"` explicitly, because **omitting** the field makes OpenAI default to `"medium"`
- Anthropic → omits `output_config.effort` entirely (`providers/anthropic/client.ts` skips the field when `effort === "none"`)

## Behavior impact

- **OpenAI / Fireworks / Together / OpenRouter / Vercel AI Gateway / Baseten / Poolside:** effectively no change on the wire — `retry.ts` already coerces `effort` to `"none"` for these providers whenever `thinking` is disabled (`DISABLED_THINKING_USES_EFFORT_PROVIDERS`). The `"low"` was dead config there.
- **Anthropic BYOK:** real change. Anthropic is *not* in that set, so a Speed-profile request previously sent `output_config.effort: "low"`; it now omits the field, which is Anthropic's documented opt-out. This is the fix.

## Not changed (worth a look)

`call-site-defaults.ts` pins `effort: "low"` per call site on `voiceFrontDecision` and `voiceFrontDoor`, both of which point at `latency-optimized`. Those overrides win over the profile, so the live-voice front model still runs at `"low"` after this PR. Left alone deliberately — the same `"low"` is applied across ~15 background call sites (classifiers, starters, etc.), so flipping it is a broader decision about the call-site layer, not this profile. Happy to follow up if we want those on `"none"` too.

Also left alone: `USER_PROFILE_TEMPLATES["custom-latency-optimized"]` derives from this template and so moves to `"none"` as well. Harmless — per the comment on that block, hatch seeding never wrote a `custom-latency-optimized`, so no install holds one for the conversion pass to recognize.

## Testing

- `bunx tsgo --noEmit` (`assistant`) — clean
- `bun run lint` (`assistant`) — clean
- `bun test src/config src/workspace src/__tests__/managed-profile-guard.test.ts src/__tests__/model-intents.test.ts src/plugin-api/model-profiles.test.ts src/__tests__/plugin-api-model-profiles.test.ts` — 569 pass / 14 fail, **identical to the clean-tree baseline on `origin/main`**. The 14 are pre-existing cross-file `mock.module` pollution in media-processing/gated-profile tests during batched local runs; every one of them passes when its file is run in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->