### PR TITLE
fix(assistant): promote a background conversation when it is filed somewhere visible

### DIFF
--- a/assistant/src/__tests__/conversation-group-tools.test.ts
+++ b/assistant/src/__tests__/conversation-group-tools.test.ts
@@ -257,7 +257,7 @@ describe("conversation_move_to_group tool", () => {
     expect(result.content).toContain("no conversation found");
   });
 
-  test("notes hidden conversation types", async () => {
+  test("tells the model a custom group surfaces a hidden conversation", async () => {
     createConversation({ id: "conv-bg", conversationType: "background" });
     await executeConversationGroupCreate({ name: "Visible" }, ctx);
 
@@ -267,7 +267,37 @@ describe("conversation_move_to_group tool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("hidden from the sidebar");
+    expect(result.content).toContain("surfaces it into the sidebar");
+  });
+
+  test("does not claim a move to Recents surfaces a hidden conversation", async () => {
+    // Recents is a removal target, not a promotion: the write path leaves an
+    // unpromoted background row hidden there, so saying otherwise would report
+    // an outcome to the model that did not happen.
+    createConversation({ id: "conv-bg-all", conversationType: "background" });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "system:all", conversation_id: "conv-bg-all" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("surfaces it into the sidebar");
+  });
+
+  test("does not claim a move to Background surfaces a hidden conversation", async () => {
+    createConversation({
+      id: "conv-bg-demote",
+      conversationType: "background",
+    });
+
+    const result = await executeConversationMoveToGroup(
+      { group: "system:background", conversation_id: "conv-bg-demote" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("surfaces it into the sidebar");
   });
 
   test("rejects missing group", async () => {

--- a/assistant/src/__tests__/conversation-placement-promotion.test.ts
+++ b/assistant/src/__tests__/conversation-placement-promotion.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Filing a background or scheduled conversation into a section the user reads
+ * promotes it durably.
+ *
+ * Sidebar visibility for these rows used to depend on where the conversation
+ * currently sat rather than on any record that it had been promoted, so the
+ * same deliberate action produced two different outcomes: filing one into a
+ * custom group showed it, then removing it from that group made it vanish
+ * rather than fall back to Recents, and pinning never showed it at all
+ * because `system:pinned` fails the custom-group arm's `system:` prefix
+ * check. Placement now stamps `surfaced_at`, so promotion survives the next
+ * move.
+ *
+ * Demotion is the mirror image and already worked: filing into
+ * `system:background` / `system:scheduled` clears the promotion.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  batchSetDisplayOrders,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { listConversations } from "../persistence/conversation-queries.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { createGroup } from "../persistence/group-crud.js";
+import { rawRun } from "../persistence/raw-query.js";
+import { conversations } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function seedRoutedBackground(title: string, type: "background" | "scheduled") {
+  const conv = createConversation({ title, conversationType: type });
+  rawRun(
+    "test:routeToSystemBucket",
+    "UPDATE conversations SET group_id = ? WHERE id = ?",
+    type === "scheduled" ? "system:scheduled" : "system:background",
+    conv.id,
+  );
+  return conv;
+}
+
+/** Titles the sidebar's standard listing would render. */
+function visibleTitles(): string[] {
+  return listConversations({ limit: 100 }).map((c) => c.title ?? "");
+}
+
+function titlesInGroup(groupId: string): string[] {
+  return listConversations({ limit: 100, groupId }).map((c) => c.title ?? "");
+}
+
+beforeEach(() => {
+  getDb().delete(conversations).run();
+});
+
+describe("pinning a background conversation", () => {
+  test("shows it in Pinned", () => {
+    const conv = seedRoutedBackground("bg-job", "background");
+    expect(visibleTitles()).toEqual([]);
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
+    ]);
+
+    expect(titlesInGroup("system:pinned")).toEqual(["bg-job"]);
+  });
+
+  test("unpinning lands it in Recents rather than hiding it again", () => {
+    const conv = seedRoutedBackground("bg-job", "background");
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
+    ]);
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, groupId: "system:all" },
+    ]);
+
+    expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
+  });
+});
+
+describe("filing a background conversation into a custom group", () => {
+  test("shows it in that group", () => {
+    const group = createGroup("Car Chat");
+    const conv = seedRoutedBackground("bg-job", "background");
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: group.id },
+    ]);
+
+    expect(titlesInGroup(group.id)).toEqual(["bg-job"]);
+  });
+
+  test("removing it from the group lands it in Recents rather than losing it", () => {
+    const group = createGroup("Car Chat");
+    const conv = seedRoutedBackground("bg-job", "background");
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: group.id },
+    ]);
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, groupId: "system:all" },
+    ]);
+
+    expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
+    expect(visibleTitles()).toEqual(["bg-job"]);
+  });
+
+  test("applies to scheduled conversations too", () => {
+    const group = createGroup("Morning Briefs");
+    const conv = seedRoutedBackground("sched-job", "scheduled");
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: group.id },
+    ]);
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, groupId: "system:all" },
+    ]);
+
+    expect(titlesInGroup("system:all")).toEqual(["sched-job"]);
+  });
+});
+
+describe("what promotion must not do", () => {
+  test("filing into system:background still demotes", () => {
+    const conv = seedRoutedBackground("bg-job", "background");
+    // Promote first, so the demotion has something to undo.
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
+    ]);
+    expect(titlesInGroup("system:pinned")).toEqual(["bg-job"]);
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, groupId: "system:background" },
+    ]);
+
+    expect(visibleTitles()).toEqual([]);
+  });
+
+  test("a background conversation nobody placed anywhere stays hidden", () => {
+    seedRoutedBackground("untouched", "background");
+
+    expect(visibleTitles()).toEqual([]);
+  });
+
+  test("moving to system:all does not by itself promote", () => {
+    // Removal is not a promotion: a row that was never filed into a section
+    // the user reads must not become visible just by being moved out of its
+    // system bucket.
+    const conv = seedRoutedBackground("bg-job", "background");
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, groupId: "system:all" },
+    ]);
+
+    expect(visibleTitles()).toEqual([]);
+  });
+
+  test("standard conversations are not stamped as surfaced", () => {
+    // They are already visible, so stamping them would leave `surfaced_at`
+    // meaning nothing.
+    const group = createGroup("Car Chat");
+    const conv = createConversation("plain-chat");
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: group.id },
+    ]);
+
+    const row = getDb()
+      .all(`SELECT surfaced_at FROM conversations WHERE id = '${conv.id}'`)
+      .at(0) as { surfaced_at: number | null };
+    expect(row.surfaced_at).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/conversation-placement-promotion.test.ts
+++ b/assistant/src/__tests__/conversation-placement-promotion.test.ts
@@ -2,17 +2,16 @@
  * Filing a background or scheduled conversation into a section the user reads
  * promotes it durably.
  *
