### PR TITLE
docs(clients): add mobile platform parity guidance

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -13,6 +13,9 @@ Applies to all code under `clients/`. Subordinate to root [`AGENTS.md`](../AGENT
   `bun.lock` and per-package `bun install`. Native shell directories
   (`clients/ios/`, `clients/android/`) are Capacitor shells built from
   `clients/web/` and have no package manifests of their own.
+- When adding or changing platform checks for iOS or Android, consider whether
+  the same behavior should apply to the other mobile platform and keep their
+  handling aligned when appropriate.
 - Exact version pinning is enforced repo-wide; see root `AGENTS.md` for the
   dependency, license, and tool-version rules.
 - All current client apps use bundlers (`clients/web/` via Vite,


### PR DESCRIPTION
## Summary

- Remind contributors to consider Android when adding iOS platform checks, and iOS when adding Android platform checks.
- Keep mobile platform behavior aligned when the same change applies to both clients.

## Original prompt

Update clients/AGENTS.md so platform-specific changes are considered across both mobile clients. An iOS check should prompt consideration of Android, and an Android check should prompt consideration of iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->