### PR TITLE
test(web): add Storybook stories for the home feed row

### DIFF
--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
@@ -56,7 +56,7 @@ export const SkillUpdated: Story = {
   args: {
     item: feedItem({
       id: "feed-skill-updated",
-      title: "Skill updated",
+      title: "Skill updated: Weekly Report Export",
       summary:
         'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
       category: "background",
@@ -125,7 +125,7 @@ export const Dismissed: Story = {
   args: {
     item: feedItem({
       id: "feed-dismissed",
-      title: "Skill updated",
+      title: "Skill updated: Weekly Report Export",
       summary: 'Updated the skill "Weekly Report Export".',
       category: "background",
       urgency: "low",
@@ -161,7 +161,7 @@ export const Mobile: Story = {
     isMobile: true,
     item: feedItem({
       id: "feed-skill-updated-mobile",
-      title: "Skill updated",
+      title: "Skill updated: Weekly Report Export",
       summary:
         'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
       category: "background",

--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
@@ -1,0 +1,172 @@
+/**
+ * `HomeDetailPanel` is what opens when a row in the Home activity feed is
+ * clicked. It renders a header (title, category tag, timestamp, and the
+ * actions for that item) over either a panel specialized to
+ * `item.detailPanel.kind` or, for everything without one, `HomeGenericDetail`,
+ * which is just the item's `summary` rendered as markdown.
+ *
+ * Most background producers set no `detailPanel`, so the generic body is the
+ * common case and these stories lead with it. That is worth seeing directly:
+ * an item whose summary is a single sentence opens to that same sentence,
+ * which is the whole detail view.
+ *
+ * Fixtures come from the shared feed fixtures so a panel story and its row
+ * story describe the same item.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  feedItem,
+  FIXTURE_CONVERSATION_ID,
+  FIXTURE_VALID_CONVERSATIONS,
+} from "@/domains/home/feed-test-fixtures";
+import { HomeDetailPanel } from "@/domains/home/detail-panel/home-detail-panel";
+
+const meta = {
+  title: "Home/HomeDetailPanel",
+  component: HomeDetailPanel,
+  parameters: { layout: "padded" },
+  args: {
+    validConversationIds: FIXTURE_VALID_CONVERSATIONS,
+    onClose: () => {},
+    onGoToThread: () => {},
+    onUpdateStatus: () => {},
+    onDismiss: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HomeDetailPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A background pass updated a skill. The item carries no `detailPanel`, so
+ * opening it shows the header plus the summary as markdown: the same sentence
+ * the row already displayed, at full width. There is nothing further to drill
+ * into, which is why a diff of the change has to live somewhere other than
+ * this panel.
+ */
+export const SkillUpdated: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-skill-updated",
+      title: "Skill updated",
+      summary:
+        'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
+      category: "background",
+      urgency: "low",
+      conversationId: FIXTURE_CONVERSATION_ID,
+    }),
+  },
+};
+
+/**
+ * A failed background job. `activity.failed`'s composed body carries the
+ * error kind and message, so the panel has more to show than the row's
+ * single preview line.
+ */
+export const BackgroundJobFailed: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-sweep-failed",
+      title: "Background job failed: memory.v2.sweep",
+      summary:
+        "exception: Qdrant collection `memory_v2_concept_pages` is unavailable after 3 retries.\n\nThe sweep will retry on its next scheduled pass. Concept pages stay readable in the meantime; only re-embedding is paused.",
+      category: "background",
+      urgency: "medium",
+      sourceLabel: "Memory sweep",
+      conversationId: FIXTURE_CONVERSATION_ID,
+    }),
+  },
+};
+
+/**
+ * A summary with real markdown structure. The generic body renders it through
+ * `HomeMarkdownContent`, so lists and emphasis survive here even though the
+ * row flattened them for its preview line.
+ */
+export const MarkdownSummary: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-markdown",
+      title: "Nightly maintenance finished",
+      summary:
+        "**Nightly maintenance finished.**\n\n- Reindexed 1,204 concept pages\n- Pruned 18 stale embeddings\n- Skipped 2 pages that failed validation\n\nNothing needs your attention; this is recorded for the audit trail.",
+      category: "system",
+      urgency: "low",
+    }),
+  },
+};
+
+/**
+ * No linkable conversation. The panel drops its jump action rather than
+ * offering a target that cannot resolve.
+ */
+export const WithoutConversation: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-no-conversation",
+      title: "Activity Complete",
+      summary: "Finished the nightly memory consolidation pass.",
+      category: "background",
+      urgency: "low",
+    }),
+  },
+};
+
+/** Already dismissed: the panel offers restore rather than dismiss. */
+export const Dismissed: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-dismissed",
+      title: "Skill updated",
+      summary: 'Updated the skill "Weekly Report Export".',
+      category: "background",
+      urgency: "low",
+      status: "dismissed",
+      conversationId: FIXTURE_CONVERSATION_ID,
+    }),
+  },
+};
+
+/**
+ * A schedule-sourced item whose schedule still exists, so the panel offers a
+ * jump to it alongside the conversation.
+ */
+export const FromSchedule: Story = {
+  args: {
+    onViewSchedule: () => {},
+    item: feedItem({
+      id: "feed-schedule",
+      title: "Weekly report is due",
+      summary:
+        "Your Monday recap is ready to send. The draft covers last week's shipped work.",
+      category: "scheduling",
+      urgency: "medium",
+      sourceLabel: "Schedule",
+      conversationId: FIXTURE_CONVERSATION_ID,
+    }),
+  },
+};
+
+/** The mobile layout, which the panel branches to before its desktop shell. */
+export const Mobile: Story = {
+  args: {
+    isMobile: true,
+    item: feedItem({
+      id: "feed-skill-updated-mobile",
+      title: "Skill updated",
+      summary:
+        'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
+      category: "background",
+      urgency: "low",
+      conversationId: FIXTURE_CONVERSATION_ID,
+    }),
+  },
+};

