### PR TITLE
feat(chrome-extension): Deslop, an in-page assistant rewrite picker

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14997,8 +14997,9 @@ paths:
       operationId: inference_send_post
       summary: Send a message to the configured LLM
       description:
-        Send a user message to the configured LLM provider and return the model response. Optionally specify a
-        system prompt, model override, named profile, or max tokens.
+        Send a user message to the configured LLM provider and return the model response. Supply either message for
+        a single user turn or messages for a conversation transcript, never both. Optionally specify a system prompt,
+        model override, named profile, or max tokens.
       tags:
         - inference
       requestBody:
@@ -15011,6 +15012,24 @@ paths:
                 message:
                   type: string
                   minLength: 1
+                messages:
+                  minItems: 1
+                  maxItems: 200
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      role:
+                        type: string
+                        enum:
+                          - user
+                          - assistant
+                      content:
+                        type: string
+                        minLength: 1
+                    required:
+                      - role
+                      - content
                 systemPrompt:
                   type: string
                 model:
@@ -15021,8 +15040,6 @@ paths:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
-              required:
-                - message
       responses:
         "200":
           description: Successful response

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -66,8 +66,17 @@ mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({ llm: configuredLlm }),
 }));
 
+// The handler re-checks live owner authority, which reads the guardian binding
+// over IPC. Stub the answer so the profile and evidence cases exercise the
+// handler body, and so one case can present a caller who is not the owner.
+let callerIsOwner = true;
+mock.module("../../auth/owner-caller.js", () => ({
+  isOwnerCaller: async () => callerIsOwner,
+}));
+
 const { ROUTES } = await import("../inference-send-routes.js");
-const { BadRequestError, UpstreamProviderError } = await import("../errors.js");
+const { BadRequestError, ForbiddenError, UpstreamProviderError } =
+  await import("../errors.js");
 const { recordProviderRequestDiagnostics } =
   await import("../../../providers/request-diagnostics.js");
 
