### PR TITLE
Hide desktop-only assistant sections on native mobile

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -36,6 +36,7 @@ import { PageShell } from "@/components/page-shell";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useElementSize } from "@/hooks/use-element-size";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
+import { useIsNativeMobile } from "@/runtime/platform-detection";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { contrastForeground } from "@/utils/avatar-tone";
@@ -203,15 +204,23 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
   } = useAssistantAvatar(assistantId);
   const identityQuery = useAssistantIdentityDetails(assistantId);
   const supportsPlugins = useSupportsPluginsSurface();
+  // The native mobile shells drop the Memory, Workspace, Contacts and
+  // Channels cards, so their measurements are dead reads there.
+  const isNativeMobile = useIsNativeMobile();
   const stats = useIdentitySectionStats(assistantId, {
     supportsPlugins,
+    isNativeMobile,
   });
   // The Memory card's measurement is the cheap page-index concept count
-  // (get-memory-stats) — NOT the concept-graph build, which is kept off
-  // identity-page load. The card itself is unconditional; only its count is
-  // conditional, so an assistant whose backend can't draw the graph still has
-  // a way into the Memory tab (which explains why, and offers the fix).
-  const memoryStats = useQuery(memoryStatsOptions(assistantId));
+  // (get-memory-stats), NOT the concept-graph build, which is kept off
+  // identity-page load. Wherever the card shows it is never gated on backend
+  // capability; only its count is, so an assistant whose backend can't draw
+  // the graph still has a way into the Memory tab (which explains why, and
+  // offers the fix).
+  const memoryStats = useQuery({
+    ...memoryStatsOptions(assistantId),
+    enabled: !isNativeMobile,
+  });
   // Only measured where concept pages are actually the substrate (memory tier
   // v2/v3). A loading query, an older daemon predating `/memory/stats`, a v1
   // assistant (memory lives in the legacy graph) and a memory-off one all read
@@ -259,7 +268,7 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
     invalidateAvatar();
   }, [invalidateAvatar]);
 
-  const sections = buildIdentitySections();
+  const sections = buildIdentitySections({ isNativeMobile });
   const isLoading = isAvatarLoading || identityQuery.isLoading;
   const avatarHex = resolveAvatarHex(components, traits);
   // Custom image (no character color): the page background becomes the

--- a/clients/web/src/domains/intelligence/components/identity-sections.test.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.test.ts
@@ -1,10 +1,9 @@
 /**
- * The overview's drill-down section list: a stable order, and nothing gated on
- * backend capability. Memory used to be gated on memory-concept-graph
- * availability and would vanish from the mosaic; it is now always present on
- * the surfaces that show it, and the Memory tab itself explains an unavailable
- * graph. The one subtraction is the native mobile shell, which drops the
- * desktop-oriented sections.
+ * The overview's drill-down section list: a stable order, with nothing gated
+ * on backend capability. Whatever the backend reports, the list is the same,
+ * so an assistant that can't draw the memory concept graph still gets a
+ * Memory card leading into the tab that explains it. The one subtraction is
+ * the native mobile shell, which omits the desktop-oriented sections.
  */
 import { describe, expect, test } from "bun:test";
 

--- a/clients/web/src/domains/intelligence/components/identity-sections.test.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.test.ts
@@ -3,7 +3,8 @@
  * on backend capability. Whatever the backend reports, the list is the same,
  * so an assistant that can't draw the memory concept graph still gets a
  * Memory card leading into the tab that explains it. The one subtraction is
- * the native mobile shell, which omits the desktop-oriented sections.
+ * the native mobile shell, which omits the sections whose UI is not ready
+ * for a phone.
  */
 import { describe, expect, test } from "bun:test";
 

--- a/clients/web/src/domains/intelligence/components/identity-sections.test.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.test.ts
@@ -1,14 +1,17 @@
 /**
- * The overview's drill-down section list: every section is unconditional, in a
- * stable order. Memory used to be gated on memory-concept-graph availability
- * and would vanish from the mosaic; it is now always present, and the Memory
- * tab itself explains an unavailable graph.
+ * The overview's drill-down section list: a stable order, and nothing gated on
+ * backend capability. Memory used to be gated on memory-concept-graph
+ * availability and would vanish from the mosaic; it is now always present on
+ * the surfaces that show it, and the Memory tab itself explains an unavailable
+ * graph. The one subtraction is the native mobile shell, which drops the
+ * desktop-oriented sections.
  */
 import { describe, expect, test } from "bun:test";
 
 import { buildIdentitySections } from "./identity-sections";
 
