### PR TITLE
fix(web): stop boot-time reachability confirmation from bouncing the SSE stream

### DIFF
--- a/clients/web/docs/EVENT_BUS.md
+++ b/clients/web/docs/EVENT_BUS.md
@@ -68,7 +68,7 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 | `app.hidden` | `{ signal: "visibility" \| "app_state" }` | Page hidden or app backgrounded. |
 | `app.online` | `{}` | `window.online` fired. Always accompanies a paired `app.resume{signal:"online"}`. |
 | `app.offline` | `{}` | `window.offline` fired. |
-| `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded on recovery into `"ready"` from `"connecting"` / `"checking"`; the bus bounces its SSE. A `"ready"` entered from any other phase (boot, remount) confirms an already-healthy stream and does not publish. |
+| `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded on recovery into `"ready"` from a degraded phase (`"connecting"`, `"checking"`, or `"failed"`); the bus bounces its SSE. A `"ready"` entered from `"idle"` or `"ready"` confirms an already-healthy stream (boot, remount) and does not publish. |
 | `power.suspend` | `{}` | Electron host: `powerMonitor` `suspend` — system going to sleep. Bus tears down its SSE so the daemon sees a clean disconnect. Off Electron (web / iOS) never fires. |
 | `power.resume` | `{}` | Electron host: `powerMonitor` `resume` — system woke. Bus bounces (teardown + reopen) its SSE regardless of `current` state — the renderer may have stayed visible during sleep (tray-resident / full-screen) so the socket may be half-dead. Off Electron never fires. |
 | `power.lock` | `{}` | Electron host: screen locked. No bus-owned action today. Off Electron never fires. |

--- a/clients/web/docs/EVENT_BUS.md
+++ b/clients/web/docs/EVENT_BUS.md
@@ -68,7 +68,7 @@ Every event name in `BusEventMap` has a typed payload. Producers:
 | `app.hidden` | `{ signal: "visibility" \| "app_state" }` | Page hidden or app backgrounded. |
 | `app.online` | `{}` | `window.online` fired. Always accompanies a paired `app.resume{signal:"online"}`. |
 | `app.offline` | `{}` | `window.offline` fired. |
-| `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded; the bus bounces its SSE. |
+| `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded on recovery into `"ready"` from `"connecting"` / `"checking"`; the bus bounces its SSE. A `"ready"` entered from any other phase (boot, remount) confirms an already-healthy stream and does not publish. |
 | `power.suspend` | `{}` | Electron host: `powerMonitor` `suspend` — system going to sleep. Bus tears down its SSE so the daemon sees a clean disconnect. Off Electron (web / iOS) never fires. |
 | `power.resume` | `{}` | Electron host: `powerMonitor` `resume` — system woke. Bus bounces (teardown + reopen) its SSE regardless of `current` state — the renderer may have stayed visible during sleep (tray-resident / full-screen) so the socket may be half-dead. Off Electron never fires. |
 | `power.lock` | `{}` | Electron host: screen locked. No bus-owned action today. Off Electron never fires. |

--- a/clients/web/src/domains/chat/hooks/use-event-stream-reachability-gate.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-event-stream-reachability-gate.test.tsx
@@ -85,13 +85,13 @@ describe("useEventStream reachability retry gate", () => {
     expect(retries).toHaveBeenCalledTimes(1);
   });
 