@@ -90,12 +99,33 @@ function baseResponse(overrides: Partial<ProviderResponse>): ProviderResponse {
 }
 
 beforeEach(() => {
+  callerIsOwner = true;
   configuredLlm = LLMSchema.parse({});
   nextResponse = baseResponse({});
   sendMessageImpl = undefined;
   getConfiguredProviderOptions = undefined;
   sendMessageOptions = undefined;
   resolutionConnectionName = undefined;
+});
+
+describe("inference_send owner authority", () => {
+  test("rejects a caller who no longer holds owner authority", async () => {
+    // GIVEN an actor token whose guardian binding no longer matches
+    callerIsOwner = false;
+
+    // WHEN the inference_send handler processes a request
+    const error = await Promise.resolve(
+      inferenceSendHandler()({ body: { message: "hi" } }),
+    ).then(
+      () => new Error("expected the request to be rejected"),
+      (err: unknown) => err,
+    );
+
+    // THEN the send is refused before any provider call is made
+    expect(error).toBeInstanceOf(ForbiddenError);
+    expect((error as Error).message).toContain("owner");
+    expect(getConfiguredProviderOptions).toBeUndefined();
+  });
 });
 
 describe("inference_send profile routing", () => {

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { LLMSchema } from "../../../config/schemas/llm.js";
 import type { ConfiguredProviderOptions } from "../../../providers/provider-send-message.js";
 import type {
+  Message,
   ProviderResponse,
   SendMessageOptions,
 } from "../../../providers/types.js";
@@ -27,6 +28,7 @@ let nextResponse: ProviderResponse;
 let sendMessageImpl: (() => Promise<ProviderResponse>) | undefined;
 let getConfiguredProviderOptions: ConfiguredProviderOptions | undefined;
 let sendMessageOptions: SendMessageOptions | undefined;
+let sentMessages: Message[] | undefined;
 // Connection the stubbed resolution reports, mirroring the real resolver:
 // the connection is chosen while resolving the provider, not while sending.
 let resolutionConnectionName: string | undefined;
@@ -44,7 +46,8 @@ mock.module("../../../providers/provider-send-message.js", () => ({
     }
     return {
       name: "stub",
-      sendMessage: async (_messages: unknown, options: SendMessageOptions) => {
+      sendMessage: async (messages: Message[], options: SendMessageOptions) => {
+        sentMessages = messages;
         sendMessageOptions = options;
         return sendMessageImpl ? sendMessageImpl() : nextResponse;
       },
@@ -105,6 +108,7 @@ beforeEach(() => {
   sendMessageImpl = undefined;
   getConfiguredProviderOptions = undefined;
   sendMessageOptions = undefined;
+  sentMessages = undefined;
   resolutionConnectionName = undefined;
 });
 
@@ -124,6 +128,75 @@ describe("inference_send owner authority", () => {
     // THEN the send is refused before any provider call is made
     expect(error).toBeInstanceOf(ForbiddenError);
     expect((error as Error).message).toContain("owner");
+    expect(getConfiguredProviderOptions).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A stateless client (e.g. a paired browser extension) carries its own short
+// transcript, so the route accepts a `messages` array as an alternative to the
+// single `message` form. The two are mutually exclusive, and the transcript is
+// size-capped because the send spends the owner's provider budget.
+// ---------------------------------------------------------------------------
+
+describe("inference_send transcript input", () => {
+  function rejection(body: Record<string, unknown>): Promise<Error> {
+    return Promise.resolve(inferenceSendHandler()({ body })).then(
+      () => new Error("expected the request to be rejected"),
+      (err: Error) => err,
+    );
+  }
+
+  test("forwards every transcript turn to the provider in order", async () => {
+    // GIVEN a transcript alternating user and assistant turns
+    const messages = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+      { role: "user", content: "third" },
+    ];
+
+    // WHEN the inference_send handler processes the request
+    const result = (await inferenceSendHandler()({ body: { messages } })) as {
+      response: string;
+    };
+
+    // THEN the provider sees all turns in the order the caller supplied them
+    expect(sentMessages).toEqual([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "second" }] },
+      { role: "user", content: [{ type: "text", text: "third" }] },
+    ]);
+
+    // AND the response echoes the model text
+    expect(result.response).toBe("hello");
+  });
+
+  test("rejects a request carrying both message and messages", async () => {
+    const err = await rejection({
+      message: "hi",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain("not both");
+    expect(getConfiguredProviderOptions).toBeUndefined();
+  });
+
+  test("rejects a request carrying neither message nor messages", async () => {
+    const err = await rejection({});
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain("Provide either message");
+    expect(getConfiguredProviderOptions).toBeUndefined();
+  });
+
+  test("rejects a transcript above the total content size cap", async () => {
+    const err = await rejection({
+      messages: [
+        { role: "user", content: "a".repeat(150_000) },
+        { role: "assistant", content: "b".repeat(60_000) },
+      ],
+    });
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain("200000 character limit");
     expect(getConfiguredProviderOptions).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -18,15 +18,31 @@ import {
 } from "../../providers/provider-send-message.js";
 import type { ProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
 import { runWithProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
+import { isOwnerCaller } from "../auth/owner-caller.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { BadRequestError, UpstreamProviderError } from "./errors.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  UpstreamProviderError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
-async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
+async function handleInferenceSend({ body = {}, headers }: RouteHandlerArgs) {
+  // The route policy admits actor principals, and an actor token is a bearer
+  // credential that stays signature-valid after the guardian binding it was
+  // minted against is revoked or rebound. Principal type alone therefore does
+  // not answer "is this still the owner", so the handler re-reads live owner
+  // authority before spending the owner's provider budget.
+  if (!(await isOwnerCaller(headers))) {
+    throw new ForbiddenError(
+      "Only the assistant's owner can send inference requests",
+    );
+  }
+
   const message = body.message;
   if (typeof message !== "string" || !message.trim()) {
     throw new BadRequestError("message must be a non-empty string");

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -18,7 +18,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import type { ProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
 import { runWithProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
-import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, UpstreamProviderError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -190,7 +190,7 @@ export const ROUTES: RouteDefinition[] = [
     method: "POST",
     policy: {
       requiredScopes: ["chat.write"],
-      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Send a message to the configured LLM",
     description:

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -1,8 +1,8 @@
 /**
  * Route definition for one-shot inference (LLM send).
  *
- * POST /v1/inference/send — send a user message to the configured LLM and
- *                           return the model response.
+ * POST /v1/inference/send sends a user message, or a short conversation
+ * transcript, to the configured LLM and returns the model response.
  */
 
 import { z } from "zod";
@@ -18,6 +18,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import type { ProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
 import { runWithProviderRequestDiagnostics } from "../../providers/request-diagnostics.js";
+import type { Message } from "../../providers/types.js";
 import { isOwnerCaller } from "../auth/owner-caller.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -26,6 +27,86 @@ import {
   UpstreamProviderError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Transcript input
+// ---------------------------------------------------------------------------
+
+/** Turns accepted in one transcript. */
+const MAX_TRANSCRIPT_TURNS = 200;
+
+/**
+ * Characters accepted across the whole transcript. The route spends the
+ * owner's provider budget on behalf of stateless clients, some of which relay
+ * page content, so the per-turn shape checks are paired with a total-size cap
+ * that bounds what a single request can cost.
+ */
+const MAX_TRANSCRIPT_CHARS = 200_000;
+
+const TranscriptSchema = z
+  .array(
+    z.object({
+      role: z.enum(["user", "assistant"]),
+      content: z.string().min(1),
+    }),
+  )
+  .min(1)
+  .max(MAX_TRANSCRIPT_TURNS);
+
+/** Build a single transcript turn in the provider Message format. */
+function transcriptMessage(role: "user" | "assistant", text: string): Message {
+  return { role, content: [{ type: "text", text }] };
+}
+
+/**
+ * Resolve the request's prompt into the provider message array.
+ *
+ * `message` carries one user turn; `messages` carries a transcript. The forms
+ * are mutually exclusive so the model's input is never assembled from two
+ * sources a caller has to reconcile.
+ */
+function resolveMessages(body: Record<string, unknown>): Message[] {
+  const hasMessage = body.message !== undefined;
+  const hasMessages = body.messages !== undefined;
+
+  if (hasMessage && hasMessages) {
+    throw new BadRequestError(
+      "Provide either message or messages, not both. Use message for a single user turn and messages for a transcript.",
+    );
+  }
+  if (!hasMessage && !hasMessages) {
+    throw new BadRequestError(
+      "Provide either message (a single user turn) or messages (a transcript).",
+    );
+  }
+
+  if (hasMessages) {
+    const parsed = TranscriptSchema.safeParse(body.messages);
+    if (!parsed.success) {
+      throw new BadRequestError(
+        `messages must be an array of 1 to ${MAX_TRANSCRIPT_TURNS} turns, each with role "user" or "assistant" and non-empty content`,
+      );
+    }
+    const totalChars = parsed.data.reduce(
+      (sum, turn) => sum + turn.content.length,
+      0,
+    );
+    if (totalChars > MAX_TRANSCRIPT_CHARS) {
+      throw new BadRequestError(
+        `messages content totals ${totalChars} characters, above the ${MAX_TRANSCRIPT_CHARS} character limit`,
+      );
+    }
+    return parsed.data.map((turn) =>
+      transcriptMessage(turn.role, turn.content),
+    );
+  }
+
+  const message = body.message;
+  if (typeof message !== "string" || !message.trim()) {
+    throw new BadRequestError("message must be a non-empty string");
+  }
+  return [userMessage(message)];
+}
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -43,10 +124,7 @@ async function handleInferenceSend({ body = {}, headers }: RouteHandlerArgs) {
     );
   }
 
-  const message = body.message;
-  if (typeof message !== "string" || !message.trim()) {
-    throw new BadRequestError("message must be a non-empty string");
-  }
+  const messages = resolveMessages(body);
 
   const systemPrompt = body.systemPrompt as string | undefined;
   const model = body.model as string | undefined;
@@ -116,7 +194,7 @@ async function handleInferenceSend({ body = {}, headers }: RouteHandlerArgs) {
         "No LLM provider is configured. Connect a provider (assistant credentials) or set llm.defaultProvider to choose one.",
       );
     }
-    return provider.sendMessage([userMessage(message)], {
+    return provider.sendMessage(messages, {
       systemPrompt,
       config: {
         callSite: "inference",
@@ -211,10 +289,12 @@ export const ROUTES: RouteDefinition[] = [
     summary: "Send a message to the configured LLM",
     description:
       "Send a user message to the configured LLM provider and return the model response. " +
+      "Supply either message for a single user turn or messages for a conversation transcript, never both. " +
       "Optionally specify a system prompt, model override, named profile, or max tokens.",
     tags: ["inference"],
     requestBody: z.object({
-      message: z.string().min(1),
+      message: z.string().min(1).optional(),
+      messages: TranscriptSchema.optional(),
       systemPrompt: z.string().optional(),
       model: z.string().optional(),
       profile: z.string().optional(),

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -70,6 +70,8 @@ That's it. The extension auto-reconnects on browser restarts, network drops, and
 
 The popup's **Deslop** button turns the current page into an inspect-element-style picker: hovering highlights the block under the cursor, clicking sends its text to your assistant with a plain-language rewrite prompt, and the response replaces the block's content in place. Rewritten blocks get a faint tint and a wand badge in their top-right corner. Press **Esc** to exit the picker; it stays active after a rewrite so you can clean up several blocks in one pass.
 
+Once Deslop has run on a page, highlighting any text raises a small menu above the selection with **Voice (v)** and **Chat (c)**; pressing a bare `v` or `c` picks the option without reaching for the mouse (voice is not built yet and says so). **Chat** opens a panel anchored to the highlight where you can ask questions about the highlighted text and follow up in a thread. The chat thread shares context with every rewrite made on that page, so you can rewrite a few blocks and then ask about them; the shared thread lives as long as the page does and resets on navigation.
+
 Rewrites go through the assistant's one-shot LLM endpoint (`POST /v1/inference/send`): via the local gateway for self-hosted assistants, or the platform's runtime proxy for cloud assistants. Deslop only works on regular `http(s)` pages (not `chrome://` pages or the Chrome Web Store).
 
 ## Environment Selector

--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -66,6 +66,12 @@ For automated publishing, the `release.yml` GitHub Actions workflow builds, pack
 
 That's it. The extension auto-reconnects on browser restarts, network drops, and assistant restarts. Click **Pause** to intentionally stop the relay.
 
+## Deslop
+
+The popup's **Deslop** button turns the current page into an inspect-element-style picker: hovering highlights the block under the cursor, clicking sends its text to your assistant with a plain-language rewrite prompt, and the response replaces the block's content in place. Rewritten blocks get a faint tint and a wand badge in their top-right corner. Press **Esc** to exit the picker; it stays active after a rewrite so you can clean up several blocks in one pass.
+
+Rewrites go through the assistant's one-shot LLM endpoint (`POST /v1/inference/send`): via the local gateway for self-hosted assistants, or the platform's runtime proxy for cloud assistants. Deslop only works on regular `http(s)` pages (not `chrome://` pages or the Chrome Web Store).
+
 ## Environment Selector
 
 The popup's **Advanced** section includes an **Environment** dropdown that lets you switch between `local`, `dev`, `staging`, and `production` without rebuilding the extension. This controls which cloud API and web URLs are used for sign-in, pairing, and relay connections.

--- a/clients/chrome-extension/background/__tests__/deslop.test.ts
+++ b/clients/chrome-extension/background/__tests__/deslop.test.ts
@@ -2,8 +2,13 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 
 import {
   buildDeslopPrompt,
+  buildHighlightedUserTurn,
+  capTranscript,
+  requestDeslopChat,
   requestDeslopRewrite,
+  DESLOP_CHAT_SYSTEM_PROMPT,
   DESLOP_SYSTEM_PROMPT,
+  type DeslopTranscriptTurn,
 } from "../deslop.js";
 
 const originalFetch = globalThis.fetch;
@@ -72,6 +77,53 @@ describe("buildDeslopPrompt", () => {
     expect(prompt).toContain("at most half the original length");
     expect(prompt).toContain("Remove fluff and pleasantries entirely");
     expect(prompt).toContain("Start directly with the substance");
+  });
+});
+
+describe("buildHighlightedUserTurn", () => {
+  test("wraps the highlighted page text alongside the message", () => {
+    expect(buildHighlightedUserTurn("the fine print", "what does this mean?")).toBe(
+      "<user_highlighted>the fine print</user_highlighted> what does this mean?",
+    );
+  });
+
+  test("returns the bare message when nothing is highlighted", () => {
+    expect(buildHighlightedUserTurn("", "what does this mean?")).toBe(
+      "what does this mean?",
+    );
+  });
+});
+
+describe("capTranscript", () => {
+  function makeTurns(count: number): DeslopTranscriptTurn[] {
+    return Array.from({ length: count }, (_unused, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `${index}`.padEnd(60, "x"),
+    }));
+  }
+
+  test("returns the transcript untouched when it fits", () => {
+    const turns = makeTurns(6);
+    expect(capTranscript(turns, 100_000)).toBe(turns);
+  });
+
+  test("drops the oldest turns in pairs until it fits", () => {
+    const turns = makeTurns(6);
+    const capped = capTranscript(turns, 400);
+
+    expect(JSON.stringify(capped).length).toBeLessThanOrEqual(400);
+    expect(capped.length).toBe(4);
+    expect(capped[0]).toEqual(turns[2]!);
+    expect(capped[3]).toEqual(turns[5]!);
+    expect(capped[0]!.role).toBe("user");
+  });
+
+  test("keeps the most recent turns even when a single turn exceeds the cap", () => {
+    const turns = makeTurns(5);
+    const capped = capTranscript(turns, 10);
+
+    expect(capped.length).toBe(1);
+    expect(capped[0]).toEqual(turns[4]!);
   });
 });
 
@@ -218,5 +270,88 @@ describe("requestDeslopRewrite (cloud)", () => {
     const headers = captured[0]!.init?.headers as Record<string, string>;
     expect(headers["X-Session-Token"]).toBe("sess-token");
     expect(headers["Vellum-Organization-Id"]).toBe("org-abc");
+  });
+});
+
+describe("requestDeslopChat", () => {
+  const transcript: DeslopTranscriptTurn[] = [
+    { role: "user", content: "rewrite this" },
+    { role: "assistant", content: "Rewritten." },
+    {
+      role: "user",
+      content: "<user_highlighted>the fine print</user_highlighted> why?",
+    },
+  ];
+
+  test("sends the transcript as messages and returns the trimmed reply", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, () =>
+      Response.json({ response: "  Because of the clause.  " }),
+    );
+
+    const reply = await requestDeslopChat(transcript, {
+      kind: "self-hosted",
+      gatewayUrl: "http://127.0.0.1:7830",
+      pairToken: "jwt-123",
+    });
+
+    expect(reply).toBe("Because of the clause.");
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.url).toBe("http://127.0.0.1:7830/v1/inference/send");
+    const body = parseBody(captured[0]!);
+    expect(body["messages"]).toEqual(transcript);
+    expect(body).not.toHaveProperty("message");
+    expect(body["systemPrompt"]).toBe(DESLOP_CHAT_SYSTEM_PROMPT);
+    expect(body["profile"]).toBe("latency-optimized");
+  });
+
+  test("retries without the profile when the assistant rejects it", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, (callIndex) =>
+      callIndex === 0
+        ? new Response('{"error":"Profile \\"latency-optimized\\" is disabled"}', {
+            status: 400,
+          })
+        : Response.json({ response: "Because of the clause." }),
+    );
+
+    const reply = await requestDeslopChat(transcript, {
+      kind: "self-hosted",
+      gatewayUrl: "http://127.0.0.1:7830",
+      pairToken: null,
+    });
+
+    expect(reply).toBe("Because of the clause.");
+    expect(captured.length).toBe(2);
+    expect(parseBody(captured[0]!)["profile"]).toBe("latency-optimized");
+    const retried = parseBody(captured[1]!);
+    expect(retried).not.toHaveProperty("profile");
+    expect(retried).not.toHaveProperty("message");
+    expect(retried["messages"]).toEqual(transcript);
+    expect(retried["systemPrompt"]).toBe(DESLOP_CHAT_SYSTEM_PROMPT);
+  });
+
+  test("throws with status detail on a non-OK response", async () => {
+    installFetchMock([], () => new Response("nope", { status: 500 }));
+
+    await expect(
+      requestDeslopChat(transcript, {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/Assistant chat failed \(500\).*nope/);
+  });
+
+  test("throws when the assistant returns an empty reply", async () => {
+    installFetchMock([], () => Response.json({ response: "   " }));
+
+    await expect(
+      requestDeslopChat(transcript, {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/empty reply/);
   });
 });

--- a/clients/chrome-extension/background/__tests__/deslop.test.ts
+++ b/clients/chrome-extension/background/__tests__/deslop.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+
+import {
+  buildDeslopPrompt,
+  requestDeslopRewrite,
+  DESLOP_SYSTEM_PROMPT,
+} from "../deslop.js";
+
+const originalFetch = globalThis.fetch;
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function installFetchMock(
+  captured: CapturedRequest[],
+  respond: () => Response,
+): void {
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    captured.push({ url: String(input), init });
+    return respond();
+  }) as typeof fetch;
+}
+
+function installChromeStorageMock(local: Record<string, unknown>): void {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      local: {
+        async get(keys?: string | string[]) {
+          if (typeof keys === "string") {
+            return keys in local ? { [keys]: local[keys] } : {};
+          }
+          return { ...local };
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete (globalThis as unknown as { chrome?: unknown }).chrome;
+});
+
+describe("buildDeslopPrompt", () => {
+  test("wraps the selected text in the rewrite prompt", () => {
+    const prompt = buildDeslopPrompt("synergize the deliverables");
+    expect(prompt).toContain(
+      "<selected_text>synergize the deliverables</selected_text>",
+    );
+    expect(prompt).toContain("without any jargon");
+    expect(prompt).toContain("one human talking to another");
+  });
+});
+
+describe("requestDeslopRewrite (self-hosted)", () => {
+  test("posts to the gateway inference endpoint with the pair token", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, () =>
+      Response.json({ response: "  Plain words.  " }),
+    );
+
+    const rewritten = await requestDeslopRewrite("leverage synergies", {
+      kind: "self-hosted",
+      gatewayUrl: "http://127.0.0.1:7830/",
+      pairToken: "jwt-123",
+    });
+
+    expect(rewritten).toBe("Plain words.");
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.url).toBe("http://127.0.0.1:7830/v1/inference/send");
+    const headers = captured[0]!.init?.headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer jwt-123");
+    const body = JSON.parse(String(captured[0]!.init?.body)) as {
+      message: string;
+      systemPrompt: string;
+    };
+    expect(body.message).toContain(
+      "<selected_text>leverage synergies</selected_text>",
+    );
+    expect(body.systemPrompt).toBe(DESLOP_SYSTEM_PROMPT);
+  });
+
+  test("omits the authorization header when no pair token exists", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, () => Response.json({ response: "ok text" }));
+
+    await requestDeslopRewrite("text", {
+      kind: "self-hosted",
+      gatewayUrl: "http://127.0.0.1:7830",
+      pairToken: null,
+    });
+
+    const headers = captured[0]!.init?.headers as Record<string, string>;
+    expect(headers["authorization"]).toBeUndefined();
+  });
+
+  test("throws with status detail on a non-OK response", async () => {
+    installFetchMock([], () => new Response("nope", { status: 403 }));
+
+    await expect(
+      requestDeslopRewrite("text", {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/403.*nope/);
+  });
+
+  test("throws when the assistant returns an empty rewrite", async () => {
+    installFetchMock([], () => Response.json({ response: "   " }));
+
+    await expect(
+      requestDeslopRewrite("text", {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/empty rewrite/);
+  });
+});
+
+describe("requestDeslopRewrite (cloud)", () => {
+  test("posts through the platform wildcard proxy with session headers", async () => {
+    installChromeStorageMock({
+      "vellum.cloudSession": {
+        email: "user@example.com",
+        environment: "dev",
+        sessionToken: "sess-token",
+        organizationId: "org-abc",
+      },
+    });
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, () => Response.json({ response: "Cleaner." }));
+
+    const rewritten = await requestDeslopRewrite("obfuscated verbiage", {
+      kind: "cloud",
+      environment: "dev",
+      assistantId: "assistant-1",
+    });
+
+    expect(rewritten).toBe("Cleaner.");
+    expect(captured.length).toBe(1);
+    expect(captured[0]!.url).toContain(
+      "/v1/assistants/assistant-1/inference/send",
+    );
+    const headers = captured[0]!.init?.headers as Record<string, string>;
+    expect(headers["X-Session-Token"]).toBe("sess-token");
+    expect(headers["Vellum-Organization-Id"]).toBe("org-abc");
+  });
+});

--- a/clients/chrome-extension/background/__tests__/deslop.test.ts
+++ b/clients/chrome-extension/background/__tests__/deslop.test.ts
@@ -15,15 +15,20 @@ interface CapturedRequest {
 
 function installFetchMock(
   captured: CapturedRequest[],
-  respond: () => Response,
+  respond: (callIndex: number) => Response,
 ): void {
   globalThis.fetch = (async (
     input: string | URL | Request,
     init?: RequestInit,
   ) => {
+    const callIndex = captured.length;
     captured.push({ url: String(input), init });
-    return respond();
+    return respond(callIndex);
   }) as typeof fetch;
+}
+
+function parseBody(request: CapturedRequest): Record<string, unknown> {
+  return JSON.parse(String(request.init?.body)) as Record<string, unknown>;
 }
 
 function installChromeStorageMock(local: Record<string, unknown>): void {
@@ -59,6 +64,13 @@ describe("buildDeslopPrompt", () => {
     expect(prompt).toContain("without any jargon");
     expect(prompt).toContain("one human talking to another");
   });
+
+  test("asks aggressively for a shorter rewrite", () => {
+    const prompt = buildDeslopPrompt("text");
+    expect(prompt).toContain("much more simply and concisely");
+    expect(prompt).toContain("Be aggressive about cutting length");
+    expect(prompt).toContain("at most half the original length");
+  });
 });
 
 describe("requestDeslopRewrite (self-hosted)", () => {
@@ -79,14 +91,12 @@ describe("requestDeslopRewrite (self-hosted)", () => {
     expect(captured[0]!.url).toBe("http://127.0.0.1:7830/v1/inference/send");
     const headers = captured[0]!.init?.headers as Record<string, string>;
     expect(headers["authorization"]).toBe("Bearer jwt-123");
-    const body = JSON.parse(String(captured[0]!.init?.body)) as {
-      message: string;
-      systemPrompt: string;
-    };
-    expect(body.message).toContain(
+    const body = parseBody(captured[0]!);
+    expect(body["message"]).toContain(
       "<selected_text>leverage synergies</selected_text>",
     );
-    expect(body.systemPrompt).toBe(DESLOP_SYSTEM_PROMPT);
+    expect(body["systemPrompt"]).toBe(DESLOP_SYSTEM_PROMPT);
+    expect(body["profile"]).toBe("latency-optimized");
   });
 
   test("omits the authorization header when no pair token exists", async () => {
@@ -113,6 +123,57 @@ describe("requestDeslopRewrite (self-hosted)", () => {
         pairToken: "jwt",
       }),
     ).rejects.toThrow(/403.*nope/);
+  });
+
+  const profileRejectionBodies: Array<[string, string]> = [
+    [
+      "a JSON error envelope",
+      '{"error":"Profile \\"latency-optimized\\" is disabled"}',
+    ],
+    ["a plain text body", 'Profile "latency-optimized" is disabled'],
+  ];
+
+  for (const [label, rejectionBody] of profileRejectionBodies) {
+    test(`retries without the profile when the assistant rejects it in ${label}`, async () => {
+      const captured: CapturedRequest[] = [];
+      installFetchMock(captured, (callIndex) =>
+        callIndex === 0
+          ? new Response(rejectionBody, { status: 400 })
+          : Response.json({ response: "Plain words." }),
+      );
+
+      const rewritten = await requestDeslopRewrite("text", {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      });
+
+      expect(rewritten).toBe("Plain words.");
+      expect(captured.length).toBe(2);
+      expect(parseBody(captured[0]!)["profile"]).toBe("latency-optimized");
+      expect(parseBody(captured[1]!)).not.toHaveProperty("profile");
+      expect(parseBody(captured[1]!)["systemPrompt"]).toBe(DESLOP_SYSTEM_PROMPT);
+    });
+  }
+
+  test("does not retry a 400 that is not a profile rejection", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(
+      captured,
+      () =>
+        new Response('{"error":"message must be a non-empty string"}', {
+          status: 400,
+        }),
+    );
+
+    await expect(
+      requestDeslopRewrite("text", {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/400.*non-empty string/);
+    expect(captured.length).toBe(1);
   });
 
   test("throws when the assistant returns an empty rewrite", async () => {

--- a/clients/chrome-extension/background/__tests__/deslop.test.ts
+++ b/clients/chrome-extension/background/__tests__/deslop.test.ts
@@ -4,8 +4,10 @@ import {
   buildDeslopPrompt,
   buildHighlightedUserTurn,
   capTranscript,
+  flattenTranscript,
   requestDeslopChat,
   requestDeslopRewrite,
+  resetDeslopTranscriptSupport,
   DESLOP_CHAT_SYSTEM_PROMPT,
   DESLOP_SYSTEM_PROMPT,
   type DeslopTranscriptTurn,
@@ -53,6 +55,7 @@ function installChromeStorageMock(local: Record<string, unknown>): void {
 
 beforeEach(() => {
   delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  resetDeslopTranscriptSupport();
 });
 
 afterEach(() => {
@@ -353,5 +356,99 @@ describe("requestDeslopChat", () => {
         pairToken: "jwt",
       }),
     ).rejects.toThrow(/empty reply/);
+  });
+});
+
+describe("assistants without transcript support", () => {
+  const transcript: DeslopTranscriptTurn[] = [
+    { role: "user", content: "Rewrite this" },
+    { role: "assistant", content: "Rewritten" },
+    { role: "user", content: "<user_highlighted>null</user_highlighted> why?" },
+  ];
+
+  // The wire shape an assistant older than the `messages` field answers with:
+  // it reads the request as a single-message send that carries no message.
+  const legacyRejection = new Response(
+    '{"error":{"code":"BAD_REQUEST","message":"message must be a non-empty string"}}',
+    { status: 400 },
+  );
+
+  test("flattenTranscript labels the history and sets apart the new turn", () => {
+    const flattened = flattenTranscript(transcript);
+    expect(flattened).toContain("Conversation so far:");
+    expect(flattened).toContain("User: Rewrite this");
+    expect(flattened).toContain("Assistant: Rewritten");
+    expect(flattened).toContain("The user now says:");
+    expect(flattened.endsWith(transcript[2]!.content)).toBe(true);
+  });
+
+  test("flattenTranscript returns a lone turn verbatim", () => {
+    expect(flattenTranscript([{ role: "user", content: "just this" }])).toBe(
+      "just this",
+    );
+  });
+
+  test("retries as a single message when the assistant rejects a transcript", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, (callIndex) =>
+      callIndex === 0
+        ? legacyRejection.clone()
+        : Response.json({ response: "Because it resolves at run time." }),
+    );
+
+    const reply = await requestDeslopChat(transcript, {
+      kind: "self-hosted",
+      gatewayUrl: "http://127.0.0.1:7830",
+      pairToken: "jwt",
+    });
+
+    expect(reply).toBe("Because it resolves at run time.");
+    expect(captured.length).toBe(2);
+    expect(parseBody(captured[0]!)).toHaveProperty("messages");
+    const fallback = parseBody(captured[1]!);
+    expect(fallback).not.toHaveProperty("messages");
+    expect(String(fallback["message"])).toContain("User: Rewrite this");
+    expect(String(fallback["message"])).toContain("why?");
+    expect(fallback["systemPrompt"]).toBe(DESLOP_CHAT_SYSTEM_PROMPT);
+  });
+
+  test("skips the transcript attempt on later turns once one is rejected", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(captured, (callIndex) =>
+      callIndex === 0
+        ? legacyRejection.clone()
+        : Response.json({ response: "ok" }),
+    );
+    const target = {
+      kind: "self-hosted" as const,
+      gatewayUrl: "http://127.0.0.1:7830",
+      pairToken: "jwt",
+    };
+
+    await requestDeslopChat(transcript, target);
+    await requestDeslopChat(transcript, target);
+
+    // Two sends for the first turn (rejected, then flattened), one for the
+    // second: the rejection is remembered.
+    expect(captured.length).toBe(3);
+    expect(parseBody(captured[2]!)).not.toHaveProperty("messages");
+    expect(parseBody(captured[2]!)).toHaveProperty("message");
+  });
+
+  test("a 400 that is not a transcript rejection still throws", async () => {
+    const captured: CapturedRequest[] = [];
+    installFetchMock(
+      captured,
+      () => new Response('{"error":"something else entirely"}', { status: 400 }),
+    );
+
+    await expect(
+      requestDeslopChat(transcript, {
+        kind: "self-hosted",
+        gatewayUrl: "http://127.0.0.1:7830",
+        pairToken: "jwt",
+      }),
+    ).rejects.toThrow(/Assistant chat failed \(400\)/);
+    expect(captured.length).toBe(1);
   });
 });

--- a/clients/chrome-extension/background/__tests__/deslop.test.ts
+++ b/clients/chrome-extension/background/__tests__/deslop.test.ts
@@ -70,6 +70,8 @@ describe("buildDeslopPrompt", () => {
     expect(prompt).toContain("much more simply and concisely");
     expect(prompt).toContain("Be aggressive about cutting length");
     expect(prompt).toContain("at most half the original length");
+    expect(prompt).toContain("Remove fluff and pleasantries entirely");
+    expect(prompt).toContain("Start directly with the substance");
   });
 });
 

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -31,6 +31,8 @@ export function buildDeslopPrompt(text: string): string {
     "State it much more simply and concisely, like one human talking to another. " +
     "Be aggressive about cutting length: drop filler, hedging, repetition, and " +
     "needless detail, and keep only what the reader actually needs. " +
+    "Remove fluff and pleasantries entirely: no greetings, compliments, " +
+    "apologies, or warm-up sentences. Start directly with the substance. " +
     "Aim for at most half the original length. " +
     `<selected_text>${text}</selected_text>`
   );

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -1,0 +1,91 @@
+/**
+ * Deslop rewrite dispatcher.
+ *
+ * Turns a block of page text into a plain-language rewrite by calling
+ * the assistant's one-shot LLM endpoint (`POST /v1/inference/send`).
+ * Self-hosted assistants are reached through the local gateway's
+ * runtime-proxy catch-all; cloud assistants through the platform's
+ * wildcard runtime proxy (`/v1/assistants/{id}/inference/send`).
+ */
+
+import { cloudApiFetch } from "./cloud-api.js";
+import type { ExtensionEnvironment } from "./extension-environment.js";
+
+/**
+ * Keeps the model's answer substitution-safe: the rewrite replaces the
+ * clicked element's content verbatim, so commentary or quoting would
+ * end up on the page.
+ */
+export const DESLOP_SYSTEM_PROMPT =
+  "You rewrite text on behalf of the user. Reply with only the rewritten text. No preamble, no surrounding quotes, no commentary.";
+
+export function buildDeslopPrompt(text: string): string {
+  return (
+    "Rewrite the selected text without any jargon and speak coherently. " +
+    "State it more simply and concisely, like one human talking to another. " +
+    `<selected_text>${text}</selected_text>`
+  );
+}
+
+export type DeslopTarget =
+  | { kind: "self-hosted"; gatewayUrl: string; pairToken: string | null }
+  | { kind: "cloud"; environment: ExtensionEnvironment; assistantId: string };
+
+interface InferenceSendResponse {
+  response?: unknown;
+}
+
+/**
+ * Ask the assistant to rewrite `text`. Resolves to the rewritten text,
+ * or throws with a message suitable for surfacing on the page.
+ */
+export async function requestDeslopRewrite(
+  text: string,
+  target: DeslopTarget,
+): Promise<string> {
+  const body = JSON.stringify({
+    message: buildDeslopPrompt(text),
+    systemPrompt: DESLOP_SYSTEM_PROMPT,
+  });
+
+  let response: Response;
+  if (target.kind === "self-hosted") {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (target.pairToken) {
+      headers["authorization"] = `Bearer ${target.pairToken}`;
+    }
+    response = await fetch(
+      `${target.gatewayUrl.replace(/\/$/, "")}/v1/inference/send`,
+      { method: "POST", headers, body },
+    );
+  } else {
+    response = await cloudApiFetch(
+      target.environment,
+      `/v1/assistants/${encodeURIComponent(target.assistantId)}/inference/send`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `Assistant rewrite failed (${response.status})${detail ? `: ${truncate(detail, 300)}` : ""}`,
+    );
+  }
+
+  const payload = (await response.json()) as InferenceSendResponse;
+  if (typeof payload.response !== "string" || payload.response.trim().length === 0) {
+    throw new Error("Assistant returned an empty rewrite");
+  }
+  return payload.response.trim();
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -18,7 +18,11 @@ import type { ExtensionEnvironment } from "./extension-environment.js";
  * end up on the page.
  */
 export const DESLOP_SYSTEM_PROMPT =
-  "You rewrite text on behalf of the user. Reply with only the rewritten text. No preamble, no surrounding quotes, no commentary.";
+  "You rewrite text on behalf of the user. Reply with only the rewritten text. " +
+  "No preamble, no surrounding quotes, no commentary. " +
+  "Mirror the structure of the original: keep code identifiers in backticks, " +
+  "keep list items as lines starting with '- ', and keep bold with **. " +
+  "Do not add formatting the original did not have.";
 
 /**
  * Governs the page-side chat thread, whose transcript interleaves rewrite

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -136,6 +136,49 @@ export async function requestDeslopRewrite(
   );
 }
 
+const CHAT_LABELS: DeslopErrorLabels = {
+  failure: "Assistant chat failed",
+  empty: "Assistant returned an empty reply",
+};
+
+/**
+ * An assistant that predates the `messages` field reads the request as a
+ * single-message send with no message at all, and says so. The extension
+ * ships independently of the assistant, so it must answer for both.
+ */
+const TRANSCRIPT_UNSUPPORTED_PATTERN = /message must be a non-empty string/;
+
+/**
+ * Latched once an assistant proves it cannot take a transcript, so later
+ * turns in the same session skip the doomed first attempt.
+ */
+let transcriptUnsupported = false;
+
+/** Test seam: forget what the last assistant supported. */
+export function resetDeslopTranscriptSupport(): void {
+  transcriptUnsupported = false;
+}
+
+/**
+ * Render a transcript as one labelled block, for assistants that take only
+ * a single message. The final turn is the question being asked now, so it
+ * is set apart from the history above it.
+ */
+export function flattenTranscript(turns: DeslopTranscriptTurn[]): string {
+  if (turns.length === 0) {
+    return "";
+  }
+  const history = turns.slice(0, -1);
+  const current = turns[turns.length - 1]!;
+  const rendered = history
+    .map((turn) => `${turn.role === "user" ? "User" : "Assistant"}: ${turn.content}`)
+    .join("\n\n");
+  if (rendered.length === 0) {
+    return current.content;
+  }
+  return `Conversation so far:\n\n${rendered}\n\nThe user now says:\n\n${current.content}`;
+}
+
 /**
  * Continue the page-side chat thread. `transcript` is the full exchange so
  * far, ending with the turn the user just sent. Resolves to the reply text.
@@ -144,16 +187,31 @@ export async function requestDeslopChat(
   transcript: DeslopTranscriptTurn[],
   target: DeslopTarget,
 ): Promise<string> {
+  if (!transcriptUnsupported) {
+    const attempt = await attemptWithProfileFallback(
+      target,
+      { messages: transcript, systemPrompt: DESLOP_CHAT_SYSTEM_PROMPT },
+      CHAT_LABELS,
+    );
+    if (attempt.ok) {
+      return attempt.reply;
+    }
+    if (
+      attempt.status !== 400 ||
+      !TRANSCRIPT_UNSUPPORTED_PATTERN.test(attempt.detail)
+    ) {
+      throw attemptFailure(attempt, CHAT_LABELS);
+    }
+    transcriptUnsupported = true;
+  }
+
   return sendDeslopRequest(
     target,
     {
-      messages: transcript,
+      message: flattenTranscript(transcript),
       systemPrompt: DESLOP_CHAT_SYSTEM_PROMPT,
     },
-    {
-      failure: "Assistant chat failed",
-      empty: "Assistant returned an empty reply",
-    },
+    CHAT_LABELS,
   );
 }
 
@@ -169,21 +227,40 @@ async function sendDeslopRequest(
   request: Record<string, unknown>,
   labels: DeslopErrorLabels,
 ): Promise<string> {
-  let attempt = await attemptDeslopSend(
+  const attempt = await attemptWithProfileFallback(target, request, labels);
+  if (!attempt.ok) {
+    throw attemptFailure(attempt, labels);
+  }
+  return attempt.reply;
+}
+
+/**
+ * Post a request with the preferred profile, retrying once without it when
+ * the assistant rejects the profile itself.
+ */
+async function attemptWithProfileFallback(
+  target: DeslopTarget,
+  request: Record<string, unknown>,
+  labels: DeslopErrorLabels,
+): Promise<DeslopAttempt> {
+  const attempt = await attemptDeslopSend(
     target,
     JSON.stringify({ ...request, profile: DESLOP_PROFILE }),
     labels,
   );
-  if (!attempt.ok && isProfileRejection(attempt)) {
-    attempt = await attemptDeslopSend(target, JSON.stringify(request), labels);
+  if (attempt.ok || !isProfileRejection(attempt)) {
+    return attempt;
   }
+  return attemptDeslopSend(target, JSON.stringify(request), labels);
+}
 
-  if (!attempt.ok) {
-    throw new Error(
-      `${labels.failure} (${attempt.status})${attempt.detail ? `: ${truncate(attempt.detail, 300)}` : ""}`,
-    );
-  }
-  return attempt.reply;
+function attemptFailure(
+  attempt: Extract<DeslopAttempt, { ok: false }>,
+  labels: DeslopErrorLabels,
+): Error {
+  return new Error(
+    `${labels.failure} (${attempt.status})${attempt.detail ? `: ${truncate(attempt.detail, 300)}` : ""}`,
+  );
 }
 
 /**

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -19,10 +19,19 @@ import type { ExtensionEnvironment } from "./extension-environment.js";
 export const DESLOP_SYSTEM_PROMPT =
   "You rewrite text on behalf of the user. Reply with only the rewritten text. No preamble, no surrounding quotes, no commentary.";
 
+/**
+ * Named profile requested for the rewrite. Installs without a usable
+ * latency-optimized profile fall back to the assistant's own resolution.
+ */
+const DESLOP_PROFILE = "latency-optimized";
+
 export function buildDeslopPrompt(text: string): string {
   return (
     "Rewrite the selected text without any jargon and speak coherently. " +
-    "State it more simply and concisely, like one human talking to another. " +
+    "State it much more simply and concisely, like one human talking to another. " +
+    "Be aggressive about cutting length: drop filler, hedging, repetition, and " +
+    "needless detail, and keep only what the reader actually needs. " +
+    "Aim for at most half the original length. " +
     `<selected_text>${text}</selected_text>`
   );
 }
@@ -35,19 +44,62 @@ interface InferenceSendResponse {
   response?: unknown;
 }
 
+type DeslopAttempt =
+  | { ok: true; rewrite: string }
+  | { ok: false; status: number; detail: string };
+
 /**
  * Ask the assistant to rewrite `text`. Resolves to the rewritten text,
  * or throws with a message suitable for surfacing on the page.
+ *
+ * The rewrite asks for the latency-optimized profile. Installs where that
+ * profile is missing or disabled answer 400 with a `Profile "..."` message,
+ * which earns a single retry without the profile field.
  */
 export async function requestDeslopRewrite(
   text: string,
   target: DeslopTarget,
 ): Promise<string> {
-  const body = JSON.stringify({
+  const request = {
     message: buildDeslopPrompt(text),
     systemPrompt: DESLOP_SYSTEM_PROMPT,
-  });
+  };
 
+  let attempt = await attemptDeslopRewrite(
+    target,
+    JSON.stringify({ ...request, profile: DESLOP_PROFILE }),
+  );
+  if (!attempt.ok && isProfileRejection(attempt)) {
+    attempt = await attemptDeslopRewrite(target, JSON.stringify(request));
+  }
+
+  if (!attempt.ok) {
+    throw new Error(
+      `Assistant rewrite failed (${attempt.status})${attempt.detail ? `: ${truncate(attempt.detail, 300)}` : ""}`,
+    );
+  }
+  return attempt.rewrite;
+}
+
+/**
+ * The daemon rejects an unusable profile with a message starting `Profile "`.
+ * The quote arrives backslash-escaped when the message is wrapped in a JSON
+ * error envelope, so both spellings count.
+ */
+const PROFILE_REJECTION_PATTERN = /Profile\s+\\?"/;
+
+function isProfileRejection(
+  attempt: Extract<DeslopAttempt, { ok: false }>,
+): boolean {
+  return (
+    attempt.status === 400 && PROFILE_REJECTION_PATTERN.test(attempt.detail)
+  );
+}
+
+async function attemptDeslopRewrite(
+  target: DeslopTarget,
+  body: string,
+): Promise<DeslopAttempt> {
   let response: Response;
   if (target.kind === "self-hosted") {
     const headers: Record<string, string> = {
@@ -74,16 +126,14 @@ export async function requestDeslopRewrite(
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
-    throw new Error(
-      `Assistant rewrite failed (${response.status})${detail ? `: ${truncate(detail, 300)}` : ""}`,
-    );
+    return { ok: false, status: response.status, detail };
   }
 
   const payload = (await response.json()) as InferenceSendResponse;
   if (typeof payload.response !== "string" || payload.response.trim().length === 0) {
     throw new Error("Assistant returned an empty rewrite");
   }
-  return payload.response.trim();
+  return { ok: true, rewrite: payload.response.trim() };
 }
 
 function truncate(value: string, max: number): string {

--- a/clients/chrome-extension/background/deslop.ts
+++ b/clients/chrome-extension/background/deslop.ts
@@ -1,11 +1,12 @@
 /**
- * Deslop rewrite dispatcher.
+ * Deslop inference dispatcher.
  *
- * Turns a block of page text into a plain-language rewrite by calling
- * the assistant's one-shot LLM endpoint (`POST /v1/inference/send`).
- * Self-hosted assistants are reached through the local gateway's
- * runtime-proxy catch-all; cloud assistants through the platform's
- * wildcard runtime proxy (`/v1/assistants/{id}/inference/send`).
+ * Turns a block of page text into a plain-language rewrite, and answers
+ * follow-up chat turns about the page, by calling the assistant's one-shot
+ * LLM endpoint (`POST /v1/inference/send`). Self-hosted assistants are
+ * reached through the local gateway's runtime-proxy catch-all; cloud
+ * assistants through the platform's wildcard runtime proxy
+ * (`/v1/assistants/{id}/inference/send`).
  */
 
 import { cloudApiFetch } from "./cloud-api.js";
@@ -20,10 +21,36 @@ export const DESLOP_SYSTEM_PROMPT =
   "You rewrite text on behalf of the user. Reply with only the rewritten text. No preamble, no surrounding quotes, no commentary.";
 
 /**
+ * Governs the page-side chat thread, whose transcript interleaves rewrite
+ * prompts, their rewrites, and free-form questions about the page.
+ */
+export const DESLOP_CHAT_SYSTEM_PROMPT =
+  "You are assisting the user on a web page they are reading. " +
+  "Earlier turns may contain requests to rewrite page text and your rewritten versions. " +
+  "The user highlights parts of the page and asks questions or requests changes about them; " +
+  "the highlighted part is marked with <user_highlighted> tags. " +
+  "Answer directly, concisely, and conversationally, in plain text with no markdown formatting.";
+
+/**
  * Named profile requested for the rewrite. Installs without a usable
  * latency-optimized profile fall back to the assistant's own resolution.
  */
 const DESLOP_PROFILE = "latency-optimized";
+
+/**
+ * A single turn of the page-side chat thread, in the shape the daemon's
+ * `messages` field expects.
+ */
+export interface DeslopTranscriptTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Serialized transcript budget. Well under the daemon's request cap, so a
+ * long-running page session never fails on size alone.
+ */
+export const DESLOP_TRANSCRIPT_MAX_CHARS = 150_000;
 
 export function buildDeslopPrompt(text: string): string {
   return (
@@ -38,6 +65,36 @@ export function buildDeslopPrompt(text: string): string {
   );
 }
 
+/**
+ * Marks the part of the page the user had highlighted when they sent
+ * `message`, so the model can tell page text from the user's own words.
+ */
+export function buildHighlightedUserTurn(
+  highlighted: string,
+  message: string,
+): string {
+  if (!highlighted) {
+    return message;
+  }
+  return `<user_highlighted>${highlighted}</user_highlighted> ${message}`;
+}
+
+/**
+ * Trim the transcript to `maxChars` of serialized JSON by dropping the
+ * oldest turns in pairs, which keeps user/assistant alternation intact.
+ * The most recent turns always survive.
+ */
+export function capTranscript(
+  turns: DeslopTranscriptTurn[],
+  maxChars: number,
+): DeslopTranscriptTurn[] {
+  let capped = turns;
+  while (capped.length > 2 && JSON.stringify(capped).length > maxChars) {
+    capped = capped.slice(2);
+  }
+  return capped;
+}
+
 export type DeslopTarget =
   | { kind: "self-hosted"; gatewayUrl: string; pairToken: string | null }
   | { kind: "cloud"; environment: ExtensionEnvironment; assistantId: string };
@@ -47,40 +104,86 @@ interface InferenceSendResponse {
 }
 
 type DeslopAttempt =
-  | { ok: true; rewrite: string }
+  | { ok: true; reply: string }
   | { ok: false; status: number; detail: string };
+
+/** Wording for the two failure modes, so each entry point reads naturally. */
+interface DeslopErrorLabels {
+  /** Prefixes the HTTP failure message, e.g. "Assistant rewrite failed". */
+  failure: string;
+  /** Thrown when the assistant answers with nothing usable. */
+  empty: string;
+}
 
 /**
  * Ask the assistant to rewrite `text`. Resolves to the rewritten text,
  * or throws with a message suitable for surfacing on the page.
- *
- * The rewrite asks for the latency-optimized profile. Installs where that
- * profile is missing or disabled answer 400 with a `Profile "..."` message,
- * which earns a single retry without the profile field.
  */
 export async function requestDeslopRewrite(
   text: string,
   target: DeslopTarget,
 ): Promise<string> {
-  const request = {
-    message: buildDeslopPrompt(text),
-    systemPrompt: DESLOP_SYSTEM_PROMPT,
-  };
+  return sendDeslopRequest(
+    target,
+    {
+      message: buildDeslopPrompt(text),
+      systemPrompt: DESLOP_SYSTEM_PROMPT,
+    },
+    {
+      failure: "Assistant rewrite failed",
+      empty: "Assistant returned an empty rewrite",
+    },
+  );
+}
 
-  let attempt = await attemptDeslopRewrite(
+/**
+ * Continue the page-side chat thread. `transcript` is the full exchange so
+ * far, ending with the turn the user just sent. Resolves to the reply text.
+ */
+export async function requestDeslopChat(
+  transcript: DeslopTranscriptTurn[],
+  target: DeslopTarget,
+): Promise<string> {
+  return sendDeslopRequest(
+    target,
+    {
+      messages: transcript,
+      systemPrompt: DESLOP_CHAT_SYSTEM_PROMPT,
+    },
+    {
+      failure: "Assistant chat failed",
+      empty: "Assistant returned an empty reply",
+    },
+  );
+}
+
+/**
+ * Post an inference request and return the assistant's text.
+ *
+ * The request asks for the latency-optimized profile. Installs where that
+ * profile is missing or disabled answer 400 with a `Profile "..."` message,
+ * which earns a single retry without the profile field.
+ */
+async function sendDeslopRequest(
+  target: DeslopTarget,
+  request: Record<string, unknown>,
+  labels: DeslopErrorLabels,
+): Promise<string> {
+  let attempt = await attemptDeslopSend(
     target,
     JSON.stringify({ ...request, profile: DESLOP_PROFILE }),
+    labels,
   );
   if (!attempt.ok && isProfileRejection(attempt)) {
-    attempt = await attemptDeslopRewrite(target, JSON.stringify(request));
+    attempt = await attemptDeslopSend(target, JSON.stringify(request), labels);
   }
 
   if (!attempt.ok) {
     throw new Error(
-      `Assistant rewrite failed (${attempt.status})${attempt.detail ? `: ${truncate(attempt.detail, 300)}` : ""}`,
+      `${labels.failure} (${attempt.status})${attempt.detail ? `: ${truncate(attempt.detail, 300)}` : ""}`,
     );
   }
-  return attempt.rewrite;
+  return attempt.reply;
 }
 
 /**
@@ -98,9 +201,10 @@ function isProfileRejection(
   );
 }
 
-async function attemptDeslopRewrite(
+async function attemptDeslopSend(
   target: DeslopTarget,
   body: string,
+  labels: DeslopErrorLabels,
 ): Promise<DeslopAttempt> {
   let response: Response;
   if (target.kind === "self-hosted") {
@@ -133,9 +237,9 @@ async function attemptDeslopRewrite(
 
   const payload = (await response.json()) as InferenceSendResponse;
   if (typeof payload.response !== "string" || payload.response.trim().length === 0) {
-    throw new Error("Assistant returned an empty rewrite");
+    throw new Error(labels.empty);
   }
-  return { ok: true, rewrite: payload.response.trim() };
+  return { ok: true, reply: payload.response.trim() };
 }
 
 function truncate(value: string, max: number): string {

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -57,6 +57,7 @@ import {
   submitFeedback,
   type FeedbackFormData,
 } from "./feedback.js";
+import { requestDeslopRewrite, type DeslopTarget } from "./deslop.js";
 
 // ── Environment resolution ──────────────────────────────────────────
 //
@@ -1466,6 +1467,52 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
     return false;
   }
 
+  if (message.type === "deslop-activate") {
+    (async () => {
+      const [activeTab] = await chrome.tabs.query({
+        active: true,
+        lastFocusedWindow: true,
+      });
+      if (activeTab?.id === undefined) {
+        throw new Error("No active tab found");
+      }
+      const url = activeTab.url ?? activeTab.pendingUrl ?? "";
+      if (!/^https?:/.test(url)) {
+        throw new Error("Deslop only works on regular web pages");
+      }
+      await chrome.scripting.executeScript({
+        target: { tabId: activeTab.id },
+        files: ["content/deslop.js"],
+      });
+      sendResponseFn({ ok: true });
+    })().catch((err) =>
+      sendResponseFn({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return true; // async
+  }
+
+  if (message.type === "deslop-rewrite") {
+    (async () => {
+      const text = typeof message.text === "string" ? message.text.trim() : "";
+      if (!text) {
+        sendResponseFn({ ok: false, error: "No text to rewrite" });
+        return;
+      }
+      const target = await resolveDeslopTarget();
+      const rewritten = await requestDeslopRewrite(text, target);
+      sendResponseFn({ ok: true, rewritten });
+    })().catch((err) =>
+      sendResponseFn({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return true; // async
+  }
+
   if (message.type === "submit-feedback") {
     (async () => {
       const form = message.form as FeedbackFormData | undefined;
@@ -1497,6 +1544,54 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
   // Unknown message type — let Chrome close the port naturally.
   return false;
 });
+
+/**
+ * Resolve where a Deslop rewrite should be sent based on the user's
+ * connection mode. Self-hosted targets pair on demand when no JWT is
+ * cached (the pair endpoint is loopback-trusted), so Deslop works even
+ * before the SSE relay has connected.
+ */
+async function resolveDeslopTarget(): Promise<DeslopTarget> {
+  const userMode = await getStoredUserMode();
+  if (userMode === "cloud") {
+    const selectedAssistant = await getSelectedAssistant();
+    if (!selectedAssistant) {
+      throw new Error("Select an assistant in the extension popup first");
+    }
+    const environment = await getEffectiveEnvironment();
+    return {
+      kind: "cloud",
+      environment,
+      assistantId: selectedAssistant.id,
+    };
+  }
+
+  const gatewayUrl = await getStoredGatewayUrl();
+  if (!selfHostedPairToken) {
+    try {
+      const pairResp = await fetch(`${gatewayUrl.replace(/\/$/, "")}/v1/pair`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-vellum-interface-id": "chrome-extension",
+        },
+      });
+      if (pairResp.ok) {
+        const body = (await pairResp.json()) as { token?: string };
+        selfHostedPairToken = body.token ?? null;
+      }
+    } catch {
+      throw new Error(
+        `Couldn't reach the assistant at ${gatewayUrl}. Make sure it is running.`,
+      );
+    }
+  }
+  return {
+    kind: "self-hosted",
+    gatewayUrl,
+    pairToken: selfHostedPairToken,
+  };
+}
 
 /**
  * Build the environment context used by the Share Feedback flow.

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -57,7 +57,16 @@ import {
   submitFeedback,
   type FeedbackFormData,
 } from "./feedback.js";
-import { requestDeslopRewrite, type DeslopTarget } from "./deslop.js";
+import {
+  buildDeslopPrompt,
+  buildHighlightedUserTurn,
+  capTranscript,
+  requestDeslopChat,
+  requestDeslopRewrite,
+  DESLOP_TRANSCRIPT_MAX_CHARS,
+  type DeslopTarget,
+  type DeslopTranscriptTurn,
+} from "./deslop.js";
 
 // ── Environment resolution ──────────────────────────────────────────
 //
@@ -1503,7 +1512,59 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
       }
       const target = await resolveDeslopTarget();
       const rewritten = await requestDeslopRewrite(text, target);
-      sendResponseFn({ ok: true, rewritten });
+      // The page records the exchange as a chat turn, so it needs the exact
+      // prompt that was sent. buildDeslopPrompt is deterministic.
+      sendResponseFn({
+        ok: true,
+        rewritten,
+        promptUsed: buildDeslopPrompt(text),
+      });
+    })().catch((err) =>
+      sendResponseFn({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return true; // async
+  }
+
+  if (message.type === "deslop-chat") {
+    (async () => {
+      const userMessage =
+        typeof message.message === "string" ? message.message.trim() : "";
+      if (!userMessage) {
+        sendResponseFn({ ok: false, error: "No message to send" });
+        return;
+      }
+      if (
+        message.transcript !== undefined &&
+        !Array.isArray(message.transcript)
+      ) {
+        sendResponseFn({ ok: false, error: "Invalid transcript" });
+        return;
+      }
+      if (
+        message.highlighted !== undefined &&
+        typeof message.highlighted !== "string"
+      ) {
+        sendResponseFn({ ok: false, error: "Invalid highlighted text" });
+        return;
+      }
+
+      const highlighted =
+        typeof message.highlighted === "string" ? message.highlighted.trim() : "";
+      const userTurn = buildHighlightedUserTurn(highlighted, userMessage);
+      const turns = capTranscript(
+        [
+          ...sanitizeDeslopTranscript(message.transcript),
+          { role: "user" as const, content: userTurn },
+        ],
+        DESLOP_TRANSCRIPT_MAX_CHARS,
+      );
+
+      const target = await resolveDeslopTarget();
+      const reply = await requestDeslopChat(turns, target);
+      sendResponseFn({ ok: true, reply, userTurn });
     })().catch((err) =>
       sendResponseFn({
         ok: false,
@@ -1544,6 +1605,31 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
   // Unknown message type — let Chrome close the port naturally.
   return false;
 });
+
+/**
+ * Keep only well-formed turns from a page-supplied transcript. The page owns
+ * the thread state, so anything malformed is dropped rather than trusted.
+ */
+function sanitizeDeslopTranscript(value: unknown): DeslopTranscriptTurn[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const turns: DeslopTranscriptTurn[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const { role, content } = entry as { role?: unknown; content?: unknown };
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+    if (typeof content !== "string" || content.trim().length === 0) {
+      continue;
+    }
+    turns.push({ role, content });
+  }
+  return turns;
+}
 
 /**
  * Resolve where a Deslop rewrite should be sent based on the user's

--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -91,6 +91,7 @@ do_build() {
 
   rm -rf "$DIST_DIR"
   mkdir -p "$DIST_DIR/background"
+  mkdir -p "$DIST_DIR/content"
   mkdir -p "$DIST_DIR/popup"
   mkdir -p "$DIST_DIR/icons"
 
@@ -104,6 +105,18 @@ do_build() {
     --minify \
     --define "process.env.VELLUM_ENVIRONMENT=\"$VELLUM_ENV\"" \
     || { echo "❌ Service worker bundle failed."; return 1; }
+
+  # Content scripts are injected via chrome.scripting.executeScript, which
+  # runs them as classic scripts. The source has no imports/exports, so the
+  # esm-format bundle contains none and is safe to inject.
+  echo "Bundling content scripts with bun build..."
+  bun build \
+    "$SCRIPT_DIR/content/deslop.ts" \
+    --outdir "$DIST_DIR/content" \
+    --target browser \
+    --format esm \
+    --minify \
+    || { echo "❌ Content script bundle failed."; return 1; }
 
   echo "Building popup with Vite..."
   (cd "$SCRIPT_DIR" && bunx vite build) \
@@ -188,7 +201,7 @@ fi
 # need it.
 # ---------------------------------------------------------------------------
 if [ "$CMD" = "run" ]; then
-  WATCH_DIRS=("background" "popup" "types" "icons")
+  WATCH_DIRS=("background" "content" "popup" "types" "icons")
   WATCH_FILES=("manifest.json" "package.json" "tsconfig.json")
   POLL_INTERVAL=3
   DEBOUNCE=2

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -1,27 +1,40 @@
 /**
- * Deslop content script: inspect-element-style picker that rewrites the
- * clicked block's text via the connected assistant.
+ * Deslop content script: an inspect-element-style rewrite picker plus a
+ * highlight-to-ask assistant surface, both driven by the connected
+ * assistant.
  *
  * Injected on demand by the service worker (`deslop-activate`), never
  * declared in the manifest. The script is bundled as a classic script
  * (no imports/exports) so `chrome.scripting.executeScript({ files })`
- * can run it directly. Re-injection while a picker session is already
- * active restarts the session instead of stacking listeners.
+ * can run it directly.
  *
- * Flow: hover highlights the element under the cursor; click sends its
- * text to the worker (`deslop-rewrite`), which asks the assistant for a
- * plain-language rewrite. While the request is in flight the block is
- * dimmed under a shimmering overlay with a spinner badge and the hint
- * pill switches to its active state; the response then replaces the
- * element's content and the element is marked with a faint tint plus a
- * wand badge that toggles between the rewrite and the original content,
- * which is kept as live DOM nodes so its markup returns intact.
- * Esc exits the picker. The picker stays active after a rewrite so
- * several blocks can be cleaned up in one session, and several rewrites
- * can be in flight at once.
+ * The script installs two layers:
+ *
+ * 1. A persistent page layer (`window.__vellumDeslopPage`), installed once
+ *    per page and never reset by re-injection. It owns the conversation
+ *    transcript, the floating selection menu, and the chat panel, so a
+ *    question asked after a rewrite still sees that rewrite.
+ * 2. A picker session (`window.__vellumDeslopSession`), restarted by every
+ *    re-injection and torn down by Esc. Hover highlights the block under
+ *    the cursor; click sends its text to the worker (`deslop-rewrite`),
+ *    which asks the assistant for a plain-language rewrite. While the
+ *    request is in flight the block is dimmed under a shimmering overlay
+ *    with a spinner badge and the hint pill switches to its active state;
+ *    the response then replaces the element's content and the element is
+ *    marked with a faint tint plus a wand badge that toggles between the
+ *    rewrite and the original content, which is kept as live DOM nodes so
+ *    its markup returns intact. The picker stays active after a rewrite so
+ *    several blocks can be cleaned up in one session, and several rewrites
+ *    can be in flight at once.
+ *
+ * With no picker session running, selecting text on the page raises a
+ * floating menu above the selection: `v` opens voice (not built yet) and
+ * `c` opens the chat panel, which sends the highlighted text plus the
+ * transcript to the worker (`deslop-chat`).
  */
 
 (() => {
+  const PAGE_PROP = "__vellumDeslopPage";
   const SESSION_PROP = "__vellumDeslopSession";
   const STYLE_ID = "vellum-deslop-style";
   const REWRITTEN_ATTR = "data-vellum-desloped";
@@ -32,24 +45,85 @@
   const SHOWING_ORIGINAL_CLASS = "vellum-deslop-showing-original";
   const HINT_CLASS = "vellum-deslop-hint";
   const HINT_ACTIVE_CLASS = "vellum-deslop-hint-active";
+  const MENU_CLASS = "vellum-deslop-menu";
+  const MENU_BUTTON_CLASS = "vellum-deslop-menu-button";
+  const MENU_DIVIDER_CLASS = "vellum-deslop-menu-divider";
+  const MENU_NOTICE_CLASS = "vellum-deslop-menu-notice";
+  const PANEL_CLASS = "vellum-deslop-panel";
+  const PANEL_HEADER_CLASS = "vellum-deslop-panel-header";
+  const PANEL_TITLE_CLASS = "vellum-deslop-panel-title";
+  const PANEL_CLOSE_CLASS = "vellum-deslop-panel-close";
+  const CONTEXT_CLASS = "vellum-deslop-context";
+  const MESSAGES_CLASS = "vellum-deslop-messages";
+  const MESSAGE_CLASS = "vellum-deslop-message";
+  const MESSAGE_USER_CLASS = "vellum-deslop-message-user";
+  const MESSAGE_ASSISTANT_CLASS = "vellum-deslop-message-assistant";
+  const MESSAGE_ERROR_CLASS = "vellum-deslop-message-error";
+  const THINKING_CLASS = "vellum-deslop-thinking";
+  const THINKING_DOT_CLASS = "vellum-deslop-thinking-dot";
+  const COMPOSER_CLASS = "vellum-deslop-composer";
+  const INPUT_CLASS = "vellum-deslop-input";
+  const SEND_CLASS = "vellum-deslop-send";
+
   const HINT_IDLE_TEXT =
     "Deslop: click a block of text to rewrite it · Esc to exit";
   const HINT_ACTIVE_TEXT = "Rewriting with your assistant…";
   const MIN_TEXT_LENGTH = 8;
   const MAX_TEXT_LENGTH = 20000;
+  const MIN_SELECTION_LENGTH = 3;
+  const SELECTION_DEBOUNCE_MS = 150;
+  const VOICE_NOTICE_MS = 2000;
+  const VIEWPORT_MARGIN = 8;
+  const ANCHOR_GAP = 8;
+  const CONTEXT_PREVIEW_LENGTH = 120;
+  const RELOADED_MESSAGE =
+    "The extension was reloaded. Reopen the popup and press Deslop again.";
   const WAND_SVG = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 4V2M15 10V8M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
 
   interface DeslopSession {
     stop(): void;
   }
 
+  /** The page-lifetime surface the picker session talks to. */
+  interface DeslopPage {
+    recordRewrite(promptUsed: unknown, rewritten: string): void;
+  }
+
+  interface TranscriptTurn {
+    role: "user" | "assistant";
+    content: string;
+  }
+
   interface DeslopRewriteResponse {
     ok: boolean;
     rewritten?: string;
+    promptUsed?: string;
     error?: string;
   }
 
+  interface DeslopChatResponse {
+    ok: boolean;
+    reply?: string;
+    userTurn?: string;
+    error?: string;
+  }
+
+  /** A selection or panel anchor in page coordinates, so scrolling keeps it valid. */
+  interface Anchor {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }
+
   const globalScope = window as unknown as Record<string, unknown>;
+
+  ensureStyles();
+
+  // The page layer outlives every picker session, so a re-injection reuses
+  // the installed one and keeps the transcript intact.
+  const page =
+    (globalScope[PAGE_PROP] as DeslopPage | undefined) ?? installPageLayer();
 
   // Restart cleanly if a previous session is still active (button
   // clicked twice, or re-activated after a rewrite).
@@ -57,8 +131,6 @@
   if (existing) {
     existing.stop();
   }
-
-  ensureStyles();
 
   const highlight = document.createElement("div");
   highlight.className = "vellum-deslop-highlight";
@@ -71,10 +143,21 @@
   let pendingCount = 0;
 
   function isPickable(el: Element | null): el is HTMLElement {
-    if (!(el instanceof HTMLElement)) return false;
-    if (el === document.documentElement || el === document.body) return false;
-    if (el === hint || el === highlight) return false;
-    if (el.closest(`.${PENDING_CLASS}`)) return false;
+    if (!(el instanceof HTMLElement)) {
+      return false;
+    }
+    if (el === document.documentElement || el === document.body) {
+      return false;
+    }
+    if (el === hint || el === highlight) {
+      return false;
+    }
+    if (el.closest(`.${PENDING_CLASS}`)) {
+      return false;
+    }
+    if (isOwnUi(el)) {
+      return false;
+    }
     const text = el.innerText?.trim() ?? "";
     return text.length >= MIN_TEXT_LENGTH;
   }
@@ -104,7 +187,9 @@
   }
 
   function onScrollOrResize(): void {
-    if (hovered) positionHighlight(hovered);
+    if (hovered) {
+      positionHighlight(hovered);
+    }
   }
 
   function onKeyDown(event: KeyboardEvent): void {
@@ -123,9 +208,13 @@
   }
 
   function onClick(event: MouseEvent): void {
-    if (isBadgeEvent(event)) return;
+    if (isBadgeEvent(event)) {
+      return;
+    }
     const target = hovered;
-    if (!target) return;
+    if (!target) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     void rewriteElement(target);
@@ -134,7 +223,9 @@
   // Swallow the mousedown/mouseup pair too so pages with mousedown-driven
   // handlers (menus, editors) don't react to the pick.
   function swallow(event: MouseEvent): void {
-    if (isBadgeEvent(event)) return;
+    if (isBadgeEvent(event)) {
+      return;
+    }
     if (hovered) {
       event.preventDefault();
       event.stopPropagation();
@@ -142,7 +233,9 @@
   }
 
   function syncHint(): void {
-    if (!hint.isConnected) return;
+    if (!hint.isConnected) {
+      return;
+    }
     const active = pendingCount > 0;
     hint.className = active ? `${HINT_CLASS} ${HINT_ACTIVE_CLASS}` : HINT_CLASS;
     hint.textContent = active ? HINT_ACTIVE_TEXT : HINT_IDLE_TEXT;
@@ -175,37 +268,18 @@
 
   async function rewriteElement(el: HTMLElement): Promise<void> {
     const text = el.innerText.trim();
-    if (text.length === 0) return;
+    if (text.length === 0) {
+      return;
+    }
 
     clearHighlight();
     clearRewrittenState(el);
     const endPending = beginPending(el);
 
-    const response = await new Promise<DeslopRewriteResponse | undefined>(
-      (resolve) => {
-        // sendMessage throws synchronously once the extension context is
-        // invalidated (the extension was reloaded while this script stayed
-        // on the page), so the throw is folded into the same failure path
-        // as an absent response rather than escaping as a rejection.
-        try {
-          chrome.runtime.sendMessage(
-            { type: "deslop-rewrite", text: text.slice(0, MAX_TEXT_LENGTH) },
-            (raw: DeslopRewriteResponse | undefined) => {
-              // Read lastError so Chrome doesn't log an unchecked error
-              // when the worker died mid-request.
-              void chrome.runtime.lastError;
-              resolve(raw);
-            },
-          );
-        } catch {
-          resolve({
-            ok: false,
-            error:
-              "The extension was reloaded. Reopen the popup and press Deslop again.",
-          });
-        }
-      },
-    );
+    const response = await sendToWorker<DeslopRewriteResponse>({
+      type: "deslop-rewrite",
+      text: text.slice(0, MAX_TEXT_LENGTH),
+    });
 
     endPending();
 
@@ -214,7 +288,9 @@
       return;
     }
 
-    markRewritten(el, response.rewritten.trim());
+    const rewritten = response.rewritten.trim();
+    page.recordRewrite(response.promptUsed, rewritten);
+    markRewritten(el, rewritten);
   }
 
   // Drops the badge and toggle state of an earlier rewrite so a block
@@ -307,8 +383,491 @@
 
   globalScope[SESSION_PROP] = { stop } satisfies DeslopSession;
 
+  /** True while a picker session owns the page's mouse and Esc handling. */
+  function isPickerActive(): boolean {
+    return globalScope[SESSION_PROP] !== undefined;
+  }
+
+  function isOwnUi(node: Node | null | undefined): boolean {
+    const el = node instanceof Element ? node : (node?.parentElement ?? null);
+    if (!el) {
+      return false;
+    }
+    return el.closest(`.${MENU_CLASS}, .${PANEL_CLASS}`) !== null;
+  }
+
+  function isEditableTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    if (target.isContentEditable) {
+      return true;
+    }
+    const tag = target.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+  }
+
+  function truncate(text: string, max: number): string {
+    return text.length <= max ? text : `${text.slice(0, max - 1).trimEnd()}…`;
+  }
+
+  function anchorFromRect(rect: DOMRect): Anchor {
+    return {
+      top: rect.top + window.scrollY,
+      left: rect.left + window.scrollX,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  // Places a fixed-position element above its anchor, centered and clamped
+  // to the viewport, dropping below when there is no room above.
+  function placeFloater(el: HTMLElement, anchor: Anchor): void {
+    const top = anchor.top - window.scrollY;
+    const left = anchor.left - window.scrollX;
+    const width = el.offsetWidth;
+    const height = el.offsetHeight;
+
+    const maxX = Math.max(VIEWPORT_MARGIN, window.innerWidth - width - VIEWPORT_MARGIN);
+    const x = Math.min(
+      Math.max(left + anchor.width / 2 - width / 2, VIEWPORT_MARGIN),
+      maxX,
+    );
+
+    const above = top - height - ANCHOR_GAP;
+    const maxY = Math.max(VIEWPORT_MARGIN, window.innerHeight - height - VIEWPORT_MARGIN);
+    const y = Math.min(
+      Math.max(above >= VIEWPORT_MARGIN ? above : top + anchor.height + ANCHOR_GAP, VIEWPORT_MARGIN),
+      maxY,
+    );
+
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+  }
+
+  // Folds a synchronous throw (the extension was reloaded while this script
+  // stayed on the page) and an absent response into one failure path.
+  function sendToWorker<T extends { ok: boolean; error?: string }>(
+    message: Record<string, unknown>,
+  ): Promise<T | undefined> {
+    return new Promise<T | undefined>((resolve) => {
+      try {
+        chrome.runtime.sendMessage(message, (raw: T | undefined) => {
+          // Read lastError so Chrome doesn't log an unchecked error when
+          // the worker died mid-request.
+          void chrome.runtime.lastError;
+          resolve(raw);
+        });
+      } catch {
+        resolve({ ok: false, error: RELOADED_MESSAGE } as T);
+      }
+    });
+  }
+
+  /**
+   * Installs the page-lifetime layer: the transcript shared by rewrites and
+   * chat, the floating selection menu, and the chat panel. Runs once per
+   * page; later injections reuse the returned object.
+   */
+  function installPageLayer(): DeslopPage {
+    const transcript: TranscriptTurn[] = [];
+
+    const menu = document.createElement("div");
+    menu.className = MENU_CLASS;
+    const voiceButton = document.createElement("button");
+    voiceButton.type = "button";
+    voiceButton.className = MENU_BUTTON_CLASS;
+    voiceButton.textContent = "Voice (v)";
+    const divider = document.createElement("span");
+    divider.className = MENU_DIVIDER_CLASS;
+    const chatButton = document.createElement("button");
+    chatButton.type = "button";
+    chatButton.className = MENU_BUTTON_CLASS;
+    chatButton.textContent = "Chat (c)";
+    const notice = document.createElement("span");
+    notice.className = MENU_NOTICE_CLASS;
+    notice.textContent = "Voice: coming soon";
+    menu.append(voiceButton, divider, chatButton);
+
+    const panel = document.createElement("div");
+    panel.className = PANEL_CLASS;
+    const panelHeader = document.createElement("div");
+    panelHeader.className = PANEL_HEADER_CLASS;
+    const panelTitle = document.createElement("span");
+    panelTitle.className = PANEL_TITLE_CLASS;
+    panelTitle.textContent = "Ask your assistant";
+    const panelClose = document.createElement("button");
+    panelClose.type = "button";
+    panelClose.className = PANEL_CLOSE_CLASS;
+    panelClose.textContent = "×";
+    panelClose.title = "Close";
+    panelHeader.append(panelTitle, panelClose);
+    const contextChip = document.createElement("div");
+    contextChip.className = CONTEXT_CLASS;
+    const messages = document.createElement("div");
+    messages.className = MESSAGES_CLASS;
+    const composer = document.createElement("div");
+    composer.className = COMPOSER_CLASS;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = INPUT_CLASS;
+    input.placeholder = "Ask about the highlighted text";
+    const sendButton = document.createElement("button");
+    sendButton.type = "button";
+    sendButton.className = SEND_CLASS;
+    sendButton.textContent = "Send";
+    composer.append(input, sendButton);
+    panel.append(panelHeader, contextChip, messages, composer);
+
+    document.documentElement.append(menu, panel);
+
+    let menuVisible = false;
+    let panelOpen = false;
+    let chatBusy = false;
+    let selectionText = "";
+    let selectionAnchor: Anchor | null = null;
+    let panelAnchor: Anchor | null = null;
+    // The highlighted text rides along with the next message only: once it
+    // is sent, the transcript already carries that context.
+    let pendingHighlight = "";
+    let selectionTimer: number | undefined;
+    let noticeTimer: number | undefined;
+
+    function showMenu(anchor: Anchor): void {
+      selectionAnchor = anchor;
+      setMenuActions();
+      menu.style.display = "flex";
+      menuVisible = true;
+      placeFloater(menu, anchor);
+    }
+
+    function hideMenu(): void {
+      if (noticeTimer !== undefined) {
+        window.clearTimeout(noticeTimer);
+        noticeTimer = undefined;
+      }
+      setMenuActions();
+      menu.style.display = "none";
+      menuVisible = false;
+      selectionAnchor = null;
+      selectionText = "";
+    }
+
+    function setMenuActions(): void {
+      menu.replaceChildren(voiceButton, divider, chatButton);
+    }
+
+    function showVoiceNotice(): void {
+      if (noticeTimer !== undefined) {
+        window.clearTimeout(noticeTimer);
+      }
+      menu.replaceChildren(notice);
+      if (selectionAnchor) {
+        placeFloater(menu, selectionAnchor);
+      }
+      noticeTimer = window.setTimeout(() => {
+        noticeTimer = undefined;
+        hideMenu();
+      }, VOICE_NOTICE_MS);
+    }
+
+    function evaluateSelection(): void {
+      // The voice notice holds the pill for its two seconds: the mouseup
+      // that opened it must not swap the buttons back in underneath.
+      if (noticeTimer !== undefined) {
+        return;
+      }
+      // The picker owns the pointer while it runs, so the menu stays out
+      // of its way.
+      if (isPickerActive()) {
+        hideMenu();
+        return;
+      }
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+        hideMenu();
+        return;
+      }
+      const text = selection.toString().trim();
+      if (text.length < MIN_SELECTION_LENGTH) {
+        hideMenu();
+        return;
+      }
+      if (isOwnUi(selection.anchorNode)) {
+        hideMenu();
+        return;
+      }
+      const rect = selection.getRangeAt(0).getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) {
+        hideMenu();
+        return;
+      }
+      selectionText = text;
+      showMenu(anchorFromRect(rect));
+    }
+
+    function scheduleEvaluate(): void {
+      window.clearTimeout(selectionTimer);
+      selectionTimer = window.setTimeout(evaluateSelection, SELECTION_DEBOUNCE_MS);
+    }
+
+    function openChatFromSelection(): void {
+      // The captured text can go stale if the menu was hidden and re-shown
+      // through an unusual event ordering, so the live selection wins when
+      // the capture is empty.
+      const text =
+        selectionText || (window.getSelection()?.toString().trim() ?? "");
+      const anchor = selectionAnchor;
+      hideMenu();
+      window.getSelection()?.removeAllRanges();
+      openChat(text, anchor);
+    }
+
+    function openChat(highlighted: string, anchor: Anchor | null): void {
+      pendingHighlight = highlighted;
+      contextChip.textContent = truncate(highlighted, CONTEXT_PREVIEW_LENGTH);
+      contextChip.style.display = highlighted ? "block" : "none";
+      panel.style.display = "flex";
+      panelOpen = true;
+      if (anchor) {
+        panelAnchor = anchor;
+      }
+      if (panelAnchor) {
+        placeFloater(panel, panelAnchor);
+      }
+      input.focus();
+      scrollMessagesToBottom();
+    }
+
+    function closeChat(): void {
+      panel.style.display = "none";
+      panelOpen = false;
+    }
+
+    function scrollMessagesToBottom(): void {
+      messages.scrollTop = messages.scrollHeight;
+    }
+
+    function appendBubble(kind: "user" | "assistant" | "error", text: string): HTMLElement {
+      const bubble = document.createElement("div");
+      const modifier =
+        kind === "user"
+          ? MESSAGE_USER_CLASS
+          : kind === "assistant"
+            ? MESSAGE_ASSISTANT_CLASS
+            : MESSAGE_ERROR_CLASS;
+      bubble.className = `${MESSAGE_CLASS} ${modifier}`;
+      bubble.textContent = text;
+      messages.appendChild(bubble);
+      scrollMessagesToBottom();
+      return bubble;
+    }
+
+    function appendThinking(): HTMLElement {
+      const thinking = document.createElement("div");
+      thinking.className = `${MESSAGE_CLASS} ${MESSAGE_ASSISTANT_CLASS} ${THINKING_CLASS}`;
+      for (let i = 0; i < 3; i += 1) {
+        const dot = document.createElement("span");
+        dot.className = THINKING_DOT_CLASS;
+        thinking.appendChild(dot);
+      }
+      messages.appendChild(thinking);
+      scrollMessagesToBottom();
+      return thinking;
+    }
+
+    function setChatBusy(busy: boolean): void {
+      chatBusy = busy;
+      input.disabled = busy;
+      sendButton.disabled = busy;
+    }
+
+    async function sendChatMessage(): Promise<void> {
+      if (chatBusy) {
+        return;
+      }
+      const message = input.value.trim();
+      if (message.length === 0) {
+        return;
+      }
+      input.value = "";
+      appendBubble("user", message);
+      const highlighted = pendingHighlight;
+      pendingHighlight = "";
+      setChatBusy(true);
+      const thinking = appendThinking();
+
+      const response = await sendToWorker<DeslopChatResponse>({
+        type: "deslop-chat",
+        highlighted,
+        message,
+        transcript: transcript.map((turn) => ({
+          role: turn.role,
+          content: turn.content,
+        })),
+      });
+
+      thinking.remove();
+      setChatBusy(false);
+      if (panelOpen) {
+        input.focus();
+      }
+
+      if (!response?.ok || typeof response.reply !== "string") {
+        // The highlight goes back on the next attempt so a retry keeps the
+        // context the failed turn never delivered, unless a fresh highlight
+        // arrived while the request was in flight.
+        if (pendingHighlight.length === 0) {
+          pendingHighlight = highlighted;
+        }
+        appendBubble(
+          "error",
+          response?.error ?? "The assistant could not answer that.",
+        );
+        return;
+      }
+
+      const userTurn =
+        typeof response.userTurn === "string" && response.userTurn.length > 0
+          ? response.userTurn
+          : message;
+      transcript.push(
+        { role: "user", content: userTurn },
+        { role: "assistant", content: response.reply },
+      );
+      appendBubble("assistant", response.reply);
+    }
+
+    function onSelectionChange(): void {
+      scheduleEvaluate();
+    }
+
+    function onDocumentMouseDown(event: MouseEvent): void {
+      if (!menuVisible) {
+        return;
+      }
+      const target = event.target;
+      if (target instanceof Node && menu.contains(target)) {
+        return;
+      }
+      hideMenu();
+    }
+
+    function onPageKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        if (panelOpen) {
+          event.preventDefault();
+          event.stopPropagation();
+          closeChat();
+          return;
+        }
+        if (menuVisible) {
+          event.preventDefault();
+          event.stopPropagation();
+          hideMenu();
+        }
+        return;
+      }
+      if (!menuVisible || event.altKey || event.ctrlKey || event.metaKey) {
+        return;
+      }
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key !== "v" && key !== "c") {
+        return;
+      }
+      // The page never sees the shortcut, so single-key hotkeys on the
+      // host page stay dormant while the menu is up.
+      event.preventDefault();
+      event.stopPropagation();
+      if (key === "v") {
+        showVoiceNotice();
+      } else {
+        openChatFromSelection();
+      }
+    }
+
+    function onPageScrollOrResize(): void {
+      if (menuVisible && selectionAnchor) {
+        placeFloater(menu, selectionAnchor);
+      }
+      if (panelOpen && panelAnchor) {
+        placeFloater(panel, panelAnchor);
+      }
+    }
+
+    // Keeping the selection alive through the click is what lets the menu
+    // hand the highlighted text to the chat panel.
+    menu.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+    });
+    voiceButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      showVoiceNotice();
+    });
+    chatButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openChatFromSelection();
+    });
+    panelClose.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      closeChat();
+    });
+    sendButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void sendChatMessage();
+    });
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void sendChatMessage();
+      }
+    });
+    // Typing in the panel stays inside the panel: host-page hotkeys never
+    // see the keystrokes.
+    panel.addEventListener("keydown", (event) => {
+      event.stopPropagation();
+    });
+
+    document.addEventListener("selectionchange", onSelectionChange);
+    document.addEventListener("mouseup", scheduleEvaluate, true);
+    document.addEventListener("mousedown", onDocumentMouseDown, true);
+    document.addEventListener("keydown", onPageKeyDown, true);
+    window.addEventListener("scroll", onPageScrollOrResize, true);
+    window.addEventListener("resize", onPageScrollOrResize, true);
+
+    const api: DeslopPage = {
+      recordRewrite(promptUsed: unknown, rewritten: string): void {
+        // Older workers answer without the prompt they used. Recording the
+        // rewrite alone would leave a dangling assistant turn, so the pair
+        // is skipped instead.
+        if (typeof promptUsed !== "string" || promptUsed.length === 0) {
+          return;
+        }
+        if (rewritten.length === 0) {
+          return;
+        }
+        transcript.push(
+          { role: "user", content: promptUsed },
+          { role: "assistant", content: rewritten },
+        );
+      },
+    };
+
+    globalScope[PAGE_PROP] = api;
+    return api;
+  }
+
   function ensureStyles(): void {
-    if (document.getElementById(STYLE_ID)) return;
+    if (document.getElementById(STYLE_ID)) {
+      return;
+    }
     const style = document.createElement("style");
     style.id = STYLE_ID;
     style.textContent = `
@@ -445,6 +1004,201 @@
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
         pointer-events: none;
         max-width: 70vw;
+      }
+      .${MENU_CLASS} {
+        position: fixed;
+        top: 0;
+        left: 0;
+        display: none;
+        align-items: center;
+        gap: 2px;
+        z-index: 2147483647;
+        box-sizing: border-box;
+        background: rgba(17, 24, 39, 0.92);
+        color: #f9fafb;
+        font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 4px 6px;
+        border-radius: 999px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+      }
+      .${MENU_CLASS} .${MENU_BUTTON_CLASS} {
+        box-sizing: border-box;
+        margin: 0;
+        border: 0;
+        background: transparent;
+        color: #f9fafb;
+        font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 5px 10px;
+        border-radius: 999px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .${MENU_CLASS} .${MENU_BUTTON_CLASS}:hover {
+        background: rgba(255, 255, 255, 0.16);
+      }
+      .${MENU_CLASS} .${MENU_DIVIDER_CLASS} {
+        width: 1px;
+        height: 14px;
+        background: rgba(255, 255, 255, 0.22);
+      }
+      .${MENU_CLASS} .${MENU_NOTICE_CLASS} {
+        color: #e5e7eb;
+        font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 5px 10px;
+        white-space: nowrap;
+      }
+      .${PANEL_CLASS} {
+        position: fixed;
+        top: 0;
+        left: 0;
+        display: none;
+        flex-direction: column;
+        box-sizing: border-box;
+        width: 340px;
+        max-height: 50vh;
+        z-index: 2147483647;
+        background: rgba(17, 24, 39, 0.97);
+        color: #f9fafb;
+        font: 400 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        border: 1px solid rgba(99, 102, 241, 0.35);
+        border-radius: 12px;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+        overflow: hidden;
+      }
+      .${PANEL_CLASS} .${PANEL_HEADER_CLASS} {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 10px 12px 6px 12px;
+      }
+      .${PANEL_CLASS} .${PANEL_TITLE_CLASS} {
+        font: 600 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: #c7d2fe;
+        letter-spacing: 0.02em;
+      }
+      .${PANEL_CLASS} .${PANEL_CLOSE_CLASS} {
+        box-sizing: border-box;
+        margin: 0;
+        border: 0;
+        background: transparent;
+        color: #9ca3af;
+        font: 500 16px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 2px 6px;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .${PANEL_CLASS} .${PANEL_CLOSE_CLASS}:hover {
+        background: rgba(255, 255, 255, 0.12);
+        color: #f9fafb;
+      }
+      .${PANEL_CLASS} .${CONTEXT_CLASS} {
+        margin: 0 12px 8px 12px;
+        padding: 6px 10px;
+        border-left: 2px solid rgba(99, 102, 241, 0.85);
+        border-radius: 0 6px 6px 0;
+        background: rgba(99, 102, 241, 0.1);
+        color: #9ca3af;
+        font: 400 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        word-break: break-word;
+      }
+      .${PANEL_CLASS} .${MESSAGES_CLASS} {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
+        padding: 0 12px;
+      }
+      .${PANEL_CLASS} .${MESSAGE_CLASS} {
+        box-sizing: border-box;
+        max-width: 85%;
+        padding: 7px 10px;
+        border-radius: 10px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .${PANEL_CLASS} .${MESSAGE_USER_CLASS} {
+        align-self: flex-end;
+        background: rgba(99, 102, 241, 0.28);
+        color: #eef2ff;
+      }
+      .${PANEL_CLASS} .${MESSAGE_ASSISTANT_CLASS} {
+        align-self: flex-start;
+        background: rgba(255, 255, 255, 0.08);
+        color: #e5e7eb;
+      }
+      .${PANEL_CLASS} .${MESSAGE_ERROR_CLASS} {
+        align-self: flex-start;
+        background: rgba(153, 27, 27, 0.35);
+        color: #fecaca;
+      }
+      .${PANEL_CLASS} .${THINKING_CLASS} {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .${PANEL_CLASS} .${THINKING_DOT_CLASS} {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background: rgba(199, 210, 254, 0.9);
+        animation: vellum-deslop-pulse 1.1s ease-in-out infinite;
+      }
+      .${PANEL_CLASS} .${THINKING_DOT_CLASS}:nth-child(2) {
+        animation-delay: 0.15s;
+      }
+      .${PANEL_CLASS} .${THINKING_DOT_CLASS}:nth-child(3) {
+        animation-delay: 0.3s;
+      }
+      @keyframes vellum-deslop-pulse {
+        0%, 100% { opacity: 0.3; }
+        50% { opacity: 1; }
+      }
+      .${PANEL_CLASS} .${COMPOSER_CLASS} {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 10px 12px 12px 12px;
+      }
+      .${PANEL_CLASS} .${INPUT_CLASS} {
+        box-sizing: border-box;
+        flex: 1 1 auto;
+        min-width: 0;
+        margin: 0;
+        padding: 7px 10px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.06);
+        color: #f9fafb;
+        font: 400 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        outline: none;
+      }
+      .${PANEL_CLASS} .${INPUT_CLASS}:focus {
+        border-color: rgba(99, 102, 241, 0.85);
+      }
+      .${PANEL_CLASS} .${INPUT_CLASS}::placeholder {
+        color: #6b7280;
+      }
+      .${PANEL_CLASS} .${SEND_CLASS} {
+        box-sizing: border-box;
+        margin: 0;
+        border: 0;
+        padding: 7px 12px;
+        border-radius: 8px;
+        background: rgba(99, 102, 241, 0.9);
+        color: #ffffff;
+        font: 600 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        cursor: pointer;
+      }
+      .${PANEL_CLASS} .${SEND_CLASS}:hover {
+        background: rgba(79, 70, 229, 0.95);
+      }
+      .${PANEL_CLASS} .${INPUT_CLASS}:disabled,
+      .${PANEL_CLASS} .${SEND_CLASS}:disabled {
+        opacity: 0.6;
+        cursor: default;
       }
     `;
     document.documentElement.appendChild(style);

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -126,15 +126,27 @@
 
     const response = await new Promise<DeslopRewriteResponse | undefined>(
       (resolve) => {
-        chrome.runtime.sendMessage(
-          { type: "deslop-rewrite", text: text.slice(0, MAX_TEXT_LENGTH) },
-          (raw: DeslopRewriteResponse | undefined) => {
-            // Read lastError so Chrome doesn't log an unchecked error
-            // when the worker died mid-request.
-            void chrome.runtime.lastError;
-            resolve(raw);
-          },
-        );
+        // sendMessage throws synchronously once the extension context is
+        // invalidated (the extension was reloaded while this script stayed
+        // on the page), so the throw is folded into the same failure path
+        // as an absent response rather than escaping as a rejection.
+        try {
+          chrome.runtime.sendMessage(
+            { type: "deslop-rewrite", text: text.slice(0, MAX_TEXT_LENGTH) },
+            (raw: DeslopRewriteResponse | undefined) => {
+              // Read lastError so Chrome doesn't log an unchecked error
+              // when the worker died mid-request.
+              void chrome.runtime.lastError;
+              resolve(raw);
+            },
+          );
+        } catch {
+          resolve({
+            ok: false,
+            error:
+              "The extension was reloaded. Reopen the popup and press Deslop again.",
+          });
+        }
       },
     );
 

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -1,0 +1,285 @@
+/**
+ * Deslop content script: inspect-element-style picker that rewrites the
+ * clicked block's text via the connected assistant.
+ *
+ * Injected on demand by the service worker (`deslop-activate`), never
+ * declared in the manifest. The script is bundled as a classic script
+ * (no imports/exports) so `chrome.scripting.executeScript({ files })`
+ * can run it directly. Re-injection while a picker session is already
+ * active restarts the session instead of stacking listeners.
+ *
+ * Flow: hover highlights the element under the cursor; click sends its
+ * text to the worker (`deslop-rewrite`), which asks the assistant for a
+ * plain-language rewrite; the response replaces the element's content
+ * and the element is marked with a faint tint plus a wand badge. Esc
+ * exits the picker. The picker stays active after a rewrite so several
+ * blocks can be cleaned up in one session.
+ */
+
+(() => {
+  const SESSION_PROP = "__vellumDeslopSession";
+  const STYLE_ID = "vellum-deslop-style";
+  const REWRITTEN_ATTR = "data-vellum-desloped";
+  const PENDING_CLASS = "vellum-deslop-pending";
+  const MIN_TEXT_LENGTH = 8;
+  const MAX_TEXT_LENGTH = 20000;
+  const WAND_SVG = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 4V2M15 10V8M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+  interface DeslopSession {
+    stop(): void;
+  }
+
+  interface DeslopRewriteResponse {
+    ok: boolean;
+    rewritten?: string;
+    error?: string;
+  }
+
+  const globalScope = window as unknown as Record<string, unknown>;
+
+  // Restart cleanly if a previous session is still active (button
+  // clicked twice, or re-activated after a rewrite).
+  const existing = globalScope[SESSION_PROP] as DeslopSession | undefined;
+  if (existing) {
+    existing.stop();
+  }
+
+  ensureStyles();
+
+  const highlight = document.createElement("div");
+  highlight.className = "vellum-deslop-highlight";
+  const hint = document.createElement("div");
+  hint.className = "vellum-deslop-hint";
+  hint.textContent = "Deslop: click a block of text to rewrite it · Esc to exit";
+  document.documentElement.append(highlight, hint);
+
+  let hovered: HTMLElement | null = null;
+
+  function isPickable(el: Element | null): el is HTMLElement {
+    if (!(el instanceof HTMLElement)) return false;
+    if (el === document.documentElement || el === document.body) return false;
+    if (el === hint || el === highlight) return false;
+    if (el.closest(`.${PENDING_CLASS}`)) return false;
+    const text = el.innerText?.trim() ?? "";
+    return text.length >= MIN_TEXT_LENGTH;
+  }
+
+  function positionHighlight(el: HTMLElement): void {
+    const rect = el.getBoundingClientRect();
+    highlight.style.display = "block";
+    highlight.style.top = `${rect.top}px`;
+    highlight.style.left = `${rect.left}px`;
+    highlight.style.width = `${rect.width}px`;
+    highlight.style.height = `${rect.height}px`;
+  }
+
+  function clearHighlight(): void {
+    hovered = null;
+    highlight.style.display = "none";
+  }
+
+  function onMouseMove(event: MouseEvent): void {
+    const el = document.elementFromPoint(event.clientX, event.clientY);
+    if (!isPickable(el)) {
+      clearHighlight();
+      return;
+    }
+    hovered = el;
+    positionHighlight(el);
+  }
+
+  function onScrollOrResize(): void {
+    if (hovered) positionHighlight(hovered);
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      stop();
+    }
+  }
+
+  function onClick(event: MouseEvent): void {
+    const target = hovered;
+    if (!target) return;
+    event.preventDefault();
+    event.stopPropagation();
+    void rewriteElement(target);
+  }
+
+  // Swallow the mousedown/mouseup pair too so pages with mousedown-driven
+  // handlers (menus, editors) don't react to the pick.
+  function swallow(event: MouseEvent): void {
+    if (hovered) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  async function rewriteElement(el: HTMLElement): Promise<void> {
+    const text = el.innerText.trim();
+    if (text.length === 0) return;
+
+    clearHighlight();
+    el.classList.add(PENDING_CLASS);
+
+    const response = await new Promise<DeslopRewriteResponse | undefined>(
+      (resolve) => {
+        chrome.runtime.sendMessage(
+          { type: "deslop-rewrite", text: text.slice(0, MAX_TEXT_LENGTH) },
+          (raw: DeslopRewriteResponse | undefined) => {
+            // Read lastError so Chrome doesn't log an unchecked error
+            // when the worker died mid-request.
+            void chrome.runtime.lastError;
+            resolve(raw);
+          },
+        );
+      },
+    );
+
+    el.classList.remove(PENDING_CLASS);
+
+    if (!response?.ok || typeof response.rewritten !== "string") {
+      flashError(el, response?.error ?? "The assistant could not rewrite this text.");
+      return;
+    }
+
+    el.innerText = response.rewritten.trim();
+    markRewritten(el);
+  }
+
+  function markRewritten(el: HTMLElement): void {
+    el.setAttribute(REWRITTEN_ATTR, "true");
+    if (getComputedStyle(el).position === "static") {
+      el.style.position = "relative";
+    }
+    const badge = document.createElement("span");
+    badge.className = "vellum-deslop-badge";
+    badge.title = "Rewritten by your Vellum assistant";
+    badge.innerHTML = WAND_SVG;
+    el.appendChild(badge);
+  }
+
+  function flashError(el: HTMLElement, message: string): void {
+    const note = document.createElement("div");
+    note.className = "vellum-deslop-error";
+    note.textContent = `Deslop failed: ${message}`;
+    document.documentElement.appendChild(note);
+    el.classList.add("vellum-deslop-failed");
+    setTimeout(() => {
+      note.remove();
+      el.classList.remove("vellum-deslop-failed");
+    }, 4000);
+  }
+
+  function stop(): void {
+    document.removeEventListener("mousemove", onMouseMove, true);
+    document.removeEventListener("click", onClick, true);
+    document.removeEventListener("mousedown", swallow, true);
+    document.removeEventListener("mouseup", swallow, true);
+    document.removeEventListener("keydown", onKeyDown, true);
+    window.removeEventListener("scroll", onScrollOrResize, true);
+    window.removeEventListener("resize", onScrollOrResize, true);
+    highlight.remove();
+    hint.remove();
+    delete globalScope[SESSION_PROP];
+  }
+
+  document.addEventListener("mousemove", onMouseMove, true);
+  document.addEventListener("click", onClick, true);
+  document.addEventListener("mousedown", swallow, true);
+  document.addEventListener("mouseup", swallow, true);
+  document.addEventListener("keydown", onKeyDown, true);
+  window.addEventListener("scroll", onScrollOrResize, true);
+  window.addEventListener("resize", onScrollOrResize, true);
+
+  globalScope[SESSION_PROP] = { stop } satisfies DeslopSession;
+
+  function ensureStyles(): void {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      .vellum-deslop-highlight {
+        position: fixed;
+        display: none;
+        pointer-events: none;
+        z-index: 2147483646;
+        background: rgba(99, 102, 241, 0.14);
+        outline: 2px solid rgba(99, 102, 241, 0.85);
+        outline-offset: -1px;
+        border-radius: 3px;
+        transition: top 40ms linear, left 40ms linear, width 40ms linear, height 40ms linear;
+      }
+      .vellum-deslop-hint {
+        position: fixed;
+        bottom: 16px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 2147483647;
+        background: rgba(17, 24, 39, 0.92);
+        color: #f9fafb;
+        font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 8px 14px;
+        border-radius: 999px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        pointer-events: none;
+      }
+      .${PENDING_CLASS} {
+        outline: 2px solid rgba(99, 102, 241, 0.85);
+        outline-offset: -1px;
+        animation: vellum-deslop-pulse 1.2s ease-in-out infinite;
+      }
+      @keyframes vellum-deslop-pulse {
+        0%, 100% { background-color: rgba(99, 102, 241, 0.06); }
+        50% { background-color: rgba(99, 102, 241, 0.18); }
+      }
+      [${REWRITTEN_ATTR}] {
+        background-color: rgba(99, 102, 241, 0.07);
+        border-radius: 3px;
+        transition: background-color 300ms ease;
+      }
+      .vellum-deslop-badge {
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: rgba(99, 102, 241, 0.9);
+        color: #ffffff;
+        pointer-events: auto;
+        z-index: 2147483645;
+      }
+      .vellum-deslop-badge svg {
+        width: 11px;
+        height: 11px;
+        display: block;
+      }
+      .vellum-deslop-failed {
+        outline: 2px solid rgba(220, 38, 38, 0.7);
+        outline-offset: -1px;
+      }
+      .vellum-deslop-error {
+        position: fixed;
+        bottom: 56px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 2147483647;
+        background: rgba(153, 27, 27, 0.95);
+        color: #fef2f2;
+        font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        padding: 8px 14px;
+        border-radius: 8px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        pointer-events: none;
+        max-width: 70vw;
+      }
+    `;
+    document.documentElement.appendChild(style);
+  }
+})();

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -10,10 +10,14 @@
  *
  * Flow: hover highlights the element under the cursor; click sends its
  * text to the worker (`deslop-rewrite`), which asks the assistant for a
- * plain-language rewrite; the response replaces the element's content
- * and the element is marked with a faint tint plus a wand badge. Esc
- * exits the picker. The picker stays active after a rewrite so several
- * blocks can be cleaned up in one session.
+ * plain-language rewrite. While the request is in flight the block is
+ * dimmed under a shimmering overlay with a spinner badge and the hint
+ * pill switches to its active state; the response then replaces the
+ * element's content and the element is marked with a faint tint plus a
+ * wand badge that toggles between the rewrite and the original text.
+ * Esc exits the picker. The picker stays active after a rewrite so
+ * several blocks can be cleaned up in one session, and several rewrites
+ * can be in flight at once.
  */
 
 (() => {
@@ -21,6 +25,15 @@
   const STYLE_ID = "vellum-deslop-style";
   const REWRITTEN_ATTR = "data-vellum-desloped";
   const PENDING_CLASS = "vellum-deslop-pending";
+  const PROGRESS_CLASS = "vellum-deslop-progress";
+  const SPINNER_CLASS = "vellum-deslop-spinner";
+  const BADGE_CLASS = "vellum-deslop-badge";
+  const SHOWING_ORIGINAL_CLASS = "vellum-deslop-showing-original";
+  const HINT_CLASS = "vellum-deslop-hint";
+  const HINT_ACTIVE_CLASS = "vellum-deslop-hint-active";
+  const HINT_IDLE_TEXT =
+    "Deslop: click a block of text to rewrite it · Esc to exit";
+  const HINT_ACTIVE_TEXT = "Rewriting with your assistant…";
   const MIN_TEXT_LENGTH = 8;
   const MAX_TEXT_LENGTH = 20000;
   const WAND_SVG = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 4V2M15 10V8M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
@@ -49,11 +62,12 @@
   const highlight = document.createElement("div");
   highlight.className = "vellum-deslop-highlight";
   const hint = document.createElement("div");
-  hint.className = "vellum-deslop-hint";
-  hint.textContent = "Deslop: click a block of text to rewrite it · Esc to exit";
+  hint.className = HINT_CLASS;
+  hint.textContent = HINT_IDLE_TEXT;
   document.documentElement.append(highlight, hint);
 
   let hovered: HTMLElement | null = null;
+  let pendingCount = 0;
 
   function isPickable(el: Element | null): el is HTMLElement {
     if (!(el instanceof HTMLElement)) return false;
@@ -100,7 +114,15 @@
     }
   }
 
+  // The wand badge owns its own click (it toggles between the rewrite and
+  // the original), so the picker lets badge events through untouched.
+  function isBadgeEvent(event: MouseEvent): boolean {
+    const target = event.target;
+    return target instanceof Element && target.closest(`.${BADGE_CLASS}`) !== null;
+  }
+
   function onClick(event: MouseEvent): void {
+    if (isBadgeEvent(event)) return;
     const target = hovered;
     if (!target) return;
     event.preventDefault();
@@ -111,10 +133,43 @@
   // Swallow the mousedown/mouseup pair too so pages with mousedown-driven
   // handlers (menus, editors) don't react to the pick.
   function swallow(event: MouseEvent): void {
+    if (isBadgeEvent(event)) return;
     if (hovered) {
       event.preventDefault();
       event.stopPropagation();
     }
+  }
+
+  function syncHint(): void {
+    if (!hint.isConnected) return;
+    const active = pendingCount > 0;
+    hint.className = active ? `${HINT_CLASS} ${HINT_ACTIVE_CLASS}` : HINT_CLASS;
+    hint.textContent = active ? HINT_ACTIVE_TEXT : HINT_IDLE_TEXT;
+  }
+
+  // Dims the block under a shimmering overlay with a spinner badge, and
+  // returns the matching teardown so concurrent rewrites clean up on
+  // their own element without touching each other.
+  function beginPending(el: HTMLElement): () => void {
+    el.classList.add(PENDING_CLASS);
+    if (getComputedStyle(el).position === "static") {
+      el.style.position = "relative";
+    }
+    const overlay = document.createElement("div");
+    overlay.className = PROGRESS_CLASS;
+    const spinner = document.createElement("div");
+    spinner.className = SPINNER_CLASS;
+    el.append(overlay, spinner);
+    pendingCount += 1;
+    syncHint();
+
+    return () => {
+      overlay.remove();
+      spinner.remove();
+      el.classList.remove(PENDING_CLASS);
+      pendingCount = Math.max(0, pendingCount - 1);
+      syncHint();
+    };
   }
 
   async function rewriteElement(el: HTMLElement): Promise<void> {
@@ -122,7 +177,8 @@
     if (text.length === 0) return;
 
     clearHighlight();
-    el.classList.add(PENDING_CLASS);
+    clearRewrittenState(el);
+    const endPending = beginPending(el);
 
     const response = await new Promise<DeslopRewriteResponse | undefined>(
       (resolve) => {
@@ -150,27 +206,60 @@
       },
     );
 
-    el.classList.remove(PENDING_CLASS);
+    endPending();
 
     if (!response?.ok || typeof response.rewritten !== "string") {
       flashError(el, response?.error ?? "The assistant could not rewrite this text.");
       return;
     }
 
-    el.innerText = response.rewritten.trim();
-    markRewritten(el);
+    markRewritten(el, text, response.rewritten.trim());
   }
 
-  function markRewritten(el: HTMLElement): void {
+  // Drops the badge and toggle state of an earlier rewrite so a block
+  // picked a second time starts from a clean slate.
+  function clearRewrittenState(el: HTMLElement): void {
+    el.classList.remove(SHOWING_ORIGINAL_CLASS);
+    for (const badge of Array.from(el.querySelectorAll(`.${BADGE_CLASS}`))) {
+      badge.remove();
+    }
+  }
+
+  function markRewritten(
+    el: HTMLElement,
+    original: string,
+    rewritten: string,
+  ): void {
     el.setAttribute(REWRITTEN_ATTR, "true");
     if (getComputedStyle(el).position === "static") {
       el.style.position = "relative";
     }
+
     const badge = document.createElement("span");
-    badge.className = "vellum-deslop-badge";
-    badge.title = "Rewritten by your Vellum assistant";
+    badge.className = BADGE_CLASS;
     badge.innerHTML = WAND_SVG;
-    el.appendChild(badge);
+
+    let showingOriginal = false;
+
+    // Writing innerText discards the element's children, so the badge is
+    // re-attached on every swap.
+    function render(): void {
+      el.innerText = showingOriginal ? original : rewritten;
+      el.classList.toggle(SHOWING_ORIGINAL_CLASS, showingOriginal);
+      badge.title = showingOriginal
+        ? "Showing the original text. Click to show the rewrite."
+        : "Rewritten by your Vellum assistant. Click to show the original.";
+      el.appendChild(badge);
+    }
+
+    badge.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      showingOriginal = !showingOriginal;
+      render();
+    });
+
+    render();
   }
 
   function flashError(el: HTMLElement, message: string): void {
@@ -224,7 +313,7 @@
         border-radius: 3px;
         transition: top 40ms linear, left 40ms linear, width 40ms linear, height 40ms linear;
       }
-      .vellum-deslop-hint {
+      .${HINT_CLASS} {
         position: fixed;
         bottom: 16px;
         left: 50%;
@@ -238,36 +327,92 @@
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
         pointer-events: none;
       }
+      .${HINT_ACTIVE_CLASS} {
+        background: rgba(79, 70, 229, 0.95);
+      }
       .${PENDING_CLASS} {
         outline: 2px solid rgba(99, 102, 241, 0.85);
         outline-offset: -1px;
-        animation: vellum-deslop-pulse 1.2s ease-in-out infinite;
+        opacity: 0.55;
       }
-      @keyframes vellum-deslop-pulse {
-        0%, 100% { background-color: rgba(99, 102, 241, 0.06); }
-        50% { background-color: rgba(99, 102, 241, 0.18); }
+      .${PROGRESS_CLASS} {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 2147483644;
+        border-radius: 3px;
+        background-color: rgba(99, 102, 241, 0.1);
+        background-image: linear-gradient(
+          110deg,
+          rgba(99, 102, 241, 0) 20%,
+          rgba(99, 102, 241, 0.28) 50%,
+          rgba(99, 102, 241, 0) 80%
+        );
+        background-repeat: no-repeat;
+        background-size: 200% 100%;
+        animation: vellum-deslop-shimmer 1.1s linear infinite;
+      }
+      @keyframes vellum-deslop-shimmer {
+        from { background-position: -100% 0; }
+        to { background-position: 200% 0; }
+      }
+      .${SPINNER_CLASS} {
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        box-sizing: border-box;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: rgba(99, 102, 241, 0.95);
+        pointer-events: none;
+        z-index: 2147483645;
+      }
+      .${SPINNER_CLASS}::after {
+        content: "";
+        position: absolute;
+        inset: 4px;
+        box-sizing: border-box;
+        border-radius: 50%;
+        border: 2px solid rgba(255, 255, 255, 0.35);
+        border-top-color: #ffffff;
+        animation: vellum-deslop-spin 0.8s linear infinite;
+      }
+      @keyframes vellum-deslop-spin {
+        to { transform: rotate(360deg); }
       }
       [${REWRITTEN_ATTR}] {
         background-color: rgba(99, 102, 241, 0.07);
         border-radius: 3px;
         transition: background-color 300ms ease;
       }
-      .vellum-deslop-badge {
+      [${REWRITTEN_ATTR}].${SHOWING_ORIGINAL_CLASS} {
+        background-color: transparent;
+      }
+      .${BADGE_CLASS} {
         position: absolute;
         top: 2px;
         right: 2px;
+        box-sizing: border-box;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         width: 18px;
         height: 18px;
         border-radius: 50%;
+        border: 1px solid transparent;
         background: rgba(99, 102, 241, 0.9);
         color: #ffffff;
+        cursor: pointer;
         pointer-events: auto;
         z-index: 2147483645;
       }
-      .vellum-deslop-badge svg {
+      .${SHOWING_ORIGINAL_CLASS} .${BADGE_CLASS} {
+        background: transparent;
+        border-color: rgba(107, 114, 128, 0.7);
+        color: rgba(107, 114, 128, 0.95);
+      }
+      .${BADGE_CLASS} svg {
         width: 11px;
         height: 11px;
         display: block;

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -54,6 +54,7 @@
   const PANEL_TITLE_CLASS = "vellum-deslop-panel-title";
   const PANEL_CLOSE_CLASS = "vellum-deslop-panel-close";
   const CONTEXT_CLASS = "vellum-deslop-context";
+  const QUOTE_CLASS = "vellum-deslop-quote";
   const MESSAGES_CLASS = "vellum-deslop-messages";
   const MESSAGE_CLASS = "vellum-deslop-message";
   const MESSAGE_USER_CLASS = "vellum-deslop-message-user";
@@ -76,6 +77,7 @@
   const VIEWPORT_MARGIN = 8;
   const ANCHOR_GAP = 8;
   const CONTEXT_PREVIEW_LENGTH = 120;
+  const QUOTE_PREVIEW_LENGTH = 90;
   const RELOADED_MESSAGE =
     "The extension was reloaded. Reopen the popup and press Deslop again.";
   const WAND_SVG = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 4V2M15 10V8M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
@@ -302,6 +304,249 @@
     }
   }
 
+  // Elements that may not contain flow content, so a rewrite placed in one
+  // stays inline instead of nesting a paragraph or list inside it.
+  const INLINE_ONLY_HOSTS =
+    /^(P|LI|H[1-6]|SPAN|A|EM|STRONG|B|I|TD|TH|DT|DD|LABEL|BUTTON|SUMMARY|FIGCAPTION)$/;
+  const CODE_FENCE_RE = /^```/;
+  const BULLET_RE = /^\s*[-*+]\s+(.*)$/;
+  const ORDERED_RE = /^\s*\d+[.)]\s+(.*)$/;
+  // Code spans are matched first so emphasis markers inside backticks stay
+  // literal, which is what a code identifier needs.
+  const INLINE_RE =
+    /`([^`]+)`|\*\*([^*]+)\*\*|__([^_]+)__|\*([^*\n]+)\*|_([^_\n]+)_|\[([^\]]+)\]\(([^)\s]+)\)/;
+
+  /**
+   * Class names lifted from the block's own markup. Sites that style by
+   * class rather than by element (rendered markdown, syntax highlighters)
+   * need them for a generated element to look like the ones it replaces.
+   */
+  interface RewriteStyle {
+    code: string;
+    strong: string;
+    em: string;
+    link: string;
+    list: string;
+    item: string;
+    paragraph: string;
+  }
+
+  function harvestStyle(el: HTMLElement): RewriteStyle {
+    const classOf = (selector: string): string => {
+      const found = el.querySelector(selector);
+      return found instanceof HTMLElement ? found.className : "";
+    };
+    return {
+      code: classOf("code, tt"),
+      strong: classOf("strong, b"),
+      em: classOf("em, i"),
+      link: classOf("a"),
+      list: classOf("ul, ol"),
+      item: classOf("li"),
+      paragraph: classOf("p"),
+    };
+  }
+
+  function createStyled(tag: string, className: string): HTMLElement {
+    const created = document.createElement(tag);
+    if (className) {
+      created.className = className;
+    }
+    return created;
+  }
+
+  interface MarkdownBlock {
+    kind: "paragraph" | "list" | "code";
+    lines: string[];
+    ordered?: boolean;
+  }
+
+  function parseMarkdownBlocks(markdown: string): MarkdownBlock[] {
+    const blocks: MarkdownBlock[] = [];
+    const lines = markdown.split("\n");
+    let index = 0;
+
+    while (index < lines.length) {
+      const line = lines[index]!;
+      if (line.trim().length === 0) {
+        index += 1;
+        continue;
+      }
+      if (CODE_FENCE_RE.test(line.trim())) {
+        const body: string[] = [];
+        index += 1;
+        while (index < lines.length && !CODE_FENCE_RE.test(lines[index]!.trim())) {
+          body.push(lines[index]!);
+          index += 1;
+        }
+        index += 1;
+        blocks.push({ kind: "code", lines: body });
+        continue;
+      }
+      const bullet = BULLET_RE.exec(line);
+      const ordered = ORDERED_RE.exec(line);
+      if (bullet || ordered) {
+        const isOrdered = bullet === null;
+        const items: string[] = [];
+        while (index < lines.length) {
+          const current = lines[index]!;
+          const nextBullet = BULLET_RE.exec(current);
+          const nextOrdered = ORDERED_RE.exec(current);
+          if (!isOrdered && nextBullet) {
+            items.push(nextBullet[1]!);
+            index += 1;
+            continue;
+          }
+          if (isOrdered && nextOrdered) {
+            items.push(nextOrdered[1]!);
+            index += 1;
+            continue;
+          }
+          // An indented continuation belongs to the item above it.
+          if (
+            items.length > 0 &&
+            current.trim().length > 0 &&
+            /^\s+/.test(current)
+          ) {
+            items[items.length - 1] += ` ${current.trim()}`;
+            index += 1;
+            continue;
+          }
+          break;
+        }
+        blocks.push({ kind: "list", lines: items, ordered: isOrdered });
+        continue;
+      }
+      const paragraph: string[] = [];
+      while (index < lines.length) {
+        const current = lines[index]!;
+        if (
+          current.trim().length === 0 ||
+          BULLET_RE.test(current) ||
+          ORDERED_RE.test(current) ||
+          CODE_FENCE_RE.test(current.trim())
+        ) {
+          break;
+        }
+        paragraph.push(current.trim());
+        index += 1;
+      }
+      blocks.push({ kind: "paragraph", lines: paragraph });
+    }
+
+    return blocks;
+  }
+
+  /**
+   * Append `text` to `parent` as nodes, turning inline markdown into real
+   * elements. Every string reaches the DOM through `textContent`, so model
+   * output can never introduce markup of its own.
+   */
+  function appendInline(parent: Node, text: string, style: RewriteStyle): void {
+    let rest = text;
+    while (rest.length > 0) {
+      const match = INLINE_RE.exec(rest);
+      if (!match) {
+        parent.appendChild(document.createTextNode(rest));
+        return;
+      }
+      if (match.index > 0) {
+        parent.appendChild(document.createTextNode(rest.slice(0, match.index)));
+      }
+      if (match[1] !== undefined) {
+        const code = createStyled("code", style.code);
+        code.textContent = match[1];
+        parent.appendChild(code);
+      } else if (match[2] !== undefined || match[3] !== undefined) {
+        const strong = createStyled("strong", style.strong);
+        strong.textContent = match[2] ?? match[3] ?? "";
+        parent.appendChild(strong);
+      } else if (match[4] !== undefined || match[5] !== undefined) {
+        const em = createStyled("em", style.em);
+        em.textContent = match[4] ?? match[5] ?? "";
+        parent.appendChild(em);
+      } else {
+        const label = match[6] ?? "";
+        const href = match[7] ?? "";
+        if (/^(https?:\/\/|mailto:)/i.test(href)) {
+          const link = createStyled("a", style.link) as HTMLAnchorElement;
+          link.href = href;
+          link.textContent = label;
+          parent.appendChild(link);
+        } else {
+          // A scheme the extension will not follow stays literal text.
+          parent.appendChild(document.createTextNode(match[0]));
+        }
+      }
+      rest = rest.slice(match.index + match[0].length);
+    }
+  }
+
+  /**
+   * Build the rewrite as DOM nodes. The assistant answers in markdown when
+   * the block it rewrote had that structure, so rendering the markup back
+   * out is what keeps code spans, emphasis, and lists looking like the rest
+   * of the page instead of arriving as literal backticks and asterisks.
+   */
+  function renderRewrite(
+    markdown: string,
+    host: HTMLElement,
+    style: RewriteStyle,
+  ): Node[] {
+    const blocksAllowed = !INLINE_ONLY_HOSTS.test(host.tagName);
+    const out: Node[] = [];
+
+    parseMarkdownBlocks(markdown).forEach((block, blockIndex) => {
+      if (!blocksAllowed && blockIndex > 0) {
+        out.push(document.createElement("br"), document.createElement("br"));
+      }
+
+      if (block.kind === "code") {
+        const code = createStyled("code", style.code);
+        code.textContent = block.lines.join("\n");
+        if (!blocksAllowed) {
+          out.push(code);
+          return;
+        }
+        const pre = document.createElement("pre");
+        pre.appendChild(code);
+        out.push(pre);
+        return;
+      }
+
+      if (block.kind === "list") {
+        if (blocksAllowed) {
+          const list = createStyled(block.ordered ? "ol" : "ul", style.list);
+          for (const item of block.lines) {
+            const listItem = createStyled("li", style.item);
+            appendInline(listItem, item, style);
+            list.appendChild(listItem);
+          }
+          out.push(list);
+          return;
+        }
+        block.lines.forEach((item, itemIndex) => {
+          if (itemIndex > 0) {
+            out.push(document.createElement("br"));
+          }
+          const line = document.createElement("span");
+          appendInline(line, `• ${item}`, style);
+          out.push(line);
+        });
+        return;
+      }
+
+      const text = block.lines.join(" ");
+      const container = blocksAllowed
+        ? createStyled("p", style.paragraph)
+        : document.createElement("span");
+      appendInline(container, text, style);
+      out.push(container);
+    });
+
+    return out;
+  }
+
   function markRewritten(el: HTMLElement, rewritten: string): void {
     el.setAttribute(REWRITTEN_ATTR, "true");
     if (getComputedStyle(el).position === "static") {
@@ -312,25 +557,26 @@
     badge.className = BADGE_CLASS;
     badge.innerHTML = WAND_SVG;
 
+    // Styling is read while the block still holds its own markup, so the
+    // rewrite's generated elements can carry the same classes.
+    const style = harvestStyle(el);
+
     // The original content is held as live nodes rather than as text, so
     // toggling back restores its exact markup: code chips, list items,
     // links, and syntax highlighting all survive the round trip. The
     // overlay and spinner are already gone by this point, so the captured
     // set is exactly what the block displayed before the rewrite.
     const originalNodes = Array.from(el.childNodes);
+    const rewrittenNodes = renderRewrite(rewritten, el, style);
 
     let showingOriginal = false;
 
-    // Emptying the element first detaches the original nodes into their
-    // array, which keeps the innerText write on the rewrite path from
-    // destroying them. The badge is re-attached on every swap.
+    // Both sets are live nodes held by their arrays while detached, so a
+    // swap moves one set in and the other out. The badge is re-attached on
+    // every swap.
     function render(): void {
       el.replaceChildren();
-      if (showingOriginal) {
-        el.append(...originalNodes);
-      } else {
-        el.innerText = rewritten;
-      }
+      el.append(...(showingOriginal ? originalNodes : rewrittenNodes));
       el.classList.toggle(SHOWING_ORIGINAL_CLASS, showingOriginal);
       badge.title = showingOriginal
         ? "Showing the original text. Click to show the rewrite."
@@ -517,7 +763,9 @@
     sendButton.className = SEND_CLASS;
     sendButton.textContent = "Send";
     composer.append(input, sendButton);
-    panel.append(panelHeader, contextChip, messages, composer);
+    // The pending quote sits directly above the input, where it reads as
+    // part of the message about to be sent rather than as a panel header.
+    panel.append(panelHeader, messages, contextChip, composer);
 
     document.documentElement.append(menu, panel);
 
@@ -648,7 +896,11 @@
       messages.scrollTop = messages.scrollHeight;
     }
 
-    function appendBubble(kind: "user" | "assistant" | "error", text: string): HTMLElement {
+    function appendBubble(
+      kind: "user" | "assistant" | "error",
+      text: string,
+      quoted?: string,
+    ): HTMLElement {
       const bubble = document.createElement("div");
       const modifier =
         kind === "user"
@@ -657,7 +909,17 @@
             ? MESSAGE_ASSISTANT_CLASS
             : MESSAGE_ERROR_CLASS;
       bubble.className = `${MESSAGE_CLASS} ${modifier}`;
-      bubble.textContent = text;
+      // A turn that carried a highlight keeps it visible above its text, so
+      // the thread still shows what each question was asked about.
+      if (quoted) {
+        const quote = document.createElement("div");
+        quote.className = QUOTE_CLASS;
+        quote.textContent = truncate(quoted, QUOTE_PREVIEW_LENGTH);
+        bubble.appendChild(quote);
+      }
+      const body = document.createElement("div");
+      body.textContent = text;
+      bubble.appendChild(body);
       messages.appendChild(bubble);
       scrollMessagesToBottom();
       return bubble;
@@ -691,9 +953,10 @@
         return;
       }
       input.value = "";
-      appendBubble("user", message);
       const highlighted = pendingHighlight;
+      appendBubble("user", message, highlighted);
       pendingHighlight = "";
+      contextChip.style.display = "none";
       setChatBusy(true);
       const thinking = appendThinking();
 
@@ -717,8 +980,10 @@
         // The highlight goes back on the next attempt so a retry keeps the
         // context the failed turn never delivered, unless a fresh highlight
         // arrived while the request was in flight.
-        if (pendingHighlight.length === 0) {
+        if (pendingHighlight.length === 0 && highlighted.length > 0) {
           pendingHighlight = highlighted;
+          contextChip.textContent = truncate(highlighted, CONTEXT_PREVIEW_LENGTH);
+          contextChip.style.display = "block";
         }
         appendBubble(
           "error",
@@ -1093,7 +1358,7 @@
         color: #f9fafb;
       }
       .${PANEL_CLASS} .${CONTEXT_CLASS} {
-        margin: 0 12px 8px 12px;
+        margin: 8px 12px 0 12px;
         padding: 6px 10px;
         border-left: 2px solid rgba(99, 102, 241, 0.85);
         border-radius: 0 6px 6px 0;
@@ -1101,6 +1366,23 @@
         color: #9ca3af;
         font: 400 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         word-break: break-word;
+        max-height: 60px;
+        overflow: hidden;
+      }
+      .${PANEL_CLASS} .${QUOTE_CLASS} {
+        margin: 0 0 4px 0;
+        padding: 3px 8px;
+        border-left: 2px solid rgba(255, 255, 255, 0.45);
+        border-radius: 0 4px 4px 0;
+        background: rgba(0, 0, 0, 0.22);
+        color: rgba(255, 255, 255, 0.72);
+        font: 400 11px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        word-break: break-word;
+      }
+      .${PANEL_CLASS} .${MESSAGE_ASSISTANT_CLASS} .${QUOTE_CLASS} {
+        border-left-color: rgba(99, 102, 241, 0.85);
+        background: rgba(99, 102, 241, 0.12);
+        color: #9ca3af;
       }
       .${PANEL_CLASS} .${MESSAGES_CLASS} {
         display: flex;

--- a/clients/chrome-extension/content/deslop.ts
+++ b/clients/chrome-extension/content/deslop.ts
@@ -14,7 +14,8 @@
  * dimmed under a shimmering overlay with a spinner badge and the hint
  * pill switches to its active state; the response then replaces the
  * element's content and the element is marked with a faint tint plus a
- * wand badge that toggles between the rewrite and the original text.
+ * wand badge that toggles between the rewrite and the original content,
+ * which is kept as live DOM nodes so its markup returns intact.
  * Esc exits the picker. The picker stays active after a rewrite so
  * several blocks can be cleaned up in one session, and several rewrites
  * can be in flight at once.
@@ -213,7 +214,7 @@
       return;
     }
 
-    markRewritten(el, text, response.rewritten.trim());
+    markRewritten(el, response.rewritten.trim());
   }
 
   // Drops the badge and toggle state of an earlier rewrite so a block
@@ -225,11 +226,7 @@
     }
   }
 
-  function markRewritten(
-    el: HTMLElement,
-    original: string,
-    rewritten: string,
-  ): void {
+  function markRewritten(el: HTMLElement, rewritten: string): void {
     el.setAttribute(REWRITTEN_ATTR, "true");
     if (getComputedStyle(el).position === "static") {
       el.style.position = "relative";
@@ -239,12 +236,25 @@
     badge.className = BADGE_CLASS;
     badge.innerHTML = WAND_SVG;
 
+    // The original content is held as live nodes rather than as text, so
+    // toggling back restores its exact markup: code chips, list items,
+    // links, and syntax highlighting all survive the round trip. The
+    // overlay and spinner are already gone by this point, so the captured
+    // set is exactly what the block displayed before the rewrite.
+    const originalNodes = Array.from(el.childNodes);
+
     let showingOriginal = false;
 
-    // Writing innerText discards the element's children, so the badge is
-    // re-attached on every swap.
+    // Emptying the element first detaches the original nodes into their
+    // array, which keeps the innerText write on the rewrite path from
+    // destroying them. The badge is re-attached on every swap.
     function render(): void {
-      el.innerText = showingOriginal ? original : rewritten;
+      el.replaceChildren();
+      if (showingOriginal) {
+        el.append(...originalNodes);
+      } else {
+        el.innerText = rewritten;
+      }
       el.classList.toggle(SHOWING_ORIGINAL_CLASS, showingOriginal);
       badge.title = showingOriginal
         ? "Showing the original text. Click to show the rewrite."

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -9,6 +9,7 @@
     "alarms",
     "debugger",
     "identity",
+    "scripting",
     "storage",
     "tabs"
   ],

--- a/clients/chrome-extension/popup/screens/MainScreen.tsx
+++ b/clients/chrome-extension/popup/screens/MainScreen.tsx
@@ -17,6 +17,7 @@ export function MainScreen() {
   const [paired, setPaired] = useState(selfHostedPaired);
   const [assistantName, setAssistantName] = useState('');
   const [accountEmail, setAccountEmail] = useState('');
+  const [deslopError, setDeslopError] = useState('');
 
   useEffect(() => {
     sendMessage<{
@@ -46,6 +47,20 @@ export function MainScreen() {
   const handleFeedbackClick = useCallback(() => {
     setScreen({ name: 'feedback' });
   }, [setScreen]);
+
+  const handleDeslopClick = useCallback(() => {
+    setDeslopError('');
+    sendMessage<{ ok: boolean; error?: string }>({
+      type: 'deslop-activate',
+    }).then((response) => {
+      if (response?.ok) {
+        // Close the popup so the user can pick an element on the page.
+        window.close();
+        return;
+      }
+      setDeslopError(response?.error ?? 'Could not start Deslop on this page.');
+    });
+  }, []);
 
   const isCloud = mode === 'cloud';
   const isSelfHosted = mode === 'self-hosted';
@@ -79,6 +94,43 @@ export function MainScreen() {
       )}
 
       {showConnectedState && <StatusCard />}
+
+      {showConnectedState && (
+        <div className="mb-2.5">
+          <button
+            type="button"
+            onClick={handleDeslopClick}
+            className="flex w-full cursor-pointer items-center justify-between rounded-xl border border-edge bg-surface px-4 py-3.5 transition-colors hover:border-edge-hover hover:bg-surface-alt"
+          >
+            <div className="flex items-center gap-2.5">
+              <svg
+                className="shrink-0 text-fg-muted"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M15 4V2M15 10V8M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2L19 5M3 21l9-9M12.2 6.2L11 5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <span className="text-[13px] font-medium text-fg">Deslop</span>
+            </div>
+            <span className="text-[11px] text-fg-subtle">
+              Click text on the page to rewrite it
+            </span>
+          </button>
+          {deslopError && (
+            <p className="mt-1.5 px-1 text-[11px] text-red-600 dark:text-red-400">
+              {deslopError}
+            </p>
+          )}
+        </div>
+      )}
 
       {showConnectedState && (
         <button

--- a/clients/chrome-extension/tsconfig.json
+++ b/clients/chrome-extension/tsconfig.json
@@ -17,6 +17,7 @@
   },
   "include": [
     "background/**/*.ts",
+    "content/**/*.ts",
     "popup/**/*.ts",
     "popup/**/*.tsx",
     "types/**/*.d.ts"

--- a/clients/chrome-extension/types/chrome-globals.d.ts
+++ b/clients/chrome-extension/types/chrome-globals.d.ts
@@ -333,6 +333,28 @@ interface ChromeDebuggerTargetInfo {
   faviconUrl?: string;
 }
 
+interface ChromeScriptingInjectionTarget {
+  tabId: number;
+  allFrames?: boolean;
+  frameIds?: number[];
+}
+
+interface ChromeScriptingInjection {
+  target: ChromeScriptingInjectionTarget;
+  files: string[];
+}
+
+interface ChromeScriptingInjectionResult {
+  frameId: number;
+  result?: unknown;
+}
+
+interface ChromeScriptingNamespace {
+  executeScript(
+    injection: ChromeScriptingInjection,
+  ): Promise<ChromeScriptingInjectionResult[]>;
+}
+
 interface ChromeActionSetIconDetails {
   path?: Record<string, string> | string;
 }
@@ -347,6 +369,7 @@ interface ChromeGlobal {
   storage: ChromeStorageNamespace;
   identity: ChromeIdentityNamespace;
   runtime: ChromeRuntimeNamespace;
+  scripting: ChromeScriptingNamespace;
   tabs: ChromeTabsNamespace;
   windows: ChromeWindowsNamespace;
   debugger: ChromeDebuggerNamespace;


### PR DESCRIPTION
## What

Adds a **Deslop** feature to the Chrome extension:

- A **Deslop** button in the popup panel (below the status card). Clicking it closes the popup and turns the active tab into an inspect-element-style picker.
- Hovering highlights the exact DOM block under the cursor (indigo overlay + hint pill); clicking sends that block's text to the connected assistant with the rewrite prompt:
  `Rewrite the selected text without any jargon and speak coherently. State it more simply and concisely, like one human talking to another. <selected_text>{text}</selected_text>`
- The response replaces the block's content in place; rewritten blocks get a faint indigo tint and a wand badge in the top-right corner. Errors show a red toast and leave the original text untouched. Esc exits; the picker stays active between rewrites so several blocks can be cleaned up in one pass.

## How

- New on-demand content script (`content/deslop.ts`) injected via `chrome.scripting.executeScript` (new `scripting` permission). Bundled as a classic script; re-injection restarts the session cleanly.
- Rewrites go through the assistant's one-shot LLM endpoint `POST /v1/inference/send`: the local gateway's runtime-proxy catch-all for self-hosted, the platform's wildcard runtime proxy (`/v1/assistants/{id}/inference/send`) for cloud. Self-hosted pairs on demand when no JWT is cached.
- **Daemon change**: `inference/send` route policy widens from `LOCAL_PRINCIPALS` to `ACTOR_PRINCIPALS` (still `chat.write`), with a new in-handler `isOwnerCaller` re-check (same pattern as schedule routes) so a stale actor token whose guardian binding was revoked or rebound is refused before any provider spend. Actors can already drive full chat turns, so this grants no new class of LLM access.

## Testing

- New unit tests: `background/__tests__/deslop.test.ts` (prompt shape, self-hosted and cloud routing, error paths), plus a new owner-authority rejection test in `inference-send-routes.test.ts` (8 pass).
- Full extension suite: 188 pass. `tsc --noEmit`, eslint, and `build.sh` all green; OpenAPI regenerated with no diff.
- **Live UX test** (content script injected into a real page in Chrome with a stubbed worker): hover highlight tracks elements precisely, pending pulse shows during the rewrite, replacement + tint + wand badge render correctly, error toast + red outline on failure, Esc tears everything down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)