### PR TITLE
fix(plugins): register the default plugin surface in conversation-running workers (ATL-1236)

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -228,6 +228,11 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../util/worker-memory.js",
     "../../../util/worker-process.js",
     "../../types.js",
+    // The memory jobs worker runs as its own OS process and hosts real agent
+    // conversations, so it registers the host's default-plugin hook and
+    // injector surface at startup (hooks only, no init hooks). Host-owned
+    // composition with no plugin-api equivalent.
+    "../../worker-plugin-surface.js",
     "../injection-presence.js",
     "../injector-order.js",
     "@qdrant/js-client-rest",

--- a/assistant/src/__tests__/worker-entrypoint-guards.test.ts
+++ b/assistant/src/__tests__/worker-entrypoint-guards.test.ts
@@ -18,10 +18,18 @@ import { Glob } from "bun";
  * - start the PID-file identity guard — the PID file is a worker's sole
  *   tracking handle, so a worker the file stops naming can never be
  *   stopped externally and must evict itself.
+ *
+ * The subset that hosts real agent conversations
+ * ({@link CONVERSATION_RUNNING_ENTRYPOINTS}) must additionally register the
+ * default plugins' hooks and injectors, since hook dispatch is process-global
+ * and a worker that skips it runs conversations with no plugin behavior at all
+ * (no image captioning or vision-rejection recovery, no tool-result
+ * truncation, no runtime injections).
  */
 
 const DISABLE_CALL = "disableStreamSeqStamping()";
 const PID_GUARD_CALL = "startWorkerPidFileGuard(";
+const PLUGIN_SURFACE_CALL = "registerWorkerPluginSurface(";
 
 /** Shape of a shutdown that schedules `process.exit` instead of calling it. */
 const DEFERRED_EXIT = ".finally(() => process.exit";
@@ -43,6 +51,16 @@ const WORK_START_MARKERS: Record<string, string> = {
   // The route host begins serving when it attaches the connection handler.
   "routes/worker.ts": 'server.on("connection"',
 };