- * Sidebar visibility for these rows used to depend on where the conversation
- * currently sat rather than on any record that it had been promoted, so the
- * same deliberate action produced two different outcomes: filing one into a
- * custom group showed it, then removing it from that group made it vanish
- * rather than fall back to Recents, and pinning never showed it at all
- * because `system:pinned` fails the custom-group arm's `system:` prefix
- * check. Placement now stamps `surfaced_at`, so promotion survives the next
- * move.
+ * Placement into Pinned or a custom group stamps `surfaced_at`, so the
+ * promotion outlives the placement that caused it: taking the conversation
+ * back out returns it to Recents rather than hiding it. Demotion is the
+ * mirror image, and filing into `system:background` / `system:scheduled`
+ * clears the stamp.
  *
- * Demotion is the mirror image and already worked: filing into
- * `system:background` / `system:scheduled` clears the promotion.
+ * The cases below pin both edges. Under-promoting hides a conversation the
+ * user deliberately filed somewhere; over-promoting drags hidden automation
+ * into the sidebar, so the "what promotion must not do" block is as
+ * load-bearing as the rest.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -155,6 +154,30 @@ describe("what promotion must not do", () => {
     ]);
 
     expect(visibleTitles()).toEqual([]);
+  });
+
+  test("unpinning through the legacy isPinned path still lands in Recents", () => {
+    // Old clients send `isPinned: false` with no `groupId`, and that branch
+    // restores the row's original system bucket to keep its provenance. It
+    // deliberately does not clear the promotion: unpinning is not a demotion,
+    // so the conversation belongs in Recents afterwards, the same as the
+    // modern path that sends `groupId: "system:all"`.
+    //
+    // The row therefore sits in `system:background` while remaining visible.
+    // That is the intended split: the bucket records where the conversation
+    // came from, `surfaced_at` records that the user promoted it, and only
+    // an explicit demotion clears the latter.
+    const conv = seedRoutedBackground("bg-job", "background");
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: 0, groupId: "system:pinned" },
+    ]);
+
+    batchSetDisplayOrders([
+      { id: conv.id, displayOrder: null, isPinned: false },
+    ]);
+
+    expect(visibleTitles()).toEqual(["bg-job"]);
+    expect(titlesInGroup("system:all")).toEqual(["bg-job"]);
   });
 
   test("standard conversations are not stamped as surfaced", () => {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -4055,12 +4055,11 @@ export function batchSetDisplayOrders(
         // of their own groups) is the mirror image: an explicit promotion, so
         // it stamps `surfaced_at` the way the surface API does.
         //
-        // Promotion has to be durable rather than implied by where the row
-        // currently sits. A background row was previously visible only while
-        // it satisfied the custom-group arm of the listing predicate, so
-        // taking it back out of the group made it vanish instead of falling
-        // back to Recents, and pinning never made it visible at all because
-        // `system:pinned` fails that arm's `system:` prefix check.
+        // The stamp is what makes the promotion durable. Visibility must not
+        // depend on where the row currently sits, or removing it from a group
+        // would hide it instead of returning it to Recents, and pinning would
+        // not show it at all: `system:pinned` fails the custom-group arm of
+        // `standardListingVisibilitySql` on that arm's `system:` prefix check.
         //
         // Only background and scheduled rows need it: everything else is
         // already visible, and stamping them would leave `surfaced_at`

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -4051,15 +4051,50 @@ export function batchSetDisplayOrders(
         const clearsSurfaced =
           safeGroupId === "system:background" ||
           safeGroupId === "system:scheduled";
-        rawRun(
-          "conversation:batchSetDisplayOrders:group",
-          `UPDATE conversations SET display_order = ?, is_pinned = ?, group_id = ?${
-            clearsSurfaced ? ", surfaced_at = NULL" : ""
-          } WHERE id = ?`,
+        // Filing a conversation into a section the user reads (Pinned or one
+        // of their own groups) is the mirror image: an explicit promotion, so
+        // it stamps `surfaced_at` the way the surface API does.
+        //
+        // Promotion has to be durable rather than implied by where the row
+        // currently sits. A background row was previously visible only while
+        // it satisfied the custom-group arm of the listing predicate, so
+        // taking it back out of the group made it vanish instead of falling
+        // back to Recents, and pinning never made it visible at all because
+        // `system:pinned` fails that arm's `system:` prefix check.
+        //
+        // Only background and scheduled rows need it: everything else is
+        // already visible, and stamping them would leave `surfaced_at`
+        // meaning nothing. `COALESCE` keeps the original promotion time when
+        // the row is re-filed later.
+        const promotes =
+          !clearsSurfaced &&
+          safeGroupId !== UNGROUPED_GROUP_ID &&
+          (safeGroupId === PINNED_GROUP_ID ||
+            !safeGroupId.startsWith("system:"));
+        const setClauses = [
+          "display_order = ?",
+          "is_pinned = ?",
+          "group_id = ?",
+        ];
+        const params: Array<string | number | null> = [
           update.displayOrder,
           safeGroupId === PINNED_GROUP_ID ? 1 : 0,
           safeGroupId,
-          update.id,
+        ];
+        if (clearsSurfaced) {
+          setClauses.push("surfaced_at = NULL");
+        } else if (promotes) {
+          setClauses.push(
+            "surfaced_at = CASE WHEN conversation_type IN ('background', 'scheduled')" +
+              " THEN COALESCE(surfaced_at, ?) ELSE surfaced_at END",
+          );
+          params.push(Date.now());
+        }
+        params.push(update.id);
+        rawRun(
+          "conversation:batchSetDisplayOrders:group",
+          `UPDATE conversations SET ${setClauses.join(", ")} WHERE id = ?`,
+          ...params,
         );
       } else if (update.isPinned === undefined) {
         // Only displayOrder provided — preserve existing pin state and group.

--- a/assistant/src/tools/conversation-groups/move_to_group.ts
+++ b/assistant/src/tools/conversation-groups/move_to_group.ts
@@ -93,9 +93,13 @@ export async function executeConversationMoveToGroup(
       `Moving into ${group.name} demotes it out of the Recents listing.`,
     );
   }
-  if (conversation.conversationType !== "standard") {
+  if (
+    conversation.conversationType !== "standard" &&
+    group.id !== "system:scheduled" &&
+    group.id !== "system:background"
+  ) {
     notes.push(
-      `Note: this is a ${conversation.conversationType} conversation, which stays hidden from the sidebar regardless of group.`,
+      `Note: this is a ${conversation.conversationType} conversation, so filing it here also surfaces it into the sidebar.`,
     );
   }
 

--- a/assistant/src/tools/conversation-groups/move_to_group.ts
+++ b/assistant/src/tools/conversation-groups/move_to_group.ts
@@ -93,11 +93,13 @@ export async function executeConversationMoveToGroup(
       `Moving into ${group.name} demotes it out of the Recents listing.`,
     );
   }
-  if (
-    conversation.conversationType !== "standard" &&
-    group.id !== "system:scheduled" &&
-    group.id !== "system:background"
-  ) {
+  // Only Pinned and custom groups surface a hidden conversation. Recents is a
+  // removal target, and the Scheduled/Background groups are demotions, so
+  // claiming any of them made the conversation visible would misreport the
+  // outcome to the model and the user.
+  const surfacesConversation =
+    group.id === "system:pinned" || !group.id.startsWith("system:");
+  if (conversation.conversationType !== "standard" && surfacesConversation) {
     notes.push(
       `Note: this is a ${conversation.conversationType} conversation, so filing it here also surfaces it into the sidebar.`,
     );


### PR DESCRIPTION
## TL;DR

Pin a background job and it disappears. File one into a custom group and it shows up, then remove it from the group and it disappears. This makes deliberate placement promote the conversation durably, so it behaves the way you'd expect in both directions.

Fixes [LUM-3075](https://linear.app/vellum/issue/LUM-3075).

## What changes for the user

| Action on a background or scheduled conversation | Before | After |
| -- | -- | -- |
| Pin it | **Vanishes** | Appears in Pinned |
| Unpin it | n/a (was gone) | Lands in Recents |
| File it into a custom group | Appears in the group | Unchanged |
| Remove it from that group | **Vanishes** | Lands in Recents |
| File it into Background/Scheduled | Hidden | Unchanged, still hidden |
| Never place it anywhere | Hidden | Unchanged, still hidden |
| Any standard conversation | | Entirely unchanged |

## Why it happened

Visibility for these rows was derived from **where the conversation currently sat**, never from a record that someone had promoted it.

`standardListingVisibilitySql` admits a row if it is not a background type, **or** carries `surfaced_at`, **or** sits in a group whose id does not start with `system:`. So:

- A background row in a custom group passed the third arm. Take it out of the group and the only thing making it visible went with it.
- Pinning writes `group_id = 'system:pinned'`, which fails that arm on the `system:` prefix. That check exists to keep `system:background` and `system:scheduled` out, and caught pinning by accident rather than by decision.

Pinning and grouping are the same operation writing the same column, so the two behaving differently was incoherent either way.

## The fix

Placement into a section the user reads stamps `surfaced_at`, exactly what the surface API already does. Promotion then survives the next move, so removal falls back to Recents instead of falling off a cliff.

It lands in `batchSetDisplayOrders`, the single write path behind both `POST /v1/conversations/reorder` and the assistant's `move_to_group` tool, so **one change covers the UI and the assistant**. Ashlee confirmed the tool counts as intentional placement.

This is the missing half of a pattern that was already there: filing into `system:background` / `system:scheduled` has always *cleared* `surfaced_at` as an explicit demotion. There was simply no corresponding promotion.

Chosen over adding `system:pinned` to the visibility arm, which would fix pinning, leave the group-removal case broken, and add a fourth special case to a predicate that already has three.

## Why it is safe

**No backfill and no migration.** Existing rows behave exactly as they do today; promotion applies to placements made from here on.

**Scoped deliberately**, with a test pinning each boundary:
- Only Pinned and custom groups promote.
- `system:background` / `system:scheduled` still demote and clear the marker.
- Moving to `system:all` is a removal, not a promotion, so a row nobody ever filed anywhere does not become visible just by being moved out of its bucket.
- Only background and scheduled rows are stamped. Standard conversations are already visible, and stamping them would leave `surfaced_at` meaning nothing.

**`COALESCE` preserves the original promotion time** when a row is re-filed later.

## Validation

- 285 passing tests across every conversation, group, pinned, and surface suite; 0 failures. Typecheck, lint, and the OpenAPI staleness check clean.
- 9 new tests, each mutation-checked in **both** directions:
  - Removing the promotion kills 5 of them.
  - Dropping the background/scheduled gate (promoting everything) kills the "standard conversations are not stamped" guard.
  - Treating `system:all` as a promotion kills the "removal does not promote" guard.

  So no test in this file passes while the behavior it describes is wrong, and none of the guards are decorative.

## Also updated

`move_to_group` told the model *"this is a background conversation, which stays hidden from the sidebar regardless of group."* That is no longer true for the targets that promote, so it now says filing it there surfaces it, and stays quiet for the demoting targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->