-  test("failed to ready requests no retry (the user retry re-enters via connecting)", () => {
+  test("a late healthy probe that lands on failed requests a retry", () => {
     const retries = trackRetryRequests();
     const { rerender } = renderEventStream({ reachabilityPhase: "failed" });
 
     rerender({ phase: "ready" });
 
-    expect(retries).not.toHaveBeenCalled();
+    expect(retries).toHaveBeenCalledTimes(1);
   });
 
   test("the 3-per-window budget still exhausts across repeated recoveries", () => {

--- a/clients/web/src/domains/chat/hooks/use-event-stream-reachability-gate.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-event-stream-reachability-gate.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { __resetForTesting, subscribe } from "@/lib/event-bus";
+
+import { useEventStream } from "@/domains/chat/hooks/use-event-stream";
+
+function renderEventStream(params: {
+  reachabilityPhase: string;
+  reachabilityReset?: () => void;
+}) {
+  return renderHook(
+    ({ phase }: { phase: string }) => {
+      useEventStream({
+        assistantStateKind: "active",
+        assistantId: "asst-1",
+        activeConversationId: "conv-A",
+        conversationExistsOnServer: true,
+        handleStreamEvent: () => {},
+        reconcileActiveConversation: async () =>
+          ({
+            changed: false,
+            messagesAdded: 0,
+            assistantProgress: false,
+          }) as never,
+        startReconciliationLoop: () => {},
+        cancelReconciliation: () => {},
+        reachabilityProbe: () => {},
+        reachabilityPhase: phase,
+        reachabilityReset: params.reachabilityReset ?? (() => {}),
+      });
+    },
+    { initialProps: { phase: params.reachabilityPhase } },
+  );
+}
+
+function trackRetryRequests(): ReturnType<typeof mock> {
+  const handler = mock(() => {});
+  subscribe("reachability.retry-requested", handler);
+  return handler;
+}
+
+beforeEach(() => {
+  __resetForTesting();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useEventStream reachability retry gate", () => {
+  test("a boot that goes idle to ready requests no retry", () => {
+    const retries = trackRetryRequests();
+    const { rerender } = renderEventStream({ reachabilityPhase: "idle" });
+
+    rerender({ phase: "ready" });
+
+    expect(retries).not.toHaveBeenCalled();
+  });
+
+  test("a mount that already observes ready requests no retry", () => {
+    const retries = trackRetryRequests();
+    renderEventStream({ reachabilityPhase: "ready" });
+
+    expect(retries).not.toHaveBeenCalled();
+  });
+
+  test("a drop and recovery through connecting requests exactly one retry", () => {
+    const retries = trackRetryRequests();
+    const { rerender } = renderEventStream({ reachabilityPhase: "ready" });
+
+    rerender({ phase: "connecting" });
+    rerender({ phase: "ready" });
+
+    expect(retries).toHaveBeenCalledTimes(1);
+  });
+
+  test("a recovery through checking requests a retry", () => {
+    const retries = trackRetryRequests();
+    const { rerender } = renderEventStream({ reachabilityPhase: "checking" });
+
+    rerender({ phase: "ready" });
+
+    expect(retries).toHaveBeenCalledTimes(1);
+  });
+
+  test("failed to ready requests no retry (the user retry re-enters via connecting)", () => {
+    const retries = trackRetryRequests();
+    const { rerender } = renderEventStream({ reachabilityPhase: "failed" });
+
+    rerender({ phase: "ready" });
+
+    expect(retries).not.toHaveBeenCalled();
+  });
+
+  test("the 3-per-window budget still exhausts across repeated recoveries", () => {
+    const retries = trackRetryRequests();
+    const reachabilityReset = mock(() => {});
+    const { rerender } = renderEventStream({
+      reachabilityPhase: "ready",
+      reachabilityReset,
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      rerender({ phase: "connecting" });
+      rerender({ phase: "ready" });
+    }
+
+    expect(retries).toHaveBeenCalledTimes(3);
+    expect(reachabilityReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/clients/web/src/domains/chat/hooks/use-event-stream.ts
@@ -356,22 +356,23 @@ export function useEventStream({
   // success so the bus bounces its SSE; `reconcileOnReopen` runs the
   // post-reconnect reconcile on the resulting `sse.opened`.
   //
-  // Only a `"ready"` reached from `"connecting"` / `"checking"` is a
-  // recovery. A `"ready"` entered from any other phase is a boot or
-  // remount confirmation over an already-healthy stream, and bouncing
-  // it costs a duplicate daemon connect plus the full non-fresh
-  // reconcile fan-out. Every other phase still reaches the limiter so
-  // its budget bookkeeping is unchanged.
+  // A `"ready"` reached from a degraded phase (`"connecting"`,
+  // `"checking"`, `"failed"`) is a recovery and must bounce: the
+  // stream is closed or stale by then. A `"ready"` reached from
+  // `"idle"` or `"ready"` is a boot or remount confirmation over an
+  // already-healthy stream, and bouncing it costs a duplicate daemon
+  // connect plus the full non-fresh reconcile fan-out. Every other
+  // phase still reaches the limiter so its budget bookkeeping is
+  // unchanged.
   // --------------------------------------------------------------------------
   const previousReachabilityPhaseRef = useRef(reachabilityPhase);
   useEffect(() => {
     const previousPhase = previousReachabilityPhaseRef.current;
     previousReachabilityPhaseRef.current = reachabilityPhase;
-    if (
+    const isHealthyStreamConfirmation =
       reachabilityPhase === "ready" &&
-      previousPhase !== "connecting" &&
-      previousPhase !== "checking"
-    ) {
+      (previousPhase === "idle" || previousPhase === "ready");
+    if (isHealthyStreamConfirmation) {
       return;
     }
     burstLimiterRef.current!.handleReachabilityPhase(reachabilityPhase);

--- a/clients/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/clients/web/src/domains/chat/hooks/use-event-stream.ts
@@ -9,9 +9,10 @@
  *    epoch bump, watchdog rescue telemetry).
  * 3. `sse.closed` → end the in-flight turn, kick the reachability
  *    probe so the burst-limiter below can take over.
- * 4. `reachabilityPhase` → `reachabilityBurstLimiter` (3-burst /
- *    10s window retry budget; on success publishes
- *    `reachability.retry-requested` so the bus bounces its SSE).
+ * 4. `reachabilityPhase` → `reachabilityBurstLimiter` on recovery
+ *    into `"ready"` (3-burst / 10s window retry budget; on success
+ *    publishes `reachability.retry-requested` so the bus bounces its
+ *    SSE).
  *
  * Bus subscriptions use `useBusSubscription` per EVENT_BUS.md. The
  * stream-context lifecycle (setup / teardown of the stream-store
@@ -354,8 +355,25 @@ export function useEventStream({
   // phase. The limiter publishes `reachability.retry-requested` on
   // success so the bus bounces its SSE; `reconcileOnReopen` runs the
   // post-reconnect reconcile on the resulting `sse.opened`.
+  //
+  // Only a `"ready"` reached from `"connecting"` / `"checking"` is a
+  // recovery. A `"ready"` entered from any other phase is a boot or
+  // remount confirmation over an already-healthy stream, and bouncing
+  // it costs a duplicate daemon connect plus the full non-fresh
+  // reconcile fan-out. Every other phase still reaches the limiter so
+  // its budget bookkeeping is unchanged.
   // --------------------------------------------------------------------------
+  const previousReachabilityPhaseRef = useRef(reachabilityPhase);
   useEffect(() => {
+    const previousPhase = previousReachabilityPhaseRef.current;
+    previousReachabilityPhaseRef.current = reachabilityPhase;
+    if (
+      reachabilityPhase === "ready" &&
+      previousPhase !== "connecting" &&
+      previousPhase !== "checking"
+    ) {
+      return;
+    }
     burstLimiterRef.current!.handleReachabilityPhase(reachabilityPhase);
   }, [reachabilityPhase]);
 

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -86,9 +86,11 @@ export interface BusEventMap {
   "sse.closed": { reason: string };
   /**
    * Published by `useEventStream`'s reachability-retry burst limiter
-   * after the reachability probe flips back to "ready". Tells the bus
-   * to close + reopen its SSE connection so the conversation-scoped
-   * reconcile pass can run.
+   * when the reachability probe recovers into "ready" from
+   * "connecting" or "checking". Tells the bus to close + reopen its
+   * SSE connection so the conversation-scoped reconcile pass can run.
+   * A "ready" entered from any other phase (boot, remount) confirms an
+   * already-healthy stream and does not publish.
    */
   "reachability.retry-requested": Record<string, never>;
   /**

--- a/clients/web/src/lib/event-bus.ts
+++ b/clients/web/src/lib/event-bus.ts
@@ -86,11 +86,12 @@ export interface BusEventMap {
   "sse.closed": { reason: string };
   /**
    * Published by `useEventStream`'s reachability-retry burst limiter
-   * when the reachability probe recovers into "ready" from
-   * "connecting" or "checking". Tells the bus to close + reopen its
-   * SSE connection so the conversation-scoped reconcile pass can run.
-   * A "ready" entered from any other phase (boot, remount) confirms an
-   * already-healthy stream and does not publish.
+   * when the reachability probe recovers into "ready" from a degraded
+   * phase ("connecting", "checking", or "failed"). Tells the bus to
+   * close + reopen its SSE connection so the conversation-scoped
+   * reconcile pass can run. A "ready" entered from "idle" or "ready"
+   * confirms an already-healthy stream (boot, remount) and does not
+   * publish.
    */
   "reachability.retry-requested": Record<string, never>;
   /**


### PR DESCRIPTION
## Summary
- Gates the reachability burst limiter so only a ready entered from connecting/checking counts as a recovery; boot and remount confirmations no longer cancel the healthy fresh SSE stream and re-run the missed-events reconcile
- Removes one guaranteed extra SSE connect plus roughly 8-12 GETs from every managed boot (web, iOS, desktop)

Note: this shifts client_resume.request_count and boot-window baselines; PR #40130 before/after comparisons must re-baseline after this lands.

Part of plan: sse-boot-bounce-fix.md (PR 1 of 1)