### PR TITLE
Align swipe-back release motion with the drawer

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -40,9 +40,10 @@ import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-s
 import { useElectronDockSync } from "@/domains/chat/hooks/use-electron-dock-sync";
 import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
 import {
-  DRAWER_SLIDE_MS,
-  useEdgeSwipeDrawer,
-} from "@/hooks/use-edge-swipe-drawer";
+  EDGE_SWIPE_EASING,
+  EDGE_SWIPE_SLIDE_MS,
+} from "@/hooks/edge-swipe-motion";
+import { useEdgeSwipeDrawer } from "@/hooks/use-edge-swipe-drawer";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 
@@ -1050,7 +1051,7 @@ export function ChatLayout({
               style={{
                 zIndex: 40,
                 transform: drawerOpen ? "translateX(0)" : "translateX(-100%)",
-                transition: `transform ${DRAWER_SLIDE_MS}ms ease-out`,
+                transition: `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`,
               }}
               role="dialog"
               aria-modal="true"

--- a/clients/web/src/hooks/edge-swipe-motion.ts
+++ b/clients/web/src/hooks/edge-swipe-motion.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared release motion for the edge-swipe gestures.
+ *
+ * Swipe-to-open-menu (`useEdgeSwipeDrawer`) and swipe-to-go-back
+ * (`useEdgeSwipeBack`) both hand a released finger off to the same slide, so
+ * the duration and easing live here instead of being restated per hook where
+ * they drift apart.
+ */
+
+/** Duration (ms) of the slide a released finger hands off to. */
+export const EDGE_SWIPE_SLIDE_MS = 200;
+
+/**
+ * Duration (ms) of the outgoing half of a two-phase transition. Shorter than
+ * the incoming half: the outgoing element travels a full viewport width while
+ * the incoming one travels a fraction of it, so matching durations would read
+ * as two different speeds.
+ */
+export const EDGE_SWIPE_EXIT_MS = 150;
+
+/**
+ * Easing for every released-finger slide. Decelerating throughout, so the
+ * element keeps the momentum the finger gave it. An accelerating curve stalls
+ * for the first frames after release, which reads as lag.
+ */
+export const EDGE_SWIPE_EASING = "ease-out";
+
+/** Slack (ms) added to a duration for its `transitionend` fallback timer. */
+export const EDGE_SWIPE_FALLBACK_SLACK_MS = 50;

--- a/clients/web/src/hooks/use-edge-swipe-back.ts
+++ b/clients/web/src/hooks/use-edge-swipe-back.ts
@@ -1,5 +1,11 @@
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 
+import {
+  EDGE_SWIPE_EASING,
+  EDGE_SWIPE_EXIT_MS,
+  EDGE_SWIPE_FALLBACK_SLACK_MS,
+  EDGE_SWIPE_SLIDE_MS,
+} from "@/hooks/edge-swipe-motion";
 import { computeVisualOffset, useEdgeSwipe } from "@/hooks/use-edge-swipe";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 
@@ -7,20 +13,8 @@ import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Duration (ms) for the cancel/snap-back animation. */
-const CANCEL_ANIMATION_MS = 200;
-
-/** Duration (ms) for the commit/slide-off-screen animation. */
-const COMMIT_ANIMATION_MS = 180;
-
-/** Duration (ms) for the incoming page entrance animation. */
-const ENTRANCE_ANIMATION_MS = 200;
-
 /** Fraction of viewport width the incoming page slides in from. */
 const ENTRANCE_OFFSET_RATIO = 0.25;
-
-/** Slack (ms) added to animation durations for the safety-fallback timers. */
-const ANIMATION_FALLBACK_SLACK_MS = 50;
 
 /** Clear the four inline styles this hook owns, returning the element to rest. */
 function resetTransientStyles(el: HTMLElement): void {
@@ -135,7 +129,7 @@ export function useEdgeSwipeBack({
   };
 
   const snapBack = (el: HTMLElement) => {
-    el.style.transition = `transform ${CANCEL_ANIMATION_MS}ms ease-out`;
+    el.style.transition = `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`;
     applyOffset(el, 0);
     const onEnd = () => {
       el.removeEventListener("transitionend", onEnd);
@@ -145,13 +139,13 @@ export function useEdgeSwipeBack({
     // Safety fallback if transitionend doesn't fire.
     scheduleTimeout(
       () => resetTransientStyles(el),
-      CANCEL_ANIMATION_MS + ANIMATION_FALLBACK_SLACK_MS,
+      EDGE_SWIPE_SLIDE_MS + EDGE_SWIPE_FALLBACK_SLACK_MS,
     );
   };
 
   const runCommitAnimation = (el: HTMLElement) => {
     // Slide the outgoing page off to the right.
-    el.style.transition = `transform ${COMMIT_ANIMATION_MS}ms ease-in`;
+    el.style.transition = `transform ${EDGE_SWIPE_EXIT_MS}ms ${EDGE_SWIPE_EASING}`;
     applyOffset(el, window.innerWidth);
     let didFinish = false;
     const finish = () => {
@@ -182,10 +176,10 @@ export function useEdgeSwipeBack({
           pendingRevealRef.current = false;
           resetTransientStyles(el);
         }
-      }, ENTRANCE_ANIMATION_MS * 2);
+      }, EDGE_SWIPE_SLIDE_MS * 2);
     };
     el.addEventListener("transitionend", finish, { once: true });
-    scheduleTimeout(finish, COMMIT_ANIMATION_MS + ANIMATION_FALLBACK_SLACK_MS);
+    scheduleTimeout(finish, EDGE_SWIPE_EXIT_MS + EDGE_SWIPE_FALLBACK_SLACK_MS);
   };
 
   useEdgeSwipe({
@@ -257,7 +251,7 @@ export function useEdgeSwipeBack({
       resetTransientStyles(el);
     };
 
-    el.style.transition = `transform ${ENTRANCE_ANIMATION_MS}ms ease-out, opacity ${ENTRANCE_ANIMATION_MS}ms ease-out`;
+    el.style.transition = `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}, opacity ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`;
     el.style.transform = "";
     el.style.opacity = "";
     el.addEventListener("transitionend", settle, { once: true });
@@ -265,7 +259,7 @@ export function useEdgeSwipeBack({
     // fire after a normal end is a no-op.
     const fallbackId = setTimeout(
       settle,
-      ENTRANCE_ANIMATION_MS + ANIMATION_FALLBACK_SLACK_MS,
+      EDGE_SWIPE_SLIDE_MS + EDGE_SWIPE_FALLBACK_SLACK_MS,
     );
 
     return () => {

--- a/clients/web/src/hooks/use-edge-swipe-drawer.ts
+++ b/clients/web/src/hooks/use-edge-swipe-drawer.ts
@@ -1,12 +1,11 @@
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 
+import {
+  EDGE_SWIPE_EASING,
+  EDGE_SWIPE_FALLBACK_SLACK_MS,
+  EDGE_SWIPE_SLIDE_MS,
+} from "@/hooks/edge-swipe-motion";
 import { computeDrawerOffset, useEdgeSwipe } from "@/hooks/use-edge-swipe";
-
-/** Duration (ms) of the open / snap-closed animation the finger hands off to. */
-export const DRAWER_SLIDE_MS = 200;
-
-/** Slack (ms) added to the animation duration for the safety-fallback timer. */
-const ANIMATION_FALLBACK_SLACK_MS = 50;
 
 /** Clear the inline styles this hook owns, returning ownership to React. */
 function resetTransientStyles(el: HTMLElement): void {
@@ -113,7 +112,7 @@ export function useEdgeSwipeDrawer({
       if (el) {
         // Slide the remaining distance to fully open, then hand the resting
         // transform back to React (which renders `translateX(0)` while open).
-        el.style.transition = `transform ${DRAWER_SLIDE_MS}ms ease-out`;
+        el.style.transition = `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`;
         el.style.transform = "translateX(0)";
         const finish = () => {
           el.removeEventListener("transitionend", finish);
@@ -122,7 +121,10 @@ export function useEdgeSwipeDrawer({
           }
         };
         el.addEventListener("transitionend", finish, { once: true });
-        scheduleTimeout(finish, DRAWER_SLIDE_MS + ANIMATION_FALLBACK_SLACK_MS);
+        scheduleTimeout(
+          finish,
+          EDGE_SWIPE_SLIDE_MS + EDGE_SWIPE_FALLBACK_SLACK_MS,
+        );
       }
       callbacksRef.current.onOpen();
     },
@@ -133,7 +135,7 @@ export function useEdgeSwipeDrawer({
         return;
       }
       // Snap the peeked panel back off-screen, then let the caller unmount it.
-      el.style.transition = `transform ${DRAWER_SLIDE_MS}ms ease-out`;
+      el.style.transition = `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`;
       el.style.transform = "translateX(-100%)";
       let done = false;
       const finish = () => {
@@ -146,7 +148,10 @@ export function useEdgeSwipeDrawer({
         callbacksRef.current.onSettle();
       };
       el.addEventListener("transitionend", finish, { once: true });
-      scheduleTimeout(finish, DRAWER_SLIDE_MS + ANIMATION_FALLBACK_SLACK_MS);
+      scheduleTimeout(
+        finish,
+        EDGE_SWIPE_SLIDE_MS + EDGE_SWIPE_FALLBACK_SLACK_MS,
+      );
     },
   });
 }

--- a/clients/web/src/hooks/use-edge-swipe.test.ts
+++ b/clients/web/src/hooks/use-edge-swipe.test.ts
@@ -177,13 +177,13 @@ describe("computeVisualOffset", () => {
   });
 
   test("damps travel past the threshold", () => {
-    // 100 + (150 - 100) * 0.3 = 115.
-    expect(computeVisualOffset(150, 100)).toBe(115);
+    // 100 + (150 - 100) * 0.5 = 125.
+    expect(computeVisualOffset(150, 100)).toBe(125);
   });
 
   test("never returns more than threshold + damped overdrag", () => {
     const offset = computeVisualOffset(1000, 100);
-    expect(offset).toBe(100 + 900 * 0.3);
+    expect(offset).toBe(100 + 900 * 0.5);
     expect(offset).toBeLessThan(1000);
   });
 });

--- a/clients/web/src/hooks/use-edge-swipe.ts
+++ b/clients/web/src/hooks/use-edge-swipe.ts
@@ -43,8 +43,12 @@ const VERTICAL_ESCAPE_RATIO = 0.7;
 /** Minimum travel (px) on either axis before the gesture direction is decided. */
 const DEADZONE_PX = 10;
 
-/** Damping applied to drag distance past the commit threshold. */
-const OVERDRAG_DAMPING = 0.3;
+/**
+ * Damping applied to drag distance past the commit threshold. Half speed, so
+ * the page keeps visibly following the finger past the commit point while
+ * still bounding how much empty background a long drag exposes behind it.
+ */
+const OVERDRAG_DAMPING = 0.5;
 
 // ---------------------------------------------------------------------------
 // Pure geometry helpers (framework-agnostic, unit-tested in isolation)


### PR DESCRIPTION
## What

Swipe-to-go-back (`useEdgeSwipeBack`) and swipe-to-open-menu (`useEdgeSwipeDrawer`) both hand a released finger off to the same slide, but each stated its own durations and easing. They had drifted, and the back-swipe was the worse of the two.

The headline problem: back-swipe left the release with `ease-in`. An accelerating curve barely moves for the first frames after the finger lifts, which reads as lag. The drawer decelerates out of the release, so it feels like the panel carries the finger's momentum.

| | Before | After |
|---|---|---|
| Exit easing | `ease-in` | **`ease-out`** |
| Exit duration | 180ms | 150ms |
| Drag damping past threshold | 0.3 | **0.5** |
| Entrance | 200ms `ease-out` | unchanged |
| Total | 380ms | 350ms |

New `hooks/edge-swipe-motion.ts` holds the shared duration and easing. Both hooks and `chat-layout.tsx` read from it, so the two gestures can no longer drift apart.

## Scope

- **Drawer motion is unchanged.** Same 200ms `ease-out`, same 1:1 finger tracking. Only its constants moved out to the shared module.
- **macOS / Electron / desktop web are unaffected.** Both gestures are coarse-pointer gated (`isPointerCoarse()`), so none of this executes there.
- Swipe-back gates on `useIsMobile()` (max-width 767px), so mobile Safari picks up the retuned motion alongside the native shells. That is deliberate: splitting the gate would recreate the two-definitions problem this PR removes.

## Deliberately not changed

The entrance still fades opacity 0 to 1 and still enters from `-25vw`. Those two are coupled: dropping the fade without widening the offset would make the incoming page appear abruptly at 75% of its resting position. Isolating the easing change keeps the on-device comparison conclusive.

## Test plan

- `bun run typecheck` clean
- `eslint` on all touched files: 2 warnings, both pre-existing on `main` (ref-cleanup pattern, on untouched lines)
- `use-edge-swipe.test.ts` 30 pass (damping assertions updated to 0.5)
- `sidebar-shell.test.tsx` 3 pass
- `edge-swipe-arbiter-store.test.ts` 7 pass

Device QA outstanding: swipe back out of Settings then Privacy, then open the chat drawer back to back, and confirm the two now read as the same motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)