### PR TITLE
feat(memory): announce background updates to an existing skill

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -1556,7 +1556,10 @@ describe("background skill update notification", () => {
     // The home feed falls back to `title`/`body` when no channel copy was
     // rendered, which is the intended quiet shape for this signal. Without
     // them a suppressed delivery would leave the feed item unwritten.
-    expect(signal.contextPayload?.title).toBe("Skill updated");
+    // Named so the row is scannable in a feed several entries deep.
+    expect(signal.contextPayload?.title).toBe(
+      "Skill updated: Weekly Report Export",
+    );
     expect(String(signal.contextPayload?.body)).toContain(
       "Weekly Report Export",
     );

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -1495,8 +1495,8 @@ describe("scaffold_managed_skill tool", () => {
 // ── Background skill updates are announced ─────────────────────────────────
 //
 // A background pass runs inside a hidden retrospective fork, so its tool call
-// renders in a conversation the user never opens. Creates already reach the
-// source conversation as a `skill_card`; an update had no signal anywhere.
+// renders in a conversation the user never opens. Creates reach the source
+// conversation as a `skill_card`; updates reach the background activity feed.
 
 describe("background skill update notification", () => {
   /** Seed an assistant-authored skill the background pass may overwrite. */

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -32,6 +32,26 @@ mock.module("../daemon/skill-memory-refresh.js", () => ({
   refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
 
+// Background skill updates route through the notification pipeline; record
+// the signals rather than standing up delivery.
+let emittedSignals: Array<{
+  sourceEventName: string;
+  sourceContextId: string;
+  dedupeKey?: string;
+  contextPayload?: Record<string, unknown>;
+}> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: {
+    sourceEventName: string;
+    sourceContextId: string;
+    dedupeKey?: string;
+    contextPayload?: Record<string, unknown>;
+  }) => {
+    emittedSignals.push(params);
+    return { signalId: "test-signal" };
+  },
+}));
+
 // Skill-card enqueue recorder. Snapshot + override (rather than a full module
 // replacement) because other modules in this import graph (e.g. the managed
 // store's capability seeding) import sibling jobs-store exports that must
@@ -104,6 +124,7 @@ beforeEach(() => {
   skillCardJobUpserts = [];
   skillCardUpsertThrows = false;
   watchdogEvents.length = 0;
+  emittedSignals = [];
 });
 
 afterEach(() => {
@@ -1468,5 +1489,140 @@ describe("scaffold_managed_skill tool", () => {
         (u.payload.skills as Array<{ skillId: string }>).map((s) => s.skillId),
       ),
     ).toEqual(["run-skill-a", "run-skill-b"]);
+  });
+});
+
+// ── Background skill updates are announced ─────────────────────────────────
+//
+// A background pass runs inside a hidden retrospective fork, so its tool call
+// renders in a conversation the user never opens. Creates already reach the
+// source conversation as a `skill_card`; an update had no signal anywhere.
+
+describe("background skill update notification", () => {
+  /** Seed an assistant-authored skill the background pass may overwrite. */
+  async function seedAssistantSkill(id: string, body: string): Promise<void> {
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: id,
+        name: "Weekly Report Export",
+        description: `seeded ${id}`,
+        body_markdown: body,
+      },
+      makeContext(),
+    );
+    writeInstallMeta(join(TEST_DIR, "skills", id), {
+      origin: "custom",
+      installedAt: new Date().toISOString(),
+      author: "assistant",
+    });
+    watchdogEvents.length = 0;
+    skillCardJobUpserts = [];
+    emittedSignals = [];
+  }
+
+  const lineage = () => ({
+    getConversation: (id: string) =>
+      id === "retro-run-conv"
+        ? { forkParentConversationId: "source-conv" }
+        : null,
+  });
+
+  test("a background overwrite of an existing skill notifies, keyed to the source conversation", async () => {
+    await seedAssistantSkill("weekly-export", "Old body.");
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "weekly-export",
+        name: "Weekly Report Export",
+        description: "export the weekly usage report",
+        body_markdown: "1. Refined steps.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineage(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(emittedSignals).toHaveLength(1);
+    const signal = emittedSignals[0]!;
+    expect(signal.sourceEventName).toBe("activity.complete");
+    // The feed item's "Go to Convo" target resolves through this id, so it
+    // must be the conversation the work came from, not the hidden fork.
+    expect(signal.sourceContextId).toBe("source-conv");
+    expect(signal.contextPayload?.skillId).toBe("weekly-export");
+    expect(String(signal.contextPayload?.summary)).toContain(
+      "Weekly Report Export",
+    );
+    // Deduped per skill per day so repeated refinements cannot flood the feed.
+    expect(signal.dedupeKey).toBe(
+      `skill-updated:weekly-export:${new Date().toISOString().slice(0, 10)}`,
+    );
+  });
+
+  test("it falls back to the run conversation when fork lineage does not resolve", async () => {
+    await seedAssistantSkill("weekly-export", "Old body.");
+
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "weekly-export",
+        name: "Weekly Report Export",
+        description: "export the weekly usage report",
+        body_markdown: "1. Refined steps.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      { getConversation: () => null },
+    );
+
+    // Still a real conversation id, so the deep link resolves rather than
+    // falling through to an unrelated target.
+    expect(emittedSignals).toHaveLength(1);
+    expect(emittedSignals[0]!.sourceContextId).toBe("retro-run-conv");
+  });
+
+  test("a background CREATE gets the skill card instead, with no duplicate signal", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "brand-new-skill",
+        name: "Brand New Skill",
+        description: "something never seen before",
+        body_markdown: "1. Do it.",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineage(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(emittedSignals).toHaveLength(0);
+  });
+
+  test("a user-directed overwrite does not notify: it is not unattended work", async () => {
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "user-skill",
+        name: "User Skill",
+        description: "asked for",
+        body_markdown: "V1.",
+      },
+      makeContext(),
+    );
+    emittedSignals = [];
+
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "user-skill",
+        name: "User Skill",
+        description: "asked for",
+        body_markdown: "V2.",
+        overwrite: true,
+      },
+      makeContext(),
+    );
+
+    expect(
+      readFileSync(join(TEST_DIR, "skills", "user-skill", "SKILL.md"), "utf-8"),
+    ).toContain("V2.");
+    expect(emittedSignals).toHaveLength(0);
   });
 });

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -1553,6 +1553,13 @@ describe("background skill update notification", () => {
     expect(String(signal.contextPayload?.summary)).toContain(
       "Weekly Report Export",
     );
+    // The home feed falls back to `title`/`body` when no channel copy was
+    // rendered, which is the intended quiet shape for this signal. Without
+    // them a suppressed delivery would leave the feed item unwritten.
+    expect(signal.contextPayload?.title).toBe("Skill updated");
+    expect(String(signal.contextPayload?.body)).toContain(
+      "Weekly Report Export",
+    );
     // Deduped per skill per day so repeated refinements cannot flood the feed.
     expect(signal.dedupeKey).toBe(
       `skill-updated:weekly-export:${new Date().toISOString().slice(0, 10)}`,

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { SkillSource } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
+import { emitNotificationSignal } from "../../notifications/emit-signal.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
 import { upsertSkillCardInsertJob } from "../../persistence/jobs-store.js";
 import { MEMORY_RETROSPECTIVE_ORIGIN } from "../../plugins/defaults/memory/memory-retrospective-constants.js";
@@ -64,6 +65,54 @@ function normalizeOptionalStringArray(
     normalized.push(cleaned);
   }
   return { value: normalized.length > 0 ? normalized : undefined };
+}
+
+/**
+ * Tell the user that a background pass changed a skill they already have.
+ *
+ * A newly authored skill announces itself in the conversation through the
+ * `skill_card` surface, but an UPDATE had no signal at all: the pass rewrites
+ * the body of a skill the user may be relying on, and `createManagedSkill`
+ * writes through an atomic rename keeping no prior version. Routing it
+ * through the notification pipeline puts it in the background feed alongside
+ * the other unattended work (sweeps, scheduled jobs, heartbeat), which is
+ * where a user already looks to see what the assistant did on its own.
+ *
+ * `sourceContextId` is a conversation id so the feed item's "Go to Convo"
+ * target resolves (see `home-feed-side-effect.ts`, which looks it up via
+ * `getConversation`): the source conversation when lineage resolved, else the
+ * run's own conversation. Deduped per skill per day, so a pass that refines
+ * the same skill repeatedly cannot flood the feed. Best-effort and
+ * non-blocking: the skill is already written, and a notification failure must
+ * never turn that into a tool error.
+ */
+function notifyBackgroundSkillUpdate(args: {
+  skillId: string;
+  name: string;
+  conversationId: string;
+}): void {
+  const day = new Date().toISOString().slice(0, 10);
+  void emitNotificationSignal({
+    sourceChannel: "scheduler",
+    sourceContextId: args.conversationId,
+    sourceEventName: "activity.complete",
+    dedupeKey: `skill-updated:${args.skillId}:${day}`,
+    contextPayload: {
+      summary: `Updated the skill "${args.name}" from something learned in an earlier conversation.`,
+      skillId: args.skillId,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+  }).catch((err: unknown) => {
+    log.warn(
+      { err, skillId: args.skillId },
+      "skill update notification failed; the skill write stands",
+    );
+  });
 }
 
 /**
@@ -353,6 +402,20 @@ export async function executeScaffoldManagedSkill(
       // recordWatchdogEvent already no-ops on opt-out and a missing
       // telemetry DB; anything past that is not worth surfacing here.
     }
+  }
+
+  // A background pass changed a skill that already existed. Creates announce
+  // themselves through the skill card below; an update had no signal at all.
+  // Covers an explicit `overwrite: true` refinement as well as any other
+  // background write onto a pre-existing skill.
+  const notifyConversationId =
+    sourceConversationId ?? retrospectiveConversationId;
+  if (fromRetrospective && managedSkillExistedBefore && notifyConversationId) {
+    notifyBackgroundSkillUpdate({
+      skillId: id,
+      name: normalizedName,
+      conversationId: notifyConversationId,
+    });
   }
 
   // Surface a genuine retrospective CREATE to the user as a skill card on the

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -71,12 +71,13 @@ function normalizeOptionalStringArray(
  * Tell the user that a background pass changed a skill they already have.
  *
  * A newly authored skill announces itself in the conversation through the
- * `skill_card` surface, but an UPDATE had no signal at all: the pass rewrites
- * the body of a skill the user may be relying on, and `createManagedSkill`
- * writes through an atomic rename keeping no prior version. Routing it
- * through the notification pipeline puts it in the background feed alongside
- * the other unattended work (sweeps, scheduled jobs, heartbeat), which is
- * where a user already looks to see what the assistant did on its own.
+ * `skill_card` surface; an update announces itself here instead. The pass
+ * runs in a background fork and rewrites the body of a skill the user may be
+ * relying on, and `createManagedSkill` writes through an atomic rename
+ * keeping no prior version, so the notification pipeline is what puts the
+ * change in the background feed alongside the other unattended work (sweeps,
+ * scheduled jobs, heartbeat), where a user already looks to see what the
+ * assistant did on its own.
  *
  * `sourceContextId` is a conversation id so the feed item's "Go to Convo"
  * target resolves (see `home-feed-side-effect.ts`, which looks it up via
@@ -93,7 +94,12 @@ function notifyBackgroundSkillUpdate(args: {
 }): void {
   const day = new Date().toISOString().slice(0, 10);
   void emitNotificationSignal({
-    sourceChannel: "scheduler",
+    // This emit is a tool executor's, not the scheduler's. The channel is
+    // provenance the pipeline reads: `home-feed-side-effect` derives
+    // `fromAssistant` from it, so labelling this "scheduler" would drop the
+    // item from the feed's assistant-initiated filter despite being exactly
+    // that.
+    sourceChannel: "assistant_tool",
     sourceContextId: args.conversationId,
     sourceEventName: "activity.complete",
     dedupeKey: `skill-updated:${args.skillId}:${day}`,
@@ -417,9 +423,10 @@ export async function executeScaffoldManagedSkill(
   }
 
   // A background pass changed a skill that already existed. Creates announce
-  // themselves through the skill card below; an update had no signal at all.
-  // Covers an explicit `overwrite: true` refinement as well as any other
-  // background write onto a pre-existing skill.
+  // themselves through the skill card below; updates announce themselves in
+  // the background activity feed. Covers an explicit `overwrite: true`
+  // refinement as well as any other background write onto a pre-existing
+  // skill.
   const notifyConversationId =
     sourceConversationId ?? retrospectiveConversationId;
   if (fromRetrospective && managedSkillExistedBefore && notifyConversationId) {

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -105,7 +105,11 @@ function notifyBackgroundSkillUpdate(args: {
       // and it skips the item entirely, so the quiet case would surface
       // nothing at all.
       summary: `Updated the skill "${args.name}" from something learned in an earlier conversation.`,
-      title: "Skill updated",
+      // Named, not just "Skill updated": the feed sits several rows deep and
+      // a generic title is unscannable next to entries that name their
+      // subject (`Background job failed: memory.v2.sweep`). The word "Skill"
+      // stays because a bare skill name does not always read as one.
+      title: `Skill updated: ${args.name}`,
       body: `Updated the skill "${args.name}" from something learned in an earlier conversation.`,
       skillId: args.skillId,
     },

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -98,7 +98,15 @@ function notifyBackgroundSkillUpdate(args: {
     sourceEventName: "activity.complete",
     dedupeKey: `skill-updated:${args.skillId}:${day}`,
     contextPayload: {
+      // `summary` feeds the copy composer; `title`/`body` are the home feed's
+      // fallback when no channel copy was rendered. Without them a fully
+      // suppressed delivery (the intended shape for this signal: low urgency,
+      // background, no interruption) leaves the feed writer with no summary
+      // and it skips the item entirely, so the quiet case would surface
+      // nothing at all.
       summary: `Updated the skill "${args.name}" from something learned in an earlier conversation.`,
+      title: "Skill updated",
+      body: `Updated the skill "${args.name}" from something learned in an earlier conversation.`,
       skillId: args.skillId,
     },
     attentionHints: {


### PR DESCRIPTION
> Draft.

## TL;DR

When a background memory pass updates a skill you already have, **you currently have no way to know.** This makes it show up in the background activity feed, the same place sweeps, scheduled jobs, and heartbeat report what the assistant did on its own.

## Why it is invisible today

When *you* ask the assistant to change a skill, it happens in your conversation, so the tool call and its result render in the transcript. You see it.

A background pass runs inside a hidden **retrospective fork** (`conversationType: "background"`, under `system:background`), so its `scaffold_managed_skill` call renders in a conversation you never open, and which is garbage collected once a later pass supersedes it.

A newly authored skill still reaches you: the `skill_card` job inserts "I just learned how to do X" into the source conversation. **An update reaches nothing.** The pass rewrites the body of a skill you may be relying on, and `createManagedSkill` writes through an atomic rename keeping no prior version, so there is nothing to compare against either.

## What changes for the user

| Situation | Before | After |
|---|---|---|
| You ask the assistant to change a skill | Renders as a tool call in your conversation | **Unchanged** |
| Background pass creates a new skill | "I just learned how to do X" card in the conversation | **Unchanged** (no second announcement) |
| Background pass updates a skill you already have | Nothing, anywhere | Appears in the background activity feed, linking to the conversation it came from |

## How

Emits `activity.complete` through `emitNotificationSignal` when a retrospective-origin write lands on a pre-existing skill.

- **The title names the skill** (`Skill updated: Weekly Report Export`). A generic "Skill updated" is not scannable in a feed several rows deep, next to entries that name their subject (`Background job failed: memory.v2.sweep`). The word "Skill" stays because a bare skill name does not always read as one.
- **`sourceContextId` is a conversation id**, so the feed item's "Go to Convo" target resolves: `home-feed-side-effect.ts` looks it up via `getConversation`. It is the source conversation when fork lineage resolves, and the run's own conversation otherwise, so the link never dangles.
- **Deduped per skill per day** (`skill-updated:<id>:<day>`), following the sweep job's pattern, so a pass that keeps refining one skill cannot flood the feed.
- **Best-effort and non-blocking.** The skill is already written; a notification failure is logged and never turns a completed write into a tool error.
- Goes through `emitNotificationSignal` rather than broadcasting directly, per `notifications/AGENTS.md`.

`activity.complete` is already declared in `notifications/signal.ts` ("Background activity finished") and routed to the `background` feed category, but nothing in production emitted it. This is its first producer.

## Why this is safe

Additive and observation-only: no skill behavior changes, nothing new is written or destroyed, and no existing surface moves. Creates keep their card and emit no signal, so there is no double announcement. User-directed writes never notify, since they are already visible where the person is looking.

No new tables, migrations, config, feature flags, or tool-schema changes.

## Not included

**Card parity for updates.** Creates land a card in the source conversation; updates still do not. Doing that means inserting a card on update and a small `clients/web` change, because `skill-created-card.tsx` hardcodes the per-row copy (`I just learned how to do ${name}`) and would render the wrong sentence for a refinement. That is the natural follow-up and is deliberately out of this PR.

**Recoverability.** No prior version of an overwritten skill is kept. This makes the change visible, which is the larger half; whether background skill edits should also be reversible is a separate decision.

## Test plan

Four tests in `scaffold-managed-skill-tool.test.ts`: a background overwrite emits `activity.complete` keyed to the **source** conversation with the skill name in the summary and the expected per-skill-per-day dedupe key; unresolvable fork lineage falls back to the run conversation so the deep link still resolves; a background create gets the card and no signal; a user-directed overwrite notifies not at all.

58 tests pass in that file, plus lint, typecheck, and the managed-skill lifecycle, skill-card, notification deep-link, and tool-executor suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