+
+/**
+ * The entrypoints whose work wakes real agent conversations. `monitoring` (a
+ * resource sampler) and `routes` (an HTTP route host) run no conversations, so
+ * they carry no plugin surface.
+ */
+const CONVERSATION_RUNNING_ENTRYPOINTS: ReadonlySet<string> = new Set([
+  "schedule/worker.ts",
+  "plugins/defaults/memory/worker.ts",
+]);
 
 function findWorkerEntrypoints(): string[] {
   const srcRoot = join(process.cwd(), "src");
@@ -135,6 +153,42 @@ describe("worker entrypoint guards", () => {
       "Each worker must arm the PID guard before its work-start call " +
         `(see WORK_START_MARKERS) so the guard's on-arm check evicts a ` +
         "worker superseded at startup before it runs orphaned work.",
+    ).toEqual([]);
+  });
+
+  test("the conversation-running entrypoints are all discovered workers", () => {
+    const discovered = new Set(findWorkerEntrypoints());
+    const unknown = [...CONVERSATION_RUNNING_ENTRYPOINTS].filter(
+      (file) => !discovered.has(file),
+    );
+    expect(
+      unknown,
+      "CONVERSATION_RUNNING_ENTRYPOINTS names an entrypoint the glob does " +
+        "not find — the worker moved or was renamed.",
+    ).toEqual([]);
+  });
+
+  test("every conversation-running entrypoint registers the default plugin surface before starting work", () => {
+    const offenders = [...CONVERSATION_RUNNING_ENTRYPOINTS]
+      .sort()
+      .filter((file) => {
+        const source = readFileSync(join(process.cwd(), "src", file), "utf8");
+        const marker = WORK_START_MARKERS[file];
+        if (marker == null) {
+          return true;
+        }
+        const registerAt = source.indexOf(PLUGIN_SURFACE_CALL);
+        const workAt = source.indexOf(marker);
+        return registerAt < 0 || workAt < 0 || registerAt > workAt;
+      });
+    expect(
+      offenders,
+      `A worker that wakes agent conversations must call ` +
+        `${PLUGIN_SURFACE_CALL}) before its work-start call (see ` +
+        "WORK_START_MARKERS). Hook dispatch is process-global, so without it " +
+        "the conversations this process runs get no default plugin behavior: " +
+        "no vision-rejection recovery, no tool-result truncation, no runtime " +
+        "injections.",
     ).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/worker-plugin-surface.test.ts
+++ b/assistant/src/__tests__/worker-plugin-surface.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for {@link registerWorkerPluginSurface}, the default-plugin surface
+ * that sidecar worker processes install at startup.
+ *
+ * A worker that wakes real agent conversations shares the daemon's
+ * process-global hook and injector registries, so registering the defaults is
+ * what gives those conversations the same behavior as daemon conversations.
+ * Registration must populate both tables and stay idempotent, and it must do so
+ * without running any plugin `init` hook (the memory plugin's init starts the
+ * memory jobs worker process itself).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getHookEntriesFor } from "../hooks/registry.js";
+import {
+  clearInjectorRegistry,
+  getRegisteredInjectors,
+} from "../plugins/injector-registry.js";
+import { resetPluginRegistryForTests } from "../plugins/registry.js";
+import { registerWorkerPluginSurface } from "../plugins/worker-plugin-surface.js";
+
+async function hookOwnersFor(name: string): Promise<string[]> {
+  const entries = await getHookEntriesFor(name);
+  return entries.map((entry) => entry.owner.id);
+}
+
+describe("registerWorkerPluginSurface", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    clearInjectorRegistry();
+  });
+
+  test("serves the default plugins' hooks from the process-global registry", async () => {
+    expect(await hookOwnersFor("post-model-call")).not.toContain(
+      "default-image-fallback",
+    );
+
+    registerWorkerPluginSurface();
+
+    // The vision-rejection recovery that a worker without this surface never
+    // ran, plus an oversized-tool-result guard on the other hook surface.
+    expect(await hookOwnersFor("post-model-call")).toContain(
+      "default-image-fallback",
+    );
+    expect(await hookOwnersFor("post-tool-use")).toContain(
+      "default-tool-result-truncate",
+    );
+  });
+
+  test("registers the injector-only defaults' runtime injectors", () => {
+    expect(
+      getRegisteredInjectors().some((i) => i.name === "unified-turn-context"),
+    ).toBe(false);
+
+    registerWorkerPluginSurface();
+
+    // `default-turn-context` contributes no hooks, so its injections only reach
+    // a worker's conversations through the injector registry.
+    expect(
+      getRegisteredInjectors().some((i) => i.name === "unified-turn-context"),
+    ).toBe(true);
+  });
+
+  test("is idempotent: a second call neither throws nor duplicates", async () => {
+    registerWorkerPluginSurface();
+    const hooksAfterFirst = await hookOwnersFor("post-model-call");
+    const injectorsAfterFirst = getRegisteredInjectors().map((i) => i.name);
+
+    expect(() => registerWorkerPluginSurface()).not.toThrow();
+
+    expect(await hookOwnersFor("post-model-call")).toEqual(hooksAfterFirst);
+    expect(getRegisteredInjectors().map((i) => i.name)).toEqual(
+      injectorsAfterFirst,
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/memory/worker.ts
+++ b/assistant/src/plugins/defaults/memory/worker.ts
@@ -27,6 +27,7 @@ import {
   cleanupWorkerPidFile,
   startWorkerPidFileGuard,
 } from "../../../util/worker-process.js";
+import { registerWorkerPluginSurface } from "../../worker-plugin-surface.js";
 import { registerMemoryPluginJobHandlers } from "./job-handler-registration.js";
 import { startMemoryJobsWorkerLoop } from "./jobs-worker.js";
 import { getLogger } from "./logging.js";
@@ -59,9 +60,11 @@ async function main(): Promise<void> {
   // and are rejected.
   await rehydratePlatformCredentials();
 
-  // This process does not run plugin bootstrap, so self-register the job
-  // handlers the worker dispatches from before starting it — the memory
-  // plugin's own plus the host's non-plugin domain handlers.
+  // Jobs in this process wake real agent conversations, so it registers the
+  // default plugin hook surface (hooks and injectors, no init hooks) the same
+  // way the daemon does, and the job handlers the worker dispatches from: the
+  // memory plugin's own plus the host's non-plugin domain handlers.
+  registerWorkerPluginSurface();
   registerMemoryPluginJobHandlers();
 
   // Populate the tool registry (core built-ins + workspace tools), exactly as

--- a/assistant/src/plugins/worker-plugin-surface.ts
+++ b/assistant/src/plugins/worker-plugin-surface.ts
@@ -1,0 +1,33 @@
+/**
+ * Default-plugin surface for sidecar worker processes.
+ *
+ * Worker processes that run real agent conversations (the memory jobs worker,
+ * the schedule worker) register the first-party default plugins' hooks and
+ * runtime injectors so those conversations get the same hook-driven behavior as
+ * conversations in the daemon: image captioning and vision-rejection recovery,
+ * tool-result truncation, history repair, and the per-turn runtime injections.
+ * Hook and injector dispatch is process-global, so one call at worker startup
+ * covers every conversation that process runs.
+ *
+ * Plugin `init` hooks are deliberately not run here. Registration is pure
+ * hook-table and injector-table population, and the default plugins degrade
+ * gracefully without their init-owned state (the image-fallback caption cache
+ * falls back to in-memory caching when its SQLite handle is absent). The memory
+ * plugin's init must never run in a worker: it starts the memory jobs worker
+ * process itself.
+ */
+
+import {
+  registerDefaultPluginInjectors,
+  registerDefaultPlugins,
+} from "./defaults/index.js";
+
+/**
+ * Register the first-party default plugins' hooks and runtime injectors in the
+ * current process. Both registration functions are idempotent, so repeat calls
+ * are safe.
+ */
+export function registerWorkerPluginSurface(): void {
+  registerDefaultPlugins();
+  registerDefaultPluginInjectors();
+}

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -16,6 +16,7 @@ import { writeFileSync } from "node:fs";
 import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { resetDb } from "../persistence/db-connection.js";
+import { registerWorkerPluginSurface } from "../plugins/worker-plugin-surface.js";
 import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
 import { initializeTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -50,6 +51,11 @@ async function main(): Promise<void> {
   // default — otherwise valid credentials are sent to the wrong platform and
   // rejected for both inference and background-wake requests.
   await rehydratePlatformCredentials();
+
+  // This process is the sole runner of schedule execution and hosts real agent
+  // conversations (wake, execute, and workflow modes), so it needs the default
+  // plugins' hooks and injectors just like the daemon.
+  registerWorkerPluginSurface();
 
   // Populate the tool registry (core built-ins + workspace tools). The daemon
   // does this at startup; this standalone process has to do it itself so


### PR DESCRIPTION
## Problem

The memory jobs worker (`assistant/src/plugins/defaults/memory/worker.ts`) and the schedule worker (`assistant/src/schedule/worker.ts`) run real agent conversations in their own OS processes, but neither registered any plugins. Plugin hook dispatch is process-global (`src/hooks/registry.ts`), so every conversation those processes run executed with an empty hook table: no image captioning or vision-rejection recovery, no tool-result truncation, no history repair, no runtime injections.

The visible symptom (ATL-1236): `image-fallback`'s `post-model-call` recovery, which recognizes a provider vision rejection, captions the offending image blocks, and retries, never ran in the memory worker. An image-bearing retrospective window on the text-only cost-optimized model failed with `vision_unsupported` permanently. Because the retrospective cursor advances only on usable output, the window was retried on every cooldown and could never succeed, so derived memory stopped forming from the conversation's first image onward, with each retry billing another retrospective fork.

## Fix

Both workers call the shared `registerWorkerPluginSurface()` at startup, which runs `registerDefaultPlugins()` + `registerDefaultPluginInjectors()`, the same registration the daemon does in `external-plugins-bootstrap.ts`. This is Option A from the [investigation on #40195](https://github.com/vellum-ai/vellum-assistant/pull/40195#issuecomment-5196677143): full parity for the default plugin hook surface, no per-process plugin subset to maintain.

Plugin `init` hooks are deliberately NOT run in workers:

- The memory plugin's init calls `runMemoryStartup`, which spawns the memory jobs worker process. Running it inside the worker would recurse (the code warns about exactly this in `jobs-worker.ts`).
- Every default plugin's hooks are safe without init-owned state. `image-fallback`'s caption cache is explicitly fail-open: with no SQLite handle it degrades to in-memory-only caching (`caption-cache.ts` guards every DB path with `if (db == null)`). The worker is long-lived, so the in-memory LRU carries most of the caching value; the durable cross-restart cache stays daemon-only for now.

Injectors are registered too, not just hooks: consolidation turns (memory worker) and execute-mode schedule turns go through `user-prompt-submit`, whose memory hook drives `applyRuntimeInjections`, and five defaults (`turn-context`, `workspace`, `documents`, `channel`, `session`) are injector-only, so hook registration alone would contribute nothing for them.

## What this restores, precisely

- Retrospective forks are wakes, and wakes bypass `runAgentLoopImpl`, so they do not fire `user-prompt-submit` (the turn-start captioning sweep). They gain the `post-model-call` vision recovery, `post-compact`, `post-tool-use`, and `stop` hooks. The recovery half is what breaks the `vision_unsupported` retry loop.
- Consolidation and schedule execute/fresh turns go through the full path and gain everything, including the turn-start sweep and runtime injections.
- All worker conversations gain `tool-result-truncate`, `tool-error` coaching, and the other repair hooks they silently lacked.
- No model change and no token cost: retrospectives stay on `cost-optimized`.

Plugins that should not act in these contexts self-gate: `title-generate` returns early for `conversationType !== "standard"`, and the `mainAgent`-gated hooks (`empty-response` re-query, `max-tokens-continue`, `surface-completion-nudge`) skip retrospective and consolidation call sites.

## Guard coverage

- `worker-entrypoint-guards.test.ts`: every conversation-running worker entrypoint (schedule + memory, not the monitoring/route workers) must call `registerWorkerPluginSurface(` before its work-start call.
- `worker-plugin-surface.test.ts` (new): registration populates the hook registry (image-fallback on `post-model-call`, tool-result-truncate on `post-tool-use`) and the injector registry (`unified-turn-context`), and is idempotent.
- `plugin-import-boundary-guard.test.ts`: baseline entry for the memory worker's import of the host-side surface module.

## Follow-up candidates (not in this PR)

- `exploration-drift`'s nudge fires for retrospective passes (only `subagentSpawn` is exempt) and its guidance ("summarize for the user", "delegate to a researcher subagent") is meaningless for a retrospective's restricted tool surface. Harmless prompt noise, but worth a call-site gate.
- Opening the durable caption cache in workers would need a `busy_timeout` and a look at the two-process LRU eviction race; today's fail-open in-memory behavior is the safe default.

Fixes ATL-1236. Supersedes #40195, which should be closed: repointing the `memoryRetrospective` default at a vision-capable profile hides the missing hook surface, costs ~5x on output tokens and ~42% on input, and flips reasoning from none to high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->