--- a/clients/web/src/domains/home/feed-test-fixtures.ts
+++ b/clients/web/src/domains/home/feed-test-fixtures.ts
@@ -1,0 +1,37 @@
+import type { FeedItem } from "@vellumai/assistant-api";
+
+/**
+ * Build a `FeedItem` carrying the fields the daemon always writes, so a
+ * caller only states what makes its case distinct.
+ *
+ * Accepts the component's own data shape: there is no transformation from
+ * some other input format, and no cast, so the type system still enforces
+ * that a fixture is something the backend could actually produce.
+ *
+ * `timestamp` is the event time and `createdAt` is when the feed writer
+ * recorded it. The daemon sets both and they are not the same value, so the
+ * defaults keep them distinct.
+ */
+export function feedItem(
+  overrides: Partial<FeedItem> & Pick<FeedItem, "id">,
+): FeedItem {
+  return {
+    type: "notification",
+    priority: 50,
+    summary: "",
+    timestamp: "2026-08-05T18:30:00.000Z",
+    createdAt: "2026-08-05T18:30:02.000Z",
+    status: "new",
+    ...overrides,
+  };
+}
+
+/** A conversation the feed is allowed to link to. */
+export const FIXTURE_CONVERSATION_ID = "conv-weekly-report";
+
+/**
+ * The resolvable-conversation set the feed passes down. A row or panel hides
+ * its jump target when an item's conversation is absent here, which is what
+ * happens once a background fork is garbage collected.
+ */
+export const FIXTURE_VALID_CONVERSATIONS = new Set([FIXTURE_CONVERSATION_ID]);