-const keys = () => buildIdentitySections().map((s) => s.key);
+const keys = (isNativeMobile = false) =>
+  buildIdentitySections({ isNativeMobile }).map((s) => s.key);
 
 describe("buildIdentitySections", () => {
   test("includes every section, in order", () => {
@@ -24,19 +27,40 @@ describe("buildIdentitySections", () => {
     ]);
   });
 
-  test("never hides Memory — the card is the way into the Memory tab", () => {
+  test("defaults to the full list when no options are passed", () => {
+    expect(buildIdentitySections().map((s) => s.key)).toEqual(keys());
+  });
+
+  test("never hides Memory on the surfaces that show it, whatever the backend reports", () => {
     expect(keys()).toContain("memory");
   });
 
-  test("always includes Channels", () => {
+  test("always includes Channels off native mobile", () => {
     expect(keys()).toContain("channels");
   });
 
+  test("native mobile drops Memory, Workspace, Contacts and Channels", () => {
+    expect(keys(true)).toEqual([
+      "personality",
+      "schedules",
+      "superpowers",
+      "library",
+    ]);
+  });
+
+  test("native mobile keeps the remaining sections in their desktop order", () => {
+    const nativeMobile = keys(true);
+    const desktopOrder = keys().filter((key) => nativeMobile.includes(key));
+    expect(nativeMobile).toEqual(desktopOrder);
+  });
+
   test("every section carries a label, description and path", () => {
-    for (const section of buildIdentitySections()) {
-      expect(section.label.length).toBeGreaterThan(0);
-      expect(section.description.length).toBeGreaterThan(0);
-      expect(section.to.startsWith("/")).toBe(true);
+    for (const isNativeMobile of [false, true]) {
+      for (const section of buildIdentitySections({ isNativeMobile })) {
+        expect(section.label.length).toBeGreaterThan(0);
+        expect(section.description.length).toBeGreaterThan(0);
+        expect(section.to.startsWith("/")).toBe(true);
+      }
     }
   });
 });

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -31,10 +31,11 @@ function section(
 }
 
 /**
- * Sections the native mobile shells leave off the overview. These are the
- * desktop-oriented surfaces (files on the host machine, the contact book, the
- * channel wiring), so on a phone they are noise rather than a way in. Only the
- * overview cards go: the routes stay registered and reachable by deep link.
+ * Sections the native mobile shells leave off the overview. Their UI needs
+ * more work before it earns a place on a phone, so on iOS and Android they
+ * offer the user little. Only the overview cards go: the routes stay
+ * registered and reachable by deep link, so putting a section back is a
+ * single edit to this list once its mobile UI is ready.
  */
 const NATIVE_MOBILE_HIDDEN_KEYS: readonly string[] = [
   "memory",

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -30,10 +30,30 @@ function section(
   return { key, label, description, to };
 }
 
-export function buildIdentitySections(): IdentitySection[] {
-  return [
+/**
+ * Sections the native mobile shells leave off the overview. These are the
+ * desktop-oriented surfaces (files on the host machine, the contact book, the
+ * channel wiring), so on a phone they are noise rather than a way in. Only the
+ * overview cards go: the routes stay registered and reachable by deep link.
+ */
+const NATIVE_MOBILE_HIDDEN_KEYS: readonly string[] = [
+  "memory",
+  "workspace",
+  "contacts",
+  "channels",
+];
+
+export interface BuildIdentitySectionsOptions {
+  /** True inside the iOS or Android Capacitor shell. */
+  isNativeMobile?: boolean;
+}
+
+export function buildIdentitySections({
+  isNativeMobile = false,
+}: BuildIdentitySectionsOptions = {}): IdentitySection[] {
+  const sections: IdentitySection[] = [
     // Personality renders bare (full-bleed stage chrome), so it is not a
-    // registry section — the overview links it directly.
+    // registry section. The overview links it directly.
     {
       key: "personality",
       label: "Personality",
@@ -44,10 +64,12 @@ export function buildIdentitySections(): IdentitySection[] {
     // Skills and plugins combined into one list; on assistants without the
     // plugin surface the page itself degrades to skills-only.
     section("superpowers", "What I can do"),
-    // Unconditional. Memory is part of what every assistant is, so the card is
-    // always the way in — an assistant whose backend can't draw the concept
-    // graph (memory off, or a pre-v3 engine) gets a Memory tab that explains
-    // that and offers the fix, rather than a card that silently disappears.
+    // Never gated on backend capability. Memory is part of what every
+    // assistant is, so wherever the card shows it is always the way in: an
+    // assistant whose backend can't draw the concept graph (memory off, or a
+    // pre-v3 engine) gets a Memory tab that explains that and offers the fix,
+    // rather than a card that silently disappears. The native mobile filter
+    // below is the only thing that removes it.
     section("memory", "What I remember"),
     // Library's list page wears the shared section chrome like its peers;
     // the app viewer (/assistant/library/:appId) renders full-bleed.
@@ -56,4 +78,10 @@ export function buildIdentitySections(): IdentitySection[] {
     section("contacts", "People I know"),
     section("channels", "Where I listen"),
   ];
+  if (!isNativeMobile) {
+    return sections;
+  }
+  return sections.filter(
+    (entry) => !NATIVE_MOBILE_HIDDEN_KEYS.includes(entry.key),
+  );
 }

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -58,11 +58,16 @@ function pluralLabel(n: number, singular: string, pluralForm: string): string {
 interface UseIdentitySectionStatsOptions {
   /** Skip the plugin fetch on assistants without the plugin routes. */
   supportsPlugins: boolean;
+  /**
+   * Skip the reads behind cards the native mobile shells don't render
+   * (see `NATIVE_MOBILE_HIDDEN_KEYS` in `components/identity-sections.ts`).
+   */
+  isNativeMobile: boolean;
 }
 
 export function useIdentitySectionStats(
   assistantId: string,
-  { supportsPlugins }: UseIdentitySectionStatsOptions,
+  { supportsPlugins, isNativeMobile }: UseIdentitySectionStatsOptions,
 ): Record<string, IdentitySectionStat | undefined> {
   const path = { assistant_id: assistantId };
   const common = { staleTime: STATS_STALE_MS, retry: false, enabled: true };
@@ -94,16 +99,19 @@ export function useIdentitySectionStats(
     ...workspaceTreeGetOptions({ path }),
     select: (data) => data.entries.length,
     ...common,
+    enabled: !isNativeMobile,
   });
   const contacts = useQuery({
     ...contactsGetOptions({ path }),
     select: (data) => data.contacts.length,
     ...common,
+    enabled: !isNativeMobile,
   });
   const channels = useQuery({
     ...channelsReadinessGetOptions({ path }),
     select: (data) => data.snapshots.filter((s) => s.ready).length,
     ...common,
+    enabled: !isNativeMobile,
   });
   // Shares the schedules cache entry owned by `fetchSchedules` (Settings
   // and the Activity page key it identically with a `Schedule[]` payload)


### PR DESCRIPTION
## Why

The assistant overview page (`/assistant/identity`) shows **Memory**, **Workspace**, **Contacts** and **Channels** cards on iOS and Android. Those surfaces still need UI work before they hold up on a phone, and as they stand today they offer mobile users little. So this hides the four cards on native mobile until they are worth showing.

This is a provisional hide, not a removal. Nothing is deleted and no route changes: when a section's mobile UI is ready, putting it back is a one-line edit to `NATIVE_MOBILE_HIDDEN_KEYS`.

Cards on native mobile:

| | Cards shown |
|---|---|
| Before | Personality, Schedules, Superpowers, Memory, Library, Workspace, Contacts, Channels |
| After | Personality, Schedules, Superpowers, Library |

## How

The four sections are not four components. They are entries in one config array (`buildIdentitySections()`) rendered through a shared `SectionCard` in **both** the desktop bento strip and the mobile stacked grid, so filtering that array is a single chokepoint and both layouts follow.

The gate is `useIsNativeMobile()` (`@/runtime/platform-detection`), which is `isNativeIOS() || isNativeAndroid()` and so covers both Capacitor shells. Deliberately **not** `useIsMobile()`, which is viewport-width only and would also hide the cards in a narrow desktop browser window.

The four reads behind those cards (workspace tree, contacts, channels readiness, memory stats) are dead on mobile once the cards are gone, so they are switched off with `enabled`, following the `supportsPlugins` pattern already in that hook. That is four fewer requests per identity-page load on the platform we have been chasing slowness on.

## Scope notes

- **Routes stay registered.** Deep links to `/assistant/memory` and friends still resolve. Only the overview cards are hidden.
- **`ABOUT_ASSISTANT_SECTIONS` in `routes.ts` is untouched.** It also drives layout chrome and the sidebar active-section highlight, so editing it would change three surfaces at once.
- **The `never hides Memory` / `always includes Channels` tests are kept, not deleted.** They guard against Memory being re-gated on *backend capability*, the failure mode being the card silently vanishing when the concept graph is unavailable. That guard is still live; the test names are scoped to the non-mobile case.

## Verification

- `bunx tsc --noEmit` clean; `eslint` clean on all four files
- All 28 `domains/intelligence` test files pass under `bun scripts/run-tests.ts` (the per-process isolated runner)
- Checked that the bento `gridTemplateAreas` only names `personality` / `greeting` / `schedules` / `avatar` / `smalls`, so removing these four cannot orphan a grid area. The mini strip degrades cleanly to Superpowers + Library in both layouts.

A plain `bun test src/domains/intelligence/` reports 12 failures in `superpowers-tab.test.tsx`. That is the known local multi-file mock-leakage artifact, unrelated to this change: the file passes alone and under the isolated runner.

**Not verified on device.** Worth a look in an actual iOS/Android shell before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)