### PR TITLE
fix(assistant): commit a fast Flux turn-end after a mid-thought pause

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -87,10 +87,20 @@ class MockFluxTranscriber implements StreamingTranscriber {
     this.onEvent?.(event);
   }
 
+  // Flux's StartOfTurn frame, numbering the turn it opens.
+  startOfTurn(turnIndex: number): void {
+    this.emit({ type: "turn-start", turnIndex });
+  }
+
   // Flux's EndOfTurn frame maps onto a `final` followed by a `turn-end`.
-  endOfTurn(text: string): void {
+  endOfTurn(text: string, turnIndex?: number): void {
     this.emit({ type: "final", text });
-    this.emit({ type: "turn-end", text, confidence: 0.9 });
+    this.emit({
+      type: "turn-end",
+      text,
+      confidence: 0.9,
+      ...(turnIndex !== undefined ? { turnIndex } : {}),
+    });
   }
 }
 
@@ -463,6 +473,124 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
       () => (transcriber?.received.length ?? 0) > receivedBeforeResume,
       "The resumed speech stopped reaching the transcriber",
     );
+
+    await session.close("client_end");
+  });
+
+  test("commits a fast turn-end for the still-open turn after a mid-thought pause", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      emitMetrics: true,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    const transcriber = transcribers[0];
+    transcriber?.startOfTurn(0);
+    transcriber?.emit({ type: "partial", text: "what is the" });
+
+    // A mid-thought pause, long enough for the local silence boundary to hand
+    // the cycle to Flux, and then the caller keeps going.
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(
+      () => countFrames(frames, "speech_started") === 2,
+      "The resumed speech never re-opened a detector turn",
+    );
+
+    // Flux ends the turn it kept open across the pause, beating the next local
+    // silence boundary: the fast commit this feature exists for. Nothing here
+    // sleeps past that boundary, on purpose.
+    const emittedAtMs = Date.now();
+    transcriber?.endOfTurn("what is the weather today", 0);
+    await waitFor(
+      () => turnCalls.length === 1,
+      "The fast turn-end after a mid-thought pause never committed",
+    );
+    const commitLatencyMs = Date.now() - emittedAtMs;
+
+    // The fail-open budget is eotTimeoutMs (500 ms) plus the margin (1000 ms).
+    // A commit anywhere near it means the turn-end was dropped and the
+    // deadline committed in its place.
+    expect(commitLatencyMs).toBeLessThan(300);
+    expect(turnCalls[0]?.content).toBe("what is the weather today");
+    // The Flux path, not the speculative hold path the deadline falls back to.
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
+
+    await waitFor(
+      () =>
+        frames.some(
+          (frame) =>
+            frame.type === "metrics" && frame.event === "turn_completed",
+        ),
+      "The completed turn never reported its metrics",
+    );
+    const metricsFrame = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(metricsFrame).toBeDefined();
+    if (metricsFrame?.type === "metrics") {
+      expect(metricsFrame.endpointDecisionSource).toBe("flux");
+    }
+
+    await session.close("client_end");
+  });
+
+  test("drops a turn-end for a turn flux has already superseded", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_ON,
+      silenceThresholdMs: 40,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    const transcriber = transcribers[0];
+    transcriber?.startOfTurn(0);
+    transcriber?.emit({ type: "partial", text: "what is the" });
+    await sleep(PAST_SILENCE_BOUNDARY_MS);
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(
+      () => countFrames(frames, "speech_started") === 2,
+      "The resumed speech never re-opened a detector turn",
+    );
+    const receivedBeforeResume = transcriber?.received.length ?? 0;
+
+    // Flux closed turn 0 and opened turn 1 for the resumed speech, so the
+    // end-of-turn for turn 0 trailing behind describes speech the caller has
+    // moved past.
+    transcriber?.startOfTurn(1);
+    transcriber?.emit({
+      type: "turn-end",
+      text: "what is the",
+      confidence: 0.9,
+      turnIndex: 0,
+    });
+    await flushAsyncCallbacks();
+
+    expect(frames.some((frame) => frame.type === "utterance_end")).toBe(false);
+    expect(transcriber?.stopped).toBe(false);
+    expect(turnCalls).toHaveLength(0);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(
+      () => (transcriber?.received.length ?? 0) > receivedBeforeResume,
+      "The resumed speech stopped reaching the transcriber",
+    );
+
+    // Turn 1's own end-of-turn is the one that commits.
+    transcriber?.endOfTurn("what is the weather today", 1);
+    await waitFor(
+      () => turnCalls.length === 1,
+      "The superseding turn never committed",
+    );
+    expect(turnCalls[0]?.content).toBe("what is the weather today");
+    expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
 
     await session.close("client_end");
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -392,9 +392,14 @@ interface UtteranceCycle {
   // `vadSpeechGeneration` as of the local silence boundary that handed this
   // cycle to Flux, or null while no boundary has fired yet (Flux routinely
   // beats the trailing-silence countdown, and that fast commit is the point).
-  // A provider end-of-turn arriving with a newer generation describes speech
-  // the caller has already spoken past (see isStaleFluxTurnEnd).
+  // The staleness signal of last resort: it stands in for the provider's own
+  // turn numbering when the provider sends none (see isStaleFluxTurnEnd).
   fluxBoundaryGeneration: number | null;
+  // Index of the newest provider turn opened in this cycle, from the turn
+  // model's own numbering, or null when the provider does not number its
+  // turns. An end-of-turn closing an older index describes a turn the
+  // provider has already superseded (see isStaleFluxTurnEnd).
+  fluxOpenTurnIndex: number | null;
   // The transcript the most recent hold verdict judged (unified front-door).
   // A final segment arriving during the extension window that extends this
   // text replays the boundary immediately — the hold was judged on stale
@@ -857,6 +862,7 @@ function createUtteranceCycle(): UtteranceCycle {
     endpointExtensionCount: 0,
     fluxTurnEndTimedOut: false,
     fluxBoundaryGeneration: null,
+    fluxOpenTurnIndex: null,
     heldSpeculativeContent: null,
     turnId: null,
     userMessageId: null,
@@ -2828,9 +2834,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // whose deadline already elapsed falls through to the hold path
         // below, which is the whole point of the fallback.
         if (this.fluxTurnEndActive && !utterance.fluxTurnEndTimedOut) {
-          // Stamp the speech run this boundary closed. handleVadSpeechStart
-          // bumps the generation when the caller resumes, so a turn-end that
-          // was already in flight is recognisably stale (isStaleFluxTurnEnd).
+          // Stamp the speech run this boundary closed. This is the staleness
+          // signal of last resort, used only for a provider that does not
+          // number its turns: where Flux's own turn index is on the wire it
+          // answers the question directly (see isStaleFluxTurnEnd).
           utterance.fluxBoundaryGeneration = this.vadSpeechGeneration;
           this.armFluxTurnEndFallbackTimer(utterance);
           return;
@@ -2939,21 +2946,50 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * A provider end-of-turn that lost its race with the caller's next breath.
-   * The local silence boundary stamps the cycle with the speech generation it
-   * closed; `handleVadSpeechStart` bumps that generation (and clears the
-   * fail-open deadline) the moment the caller resumes. A turn-end arriving
-   * afterwards therefore describes speech the caller has already spoken past:
-   * acting on it would send utterance_end and stop the transcriber while local
-   * VAD is still routing the resumed speech into this same cycle, cutting off
-   * the next words or folding them into the wrong turn. This is the same
-   * active-detector / generation staleness test the silence fallback and the
-   * speculative hold paths already apply. Before any boundary has fired the
-   * stamp is null and nothing is stale: Flux routinely closes a turn while the
-   * trailing-silence countdown is still running, and that fast commit is the
-   * whole feature.
+   * Record the provider turn a cycle is currently inside. Providers without
+   * turn numbering send no index, which leaves the cycle on the local speech
+   * generation as its only staleness signal (see isStaleFluxTurnEnd).
    */
-  private isStaleFluxTurnEnd(utterance: UtteranceCycle): boolean {
+  private recordFluxTurnStart(
+    utterance: UtteranceCycle,
+    turnIndex: number | undefined,
+  ): void {
+    if (turnIndex === undefined) {
+      return;
+    }
+    utterance.fluxOpenTurnIndex = turnIndex;
+  }
+
+  /**
+   * A provider end-of-turn that lost its race with the caller's next breath:
+   * it describes speech the caller has already spoken past. Acting on one
+   * would send utterance_end and stop the transcriber while local VAD is
+   * still routing the resumed speech into this same cycle, cutting off the
+   * next words or folding them into the wrong turn.
+   *
+   * Flux's own turn numbering answers this directly and is preferred
+   * wherever it is available: the cycle records the newest turn Flux has
+   * opened, so an end-of-turn for an older index closes a turn Flux itself
+   * has already superseded. An end-of-turn for the turn still in progress is
+   * never stale, however many times the caller drew breath inside it: the
+   * mid-thought pause is exactly the case Flux's turn model exists to judge,
+   * and its verdict covers the resumed speech too.
+   *
+   * With no turn numbering the local speech generation is the only signal
+   * left. The silence boundary stamps the cycle with the generation it
+   * closed and `handleVadSpeechStart` bumps that generation when the caller
+   * resumes, so a turn-end arriving on a newer generation is treated as
+   * stale. That is conservative: it also drops the fast end-of-turn this
+   * feature exists for, which the turn index would have committed. Before
+   * any boundary has fired the stamp is null and nothing is stale.
+   */
+  private isStaleFluxTurnEnd(
+    utterance: UtteranceCycle,
+    turnIndex: number | undefined,
+  ): boolean {
+    if (turnIndex !== undefined && utterance.fluxOpenTurnIndex !== null) {
+      return turnIndex < utterance.fluxOpenTurnIndex;
+    }
     return (
       utterance.fluxBoundaryGeneration !== null &&
       utterance.fluxBoundaryGeneration !== this.vadSpeechGeneration
@@ -2987,7 +3023,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * the caller has finished. The escalate verdict and the spoken ack /
    * progress phrasing are untouched; only the hold verdict is bypassed.
    */
-  private async handleFluxTurnEnd(utterance: UtteranceCycle): Promise<void> {
+  private async handleFluxTurnEnd(
+    utterance: UtteranceCycle,
+    turnIndex: number | undefined,
+  ): Promise<void> {
     if (
       !this.fluxTurnEndActive ||
       this.currentUtterance !== utterance ||
@@ -2999,9 +3038,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       return;
     }
-    if (this.isStaleFluxTurnEnd(utterance)) {
+    if (this.isStaleFluxTurnEnd(utterance, turnIndex)) {
       log.debug(
         {
+          turnIndex,
+          openTurnIndex: utterance.fluxOpenTurnIndex,
           boundaryGeneration: utterance.fluxBoundaryGeneration,
           speechGeneration: this.vadSpeechGeneration,
         },
@@ -3448,9 +3489,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // completion signal has no cycle to advance here.
         return;
       case "turn-start":
-        // Deliberately a no-op: local VAD still owns barge-in, because a
-        // provider roundtrip cannot beat a local energy gate on an interrupt
-        // during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS).
+        // Barge-in is deliberately untouched: local VAD still owns it,
+        // because a provider roundtrip cannot beat a local energy gate on an
+        // interrupt during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS). The
+        // index is recorded so a later end-of-turn can be told apart from one
+        // this turn superseded (see isStaleFluxTurnEnd).
+        this.recordFluxTurnStart(utterance, event.turnIndex);
         return;
       case "eager-turn-end":
       case "turn-resumed":
@@ -3460,7 +3504,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // follow-up.
         return;
       case "turn-end":
-        await this.handleFluxTurnEnd(utterance);
+        await this.handleFluxTurnEnd(utterance, event.turnIndex);
         return;
       case "error":
         await this.sendTranscriberErrorFrame(event);
@@ -3585,11 +3629,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.startAssistantTurnIfReady();
         return;
       }
-      case "turn-start":
-        // Deliberately a no-op: local VAD still owns barge-in, because a
-        // provider roundtrip cannot beat a local energy gate on an interrupt
-        // during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS).
+      case "turn-start": {
+        // Barge-in is deliberately untouched: local VAD still owns it,
+        // because a provider roundtrip cannot beat a local energy gate on an
+        // interrupt during playback (see DEFAULT_BARGE_IN_MIN_SPEECH_MS). The
+        // index is recorded so a later end-of-turn can be told apart from one
+        // this turn superseded (see isStaleFluxTurnEnd).
+        const target = this.pendingTranscriptCycle();
+        if (target) {
+          this.recordFluxTurnStart(target, event.turnIndex);
+        }
         return;
+      }
       case "eager-turn-end":
       case "turn-resumed":
         // Speculative end-of-turn stays off (the config leaves
@@ -3602,7 +3653,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // transcript owns the turn the provider just closed.
         const target = this.pendingTranscriptCycle();
         if (target) {
-          await this.handleFluxTurnEnd(target);
+          await this.handleFluxTurnEnd(target, event.turnIndex);
         }
         return;
       }

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
@@ -77,8 +77,10 @@ describe("parseFluxFrame", () => {
     expect(parseFluxFrame(CONNECTED)).toEqual([]);
   });
 
-  test("StartOfTurn emits turn-start", () => {
-    expect(parseFluxFrame(START_OF_TURN)).toEqual([{ type: "turn-start" }]);
+  test("StartOfTurn emits turn-start carrying the turn index", () => {
+    expect(parseFluxFrame(START_OF_TURN)).toEqual([
+      { type: "turn-start", turnIndex: 0 },
+    ]);
   });
 
   test("Update emits a partial with the interim transcript", () => {
@@ -111,6 +113,7 @@ describe("parseFluxFrame", () => {
         type: "turn-end",
         text: "what is the weather today",
         confidence: 0.88,
+        turnIndex: 0,
       },
     ]);
     // Consumers that ignore turn events must still see the commit first.
@@ -144,7 +147,35 @@ describe("parseFluxFrame", () => {
         type: "turn-end",
         text: "what is the weather today",
         confidence: 0.88,
+        turnIndex: 0,
       },
+    ]);
+  });
+
+  test("a later turn keeps its own index on both turn events", () => {
+    expect(
+      parseFluxFrame({ ...START_OF_TURN, turn_index: 3, transcript: "" }),
+    ).toEqual([{ type: "turn-start", turnIndex: 3 }]);
+    expect(
+      parseFluxFrame({
+        type: "TurnInfo",
+        event: "EndOfTurn",
+        turn_index: 3,
+        transcript: "and then some",
+      }),
+    ).toEqual([
+      { type: "final", text: "and then some" },
+      { type: "turn-end", text: "and then some", turnIndex: 3 },
+    ]);
+  });
+
+  test("turn events omit the index when Deepgram sends none", () => {
+    expect(parseFluxFrame({ type: "StartOfTurn" })).toEqual([
+      { type: "turn-start" },
+    ]);
+    expect(parseFluxFrame({ type: "EndOfTurn", transcript: "done" })).toEqual([
+      { type: "final", text: "done" },
+      { type: "turn-end", text: "done" },
     ]);
   });
 

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
@@ -327,12 +327,17 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       );
 
       expect(events).toEqual([
-        { type: "turn-start" },
+        { type: "turn-start", turnIndex: 0 },
         { type: "partial", text: "what is the" },
         // The final comes first so a consumer that ignores turn events still
         // commits the transcript exactly as it does for any other provider.
         { type: "final", text: "what is the weather" },
-        { type: "turn-end", text: "what is the weather", confidence: 0.91 },
+        {
+          type: "turn-end",
+          text: "what is the weather",
+          confidence: 0.91,
+          turnIndex: 0,
+        },
       ]);
     });
 

--- a/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
@@ -143,6 +143,10 @@ type InboundFluxFrame = Partial<FluxTurnFrame> &
  *   it does for a provider without turn detection.
  * - `Error` emits `error`. This frame is fatal and is the only place the
  *   provider's own diagnostic appears, so it is surfaced rather than dropped.
+ *
+ * `turn-start` and `turn-end` carry the frame's `turn_index` when Deepgram
+ * sends one, which is what lets a consumer tell an end-of-turn for the turn
+ * still in progress from one Deepgram has already superseded.
  */
 export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
   const frame = coerceFrame(raw);
@@ -151,11 +155,17 @@ export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
   }
 
   const kind = readFrameKind(frame);
+  const turnIndex = readNumber(frame.turn_index);
   switch (kind) {
     case "Connected":
       return [];
     case "StartOfTurn":
-      return [{ type: "turn-start" }];
+      return [
+        {
+          type: "turn-start",
+          ...(turnIndex !== undefined ? { turnIndex } : {}),
+        },
+      ];
     case "Update":
     case "TurnInfo":
       return [{ type: "partial", text: readTranscript(frame) }];
@@ -172,6 +182,7 @@ export function parseFluxFrame(raw: unknown): SttStreamServerEvent[] {
           type: "turn-end",
           text,
           ...(confidence !== undefined ? { confidence } : {}),
+          ...(turnIndex !== undefined ? { turnIndex } : {}),
         },
       ];
     }

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -322,6 +322,11 @@ export interface SttStreamServerFinalizedEvent {
  */
 export interface SttStreamServerTurnStartEvent {
   readonly type: "turn-start";
+  /**
+   * Provider's index for the turn being opened, monotonically increasing
+   * within a stream. Undefined when the provider does not number its turns.
+   */
+  readonly turnIndex?: number;
 }
 
 /**
@@ -365,6 +370,15 @@ export interface SttStreamServerTurnEndEvent {
    * provider does not surface a score.
    */
   readonly confidence?: number;
+  /**
+   * Provider's index for the turn being closed, matching the
+   * {@link SttStreamServerTurnStartEvent} that opened it. A consumer can
+   * compare it against the newest turn it has seen opened to tell an
+   * end-of-turn for the turn still in progress from one the provider has
+   * already superseded. Undefined when the provider does not number its
+   * turns.
+   */
+  readonly turnIndex?: number;
 }
 
 /** An error occurred during streaming transcription. */


### PR DESCRIPTION
## Summary

- A legitimate fast Flux end-of-turn was dropped as stale after any mid-thought pause, and the turn then stalled for the whole fail-open budget before committing via the speculative hold path the feature was meant to replace. Measured commit latency was 1503 ms with the test config (eotTimeoutMs 500 plus the 1000 ms margin), which is roughly 5.2 s with the production default of 5000 ms.
- The stall also mislabelled the commit: it reported endpointDecisionSource "front-door", so the A/B this change exists to enable was measuring the bug instead of the feature.
- Deepgram Flux numbers its turns and the frame parser already read turn_index before discarding it. turnIndex is now carried on the turn-start and turn-end stream events, each cycle records the newest turn Flux has opened, and an end-of-turn is stale only when it closes an index Flux has already superseded.
- The VAD speech generation stamp remains the fallback for a provider that sends no turn numbering, so the original stale-event race stays closed there too.
- Local VAD still owns barge-in in both modes, the echo-adaptive gate stays upstream of Flux, the hold machinery is untouched, forceEnd after a Flux commit is unchanged, and the flag-off default path behaves exactly as before.

## Tests

- New: a fast turn-end for the still-open turn after a mid-thought pause commits promptly (asserted under 300 ms), takes the Flux path, and reports endpointDecisionSource "flux". It deliberately does not sleep past the next silence boundary, which is what hid the bug from the existing coverage. Verified failing on the pre-fix session at 1503 ms.
- New: an end-of-turn for a turn Flux has already superseded is still dropped, and the superseding turn commits on its own end-of-turn.
- Kept: the existing stale-event test for a provider that sends no turn index, which still drops.
- Frame and realtime parser coverage for turn_index on both turn events, including the omitted case.

Fixes a gap found during plan review for flux-turn-detection.md.