### PR TITLE
feat(assistant): commit live-voice turns on Flux end-of-turn behind a flag

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type { LiveVoiceFluxConfig } from "../../config/schemas/live-voice.js";
+import type {
+  StreamingTranscriber,
+  SttProviderId,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTtsStreamer,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const SAMPLE_RATE = 24_000;
+
+const VAD_START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  turnDetection: "server_vad",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: SAMPLE_RATE,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+function pcm(amplitude: number, sampleCount = 240): Uint8Array {
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer.writeInt16LE(amplitude, index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
+// 10 ms of speech at 24 kHz.
+const LOUD_CHUNK = pcm(8_000);
+// 300 ms of speech at 24 kHz, comfortably past the default sustained-speech
+// barge-in guard (250 ms) in a single chunk.
+const SUSTAINED_LOUD_CHUNK = pcm(8_000, 7_200);
+
+/**
+ * Flux-shaped streaming transcriber: no `finalizeUtterance` (Flux owns turn
+ * boundaries, so the session runs it per cycle), and every transcript event is
+ * scripted by the test. `stop()` closes without inventing a trailing final,
+ * exactly as Flux does: its transcript is committed by EndOfTurn.
+ */
+class MockFluxTranscriber implements StreamingTranscriber {
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly received: Buffer[] = [];
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(readonly providerId: SttProviderId) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(chunk: Buffer): void {
+    this.received.push(Buffer.from(chunk));
+  }
+
+  stop(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    this.onEvent?.({ type: "closed" });
+  }
+
+  emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+
+  // Flux's EndOfTurn frame maps onto a `final` followed by a `turn-end`.
+  endOfTurn(text: string): void {
+    this.emit({ type: "final", text });
+    this.emit({ type: "turn-end", text, confidence: 0.9 });
+  }
+}
+
+function createHarness(options: {
+  providerId?: SttProviderId;
+  fluxConfig?: Partial<LiveVoiceFluxConfig>;
+  silenceThresholdMs?: number;
+  startVoiceTurn?: (options: VoiceTurnOptions) => Promise<{
+    turnId: string;
+    abort: () => void;
+  }>;
+  streamTtsAudio?: LiveVoiceTtsStreamer | null;
+  emitMetrics?: boolean;
+}) {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  const context: LiveVoiceSessionFactoryContext = {
+    sessionId: "session-123",
+    startFrame: VAD_START_FRAME,
+    sendFrame: mock(async (payload) => {
+      const frame = sequencer.next(payload);
+      frames.push(frame);
+      return frame;
+    }),
+  };
+
+  const transcribers: MockFluxTranscriber[] = [];
+  const resolveTranscriber = mock(async () => {
+    const transcriber = new MockFluxTranscriber(
+      options.providerId ?? "deepgram-flux",
+    );
+    transcribers.push(transcriber);
+    return transcriber;
+  });
+
+  const turnCalls: VoiceTurnOptions[] = [];
+  const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+    turnCalls.push(turnOptions);
+    if (options.startVoiceTurn) {
+      return await options.startVoiceTurn(turnOptions);
+    }
+    return { turnId: `bridge-turn-${turnCalls.length}`, abort: mock() };
+  });
+
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber,
+    startVoiceTurn,
+    streamTtsAudio: options.streamTtsAudio ?? null,
+    emitMetrics: options.emitMetrics ?? false,
+    spawnBackgroundContinuation: mock(async () => ""),
+    turnDetectorConfig: {
+      silenceThresholdMs: options.silenceThresholdMs ?? 40,
+    },
+    ...(options.fluxConfig ? { fluxConfig: options.fluxConfig } : {}),
+  });
+
+  return { frames, session, transcribers, turnCalls };
+}
+
+function makeTextDelta(
+  text: string,
+): Parameters<NonNullable<VoiceTurnCallbacks["assistant_text_delta"]>>[0] {
+  return {
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  };
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+// Answers immediately: one text delta (which commits a speculative leg), then
+// message_complete.
+function autoCompletingTurn(
+  reply = "Okay.",
+): (
+  options: VoiceTurnOptions,
+) => Promise<{ turnId: string; abort: () => void }> {
+  let count = 0;
+  return async (options) => {
+    count += 1;
+    options.callbacks?.assistant_text_delta?.(makeTextDelta(reply));
+    options.callbacks?.message_complete?.(makeMessageComplete());
+    return { turnId: `bridge-turn-${count}`, abort: mock() };
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for a live voice Flux test condition",
+): Promise<void> {
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+const FLUX_ON = {
+  turnEnd: { enabled: true },
+  eotTimeoutMs: 500,
+} as const satisfies Partial<LiveVoiceFluxConfig>;
+
+describe("LiveVoiceSession Flux end-of-turn", () => {
+  test("commits the turn on turn-end without an endpoint-decision leg", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      // Long enough that the local silence boundary cannot be what commits.
+      silenceThresholdMs: 10_000,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("what is the weather");
+
+    await waitFor(() => turnCalls.length === 1);
+    expect(turnCalls[0]?.content).toBe("what is the weather");
+    // Non-speculative dispatch: the front-door leg's decision rule is built
+    // with includeHold false, so the hold token is never taught.
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
+    expect(turnCalls[0]?.routingLeg).toBe("front-door");
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
+
+    await session.close("client_end");
+  });
+
+  test("still escalates on the [1] verdict after a flux commit", async () => {
+    const { session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 10_000,
+      startVoiceTurn: async (turnOptions) => {
+        if (turnOptions.routingLeg === "front-door") {
+          turnOptions.callbacks?.assistant_text_delta?.(
+            makeTextDelta("[1] Let me check that for you."),
+          );
+        }
+        return { turnId: "bridge-turn", abort: mock() };
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("what is on my calendar");
+
+    await waitFor(
+      () => turnCalls.some((call) => call.routingLeg === "escalated"),
+      "The escalate verdict never handed off to the escalated leg",
+    );
+
+    await session.close("client_end");
+  });
+
+  test("ignores turn-end when the flag is off and keeps the hold path", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.emit({ type: "partial", text: "hello there" });
+    transcribers[0]?.endOfTurn("hello there");
+    await flushAsyncCallbacks();
+
+    // The turn-end event committed nothing: the silence boundary still owns
+    // the commit, and it dispatches speculatively (the hold path).
+    await waitFor(() => turnCalls.length === 1);
+    expect(turnCalls[0]?.unifiedVerdict).toBe(true);
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
+
+    await session.close("client_end");
+  });
+
+  test("ignores turn-end from a provider that is not deepgram-flux", async () => {
+    const { session, transcribers, turnCalls } = createHarness({
+      providerId: "deepgram",
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 10_000,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("hello there");
+    await flushAsyncCallbacks();
+
+    expect(turnCalls).toHaveLength(0);
+
+    await session.close("client_end");
+  });
+
+  test("reports the endpoint decision as flux", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 10_000,
+      emitMetrics: true,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("hello there");
+    await waitFor(() => turnCalls.length === 1);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    const metricsFrame = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(metricsFrame).toBeDefined();
+    if (metricsFrame?.type === "metrics") {
+      expect(metricsFrame.endpointDecisionSource).toBe("flux");
+      expect(metricsFrame.endpointHoldCount).toBe(0);
+    }
+
+    await session.close("client_end");
+  });
+
+  test("falls back to the silence-boundary path when no turn-end arrives", async () => {
+    const { session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    // Flux is transcribing but its EndOfTurn never arrives.
+    transcribers[0]?.emit({ type: "partial", text: "are you still there" });
+
+    // The local silence boundary (40 ms) passes without committing anything:
+    // the fallback deadline (eotTimeoutMs plus the margin) owns this
+    // utterance.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(turnCalls).toHaveLength(0);
+
+    await waitFor(
+      () => turnCalls.length === 1,
+      "Flux fallback never replayed the silence boundary",
+    );
+    // Back on the existing path: a speculative dispatch that knows the hold
+    // token, judging the partial the silence boundary saw.
+    expect(turnCalls[0]?.content).toBe("are you still there");
+    expect(turnCalls[0]?.unifiedVerdict).toBe(true);
+
+    await session.close("client_end");
+  }, 10_000);
+
+  for (const flagOn of [false, true]) {
+    test(`barge-in during playback fires from local VAD (flux turn end ${
+      flagOn ? "on" : "off"
+    })`, async () => {
+      const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+        ttsOptions.onAudioChunk({
+          type: "tts_audio",
+          contentType: "audio/pcm",
+          sampleRate: SAMPLE_RATE,
+          dataBase64: Buffer.from("assistant audio").toString("base64"),
+        });
+        return {
+          provider: "fish-audio",
+          contentType: "audio/pcm",
+          sampleRate: SAMPLE_RATE,
+          chunks: 1,
+          bytes: 15,
+        } satisfies LiveVoiceTtsResult;
+      });
+      const { frames, session, transcribers } = createHarness({
+        ...(flagOn ? { fluxConfig: FLUX_ON } : {}),
+        silenceThresholdMs: 10_000,
+        streamTtsAudio,
+        // The leg never completes, so the turn is still in flight when the
+        // caller speaks over it.
+        startVoiceTurn: async (turnOptions) => {
+          turnOptions.callbacks?.assistant_text_delta?.(
+            makeTextDelta("Let me tell you a long story."),
+          );
+          return { turnId: "bridge-turn-1", abort: mock() };
+        },
+      });
+
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await waitFor(() => transcribers.length > 0);
+      if (flagOn) {
+        transcribers[0]?.endOfTurn("tell me a story");
+      } else {
+        transcribers[0]?.emit({ type: "final", text: "tell me a story" });
+        await session.handleClientFrame({ type: "ptt_release" });
+      }
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // Local energy detection, not the provider's turn model, is what
+      // interrupts the assistant.
+      await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+      await waitFor(
+        () => frames.some((frame) => frame.type === "speech_started"),
+        "Local VAD barge-in never fired",
+      );
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+
+      await session.close("client_end");
+    });
+  }
+});

--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -203,6 +203,21 @@ async function flushAsyncCallbacks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function countFrames(
+  frames: LiveVoiceServerFrame[],
+  type: LiveVoiceServerFrame["type"],
+): number {
+  return frames.filter((frame) => frame.type === type).length;
+}
+
+// Long enough for the 40 ms local silence timer to fire and hand the boundary
+// to Flux (which arms the fail-open deadline and commits nothing).
+const PAST_SILENCE_BOUNDARY_MS = 150;
+
 const FLUX_ON = {
   turnEnd: { enabled: true },
   eotTimeoutMs: 500,
@@ -355,6 +370,153 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
     );
     // Back on the existing path: a speculative dispatch that knows the hold
     // token, judging the partial the silence boundary saw.
+    expect(turnCalls[0]?.content).toBe("are you still there");
+    expect(turnCalls[0]?.unifiedVerdict).toBe(true);
+
+    await session.close("client_end");
+  }, 10_000);
+
+  test("commits a turn-end that arrives after the local silence boundary", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+
+    // The boundary passes and commits nothing: Flux owns it.
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+    expect(turnCalls).toHaveLength(0);
+
+    // No resumed speech, so this turn-end is the one the boundary was waiting
+    // for and it commits exactly as before.
+    transcribers[0]?.endOfTurn("what is the weather");
+    await waitFor(
+      () => turnCalls.length === 1,
+      "A non-stale turn-end after the silence boundary never committed",
+    );
+    expect(turnCalls[0]?.content).toBe("what is the weather");
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
+
+    await session.close("client_end");
+  });
+
+  test("drops a turn-end that arrives after the caller resumed speaking", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    const transcriber = transcribers[0];
+    transcriber?.emit({ type: "partial", text: "what is the" });
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+
+    // The caller draws breath and keeps going before the provider's turn-end
+    // for the speech that boundary closed reaches the session.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(
+      () => countFrames(frames, "speech_started") === 2,
+      "The resumed speech never re-opened a detector turn",
+    );
+    const receivedBeforeResume = transcriber?.received.length ?? 0;
+
+    transcriber?.emit({
+      type: "turn-end",
+      text: "what is the",
+      confidence: 0.9,
+    });
+    await flushAsyncCallbacks();
+
+    // Dropped: no boundary frame, the transcriber keeps running, no turn.
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(false);
+    expect(transcriber?.stopped).toBe(false);
+    expect(turnCalls).toHaveLength(0);
+
+    // ...and the resumed speech still routes into the same open utterance.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(
+      () => (transcriber?.received.length ?? 0) > receivedBeforeResume,
+      "The resumed speech stopped reaching the transcriber",
+    );
+
+    await session.close("client_end");
+  });
+
+  test("commits the resumed turn on the next turn-end after dropping a stale one", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countFrames(frames, "speech_started") === 2);
+    transcribers[0]?.emit({
+      type: "turn-end",
+      text: "what is the",
+      confidence: 0.9,
+    });
+    await flushAsyncCallbacks();
+    expect(turnCalls).toHaveLength(0);
+
+    // The caller finishes for real: the next silence boundary re-stamps the
+    // cycle, so Flux's turn-end for the resumed speech commits it.
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+    transcribers[0]?.endOfTurn("what is the weather today");
+
+    await waitFor(
+      () => turnCalls.length === 1,
+      "The resumed turn never committed after the stale turn-end was dropped",
+    );
+    expect(turnCalls[0]?.content).toBe("what is the weather today");
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
+
+    await session.close("client_end");
+  });
+
+  test("falls back to the deadline when nothing follows the dropped turn-end", async () => {
+    const { session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.emit({ type: "partial", text: "are you still there" });
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    transcribers[0]?.emit({
+      type: "turn-end",
+      text: "are you still there",
+      confidence: 0.9,
+    });
+    await flushAsyncCallbacks();
+    expect(turnCalls).toHaveLength(0);
+
+    // Flux says nothing more. The next silence boundary re-arms the fail-open
+    // deadline, so the utterance still commits on the silence path instead of
+    // hanging open forever.
+    await waitFor(
+      () => turnCalls.length === 1,
+      "The utterance hung after the stale turn-end was dropped",
+    );
     expect(turnCalls[0]?.content).toBe("are you still there");
     expect(turnCalls[0]?.unifiedVerdict).toBe(true);
 

--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { setConfig } from "../../__tests__/helpers/set-config.js";
 import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
@@ -103,6 +104,9 @@ function createHarness(options: {
   }>;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
   emitMetrics?: boolean;
+  // Holds the STT dial open so a test can drive a whole utterance through the
+  // window between `ready` and the resolved provider.
+  resolveGate?: Promise<unknown>;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -118,6 +122,9 @@ function createHarness(options: {
 
   const transcribers: MockFluxTranscriber[] = [];
   const resolveTranscriber = mock(async () => {
+    if (options.resolveGate) {
+      await options.resolveGate;
+    }
     const transcriber = new MockFluxTranscriber(
       options.providerId ?? "deepgram-flux",
     );
@@ -205,6 +212,16 @@ async function flushAsyncCallbacks(): Promise<void> {
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Holds the STT dial open until the test opens it, so the whole
+// ready-before-resolve window is under the test's control.
+function createDialGate(): { promise: Promise<void>; open: () => void } {
+  let open = (): void => {};
+  const promise = new Promise<void>((resolve) => {
+    open = () => resolve();
+  });
+  return { promise, open };
 }
 
 function countFrames(
@@ -581,4 +598,136 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
       await session.close("client_end");
     });
   }
+});
+
+/**
+ * The window between `ready` and the resolved transcriber. `start()` arms the
+ * utterance in the background so the client's mic acquisition overlaps the STT
+ * handshake, which means a fast caller can speak AND fall silent before the
+ * dial answers. These tests seed `services.stt.provider` for real, because the
+ * latch is armed from the configured provider before the dial and reconciled
+ * with the resolved one after it.
+ */
+describe("LiveVoiceSession Flux end-of-turn during the STT dial", () => {
+  beforeEach(() => {
+    setConfig("services", {
+      stt: { provider: "deepgram-flux", providers: {} },
+    });
+  });
+
+  afterEach(() => {
+    setConfig("services", { stt: { provider: "deepgram", providers: {} } });
+  });
+
+  test("waits for turn-end when the boundary lands before the dial resolves", async () => {
+    const gate = createDialGate();
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      resolveGate: gate.promise,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    expect(transcribers).toHaveLength(0);
+
+    // The caller speaks and falls silent entirely inside the handshake
+    // window, so the whole first turn is decided before any provider answers.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+
+    // The silence boundary passed and committed nothing: the latch was seeded
+    // from the configured provider, so Flux owns this boundary like any other.
+    expect(transcribers).toHaveLength(0);
+    expect(countFrames(frames, "utterance_end")).toBe(0);
+    expect(turnCalls).toHaveLength(0);
+
+    gate.open();
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("what is the weather");
+
+    await waitFor(
+      () => turnCalls.length === 1,
+      "The first utterance never committed on the Flux end-of-turn",
+    );
+    // Committed by Flux, not by the silence path: non-speculative dispatch.
+    expect(turnCalls[0]?.content).toBe("what is the weather");
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
+    expect(countFrames(frames, "utterance_end")).toBe(1);
+
+    await session.close("client_end");
+  });
+
+  test("unwinds the seeded latch when the dial resolves to another provider", async () => {
+    const gate = createDialGate();
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      // Config names Flux, so the latch is seeded, but the dial answers with
+      // another provider: a fallback, or a resolver reading a config the
+      // session no longer matches. That provider never sends an end-of-turn.
+      providerId: "deepgram",
+      // Far enough out that the fail-open deadline alone cannot be what
+      // releases this utterance inside the test's budget.
+      fluxConfig: { turnEnd: { enabled: true }, eotTimeoutMs: 30_000 },
+      silenceThresholdMs: 40,
+      resolveGate: gate.promise,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+    // Deferred under the seeded latch, exactly as a real Flux session would.
+    expect(countFrames(frames, "utterance_end")).toBe(0);
+
+    gate.open();
+    await waitFor(() => transcribers.length > 0);
+
+    // The deferred boundary is replayed as soon as the dial disproves the
+    // seed, instead of being stranded on a deadline 30 s away.
+    await waitFor(
+      () => countFrames(frames, "utterance_end") === 1,
+      "The utterance deferred under the seeded latch never released",
+    );
+    await waitFor(
+      () => transcribers[0]?.stopped === true,
+      "The utterance never finished releasing",
+    );
+    // ...and nothing routed through the Flux commit path.
+    expect(turnCalls.every((call) => call.unifiedVerdict !== undefined)).toBe(
+      true,
+    );
+
+    await session.close("client_end");
+  });
+
+  test("never seeds the latch when the flag is off", async () => {
+    const gate = createDialGate();
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      // No fluxConfig: `turnEnd.enabled` keeps its schema default of false
+      // while config still names deepgram-flux as the provider.
+      silenceThresholdMs: 40,
+      resolveGate: gate.promise,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // Unchanged from today: the silence boundary releases during the dial.
+    await waitFor(
+      () => countFrames(frames, "utterance_end") === 1,
+      "The flag-off silence boundary stopped releasing during the dial",
+    );
+    expect(turnCalls).toHaveLength(0);
+
+    gate.open();
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.endOfTurn("hello there");
+    await flushAsyncCallbacks();
+
+    // The turn-end commits nothing on top of the boundary that already ran.
+    expect(countFrames(frames, "utterance_end")).toBe(1);
+
+    await session.close("client_end");
+  });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1418,11 +1418,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     try {
-      // One language snapshot serves both the dial and the re-arm
-      // comparison: passing it to the resolver keeps the stream's actual
-      // language and the recorded sharedTranscriberLanguage identical even
-      // when config changes while the resolver awaits credentials.
-      const sttLanguage = getConfig().services.stt.language;
+      // One config snapshot serves the dial, the re-arm comparison and the
+      // latch seed below: passing the language to the resolver keeps the
+      // stream's actual language and the recorded sharedTranscriberLanguage
+      // identical even when config changes while the resolver awaits
+      // credentials.
+      const stt = getConfig().services.stt;
+      const sttLanguage = stt.language;
+      // Seed the latch from the CONFIGURED provider before the dial, not
+      // only from the resolved one after it. `start()` sends `ready` without
+      // waiting on this resolve, so the caller can speak and close an entire
+      // silence boundary while the provider handshake is still in flight. A
+      // latch still on its default `false` at that boundary hands the first
+      // turn of the session to the old silence path and then ignores the
+      // Flux end-of-turn that follows, which is invisible from the outside:
+      // the session looks like a Flux session while its opening turn is not
+      // one. The resolved provider reconciles this guess below.
+      this.setFluxTurnEndActive(
+        this.fluxConfig.turnEnd.enabled &&
+          stt.provider === "deepgram-flux" &&
+          this.turnDetector !== null,
+      );
       const transcriber = await this.resolveTranscriber({
         sampleRate: this.context.startFrame.audio.sampleRate,
         ...(sttLanguage ? { language: sttLanguage } : {}),
@@ -1434,6 +1450,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       if (!transcriber) {
+        // No stream answered, so no end-of-turn ever will: the guess above
+        // must not outlive the dial that disproved it.
+        this.setFluxTurnEndActive(false);
         return {
           status: "unavailable",
           message: unavailableTranscriberMessage(),
@@ -1441,12 +1460,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       utterance.transcriber = transcriber;
-      // The resolver reads the provider from config, which cannot change
-      // under a live session, so every arm computes the same latch.
-      this.fluxTurnEndActive =
+      // Reconcile the pre-dial guess with the provider that actually
+      // answered. The resolver reads the provider from config, which cannot
+      // change under a live session, so this normally confirms the guess; it
+      // clears it when the dial fell back to another provider or resolved
+      // one the config did not name.
+      this.setFluxTurnEndActive(
         this.fluxConfig.turnEnd.enabled &&
-        transcriber.providerId === "deepgram-flux" &&
-        this.turnDetector !== null;
+          transcriber.providerId === "deepgram-flux" &&
+          this.turnDetector !== null,
+      );
       if (
         this.turnDetector &&
         typeof transcriber.finalizeUtterance === "function"
@@ -1480,6 +1503,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (this.isUtteranceStale(utterance)) {
         return { status: "stale" };
       }
+      // The dial threw, so the pre-dial guess is disproved the same way the
+      // unavailable case disproves it: nothing will send an end-of-turn.
+      this.setFluxTurnEndActive(false);
       return {
         status: "error",
         message: `Live voice transcription could not be started: ${errorMessage(
@@ -2843,11 +2869,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // own turn after `eotTimeoutMs` of silence, so once that budget plus a
   // margin has passed since the caller stopped speaking, no end-of-turn is
   // coming and the utterance replays this boundary on the silence path.
-  private armFluxTurnEndFallbackTimer(utterance: UtteranceCycle): void {
+  // `waitMsOverride` collapses that wait when the caller already knows no
+  // end-of-turn is coming (see setFluxTurnEndActive).
+  private armFluxTurnEndFallbackTimer(
+    utterance: UtteranceCycle,
+    waitMsOverride?: number,
+  ): void {
     this.clearFluxTurnEndTimer();
     const budgetMs =
       this.fluxConfig.eotTimeoutMs + FLUX_TURN_END_FALLBACK_MARGIN_MS;
-    const waitMs = Math.max(0, budgetMs - this.msSinceLocalSpeechStop());
+    const waitMs =
+      waitMsOverride ?? Math.max(0, budgetMs - this.msSinceLocalSpeechStop());
     this.fluxTurnEndTimer = setTimeout(() => {
       this.fluxTurnEndTimer = null;
       if (
@@ -2863,11 +2895,47 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       utterance.fluxTurnEndTimedOut = true;
       log.warn(
-        { budgetMs },
-        "Flux end-of-turn did not arrive; falling back to the silence boundary for this utterance",
+        { budgetMs, waitMs },
+        "No Flux end-of-turn is coming; falling back to the silence boundary for this utterance",
       );
       this.handleVadUtteranceEnd("silence");
     }, waitMs);
+  }
+
+  /**
+   * Flips the Flux end-of-turn latch, unwinding an optimistic arm.
+   *
+   * `beginUtterance` arms the latch from the configured provider before the
+   * dial resolves, so a silence boundary can already have deferred to Flux by
+   * the time the resolved provider says otherwise. That deferred boundary is
+   * parked on the fail-open deadline, a whole Flux end-of-turn budget away,
+   * waiting for an event that will now never arrive. Collapse the wait to
+   * zero rather than burn the budget: the deadline body re-checks the cycle
+   * and replays the silence boundary, which with the latch down takes the
+   * ordinary hold path. Replaying through the deadline instead of calling
+   * `handleVadUtteranceEnd` directly keeps the release off the arming
+   * caller's stack, which is still mid-dial.
+   *
+   * A cleared latch with no deadline armed needs no unwind: either no
+   * boundary ever deferred, or the caller resumed speaking and
+   * `handleVadSpeechStart` already dropped the deadline, leaving the detector
+   * owning the next boundary. The cycle's `fluxBoundaryGeneration` stamp is
+   * left as it is: `isStaleFluxTurnEnd` is only ever consulted from
+   * `handleFluxTurnEnd`, which returns immediately once the latch is down.
+   */
+  private setFluxTurnEndActive(active: boolean): void {
+    if (active === this.fluxTurnEndActive) {
+      return;
+    }
+    this.fluxTurnEndActive = active;
+    if (active || this.fluxTurnEndTimer === null) {
+      return;
+    }
+    const utterance = this.currentUtterance;
+    this.clearFluxTurnEndTimer();
+    if (utterance && !utterance.released && !utterance.completed) {
+      this.armFluxTurnEndFallbackTimer(utterance, 0);
+    }
   }
 
   /**

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -32,6 +32,8 @@ import {
 } from "../calls/voice-triage-escalate.js";
 import { getConfig } from "../config/loader.js";
 import {
+  type LiveVoiceFluxConfig,
+  LiveVoiceFluxConfigSchema,
   type LiveVoiceFrontModelConfig,
   LiveVoiceFrontModelConfigSchema,
 } from "../config/schemas/live-voice.js";
@@ -88,6 +90,7 @@ import {
   type LiveVoiceSpokenAckKind,
   type LiveVoiceTurnSeedMarks,
   type VoiceEndpointAction,
+  type VoiceEndpointSource,
 } from "./live-voice-metrics.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
@@ -135,6 +138,14 @@ const FINALIZE_GRACE_MS = 1_000;
 // cancellation cannot kill a reply mid-sentence. Mirrors the
 // liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
 // instant barge-in.
+//
+// Local energy detection owns barge-in in every mode, including when a
+// turn-detecting provider owns the turn boundary: an interrupt during TTS has
+// to feel instant, and no provider roundtrip beats a local gate on the audio
+// already in hand. The echo-adaptive part of this guard also has to stay
+// upstream of the provider, which hears only the microphone: it cannot tell
+// our own TTS bleeding through imperfect echo cancellation from the caller,
+// and would report a user turn nobody took.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // Mirrors MediaTurnDetector's DEFAULT_SILENCE_THRESHOLD_MS: the session
 // tracks the effective trailing-silence threshold (the detector keeps its own
@@ -158,6 +169,12 @@ const BARGE_IN_GAP_TOLERANCE_MS = 200;
 // (1 / (1 + ratio) ≈ 20%): once the run is mostly silence it resets, so genuine
 // choppy speech still lands but periodic noise cannot accumulate into one.
 const BARGE_IN_MAX_TOLERATED_SILENCE_RATIO = 4;
+// Slack added to `liveVoice.flux.eotTimeoutMs` before the session stops
+// waiting for an end-of-turn event that is not coming and falls the utterance
+// back onto the silence-boundary path. Flux force-ends its own turn at
+// `eotTimeoutMs` of silence, so anything past that plus a frame's network and
+// parse hop means the stream is gone, not slow.
+const FLUX_TURN_END_FALLBACK_MARGIN_MS = 1_000;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -279,6 +296,12 @@ export interface LiveVoiceSessionOptions {
    */
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
   /**
+   * Deepgram Flux turn-detection tuning. The production factory seeds this
+   * from `liveVoice.flux` config when unset; absent fields fall back to the
+   * schema defaults, which leave `turnEnd.enabled` false.
+   */
+  fluxConfig?: Partial<LiveVoiceFluxConfig>;
+  /**
    * Front-model phrasing service: spoken acks and progress narration. The
    * production factory constructs it from `liveVoice.frontModel` config when
    * unset; `null` disables front-model LLM calls, so no ack is ever spoken
@@ -362,6 +385,10 @@ interface UtteranceCycle {
   // Consecutive semantic-endpointing "hold" extensions this utterance has
   // consumed, bounded by `endpointMaxExtensions`.
   endpointExtensionCount: number;
+  // The provider's end-of-turn never arrived for this cycle, so it fell back
+  // to the silence-boundary path and stays there: a late event must not
+  // commit a boundary the fallback already owns.
+  fluxTurnEndTimedOut: boolean;
   // The transcript the most recent hold verdict judged (unified front-door).
   // A final segment arriving during the extension window that extends this
   // text replays the boundary immediately — the hold was judged on stale
@@ -822,6 +849,7 @@ function createUtteranceCycle(): UtteranceCycle {
     finalTranscriptSegments: [],
     latestPartialText: null,
     endpointExtensionCount: 0,
+    fluxTurnEndTimedOut: false,
     heldSpeculativeContent: null,
     turnId: null,
     userMessageId: null,
@@ -1102,6 +1130,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // option once, so every field carries its `liveVoice.frontModel` schema
   // default when unset.
   private readonly frontModelConfig: LiveVoiceFrontModelConfig;
+  // Complete Flux tunables (the constructor schema-parses the partial option
+  // once, so every field carries its `liveVoice.flux` schema default).
+  private readonly fluxConfig: LiveVoiceFluxConfig;
+  /**
+   * Per-session latch: the provider's committed end-of-turn owns the turn
+   * boundary instead of the silence boundary's front-door hold verdict. Set
+   * when the config flag is on AND the resolved streaming provider is
+   * `deepgram-flux` AND the session runs server VAD. Push-to-talk is excluded
+   * deliberately: there the client's release IS the boundary, and answering
+   * while the caller still holds the button is not turn detection, it is a
+   * bug. False leaves every other code path exactly as it is with no Flux in
+   * the picture.
+   */
+  private fluxTurnEndActive = false;
+  // Wall-clock of the newest above-gate audio chunk, tracked only while the
+  // latch is active. It is the local VAD's speech-stop mark: the anchor for
+  // the end-of-turn latency this path reports, and for the fallback deadline.
+  private fluxLastSpeechAtMs: number | null = null;
+  // Fail-open deadline for a Flux end-of-turn that never arrives. On expiry
+  // the utterance falls back to the silence-boundary path, so a dead Flux
+  // stream degrades to today's behavior instead of a hung turn.
+  private fluxTurnEndTimer: ReturnType<typeof setTimeout> | null = null;
   // Effective trailing-silence threshold, mirroring the detector's private
   // copy (constructor seed + update_config), reported to the endpoint decider.
   private silenceThresholdMs: number;
@@ -1169,6 +1219,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.frontModelConfig = LiveVoiceFrontModelConfigSchema.parse(
       options.frontModelConfig ?? {},
     );
+    this.fluxConfig = LiveVoiceFluxConfigSchema.parse(options.fluxConfig ?? {});
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
       ...(context.startFrame.silenceThresholdMs !== undefined
@@ -1309,6 +1360,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.liveActivityReporter.end();
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
+    this.clearFluxTurnEndTimer();
     // There is no longer anyone on the call to speak to, so a queued
     // announcement cannot be spoken — but the answer behind it is finished
     // work the user asked for, so it takes the same conversation route a
@@ -1382,6 +1434,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       utterance.transcriber = transcriber;
+      // The resolver reads the provider from config, which cannot change
+      // under a live session, so every arm computes the same latch.
+      this.fluxTurnEndActive =
+        this.fluxConfig.turnEnd.enabled &&
+        transcriber.providerId === "deepgram-flux" &&
+        this.turnDetector !== null;
       if (
         this.turnDetector &&
         typeof transcriber.finalizeUtterance === "function"
@@ -1542,6 +1600,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     this.state = "failed";
     this.clearEndpointExtensionTimer();
+    this.clearFluxTurnEndTimer();
     await this.sendFrame({
       type: "error",
       code:
@@ -1608,6 +1667,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
+    if (this.fluxTurnEndActive && hasSpeech) {
+      this.fluxLastSpeechAtMs = Date.now();
+    }
 
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
@@ -1814,6 +1876,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // utterance keeps accumulating and the detector fires a fresh turn-end.
     this.vadSpeechGeneration += 1;
     this.clearEndpointExtensionTimer();
+    // ...and so is a fallback deadline armed for the boundary the caller just
+    // spoke through. The next silence boundary arms a fresh one.
+    this.clearFluxTurnEndTimer();
 
     // Speech resumed while a speculative leg was awaiting its verdict: the
     // pause was mid-thought after all. Discard silently (no frames were ever
@@ -2700,8 +2765,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.pendingBargeIn = null;
       if (reason === "max-duration") {
         // A max-duration boundary always releases: drop any pending hold
-        // replay so it cannot re-fire a boundary this one already owns.
+        // replay (or Flux fallback deadline) so it cannot re-fire a boundary
+        // this one already owns.
         this.clearEndpointExtensionTimer();
+        this.clearFluxTurnEndTimer();
       }
       const utterance = this.currentUtterance;
       if (!utterance || utterance.released || utterance.completed) {
@@ -2723,6 +2790,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // release (ptt_release forced the boundary) is the user saying "answer
       // now" — never second-guess it.
       if (reason === "silence" && !manualRelease) {
+        // Flux owns this boundary: its end-of-turn commits the utterance, so
+        // the silence timer only arms the fail-open deadline. An utterance
+        // whose deadline already elapsed falls through to the hold path
+        // below, which is the whole point of the fallback.
+        if (this.fluxTurnEndActive && !utterance.fluxTurnEndTimedOut) {
+          this.armFluxTurnEndFallbackTimer(utterance);
+          return;
+        }
         if (await this.launchSpeculativeAssistantTurn(utterance)) {
           return;
         }
@@ -2751,6 +2826,94 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       this.handleVadUtteranceEnd("silence");
     }, this.frontModelConfig.endpointExtensionMs);
+  }
+
+  // Arms the fail-open deadline for a Flux end-of-turn. Flux force-ends its
+  // own turn after `eotTimeoutMs` of silence, so once that budget plus a
+  // margin has passed since the caller stopped speaking, no end-of-turn is
+  // coming and the utterance replays this boundary on the silence path.
+  private armFluxTurnEndFallbackTimer(utterance: UtteranceCycle): void {
+    this.clearFluxTurnEndTimer();
+    const budgetMs =
+      this.fluxConfig.eotTimeoutMs + FLUX_TURN_END_FALLBACK_MARGIN_MS;
+    const waitMs = Math.max(0, budgetMs - this.msSinceLocalSpeechStop());
+    this.fluxTurnEndTimer = setTimeout(() => {
+      this.fluxTurnEndTimer = null;
+      if (
+        this.currentUtterance !== utterance ||
+        utterance.released ||
+        utterance.completed ||
+        utterance.assistantTurnStarted ||
+        // Speech resumed (the detector owns the next boundary). Onset also
+        // clears this timer, so this is a belt to that suspender.
+        this.turnDetector?.isActive
+      ) {
+        return;
+      }
+      utterance.fluxTurnEndTimedOut = true;
+      log.warn(
+        { budgetMs },
+        "Flux end-of-turn did not arrive; falling back to the silence boundary for this utterance",
+      );
+      this.handleVadUtteranceEnd("silence");
+    }, waitMs);
+  }
+
+  private clearFluxTurnEndTimer(): void {
+    if (this.fluxTurnEndTimer !== null) {
+      clearTimeout(this.fluxTurnEndTimer);
+      this.fluxTurnEndTimer = null;
+    }
+  }
+
+  // Time since the local VAD last heard above-gate audio: the speech-stop
+  // mark both the fallback deadline and the reported end-of-turn latency are
+  // measured from. Zero when no speech has been heard at all.
+  private msSinceLocalSpeechStop(): number {
+    if (this.fluxLastSpeechAtMs === null) {
+      return 0;
+    }
+    return Math.max(0, Date.now() - this.fluxLastSpeechAtMs);
+  }
+
+  /**
+   * Flux committed an end of turn: the caller has finished, so the utterance
+   * commits now instead of waiting out the trailing-silence timer and asking
+   * the front door whether the pause was mid-thought. This runs the ordinary
+   * post-release path (utterance_end, then release), so the front-door leg it
+   * dispatches is non-speculative: `speculativeHoldAllowed` is false, its
+   * decision rule is built with `includeHold: false`, and the model is told
+   * the caller has finished. The escalate verdict and the spoken ack /
+   * progress phrasing are untouched; only the hold verdict is bypassed.
+   */
+  private async handleFluxTurnEnd(utterance: UtteranceCycle): Promise<void> {
+    if (
+      !this.fluxTurnEndActive ||
+      this.currentUtterance !== utterance ||
+      utterance.released ||
+      utterance.completed ||
+      utterance.assistantTurnStarted ||
+      // The fallback already took this utterance back to the silence path.
+      utterance.fluxTurnEndTimedOut
+    ) {
+      return;
+    }
+    this.clearFluxTurnEndTimer();
+    this.markEndpointDecision(
+      utterance,
+      "release",
+      this.msSinceLocalSpeechStop(),
+      "flux",
+    );
+    await this.sendFrame({ type: "utterance_end", reason: "silence" });
+    await this.releaseUtterance();
+    // Leave the local detector idle, which is where every other commit path
+    // leaves it. Flux can close a turn while the trailing-silence countdown
+    // is still running, and barge-in fires from the detector's next speech
+    // ONSET: a detector left mid-turn reports no onset, so the caller could
+    // not interrupt the reply they just triggered. The forced boundary
+    // reaches an already-released utterance and returns.
+    this.turnDetector?.forceEnd();
   }
 
   /**
@@ -2964,6 +3127,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       !utterance.completed
     ) {
       this.clearEndpointExtensionTimer();
+      this.clearFluxTurnEndTimer();
       await this.sendFrame({ type: "utterance_end", reason: "silence" });
     }
     await this.releaseUtterance();
@@ -3162,12 +3326,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // completion signal has no cycle to advance here.
         return;
       case "turn-start":
+        // Deliberately a no-op: local VAD still owns barge-in, because a
+        // provider roundtrip cannot beat a local energy gate on an interrupt
+        // during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS).
+        return;
       case "eager-turn-end":
       case "turn-resumed":
+        // Speculative end-of-turn stays off (the config leaves
+        // `eagerEotThreshold` unset, so Deepgram never emits these). Wiring
+        // them onto the speculative dispatch machinery is a deferred
+        // follow-up.
+        return;
       case "turn-end":
-        // The silence boundary owns turn commits. Listed case-by-case
-        // rather than under `default` so the exhaustiveness check flags
-        // this site when turn detection is wired in.
+        await this.handleFluxTurnEnd(utterance);
         return;
       case "error":
         await this.sendTranscriberErrorFrame(event);
@@ -3293,13 +3464,26 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "turn-start":
+        // Deliberately a no-op: local VAD still owns barge-in, because a
+        // provider roundtrip cannot beat a local energy gate on an interrupt
+        // during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS).
+        return;
       case "eager-turn-end":
       case "turn-resumed":
-      case "turn-end":
-        // The silence boundary owns turn commits. Listed case-by-case
-        // rather than under `default` so the exhaustiveness check flags
-        // this site when turn detection is wired in.
+        // Speculative end-of-turn stays off (the config leaves
+        // `eagerEotThreshold` unset, so Deepgram never emits these). Wiring
+        // them onto the speculative dispatch machinery is a deferred
+        // follow-up.
         return;
+      case "turn-end": {
+        // Same routing as transcript events: the cycle awaiting its
+        // transcript owns the turn the provider just closed.
+        const target = this.pendingTranscriptCycle();
+        if (target) {
+          await this.handleFluxTurnEnd(target);
+        }
+        return;
+      }
       case "error":
         await this.sendTranscriberErrorFrame(event);
         return;
@@ -3419,8 +3603,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.assistantPlaybackTailUntilMs = 0;
     this.takeVadPreRoll();
     this.vadPendingTurnEnd = null;
-    // ...and abandons any semantic-endpointing hold still awaiting replay.
+    // ...and abandons any semantic-endpointing hold still awaiting replay,
+    // along with any Flux end-of-turn the session was still waiting on.
     this.clearEndpointExtensionTimer();
+    this.clearFluxTurnEndTimer();
     // A client interrupt is a hard reset: any barge-in merge context waiting for
     // the next turn is now stale (the interrupted utterance may be discarded
     // without ever reaching finalizePendingUtterance).
@@ -5243,12 +5429,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     action: VoiceEndpointAction,
     latencyMs: number,
+    // Absent means the front door decided, which is what the collector
+    // defaults to; the Flux path names itself so one metrics frame can
+    // compare the two.
+    source?: VoiceEndpointSource,
   ): void {
     const turnId = this.ensureTurnId(utterance);
     if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
       return;
     }
-    this.metrics.markEndpointDecision(turnId, { action, latencyMs });
+    this.metrics.markEndpointDecision(turnId, {
+      action,
+      latencyMs,
+      ...(source ? { source } : {}),
+    });
   }
 
   private markAckSpoken(
@@ -5642,6 +5836,9 @@ export function createLiveVoiceSession(
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
     frontModelConfig,
+    // Absent config leaves the schema defaults, which keep Flux turn
+    // detection off.
+    fluxConfig: options.fluxConfig ?? liveVoiceConfig?.flux,
     // Eager construction is safe even when the `liveVoice.frontModel` config
     // namespace is absent — schema defaults fill the tunables. An explicit
     // option (incl. `null`) always wins — the test seam.

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -389,6 +389,12 @@ interface UtteranceCycle {
   // to the silence-boundary path and stays there: a late event must not
   // commit a boundary the fallback already owns.
   fluxTurnEndTimedOut: boolean;
+  // `vadSpeechGeneration` as of the local silence boundary that handed this
+  // cycle to Flux, or null while no boundary has fired yet (Flux routinely
+  // beats the trailing-silence countdown, and that fast commit is the point).
+  // A provider end-of-turn arriving with a newer generation describes speech
+  // the caller has already spoken past (see isStaleFluxTurnEnd).
+  fluxBoundaryGeneration: number | null;
   // The transcript the most recent hold verdict judged (unified front-door).
   // A final segment arriving during the extension window that extends this
   // text replays the boundary immediately — the hold was judged on stale
@@ -850,6 +856,7 @@ function createUtteranceCycle(): UtteranceCycle {
     latestPartialText: null,
     endpointExtensionCount: 0,
     fluxTurnEndTimedOut: false,
+    fluxBoundaryGeneration: null,
     heldSpeculativeContent: null,
     turnId: null,
     userMessageId: null,
@@ -2795,6 +2802,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // whose deadline already elapsed falls through to the hold path
         // below, which is the whole point of the fallback.
         if (this.fluxTurnEndActive && !utterance.fluxTurnEndTimedOut) {
+          // Stamp the speech run this boundary closed. handleVadSpeechStart
+          // bumps the generation when the caller resumes, so a turn-end that
+          // was already in flight is recognisably stale (isStaleFluxTurnEnd).
+          utterance.fluxBoundaryGeneration = this.vadSpeechGeneration;
           this.armFluxTurnEndFallbackTimer(utterance);
           return;
         }
@@ -2859,6 +2870,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }, waitMs);
   }
 
+  /**
+   * A provider end-of-turn that lost its race with the caller's next breath.
+   * The local silence boundary stamps the cycle with the speech generation it
+   * closed; `handleVadSpeechStart` bumps that generation (and clears the
+   * fail-open deadline) the moment the caller resumes. A turn-end arriving
+   * afterwards therefore describes speech the caller has already spoken past:
+   * acting on it would send utterance_end and stop the transcriber while local
+   * VAD is still routing the resumed speech into this same cycle, cutting off
+   * the next words or folding them into the wrong turn. This is the same
+   * active-detector / generation staleness test the silence fallback and the
+   * speculative hold paths already apply. Before any boundary has fired the
+   * stamp is null and nothing is stale: Flux routinely closes a turn while the
+   * trailing-silence countdown is still running, and that fast commit is the
+   * whole feature.
+   */
+  private isStaleFluxTurnEnd(utterance: UtteranceCycle): boolean {
+    return (
+      utterance.fluxBoundaryGeneration !== null &&
+      utterance.fluxBoundaryGeneration !== this.vadSpeechGeneration
+    );
+  }
+
   private clearFluxTurnEndTimer(): void {
     if (this.fluxTurnEndTimer !== null) {
       clearTimeout(this.fluxTurnEndTimer);
@@ -2896,6 +2929,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // The fallback already took this utterance back to the silence path.
       utterance.fluxTurnEndTimedOut
     ) {
+      return;
+    }
+    if (this.isStaleFluxTurnEnd(utterance)) {
+      log.debug(
+        {
+          boundaryGeneration: utterance.fluxBoundaryGeneration,
+          speechGeneration: this.vadSpeechGeneration,
+        },
+        "Dropping a stale Flux end-of-turn: the caller resumed speaking past the boundary it closed",
+      );
+      // The cycle stays open and local VAD keeps routing the resumed speech
+      // into it. The detector's next silence boundary re-stamps the
+      // generation and re-arms the fail-open deadline, so the turn still
+      // commits: on the end-of-turn for the resumed speech, or on that
+      // deadline. Re-arm here only if the detector has somehow already gone
+      // idle, so the deadline handleVadSpeechStart cleared can never strand
+      // the cycle with nothing left to close it.
+      if (this.turnDetector?.isActive !== true) {
+        utterance.fluxBoundaryGeneration = this.vadSpeechGeneration;
+        this.armFluxTurnEndFallbackTimer(utterance);
+      }
       return;
     }
     this.clearFluxTurnEndTimer();

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -326,6 +326,12 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly endpointHoldCount?: number;
   /** Worst endpoint-decision latency observed during the turn. */
   readonly endpointDecisionMaxLatencyMs?: number;
+  /**
+   * Which path decided the turn's endpoint: the front-door hold verdict or
+   * the STT provider's model-integrated end-of-turn. Present under the same
+   * condition as the two fields above.
+   */
+  readonly endpointDecisionSource?: "front-door" | "flux";
   /** Which floor-holding ack actually spoke during the turn, if any. */
   readonly ackSpoken?: "first_delta" | "tool_use";
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -298,6 +298,12 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly endpointHoldCount?: number;
   /** Worst endpoint-decision latency observed during the turn. */
   readonly endpointDecisionMaxLatencyMs?: number;
+  /**
+   * Which path decided the turn's endpoint: the front-door hold verdict or
+   * the STT provider's model-integrated end-of-turn. Present under the same
+   * condition as the two fields above.
+   */
+  readonly endpointDecisionSource?: "front-door" | "flux";
   /** Which floor-holding ack actually spoke during the turn, if any. */
   readonly ackSpoken?: "first_delta" | "tool_use";
   /**


### PR DESCRIPTION
## Summary

- Live voice commits the turn on Deepgram Flux's committed end-of-turn instead of the front-door [0] hold verdict, behind `liveVoice.flux.turnEnd.enabled` (default off) and only when the resolved streaming provider is `deepgram-flux`. The commit runs the ordinary post-release path, so the front-door leg is non-speculative: escalate and ack/progress phrasing still work, only the hold branch is bypassed.
- Local VAD keeps the barge-in trigger in both modes, the echo-adaptive gate stays upstream of Flux, and the hold machinery is left fully in place: it is both the flag-off path and the fail-open fallback when no end-of-turn arrives within `eotTimeoutMs` plus a margin.
- Declares `endpointDecisionSource` on `LiveVoiceMetricsServerFrame` in the daemon protocol and its web mirror, so the value the metrics collector already emits is typed at the client.

Part of plan: flux-turn-detection.md (PR 7 of 8)