### PR TITLE
fix(web): stop offering profiles the resolver cannot dispatch

### DIFF
--- a/clients/web/src/assistant/profile-pickers.ts
+++ b/clients/web/src/assistant/profile-pickers.ts
@@ -2,29 +2,57 @@
  * Helpers for profile picker UIs (Default Profile dropdown, call-site
  * override pickers, the composer profile menu).
  *
- * Disabled profiles are hidden from pickers in normal usage, but the
- * currently-selected one must remain visible so the picker can render
- * its trigger label and the user has a visible recovery path. Without
- * this carve-out, disabling the active profile leaves the trigger with
- * an empty label and the user wondering what's still in effect.
+ * A picker shows the profiles the resolver would actually accept. It hides
+ * the ones it would skip, EXCEPT the current selection, which stays visible
+ * so the picker can render its trigger label and the user has a visible
+ * recovery path. Without that carve-out, a profile becoming unusable leaves
+ * the trigger with an empty label and the user wondering what's in effect.
  */
 
 export interface ProfilePickerEntry {
   readonly name: string;
   readonly label?: string | null;
   readonly status?: "active" | "disabled" | null;
+  readonly provider?: string | null;
+  readonly model?: string | null;
+  readonly mix?: unknown;
+}
+
+/**
+ * Whether the resolver would accept this profile when a rung names it.
+ *
+ * Mirrors `usableEntry` in `assistant/src/config/llm-resolver.ts`: a rung
+ * only wins if its profile is enabled and carries its own provider AND
+ * model. A profile missing either is reported as `"incomplete"` and skipped,
+ * so offering it in a picker produces a pin that silently falls through to
+ * the next rung while the UI still shows it as the selection.
+ *
+ * A mix carries no provider or model of its own: the daemon expands it to a
+ * seeded arm and judges that arm. Treat mixes as dispatchable rather than
+ * re-deriving arm selection here, so a working mix is never hidden. A mix
+ * whose arms are all broken still falls through at resolution time, which is
+ * the same outcome as today.
+ */
+export function isDispatchableProfile(p: ProfilePickerEntry): boolean {
+  if (p.status === "disabled") {
+    return false;
+  }
+  if (p.mix != null) {
+    return true;
+  }
+  return !!p.provider && !!p.model;
 }
 
 /**
  * Chooses the profile used when a call-site override is toggled on.
- * The optional preferred profile is used only when it is active; otherwise the
- * first active profile is used.
+ * The optional preferred profile is used only when it is dispatchable;
+ * otherwise the first dispatchable profile is used.
  */
 export function selectSeedProfileForOverride<T extends ProfilePickerEntry>(
   profiles: ReadonlyArray<T>,
   preferredProfile: string | null | undefined,
 ): string | undefined {
-  const candidates = profiles.filter((p) => p.status !== "disabled");
+  const candidates = profiles.filter(isDispatchableProfile);
   if (preferredProfile && candidates.some((p) => p.name === preferredProfile)) {
     return preferredProfile;
   }
@@ -34,9 +62,9 @@ export function selectSeedProfileForOverride<T extends ProfilePickerEntry>(
 /**
  * Returns the subset of `profiles` to render in a picker.
  *
- * Drops `status === "disabled"` entries, EXCEPT for any entry whose
- * `name` appears in `selectedNames` — those stay visible so the picker
- * can show the current selection.
+ * Drops entries the resolver would skip (see `isDispatchableProfile`),
+ * EXCEPT for any entry whose `name` appears in `selectedNames`, which stay
+ * visible so the picker can show the current selection.
  *
  * `selectedNames` accepts loose values (string | null | undefined) so
  * callers can splat the raw active-profile state without pre-filtering.
@@ -52,18 +80,24 @@ export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
     }
   }
   return profiles.filter(
-    (p) => p.status !== "disabled" || selected.has(p.name),
+    (p) => isDispatchableProfile(p) || selected.has(p.name),
   );
 }
 
 /**
- * Label to render in a picker for a profile. Appends a " (Disabled)"
- * suffix when the profile is disabled — the only path a disabled entry
- * appears in a picker is via `visibleProfilesForPicker` keeping it
- * because it's the current selection, so the suffix makes that state
- * legible at a glance.
+ * Label to render in a picker for a profile. Flags the states the resolver
+ * would skip, since the only path such an entry appears in a picker is
+ * `visibleProfilesForPicker` keeping it as the current selection: without
+ * the suffix the user sees a normal-looking selection that is not the
+ * profile the action actually runs on.
  */
 export function profilePickerLabel(p: ProfilePickerEntry): string {
   const base = p.label ?? p.name;
-  return p.status === "disabled" ? `${base} (Disabled)` : base;
+  if (p.status === "disabled") {
+    return `${base} (Disabled)`;
+  }
+  if (!isDispatchableProfile(p)) {
+    return `${base} (Unavailable)`;
+  }
+  return base;
 }

--- a/clients/web/src/assistant/profile-pickers.ts
+++ b/clients/web/src/assistant/profile-pickers.ts
@@ -25,9 +25,32 @@ export interface ProfilePickerEntry {
   readonly mix?: ProfileEntry["mix"];
 }
 
+/**
+ * Options describing what the connected assistant guarantees about the
+ * profile shapes it serves.
+ */
+export interface ProfileDispatchOptions {
+  /**
+   * Whether a profile must carry its own provider and model to dispatch.
+   *
+   * True from assistant 0.10.8 on, where blank fields are baked at write
+   * time (`complete-profile-snapshots`). Older assistants deep-merge at
+   * resolution time, so a blank field live-inherits and a sparse profile
+   * dispatches fine. Judging those by the strict rule would hide a working
+   * profile, so only the disabled check applies there.
+   */
+  readonly requireOwnProviderAndModel: boolean;
+}
+
 /** A profile that names no other profiles: it dispatches on its own fields. */
-function isDispatchableStandardProfile(p: ProfilePickerEntry): boolean {
-  return p.status !== "disabled" && !!p.provider && !!p.model;
+function isDispatchableStandardProfile(
+  p: ProfilePickerEntry,
+  { requireOwnProviderAndModel }: ProfileDispatchOptions,
+): boolean {
+  if (p.status === "disabled") {
+    return false;
+  }
+  return requireOwnProviderAndModel ? !!p.provider && !!p.model : true;
 }
 
 /**
@@ -51,16 +74,21 @@ function isDispatchableStandardProfile(p: ProfilePickerEntry): boolean {
  * let `filter(isDispatchableProfile)` pass the array index in its place.
  * An arm naming a profile absent from the set is treated as broken, matching
  * the resolver reporting that expansion as `"missing"`.
+ *
+ * `options` carries what the connected assistant guarantees; see
+ * `ProfileDispatchOptions`. Callers in React read it from
+ * `useSupportsCompleteProfileSnapshots()`.
  */
 export function isDispatchableProfile(
   p: ProfilePickerEntry,
   siblings: ReadonlyArray<ProfilePickerEntry>,
+  options: ProfileDispatchOptions,
 ): boolean {
   if (p.status === "disabled") {
     return false;
   }
   if (p.mix == null) {
-    return isDispatchableStandardProfile(p);
+    return isDispatchableStandardProfile(p, options);
   }
   const arms = Array.isArray(p.mix) ? p.mix : [];
   if (arms.length === 0) {
@@ -68,7 +96,7 @@ export function isDispatchableProfile(
   }
   return arms.every((arm) => {
     const target = siblings.find((s) => s.name === arm?.profile);
-    return target != null && isDispatchableStandardProfile(target);
+    return target != null && isDispatchableStandardProfile(target, options);
   });
 }
 
@@ -80,8 +108,11 @@ export function isDispatchableProfile(
 export function selectSeedProfileForOverride<T extends ProfilePickerEntry>(
   profiles: ReadonlyArray<T>,
   preferredProfile: string | null | undefined,
+  options: ProfileDispatchOptions,
 ): string | undefined {
-  const candidates = profiles.filter((p) => isDispatchableProfile(p, profiles));
+  const candidates = profiles.filter((p) =>
+    isDispatchableProfile(p, profiles, options),
+  );
   if (preferredProfile && candidates.some((p) => p.name === preferredProfile)) {
     return preferredProfile;
   }
@@ -101,6 +132,7 @@ export function selectSeedProfileForOverride<T extends ProfilePickerEntry>(
 export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
   profiles: ReadonlyArray<T>,
   selectedNames: ReadonlyArray<string | null | undefined>,
+  options: ProfileDispatchOptions,
 ): T[] {
   const selected = new Set<string>();
   for (const n of selectedNames) {
@@ -109,7 +141,7 @@ export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
     }
   }
   return profiles.filter(
-    (p) => isDispatchableProfile(p, profiles) || selected.has(p.name),
+    (p) => isDispatchableProfile(p, profiles, options) || selected.has(p.name),
   );
 }
 
@@ -140,11 +172,12 @@ export type ProfilePickerIssue = "disabled" | "undispatchable";
 export function profilePickerIssue(
   p: ProfilePickerEntry,
   siblings: ReadonlyArray<ProfilePickerEntry>,
+  options: ProfileDispatchOptions,
 ): ProfilePickerIssue | null {
   if (p.status === "disabled") {
     return "disabled";
   }
-  return isDispatchableProfile(p, siblings) ? null : "undispatchable";
+  return isDispatchableProfile(p, siblings, options) ? null : "undispatchable";
 }
 
 /** Hover copy for an `"undispatchable"` entry. */

--- a/clients/web/src/assistant/profile-pickers.ts
+++ b/clients/web/src/assistant/profile-pickers.ts
@@ -25,6 +25,11 @@ export interface ProfilePickerEntry {
   readonly mix?: ProfileEntry["mix"];
 }
 
+/** A profile that names no other profiles: it dispatches on its own fields. */
+function isDispatchableStandardProfile(p: ProfilePickerEntry): boolean {
+  return p.status !== "disabled" && !!p.provider && !!p.model;
+}
+
 /**
  * Whether the resolver would accept this profile when a rung names it.
  *
@@ -34,20 +39,37 @@ export interface ProfilePickerEntry {
  * so offering it in a picker produces a pin that silently falls through to
  * the next rung while the UI still shows it as the selection.
  *
- * A mix carries no provider or model of its own: the daemon expands it to a
- * seeded arm and judges that arm. Treat mixes as dispatchable rather than
- * re-deriving arm selection here, so a working mix is never hidden. A mix
- * whose arms are all broken still falls through at resolution time, which is
- * the same outcome as today.
+ * A mix carries no provider or model of its own. The resolver expands it to
+ * one arm by a weighted pick seeded on the conversation, then judges that
+ * arm, so which arm runs is not knowable when the picker is drawn: a mix
+ * with one broken arm dispatches on some turns and falls through on others.
+ * A mix is therefore offered only when EVERY arm is dispatchable. Arms are
+ * standard profiles (the schema rejects nesting), so this does not recurse.
+ *
+ * `siblings` is the profile set the arms are resolved against, and is
+ * required: defaulting it would make a mix silently unjudgeable, and would
+ * let `filter(isDispatchableProfile)` pass the array index in its place.
+ * An arm naming a profile absent from the set is treated as broken, matching
+ * the resolver reporting that expansion as `"missing"`.
  */
-export function isDispatchableProfile(p: ProfilePickerEntry): boolean {
+export function isDispatchableProfile(
+  p: ProfilePickerEntry,
+  siblings: ReadonlyArray<ProfilePickerEntry>,
+): boolean {
   if (p.status === "disabled") {
     return false;
   }
-  if (p.mix != null) {
-    return true;
+  if (p.mix == null) {
+    return isDispatchableStandardProfile(p);
   }
-  return !!p.provider && !!p.model;
+  const arms = Array.isArray(p.mix) ? p.mix : [];
+  if (arms.length === 0) {
+    return false;
+  }
+  return arms.every((arm) => {
+    const target = siblings.find((s) => s.name === arm?.profile);
+    return target != null && isDispatchableStandardProfile(target);
+  });
 }
 
 /**
@@ -59,7 +81,7 @@ export function selectSeedProfileForOverride<T extends ProfilePickerEntry>(
   profiles: ReadonlyArray<T>,
   preferredProfile: string | null | undefined,
 ): string | undefined {
-  const candidates = profiles.filter(isDispatchableProfile);
+  const candidates = profiles.filter((p) => isDispatchableProfile(p, profiles));
   if (preferredProfile && candidates.some((p) => p.name === preferredProfile)) {
     return preferredProfile;
   }
@@ -87,7 +109,7 @@ export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
     }
   }
   return profiles.filter(
-    (p) => isDispatchableProfile(p) || selected.has(p.name),
+    (p) => isDispatchableProfile(p, profiles) || selected.has(p.name),
   );
 }
 
@@ -98,12 +120,15 @@ export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
  * the suffix the user sees a normal-looking selection that is not the
  * profile the action actually runs on.
  */
-export function profilePickerLabel(p: ProfilePickerEntry): string {
+export function profilePickerLabel(
+  p: ProfilePickerEntry,
+  siblings: ReadonlyArray<ProfilePickerEntry>,
+): string {
   const base = p.label ?? p.name;
   if (p.status === "disabled") {
     return `${base} (Disabled)`;
   }
-  if (!isDispatchableProfile(p)) {
+  if (!isDispatchableProfile(p, siblings)) {
     return `${base} (Unavailable)`;
   }
   return base;

--- a/clients/web/src/assistant/profile-pickers.ts
+++ b/clients/web/src/assistant/profile-pickers.ts
@@ -9,13 +9,20 @@
  * the trigger with an empty label and the user wondering what's in effect.
  */
 
+import type { ProfileEntry } from "@/generated/daemon/types.gen";
+
+/**
+ * The subset of a profile a picker needs. Fields are typed from the generated
+ * `ProfileEntry` so they cannot drift from the wire, and stay optional so
+ * callers can pass a summary shape that omits some of them.
+ */
 export interface ProfilePickerEntry {
   readonly name: string;
-  readonly label?: string | null;
-  readonly status?: "active" | "disabled" | null;
-  readonly provider?: string | null;
-  readonly model?: string | null;
-  readonly mix?: unknown;
+  readonly label?: ProfileEntry["label"];
+  readonly status?: ProfileEntry["status"];
+  readonly provider?: ProfileEntry["provider"] | null;
+  readonly model?: ProfileEntry["model"] | null;
+  readonly mix?: ProfileEntry["mix"];
 }
 
 /**

--- a/clients/web/src/assistant/profile-pickers.ts
+++ b/clients/web/src/assistant/profile-pickers.ts
@@ -120,16 +120,38 @@ export function visibleProfilesForPicker<T extends ProfilePickerEntry>(
  * the suffix the user sees a normal-looking selection that is not the
  * profile the action actually runs on.
  */
-export function profilePickerLabel(
+export function profilePickerLabel(p: ProfilePickerEntry): string {
+  const base = p.label ?? p.name;
+  return p.status === "disabled" ? `${base} (Disabled)` : base;
+}
+
+/**
+ * Why a picker entry is not a usable choice, for surfaces that render an
+ * affordance rather than reading the predicate directly.
+ *
+ * `"disabled"` is a state the user chose and `profilePickerLabel` already
+ * says so in words. `"undispatchable"` is a misconfiguration: the profile
+ * looks selectable but the resolver skips it, so surfaces flag it the way
+ * the Profiles row flags an availability problem, with a warning icon and
+ * the reason on hover, rather than with a word appended to its name.
+ */
+export type ProfilePickerIssue = "disabled" | "undispatchable";
+
+export function profilePickerIssue(
   p: ProfilePickerEntry,
   siblings: ReadonlyArray<ProfilePickerEntry>,
-): string {
-  const base = p.label ?? p.name;
+): ProfilePickerIssue | null {
   if (p.status === "disabled") {
-    return `${base} (Disabled)`;
+    return "disabled";
   }
-  if (!isDispatchableProfile(p, siblings)) {
-    return `${base} (Unavailable)`;
+  return isDispatchableProfile(p, siblings) ? null : "undispatchable";
+}
+
+/** Hover copy for an `"undispatchable"` entry. */
+export function undispatchableProfileReason(p: ProfilePickerEntry): string {
+  const base = p.label ?? p.name;
+  if (p.mix != null) {
+    return `"${base}" mixes a profile that has no provider and model, so some turns would fall back to another profile.`;
   }
-  return base;
+  return `"${base}" has no provider and model, so it cannot be used and the action falls back to another profile.`;
 }

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -143,7 +143,13 @@ const configGetMock = mock(
     data: {
       llm: {
         profileOrder: ["smart"],
-        profiles: { smart: { label: "Smart" } },
+        profiles: {
+          smart: {
+            label: "Smart",
+            provider: "anthropic",
+            model: "claude-fable-5",
+          },
+        },
         activeProfile: "smart",
       },
     },
@@ -284,8 +290,16 @@ describe("Model Profile quick-add", () => {
         llm: {
           profileOrder: ["smart", NEW_PROFILE_NAME],
           profiles: {
-            smart: { label: "Smart" },
-            [NEW_PROFILE_NAME]: { label: NEW_PROFILE_LABEL },
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+            [NEW_PROFILE_NAME]: {
+              label: NEW_PROFILE_LABEL,
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
           },
           activeProfile: "smart",
         },
@@ -412,8 +426,16 @@ describe("Profile trigger updates", () => {
       llm: {
         profileOrder: ["balanced", "quality"],
         profiles: {
-          balanced: { label: "Balanced" },
-          quality: { label: "Quality" },
+          balanced: {
+            label: "Balanced",
+            provider: "anthropic",
+            model: "claude-fable-5",
+          },
+          quality: {
+            label: "Quality",
+            provider: "anthropic",
+            model: "claude-fable-5",
+          },
         },
         activeProfile: "balanced",
       },
@@ -483,7 +505,13 @@ describe("Profile selection with no active conversation (new draft chat)", () =>
       data: {
         llm: {
           profileOrder: ["smart"],
-          profiles: { smart: { label: "Smart" } },
+          profiles: {
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+          },
           activeProfile: "smart",
         },
       },
@@ -541,7 +569,13 @@ describe("Profile activation rejected by the daemon", () => {
       data: {
         llm: {
           profileOrder: ["smart"],
-          profiles: { smart: { label: "Smart" } },
+          profiles: {
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+          },
           activeProfile: "smart",
         },
       },

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 import {
   profilePickerLabel,
   visibleProfilesForPicker,
@@ -441,9 +442,15 @@ export function ComposerSettingsMenu({
     return [...ordered, ...extras];
   }, [profiles, profileOrder]);
 
+  // Older assistants live-inherit blank profile fields at resolution time,
+  // so a sparse profile dispatches there and must not be hidden.
+  const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();
   const visibleProfileEntries = useMemo(
-    () => visibleProfilesForPicker(orderedProfileEntries, [profileActiveKey]),
-    [orderedProfileEntries, profileActiveKey],
+    () =>
+      visibleProfilesForPicker(orderedProfileEntries, [profileActiveKey], {
+        requireOwnProviderAndModel,
+      }),
+    [orderedProfileEntries, profileActiveKey, requireOwnProviderAndModel],
   );
 
   // Label for the currently-active profile, shown inline on the composer

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -456,7 +456,7 @@ export function ComposerSettingsMenu({
     const entry = orderedProfileEntries.find(
       (e) => e.name === profileActiveKey,
     );
-    return entry ? profilePickerLabel(entry, orderedProfileEntries) : null;
+    return entry ? profilePickerLabel(entry) : null;
   }, [orderedProfileEntries, profileActiveKey]);
 
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
@@ -658,7 +658,7 @@ export function ComposerSettingsMenu({
                     <PanelItem
                       key={entry.name}
                       icon={Sparkles}
-                      label={profilePickerLabel(entry, orderedProfileEntries)}
+                      label={profilePickerLabel(entry)}
                       active={isActive}
                       className="max-md:[&>span:first-child]:gap-[11px]"
                       trailingAction={
@@ -752,7 +752,7 @@ export function ComposerSettingsMenu({
                     ) : undefined
                   }
                 >
-                  {profilePickerLabel(entry, orderedProfileEntries)}
+                  {profilePickerLabel(entry)}
                 </Menu.Item>
               );
             })}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -456,7 +456,7 @@ export function ComposerSettingsMenu({
     const entry = orderedProfileEntries.find(
       (e) => e.name === profileActiveKey,
     );
-    return entry ? profilePickerLabel(entry) : null;
+    return entry ? profilePickerLabel(entry, orderedProfileEntries) : null;
   }, [orderedProfileEntries, profileActiveKey]);
 
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
@@ -658,7 +658,7 @@ export function ComposerSettingsMenu({
                     <PanelItem
                       key={entry.name}
                       icon={Sparkles}
-                      label={profilePickerLabel(entry)}
+                      label={profilePickerLabel(entry, orderedProfileEntries)}
                       active={isActive}
                       className="max-md:[&>span:first-child]:gap-[11px]"
                       trailingAction={
@@ -752,7 +752,7 @@ export function ComposerSettingsMenu({
                     ) : undefined
                   }
                 >
-                  {profilePickerLabel(entry)}
+                  {profilePickerLabel(entry, orderedProfileEntries)}
                 </Menu.Item>
               );
             })}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.stories.tsx
@@ -121,3 +121,112 @@ type Story = StoryObj<typeof OverridesDetailPanel>;
  * never enters the `llm.callSites` patch.
  */
 export const Default: Story = {};
+
+// A config carrying every state the picker has to judge. Only the two
+// healthy profiles and the sound mix are dispatchable; the rest are what the
+// resolver would skip.
+const MIXED_HEALTH_CONFIG: ConfigGetResponse = {
+  llm: {
+    profiles: {
+      balanced: {
+        label: "Balanced",
+        provider: "vellum",
+        model: "glm-5.2",
+        source: "managed",
+        status: "active",
+      },
+      "quality-optimized": {
+        label: "Quality",
+        provider: "vellum",
+        model: "gpt-5.6-sol",
+        source: "managed",
+        status: "active",
+      },
+      // Names a provider but no model, so the resolver reports the rung as
+      // "incomplete" and falls through.
+      "half-made": { label: "Half Made", provider: "anthropic" },
+      retired: {
+        label: "Retired",
+        provider: "vellum",
+        model: "glm-5.2",
+        status: "disabled",
+      },
+      // Every arm dispatches, so the mix is offered.
+      "sound-mix": {
+        label: "Sound Mix",
+        mix: [
+          { profile: "balanced", weight: 1 },
+          { profile: "quality-optimized", weight: 1 },
+        ],
+      },
+      // One arm cannot dispatch. The arm is picked per conversation, so this
+      // would work on some turns and silently fall through on others.
+      "flaky-mix": {
+        label: "Flaky Mix",
+        mix: [
+          { profile: "balanced", weight: 1 },
+          { profile: "half-made", weight: 1 },
+        ],
+      },
+    },
+    profileOrder: [
+      "balanced",
+      "quality-optimized",
+      "half-made",
+      "retired",
+      "sound-mix",
+      "flaky-mix",
+    ],
+    activeProfile: "balanced",
+    // Deliberately pointing at a profile that cannot dispatch, to show the
+    // carve-out: the current selection is never hidden, or the trigger would
+    // render blank with no way out.
+    advisorProfile: "half-made",
+    callSites: {},
+  },
+};
+
+/**
+ * What the pickers hide and what they keep.
+ *
+ * Open the Advisor dropdown, or toggle a call-site row on and open its
+ * dropdown: only Balanced, Quality, and Sound Mix are offered. Half Made
+ * (no model), Retired (disabled), and Flaky Mix (one arm with no model) are
+ * all absent, because the resolver would skip each of them and run something
+ * else while the picker showed your choice.
+ *
+ * The Advisor is set to Half Made, so it renders as the current selection
+ * labeled "(Unavailable)": the one entry that stays visible whatever its
+ * state, so the trigger has a label and there is a way back.
+ */
+export const UndispatchableProfilesHidden: Story = {
+  decorators: [
+    (Story) => {
+      const client = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            refetchOnWindowFocus: false,
+            staleTime: Infinity,
+          },
+        },
+      });
+      const path = { assistant_id: ASSISTANT_ID };
+      client.setQueryData(
+        configLlmCallsitesGetOptions({ path }).queryKey,
+        CATALOG,
+      );
+      client.setQueryData(
+        configGetOptions({ path }).queryKey,
+        MIXED_HEALTH_CONFIG,
+      );
+      return (
+        <QueryClientProvider client={client}>
+          <div style={{ maxWidth: 560, height: 720 }}>
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -27,6 +27,7 @@ import {
   configLlmCallsitesGetOptions,
   useConfigPatchMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 import { captureError } from "@/lib/sentry/capture-error";
 import { DetailShell } from "@/components/detail-shell";
 import { Button } from "@vellumai/design-library/components/button";
@@ -74,6 +75,13 @@ export function OverridesDetailPanel({
     [profiles, profileOrder],
   );
   const selectableInferenceProviders = useSelectableInferenceProviders();
+  // Older assistants live-inherit blank profile fields at resolution time,
+  // so a sparse profile dispatches there and must not be judged incomplete.
+  const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();
+  const dispatchOptions = useMemo(
+    () => ({ requireOwnProviderAndModel }),
+    [requireOwnProviderAndModel],
+  );
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
@@ -162,7 +170,8 @@ export function OverridesDetailPanel({
     (p: (typeof orderedProfiles)[number]) => ({
       value: p.name,
       label: profilePickerLabel(p),
-      ...(profilePickerIssue(p, orderedProfiles) === "undispatchable"
+      ...(profilePickerIssue(p, orderedProfiles, dispatchOptions) ===
+      "undispatchable"
         ? {
             icon: (
               <AlertCircle className="h-3.5 w-3.5 text-[var(--system-mid-strong)]" />
@@ -171,14 +180,16 @@ export function OverridesDetailPanel({
           }
         : {}),
     }),
-    [orderedProfiles],
+    [orderedProfiles, dispatchOptions],
   );
 
   const advisorOptions = useMemo(
     () =>
-      visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map(
-        toProfileOption,
-      ),
+      visibleProfilesForPicker(
+        orderedProfiles,
+        [persistedAdvisor],
+        dispatchOptions,
+      ).map(toProfileOption),
     [orderedProfiles, persistedAdvisor, toProfileOption],
   );
 
@@ -201,15 +212,17 @@ export function OverridesDetailPanel({
 
   const buildProfileOptionsForRow = useCallback(
     (selectedProfile: string | null) => {
-      const visible = visibleProfilesForPicker(orderedProfiles, [
-        selectedProfile,
-      ]);
+      const visible = visibleProfilesForPicker(
+        orderedProfiles,
+        [selectedProfile],
+        dispatchOptions,
+      );
       return [
         ...visible.map(toProfileOption),
         { value: CUSTOM_SENTINEL, label: "Custom" },
       ];
     },
-    [orderedProfiles, toProfileOption],
+    [orderedProfiles, toProfileOption, dispatchOptions],
   );
 
   const filteredCallSites = useMemo(() => {
@@ -265,6 +278,7 @@ export function OverridesDetailPanel({
       const seedProfile = selectSeedProfileForOverride(
         orderedProfiles,
         cs?.defaultProfile,
+        dispatchOptions,
       );
       if (seedProfile) {
         setDraft(id, { profile: seedProfile });

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -190,7 +190,7 @@ export function OverridesDetailPanel({
         [persistedAdvisor],
         dispatchOptions,
       ).map(toProfileOption),
-    [orderedProfiles, persistedAdvisor, toProfileOption],
+    [orderedProfiles, persistedAdvisor, toProfileOption, dispatchOptions],
   );
 
   // "advisor" isn't in the call-site catalog, so its row filters on its own
@@ -289,7 +289,13 @@ export function OverridesDetailPanel({
         setDraft(id, { provider: defaultProvider, model: defaultModel });
       }
     },
-    [gatedCallSites, orderedProfiles, selectableInferenceProviders, setDraft],
+    [
+      gatedCallSites,
+      orderedProfiles,
+      selectableInferenceProviders,
+      setDraft,
+      dispatchOptions,
+    ],
   );
 
   // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -158,7 +158,7 @@ export function OverridesDetailPanel({
       visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map(
         (p) => ({
           value: p.name,
-          label: profilePickerLabel(p),
+          label: profilePickerLabel(p, orderedProfiles),
         }),
       ),
     [orderedProfiles, persistedAdvisor],
@@ -189,7 +189,7 @@ export function OverridesDetailPanel({
       return [
         ...visible.map((p) => ({
           value: p.name,
-          label: profilePickerLabel(p),
+          label: profilePickerLabel(p, orderedProfiles),
         })),
         { value: CUSTOM_SENTINEL, label: "Custom" },
       ];

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -1,11 +1,13 @@
-import { Loader2, Search } from "lucide-react";
+import { AlertCircle, Loader2, Search } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  profilePickerIssue,
   profilePickerLabel,
   selectSeedProfileForOverride,
+  undispatchableProfileReason,
   visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
 import { getDefaultModelForProvider } from "@/assistant/llm-model-catalog";
@@ -153,15 +155,31 @@ export function OverridesDetailPanel({
     [orderedProfiles],
   );
 
+  // An entry only reaches a picker while undispatchable when it is the
+  // current selection. It carries the same warning affordance the Profiles
+  // row uses, rather than a word appended to its name.
+  const toProfileOption = useCallback(
+    (p: (typeof orderedProfiles)[number]) => ({
+      value: p.name,
+      label: profilePickerLabel(p),
+      ...(profilePickerIssue(p, orderedProfiles) === "undispatchable"
+        ? {
+            icon: (
+              <AlertCircle className="h-3.5 w-3.5 text-[var(--system-mid-strong)]" />
+            ),
+            tooltip: undispatchableProfileReason(p),
+          }
+        : {}),
+    }),
+    [orderedProfiles],
+  );
+
   const advisorOptions = useMemo(
     () =>
       visibleProfilesForPicker(orderedProfiles, [persistedAdvisor]).map(
-        (p) => ({
-          value: p.name,
-          label: profilePickerLabel(p, orderedProfiles),
-        }),
+        toProfileOption,
       ),
-    [orderedProfiles, persistedAdvisor],
+    [orderedProfiles, persistedAdvisor, toProfileOption],
   );
 
   // "advisor" isn't in the call-site catalog, so its row filters on its own
@@ -187,14 +205,11 @@ export function OverridesDetailPanel({
         selectedProfile,
       ]);
       return [
-        ...visible.map((p) => ({
-          value: p.name,
-          label: profilePickerLabel(p, orderedProfiles),
-        })),
+        ...visible.map(toProfileOption),
         { value: CUSTOM_SENTINEL, label: "Custom" },
       ];
     },
-    [orderedProfiles],
+    [orderedProfiles, toProfileOption],
   );
 
   const filteredCallSites = useMemo(() => {

--- a/clients/web/src/domains/settings/ai/profile-pickers.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-pickers.test.ts
@@ -37,44 +37,97 @@ const profiles: ProfilePickerEntry[] = [
 
 describe("isDispatchableProfile", () => {
   test("true only when enabled with a provider and a model", () => {
-    expect(isDispatchableProfile(profiles[0]!)).toBe(true);
+    expect(isDispatchableProfile(profiles[0]!, profiles)).toBe(true);
   });
 
   test("false when disabled, even if complete", () => {
-    expect(isDispatchableProfile(profiles[2]!)).toBe(false);
+    expect(isDispatchableProfile(profiles[2]!, profiles)).toBe(false);
   });
 
   test("false when either half of the pair is missing", () => {
-    expect(isDispatchableProfile({ name: "a", provider: "anthropic" })).toBe(
-      false,
-    );
-    expect(isDispatchableProfile({ name: "b", model: "claude-opus-5" })).toBe(
-      false,
-    );
-    expect(isDispatchableProfile({ name: "c" })).toBe(false);
+    expect(
+      isDispatchableProfile({ name: "a", provider: "anthropic" }, profiles),
+    ).toBe(false);
+    expect(
+      isDispatchableProfile({ name: "b", model: "claude-opus-5" }, profiles),
+    ).toBe(false);
+    expect(isDispatchableProfile({ name: "c" }, profiles)).toBe(false);
   });
 
-  // A mix reports no provider or model of its own: the daemon expands it to
-  // a seeded arm. Hiding mixes would remove working profiles from pickers.
-  test("true for a mix despite having no provider or model", () => {
+  // A mix is expanded to ONE arm by a weighted pick seeded on the
+  // conversation, so which arm runs is not knowable when the picker is
+  // drawn. Offering a mix with a broken arm would dispatch on some turns
+  // and silently fall through on others.
+  test("true when every arm is dispatchable", () => {
     expect(
-      isDispatchableProfile({
-        name: "ab",
-        mix: [
-          { profile: "balanced", weight: 1 },
-          { profile: "quality", weight: 1 },
-        ],
-      }),
+      isDispatchableProfile(
+        {
+          name: "ab",
+          mix: [
+            { profile: "balanced", weight: 1 },
+            { profile: "quality", weight: 1 },
+          ],
+        },
+        profiles,
+      ),
     ).toBe(true);
   });
 
-  test("false for a disabled mix", () => {
+  test("false when any arm is incomplete", () => {
     expect(
-      isDispatchableProfile({
-        name: "ab",
-        status: "disabled",
-        mix: [{ profile: "balanced", weight: 1 }],
-      }),
+      isDispatchableProfile(
+        {
+          name: "ab",
+          mix: [
+            { profile: "balanced", weight: 1 },
+            { profile: "halfmade", weight: 1 },
+          ],
+        },
+        profiles,
+      ),
+    ).toBe(false);
+  });
+
+  test("false when any arm is disabled", () => {
+    expect(
+      isDispatchableProfile(
+        {
+          name: "ab",
+          mix: [
+            { profile: "balanced", weight: 1 },
+            { profile: "off", weight: 1 },
+          ],
+        },
+        profiles,
+      ),
+    ).toBe(false);
+  });
+
+  test("false when an arm names a profile that is not defined", () => {
+    expect(
+      isDispatchableProfile(
+        { name: "ab", mix: [{ profile: "ghost", weight: 1 }] },
+        profiles,
+      ),
+    ).toBe(false);
+  });
+
+  test("false for an empty mix", () => {
+    expect(isDispatchableProfile({ name: "ab", mix: [] }, profiles)).toBe(
+      false,
+    );
+  });
+
+  test("false for a disabled mix whose arms are all fine", () => {
+    expect(
+      isDispatchableProfile(
+        {
+          name: "ab",
+          status: "disabled",
+          mix: [{ profile: "balanced", weight: 1 }],
+        },
+        profiles,
+      ),
     ).toBe(false);
   });
 });
@@ -128,26 +181,27 @@ describe("visibleProfilesForPicker", () => {
 
 describe("profilePickerLabel", () => {
   test("plain label when dispatchable", () => {
-    expect(profilePickerLabel(profiles[0]!)).toBe("Balanced");
+    expect(profilePickerLabel(profiles[0]!, profiles)).toBe("Balanced");
   });
 
   test("flags disabled", () => {
-    expect(profilePickerLabel(profiles[2]!)).toBe("Off (Disabled)");
+    expect(profilePickerLabel(profiles[2]!, profiles)).toBe("Off (Disabled)");
   });
 
   // Kept visible only as a current selection, so it has to read as broken
   // rather than as a normal choice.
   test("flags an entry that cannot dispatch", () => {
-    expect(profilePickerLabel(profiles[3]!)).toBe("Half Made (Unavailable)");
+    expect(profilePickerLabel(profiles[3]!, profiles)).toBe(
+      "Half Made (Unavailable)",
+    );
   });
 
   test("falls back to the name when unlabeled", () => {
     expect(
-      profilePickerLabel({
-        name: "raw",
-        provider: "anthropic",
-        model: "claude-opus-5",
-      }),
+      profilePickerLabel(
+        { name: "raw", provider: "anthropic", model: "claude-opus-5" },
+        profiles,
+      ),
     ).toBe("raw");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-pickers.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-pickers.test.ts
@@ -1,26 +1,153 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isDispatchableProfile,
+  profilePickerLabel,
   selectSeedProfileForOverride,
+  visibleProfilesForPicker,
   type ProfilePickerEntry,
 } from "@/assistant/profile-pickers";
 
-describe("selectSeedProfileForOverride", () => {
-  const profiles: ProfilePickerEntry[] = [
-    { name: "balanced", label: "Balanced" },
-    { name: "quality", label: "Quality" },
-    { name: "disabled", label: "Disabled", status: "disabled" },
-  ];
+// Config-shaped entries: `llm.profiles` values always carry a provider and
+// model, or a `mix` that the daemon expands to an arm that does.
+const profiles: ProfilePickerEntry[] = [
+  {
+    name: "balanced",
+    label: "Balanced",
+    provider: "anthropic",
+    model: "claude-fable-5",
+  },
+  {
+    name: "quality",
+    label: "Quality",
+    provider: "anthropic",
+    model: "claude-opus-5",
+  },
+  {
+    name: "off",
+    label: "Off",
+    status: "disabled",
+    provider: "anthropic",
+    model: "claude-opus-5",
+  },
+  // Names a provider but nothing to dispatch with. The resolver reports this
+  // rung as "incomplete" and falls through to the next one.
+  { name: "halfmade", label: "Half Made", provider: "anthropic" },
+];
 
-  test("uses the first active profile as the fallback seed", () => {
+describe("isDispatchableProfile", () => {
+  test("true only when enabled with a provider and a model", () => {
+    expect(isDispatchableProfile(profiles[0]!)).toBe(true);
+  });
+
+  test("false when disabled, even if complete", () => {
+    expect(isDispatchableProfile(profiles[2]!)).toBe(false);
+  });
+
+  test("false when either half of the pair is missing", () => {
+    expect(isDispatchableProfile({ name: "a", provider: "anthropic" })).toBe(
+      false,
+    );
+    expect(isDispatchableProfile({ name: "b", model: "claude-opus-5" })).toBe(
+      false,
+    );
+    expect(isDispatchableProfile({ name: "c" })).toBe(false);
+  });
+
+  // A mix reports no provider or model of its own: the daemon expands it to
+  // a seeded arm. Hiding mixes would remove working profiles from pickers.
+  test("true for a mix despite having no provider or model", () => {
+    expect(
+      isDispatchableProfile({
+        name: "ab",
+        mix: [
+          { profile: "balanced", weight: 1 },
+          { profile: "quality", weight: 1 },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("false for a disabled mix", () => {
+    expect(
+      isDispatchableProfile({
+        name: "ab",
+        status: "disabled",
+        mix: [{ profile: "balanced", weight: 1 }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("selectSeedProfileForOverride", () => {
+  test("uses the first dispatchable profile as the fallback seed", () => {
     expect(selectSeedProfileForOverride(profiles, undefined)).toBe("balanced");
   });
 
-  test("honors an active preferred seed", () => {
+  test("honors a dispatchable preferred seed", () => {
     expect(selectSeedProfileForOverride(profiles, "quality")).toBe("quality");
   });
 
   test("falls back when the preferred seed is disabled", () => {
-    expect(selectSeedProfileForOverride(profiles, "disabled")).toBe("balanced");
+    expect(selectSeedProfileForOverride(profiles, "off")).toBe("balanced");
+  });
+
+  // Seeding an override with a profile the resolver skips would create a pin
+  // that silently does nothing.
+  test("falls back when the preferred seed cannot dispatch", () => {
+    expect(selectSeedProfileForOverride(profiles, "halfmade")).toBe("balanced");
+  });
+});
+
+describe("visibleProfilesForPicker", () => {
+  test("hides profiles the resolver would skip", () => {
+    const names = visibleProfilesForPicker(profiles, []).map((p) => p.name);
+    expect(names).toEqual(["balanced", "quality"]);
+  });
+
+  test("keeps the current selection visible even when unusable", () => {
+    // Otherwise the trigger renders an empty label and the user has no
+    // recovery path from the state they are already in.
+    const incomplete = visibleProfilesForPicker(profiles, ["halfmade"]).map(
+      (p) => p.name,
+    );
+    expect(incomplete).toContain("halfmade");
+    const disabled = visibleProfilesForPicker(profiles, ["off"]).map(
+      (p) => p.name,
+    );
+    expect(disabled).toContain("off");
+  });
+
+  test("ignores null and undefined selections", () => {
+    const names = visibleProfilesForPicker(profiles, [null, undefined]).map(
+      (p) => p.name,
+    );
+    expect(names).toEqual(["balanced", "quality"]);
+  });
+});
+
+describe("profilePickerLabel", () => {
+  test("plain label when dispatchable", () => {
+    expect(profilePickerLabel(profiles[0]!)).toBe("Balanced");
+  });
+
+  test("flags disabled", () => {
+    expect(profilePickerLabel(profiles[2]!)).toBe("Off (Disabled)");
+  });
+
+  // Kept visible only as a current selection, so it has to read as broken
+  // rather than as a normal choice.
+  test("flags an entry that cannot dispatch", () => {
+    expect(profilePickerLabel(profiles[3]!)).toBe("Half Made (Unavailable)");
+  });
+
+  test("falls back to the name when unlabeled", () => {
+    expect(
+      profilePickerLabel({
+        name: "raw",
+        provider: "anthropic",
+        model: "claude-opus-5",
+      }),
+    ).toBe("raw");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-pickers.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-pickers.test.ts
@@ -6,6 +6,8 @@ import {
   selectSeedProfileForOverride,
   visibleProfilesForPicker,
   type ProfilePickerEntry,
+  profilePickerIssue,
+  undispatchableProfileReason,
 } from "@/assistant/profile-pickers";
 
 // Config-shaped entries: `llm.profiles` values always carry a provider and
@@ -181,27 +183,66 @@ describe("visibleProfilesForPicker", () => {
 
 describe("profilePickerLabel", () => {
   test("plain label when dispatchable", () => {
-    expect(profilePickerLabel(profiles[0]!, profiles)).toBe("Balanced");
+    expect(profilePickerLabel(profiles[0]!)).toBe("Balanced");
   });
 
   test("flags disabled", () => {
-    expect(profilePickerLabel(profiles[2]!, profiles)).toBe("Off (Disabled)");
+    expect(profilePickerLabel(profiles[2]!)).toBe("Off (Disabled)");
   });
 
-  // Kept visible only as a current selection, so it has to read as broken
-  // rather than as a normal choice.
-  test("flags an entry that cannot dispatch", () => {
-    expect(profilePickerLabel(profiles[3]!, profiles)).toBe(
-      "Half Made (Unavailable)",
-    );
+  // The undispatchable case is not a word in the label: surfaces render the
+  // warning affordance for it, so the label stays the profile's own name.
+  test("leaves an undispatchable entry's name alone", () => {
+    expect(profilePickerLabel(profiles[3]!)).toBe("Half Made");
   });
 
   test("falls back to the name when unlabeled", () => {
     expect(
-      profilePickerLabel(
-        { name: "raw", provider: "anthropic", model: "claude-opus-5" },
+      profilePickerLabel({
+        name: "raw",
+        provider: "anthropic",
+        model: "claude-opus-5",
+      }),
+    ).toBe("raw");
+  });
+});
+
+describe("profilePickerIssue", () => {
+  test("null when the profile is a usable choice", () => {
+    expect(profilePickerIssue(profiles[0]!, profiles)).toBeNull();
+  });
+
+  // Disabled is a state the user chose, and the label already says so. The
+  // undispatchable case is a misconfiguration, so surfaces flag it the way
+  // the Profiles row flags an availability problem.
+  test("distinguishes a chosen off state from a broken one", () => {
+    expect(profilePickerIssue(profiles[2]!, profiles)).toBe("disabled");
+    expect(profilePickerIssue(profiles[3]!, profiles)).toBe("undispatchable");
+  });
+
+  test("a mix with a broken arm is undispatchable, not disabled", () => {
+    expect(
+      profilePickerIssue(
+        { name: "ab", mix: [{ profile: "halfmade", weight: 1 }] },
         profiles,
       ),
-    ).toBe("raw");
+    ).toBe("undispatchable");
+  });
+});
+
+describe("undispatchableProfileReason", () => {
+  test("names the profile and what happens instead", () => {
+    const reason = undispatchableProfileReason(profiles[3]!);
+    expect(reason).toContain("Half Made");
+    expect(reason).toContain("falls back");
+  });
+
+  test("a mix explains that only some turns fall back", () => {
+    const reason = undispatchableProfileReason({
+      name: "ab",
+      label: "A/B",
+      mix: [{ profile: "halfmade", weight: 1 }],
+    });
+    expect(reason).toContain("some turns");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-pickers.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-pickers.test.ts
@@ -37,23 +37,37 @@ const profiles: ProfilePickerEntry[] = [
   { name: "halfmade", label: "Half Made", provider: "anthropic" },
 ];
 
+// Assistant 0.10.8 and later bake blank profile fields at write time, so a
+// profile must carry its own provider and model. Older assistants deep-merge
+// at resolution, so blanks live-inherit and a sparse profile dispatches.
+const STRICT = { requireOwnProviderAndModel: true } as const;
+const LEGACY = { requireOwnProviderAndModel: false } as const;
+
 describe("isDispatchableProfile", () => {
   test("true only when enabled with a provider and a model", () => {
-    expect(isDispatchableProfile(profiles[0]!, profiles)).toBe(true);
+    expect(isDispatchableProfile(profiles[0]!, profiles, STRICT)).toBe(true);
   });
 
   test("false when disabled, even if complete", () => {
-    expect(isDispatchableProfile(profiles[2]!, profiles)).toBe(false);
+    expect(isDispatchableProfile(profiles[2]!, profiles, STRICT)).toBe(false);
   });
 
   test("false when either half of the pair is missing", () => {
     expect(
-      isDispatchableProfile({ name: "a", provider: "anthropic" }, profiles),
+      isDispatchableProfile(
+        { name: "a", provider: "anthropic" },
+        profiles,
+        STRICT,
+      ),
     ).toBe(false);
     expect(
-      isDispatchableProfile({ name: "b", model: "claude-opus-5" }, profiles),
+      isDispatchableProfile(
+        { name: "b", model: "claude-opus-5" },
+        profiles,
+        STRICT,
+      ),
     ).toBe(false);
-    expect(isDispatchableProfile({ name: "c" }, profiles)).toBe(false);
+    expect(isDispatchableProfile({ name: "c" }, profiles, STRICT)).toBe(false);
   });
 
   // A mix is expanded to ONE arm by a weighted pick seeded on the
@@ -71,6 +85,7 @@ describe("isDispatchableProfile", () => {
           ],
         },
         profiles,
+        STRICT,
       ),
     ).toBe(true);
   });
@@ -86,6 +101,7 @@ describe("isDispatchableProfile", () => {
           ],
         },
         profiles,
+        STRICT,
       ),
     ).toBe(false);
   });
@@ -101,6 +117,7 @@ describe("isDispatchableProfile", () => {
           ],
         },
         profiles,
+        STRICT,
       ),
     ).toBe(false);
   });
@@ -110,14 +127,15 @@ describe("isDispatchableProfile", () => {
       isDispatchableProfile(
         { name: "ab", mix: [{ profile: "ghost", weight: 1 }] },
         profiles,
+        STRICT,
       ),
     ).toBe(false);
   });
 
   test("false for an empty mix", () => {
-    expect(isDispatchableProfile({ name: "ab", mix: [] }, profiles)).toBe(
-      false,
-    );
+    expect(
+      isDispatchableProfile({ name: "ab", mix: [] }, profiles, STRICT),
+    ).toBe(false);
   });
 
   test("false for a disabled mix whose arms are all fine", () => {
@@ -129,6 +147,7 @@ describe("isDispatchableProfile", () => {
           mix: [{ profile: "balanced", weight: 1 }],
         },
         profiles,
+        STRICT,
       ),
     ).toBe(false);
   });
@@ -136,47 +155,61 @@ describe("isDispatchableProfile", () => {
 
 describe("selectSeedProfileForOverride", () => {
   test("uses the first dispatchable profile as the fallback seed", () => {
-    expect(selectSeedProfileForOverride(profiles, undefined)).toBe("balanced");
+    expect(selectSeedProfileForOverride(profiles, undefined, STRICT)).toBe(
+      "balanced",
+    );
   });
 
   test("honors a dispatchable preferred seed", () => {
-    expect(selectSeedProfileForOverride(profiles, "quality")).toBe("quality");
+    expect(selectSeedProfileForOverride(profiles, "quality", STRICT)).toBe(
+      "quality",
+    );
   });
 
   test("falls back when the preferred seed is disabled", () => {
-    expect(selectSeedProfileForOverride(profiles, "off")).toBe("balanced");
+    expect(selectSeedProfileForOverride(profiles, "off", STRICT)).toBe(
+      "balanced",
+    );
   });
 
   // Seeding an override with a profile the resolver skips would create a pin
   // that silently does nothing.
   test("falls back when the preferred seed cannot dispatch", () => {
-    expect(selectSeedProfileForOverride(profiles, "halfmade")).toBe("balanced");
+    expect(selectSeedProfileForOverride(profiles, "halfmade", STRICT)).toBe(
+      "balanced",
+    );
   });
 });
 
 describe("visibleProfilesForPicker", () => {
   test("hides profiles the resolver would skip", () => {
-    const names = visibleProfilesForPicker(profiles, []).map((p) => p.name);
+    const names = visibleProfilesForPicker(profiles, [], STRICT).map(
+      (p) => p.name,
+    );
     expect(names).toEqual(["balanced", "quality"]);
   });
 
   test("keeps the current selection visible even when unusable", () => {
     // Otherwise the trigger renders an empty label and the user has no
     // recovery path from the state they are already in.
-    const incomplete = visibleProfilesForPicker(profiles, ["halfmade"]).map(
-      (p) => p.name,
-    );
+    const incomplete = visibleProfilesForPicker(
+      profiles,
+      ["halfmade"],
+      STRICT,
+    ).map((p) => p.name);
     expect(incomplete).toContain("halfmade");
-    const disabled = visibleProfilesForPicker(profiles, ["off"]).map(
+    const disabled = visibleProfilesForPicker(profiles, ["off"], STRICT).map(
       (p) => p.name,
     );
     expect(disabled).toContain("off");
   });
 
   test("ignores null and undefined selections", () => {
-    const names = visibleProfilesForPicker(profiles, [null, undefined]).map(
-      (p) => p.name,
-    );
+    const names = visibleProfilesForPicker(
+      profiles,
+      [null, undefined],
+      STRICT,
+    ).map((p) => p.name);
     expect(names).toEqual(["balanced", "quality"]);
   });
 });
@@ -209,15 +242,17 @@ describe("profilePickerLabel", () => {
 
 describe("profilePickerIssue", () => {
   test("null when the profile is a usable choice", () => {
-    expect(profilePickerIssue(profiles[0]!, profiles)).toBeNull();
+    expect(profilePickerIssue(profiles[0]!, profiles, STRICT)).toBeNull();
   });
 
   // Disabled is a state the user chose, and the label already says so. The
   // undispatchable case is a misconfiguration, so surfaces flag it the way
   // the Profiles row flags an availability problem.
   test("distinguishes a chosen off state from a broken one", () => {
-    expect(profilePickerIssue(profiles[2]!, profiles)).toBe("disabled");
-    expect(profilePickerIssue(profiles[3]!, profiles)).toBe("undispatchable");
+    expect(profilePickerIssue(profiles[2]!, profiles, STRICT)).toBe("disabled");
+    expect(profilePickerIssue(profiles[3]!, profiles, STRICT)).toBe(
+      "undispatchable",
+    );
   });
 
   test("a mix with a broken arm is undispatchable, not disabled", () => {
@@ -225,6 +260,7 @@ describe("profilePickerIssue", () => {
       profilePickerIssue(
         { name: "ab", mix: [{ profile: "halfmade", weight: 1 }] },
         profiles,
+        STRICT,
       ),
     ).toBe("undispatchable");
   });
@@ -244,5 +280,43 @@ describe("undispatchableProfileReason", () => {
       mix: [{ profile: "halfmade", weight: 1 }],
     });
     expect(reason).toContain("some turns");
+  });
+});
+
+describe("assistants older than complete-profile-snapshots (0.10.8)", () => {
+  // Blank fields live-inherit there, so judging them by the strict rule
+  // would hide a profile the resolver dispatches perfectly well.
+  test("a sparse profile is dispatchable", () => {
+    expect(isDispatchableProfile({ name: "sparse" }, profiles, LEGACY)).toBe(
+      true,
+    );
+    expect(isDispatchableProfile(profiles[3]!, profiles, LEGACY)).toBe(true);
+  });
+
+  test("disabled still wins: it is a choice, not an inherited blank", () => {
+    expect(isDispatchableProfile(profiles[2]!, profiles, LEGACY)).toBe(false);
+  });
+
+  // Its one arm is sparse, which dispatches on a legacy assistant, so the
+  // mix does too. The same mix is undispatchable under STRICT above.
+  test("a mix whose arms are sparse is dispatchable", () => {
+    expect(
+      isDispatchableProfile(
+        { name: "ab", mix: [{ profile: "halfmade", weight: 1 }] },
+        profiles,
+        LEGACY,
+      ),
+    ).toBe(true);
+  });
+
+  test("nothing is flagged as undispatchable", () => {
+    expect(profilePickerIssue(profiles[3]!, profiles, LEGACY)).toBeNull();
+  });
+
+  test("no profile is hidden from the picker", () => {
+    const names = visibleProfilesForPicker(profiles, [], LEGACY).map(
+      (p) => p.name,
+    );
+    expect(names).toEqual(["balanced", "quality", "halfmade"]);
   });
 });

--- a/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 
+import { isDispatchableProfile } from "@/assistant/profile-pickers";
 import type { BlockedDeleteState } from "@/domains/settings/ai/manage-profiles-blocked-delete-modal";
 import { useProfileActions } from "@/domains/settings/ai/use-profile-actions";
 import {
@@ -140,14 +141,19 @@ export function useProfileDeleteFlow(
     void deleteNow(nameToDelete);
   }
 
+  // Reassignment rewrites live references, so a replacement the resolver
+  // would skip leaves every call site it touched silently resolving
+  // elsewhere. Candidates are filtered the same way the pickers are.
+  const replacementCandidates = orderedProfiles.filter(
+    (p) =>
+      p.name !== blocked?.name && isDispatchableProfile(p, orderedProfiles),
+  );
   // Prefer non-managed profiles as replacement targets.
-  const userReplacements = orderedProfiles.filter(
-    (p) => p.name !== blocked?.name && p.source !== "managed",
+  const userReplacements = replacementCandidates.filter(
+    (p) => p.source !== "managed",
   );
   const availableReplacements =
-    userReplacements.length > 0
-      ? userReplacements
-      : orderedProfiles.filter((p) => p.name !== blocked?.name);
+    userReplacements.length > 0 ? userReplacements : replacementCandidates;
 
   return {
     requestDelete,

--- a/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 
 import { isDispatchableProfile } from "@/assistant/profile-pickers";
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 import type { BlockedDeleteState } from "@/domains/settings/ai/manage-profiles-blocked-delete-modal";
 import { useProfileActions } from "@/domains/settings/ai/use-profile-actions";
 import {
@@ -45,6 +46,9 @@ export function useProfileDeleteFlow(
   options?: { onDeleted?: (name: string) => void },
 ): ProfileDeleteFlow {
   const actions = useProfileActions(assistantId);
+  // Older assistants live-inherit blank profile fields at resolution time,
+  // so a sparse profile is a valid reassignment target there.
+  const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();
 
   const activeProfile = config?.llm?.activeProfile ?? null;
   const advisorProfile = config?.llm?.advisorProfile ?? null;
@@ -146,7 +150,10 @@ export function useProfileDeleteFlow(
   // elsewhere. Candidates are filtered the same way the pickers are.
   const replacementCandidates = orderedProfiles.filter(
     (p) =>
-      p.name !== blocked?.name && isDispatchableProfile(p, orderedProfiles),
+      p.name !== blocked?.name &&
+      isDispatchableProfile(p, orderedProfiles, {
+        requireOwnProviderAndModel,
+      }),
   );
   // Prefer non-managed profiles as replacement targets.
   const userReplacements = replacementCandidates.filter(

--- a/clients/web/src/domains/settings/components/model-profile-select.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-select.tsx
@@ -1,3 +1,5 @@
+import { AlertCircle } from "lucide-react";
+
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 
 import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
@@ -30,6 +32,14 @@ export function ModelProfileSelect({
   className,
 }: ModelProfileSelectProps) {
   const options = useProfileOptions(assistantId, value).map((option) => ({
+    ...(option.issue === "undispatchable"
+      ? {
+          icon: (
+            <AlertCircle className="h-3.5 w-3.5 text-[var(--system-mid-strong)]" />
+          ),
+          ...(option.reason ? { tooltip: option.reason } : {}),
+        }
+      : {}),
     value: profileOptionToDropdownValue(option.value),
     label: option.label,
   }));

--- a/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
@@ -37,18 +37,23 @@ describe("buildProfileOptions", () => {
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
-      { value: "legacy", label: "Legacy (Disabled)" },
+      { value: "legacy", label: "Legacy (Disabled)", issue: "disabled" },
     ]);
   });
 
   // Hiding the current selection would leave the trigger blank with no way
   // back, so it stays and is flagged instead.
-  test("keeps a selected undispatchable profile visible and flags it", () => {
+  test("keeps a selected undispatchable profile visible and marks the issue", () => {
     expect(buildProfileOptions(llm, "extra")).toEqual([
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
-      { value: "extra", label: "extra (Unavailable)" },
+      {
+        value: "extra",
+        label: "extra",
+        issue: "undispatchable",
+        reason: expect.stringContaining("cannot be used"),
+      },
     ]);
   });
 

--- a/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
@@ -9,20 +9,26 @@ type LlmConfig = NonNullable<ConfigGetResponse["llm"]>;
 const llm: LlmConfig = {
   profileOrder: ["smart", "fast", "legacy"],
   profiles: {
-    fast: { label: "Fast" },
-    smart: { label: "Smart" },
-    legacy: { label: "Legacy", status: "disabled" },
+    fast: { label: "Fast", provider: "anthropic", model: "claude-fable-5" },
+    smart: { label: "Smart", provider: "anthropic", model: "claude-opus-5" },
+    legacy: {
+      label: "Legacy",
+      status: "disabled",
+      provider: "anthropic",
+      model: "claude-opus-5",
+    },
+    // Carries nothing to dispatch with. The resolver skips such a rung, so
+    // offering it would produce a selection that silently does nothing.
     extra: {},
   },
 } as LlmConfig;
 
 describe("buildProfileOptions", () => {
-  test("orders by profileOrder, omits disabled profiles, and prepends Default", () => {
+  test("orders by profileOrder, omits what the resolver would skip, and prepends Default", () => {
     expect(buildProfileOptions(llm)).toEqual([
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
-      { value: "extra", label: "extra" },
     ]);
   });
 
@@ -32,7 +38,17 @@ describe("buildProfileOptions", () => {
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
       { value: "legacy", label: "Legacy (Disabled)" },
-      { value: "extra", label: "extra" },
+    ]);
+  });
+
+  // Hiding the current selection would leave the trigger blank with no way
+  // back, so it stays and is flagged instead.
+  test("keeps a selected undispatchable profile visible and flags it", () => {
+    expect(buildProfileOptions(llm, "extra")).toEqual([
+      { value: null, label: "Default" },
+      { value: "smart", label: "Smart" },
+      { value: "fast", label: "Fast" },
+      { value: "extra", label: "extra (Unavailable)" },
     ]);
   });
 

--- a/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.test.ts
@@ -23,9 +23,14 @@ const llm: LlmConfig = {
   },
 } as LlmConfig;
 
+// 0.10.8+ bakes blank profile fields at write time; older assistants
+// live-inherit them, so a sparse profile dispatches there.
+const STRICT = { requireOwnProviderAndModel: true } as const;
+const LEGACY = { requireOwnProviderAndModel: false } as const;
+
 describe("buildProfileOptions", () => {
   test("orders by profileOrder, omits what the resolver would skip, and prepends Default", () => {
-    expect(buildProfileOptions(llm)).toEqual([
+    expect(buildProfileOptions(llm, null, STRICT)).toEqual([
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
@@ -33,7 +38,7 @@ describe("buildProfileOptions", () => {
   });
 
   test("keeps the selected disabled profile visible", () => {
-    expect(buildProfileOptions(llm, "legacy")).toEqual([
+    expect(buildProfileOptions(llm, "legacy", STRICT)).toEqual([
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
@@ -44,7 +49,7 @@ describe("buildProfileOptions", () => {
   // Hiding the current selection would leave the trigger blank with no way
   // back, so it stays and is flagged instead.
   test("keeps a selected undispatchable profile visible and marks the issue", () => {
-    expect(buildProfileOptions(llm, "extra")).toEqual([
+    expect(buildProfileOptions(llm, "extra", STRICT)).toEqual([
       { value: null, label: "Default" },
       { value: "smart", label: "Smart" },
       { value: "fast", label: "Fast" },
@@ -58,8 +63,21 @@ describe("buildProfileOptions", () => {
   });
 
   test("returns just the Default option when config is missing", () => {
-    expect(buildProfileOptions(undefined)).toEqual([
+    expect(buildProfileOptions(undefined, null, STRICT)).toEqual([
       { value: null, label: "Default" },
+    ]);
+  });
+});
+
+describe("buildProfileOptions on a pre-0.10.8 assistant", () => {
+  // `extra` carries nothing, which live-inherits there, so it is a normal
+  // option rather than being hidden or flagged.
+  test("keeps sparse profiles as ordinary options", () => {
+    expect(buildProfileOptions(llm, null, LEGACY)).toEqual([
+      { value: null, label: "Default" },
+      { value: "smart", label: "Smart" },
+      { value: "fast", label: "Fast" },
+      { value: "extra", label: "extra" },
     ]);
   });
 });

--- a/clients/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.ts
@@ -23,16 +23,16 @@ export function buildProfileOptions(
 ): ProfileOption[] {
   const profiles = llm?.profiles ?? {};
   const profileOrder = llm?.profileOrder ?? [];
-  const visibleProfiles = visibleProfilesForPicker(
-    buildOrderedProfiles(profiles, profileOrder),
-    [selectedProfile],
-  );
+  const orderedProfiles = buildOrderedProfiles(profiles, profileOrder);
+  const visibleProfiles = visibleProfilesForPicker(orderedProfiles, [
+    selectedProfile,
+  ]);
 
   return [
     { value: null, label: "Default" },
     ...visibleProfiles.map((profile) => ({
       value: profile.name,
-      label: profilePickerLabel(profile),
+      label: profilePickerLabel(profile, orderedProfiles),
     })),
   ];
 }

--- a/clients/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.ts
@@ -2,7 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import {
+  type ProfilePickerIssue,
+  profilePickerIssue,
   profilePickerLabel,
+  undispatchableProfileReason,
   visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
 import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
@@ -15,6 +18,10 @@ type LlmConfig = ConfigGetResponse["llm"];
 export interface ProfileOption {
   readonly value: string | null;
   readonly label: string;
+  /** Set when the resolver would skip this profile; the view renders it. */
+  readonly issue?: ProfilePickerIssue;
+  /** Hover copy for an `"undispatchable"` option. */
+  readonly reason?: string;
 }
 
 export function buildProfileOptions(
@@ -30,10 +37,17 @@ export function buildProfileOptions(
 
   return [
     { value: null, label: "Default" },
-    ...visibleProfiles.map((profile) => ({
-      value: profile.name,
-      label: profilePickerLabel(profile, orderedProfiles),
-    })),
+    ...visibleProfiles.map((profile) => {
+      const issue = profilePickerIssue(profile, orderedProfiles);
+      return {
+        value: profile.name,
+        label: profilePickerLabel(profile),
+        ...(issue ? { issue } : {}),
+        ...(issue === "undispatchable"
+          ? { reason: undispatchableProfileReason(profile) }
+          : {}),
+      };
+    }),
   ];
 }
 

--- a/clients/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import {
+  type ProfileDispatchOptions,
   type ProfilePickerIssue,
   profilePickerIssue,
   profilePickerLabel,
@@ -10,6 +11,7 @@ import {
 } from "@/assistant/profile-pickers";
 import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
 import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
 
 import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
 
@@ -26,19 +28,22 @@ export interface ProfileOption {
 
 export function buildProfileOptions(
   llm: LlmConfig | undefined,
-  selectedProfile?: string | null,
+  selectedProfile: string | null | undefined,
+  options: ProfileDispatchOptions,
 ): ProfileOption[] {
   const profiles = llm?.profiles ?? {};
   const profileOrder = llm?.profileOrder ?? [];
   const orderedProfiles = buildOrderedProfiles(profiles, profileOrder);
-  const visibleProfiles = visibleProfilesForPicker(orderedProfiles, [
-    selectedProfile,
-  ]);
+  const visibleProfiles = visibleProfilesForPicker(
+    orderedProfiles,
+    [selectedProfile],
+    options,
+  );
 
   return [
     { value: null, label: "Default" },
     ...visibleProfiles.map((profile) => {
-      const issue = profilePickerIssue(profile, orderedProfiles);
+      const issue = profilePickerIssue(profile, orderedProfiles, options);
       return {
         value: profile.name,
         label: profilePickerLabel(profile),
@@ -61,8 +66,13 @@ export function useProfileOptions(
     staleTime: 60_000,
   });
 
+  const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();
+
   return useMemo(
-    () => buildProfileOptions(daemonConfig?.llm, selectedProfile),
+    () =>
+      buildProfileOptions(daemonConfig?.llm, selectedProfile, {
+        requireOwnProviderAndModel,
+      }),
     [daemonConfig?.llm, selectedProfile],
   );
 }

--- a/clients/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/clients/web/src/domains/settings/hooks/use-profile-options.ts
@@ -73,6 +73,6 @@ export function useProfileOptions(
       buildProfileOptions(daemonConfig?.llm, selectedProfile, {
         requireOwnProviderAndModel,
       }),
-    [daemonConfig?.llm, selectedProfile],
+    [daemonConfig?.llm, selectedProfile, requireOwnProviderAndModel],
   );
 }


### PR DESCRIPTION
## TL;DR

Every profile picker filtered only on `status === "disabled"`, but the resolver skips a rung on three grounds: missing, disabled, or **incomplete**, meaning the profile carries no provider and model of its own. An incomplete profile is still `active`, so pickers offered it, and choosing it wrote a pin the resolver silently skipped while the UI kept showing it as the selection.

Fixes [LUM-3072](https://linear.app/vellum/issue/LUM-3072/profile-pickers-offer-profiles-that-cannot-dispatch-so-the-selection)

## What changes for the user

| Before | After |
| --- | --- |
| A profile that cannot dispatch appears as a normal choice in the Action Overrides row pickers, the Advisor picker, and the chat composer's profile menu | It is not offered |
| Choosing one writes a pin the resolver skips, so the action keeps running on something else while the dropdown shows the profile you picked, with no error anywhere | The situation cannot be entered from a picker |
| If your current selection is in that state, it renders like any other selection | It stays visible, so the trigger still has a label and you can pick your way out, but reads `(Unavailable)` |

## Why the predicate is shaped this way

`isDispatchableProfile` mirrors `usableEntry` in `assistant/src/config/llm-resolver.ts`, which is the function that decides whether a rung wins:

- **disabled** is out, as before.
- **no provider or no model** is out. This is the case the pickers missed.
- **a mix is in**, even though it reports neither. A mix is expanded by the daemon to a seeded arm and judged on that arm, so testing a mix for its own provider and model would hide every working mix profile. A mix whose arms are all broken still falls through at resolution time, exactly as it does today.

That last point is the reason this is not simply `!!provider && !!model`: `GET /v1/inference/profiles` reports `provider: null, model: null` for mixes, so the naive predicate would have quietly removed them from every picker.

The current selection is always kept regardless, preserving the existing carve-out: hiding it would blank the trigger and leave no way back from the state the user is already in. `profilePickerLabel` flags it instead, alongside the existing `(Disabled)` suffix.

## Why this is safe

- One shared helper, so all three picker surfaces change together and cannot drift: per-action override rows, the Advisor row, and the chat composer menu.
- No wire or daemon changes; the predicate reads fields the config document already carries.
- The selection carve-out means no user is stranded by the stricter filter.
- 68 tests pass across the seven affected files, typecheck and lint clean.

## Note on the test-fixture changes

The stricter predicate initially failed 8 tests across `composer-settings-menu.test.tsx` and `use-profile-options.test.ts`. Every one was a fixture like `{ label: "Smart" }`, with no provider or model, which no real `llm.profiles` entry looks like. The fixtures now carry a provider and model, per the repo's rule that story and test data match production format. The one deliberately empty entry (`extra: {}`) is kept and its expectations updated, so it now documents the fix: it is hidden from the list, and flagged rather than hidden when it is the current selection.

## Sequencing

This lands before [#40180](https://github.com/vellum-ai/vellum-assistant/pull/40180) (bulk profile override swap), which is back in draft until it does. That feature adds a third picker for choosing a swap target, and shipping it onto a surface that still offers undispatchable profiles would let a bulk action apply an unusable profile to many actions at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->