### PR TITLE
Copy pass on toast notifications: no em dashes (LUM-3071)

### DIFF
--- a/clients/web/src/components/runtime-upgrade-banner.tsx
+++ b/clients/web/src/components/runtime-upgrade-banner.tsx
@@ -219,7 +219,7 @@ export function RuntimeUpgradeBanner({
         }
       } else {
         await localUpgrade.upgrade();
-        toast.success("Update complete — assistant is healthy.", {
+        toast.success("Update complete. Your assistant is healthy.", {
           id: "runtime-upgrade-complete",
           tone: "strong",
         });
@@ -351,7 +351,7 @@ function usePlatformRuntimeUpgrade({
           }
           targetVersionRef.current = null;
           setIsPollingUpgrade(false);
-          toast.success("Update complete — assistant is healthy.", {
+          toast.success("Update complete. Your assistant is healthy.", {
             id: "runtime-upgrade-complete",
             tone: "strong",
           });

--- a/clients/web/src/components/update-toast.tsx
+++ b/clients/web/src/components/update-toast.tsx
@@ -48,7 +48,7 @@ function UpdateToastContent({
       <div className="min-w-0 flex-1 space-y-2">
         {state.status === "available" && (
           <p className="text-body-medium-default">
-            Update available — downloading will begin shortly.
+            Update available. Starting download…
           </p>
         )}
 

--- a/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
@@ -344,7 +344,7 @@ describe("StoreCredentialDialog", () => {
     expect(toasts).toEqual([
       {
         kind: "success",
-        message: "Stored securely — the key never entered the chat",
+        message: "Stored securely. The key never entered the chat.",
       },
     ]);
   });

--- a/clients/web/src/domains/chat/components/store-credential-dialog.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.tsx
@@ -237,7 +237,7 @@ export function StoreCredentialDialog({
       open={open && storable}
       onClose={onClose}
       onSaved={handleSaved}
-      successToastMessage="Stored securely — the key never entered the chat"
+      successToastMessage="Stored securely. The key never entered the chat."
       initialValues={{
         service: suggestion.service,
         field: suggestion.field,

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -158,7 +158,7 @@ export function useConversationSecondaryActions({
         captureError(err, { context: "summarize_up_to_here" });
         toast.error(
           err instanceof ApiError && err.status === 409
-            ? "The assistant is busy — try again when the current response finishes"
+            ? "Your assistant is busy. Try again when it finishes replying."
             : "Couldn't summarize the conversation",
         );
       }
@@ -189,7 +189,7 @@ export function useConversationSecondaryActions({
       captureError(err, { context: "retry_latest_turn" });
       toast.error(
         err instanceof ApiError && err.status === 409
-          ? "The assistant is busy — try again when the current response finishes"
+          ? "Your assistant is busy. Try again when it finishes replying."
           : "Couldn't retry the response",
       );
     }

--- a/clients/web/src/domains/intelligence/personality-page.tsx
+++ b/clients/web/src/domains/intelligence/personality-page.tsx
@@ -81,7 +81,7 @@ export function PersonalityPage() {
         void queryClient.invalidateQueries({
           queryKey: assistantIdentityDetailsQueryKey(assistantId),
         });
-        toast.success("Personality updated — come say hi!");
+        toast.success("Personality updated. Go say hi!");
         void navigate(routes.identity);
       } else {
         toast.error(

--- a/clients/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/clients/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -123,8 +123,8 @@ export function AssistantUpgrades({
         setSelectedVersion(null);
         toast.success(
           isPollingRollback
-            ? "Rollback complete — assistant is healthy."
-            : "Update complete — assistant is healthy.",
+            ? "Rollback complete. Your assistant is healthy."
+            : "Update complete. Your assistant is healthy.",
           { id: "runtime-upgrade-complete", tone: "strong" },
         );
         onUpgradeComplete?.();
@@ -446,7 +446,7 @@ export function LocalAssistantUpgrades({
           ? `Successfully updated to version ${result.version}.`
           : `Successfully updated to version ${targetVersion ?? "latest"}.`,
       );
-      toast.success("Update complete — assistant is healthy.", {
+      toast.success("Update complete. Your assistant is healthy.", {
         id: "runtime-upgrade-complete",
         tone: "strong",
       });

--- a/clients/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/assistant-lifecycle-panel.tsx
@@ -78,7 +78,7 @@ export function AssistantLifecyclePanel() {
         toast.success(
           result.status === 201
             ? "New assistant hatched successfully."
-            : "Returned your existing assistant — no new one was created.",
+            : "You already have an assistant. Nothing new was created.",
         );
         // Invalidate the panel's own queries by their real generated keys so
         // the info + list cards refresh (the previous `["assistants"]` key

--- a/clients/web/src/stores/assistant-feature-flag-store.ts
+++ b/clients/web/src/stores/assistant-feature-flag-store.ts
@@ -144,7 +144,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()((
           return { [key]: confirmedValue };
         });
         toast.error(
-          `Couldn't update "${getFlagDefinition(key)?.label ?? key}" — change reverted.`,
+          `Couldn't update "${getFlagDefinition(key)?.label ?? key}". Your change was reverted.`,
         );
       };
       const flagKey = storeKeyToFlagKey(key);
@@ -219,7 +219,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()((
           };
         });
         toast.error(
-          `Couldn't update "${getFlagDefinition(key)?.label ?? key}" — change reverted.`,
+          `Couldn't update "${getFlagDefinition(key)?.label ?? key}". Your change was reverted.`,
         );
       };
       const flagKey = storeKeyToFlagKey(key);


### PR DESCRIPTION
Ten toast call sites in `clients/web` split a sentence with an em dash. This is a copy pass, not a punctuation swap — each string is rewritten as plain sentences.

| Before | After |
|---|---|
| Update complete — assistant is healthy. | Update complete. Your assistant is healthy. |
| Rollback complete — assistant is healthy. | Rollback complete. Your assistant is healthy. |
| Returned your existing assistant — no new one was created. | You already have an assistant. Nothing new was created. |
| The assistant is busy — try again when the current response finishes | Your assistant is busy. Try again when it finishes replying. |
| Personality updated — come say hi! | Personality updated. Go say hi! |
| Couldn't update "X" — change reverted. | Couldn't update "X". Your change was reverted. |
| Stored securely — the key never entered the chat | Stored securely. The key never entered the chat. |
| Update available — downloading will begin shortly. | Update available. Starting download… |

`store-credential-dialog.test.tsx` asserts on its toast string, so it moves with the copy.

**Deliberately out of scope:** `cli/src/commands/upgrade.ts:1179` (CLI stdout, not a toast) and `packages/design-library/src/components/toast.test.tsx:29` (arbitrary test fixture). Both still contain em dashes; neither is shipped toast copy.

## Testing
- `bun test src/domains/chat/components/store-credential-dialog.test.tsx` — 78 pass, 0 fail
- `bunx tsc --noEmit` in `clients/web` — clean
- Re-scanned every `toast.*()` call expression in `clients/web`, `apps`, `clients/macos`, and `packages`: zero em or en dashes remain.

Closes LUM-3071

🤖 Generated with [Claude Code](https://claude.com/claude-code)