### PR TITLE
feat(assistant): add the Deepgram Flux streaming transcriber

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
@@ -205,7 +205,7 @@ describe("parseFluxFrame", () => {
     expect(categoryOf({ code: "SOMETHING_NEW" })).toBe("provider-error");
     expect(categoryOf({})).toBe("provider-error");
     // A complaint about eot_timeout_ms is a config error, not a transport
-    // timeout — the timeout matcher must not claim it.
+    // timeout, so the timeout matcher must not claim it.
     expect(
       categoryOf({
         code: "INVALID_EOT_TIMEOUT_MS",

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
@@ -8,7 +8,7 @@ import type {
 import { SttError } from "../../../stt/types.js";
 
 // ---------------------------------------------------------------------------
-// Logger mock — must be declared before the subject import
+// Logger mock: must be declared before the subject import
 //
 // The adapter's only observable output for the chunk-cadence measurement is a
 // debug log line, and the Configure-failure contract is "warn, never a stream
@@ -504,6 +504,65 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       expect(events[1]).toEqual({ type: "closed" });
     });
 
+    test("a normal close after a fatal Error frame adds no second error", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "Error",
+          code: "INVALID_AUTH",
+          description: "Invalid credentials",
+        }),
+      );
+      mockWs.simulateClose(1000, "closing");
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({
+        type: "error",
+        category: "auth",
+        message: "Deepgram Flux error (INVALID_AUTH): Invalid credentials",
+      });
+      expect(events[1]).toEqual({ type: "closed" });
+    });
+
+    test("an abnormal close after a fatal Error frame adds no second error", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "Error",
+          code: "RATE_LIMIT_EXCEEDED",
+          description: "Too many requests",
+        }),
+      );
+      mockWs.simulateClose(1006, "abnormal");
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({
+        type: "error",
+        category: "rate-limit",
+        message: "Deepgram Flux error (RATE_LIMIT_EXCEEDED): Too many requests",
+      });
+      expect(events[1]).toEqual({ type: "closed" });
+    });
+
+    test("a socket error after a fatal Error frame adds no second error", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "Error",
+          code: "INTERNAL_SERVER_ERROR",
+          description: "Something broke",
+        }),
+      );
+      mockWs.simulateError(new Error("connection reset"));
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({ type: "error" });
+      expect(events[1]).toEqual({ type: "closed" });
+    });
+
     test("the inactivity watchdog only fires while audio awaits a response", async () => {
       const { transcriber, events } = await startSession({
         inactivityTimeoutMs: 20,
@@ -571,13 +630,13 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       expect(keepalives.length).toBeGreaterThanOrEqual(2);
     });
 
-    test("finalizeUtterance is deliberately absent — Flux owns turn boundaries", async () => {
+    test("finalizeUtterance is deliberately absent, Flux owns turn boundaries", async () => {
       const { transcriber } = await startSession();
 
       // Callers feature-detect this method and fall back to stop(), which is
       // the correct semantics for a provider whose model ends the turn. The
       // contract type is where the optional method lives, so the check goes
-      // through it — the class not declaring it at all is the point.
+      // through it. The class not declaring it at all is the point.
       const asContract: StreamingTranscriber = transcriber;
       expect(asContract.finalizeUtterance).toBeUndefined();
     });

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
@@ -1,0 +1,606 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setConfig } from "../../../__tests__/helpers/set-config.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../../stt/types.js";
+import { SttError } from "../../../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Logger mock — must be declared before the subject import
+//
+// The adapter's only observable output for the chunk-cadence measurement is a
+// debug log line, and the Configure-failure contract is "warn, never a stream
+// error", so both are asserted through captured logs.
+// ---------------------------------------------------------------------------
+
+interface CapturedLog {
+  data: unknown;
+  message: string;
+}
+
+const debugLogs: CapturedLog[] = [];
+const warnLogs: CapturedLog[] = [];
+
+function capture(sink: CapturedLog[]) {
+  return (data: unknown, message?: string) => {
+    sink.push(
+      typeof data === "string"
+        ? { data: undefined, message: data }
+        : { data, message: message ?? "" },
+    );
+  };
+}
+
+mock.module("../../../util/logger.js", () => {
+  const logger = {
+    debug: capture(debugLogs),
+    warn: capture(warnLogs),
+    info: () => {},
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => logger,
+  };
+  return { getLogger: () => logger };
+});
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+type WsEventType = "open" | "close" | "error" | "message";
+type WsListener = (...args: unknown[]) => void;
+
+/** Minimal mock WebSocket standing in for Deepgram's `/v2/listen` endpoint. */
+class MockWebSocket {
+  readyState = 0; // CONNECTING
+  bufferedAmount = 0;
+
+  /** Everything passed to `.send()`, in order. */
+  sentData: (string | Uint8Array)[] = [];
+
+  private listeners = new Map<WsEventType, WsListener[]>();
+
+  addEventListener(type: WsEventType, listener: WsListener): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  removeEventListener(type: string, listener: unknown): void {
+    const list = this.listeners.get(type as WsEventType);
+    const idx = list?.indexOf(listener as WsListener) ?? -1;
+    if (list && idx !== -1) {
+      list.splice(idx, 1);
+    }
+  }
+
+  send(data: string | Uint8Array): void {
+    if (this.readyState !== 1) {
+      throw new Error("WebSocket is not open");
+    }
+    this.sentData.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3; // CLOSED
+  }
+
+  // ── Test helpers ──────────────────────────────────────────────────
+
+  simulateOpen(): void {
+    this.readyState = 1; // OPEN
+    for (const l of this.listeners.get("open") ?? []) {
+      l();
+    }
+  }
+
+  simulateMessage(data: string): void {
+    for (const l of this.listeners.get("message") ?? []) {
+      l({ data });
+    }
+  }
+
+  simulateClose(code = 1000, reason = ""): void {
+    this.readyState = 3;
+    for (const l of this.listeners.get("close") ?? []) {
+      l({ code, reason });
+    }
+  }
+
+  simulateError(err: unknown): void {
+    for (const l of this.listeners.get("error") ?? []) {
+      l(err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subject import (after mocks)
+// ---------------------------------------------------------------------------
+
+const { DeepgramFluxRealtimeTranscriber } =
+  await import("../deepgram-flux-realtime.js");
+
+const TEST_API_KEY = "dg-flux-test-key";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Flux `TurnInfo` frame carrying the given turn state. */
+function turnInfoFrame(
+  event: string,
+  extra: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    type: "TurnInfo",
+    event,
+    request_id: "flux-request-id",
+    turn_index: 0,
+    audio_window_start: 0,
+    audio_window_end: 1.5,
+    ...extra,
+  });
+}
+
+describe("DeepgramFluxRealtimeTranscriber", () => {
+  let mockWs: MockWebSocket;
+  let dialedUrls: string[];
+  let dialedOptions: ({ headers?: Record<string, string> } | undefined)[];
+  let originalWebSocket: unknown;
+
+  beforeEach(() => {
+    // A fully default config: the acceptance criteria are about what the
+    // shipped defaults dial.
+    setConfig("liveVoice", {});
+
+    mockWs = new MockWebSocket();
+    dialedUrls = [];
+    dialedOptions = [];
+    debugLogs.length = 0;
+    warnLogs.length = 0;
+
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket;
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(url: string, options?: { headers?: Record<string, string> }) {
+        dialedUrls.push(url);
+        dialedOptions.push(options);
+        return mockWs;
+      }
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+  });
+
+  async function startSession(
+    options: ConstructorParameters<
+      typeof DeepgramFluxRealtimeTranscriber
+    >[1] = {},
+  ): Promise<{
+    transcriber: InstanceType<typeof DeepgramFluxRealtimeTranscriber>;
+    events: SttStreamServerEvent[];
+  }> {
+    const transcriber = new DeepgramFluxRealtimeTranscriber(TEST_API_KEY, {
+      // Long enough that no watchdog fires mid-test.
+      inactivityTimeoutMs: 60_000,
+      keepaliveIntervalMs: 0,
+      ...options,
+    });
+    const events: SttStreamServerEvent[] = [];
+
+    const startPromise = transcriber.start((event) => events.push(event));
+    mockWs.simulateOpen();
+    await startPromise;
+
+    return { transcriber, events };
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Dialed URL
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("session URL", () => {
+    test("dials /v2/listen with the default Flux tuning and no eager threshold", async () => {
+      await startSession();
+
+      expect(dialedUrls).toHaveLength(1);
+      const url = new URL(dialedUrls[0]!);
+
+      expect(url.protocol).toBe("wss:");
+      expect(url.host).toBe("api.deepgram.com");
+      expect(url.pathname).toBe("/v2/listen");
+      expect(url.searchParams.get("model")).toBe("flux-general-en");
+      expect(url.searchParams.get("eot_threshold")).toBe("0.7");
+      expect(url.searchParams.get("eot_timeout_ms")).toBe("5000");
+      // Unset eager threshold is what keeps Deepgram from speculating turns.
+      expect(url.searchParams.has("eager_eot_threshold")).toBe(false);
+    });
+
+    test("sends the negotiated raw-audio format", async () => {
+      await startSession({ sampleRate: 24_000 });
+
+      const url = new URL(dialedUrls[0]!);
+      expect(url.searchParams.get("encoding")).toBe("linear16");
+      expect(url.searchParams.get("sample_rate")).toBe("24000");
+    });
+
+    test("authenticates with the Token header, never the query string", async () => {
+      await startSession();
+
+      expect(dialedOptions[0]?.headers?.Authorization).toBe(
+        `Token ${TEST_API_KEY}`,
+      );
+      expect(dialedUrls[0]).not.toContain(TEST_API_KEY);
+    });
+
+    test("takes its tuning from liveVoice.flux", async () => {
+      setConfig("liveVoice", {
+        flux: {
+          model: "flux-general-multi",
+          eotThreshold: 0.9,
+          eagerEotThreshold: 0.4,
+          eotTimeoutMs: 1_500,
+        },
+      });
+
+      await startSession();
+
+      const url = new URL(dialedUrls[0]!);
+      expect(url.searchParams.get("model")).toBe("flux-general-multi");
+      expect(url.searchParams.get("eot_threshold")).toBe("0.9");
+      expect(url.searchParams.get("eager_eot_threshold")).toBe("0.4");
+      expect(url.searchParams.get("eot_timeout_ms")).toBe("1500");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Audio forwarding
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("audio forwarding", () => {
+    test("forwards audio chunks to the socket as raw bytes", async () => {
+      const { transcriber } = await startSession();
+
+      transcriber.sendAudio(Buffer.from([1, 2, 3, 4]), "audio/pcm");
+      transcriber.sendAudio(Buffer.from([5, 6]), "audio/pcm");
+
+      expect(mockWs.sentData).toHaveLength(2);
+      expect(Array.from(mockWs.sentData[0] as Uint8Array)).toEqual([
+        1, 2, 3, 4,
+      ]);
+      expect(Array.from(mockWs.sentData[1] as Uint8Array)).toEqual([5, 6]);
+    });
+
+    test("drops audio once the outbound buffer is saturated", async () => {
+      const { transcriber } = await startSession();
+      mockWs.bufferedAmount = 8 * 1024 * 1024;
+
+      transcriber.sendAudio(Buffer.from([1, 2]), "audio/pcm");
+
+      expect(mockWs.sentData).toHaveLength(0);
+    });
+
+    test("logs the observed chunk duration once per session", async () => {
+      const { transcriber } = await startSession({ sampleRate: 16_000 });
+
+      // 2560 bytes of mono linear16 at 16kHz is exactly 80ms.
+      transcriber.sendAudio(Buffer.alloc(2560), "audio/pcm");
+      transcriber.sendAudio(Buffer.alloc(2560), "audio/pcm");
+
+      const cadenceLogs = debugLogs.filter((entry) =>
+        entry.message.includes("chunk cadence"),
+      );
+      expect(cadenceLogs).toHaveLength(1);
+      expect(cadenceLogs[0]!.data).toMatchObject({
+        observedChunkMs: 80,
+        recommendedChunkMs: 80,
+        sampleRate: 16_000,
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Frame handling
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("frame handling", () => {
+    test("a scripted turn produces the expected event stream", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({ type: "Connected", request_id: "flux-request-id" }),
+      );
+      mockWs.simulateMessage(turnInfoFrame("StartOfTurn"));
+      mockWs.simulateMessage(
+        turnInfoFrame("Update", { transcript: "what is the" }),
+      );
+      mockWs.simulateMessage(
+        turnInfoFrame("EndOfTurn", {
+          transcript: "what is the weather",
+          end_of_turn_confidence: 0.91,
+        }),
+      );
+
+      expect(events).toEqual([
+        { type: "turn-start" },
+        { type: "partial", text: "what is the" },
+        // The final comes first so a consumer that ignores turn events still
+        // commits the transcript exactly as it does for any other provider.
+        { type: "final", text: "what is the weather" },
+        { type: "turn-end", text: "what is the weather", confidence: 0.91 },
+      ]);
+    });
+
+    test("an EndOfTurn frame emits final before turn-end", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        turnInfoFrame("EndOfTurn", { transcript: "done" }),
+      );
+
+      expect(events.map((event) => event.type)).toEqual(["final", "turn-end"]);
+    });
+
+    test("a fatal Error frame surfaces its category", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "Error",
+          code: "INVALID_AUTH",
+          description: "Invalid credentials",
+        }),
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: "error", category: "auth" });
+    });
+
+    test("malformed frames are dropped rather than surfaced", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage("not json at all");
+      mockWs.simulateMessage(JSON.stringify([1, 2, 3]));
+      mockWs.simulateMessage(
+        JSON.stringify({ type: "SomethingNewFromDeepgram" }),
+      );
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Configure acknowledgements
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("Configure acknowledgements", () => {
+    test("ConfigureSuccess logs the authoritative thresholds and emits nothing", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "ConfigureSuccess",
+          thresholds: {
+            eot_threshold: 0.8,
+            eager_eot_threshold: 0.4,
+            eot_timeout_ms: 6_000,
+          },
+        }),
+      );
+
+      expect(events).toEqual([]);
+      const ack = debugLogs.find((entry) =>
+        entry.message.includes("accepted a Configure"),
+      );
+      expect(ack).toBeDefined();
+      expect(ack!.data).toMatchObject({
+        thresholds: { eot_threshold: 0.8, eot_timeout_ms: 6_000 },
+      });
+    });
+
+    test("ConfigureFailure warns and leaves the session usable", async () => {
+      const { transcriber, events } = await startSession();
+
+      mockWs.simulateMessage(
+        JSON.stringify({
+          type: "ConfigureFailure",
+          sequence_id: 42,
+          code: "INVALID_THRESHOLD",
+          description:
+            "eager_eot_threshold must be less than or equal to eot_threshold",
+        }),
+      );
+
+      // A rejected Configure leaves the stream on its previous settings, so
+      // it must not become a stream error that tears the session down.
+      expect(events).toEqual([]);
+      const rejection = warnLogs.find((entry) =>
+        entry.message.includes("rejected a Configure"),
+      );
+      expect(rejection).toBeDefined();
+      expect(rejection!.data).toMatchObject({ code: "INVALID_THRESHOLD" });
+
+      // The session still transcribes.
+      mockWs.simulateMessage(
+        turnInfoFrame("EndOfTurn", { transcript: "still here" }),
+      );
+      expect(events.map((event) => event.type)).toEqual(["final", "turn-end"]);
+
+      transcriber.stop();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Error mapping
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("error mapping", () => {
+    test("an auth rejection during connect rejects with an auth SttError", async () => {
+      const transcriber = new DeepgramFluxRealtimeTranscriber(TEST_API_KEY);
+      const startPromise = transcriber.start(() => {});
+      mockWs.simulateClose(1008, "invalid credentials");
+
+      const err = await startPromise.catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("auth");
+    });
+
+    test("a connect timeout rejects with a timeout SttError", async () => {
+      const transcriber = new DeepgramFluxRealtimeTranscriber(TEST_API_KEY, {
+        connectTimeoutMs: 20,
+      });
+
+      const err = await transcriber.start(() => {}).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("timeout");
+    });
+
+    test("an in-session auth close emits an auth error then closed", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateClose(1008, "invalid credentials");
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({ type: "error", category: "auth" });
+      expect(events[1]).toEqual({ type: "closed" });
+    });
+
+    test("a load-shedding close maps to rate-limit", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateClose(1013, "try again later");
+
+      expect(events[0]).toMatchObject({
+        type: "error",
+        category: "rate-limit",
+      });
+    });
+
+    test("any other unexpected close maps to provider-error", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateClose(1006, "abnormal");
+
+      expect(events[0]).toMatchObject({
+        type: "error",
+        category: "provider-error",
+      });
+    });
+
+    test("a socket error emits provider-error then closed", async () => {
+      const { events } = await startSession();
+
+      mockWs.simulateError(new Error("connection reset"));
+
+      expect(events[0]).toMatchObject({
+        type: "error",
+        category: "provider-error",
+      });
+      expect(events[1]).toEqual({ type: "closed" });
+    });
+
+    test("the inactivity watchdog only fires while audio awaits a response", async () => {
+      const { transcriber, events } = await startSession({
+        inactivityTimeoutMs: 20,
+      });
+
+      // Idle with nothing owed: the watchdog re-arms rather than firing.
+      await Bun.sleep(60);
+      expect(events).toEqual([]);
+
+      transcriber.sendAudio(Buffer.from([1, 2]), "audio/pcm");
+      await Bun.sleep(80);
+
+      expect(events[0]).toMatchObject({ type: "error", category: "timeout" });
+      expect(events.at(-1)).toEqual({ type: "closed" });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Lifecycle
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("lifecycle", () => {
+    test("start() throws when called twice", async () => {
+      const { transcriber } = await startSession();
+
+      await expect(transcriber.start(() => {})).rejects.toThrow(
+        "start() called twice",
+      );
+    });
+
+    test("stop() sends CloseStream and reports closed once the socket closes", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.stop();
+
+      expect(mockWs.sentData).toEqual([
+        JSON.stringify({ type: "CloseStream" }),
+      ]);
+      expect(events).toEqual([]);
+
+      mockWs.simulateClose(1000, "");
+      expect(events).toEqual([{ type: "closed" }]);
+    });
+
+    test("stop() is idempotent and closed is emitted exactly once", async () => {
+      const { transcriber, events } = await startSession();
+
+      transcriber.stop();
+      mockWs.simulateClose(1000, "");
+      transcriber.stop();
+      mockWs.simulateClose(1000, "");
+
+      expect(events).toEqual([{ type: "closed" }]);
+    });
+
+    test("keepalive frames go out on the configured interval", async () => {
+      const { transcriber } = await startSession({ keepaliveIntervalMs: 10 });
+
+      await Bun.sleep(35);
+      transcriber.stop();
+
+      const keepalives = mockWs.sentData.filter(
+        (data) => data === JSON.stringify({ type: "KeepAlive" }),
+      );
+      expect(keepalives.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("finalizeUtterance is deliberately absent — Flux owns turn boundaries", async () => {
+      const { transcriber } = await startSession();
+
+      // Callers feature-detect this method and fall back to stop(), which is
+      // the correct semantics for a provider whose model ends the turn. The
+      // contract type is where the optional method lives, so the check goes
+      // through it — the class not declaring it at all is the point.
+      const asContract: StreamingTranscriber = transcriber;
+      expect(asContract.finalizeUtterance).toBeUndefined();
+    });
+
+    test("audio sent after stop() never reaches the socket", async () => {
+      const { transcriber } = await startSession();
+
+      transcriber.stop();
+      mockWs.sentData.length = 0;
+      transcriber.sendAudio(Buffer.from([1, 2]), "audio/pcm");
+
+      expect(mockWs.sentData).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Identity
+  // ─────────────────────────────────────────────────────────────────
+
+  test("reports the deepgram-flux provider on the daemon-streaming boundary", () => {
+    const transcriber = new DeepgramFluxRealtimeTranscriber(TEST_API_KEY);
+
+    expect(transcriber.providerId).toBe("deepgram-flux");
+    expect(transcriber.boundaryId).toBe("daemon-streaming");
+  });
+});

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -492,7 +492,11 @@ describe("resolveTelephonySttCapability", () => {
 // ---------------------------------------------------------------------------
 
 import type { SttProviderId } from "../../../stt/types.js";
-import { getProviderEntry, listProviderIds } from "../provider-catalog.js";
+import {
+  getProviderEntry,
+  listProviderIds,
+  supportsBoundary,
+} from "../provider-catalog.js";
 
 describe("telephony capability catalog alignment", () => {
   /**
@@ -1409,6 +1413,191 @@ describe("resolveStreamingTranscriber language plumbing", () => {
       language: "multi",
       model: "nova-3",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — advertised streaming capability vs. what the factory can build
+// ---------------------------------------------------------------------------
+
+describe("streaming capability matches the streaming factory", () => {
+  /**
+   * The catalog's `daemon-streaming` boundary is load-bearing in three
+   * places that must never disagree:
+   *
+   * 1. `resolveConversationStreamingSttCapability`, which preflight reports
+   *    as `supported`.
+   * 2. `resolveStreamingTranscriber`, which has to actually build an adapter.
+   * 3. The two user-facing "streaming-capable providers" strings, which list
+   *    exactly `listProviderIds().filter(id => supportsBoundary(id,
+   *    "daemon-streaming"))` — `stt/stt-stream-session.ts` and
+   *    `live-voice/live-voice-session.ts`.
+   *
+   * A provider that is advertised by (1) and (3) but resolves to `null` in
+   * (2) makes preflight lie and sends the session down the provider-error
+   * path, and the error message it lands on names the very provider that
+   * just failed as a supported alternative. This suite is the guard: every
+   * advertised provider must build.
+   *
+   * `deepgram-flux-realtime.js` is deliberately NOT mocked in this file, so
+   * the Flux case constructs the real adapter.
+   */
+  const STREAMING_CREDENTIAL: Record<string, string> = {
+    deepgram: "deepgram",
+    "deepgram-flux": "deepgram",
+    "google-gemini": "gemini",
+    "openai-whisper": "openai",
+    xai: "xai",
+    // vellum's credential is the platform connection, mocked below.
+    vellum: "vellum",
+  };
+
+  /** The exact list both user-facing error strings advertise. */
+  function advertisedStreamingProviders(): readonly SttProviderId[] {
+    return listProviderIds().filter((id) =>
+      supportsBoundary(id, "daemon-streaming"),
+    );
+  }
+
+  function seedCredentialsFor(id: SttProviderId): void {
+    const credential = STREAMING_CREDENTIAL[id];
+    expect(credential).toBeDefined();
+    mockVellumAvailable = id === "vellum";
+    mockVelayConnection =
+      id === "vellum"
+        ? {
+            wsBaseUrl: "ws://gateway.test",
+            httpBaseUrl: "http://gateway.test",
+            mintServiceToken: () => "vk-test",
+          }
+        : null;
+    mockProviderKeys = id === "vellum" ? {} : { [credential!]: `key-${id}` };
+    applyConfig({ provider: id });
+  }
+
+  beforeEach(() => {
+    mockVellumAvailable = false;
+    mockVelayConnection = null;
+    mockProviderKeys = {};
+    loggerWarnings.length = 0;
+  });
+
+  test("the advertised list includes deepgram-flux", () => {
+    // Guards the suite below against passing vacuously: Flux is the provider
+    // whose capability and factory used to disagree.
+    expect(advertisedStreamingProviders()).toContain("deepgram-flux");
+  });
+
+  test("every advertised provider reports supported AND builds a transcriber", async () => {
+    for (const id of advertisedStreamingProviders()) {
+      seedCredentialsFor(id);
+
+      const capability = await resolveConversationStreamingSttCapability();
+      expect(capability.status).toBe("supported");
+
+      const transcriber = await resolveStreamingTranscriber();
+      expect(transcriber).not.toBeNull();
+      expect(transcriber!.boundaryId).toBe("daemon-streaming");
+    }
+  });
+
+  test("every advertised provider reports missing credentials AND builds nothing without them", async () => {
+    for (const id of advertisedStreamingProviders()) {
+      mockVellumAvailable = false;
+      mockVelayConnection = null;
+      mockProviderKeys = {};
+      applyConfig({ provider: id });
+
+      const capability = await resolveConversationStreamingSttCapability();
+      expect(capability.status).toBe("missing-credentials");
+      expect(await resolveStreamingTranscriber()).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — deepgram-flux streaming resolution
+// ---------------------------------------------------------------------------
+
+describe("deepgram-flux streaming resolution", () => {
+  beforeEach(() => {
+    mockVellumAvailable = false;
+    mockVelayConnection = null;
+    mockProviderKeys = {};
+    loggerWarnings.length = 0;
+  });
+
+  test("resolves a real Flux transcriber on the shared Deepgram key", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      sampleRate: 16_000,
+    });
+
+    expect(transcriber).not.toBeNull();
+    expect(transcriber!.providerId).toBe("deepgram-flux");
+    expect(transcriber!.boundaryId).toBe("daemon-streaming");
+    // Flux owns turn boundaries, so callers feature-detecting this method
+    // must fall back to stop().
+    expect(transcriber!.finalizeUtterance).toBeUndefined();
+  });
+
+  test("resolves from an explicit providerId, the way live voice asks", async () => {
+    // Live voice derives its provider itself and passes it in rather than
+    // letting the resolver re-read config.
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "openai-whisper" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      providerId: "deepgram-flux",
+    });
+
+    expect(transcriber?.providerId).toBe("deepgram-flux");
+  });
+
+  test("resolves null without a Deepgram key", async () => {
+    mockProviderKeys = { openai: "sk-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    expect(await resolveStreamingTranscriber()).toBeNull();
+  });
+
+  test("telephony callers resolve to null without a Flux-specific conditional", async () => {
+    // The catalog's telephonyMode: "none" is the only gate — boundary-
+    // requiring callers fall back to per-turn batch transcription.
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      utteranceBoundaryFinals: true,
+    });
+
+    expect(transcriber).toBeNull();
+    expect(loggerWarnings).toHaveLength(1);
+    expect(
+      (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
+    ).toBe("deepgram-flux");
+  });
+
+  test("telephony capability reports Flux as unsupported", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    const result = await resolveTelephonySttCapability();
+
+    expect(result.status).toBe("unsupported");
+  });
+
+  test("diarize: 'required' rejects Flux rather than silently dropping labels", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      diarize: "required",
+    });
+
+    expect(transcriber).toBeNull();
   });
 });
 

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -1417,7 +1417,7 @@ describe("resolveStreamingTranscriber language plumbing", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests — advertised streaming capability vs. what the factory can build
+// Tests: advertised streaming capability vs. what the factory can build
 // ---------------------------------------------------------------------------
 
 describe("streaming capability matches the streaming factory", () => {
@@ -1430,7 +1430,7 @@ describe("streaming capability matches the streaming factory", () => {
    * 2. `resolveStreamingTranscriber`, which has to actually build an adapter.
    * 3. The two user-facing "streaming-capable providers" strings, which list
    *    exactly `listProviderIds().filter(id => supportsBoundary(id,
-   *    "daemon-streaming"))` — `stt/stt-stream-session.ts` and
+   *    "daemon-streaming"))`: `stt/stt-stream-session.ts` and
    *    `live-voice/live-voice-session.ts`.
    *
    * A provider that is advertised by (1) and (3) but resolves to `null` in
@@ -1516,7 +1516,7 @@ describe("streaming capability matches the streaming factory", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests — deepgram-flux streaming resolution
+// Tests: deepgram-flux streaming resolution
 // ---------------------------------------------------------------------------
 
 describe("deepgram-flux streaming resolution", () => {
@@ -1564,7 +1564,7 @@ describe("deepgram-flux streaming resolution", () => {
   });
 
   test("telephony callers resolve to null without a Flux-specific conditional", async () => {
-    // The catalog's telephonyMode: "none" is the only gate — boundary-
+    // The catalog's telephonyMode: "none" is the only gate. Boundary-
     // requiring callers fall back to per-turn batch transcription.
     mockProviderKeys = { deepgram: "dg-key" };
     applyConfig({ provider: "deepgram-flux" });

--- a/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
@@ -348,8 +348,8 @@ export interface FluxQueryParamOptions {
  * its `eot_threshold`
  * (https://developers.deepgram.com/docs/flux/configuration#validation-rules),
  * so after each threshold is clamped to its own range the eager value is
- * clamped down again to the EOT threshold in force — the one being sent, or
- * Deepgram's {@link DEFAULT_EOT_THRESHOLD} when none is. Clamping keeps a
+ * clamped down again to the EOT threshold in force (the one being sent, or
+ * Deepgram's {@link DEFAULT_EOT_THRESHOLD} when none is). Clamping keeps a
  * misconfigured pair from failing the whole session; the adjustment is logged
  * at debug when it fires.
  */

--- a/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
@@ -24,7 +24,9 @@
  * Error handling mirrors `deepgram-realtime.ts`: socket closes and errors map
  * onto {@link SttErrorCategory} values (`auth`, `rate-limit`, `timeout`,
  * `provider-error`), in-session failures surface as `error` events, and
- * teardown always emits `closed`.
+ * teardown always emits `closed`. One failure produces exactly one `error`:
+ * a fatal `Error` frame is reported with the provider's own diagnostic, and
+ * the close Deepgram sends immediately after it goes straight to `closed`.
  */
 
 import { getConfig } from "../../config/loader.js";
@@ -67,8 +69,8 @@ const DEFAULT_INACTIVITY_TIMEOUT_MS = 30_000;
 
 /**
  * Interval (ms) between `KeepAlive` control frames. Deepgram closes a socket
- * that carries no audio for ~10s, and raw silence does not reset that timer —
- * only the explicit control message does.
+ * that carries no audio for ~10s, and raw silence does not reset that timer.
+ * Only the explicit control message does.
  */
 const DEFAULT_KEEPALIVE_INTERVAL_MS = 5_000;
 
@@ -104,7 +106,7 @@ export interface DeepgramFluxRealtimeOptions {
   eotThreshold?: number;
   /**
    * Eager end-of-turn confidence. Defaults to
-   * `liveVoice.flux.eagerEotThreshold`, which is unset by default — and
+   * `liveVoice.flux.eagerEotThreshold`, which is unset by default, and
    * leaving it unset is what stops Deepgram emitting `EagerEndOfTurn` /
    * `TurnResumed` at all.
    */
@@ -123,7 +125,7 @@ export interface DeepgramFluxRealtimeOptions {
   inactivityTimeoutMs?: number;
   /**
    * Interval (ms) between `KeepAlive` control frames. Default: 5_000. Set to
-   * 0 to disable (tests only — Deepgram closes silent sockets after ~10s).
+   * 0 to disable (tests only, because Deepgram closes silent sockets after ~10s).
    */
   keepaliveIntervalMs?: number;
 }
@@ -194,6 +196,14 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   /** Whether stop() has been called. */
   private stopping = false;
 
+  /**
+   * Whether a fatal `Error` frame has already been reported as an `error`
+   * event. Deepgram closes the socket right after that frame, so the close
+   * that follows carries no information the provider's own diagnostic did not
+   * already carry and must not raise a second, more generic error.
+   */
+  private fatalErrorReported = false;
+
   /** Whether the per-session chunk-cadence line has already been logged. */
   private chunkCadenceLogged = false;
 
@@ -203,7 +213,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   /**
    * When the first audio frame went out after the last inbound provider
    * message; null while nothing is owed a response. The inactivity watchdog
-   * only rules "hung" while this is set — Flux says nothing during silence,
+   * only rules "hung" while this is set: Flux says nothing during silence,
    * so inbound quiet alone is not evidence of a hang.
    */
   private awaitingResponseSinceMs: number | null = null;
@@ -252,7 +262,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
 
     // Wait for the WebSocket to open or fail. Failures reject as SttError so
     // the caller gets the same normalized category an in-session failure
-    // would carry — a bad key is an `auth` problem whether it lands during
+    // would carry. A bad key is an `auth` problem whether it lands during
     // the handshake or after it.
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -310,7 +320,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
       ws.addEventListener("close", onClose);
     });
 
-    // Socket is open — attach the handlers for the active session lifetime.
+    // Socket is open. Attach the handlers for the active session lifetime.
     this.attachSessionHandlers(ws);
     this.resetInactivityTimer();
     this.startKeepaliveTimer();
@@ -328,7 +338,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
       return;
     }
 
-    // Backpressure check — drop frames rather than grow the outbound buffer
+    // Backpressure check: drop frames rather than grow the outbound buffer
     // without bound when the network cannot keep up with the audio rate.
     if (ws.bufferedAmount > MAX_BUFFERED_AMOUNT) {
       log.warn(
@@ -367,7 +377,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     }
 
     this.closeGraceTimer = setTimeout(() => {
-      log.warn("Deepgram Flux close grace timeout — forcing close");
+      log.warn("Deepgram Flux close grace timeout, forcing close");
       this.emitClosedAndCleanup();
     }, CLOSE_GRACE_MS);
   }
@@ -377,7 +387,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   /**
    * Create a WebSocket instance. Factored out for test mockability.
    *
-   * The key travels in the `Authorization: Token` header — Flux needs no
+   * The key travels in the `Authorization: Token` header. Flux needs no
    * query auth, so no URL ever carries the credential and nothing here needs
    * redacting before it reaches a log.
    */
@@ -418,7 +428,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
    * Normalize one inbound Flux frame into daemon events.
    *
    * Everything except the `Configure*` acknowledgements goes straight to
-   * {@link parseFluxFrame} — the wire shapes live there, not here.
+   * {@link parseFluxFrame}: the wire shapes live there, not here.
    */
   private handleProviderMessage(data: unknown): void {
     if (this.closed) {
@@ -434,7 +444,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
           ? new TextDecoder().decode(data)
           : null;
     if (raw === null) {
-      // Unexpected binary format — ignore.
+      // Unexpected binary format, ignore.
       return;
     }
 
@@ -449,6 +459,9 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     }
 
     for (const event of parseFluxFrame(frame)) {
+      if (event.type === "error") {
+        this.fatalErrorReported = true;
+      }
       this.emitEvent(event);
     }
   }
@@ -461,8 +474,8 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
    *
    * Neither becomes a stream event. `ConfigureSuccess` echoes the
    * configuration actually in force, which is the cheapest confirmation that
-   * the thresholds we clamped are the ones Deepgram is using — worth a debug
-   * line, nothing more. `ConfigureFailure` leaves the stream running on the
+   * the thresholds we clamped are the ones Deepgram is using, worth a debug
+   * line and nothing more. `ConfigureFailure` leaves the stream running on the
    * previous settings, so raising an `error` event would tear down a session
    * that is still perfectly usable.
    */
@@ -474,7 +487,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
           keyterms: frame.keyterms,
           languageHints: frame.language_hints,
         },
-        "Deepgram Flux accepted a Configure — thresholds now in force",
+        "Deepgram Flux accepted a Configure, thresholds now in force",
       );
       return true;
     }
@@ -486,7 +499,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
           description: frame.description,
           sequenceId: frame.sequence_id,
         },
-        "Deepgram Flux rejected a Configure — the session continues at its previous settings",
+        "Deepgram Flux rejected a Configure, the session continues at its previous settings",
       );
       return true;
     }
@@ -503,6 +516,18 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     // Normal close (1000) or going-away (1001) after stop() is expected.
     if (this.stopping && (code === 1000 || code === 1001)) {
       log.info({ code, reason }, "Deepgram Flux session closed normally");
+      this.emitClosedAndCleanup();
+      return;
+    }
+
+    // A fatal `Error` frame already reported the provider's own diagnostic,
+    // and the close is that frame's second half. Go straight to `closed` so
+    // callers see exactly one error for one failure.
+    if (this.fatalErrorReported) {
+      log.info(
+        { code, reason },
+        "Deepgram Flux session closed after a fatal error frame",
+      );
       this.emitClosedAndCleanup();
       return;
     }
@@ -524,6 +549,18 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     }
 
     const message = describeSocketEvent(ev);
+
+    // Same one-error-per-failure rule as the close path: a socket error that
+    // trails a fatal `Error` frame is that failure surfacing again.
+    if (this.fatalErrorReported) {
+      log.info(
+        { error: message },
+        "Deepgram Flux WebSocket error after a fatal error frame",
+      );
+      this.emitClosedAndCleanup();
+      return;
+    }
+
     log.error({ error: message }, "Deepgram Flux WebSocket error");
 
     this.emitEvent({
@@ -584,7 +621,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   }
 
   /**
-   * Emit `closed` and release every resource. Idempotent — safe to call from
+   * Emit `closed` and release every resource. Idempotent, safe to call from
    * any teardown path.
    */
   private emitClosedAndCleanup(): void {
@@ -611,7 +648,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     try {
       ws.close();
     } catch {
-      // Best effort — already closed sockets may throw.
+      // Best effort: already closed sockets may throw.
     }
   }
 
@@ -633,7 +670,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   /**
    * Start the periodic keepalive. A `KeepAlive` control frame is the only
    * thing that resets Deepgram's server-side inactivity timer while the
-   * stream carries silence — raw silent PCM does not count.
+   * stream carries silence. Raw silent PCM does not count.
    */
   private startKeepaliveTimer(): void {
     if (this.closed || this.stopping || this.keepaliveIntervalMs <= 0) {
@@ -657,7 +694,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
 
   /**
    * Reset the inactivity watchdog on inbound provider messages. Not reset on
-   * outbound audio — continuous audio from the caller must not mask a silent
+   * outbound audio: continuous audio from the caller must not mask a silent
    * provider.
    */
   private resetInactivityTimer(): void {

--- a/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
@@ -1,0 +1,757 @@
+/**
+ * Deepgram Flux realtime streaming STT adapter (`wss://api.deepgram.com/v2/listen`).
+ *
+ * Flux is Deepgram's conversational speech API: the model itself decides where
+ * a turn ends, so this adapter carries no endpointing heuristics of its own.
+ * It owns the socket lifecycle (connect, keepalive, teardown) and delegates
+ * every inbound transcript frame to {@link parseFluxFrame}, the pure protocol
+ * module, which maps Flux's wire shapes onto the daemon's
+ * {@link SttStreamServerEvent} contract.
+ *
+ * Lifecycle:
+ * 1. {@link start} opens the WebSocket and resolves once it is established.
+ * 2. {@link sendAudio} forwards raw audio with a backpressure guard.
+ * 3. {@link stop} sends `CloseStream` and waits for Flux to flush the turn
+ *    in progress before closing.
+ * 4. The `onEvent` callback receives `partial`, `final`, the four
+ *    turn-detection events, `error`, and finally `closed`.
+ *
+ * There is deliberately **no `finalizeUtterance`**. Flux owns turn
+ * boundaries, so there is nothing for a caller to flush mid-stream; leaving
+ * the optional method off makes callers feature-detect and fall back to
+ * {@link stop}, which is the correct semantics for this provider.
+ *
+ * Error handling mirrors `deepgram-realtime.ts`: socket closes and errors map
+ * onto {@link SttErrorCategory} values (`auth`, `rate-limit`, `timeout`,
+ * `provider-error`), in-session failures surface as `error` events, and
+ * teardown always emits `closed`.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import type {
+  StreamingTranscriber,
+  SttErrorCategory,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { SttError } from "../../stt/types.js";
+import { parseJsonSafe } from "../../util/json.js";
+import { getLogger } from "../../util/logger.js";
+import { isPlainObject } from "../../util/object.js";
+import type { FluxEncoding } from "./deepgram-flux-frames.js";
+import {
+  buildFluxQueryParams,
+  parseFluxFrame,
+} from "./deepgram-flux-frames.js";
+
+const log = getLogger("deepgram-flux-realtime");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WS_BASE_URL = "wss://api.deepgram.com";
+
+/** Flux lives on the v2 listen route; the v1 route speaks a different protocol. */
+const FLUX_PATH = "/v2/listen";
+
+/** Timeout (ms) for the WebSocket handshake before {@link start} rejects. */
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Inactivity timeout (ms). If audio has been sent but Flux says nothing back
+ * for this long, the adapter closes with a `timeout` error. A stream with no
+ * audio awaiting a response (mic gated while the assistant speaks) is
+ * legitimately silent and never times out.
+ */
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 30_000;
+
+/**
+ * Interval (ms) between `KeepAlive` control frames. Deepgram closes a socket
+ * that carries no audio for ~10s, and raw silence does not reset that timer —
+ * only the explicit control message does.
+ */
+const DEFAULT_KEEPALIVE_INTERVAL_MS = 5_000;
+
+/** Outbound buffer ceiling (bytes) before {@link sendAudio} drops frames. */
+const MAX_BUFFERED_AMOUNT = 1024 * 1024; // 1 MiB
+
+/** Grace (ms) after `CloseStream` before the socket is force-closed. */
+const CLOSE_GRACE_MS = 5_000;
+
+/** Default raw-audio encoding: clients send linear16 PCM. */
+const DEFAULT_ENCODING: FluxEncoding = "linear16";
+
+/** Default sample rate (Hz) when the client negotiates none. */
+const DEFAULT_SAMPLE_RATE = 16_000;
+
+/** Bytes per sample of mono linear16 PCM. */
+const LINEAR16_BYTES_PER_SAMPLE = 2;
+
+/**
+ * Chunk duration Deepgram recommends for Flux. Logged alongside the observed
+ * duration so a runbook can compare the two without instrumenting capture.
+ */
+const RECOMMENDED_CHUNK_MS = 80;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface DeepgramFluxRealtimeOptions {
+  /** Flux model. Defaults to `liveVoice.flux.model`. */
+  model?: string;
+  /** End-of-turn confidence. Defaults to `liveVoice.flux.eotThreshold`. */
+  eotThreshold?: number;
+  /**
+   * Eager end-of-turn confidence. Defaults to
+   * `liveVoice.flux.eagerEotThreshold`, which is unset by default — and
+   * leaving it unset is what stops Deepgram emitting `EagerEndOfTurn` /
+   * `TurnResumed` at all.
+   */
+  eagerEotThreshold?: number;
+  /** Force-end silence (ms). Defaults to `liveVoice.flux.eotTimeoutMs`. */
+  eotTimeoutMs?: number;
+  /** Audio sample rate in Hz (default: 16000). */
+  sampleRate?: number;
+  /** Raw audio encoding (default: linear16). */
+  encoding?: FluxEncoding;
+  /** Override the WebSocket base URL (proxies, on-prem). */
+  baseUrl?: string;
+  /** Connect timeout in milliseconds. Default: 10_000. */
+  connectTimeoutMs?: number;
+  /** Inactivity timeout in milliseconds. Default: 30_000. */
+  inactivityTimeoutMs?: number;
+  /**
+   * Interval (ms) between `KeepAlive` control frames. Default: 5_000. Set to
+   * 0 to disable (tests only — Deepgram closes silent sockets after ~10s).
+   */
+  keepaliveIntervalMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal WebSocket interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural WebSocket interface so tests can substitute a mock
+ * without depending on Bun's global WebSocket type at the type level.
+ */
+interface WsLike {
+  readonly readyState: number;
+  readonly bufferedAmount: number;
+  send(data: string | ArrayBufferLike | ArrayBuffer | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (ev: { code: number; reason: string }) => void,
+  ): void;
+  addEventListener(type: "error", listener: (ev: unknown) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (ev: { data: unknown }) => void,
+  ): void;
+  removeEventListener(type: string, listener: unknown): void;
+}
+
+const WS_OPEN = 1;
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Deepgram Flux streaming transcriber.
+ *
+ * Implements the daemon {@link StreamingTranscriber} contract on top of
+ * Deepgram's conversational `/v2/listen` WebSocket API.
+ */
+export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram-flux" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly eotThreshold: number | undefined;
+  private readonly eagerEotThreshold: number | undefined;
+  private readonly eotTimeoutMs: number | undefined;
+  private readonly sampleRate: number;
+  private readonly encoding: FluxEncoding;
+  private readonly baseUrl: string;
+  private readonly connectTimeoutMs: number;
+  private readonly inactivityTimeoutMs: number;
+  private readonly keepaliveIntervalMs: number;
+
+  /** The live WebSocket connection, set during start(). */
+  private ws: WsLike | null = null;
+
+  /** Callback for emitting events to the session orchestrator. */
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  /** Whether the session has been fully closed. */
+  private closed = false;
+
+  /** Whether stop() has been called. */
+  private stopping = false;
+
+  /** Whether the per-session chunk-cadence line has already been logged. */
+  private chunkCadenceLogged = false;
+
+  /** Inactivity timer handle. */
+  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * When the first audio frame went out after the last inbound provider
+   * message; null while nothing is owed a response. The inactivity watchdog
+   * only rules "hung" while this is set — Flux says nothing during silence,
+   * so inbound quiet alone is not evidence of a hang.
+   */
+  private awaitingResponseSinceMs: number | null = null;
+
+  /** Close grace timer handle. */
+  private closeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Periodic `KeepAlive` timer. */
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(apiKey: string, options: DeepgramFluxRealtimeOptions = {}) {
+    // Tuning comes from `liveVoice.flux` so the spike has one place to turn
+    // the dials; explicit options win for callers that already know better.
+    const flux = getConfig().liveVoice.flux;
+
+    this.apiKey = apiKey;
+    this.model = options.model ?? flux.model;
+    this.eotThreshold = options.eotThreshold ?? flux.eotThreshold;
+    this.eagerEotThreshold =
+      options.eagerEotThreshold ?? flux.eagerEotThreshold;
+    this.eotTimeoutMs = options.eotTimeoutMs ?? flux.eotTimeoutMs;
+    this.sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE;
+    this.encoding = options.encoding ?? DEFAULT_ENCODING;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_WS_BASE_URL).replace(/\/+$/, "");
+    this.connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    this.inactivityTimeoutMs =
+      options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+    this.keepaliveIntervalMs =
+      options.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS;
+  }
+
+  // ── StreamingTranscriber interface ──────────────────────────────────
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    if (this.ws) {
+      throw new Error("DeepgramFluxRealtimeTranscriber: start() called twice");
+    }
+    this.onEvent = onEvent;
+
+    const url = this.buildWebSocketUrl();
+    log.info({ url }, "Opening Deepgram Flux session");
+
+    const ws = this.createWebSocket(url);
+    this.ws = ws;
+
+    // Wait for the WebSocket to open or fail. Failures reject as SttError so
+    // the caller gets the same normalized category an in-session failure
+    // would carry — a bad key is an `auth` problem whether it lands during
+    // the handshake or after it.
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const connectTimer = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.forceClose();
+        reject(
+          new SttError("timeout", "Deepgram Flux realtime connect timeout"),
+        );
+      }, this.connectTimeoutMs);
+
+      const onOpen = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimer);
+        resolve();
+      };
+
+      const onError = (ev: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimer);
+        reject(
+          new SttError(
+            "provider-error",
+            `Deepgram Flux realtime connect error: ${describeSocketEvent(ev)}`,
+          ),
+        );
+      };
+
+      const onClose = (ev: { code: number; reason: string }) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimer);
+        reject(
+          new SttError(
+            closeCodeCategory(ev.code),
+            `Deepgram Flux WebSocket closed before open (code=${ev.code}, reason=${ev.reason})`,
+          ),
+        );
+      };
+
+      ws.addEventListener("open", onOpen);
+      ws.addEventListener("error", onError);
+      ws.addEventListener("close", onClose);
+    });
+
+    // Socket is open — attach the handlers for the active session lifetime.
+    this.attachSessionHandlers(ws);
+    this.resetInactivityTimer();
+    this.startKeepaliveTimer();
+
+    log.info({ model: this.model }, "Deepgram Flux session opened");
+  }
+
+  sendAudio(audio: Buffer, _mimeType: string): void {
+    if (this.closed || this.stopping) {
+      return;
+    }
+
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WS_OPEN) {
+      return;
+    }
+
+    // Backpressure check — drop frames rather than grow the outbound buffer
+    // without bound when the network cannot keep up with the audio rate.
+    if (ws.bufferedAmount > MAX_BUFFERED_AMOUNT) {
+      log.warn(
+        { bufferedAmount: ws.bufferedAmount },
+        "Deepgram Flux backpressure: dropping audio frame",
+      );
+      return;
+    }
+
+    ws.send(new Uint8Array(audio));
+    this.awaitingResponseSinceMs ??= Date.now();
+    this.logChunkCadenceOnce(audio.byteLength);
+  }
+
+  stop(): void {
+    if (this.closed || this.stopping) {
+      return;
+    }
+    this.stopping = true;
+
+    log.info("Stopping Deepgram Flux session");
+
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WS_OPEN) {
+      this.emitClosedAndCleanup();
+      return;
+    }
+
+    // `CloseStream` tells Flux to finish the turn in progress and answer
+    // before it terminates the socket.
+    try {
+      ws.send(JSON.stringify({ type: "CloseStream" }));
+    } catch {
+      this.emitClosedAndCleanup();
+      return;
+    }
+
+    this.closeGraceTimer = setTimeout(() => {
+      log.warn("Deepgram Flux close grace timeout — forcing close");
+      this.emitClosedAndCleanup();
+    }, CLOSE_GRACE_MS);
+  }
+
+  // ── WebSocket lifecycle ─────────────────────────────────────────────
+
+  /**
+   * Create a WebSocket instance. Factored out for test mockability.
+   *
+   * The key travels in the `Authorization: Token` header — Flux needs no
+   * query auth, so no URL ever carries the credential and nothing here needs
+   * redacting before it reaches a log.
+   */
+  private createWebSocket(url: string): WsLike {
+    const WebSocketCtor = (
+      globalThis as unknown as {
+        WebSocket: new (
+          url: string,
+          options?: { headers?: Record<string, string> },
+        ) => WsLike;
+      }
+    ).WebSocket;
+    if (typeof WebSocketCtor !== "function") {
+      throw new Error("global WebSocket is not available in this runtime");
+    }
+    return new WebSocketCtor(url, {
+      headers: { Authorization: `Token ${this.apiKey}` },
+    });
+  }
+
+  private attachSessionHandlers(ws: WsLike): void {
+    ws.addEventListener("message", (ev: { data: unknown }) => {
+      this.handleProviderMessage(ev.data);
+    });
+
+    ws.addEventListener("close", (ev: { code: number; reason: string }) => {
+      this.handleProviderClose(ev.code, ev.reason);
+    });
+
+    ws.addEventListener("error", (ev: unknown) => {
+      this.handleProviderError(ev);
+    });
+  }
+
+  // ── Provider message handling ───────────────────────────────────────
+
+  /**
+   * Normalize one inbound Flux frame into daemon events.
+   *
+   * Everything except the `Configure*` acknowledgements goes straight to
+   * {@link parseFluxFrame} — the wire shapes live there, not here.
+   */
+  private handleProviderMessage(data: unknown): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.resetInactivityTimer();
+
+    const raw =
+      typeof data === "string"
+        ? data
+        : data instanceof ArrayBuffer
+          ? new TextDecoder().decode(data)
+          : null;
+    if (raw === null) {
+      // Unexpected binary format — ignore.
+      return;
+    }
+
+    const frame = parseJsonSafe(raw);
+    if (!isPlainObject(frame)) {
+      log.debug("Dropped a Deepgram Flux payload that is not a frame object");
+      return;
+    }
+
+    if (this.handleConfigureAck(frame)) {
+      return;
+    }
+
+    for (const event of parseFluxFrame(frame)) {
+      this.emitEvent(event);
+    }
+  }
+
+  /**
+   * Absorb the acknowledgements for a mid-stream `Configure`, returning true
+   * when the frame was one. This adapter is the layer that knows whether a
+   * `Configure` is in flight, so the two frames are handled here rather than
+   * in the pure parser.
+   *
+   * Neither becomes a stream event. `ConfigureSuccess` echoes the
+   * configuration actually in force, which is the cheapest confirmation that
+   * the thresholds we clamped are the ones Deepgram is using — worth a debug
+   * line, nothing more. `ConfigureFailure` leaves the stream running on the
+   * previous settings, so raising an `error` event would tear down a session
+   * that is still perfectly usable.
+   */
+  private handleConfigureAck(frame: Record<string, unknown>): boolean {
+    if (frame.type === "ConfigureSuccess") {
+      log.debug(
+        {
+          thresholds: frame.thresholds,
+          keyterms: frame.keyterms,
+          languageHints: frame.language_hints,
+        },
+        "Deepgram Flux accepted a Configure — thresholds now in force",
+      );
+      return true;
+    }
+
+    if (frame.type === "ConfigureFailure") {
+      log.warn(
+        {
+          code: frame.code,
+          description: frame.description,
+          sequenceId: frame.sequence_id,
+        },
+        "Deepgram Flux rejected a Configure — the session continues at its previous settings",
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Handle provider-side WebSocket close. */
+  private handleProviderClose(code: number, reason: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    // Normal close (1000) or going-away (1001) after stop() is expected.
+    if (this.stopping && (code === 1000 || code === 1001)) {
+      log.info({ code, reason }, "Deepgram Flux session closed normally");
+      this.emitClosedAndCleanup();
+      return;
+    }
+
+    log.warn({ code, reason }, "Deepgram Flux session closed unexpectedly");
+
+    this.emitEvent({
+      type: "error",
+      category: closeCodeCategory(code),
+      message: `Deepgram Flux WebSocket closed (code=${code}, reason=${reason})`,
+    });
+    this.emitClosedAndCleanup();
+  }
+
+  /** Handle provider-side WebSocket error. */
+  private handleProviderError(ev: unknown): void {
+    if (this.closed) {
+      return;
+    }
+
+    const message = describeSocketEvent(ev);
+    log.error({ error: message }, "Deepgram Flux WebSocket error");
+
+    this.emitEvent({
+      type: "error",
+      category: "provider-error",
+      message: `Deepgram Flux WebSocket error: ${message}`,
+    });
+    this.emitClosedAndCleanup();
+  }
+
+  // ── Event emission & cleanup ────────────────────────────────────────
+
+  /**
+   * Emit a server event to the session orchestrator. Swallows listener errors
+   * so a bad consumer cannot tear down the adapter.
+   */
+  private emitEvent(event: SttStreamServerEvent): void {
+    if (!this.onEvent) {
+      return;
+    }
+    try {
+      this.onEvent(event);
+    } catch (err) {
+      log.warn({ error: err }, "Listener error in Deepgram Flux adapter");
+    }
+  }
+
+  /**
+   * Log the observed audio chunk duration once per session, next to the
+   * cadence Deepgram recommends for Flux. Capture cadence is a client
+   * concern; this only makes it measurable from the daemon side.
+   */
+  private logChunkCadenceOnce(byteLength: number): void {
+    if (this.chunkCadenceLogged) {
+      return;
+    }
+    this.chunkCadenceLogged = true;
+
+    // Only linear16 has a byte length that maps to a duration without
+    // decoding the payload.
+    const observedChunkMs =
+      this.encoding === "linear16" && this.sampleRate > 0
+        ? Math.round(
+            (byteLength / LINEAR16_BYTES_PER_SAMPLE / this.sampleRate) * 1_000,
+          )
+        : undefined;
+
+    log.debug(
+      {
+        byteLength,
+        sampleRate: this.sampleRate,
+        encoding: this.encoding,
+        observedChunkMs,
+        recommendedChunkMs: RECOMMENDED_CHUNK_MS,
+      },
+      "Deepgram Flux audio chunk cadence",
+    );
+  }
+
+  /**
+   * Emit `closed` and release every resource. Idempotent — safe to call from
+   * any teardown path.
+   */
+  private emitClosedAndCleanup(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+
+    this.clearTimers();
+    this.forceClose();
+
+    this.emitEvent({ type: "closed" });
+    this.onEvent = null;
+  }
+
+  /** Force-close the WebSocket without emitting events. */
+  private forceClose(): void {
+    const ws = this.ws;
+    this.ws = null;
+    if (!ws) {
+      return;
+    }
+
+    try {
+      ws.close();
+    } catch {
+      // Best effort — already closed sockets may throw.
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+    if (this.closeGraceTimer !== null) {
+      clearTimeout(this.closeGraceTimer);
+      this.closeGraceTimer = null;
+    }
+    if (this.keepaliveTimer !== null) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+
+  /**
+   * Start the periodic keepalive. A `KeepAlive` control frame is the only
+   * thing that resets Deepgram's server-side inactivity timer while the
+   * stream carries silence — raw silent PCM does not count.
+   */
+  private startKeepaliveTimer(): void {
+    if (this.closed || this.stopping || this.keepaliveIntervalMs <= 0) {
+      return;
+    }
+    this.keepaliveTimer = setInterval(() => {
+      if (this.closed || this.stopping) {
+        return;
+      }
+      const ws = this.ws;
+      if (!ws || ws.readyState !== WS_OPEN) {
+        return;
+      }
+      try {
+        ws.send(JSON.stringify({ type: "KeepAlive" }));
+      } catch (err) {
+        log.warn({ err }, "Deepgram Flux KeepAlive send failed");
+      }
+    }, this.keepaliveIntervalMs);
+  }
+
+  /**
+   * Reset the inactivity watchdog on inbound provider messages. Not reset on
+   * outbound audio — continuous audio from the caller must not mask a silent
+   * provider.
+   */
+  private resetInactivityTimer(): void {
+    this.awaitingResponseSinceMs = null;
+    this.armInactivityTimer(this.inactivityTimeoutMs);
+  }
+
+  /**
+   * (Re)arm the inactivity watchdog. On fire it only rules "hung" when audio
+   * has been awaiting a response for a full timeout window; otherwise the
+   * stream is merely idle and the timer re-arms for the remainder.
+   */
+  private armInactivityTimer(delayMs: number): void {
+    if (this.closed || this.stopping) {
+      return;
+    }
+
+    if (this.inactivityTimer !== null) {
+      clearTimeout(this.inactivityTimer);
+    }
+
+    this.inactivityTimer = setTimeout(() => {
+      if (this.closed) {
+        return;
+      }
+
+      const since = this.awaitingResponseSinceMs;
+      if (since === null) {
+        this.armInactivityTimer(this.inactivityTimeoutMs);
+        return;
+      }
+      const waitedMs = Date.now() - since;
+      if (waitedMs < this.inactivityTimeoutMs) {
+        this.armInactivityTimer(this.inactivityTimeoutMs - waitedMs);
+        return;
+      }
+
+      log.warn("Deepgram Flux inactivity timeout");
+      this.emitEvent({
+        type: "error",
+        category: "timeout",
+        message: "Deepgram Flux session timed out due to inactivity",
+      });
+      this.emitClosedAndCleanup();
+    }, delayMs);
+  }
+
+  // ── URL construction ────────────────────────────────────────────────
+
+  /**
+   * Build the Flux WebSocket URL. Query construction (including threshold
+   * clamping and omitting `eager_eot_threshold` when unset) belongs to
+   * {@link buildFluxQueryParams}.
+   */
+  private buildWebSocketUrl(): string {
+    const query = buildFluxQueryParams({
+      model: this.model,
+      encoding: this.encoding,
+      sampleRate: this.sampleRate,
+      eotThreshold: this.eotThreshold,
+      eagerEotThreshold: this.eagerEotThreshold,
+      eotTimeoutMs: this.eotTimeoutMs,
+    });
+    return `${this.baseUrl}${FLUX_PATH}?${query}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a WebSocket close code onto a normalized STT error category, matching
+ * how `DeepgramRealtimeTranscriber` classifies the same codes: 1008 (policy
+ * violation) and 4001 are how Deepgram rejects credentials, and 1013 (try
+ * again later) is how it sheds load.
+ */
+function closeCodeCategory(code: number): SttErrorCategory {
+  if (code === 1008 || code === 4001) {
+    return "auth";
+  }
+  if (code === 1013) {
+    return "rate-limit";
+  }
+  return "provider-error";
+}
+
+/** Best-effort human-readable text for a WebSocket error event. */
+function describeSocketEvent(ev: unknown): string {
+  if (ev instanceof Error) {
+    return ev.message;
+  }
+  if (typeof ev === "object" && ev !== null && "message" in ev) {
+    return String((ev as { message: unknown }).message);
+  }
+  return "WebSocket error";
+}

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -118,8 +118,8 @@ interface SttProviderEntry {
 // ---------------------------------------------------------------------------
 
 /**
- * Shared by every provider that authenticates against a Deepgram account —
- * the key is the same one, so the instructions must not drift apart.
+ * Shared by every provider that authenticates against a Deepgram account.
+ * The key is the same one, so the instructions must not drift apart.
  */
 const DEEPGRAM_CREDENTIALS_GUIDE: SttCredentialsGuide = {
   description:
@@ -171,11 +171,11 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
         "Conversational speech-to-text with model-native turn detection. Uses your Deepgram API key.",
       setupMode: "api-key",
       setupHint:
-        "Enter your Deepgram API key — Flux shares the same key as Deepgram.",
+        "Enter your Deepgram API key. Flux shares the same key as Deepgram.",
       // Shared with the `deepgram` provider: Flux is a model on the same
       // account, not a separate credential.
       credentialProvider: "deepgram",
-      // Streaming only — Flux has no batch endpoint.
+      // Streaming only: Flux has no batch endpoint.
       supportedBoundaries: new Set<SttBoundaryId>(["daemon-streaming"]),
       // Phone calls stay on the `deepgram` provider while Flux is a spike.
       telephonyMode: "none",

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -632,10 +632,20 @@ async function createStreamingTranscriber(
           : {}),
       });
     }
-    case "deepgram-flux":
-      // Flux has no streaming adapter in this factory; `null` is the
-      // documented "no streaming adapter" signal callers fall back on.
-      return null;
+    case "deepgram-flux": {
+      // Flux is streaming-only and dials Deepgram's /v2/listen conversational
+      // endpoint. Turn-detection tuning comes from `liveVoice.flux`, which
+      // the adapter reads itself, so only the transport-level sample rate is
+      // passed here. No language is forwarded: the spike pins the
+      // English-only `flux-general-en`, and `language_hint` means nothing to
+      // a monolingual model. Diarization is off in the catalog, so a
+      // `"required"` caller never reaches this case.
+      const { DeepgramFluxRealtimeTranscriber } =
+        await import("./deepgram-flux-realtime.js");
+      return new DeepgramFluxRealtimeTranscriber(apiKey, {
+        sampleRate: options.sampleRate,
+      });
+    }
     default: {
       const _exhaustive: never = providerId;
       return null;


### PR DESCRIPTION
## Summary

- Adds `DeepgramFluxRealtimeTranscriber`: dials `wss://api.deepgram.com/v2/listen`, owns the socket lifecycle/keepalive/teardown, and delegates all frame handling to `parseFluxFrame`. Tuning comes from `liveVoice.flux`; no `finalizeUtterance` (Flux owns turn boundaries, callers fall back to `stop()`).
- Replaces the `deepgram-flux` stub in `resolve.ts` so the provider actually resolves. Telephony callers still get `null` from the catalog's `telephonyMode: "none"` — verified by test, not by a new conditional.
- Closes the PR 4 P1: a new suite proves capability and factory now agree for every provider the two user-facing "streaming-capable providers" strings advertise. Handles Flux's `ConfigureSuccess` (debug-log the authoritative thresholds) and `ConfigureFailure` (warn only — a rejected Configure leaves the session usable).

No live-voice behavior changes: nothing constructs this provider until `liveVoice.flux.turnEnd.enabled` is wired in PR 7.

Part of plan: flux-turn-detection.md (PR 6 of 8)