### PR TITLE
Slack setup wizard: restore the walkthrough over Slack's current flow (LUM-3000)

### DIFF
--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -85,11 +85,14 @@ export function SlackSetupCreateStep({
         first.
       </Typography>
 
-      <div className="flex">
-        <Button type="button" variant="primary" onClick={onContinue}>
-          I created the app
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="primary"
+        className="self-start"
+        onClick={onContinue}
+      >
+        I created the app
+      </Button>
     </div>
   );
 }

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -78,7 +78,7 @@ export function SlackSetupCreateStep({
       <Typography
         as="p"
         variant="body-small-default"
-        className="text-[color:var(--content-faint)]"
+        className="text-[color:var(--content-secondary)]"
       >
         If Slack shows &ldquo;Request approval&rdquo; instead of{" "}
         <strong>Install</strong>, a workspace admin needs to approve the app

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -1,62 +1,21 @@
-import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
-
 import { Button, Notice, Typography } from "@vellumai/design-library";
 
 export interface SlackSetupCreateStepProps {
-  copied: boolean;
-  onOpenSlack: () => void;
-  onCopyManifest: () => void;
   onContinue: () => void;
 }
 
 /**
- * Step 2 of `SlackSetupWizard`: hand the manifest to Slack.
+ * Step 3 of `SlackSetupWizard`: what to do inside Slack.
  *
- * "Open Slack" leads, because everything below it happens in the tab that
- * button opens. The directions stay on screen here for the round trip back.
+ * These directions stay on screen while the user works in the other tab, so
+ * this step holds no handoff control of its own. Reopening Slack means
+ * stepping back, which the stepper already allows.
  */
 export function SlackSetupCreateStep({
-  copied,
-  onOpenSlack,
-  onCopyManifest,
   onContinue,
 }: SlackSetupCreateStepProps) {
   return (
     <div className="flex flex-col gap-4">
-      <Typography
-        as="p"
-        variant="body-medium-lighter"
-        className="text-[color:var(--content-default)]"
-      >
-        The manifest is on your clipboard. Create the app in Slack, then come
-        back here.
-      </Typography>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <Button
-          type="button"
-          variant="primary"
-          onClick={onOpenSlack}
-          rightIcon={<ExternalLink aria-hidden className="size-4" />}
-        >
-          Open Slack
-        </Button>
-        <Button
-          type="button"
-          variant="outlined"
-          onClick={onCopyManifest}
-          leftIcon={
-            copied ? (
-              <Check aria-hidden className="size-4" />
-            ) : (
-              <ClipboardCopy aria-hidden className="size-4" />
-            )
-          }
-        >
-          {copied ? "Copied!" : "Copy again"}
-        </Button>
-      </div>
-
       <Typography
         as="p"
         variant="body-medium-lighter"

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -1,0 +1,95 @@
+import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+export interface SlackSetupCreateStepProps {
+  copied: boolean;
+  onOpenSlack: () => void;
+  onCopyManifest: () => void;
+  onContinue: () => void;
+}
+
+/**
+ * Step 2 of `SlackSetupWizard`: hand the manifest to Slack.
+ *
+ * "Open Slack" leads, because everything below it happens in the tab that
+ * button opens. The directions stay on screen here for the round trip back.
+ */
+export function SlackSetupCreateStep({
+  copied,
+  onOpenSlack,
+  onCopyManifest,
+  onContinue,
+}: SlackSetupCreateStepProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Typography
+        as="p"
+        variant="body-medium-lighter"
+        className="text-[color:var(--content-default)]"
+      >
+        The manifest is on your clipboard. Create the app in Slack, then come
+        back here.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onOpenSlack}
+          rightIcon={<ExternalLink aria-hidden className="size-4" />}
+        >
+          Open Slack
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          onClick={onCopyManifest}
+          leftIcon={
+            copied ? (
+              <Check aria-hidden className="size-4" />
+            ) : (
+              <ClipboardCopy aria-hidden className="size-4" />
+            )
+          }
+        >
+          {copied ? "Copied!" : "Copy again"}
+        </Button>
+      </div>
+
+      <Typography
+        as="p"
+        variant="body-medium-lighter"
+        className="text-[color:var(--content-default)]"
+      >
+        In Slack:
+      </Typography>
+      <ol className="list-decimal list-outside space-y-1 pl-5 text-body-medium-lighter text-[var(--content-default)]">
+        <li>
+          Under <strong>Or start your own way</strong>, pick{" "}
+          <strong>From a manifest</strong>, then <strong>Continue</strong>
+        </li>
+        <li>Choose your workspace and paste the manifest</li>
+        <li>
+          Review the permissions, then click <strong>Create and Install</strong>
+        </li>
+      </ol>
+
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-faint)]"
+      >
+        If Slack shows &ldquo;Request approval&rdquo; instead of{" "}
+        <strong>Install</strong>, a workspace admin needs to approve the app
+        first.
+      </Typography>
+
+      <div className="flex">
+        <Button type="button" variant="primary" onClick={onContinue}>
+          I created the app
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -1,6 +1,6 @@
 import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Button, Notice, Typography } from "@vellumai/design-library";
 
 export interface SlackSetupCreateStepProps {
   copied: boolean;
@@ -75,15 +75,11 @@ export function SlackSetupCreateStep({
         </li>
       </ol>
 
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-secondary)]"
-      >
+      <Notice tone="info">
         If Slack shows &ldquo;Request approval&rdquo; instead of{" "}
         <strong>Install</strong>, a workspace admin needs to approve the app
         first.
-      </Typography>
+      </Notice>
 
       <Button
         type="button"

--- a/clients/web/src/components/slack-setup-name-step.tsx
+++ b/clients/web/src/components/slack-setup-name-step.tsx
@@ -1,12 +1,10 @@
 import { Check, ClipboardCopy } from "lucide-react";
 
 import { Button, Input, Typography } from "@vellumai/design-library";
-
-/** Slack's limit for `display_information.name`. */
-const APP_NAME_MAX_LENGTH = 35;
-
-/** Slack's limit for `display_information.description`. */
-const DESCRIPTION_MAX_LENGTH = 140;
+import {
+  SLACK_APP_DESCRIPTION_MAX_LENGTH,
+  SLACK_APP_NAME_MAX_LENGTH,
+} from "@/utils/slack-manifest";
 
 export interface SlackSetupNameStepProps {
   appName: string;
@@ -49,7 +47,7 @@ export function SlackSetupNameStep({
         label="App Name"
         value={appName}
         onChange={(e) =>
-          onAppNameChange(e.target.value.slice(0, APP_NAME_MAX_LENGTH))
+          onAppNameChange(e.target.value.slice(0, SLACK_APP_NAME_MAX_LENGTH))
         }
         placeholder="My Assistant"
         fullWidth
@@ -59,30 +57,31 @@ export function SlackSetupNameStep({
         label="Description (optional)"
         value={description}
         onChange={(e) =>
-          onDescriptionChange(e.target.value.slice(0, DESCRIPTION_MAX_LENGTH))
+          onDescriptionChange(
+            e.target.value.slice(0, SLACK_APP_DESCRIPTION_MAX_LENGTH),
+          )
         }
         placeholder="What this assistant helps with"
         helperText="Shown on the app's Slack profile."
         fullWidth
       />
 
-      <div className="flex">
-        <Button
-          type="button"
-          variant="primary"
-          disabled={!nameValid}
-          onClick={onCopyAndContinue}
-          leftIcon={
-            copied ? (
-              <Check aria-hidden className="size-4" />
-            ) : (
-              <ClipboardCopy aria-hidden className="size-4" />
-            )
-          }
-        >
-          Copy manifest and continue
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="primary"
+        className="self-start"
+        disabled={!nameValid}
+        onClick={onCopyAndContinue}
+        leftIcon={
+          copied ? (
+            <Check aria-hidden className="size-4" />
+          ) : (
+            <ClipboardCopy aria-hidden className="size-4" />
+          )
+        }
+      >
+        Copy manifest and continue
+      </Button>
     </div>
   );
 }

--- a/clients/web/src/components/slack-setup-name-step.tsx
+++ b/clients/web/src/components/slack-setup-name-step.tsx
@@ -1,0 +1,88 @@
+import { Check, ClipboardCopy } from "lucide-react";
+
+import { Button, Input, Typography } from "@vellumai/design-library";
+
+/** Slack's limit for `display_information.name`. */
+const APP_NAME_MAX_LENGTH = 35;
+
+/** Slack's limit for `display_information.description`. */
+const DESCRIPTION_MAX_LENGTH = 140;
+
+export interface SlackSetupNameStepProps {
+  appName: string;
+  description: string;
+  copied: boolean;
+  onAppNameChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onCopyAndContinue: () => void;
+}
+
+/**
+ * Step 1 of `SlackSetupWizard`: name the app and take its manifest.
+ *
+ * Copying and advancing are one action rather than two controls, so the
+ * manifest is on the clipboard before the next step sends anyone to Slack.
+ * Slack's create-app modal has nowhere to fetch it from.
+ */
+export function SlackSetupNameStep({
+  appName,
+  description,
+  copied,
+  onAppNameChange,
+  onDescriptionChange,
+  onCopyAndContinue,
+}: SlackSetupNameStepProps) {
+  const nameValid = appName.trim().length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Typography
+        as="p"
+        variant="body-medium-lighter"
+        className="text-[color:var(--content-default)]"
+      >
+        Name your Slack app and copy its manifest. Every permission and setting
+        comes pre-configured.
+      </Typography>
+
+      <Input
+        label="App Name"
+        value={appName}
+        onChange={(e) =>
+          onAppNameChange(e.target.value.slice(0, APP_NAME_MAX_LENGTH))
+        }
+        placeholder="My Assistant"
+        fullWidth
+      />
+
+      <Input
+        label="Description (optional)"
+        value={description}
+        onChange={(e) =>
+          onDescriptionChange(e.target.value.slice(0, DESCRIPTION_MAX_LENGTH))
+        }
+        placeholder="What this assistant helps with"
+        helperText="Shown on the app's Slack profile."
+        fullWidth
+      />
+
+      <div className="flex">
+        <Button
+          type="button"
+          variant="primary"
+          disabled={!nameValid}
+          onClick={onCopyAndContinue}
+          leftIcon={
+            copied ? (
+              <Check aria-hidden className="size-4" />
+            ) : (
+              <ClipboardCopy aria-hidden className="size-4" />
+            )
+          }
+        >
+          Copy manifest and continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/components/slack-setup-name-step.tsx
+++ b/clients/web/src/components/slack-setup-name-step.tsx
@@ -12,15 +12,17 @@ export interface SlackSetupNameStepProps {
   copied: boolean;
   onAppNameChange: (value: string) => void;
   onDescriptionChange: (value: string) => void;
-  onCopyAndContinue: () => void;
+  onCopyManifest: () => void;
+  onContinue: () => void;
 }
 
 /**
  * Step 1 of `SlackSetupWizard`: name the app and take its manifest.
  *
- * Copying and advancing are one action rather than two controls, so the
- * manifest is on the clipboard before the next step sends anyone to Slack.
- * Slack's create-app modal has nowhere to fetch it from.
+ * Copying and continuing are separate controls. Folding them together meant a
+ * copy could not be repeated without navigating, and made moving forward
+ * depend on a clipboard write that can fail. The next step offers the manifest
+ * again, so nothing is lost by continuing without copying here.
  */
 export function SlackSetupNameStep({
   appName,
@@ -28,7 +30,8 @@ export function SlackSetupNameStep({
   copied,
   onAppNameChange,
   onDescriptionChange,
-  onCopyAndContinue,
+  onCopyManifest,
+  onContinue,
 }: SlackSetupNameStepProps) {
   const nameValid = appName.trim().length > 0;
 
@@ -66,22 +69,31 @@ export function SlackSetupNameStep({
         fullWidth
       />
 
-      <Button
-        type="button"
-        variant="primary"
-        className="self-start"
-        disabled={!nameValid}
-        onClick={onCopyAndContinue}
-        leftIcon={
-          copied ? (
-            <Check aria-hidden className="size-4" />
-          ) : (
-            <ClipboardCopy aria-hidden className="size-4" />
-          )
-        }
-      >
-        Copy manifest and continue
-      </Button>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="outlined"
+          disabled={!nameValid}
+          onClick={onCopyManifest}
+          leftIcon={
+            copied ? (
+              <Check aria-hidden className="size-4" />
+            ) : (
+              <ClipboardCopy aria-hidden className="size-4" />
+            )
+          }
+        >
+          {copied ? "Copied!" : "Copy manifest"}
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          disabled={!nameValid}
+          onClick={onContinue}
+        >
+          Next
+        </Button>
+      </div>
     </div>
   );
 }

--- a/clients/web/src/components/slack-setup-open-step.tsx
+++ b/clients/web/src/components/slack-setup-open-step.tsx
@@ -1,0 +1,61 @@
+import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+export interface SlackSetupOpenStepProps {
+  copied: boolean;
+  onOpenSlack: () => void;
+  onCopyManifest: () => void;
+}
+
+/**
+ * Step 2 of `SlackSetupWizard`: hand off to Slack.
+ *
+ * "Open Slack" also advances, so this step carries one forward action and the
+ * directions for what to do over there get a screen of their own. Copying
+ * again is deliberately not a forward action: it exists for a clipboard
+ * clobbered between steps, and advancing on it would skip the handoff.
+ */
+export function SlackSetupOpenStep({
+  copied,
+  onOpenSlack,
+  onCopyManifest,
+}: SlackSetupOpenStepProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Typography
+        as="p"
+        variant="body-medium-lighter"
+        className="text-[color:var(--content-default)]"
+      >
+        The manifest is on your clipboard. Open Slack to create the app, then
+        come back here.
+      </Typography>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onOpenSlack}
+          rightIcon={<ExternalLink aria-hidden className="size-4" />}
+        >
+          Open Slack
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          onClick={onCopyManifest}
+          leftIcon={
+            copied ? (
+              <Check aria-hidden className="size-4" />
+            ) : (
+              <ClipboardCopy aria-hidden className="size-4" />
+            )
+          }
+        >
+          {copied ? "Copied!" : "Copy again"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/components/slack-setup-open-step.tsx
+++ b/clients/web/src/components/slack-setup-open-step.tsx
@@ -1,25 +1,23 @@
-import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
 export interface SlackSetupOpenStepProps {
-  copied: boolean;
   onOpenSlack: () => void;
-  onCopyManifest: () => void;
+  onContinue: () => void;
 }
 
 /**
  * Step 2 of `SlackSetupWizard`: hand off to Slack.
  *
- * "Open Slack" also advances, so this step carries one forward action and the
- * directions for what to do over there get a screen of their own. Copying
- * again is deliberately not a forward action: it exists for a clipboard
- * clobbered between steps, and advancing on it would skip the handoff.
+ * Opening Slack does not advance. A popup blocker or a stolen focus would
+ * otherwise move the flow on without the tab it claims to have opened, and
+ * navigating for the user is what made the previous shape confusing. To copy
+ * the manifest again, step back to Name, which the stepper keeps reachable.
  */
 export function SlackSetupOpenStep({
-  copied,
   onOpenSlack,
-  onCopyManifest,
+  onContinue,
 }: SlackSetupOpenStepProps) {
   return (
     <div className="flex flex-col gap-4">
@@ -28,8 +26,8 @@ export function SlackSetupOpenStep({
         variant="body-medium-lighter"
         className="text-[color:var(--content-default)]"
       >
-        The manifest is on your clipboard. Open Slack to create the app, then
-        come back here.
+        Open Slack in a new tab to create the app, then come back here for the
+        steps to follow.
       </Typography>
 
       <div className="flex flex-wrap items-center gap-3">
@@ -41,19 +39,8 @@ export function SlackSetupOpenStep({
         >
           Open Slack
         </Button>
-        <Button
-          type="button"
-          variant="outlined"
-          onClick={onCopyManifest}
-          leftIcon={
-            copied ? (
-              <Check aria-hidden className="size-4" />
-            ) : (
-              <ClipboardCopy aria-hidden className="size-4" />
-            )
-          }
-        >
-          {copied ? "Copied!" : "Copy again"}
+        <Button type="button" variant="outlined" onClick={onContinue}>
+          Next
         </Button>
       </div>
     </div>

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -90,16 +90,15 @@ export function SlackSetupTokensStep({
         fullWidth
       />
 
-      <div className="flex">
-        <Button
-          type="button"
-          variant="primary"
-          onClick={onSave}
-          disabled={!canSave}
-        >
-          {saveStatus === "pending" ? "Connecting…" : "Connect Slack"}
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="primary"
+        className="self-start"
+        onClick={onSave}
+        disabled={!canSave}
+      >
+        {saveStatus === "pending" ? "Connecting…" : "Connect Slack"}
+      </Button>
 
       {saveStatus === "success" && (
         <Typography

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -63,7 +63,7 @@ export function SlackSetupTokensStep({
       <Typography
         as="p"
         variant="body-small-default"
-        className="text-[color:var(--content-faint)]"
+        className="text-[color:var(--content-secondary)]"
       >
         That screen also offers a command-line walkthrough and a{" "}
         <strong>Download app files</strong> button. Skip both. They set up a

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -1,0 +1,124 @@
+import { Button, Input, Typography } from "@vellumai/design-library";
+import type { MutationStatus } from "@/components/slack-setup-wizard";
+import {
+  APP_TOKEN_PREFIX,
+  BOT_TOKEN_PREFIX,
+  validateSlackToken,
+} from "@/utils/slack-token-validation";
+
+export interface SlackSetupTokensStepProps {
+  botToken: string;
+  appToken: string;
+  saveStatus: MutationStatus;
+  saveError: string | null;
+  onBotTokenChange: (value: string) => void;
+  onAppTokenChange: (value: string) => void;
+  onSave: () => void;
+}
+
+/**
+ * Step 3 of `SlackSetupWizard`: bring both tokens back from Slack.
+ *
+ * Slack mints the `xapp-` app token alongside the `xoxb-` bot token on Create
+ * and Install, so both are collected here rather than across separate steps.
+ */
+export function SlackSetupTokensStep({
+  botToken,
+  appToken,
+  saveStatus,
+  saveError,
+  onBotTokenChange,
+  onAppTokenChange,
+  onSave,
+}: SlackSetupTokensStepProps) {
+  const botTokenError = validateSlackToken(
+    botToken,
+    BOT_TOKEN_PREFIX,
+    "Bot token",
+  );
+  const appTokenError = validateSlackToken(
+    appToken,
+    APP_TOKEN_PREFIX,
+    "App token",
+  );
+
+  const canSave =
+    botToken.trim().length > 0 &&
+    appToken.trim().length > 0 &&
+    !botTokenError &&
+    !appTokenError &&
+    saveStatus !== "pending";
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Typography
+        as="p"
+        variant="body-medium-lighter"
+        className="text-[color:var(--content-default)]"
+      >
+        On Slack&apos;s confirmation screen, expand{" "}
+        <strong>Your app credentials</strong> and copy both tokens.
+      </Typography>
+
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-faint)]"
+      >
+        That screen also offers a command-line walkthrough and a{" "}
+        <strong>Download app files</strong> button. Skip both. They set up a
+        separate local app, and this assistant needs only the two tokens.
+      </Typography>
+
+      <Input
+        label="Bot Token"
+        type="password"
+        value={botToken}
+        onChange={(e) => onBotTokenChange(e.target.value)}
+        placeholder={`${BOT_TOKEN_PREFIX}...`}
+        errorText={botTokenError ?? undefined}
+        fullWidth
+      />
+
+      <Input
+        label="App Token"
+        type="password"
+        value={appToken}
+        onChange={(e) => onAppTokenChange(e.target.value)}
+        placeholder={`${APP_TOKEN_PREFIX}...`}
+        errorText={appTokenError ?? undefined}
+        fullWidth
+      />
+
+      <div className="flex">
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onSave}
+          disabled={!canSave}
+        >
+          {saveStatus === "pending" ? "Connecting…" : "Connect Slack"}
+        </Button>
+      </div>
+
+      {saveStatus === "success" && (
+        <Typography
+          as="p"
+          variant="body-small-default"
+          className="text-[color:var(--content-positive)]"
+        >
+          Credentials saved.
+        </Typography>
+      )}
+      {saveStatus === "error" && saveError && (
+        <Typography
+          as="p"
+          variant="body-small-default"
+          className="text-[color:var(--system-negative-strong)]"
+        >
+          {saveError}
+        </Typography>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Typography } from "@vellumai/design-library";
+import { Button, Input, Notice, Typography } from "@vellumai/design-library";
 import type { MutationStatus } from "@/components/slack-setup-wizard";
 import {
   APP_TOKEN_PREFIX,
@@ -60,15 +60,11 @@ export function SlackSetupTokensStep({
         <strong>Your app credentials</strong> and copy both tokens.
       </Typography>
 
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-secondary)]"
-      >
+      <Notice tone="warning">
         That screen also offers a command-line walkthrough and a{" "}
         <strong>Download app files</strong> button. Skip both. They set up a
         separate local app, and this assistant needs only the two tokens.
-      </Typography>
+      </Notice>
 
       <Input
         label="Bot Token"

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -17,7 +17,7 @@ export interface SlackSetupTokensStepProps {
 }
 
 /**
- * Step 3 of `SlackSetupWizard`: bring both tokens back from Slack.
+ * Step 4 of `SlackSetupWizard`: bring both tokens back from Slack.
  *
  * Slack mints the `xapp-` app token alongside the `xoxb-` bot token on Create
  * and Install, so both are collected here rather than across separate steps.

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -9,9 +9,13 @@ const meta: Meta<typeof SlackSetupWizard> = {
   args: {
     assistantName: "Example Assistant",
   },
+  // 400px matches the drawer the wizard actually renders in: `chat-content-
+  // layout.tsx` mounts it in an `AnimatedRightDrawer` with `defaultWidth` and
+  // `minWidth` both 400. A wider frame hides the density these stories exist to
+  // show.
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: 800, margin: "2rem auto" }}>
+      <div style={{ width: 400, margin: "2rem auto" }}>
         <Story />
       </div>
     ),

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -38,22 +38,55 @@ const fillTokens: Story["play"] = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByLabelText(/App Token/i), APP_TOKEN);
 };
 
-export const Default: Story = {};
+/** Step 1: name the app and take its manifest. */
+export const Name: Story = {};
+
+/**
+ * Step 1 with the name cleared. "Copy manifest and continue" is the only way
+ * forward, so an empty name has to block it.
+ */
+export const NameEmpty: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.clear(canvas.getByLabelText(/App Name/i));
+  },
+};
+
+/**
+ * Step 2, reached by copying rather than by `initialStepId`, so this also
+ * covers the copy-and-advance handoff the flow depends on.
+ */
+export const CreateApp: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: /Copy manifest and continue/i }),
+    );
+  },
+};
+
+/** Step 3: both tokens, empty. */
+export const Connect: Story = {
+  args: { initialStepId: "connect" },
+};
 
 export const Saving: Story = {
-  args: { saveStatus: "pending" },
+  args: { initialStepId: "connect", saveStatus: "pending" },
+  play: fillTokens,
 };
 
 export const Connected: Story = {
-  args: { saveStatus: "success" },
+  args: { initialStepId: "connect", saveStatus: "success" },
   play: fillTokens,
 };
 
 export const SaveFailed: Story = {
   args: {
+    initialStepId: "connect",
     saveStatus: "error",
     saveError: "Slack rejected the bot token (invalid_auth).",
   },
+  play: fillTokens,
 };
 
 /**
@@ -62,6 +95,7 @@ export const SaveFailed: Story = {
  * Connect stays disabled.
  */
 export const TokenFormatValidation: Story = {
+  args: { initialStepId: "connect" },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText(/Bot Token/i), APP_TOKEN);

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -41,10 +41,7 @@ const fillTokens: Story["play"] = async ({ canvasElement }) => {
 /** Step 1: name the app and take its manifest. */
 export const Name: Story = {};
 
-/**
- * Step 1 with the name cleared. "Copy manifest and continue" is the only way
- * forward, so an empty name has to block it.
- */
+/** Step 1 with the name cleared: both Copy manifest and Next are blocked. */
 export const NameEmpty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -52,16 +49,21 @@ export const NameEmpty: Story = {
   },
 };
 
-/**
- * Step 2, reached by copying rather than by `initialStepId`, so this also
- * covers the copy-and-advance handoff the flow depends on.
- */
-export const OpenSlack: Story = {
+/** Step 1 after a successful copy, showing the transient confirmation. */
+export const Copied: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
-      canvas.getByRole("button", { name: /Copy manifest and continue/i }),
+      canvas.getByRole("button", { name: /Copy manifest/i }),
     );
+  },
+};
+
+/** Step 2, reached through Next rather than `initialStepId`. */
+export const OpenSlack: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
   },
 };
 

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -56,7 +56,7 @@ export const NameEmpty: Story = {
  * Step 2, reached by copying rather than by `initialStepId`, so this also
  * covers the copy-and-advance handoff the flow depends on.
  */
-export const CreateApp: Story = {
+export const OpenSlack: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
@@ -65,7 +65,12 @@ export const CreateApp: Story = {
   },
 };
 
-/** Step 3: both tokens, empty. */
+/** Step 3: the in-Slack directions, with one way forward. */
+export const CreateApp: Story = {
+  args: { initialStepId: "create" },
+};
+
+/** Step 4: both tokens, empty. */
 export const Connect: Story = {
   args: { initialStepId: "connect" },
 };

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -75,8 +75,13 @@ describe("SlackSetupWizard step flow", () => {
     // Counted rather than probed by name: a bare "Next" or "Skip" added later
     // would reach step 2 with an empty clipboard, and Slack's modal has
     // nowhere to fetch the manifest from.
-    const panel = document.querySelector('[data-slot="slack-setup-step-panel"]');
-    const stepButtons = panel!.querySelectorAll("button");
+    const panel = document.querySelector(
+      '[data-slot="slack-setup-step-panel"]',
+    );
+    if (!panel) {
+      throw new Error("step panel did not render");
+    }
+    const stepButtons = panel.querySelectorAll("button");
     expect(stepButtons).toHaveLength(1);
     expect(stepButtons[0].textContent).toMatch(/Copy manifest and continue/i);
   });

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -1,17 +1,17 @@
 /**
  * Tests for `SlackSetupWizard`'s step flow:
  *
- *   1. Copy and advance are one action, and the manifest that reaches the
- *      clipboard carries what was typed on step 1.
- *   2. Step 1 offers no second way forward. Slack's create-app modal cannot
- *      fetch the manifest, so a path to step 2 that skips the copy would
- *      strand the user with nothing to paste.
- *   3. An empty app name blocks the only control that advances.
- *   4. Step 3 hands both tokens to `onSave`, trimmed.
+ *   1. Copying puts the live manifest on the clipboard, carrying what was
+ *      typed, and does not navigate.
+ *   2. A failed clipboard write neither claims success nor moves the flow on.
+ *   3. Navigation is never a side effect of another control: Next advances,
+ *      Copy and Open Slack do not.
+ *   4. An empty app name blocks both controls on step 1.
+ *   5. Step 4 hands both tokens to `onSave`, trimmed.
  *
  * All token values are synthetic fixtures.
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   cleanup,
   fireEvent,
@@ -20,7 +20,26 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-import { SlackSetupWizard } from "@/components/slack-setup-wizard";
+import * as toastModule from "@vellumai/design-library/components/toast";
+
+const toasts: string[] = [];
+// Spread the real module: the design library's barrel re-exports `Toaster` and
+// `ToastContent` from here, so a partial mock breaks unrelated imports.
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: {
+    ...toastModule.toast,
+    success: () => {},
+    error: (message: string) => {
+      toasts.push(message);
+    },
+  },
+}));
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+const { SlackSetupWizard } = await import("@/components/slack-setup-wizard");
 
 const ASSISTANT_NAME = "Example Assistant";
 const DIGITS = "0".repeat(10);
@@ -29,47 +48,77 @@ const APP_TOKEN = `xapp-1-A${DIGITS}-${DIGITS}-abcdefghij`;
 
 let clipboardWrites: string[] = [];
 
-beforeEach(() => {
-  clipboardWrites = [];
+function stubClipboard(result: () => Promise<void>) {
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: {
       writeText: (text: string) => {
         clipboardWrites.push(text);
-        return Promise.resolve();
+        return result();
       },
     },
   });
+}
+
+beforeEach(() => {
+  clipboardWrites = [];
+  toasts.length = 0;
+  stubClipboard(() => Promise.resolve());
 });
 
 afterEach(cleanup);
 
-function continueButton() {
-  return screen.getByRole("button", { name: /Copy manifest and continue/i });
-}
+const copyButton = () =>
+  screen.getByRole("button", { name: /Copy manifest|Copied!/i });
+const nextButton = () => screen.getByRole("button", { name: /^Next$/i });
+const onOpenStep = () =>
+  screen.queryByRole("button", { name: /Open Slack/i }) !== null;
 
 describe("SlackSetupWizard step flow", () => {
-  test("copying the manifest is what advances to step 2", async () => {
+  test("copying puts the live manifest on the clipboard without navigating", async () => {
     render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
 
     fireEvent.change(screen.getByLabelText(/App Name/i), {
       target: { value: "Support Bot" },
     });
-    fireEvent.click(continueButton());
+    fireEvent.click(copyButton());
 
-    // The clipboard carries the edited name, not the assistant's default, so
-    // this proves the live manifest was copied rather than a stale render.
+    // The edited name proves this is the live manifest, not a stale render.
     expect(clipboardWrites).toHaveLength(1);
     expect(JSON.parse(clipboardWrites[0]).display_information.name).toBe(
       "Support Bot",
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Open Slack/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Copied!/i })).toBeTruthy();
     });
+    expect(onOpenStep()).toBe(false);
   });
 
-  test("opening Slack is what advances past the handoff step", async () => {
+  test("a failed clipboard write neither claims success nor advances", async () => {
+    stubClipboard(() => Promise.reject(new Error("NotAllowedError")));
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() => {
+      expect(toasts).toHaveLength(1);
+    });
+    // "Copied!" would tell the user to go paste something that isn't there.
+    expect(screen.queryByRole("button", { name: /Copied!/i })).toBeNull();
+    expect(onOpenStep()).toBe(false);
+  });
+
+  test("Next advances without requiring a copy", () => {
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+
+    fireEvent.click(nextButton());
+
+    expect(clipboardWrites).toHaveLength(0);
+    expect(onOpenStep()).toBe(true);
+  });
+
+  test("opening Slack opens a tab but does not navigate the wizard", () => {
     const opened: string[] = [];
     const realOpen = window.open;
     window.open = ((url: string) => {
@@ -79,72 +128,38 @@ describe("SlackSetupWizard step flow", () => {
 
     try {
       render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
-      fireEvent.click(continueButton());
+      fireEvent.click(nextButton());
       fireEvent.click(screen.getByRole("button", { name: /Open Slack/i }));
 
       expect(opened).toHaveLength(1);
       expect(opened[0]).toContain("api.slack.com/apps");
 
-      // The in-Slack directions are the next screen, not a peer of the button
-      // that sent the user there.
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: /I created the app/i }),
-        ).toBeTruthy();
-      });
+      // A blocked popup would otherwise move the flow past the tab it claims
+      // to have opened.
+      expect(onOpenStep()).toBe(true);
+      expect(
+        screen.queryByRole("button", { name: /I created the app/i }),
+      ).toBeNull();
     } finally {
       window.open = realOpen;
     }
   });
 
-  test("copying again does not advance past the handoff step", () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
-    fireEvent.click(continueButton());
-    // Arriving here right after the copy, the button still reads "Copied!";
-    // it settles to "Copy again" once the transient flag resets.
-    fireEvent.click(
-      screen.getByRole("button", { name: /Copied!|Copy again/i }),
-    );
-
-    expect(clipboardWrites).toHaveLength(2);
-    expect(screen.getByRole("button", { name: /Open Slack/i })).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: /I created the app/i }),
-    ).toBeNull();
-  });
-
-  test("step 1 offers no way forward that skips the copy", () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
-
-    // Counted rather than probed by name: a bare "Next" or "Skip" added later
-    // would reach step 2 with an empty clipboard, and Slack's modal has
-    // nowhere to fetch the manifest from.
-    const panel = document.querySelector(
-      '[data-slot="slack-setup-step-panel"]',
-    );
-    if (!panel) {
-      throw new Error("step panel did not render");
-    }
-    const stepButtons = panel.querySelectorAll("button");
-    expect(stepButtons).toHaveLength(1);
-    expect(stepButtons[0].textContent).toMatch(/Copy manifest and continue/i);
-  });
-
-  test("an empty app name blocks the only control that advances", () => {
+  test("an empty app name blocks both controls on step 1", () => {
     render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
 
     fireEvent.change(screen.getByLabelText(/App Name/i), {
       target: { value: "   " },
     });
 
-    expect(continueButton().hasAttribute("disabled")).toBe(true);
+    expect(copyButton().hasAttribute("disabled")).toBe(true);
+    expect(nextButton().hasAttribute("disabled")).toBe(true);
 
-    fireEvent.click(continueButton());
-    expect(clipboardWrites).toHaveLength(0);
-    expect(screen.queryByRole("button", { name: /Open Slack/i })).toBeNull();
+    fireEvent.click(nextButton());
+    expect(onOpenStep()).toBe(false);
   });
 
-  test("step 3 hands both tokens to onSave, trimmed", () => {
+  test("step 4 hands both tokens to onSave, trimmed", () => {
     const saved: Array<[string, string]> = [];
     render(
       <SlackSetupWizard

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -69,6 +69,50 @@ describe("SlackSetupWizard step flow", () => {
     });
   });
 
+  test("opening Slack is what advances past the handoff step", async () => {
+    const opened: string[] = [];
+    const realOpen = window.open;
+    window.open = ((url: string) => {
+      opened.push(url);
+      return null;
+    }) as typeof window.open;
+
+    try {
+      render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+      fireEvent.click(continueButton());
+      fireEvent.click(screen.getByRole("button", { name: /Open Slack/i }));
+
+      expect(opened).toHaveLength(1);
+      expect(opened[0]).toContain("api.slack.com/apps");
+
+      // The in-Slack directions are the next screen, not a peer of the button
+      // that sent the user there.
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /I created the app/i }),
+        ).toBeTruthy();
+      });
+    } finally {
+      window.open = realOpen;
+    }
+  });
+
+  test("copying again does not advance past the handoff step", () => {
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    fireEvent.click(continueButton());
+    // Arriving here right after the copy, the button still reads "Copied!";
+    // it settles to "Copy again" once the transient flag resets.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Copied!|Copy again/i }),
+    );
+
+    expect(clipboardWrites).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /Open Slack/i })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /I created the app/i }),
+    ).toBeNull();
+  });
+
   test("step 1 offers no way forward that skips the copy", () => {
     render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
 

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for `SlackSetupWizard`'s step flow:
+ *
+ *   1. Copy and advance are one action, and the manifest that reaches the
+ *      clipboard carries what was typed on step 1.
+ *   2. Step 1 offers no second way forward. Slack's create-app modal cannot
+ *      fetch the manifest, so a path to step 2 that skips the copy would
+ *      strand the user with nothing to paste.
+ *   3. An empty app name blocks the only control that advances.
+ *   4. Step 3 hands both tokens to `onSave`, trimmed.
+ *
+ * All token values are synthetic fixtures.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import { SlackSetupWizard } from "@/components/slack-setup-wizard";
+
+const ASSISTANT_NAME = "Example Assistant";
+const DIGITS = "0".repeat(10);
+const BOT_TOKEN = `xoxb-${DIGITS}-${DIGITS}-abcdefghij`;
+const APP_TOKEN = `xapp-1-A${DIGITS}-${DIGITS}-abcdefghij`;
+
+let clipboardWrites: string[] = [];
+
+beforeEach(() => {
+  clipboardWrites = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: (text: string) => {
+        clipboardWrites.push(text);
+        return Promise.resolve();
+      },
+    },
+  });
+});
+
+afterEach(cleanup);
+
+function continueButton() {
+  return screen.getByRole("button", { name: /Copy manifest and continue/i });
+}
+
+describe("SlackSetupWizard step flow", () => {
+  test("copying the manifest is what advances to step 2", async () => {
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+
+    fireEvent.change(screen.getByLabelText(/App Name/i), {
+      target: { value: "Support Bot" },
+    });
+    fireEvent.click(continueButton());
+
+    // The clipboard carries the edited name, not the assistant's default, so
+    // this proves the live manifest was copied rather than a stale render.
+    expect(clipboardWrites).toHaveLength(1);
+    expect(JSON.parse(clipboardWrites[0]).display_information.name).toBe(
+      "Support Bot",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open Slack/i })).toBeTruthy();
+    });
+  });
+
+  test("step 1 offers no way forward that skips the copy", () => {
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+
+    // Counted rather than probed by name: a bare "Next" or "Skip" added later
+    // would reach step 2 with an empty clipboard, and Slack's modal has
+    // nowhere to fetch the manifest from.
+    const panel = document.querySelector('[data-slot="slack-setup-step-panel"]');
+    const stepButtons = panel!.querySelectorAll("button");
+    expect(stepButtons).toHaveLength(1);
+    expect(stepButtons[0].textContent).toMatch(/Copy manifest and continue/i);
+  });
+
+  test("an empty app name blocks the only control that advances", () => {
+    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+
+    fireEvent.change(screen.getByLabelText(/App Name/i), {
+      target: { value: "   " },
+    });
+
+    expect(continueButton().hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(continueButton());
+    expect(clipboardWrites).toHaveLength(0);
+    expect(screen.queryByRole("button", { name: /Open Slack/i })).toBeNull();
+  });
+
+  test("step 3 hands both tokens to onSave, trimmed", () => {
+    const saved: Array<[string, string]> = [];
+    render(
+      <SlackSetupWizard
+        assistantName={ASSISTANT_NAME}
+        initialStepId="connect"
+        onSave={(bot, app) => saved.push([bot, app])}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Bot Token/i), {
+      target: { value: `  ${BOT_TOKEN}  ` },
+    });
+    fireEvent.change(screen.getByLabelText(/App Token/i), {
+      target: { value: APP_TOKEN },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Connect Slack/i }));
+
+    expect(saved).toEqual([[BOT_TOKEN, APP_TOKEN]]);
+  });
+});

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -1,7 +1,9 @@
-import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Button, Input, Typography } from "@vellumai/design-library";
+import { Stepper, type StepperStep } from "@vellumai/design-library";
+import { SlackSetupCreateStep } from "@/components/slack-setup-create-step";
+import { SlackSetupNameStep } from "@/components/slack-setup-name-step";
+import { SlackSetupTokensStep } from "@/components/slack-setup-tokens-step";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildSlackManifest } from "@/utils/slack-manifest";
 
@@ -14,59 +16,45 @@ export type MutationStatus = "idle" | "pending" | "success" | "error";
  */
 const SLACK_NEW_APP_URL = "https://api.slack.com/apps?new_app=1";
 
-const BOT_TOKEN_PREFIX = "xoxb-";
-const APP_TOKEN_PREFIX = "xapp-";
+const WIZARD_STEP_IDS = ["name", "create", "connect"] as const;
+export type SlackSetupStepId = (typeof WIZARD_STEP_IDS)[number];
 
-/**
- * Shortest plausible Slack token. Real tokens run far longer; this only needs
- * to catch a truncated paste, not to validate the credential.
- */
-const TOKEN_MIN_LENGTH = 20;
-
-/**
- * Format-check a pasted Slack token. Returns an error string, or null when the
- * value is acceptable *or* still empty — an untouched field is not an error.
- */
-export function validateSlackToken(
-  value: string,
-  prefix: string,
-  label: string,
-): string | null {
-  const token = value.trim();
-  if (!token) {
-    return null;
-  }
-  if (!token.startsWith(prefix)) {
-    return `${label} should start with "${prefix}".`;
-  }
-  if (token.length < TOKEN_MIN_LENGTH) {
-    return `${label} looks truncated — copy the whole value from Slack.`;
-  }
-  return null;
-}
+const WIZARD_STEPS: StepperStep[] = [
+  { id: "name", label: "Name" },
+  { id: "create", label: "Create app" },
+  { id: "connect", label: "Connect" },
+];
 
 export interface SlackSetupWizardProps {
   assistantName: string;
+  /**
+   * Step to open on. Production always starts at the beginning; stories use
+   * this to render a later step without clicking through the earlier ones.
+   */
+  initialStepId?: SlackSetupStepId;
   onSave?: (botToken: string, appToken: string) => void;
   saveStatus?: MutationStatus;
   saveError?: string | null;
 }
 
 /**
- * Single-step guided setup for connecting a Slack app.
+ * Guided setup for connecting a Slack app, paced across three steps.
  *
  * Slack's create-app modal ignores manifest deep links and mints both the bot
- * and app-level tokens itself on Create and Install, so the flow is: copy the
- * manifest, hand it to the modal's "From a manifest" option, then bring both
- * tokens back here. Settings for an already-connected Slack (thread behavior)
- * live in `SlackThreadBehavior`.
+ * and app-level tokens itself on Create and Install. That makes the flow one
+ * round trip: configure the app here, hand its manifest to Slack's "From a
+ * manifest" option, then bring both tokens back. The steps follow that shape
+ * rather than Slack's old settings pages. Settings for an already-connected
+ * Slack (thread behavior) live in `SlackThreadBehavior`.
  */
 export function SlackSetupWizard({
   assistantName,
+  initialStepId = "name",
   onSave,
   saveStatus = "idle",
   saveError = null,
 }: SlackSetupWizardProps) {
+  const [stepId, setStepId] = useState<SlackSetupStepId>(initialStepId);
   const [slackAppName, setSlackAppName] = useState(assistantName);
   const [description, setDescription] = useState("");
   const userEditedName = useRef(false);
@@ -88,28 +76,20 @@ export function SlackSetupWizard({
     [slackAppName, description],
   );
 
-  const nameValid = slackAppName.trim().length > 0;
+  const stepIndex = WIZARD_STEP_IDS.indexOf(stepId);
 
-  const botTokenError = validateSlackToken(
-    botToken,
-    BOT_TOKEN_PREFIX,
-    "Bot token",
-  );
-  const appTokenError = validateSlackToken(
-    appToken,
-    APP_TOKEN_PREFIX,
-    "App token",
-  );
-
-  const canSave =
-    botToken.trim().length > 0 &&
-    appToken.trim().length > 0 &&
-    !botTokenError &&
-    !appTokenError &&
-    saveStatus !== "pending";
+  const handleAppNameChange = useCallback((value: string) => {
+    userEditedName.current = true;
+    setSlackAppName(value);
+  }, []);
 
   const handleCopyManifest = useCallback(() => {
     copy(manifestJson);
+  }, [copy, manifestJson]);
+
+  const handleCopyAndContinue = useCallback(() => {
+    copy(manifestJson);
+    setStepId("create");
   }, [copy, manifestJson]);
 
   const handleOpenSlack = useCallback(() => {
@@ -117,176 +97,62 @@ export function SlackSetupWizard({
   }, []);
 
   const handleSave = useCallback(() => {
-    if (!canSave) {
-      return;
-    }
     onSave?.(botToken.trim(), appToken.trim());
-  }, [canSave, onSave, botToken, appToken]);
+  }, [onSave, botToken, appToken]);
+
+  const handleStepSelect = useCallback(
+    (index: number) => {
+      if (index < stepIndex) {
+        setStepId(WIZARD_STEP_IDS[index]);
+      }
+    },
+    [stepIndex],
+  );
 
   return (
     <div data-slot="slack-setup-wizard">
-      <div className="flex flex-col gap-5 rounded-lg bg-[var(--surface-sunken)] p-4">
-        <div className="flex flex-col gap-4">
-          <Typography
-            as="p"
-            variant="body-medium-lighter"
-            className="text-[color:var(--content-default)]"
-          >
-            Name your Slack app, copy its manifest, then create it in Slack. All
-            permissions and settings come pre-configured.
-          </Typography>
+      <div className="flex flex-col gap-4">
+        <Stepper
+          steps={WIZARD_STEPS}
+          current={stepIndex}
+          onStepSelect={handleStepSelect}
+          disabled={saveStatus === "pending"}
+        />
 
-          <Input
-            label="App Name"
-            value={slackAppName}
-            onChange={(e) => {
-              userEditedName.current = true;
-              setSlackAppName(e.target.value.slice(0, 35));
-            }}
-            placeholder="My Assistant"
-            fullWidth
-          />
-
-          <Input
-            label="Description (optional)"
-            value={description}
-            onChange={(e) => setDescription(e.target.value.slice(0, 140))}
-            placeholder="What this assistant helps with"
-            helperText="Shown on the app's Slack profile."
-            fullWidth
-          />
-        </div>
-
-        <div className="flex flex-col gap-3">
-          <Typography
-            as="p"
-            variant="body-medium-lighter"
-            className="text-[color:var(--content-default)]"
-          >
-            In Slack:
-          </Typography>
-          <ol className="list-decimal list-inside space-y-1 text-body-medium-lighter text-[var(--content-default)]">
-            <li>
-              Under <strong>Or start your own way</strong>, pick{" "}
-              <strong>From a manifest</strong>, then <strong>Continue</strong>
-            </li>
-            <li>Choose your workspace and give it the manifest you copied</li>
-            <li>
-              Review the permissions, then click{" "}
-              <strong>Create and Install</strong>
-            </li>
-            <li>
-              Expand <strong>Your app credentials</strong> and copy both the{" "}
-              <strong>Bot token</strong> and <strong>App token</strong>
-            </li>
-          </ol>
-
-          <Typography
-            as="p"
-            variant="body-small-default"
-            className="text-[color:var(--content-faint)]"
-          >
-            Slack&apos;s last screen also offers a command-line walkthrough and
-            a <strong>Download app files</strong> button. Skip both — they set
-            up a separate local app, and this assistant needs only the two
-            tokens.
-          </Typography>
-
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              variant="outlined"
-              disabled={!nameValid}
-              onClick={handleCopyManifest}
-              leftIcon={
-                copied ? (
-                  <Check aria-hidden className="size-4" />
-                ) : (
-                  <ClipboardCopy aria-hidden className="size-4" />
-                )
-              }
-            >
-              {copied ? "Copied!" : "Copy manifest JSON"}
-            </Button>
-            <Button
-              type="button"
-              disabled={!nameValid}
-              onClick={handleOpenSlack}
-              rightIcon={<ExternalLink aria-hidden className="size-4" />}
-            >
-              Open Slack
-            </Button>
-          </div>
-
-          <Typography
-            as="p"
-            variant="body-small-default"
-            className="text-[color:var(--content-faint)]"
-          >
-            If Slack shows &ldquo;Request approval&rdquo; instead of{" "}
-            <strong>Install</strong>, a workspace admin needs to approve the app
-            first.
-          </Typography>
-        </div>
-
-        <div className="flex flex-col gap-3">
-          <Typography
-            as="p"
-            variant="body-medium-lighter"
-            className="text-[color:var(--content-default)]"
-          >
-            Paste both tokens from Slack&apos;s{" "}
-            <strong>Your app credentials</strong> panel:
-          </Typography>
-
-          <Input
-            label="Bot Token"
-            type="password"
-            value={botToken}
-            onChange={(e) => setBotToken(e.target.value)}
-            placeholder={`${BOT_TOKEN_PREFIX}...`}
-            errorText={botTokenError ?? undefined}
-            fullWidth
-          />
-
-          <Input
-            label="App Token"
-            type="password"
-            value={appToken}
-            onChange={(e) => setAppToken(e.target.value)}
-            placeholder={`${APP_TOKEN_PREFIX}...`}
-            errorText={appTokenError ?? undefined}
-            fullWidth
-          />
-
-          <div className="flex items-center gap-3">
-            <Button
-              type="button"
-              variant="primary"
-              onClick={handleSave}
-              disabled={!canSave}
-            >
-              {saveStatus === "pending" ? "Connecting…" : "Connect Slack"}
-            </Button>
-          </div>
-
-          {saveStatus === "success" && (
-            <Typography
-              as="p"
-              variant="body-small-default"
-              className="text-[color:var(--content-positive)]"
-            >
-              Credentials saved.
-            </Typography>
+        <div
+          data-slot="slack-setup-step-panel"
+          className="rounded-lg bg-[var(--surface-sunken)] p-4"
+        >
+          {stepId === "name" && (
+            <SlackSetupNameStep
+              appName={slackAppName}
+              description={description}
+              copied={copied}
+              onAppNameChange={handleAppNameChange}
+              onDescriptionChange={setDescription}
+              onCopyAndContinue={handleCopyAndContinue}
+            />
           )}
-          {saveStatus === "error" && saveError && (
-            <Typography
-              as="p"
-              variant="body-small-default"
-              className="text-[color:var(--system-negative-strong)]"
-            >
-              {saveError}
-            </Typography>
+
+          {stepId === "create" && (
+            <SlackSetupCreateStep
+              copied={copied}
+              onOpenSlack={handleOpenSlack}
+              onCopyManifest={handleCopyManifest}
+              onContinue={() => setStepId("connect")}
+            />
+          )}
+
+          {stepId === "connect" && (
+            <SlackSetupTokensStep
+              botToken={botToken}
+              appToken={appToken}
+              saveStatus={saveStatus}
+              saveError={saveError}
+              onBotTokenChange={setBotToken}
+              onAppTokenChange={setAppToken}
+              onSave={handleSave}
+            />
           )}
         </div>
       </div>

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Stepper, type StepperStep } from "@vellumai/design-library";
 import { SlackSetupCreateStep } from "@/components/slack-setup-create-step";
 import { SlackSetupNameStep } from "@/components/slack-setup-name-step";
+import { SlackSetupOpenStep } from "@/components/slack-setup-open-step";
 import { SlackSetupTokensStep } from "@/components/slack-setup-tokens-step";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildSlackManifest } from "@/utils/slack-manifest";
@@ -16,12 +17,13 @@ export type MutationStatus = "idle" | "pending" | "success" | "error";
  */
 const SLACK_NEW_APP_URL = "https://api.slack.com/apps?new_app=1";
 
-const WIZARD_STEP_IDS = ["name", "create", "connect"] as const;
+const WIZARD_STEP_IDS = ["name", "open", "create", "connect"] as const;
 export type SlackSetupStepId = (typeof WIZARD_STEP_IDS)[number];
 
 const WIZARD_STEPS: StepperStep[] = [
   { id: "name", label: "Name" },
-  { id: "create", label: "Create app" },
+  { id: "open", label: "Open" },
+  { id: "create", label: "Create" },
   { id: "connect", label: "Connect" },
 ];
 
@@ -89,11 +91,14 @@ export function SlackSetupWizard({
 
   const handleCopyAndContinue = useCallback(() => {
     handleCopyManifest();
-    setStepId("create");
+    setStepId("open");
   }, [handleCopyManifest]);
 
+  // Opening Slack is also what advances, so this step keeps a single forward
+  // action and the in-Slack directions get a screen of their own.
   const handleOpenSlack = useCallback(() => {
     window.open(SLACK_NEW_APP_URL, "_blank", "noopener,noreferrer");
+    setStepId("create");
   }, []);
 
   const handleSave = useCallback(() => {
@@ -133,13 +138,16 @@ export function SlackSetupWizard({
           />
         )}
 
-        {stepId === "create" && (
-          <SlackSetupCreateStep
+        {stepId === "open" && (
+          <SlackSetupOpenStep
             copied={copied}
             onOpenSlack={handleOpenSlack}
             onCopyManifest={handleCopyManifest}
-            onContinue={() => setStepId("connect")}
           />
+        )}
+
+        {stepId === "create" && (
+          <SlackSetupCreateStep onContinue={() => setStepId("connect")} />
         )}
 
         {stepId === "connect" && (

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -88,9 +88,9 @@ export function SlackSetupWizard({
   }, [copy, manifestJson]);
 
   const handleCopyAndContinue = useCallback(() => {
-    copy(manifestJson);
+    handleCopyManifest();
     setStepId("create");
-  }, [copy, manifestJson]);
+  }, [handleCopyManifest]);
 
   const handleOpenSlack = useCallback(() => {
     window.open(SLACK_NEW_APP_URL, "_blank", "noopener,noreferrer");
@@ -110,51 +110,49 @@ export function SlackSetupWizard({
   );
 
   return (
-    <div data-slot="slack-setup-wizard">
-      <div className="flex flex-col gap-4">
-        <Stepper
-          steps={WIZARD_STEPS}
-          current={stepIndex}
-          onStepSelect={handleStepSelect}
-          disabled={saveStatus === "pending"}
-        />
+    <div data-slot="slack-setup-wizard" className="flex flex-col gap-4">
+      <Stepper
+        steps={WIZARD_STEPS}
+        current={stepIndex}
+        onStepSelect={handleStepSelect}
+        disabled={saveStatus === "pending"}
+      />
 
-        <div
-          data-slot="slack-setup-step-panel"
-          className="rounded-lg bg-[var(--surface-sunken)] p-4"
-        >
-          {stepId === "name" && (
-            <SlackSetupNameStep
-              appName={slackAppName}
-              description={description}
-              copied={copied}
-              onAppNameChange={handleAppNameChange}
-              onDescriptionChange={setDescription}
-              onCopyAndContinue={handleCopyAndContinue}
-            />
-          )}
+      <div
+        data-slot="slack-setup-step-panel"
+        className="rounded-lg bg-[var(--surface-sunken)] p-4"
+      >
+        {stepId === "name" && (
+          <SlackSetupNameStep
+            appName={slackAppName}
+            description={description}
+            copied={copied}
+            onAppNameChange={handleAppNameChange}
+            onDescriptionChange={setDescription}
+            onCopyAndContinue={handleCopyAndContinue}
+          />
+        )}
 
-          {stepId === "create" && (
-            <SlackSetupCreateStep
-              copied={copied}
-              onOpenSlack={handleOpenSlack}
-              onCopyManifest={handleCopyManifest}
-              onContinue={() => setStepId("connect")}
-            />
-          )}
+        {stepId === "create" && (
+          <SlackSetupCreateStep
+            copied={copied}
+            onOpenSlack={handleOpenSlack}
+            onCopyManifest={handleCopyManifest}
+            onContinue={() => setStepId("connect")}
+          />
+        )}
 
-          {stepId === "connect" && (
-            <SlackSetupTokensStep
-              botToken={botToken}
-              appToken={appToken}
-              saveStatus={saveStatus}
-              saveError={saveError}
-              onBotTokenChange={setBotToken}
-              onAppTokenChange={setAppToken}
-              onSave={handleSave}
-            />
-          )}
-        </div>
+        {stepId === "connect" && (
+          <SlackSetupTokensStep
+            botToken={botToken}
+            appToken={appToken}
+            saveStatus={saveStatus}
+            saveError={saveError}
+            onBotTokenChange={setBotToken}
+            onAppTokenChange={setAppToken}
+            onSave={handleSave}
+          />
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -40,7 +40,7 @@ export interface SlackSetupWizardProps {
 }
 
 /**
- * Guided setup for connecting a Slack app, paced across three steps.
+ * Guided setup for connecting a Slack app, paced across four steps.
  *
  * Slack's create-app modal ignores manifest deep links and mints both the bot
  * and app-level tokens itself on Create and Install. That makes the flow one
@@ -70,7 +70,10 @@ export function SlackSetupWizard({
   const [botToken, setBotToken] = useState("");
   const [appToken, setAppToken] = useState("");
 
-  const { copy, copied } = useCopyToClipboard();
+  const { copy, copied } = useCopyToClipboard({
+    errorMessage:
+      "Could not copy the manifest. Copy it again before continuing.",
+  });
 
   const manifestJson = useMemo(
     () =>
@@ -89,17 +92,13 @@ export function SlackSetupWizard({
     copy(manifestJson);
   }, [copy, manifestJson]);
 
-  const handleCopyAndContinue = useCallback(() => {
-    handleCopyManifest();
-    setStepId("open");
-  }, [handleCopyManifest]);
-
-  // Opening Slack is also what advances, so this step keeps a single forward
-  // action and the in-Slack directions get a screen of their own.
   const handleOpenSlack = useCallback(() => {
     window.open(SLACK_NEW_APP_URL, "_blank", "noopener,noreferrer");
-    setStepId("create");
   }, []);
+
+  const handleContinueToOpen = useCallback(() => setStepId("open"), []);
+  const handleContinueToCreate = useCallback(() => setStepId("create"), []);
+  const handleContinueToConnect = useCallback(() => setStepId("connect"), []);
 
   const handleSave = useCallback(() => {
     onSave?.(botToken.trim(), appToken.trim());
@@ -134,20 +133,20 @@ export function SlackSetupWizard({
             copied={copied}
             onAppNameChange={handleAppNameChange}
             onDescriptionChange={setDescription}
-            onCopyAndContinue={handleCopyAndContinue}
+            onCopyManifest={handleCopyManifest}
+            onContinue={handleContinueToOpen}
           />
         )}
 
         {stepId === "open" && (
           <SlackSetupOpenStep
-            copied={copied}
             onOpenSlack={handleOpenSlack}
-            onCopyManifest={handleCopyManifest}
+            onContinue={handleContinueToCreate}
           />
         )}
 
         {stepId === "create" && (
-          <SlackSetupCreateStep onContinue={() => setStepId("connect")} />
+          <SlackSetupCreateStep onContinue={handleContinueToConnect} />
         )}
 
         {stepId === "connect" && (

--- a/clients/web/src/domains/chat/inspector/components/copy-button.tsx
+++ b/clients/web/src/domains/chat/inspector/components/copy-button.tsx
@@ -19,7 +19,9 @@ export function CopyButton({
   ariaLabel,
   className,
 }: CopyButtonProps): ReactNode {
-  const { copy, copied } = useCopyToClipboard();
+  const { copy, copied } = useCopyToClipboard({
+    errorMessage: "Could not copy to the clipboard.",
+  });
 
   return (
     <Button

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -36,7 +36,9 @@ export function PairDeviceCard() {
     webRemoteIngressOn,
     target?.ingressUrl ?? null,
   );
-  const { copy, copied } = useCopyToClipboard();
+  const { copy, copied } = useCopyToClipboard({
+    errorMessage: "Could not copy the pairing address.",
+  });
 
   if (!target || !supported) {
     return null;

--- a/clients/web/src/hooks/use-copy-to-clipboard.ts
+++ b/clients/web/src/hooks/use-copy-to-clipboard.ts
@@ -1,12 +1,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+
 const COPIED_RESET_MS = 1500;
+
+export interface UseCopyToClipboardOptions {
+  /** Toast shown when the clipboard write fails. */
+  errorMessage: string;
+}
 
 /**
  * Copies text to the clipboard and tracks a transient "copied" flag that
  * auto-resets after a short delay. Handles cleanup on unmount.
+ *
+ * The write goes through `copyToClipboard`, so a failed write toasts and is
+ * reported rather than passing silently, and the flag flips only once the
+ * write resolves. A "Copied!" affordance that appears whether or not the
+ * clipboard took the text is worse than none: it tells the user to go paste
+ * something that isn't there.
+ *
+ * `copy` takes an optional `onCopied` for work that must not happen on a
+ * failed write, such as advancing a flow that depends on the clipboard.
  */
-export function useCopyToClipboard() {
+export function useCopyToClipboard({
+  errorMessage,
+}: UseCopyToClipboardOptions) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -18,14 +36,25 @@ export function useCopyToClipboard() {
     };
   }, []);
 
-  const copy = useCallback((text: string) => {
-    void navigator.clipboard.writeText(text);
-    setCopied(true);
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-    timerRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
-  }, []);
+  const copy = useCallback(
+    (text: string, onCopied?: () => void) => {
+      copyToClipboard(text, {
+        errorMessage,
+        onCopied: () => {
+          setCopied(true);
+          if (timerRef.current) {
+            clearTimeout(timerRef.current);
+          }
+          timerRef.current = setTimeout(
+            () => setCopied(false),
+            COPIED_RESET_MS,
+          );
+          onCopied?.();
+        },
+      });
+    },
+    [errorMessage],
+  );
 
   return { copy, copied } as const;
 }

--- a/clients/web/src/utils/slack-manifest.ts
+++ b/clients/web/src/utils/slack-manifest.ts
@@ -60,10 +60,10 @@ const SLACK_MANIFEST_USER_SCOPES = [
 const SLACK_USER_SCOPES_OPTIONAL = ["reactions:read", "search:read"] as const;
 
 /** Slack caps `display_information.name` at 35 characters. */
-const MAX_NAME_LENGTH = 35;
+export const SLACK_APP_NAME_MAX_LENGTH = 35;
 
 /** Slack caps `display_information.description` at 140 characters. */
-const MAX_DESCRIPTION_LENGTH = 140;
+export const SLACK_APP_DESCRIPTION_MAX_LENGTH = 140;
 
 /** Slack caps `features.agent_view.agent_description` at 300 characters. */
 const MAX_AGENT_DESCRIPTION_LENGTH = 300;
@@ -78,12 +78,15 @@ const MAX_AGENT_DESCRIPTION_LENGTH = 300;
  * Keep both in sync when changing scopes, events, or manifest shape.
  */
 export function buildSlackManifest(name: string, desc = "") {
-  const safeName = name.trim().slice(0, MAX_NAME_LENGTH) || "My Assistant";
+  const safeName =
+    name.trim().slice(0, SLACK_APP_NAME_MAX_LENGTH) || "My Assistant";
 
   return {
     display_information: {
       name: safeName,
-      ...(desc ? { description: desc.slice(0, MAX_DESCRIPTION_LENGTH) } : {}),
+      ...(desc
+        ? { description: desc.slice(0, SLACK_APP_DESCRIPTION_MAX_LENGTH) }
+        : {}),
       background_color: "#1a1a2e",
     },
     features: {

--- a/clients/web/src/utils/slack-token-validation.test.ts
+++ b/clients/web/src/utils/slack-token-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { validateSlackToken } from "./slack-setup-wizard";
+import { validateSlackToken } from "./slack-token-validation";
 
 const BOT = "xoxb-";
 const APP = "xapp-";
@@ -48,7 +48,7 @@ describe("validateSlackToken", () => {
 
   it("rejects a correctly-prefixed but truncated token", () => {
     expect(validateSlackToken(`${BOT}123`, BOT, "Bot token")).toBe(
-      "Bot token looks truncated — copy the whole value from Slack.",
+      "Bot token looks truncated. Copy the whole value from Slack.",
     );
   });
 

--- a/clients/web/src/utils/slack-token-validation.ts
+++ b/clients/web/src/utils/slack-token-validation.ts
@@ -1,0 +1,30 @@
+export const BOT_TOKEN_PREFIX = "xoxb-";
+export const APP_TOKEN_PREFIX = "xapp-";
+
+/**
+ * Shortest plausible Slack token. Real tokens run far longer; this only needs
+ * to catch a truncated paste, not to validate the credential.
+ */
+const TOKEN_MIN_LENGTH = 20;
+
+/**
+ * Format-check a pasted Slack token. Returns an error string, or null when the
+ * value is acceptable *or* still empty: an untouched field is not an error.
+ */
+export function validateSlackToken(
+  value: string,
+  prefix: string,
+  label: string,
+): string | null {
+  const token = value.trim();
+  if (!token) {
+    return null;
+  }
+  if (!token.startsWith(prefix)) {
+    return `${label} should start with "${prefix}".`;
+  }
+  if (token.length < TOKEN_MIN_LENGTH) {
+    return `${label} looks truncated. Copy the whole value from Slack.`;
+  }
+  return null;
+}


### PR DESCRIPTION
## TL;DR

The Slack setup wizard went from a guided walkthrough to one long scrolling form in #39141 (LUM-2830, Jul 24). That rewrite was substantively right, but it collapsed the pacing along with the steps. This restores the walkthrough over Slack's *current* flow, and fixes a contrast bug that made two of the caveats close to unreadable in light mode.

Fixes LUM-3000

## Why the wizard changed in the first place, and what stays

#39141 was correct about Slack: the create-app modal ignores the `?manifest_json=` deep link, folds Create and Install into one button, and mints the `xapp-` app token alongside the `xoxb-` bot token. The old steps 2 and 3 walked users to pages that no longer carried what they asked for.

None of that is reverted. The manifest still travels by clipboard, both tokens are still collected together, and scope-drift detection stays where #39141 put it, server-side in `channel-readiness-service.ts`. What changed is only how the flow is paced.

## What changes for the user

| Before | After |
| -- | -- |
| One screen with ~10 stacked blocks in a 400px drawer | Four steps, one job each: Name, Open, Create, Connect |
| Directions said "the manifest you copied" above the button that copies it | Copying is what advances, so the clipboard is always loaded first |
| "Open Slack" enabled on a non-empty name alone, so you could reach Slack's modal with an empty clipboard | Not reachable. Opening Slack is only offered after the manifest is copied |
| Three buttons on one screen, two of them forward actions for different moments | One primary action per step |
| Both token fields visible from the start, before the app exists | Tokens appear on the last step |
| Two caveats in faint grey bracketing the buttons | Two `Notice` callouts, each on the step where it applies |
| Caveat text at 1.97:1 in light mode | 5.39:1, passing WCAG AA in both themes |

## The contrast bug

Both caveats used `--content-faint`, which measures **1.97:1** against `--surface-sunken` in light mode. AA wants 4.5:1 for body text. Dark mode passed at 5.64:1, which is likely why it survived review.

The token was not the root cause. `Typography`'s variants carry size and weight only; it has no colour prop, so all 243 of the 321 call sites that want colour pick a content token by hand, and nothing stops one picking badly. Both caveats are now `Notice`, which owns its colour, container, icon, and ARIA role, so the call site no longer chooses.

## Why this is safe

- Presentation only. No manifest, scope, or token-handling changes.
- `validateSlackToken` and `buildSlackManifest` move but their logic is untouched.
- `MutationStatus` is still exported from `slack-setup-wizard.tsx`, so the two other files importing it are unaffected.
- The wizard sets `bg-[var(--surface-sunken)]` on its own step panel, so it renders identically in both of its mounts: the chat drawer and the Channels page.
- 867/867 web test files pass, plus typecheck, lint, and the assistant-side `slack-required-scopes-mirror` test, which parses this branch's edited `slack-manifest.ts`.
- Verified in Storybook at the real 400px drawer width, in light and dark.

## Tests

`slack-setup-wizard.test.tsx` pins the three behaviours the flow depends on:

- Copying is what advances, and the manifest on the clipboard carries the edited name.
- Step 1 exposes **exactly one** button, so a "Next" or "Skip" added later cannot reintroduce the empty-clipboard path. Sensitivity-checked by adding a second button and confirming the test fails.
- Opening Slack advances and calls `window.open`; copying again does neither.

Stories now render at 400px instead of 800px. The old decorator was twice the shipping width, which is why the original density never showed up in review.

## Deferred

**The wider contrast problem is not fixed here.** 63 call sites pair `--content-tertiary` (3.72:1) with `body-small` or `caption`, which is under AA for normal text. That is a design-system decision spanning 10+ unrelated files, so folding it into a Slack wizard PR would be the wrong seam. Measured and written up in LUM-696, which is reframed from its original "theme caption too light" symptom and back in Todo.

**`skills/slack-app-setup/SKILL.md` needs no change.** Checked: it describes the flow generically (copy the manifest, hand it to "From a manifest", collect both tokens) and its own "Step 1-5" are the assistant's steps, not the wizard's. Still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->