--- a/clients/web/src/domains/home/home-recap-row.stories.tsx
+++ b/clients/web/src/domains/home/home-recap-row.stories.tsx
@@ -81,7 +81,7 @@ export const SkillUpdated: Story = {
   args: {
     item: feedItem({
       id: "feed-skill-updated",
-      title: "Skill updated",
+      title: "Skill updated: Weekly Report Export",
       summary:
         'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
       category: "background",
@@ -165,7 +165,7 @@ export const StaleConversationLink: Story = {
   args: {
     item: feedItem({
       id: "feed-stale-link",
-      title: "Skill updated",
+      title: "Skill updated: Weekly Report Export",
       summary: 'Updated the skill "Weekly Report Export".',
       category: "background",
       urgency: "low",

--- a/clients/web/src/domains/home/home-recap-row.stories.tsx
+++ b/clients/web/src/domains/home/home-recap-row.stories.tsx
@@ -20,36 +20,12 @@
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import type { FeedItem } from "@vellumai/assistant-api";
-
+import {
+  feedItem,
+  FIXTURE_CONVERSATION_ID,
+  FIXTURE_VALID_CONVERSATIONS,
+} from "@/domains/home/feed-test-fixtures";
 import { HomeRecapRow } from "@/domains/home/home-recap-row";
-
-/**
- * Build a `FeedItem` with the fields the daemon always writes, so a story
- * only states what makes its case distinct. Accepts the component's own data
- * shape: no transformation, no alternate input format.
- */
-function feedItem(
-  overrides: Partial<FeedItem> & Pick<FeedItem, "id">,
-): FeedItem {
-  return {
-    type: "notification",
-    priority: 50,
-    summary: "",
-    // `timestamp` is the event time; `createdAt` is when the feed writer
-    // recorded it. The daemon sets both and they are not the same value, so
-    // the fixtures keep them distinct.
-    timestamp: "2026-08-05T18:30:00.000Z",
-    createdAt: "2026-08-05T18:30:02.000Z",
-    status: "new",
-    ...overrides,
-  };
-}
-
-const CONVERSATION_ID = "conv-weekly-report";
-
-/** Conversations the feed is allowed to link to (the row hides a dead link). */
-const VALID_CONVERSATIONS = new Set([CONVERSATION_ID]);
 
 const meta = {
   title: "Home/HomeRecapRow",
@@ -60,7 +36,7 @@ const meta = {
     onDismiss: () => {},
     onToggleRead: () => {},
     onGoToThread: () => {},
-    validConversationIds: VALID_CONVERSATIONS,
+    validConversationIds: FIXTURE_VALID_CONVERSATIONS,
   },
   decorators: [
     (Story) => (
@@ -110,7 +86,7 @@ export const SkillUpdated: Story = {
         'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
       category: "background",
       urgency: "low",
-      conversationId: CONVERSATION_ID,
+      conversationId: FIXTURE_CONVERSATION_ID,
     }),
   },
 };
@@ -125,7 +101,7 @@ export const ScheduledReminder: Story = {
         "Your Monday recap is ready to send. The draft covers last week's shipped work.",
       category: "scheduling",
       urgency: "medium",
-      conversationId: CONVERSATION_ID,
+      conversationId: FIXTURE_CONVERSATION_ID,
       sourceLabel: "Schedule",
     }),
   },
@@ -141,7 +117,7 @@ export const SecurityRequest: Story = {
         "A tool wants to send an email on your behalf to the finance team.",
       category: "security",
       urgency: "high",
-      conversationId: CONVERSATION_ID,
+      conversationId: FIXTURE_CONVERSATION_ID,
     }),
   },
 };

--- a/clients/web/src/domains/home/home-recap-row.stories.tsx
+++ b/clients/web/src/domains/home/home-recap-row.stories.tsx
@@ -1,0 +1,253 @@
+/**
+ * `HomeRecapRow` is the row the Home activity feed renders for every
+ * notification the daemon mirrors into it (`notifications/home-feed-side-effect.ts`).
+ * It is the only place background work becomes visible without opening a
+ * conversation, so these stories cover the shapes it actually receives:
+ * a failed background job, a completed one, a scheduled reminder, and a
+ * guardian request.
+ *
+ * Fixtures are production-shaped. The daemon fills `summary` from the
+ * rendered channel copy (falling back to the signal's `contextPayload`
+ * `body`/`title`), so it arrives as markdown and the row flattens it for the
+ * title line: `Failing` therefore carries a real multi-line body rather than
+ * a pre-flattened string, which is what exercises `flattenSummary` /
+ * `resolvePreview`.
+ *
+ * `category` drives the chip hue and comes from `EVENT_CATEGORY_MAP` in the
+ * side effect, so each story sets the one its source event maps to.
+ *
+ * The row is not responsive (no `md:` variants), so no viewport is pinned.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { FeedItem } from "@vellumai/assistant-api";
+
+import { HomeRecapRow } from "@/domains/home/home-recap-row";
+
+/**
+ * Build a `FeedItem` with the fields the daemon always writes, so a story
+ * only states what makes its case distinct. Accepts the component's own data
+ * shape: no transformation, no alternate input format.
+ */
+function feedItem(
+  overrides: Partial<FeedItem> & Pick<FeedItem, "id">,
+): FeedItem {
+  return {
+    type: "notification",
+    priority: 50,
+    summary: "",
+    // `timestamp` is the event time; `createdAt` is when the feed writer
+    // recorded it. The daemon sets both and they are not the same value, so
+    // the fixtures keep them distinct.
+    timestamp: "2026-08-05T18:30:00.000Z",
+    createdAt: "2026-08-05T18:30:02.000Z",
+    status: "new",
+    ...overrides,
+  };
+}
+
+const CONVERSATION_ID = "conv-weekly-report";
+
+/** Conversations the feed is allowed to link to (the row hides a dead link). */
+const VALID_CONVERSATIONS = new Set([CONVERSATION_ID]);
+
+const meta = {
+  title: "Home/HomeRecapRow",
+  component: HomeRecapRow,
+  parameters: { layout: "padded" },
+  args: {
+    onSelect: () => {},
+    onDismiss: () => {},
+    onToggleRead: () => {},
+    onGoToThread: () => {},
+    validConversationIds: VALID_CONVERSATIONS,
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HomeRecapRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A background job that failed. `activity.failed` is the most common feed
+ * producer today (the memory sweep, the scheduler, the background job
+ * runner), and its copy composer emits `Background job failed: <jobName>`
+ * with `<errorKind>: <message>` as the body.
+ */
+export const BackgroundJobFailed: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-sweep-failed",
+      title: "Background job failed: memory.v2.sweep",
+      summary:
+        "exception: Qdrant collection `memory_v2_concept_pages` is unavailable after 3 retries.",
+      category: "background",
+      urgency: "medium",
+      sourceLabel: "Memory sweep",
+    }),
+  },
+};
+
+/**
+ * A background pass updated a skill the assistant had already written. This
+ * is the shape the retrospective's `activity.complete` signal produces: the
+ * work happened inside a hidden background fork, so the feed row is the only
+ * place it surfaces, and `conversationId` points at the conversation the
+ * procedure came from rather than the fork.
+ */
+export const SkillUpdated: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-skill-updated",
+      title: "Skill updated",
+      summary:
+        'Updated the skill "Weekly Report Export" from something learned in an earlier conversation.',
+      category: "background",
+      urgency: "low",
+      conversationId: CONVERSATION_ID,
+    }),
+  },
+};
+
+/** A scheduled reminder firing: `schedule.notify`, category `scheduling`. */
+export const ScheduledReminder: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-schedule",
+      title: "Weekly report is due",
+      summary:
+        "Your Monday recap is ready to send. The draft covers last week's shipped work.",
+      category: "scheduling",
+      urgency: "medium",
+      conversationId: CONVERSATION_ID,
+      sourceLabel: "Schedule",
+    }),
+  },
+};
+
+/** A guardian request: `security` category, high urgency. */
+export const SecurityRequest: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-guardian",
+      title: "Approval needed",
+      summary:
+        "A tool wants to send an email on your behalf to the finance team.",
+      category: "security",
+      urgency: "high",
+      conversationId: CONVERSATION_ID,
+    }),
+  },
+};
+
+/**
+ * Already seen. The unread affordance flips (`Mail` becomes `MailOpen`) and
+ * the row loses its unread emphasis, so this is the state most rows sit in
+ * after a first visit.
+ */
+export const Read: Story = {
+  args: {
+    item: feedItem({
+      ...SkillUpdated.args.item,
+      id: "feed-skill-updated-read",
+      status: "seen",
+    }),
+  },
+};
+
+/**
+ * No linkable conversation. The row hides "Go to thread" entirely rather
+ * than offering a dead target, which is what happens once a background fork
+ * is garbage collected or when a producer's source context is a sentinel
+ * rather than a real conversation.
+ */
+export const WithoutConversation: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-no-conversation",
+      title: "Activity Complete",
+      summary: "Finished the nightly memory consolidation pass.",
+      category: "background",
+      urgency: "low",
+      sourceLabel: "Memory consolidation",
+    }),
+  },
+};
+
+/**
+ * A conversation id the feed cannot resolve. `validConversationIds` gates the
+ * jump target, so a stale id degrades to the same treatment as no id at all
+ * instead of navigating into a deleted thread.
+ */
+export const StaleConversationLink: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-stale-link",
+      title: "Skill updated",
+      summary: 'Updated the skill "Weekly Report Export".',
+      category: "background",
+      urgency: "low",
+      conversationId: "conv-deleted-fork",
+    }),
+  },
+};
+
+/**
+ * Markdown summary with no title of its own. The row flattens the summary for
+ * the title line and derives the preview from what is left, so structure in
+ * the body never leaks into the header as syntax.
+ */
+export const MarkdownSummaryWithoutTitle: Story = {
+  args: {
+    item: feedItem({
+      id: "feed-markdown",
+      summary:
+        "**Nightly maintenance finished.**\n\n- Reindexed 1,204 concept pages\n- Pruned 18 stale embeddings\n- Skipped 2 pages that failed validation",
+      category: "system",
+      urgency: "low",
+    }),
+  },
+};
+
+/** The compact density the feed uses where vertical space is tight. */
+export const Compact: Story = {
+  args: {
+    density: "compact",
+    item: feedItem({
+      ...SkillUpdated.args.item,
+      id: "feed-skill-updated-compact",
+    }),
+  },
+};
+
+/** Selected, as when its detail panel is open beside the list. */
+export const Active: Story = {
+  args: {
+    isActive: true,
+    item: feedItem({
+      ...SkillUpdated.args.item,
+      id: "feed-skill-updated-active",
+    }),
+  },
+};
+
+/**
+ * A dismissed row offers restore instead of dismiss, the treatment the
+ * feed uses in its dismissed filter.
+ */
+export const Restorable: Story = {
+  args: {
+    trailingAction: "restore",
+    item: feedItem({
+      ...SkillUpdated.args.item,
+      id: "feed-skill-updated-dismissed",
+      status: "dismissed",
+    }),
+  },
+};


### PR DESCRIPTION
## TL;DR

The Home activity feed had **no visual coverage**. `HomeRecapRow`, the list, the category chips, and the detail panels all ship with unit tests but no stories, so there is nothing to look at and no baseline to judge a feed change against.

This adds 11 stories for `HomeRecapRow`, the row every notification the daemon mirrors into the feed renders as.

## Why this first

It is the only place background work becomes visible without opening a conversation, and it is about to matter more: there is pending work to surface background skill edits there. Reviewing that is much easier with a before/after to flip between than by reasoning about a row nobody can see.

Useful on its own regardless of what lands after it.

## What is covered

The shapes the daemon actually produces, per `notifications/home-feed-side-effect.ts` and its `EVENT_CATEGORY_MAP`:

- **Background job failed** (`activity.failed`) — the most common producer today: the memory sweep, the scheduler, the background job runner
- **Skill updated** (`activity.complete`) — background category, low urgency, linking to the source conversation
- **Scheduled reminder** (`schedule.notify`) — scheduling category
- **Security request** (`guardian.question`) — security category, high urgency

Plus the states that change the row's affordances:

- **Read** — the unread treatment flips (`Mail` → `MailOpen`)
- **Without conversation** — "Go to thread" is hidden rather than offering a dead target
- **Stale conversation link** — an id `validConversationIds` rejects degrades to the same treatment, instead of navigating into a deleted thread
- **Markdown summary without title** — exercises `flattenSummary` / `resolvePreview`, so body structure never leaks into the header as syntax
- **Compact**, **Active**, **Restorable** — density, selection, and the dismissed-filter treatment

## Conventions

Per `clients/web/docs/CONVENTIONS.md`:

- Fixtures are built through the component's own `FeedItem` type with **no cast**. That is what caught that `createdAt` is required and semantically distinct from `timestamp` (writer-record time vs event time) — an `as`-cast fixture would have shipped a shape the daemon never produces, which is exactly the failure the rule exists to prevent.
- The helper only fills the fields the daemon always writes and accepts the component's data shape directly. No transformation layer.
- The decorator frames width only; it does not restyle the subject.
- No viewport pinned: the row has no `md:` variants, so it is not responsive.
- Real component throughout, no story-local lookalike.

## Test plan

`bunx storybook build` succeeds and all 11 stories register in the built index. `bunx tsc --noEmit` and eslint pass.

Run locally with `bun run storybook` (port 6007), under **Home/HomeRecapRow**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
