### PR TITLE
fix(assistant): surface a real diagnostic when batch transcription hits a streaming-only provider

### DIFF
--- a/assistant/docs/flux-turn-detection-spike.md
+++ b/assistant/docs/flux-turn-detection-spike.md
@@ -64,6 +64,8 @@ If it does not, set the Deepgram key the ordinary way (client Settings, Speech-t
 
 ## 2. Enable Flux
 
+> **Setting `services.stt.provider` to `deepgram-flux` turns off batch transcription for the whole workspace, not just live voice.** `services.stt.provider` is the single source of truth for every STT route, and Flux is the only provider in the catalog with no `daemon-batch` boundary. For as long as it is set, these all stop working: voice-message and inbound-attachment transcription, the `transcribe` skill, the `media-processing` skill's audio segments, `POST /v1/stt/transcribe`, and phone-call transcription. Each reports a message naming Flux as the cause rather than failing silently, but they do not fall back to `deepgram` on their own. **Set `services.stt.provider` back to `deepgram` when the spike is over**, and do not run the spike on an assistant that is also taking calls or handling voice messages.
+
 Two keys in `config.json`, which lives at `$VELLUM_WORKSPACE_DIR/config.json` (default `~/.vellum/workspace/config.json`):
 
 ```json
@@ -184,8 +186,8 @@ with `byteLength`, `sampleRate`, `encoding`, `observedChunkMs`, and `recommended
 Do not rediscover these.
 
 - **English only.** The spike pins `flux-general-en`. No language is forwarded to the adapter, because `language_hint` means nothing to a monolingual model. The web language catalog is untouched.
-- **No telephony.** The catalog entry sets `telephonyMode: "none"`, so phone calls resolve to `null` for Flux and stay on the `deepgram` provider. That is verified by test, not by a runtime conditional.
-- **No batch.** `supportedBoundaries` is `daemon-streaming` only. A batch transcription request on `deepgram-flux` fails with an explicit streaming-only message.
+- **No telephony, and no fallback either.** The catalog entry sets `telephonyMode: "none"`, so `resolveTelephonySttCapability` reports Flux as unsupported and the call session reports that as its error. Nothing reroutes the call to the `deepgram` provider: with Flux configured, calls on this assistant are not transcribed at all.
+- **No batch, workspace-wide.** `supportedBoundaries` is `daemon-streaming` only, and `resolveBatchTranscriber` throws for it rather than returning the `null` that every batch caller reports as "no speech-to-text provider is configured". Callers surface the thrown message instead: `Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".` See the warning in section 2 for the full list of surfaces this takes down.
 - **No managed / velay path.** This is BYOK through the daemon only. The relay pins the model server-side, so managed rollout is a relay change.
 - **Eager end-of-turn is off, and its being off is load-bearing.** `eagerEotThreshold` is optional with no default, and leaving it unset is precisely what stops Deepgram emitting `EagerEndOfTurn` / `TurnResumed` at all. The parser handles both frames and the session no-ops them, so the follow-up is small, but Deepgram warns that enabling speculation raises LLM calls by 50 to 70 percent. Note also that `buildFluxQueryParams` clamps `eager_eot_threshold` **down** to the effective `eot_threshold`, because Deepgram rejects the inverse combination.
 - **The hold machinery is present and unchanged.** `HOLD_VERDICT_TOKEN`, the `includeHold` branch, the speculative dispatch and rollback state, `endpointExtensionMs`, and `endpointMaxExtensions` are all still there. The latch only skips them.

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -19,6 +19,7 @@ import {
   updateProcessingStage,
 } from "../../../../persistence/media-store.js";
 import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
+import type { BatchTranscriber } from "../../../../stt/types.js";
 import { silentlyWithLog } from "../../../../util/silently.js";
 import {
   FFMPEG_PALETTE_TIMEOUT_MS,
@@ -459,10 +460,19 @@ export async function preprocessForAsset(
     const allFramePaths: string[] = [];
 
     // Resolve the STT transcriber once for all segments to avoid repeated
-    // credential lookups in the per-segment loop.
-    const transcriber = options.includeAudio
-      ? await resolveBatchTranscriber()
-      : null;
+    // credential lookups in the per-segment loop. A resolver failure degrades
+    // to transcript-less segments like an absent provider does, reporting the
+    // reason on the progress stream rather than killing the whole run.
+    let transcriber: BatchTranscriber | null = null;
+    if (options.includeAudio) {
+      try {
+        transcriber = await resolveBatchTranscriber();
+      } catch (err) {
+        onProgress?.(
+          `Audio transcription unavailable: ${(err as Error).message}\n`,
+        );
+      }
+    }
 
     const scaleFilter = `scale='if(gt(iw,ih),-1,${config.shortEdge})':'if(gt(iw,ih),${config.shortEdge},-1)'`;
 

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.test.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { BatchTranscriber } from "../../../../stt/types.js";
+import { SttError } from "../../../../stt/types.js";
 import type { ToolContext } from "../../../../tools/types.js";
 
 // ---------------------------------------------------------------------------
@@ -8,9 +9,15 @@ import type { ToolContext } from "../../../../tools/types.js";
 // ---------------------------------------------------------------------------
 
 let mockTranscriber: BatchTranscriber | null = null;
+let mockResolveError: Error | null = null;
 
 mock.module("../../../../providers/speech-to-text/resolve.js", () => ({
-  resolveBatchTranscriber: async () => mockTranscriber,
+  resolveBatchTranscriber: async () => {
+    if (mockResolveError) {
+      throw mockResolveError;
+    }
+    return mockTranscriber;
+  },
 }));
 
 // Track calls to spawnWithTimeout so we can simulate ffmpeg/ffprobe results.
@@ -103,6 +110,7 @@ function makeMockTranscriber(
 describe("transcribe_media tool", () => {
   beforeEach(() => {
     mockTranscriber = null;
+    mockResolveError = null;
     spawnResults = {};
     accessiblePaths = new Set();
     mockFileContents = {};
@@ -118,6 +126,19 @@ describe("transcribe_media tool", () => {
       expect(result.content).toContain(
         "No speech-to-text provider is configured",
       );
+    });
+
+    test("surfaces a resolver error verbatim rather than the not-configured copy", async () => {
+      const reason =
+        'Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".';
+      mockResolveError = new SttError("provider-error", reason, {
+        userFacing: true,
+      });
+
+      const result = await run({ file_path: "/tmp/test.mp3" }, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(reason);
     });
   });
 

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -234,8 +234,15 @@ export async function run(
     };
   }
 
-  // Resolve the configured STT provider
-  const transcriber = await resolveBatchTranscriber();
+  // Resolve the configured STT provider. A typed resolver error already names
+  // the mismatch (e.g. a streaming-only provider) and its fix, so it reaches
+  // the model verbatim rather than as the "nothing configured" copy below.
+  let transcriber: BatchTranscriber | null;
+  try {
+    transcriber = await resolveBatchTranscriber();
+  } catch (err) {
+    return { content: (err as Error).message, isError: true };
+  }
   if (!transcriber) {
     return {
       content:

--- a/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/provider-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  batchBoundaryGapReason,
   getCredentialProvider,
   getProviderEntry,
   listCredentialProviderNames,
@@ -107,6 +108,20 @@ describe("STT provider catalog", () => {
     // explicitly rather than silently falling through.
     expect(supportsBoundary("deepgram-flux", "daemon-streaming")).toBe(true);
     expect(supportsBoundary("deepgram-flux", "daemon-batch")).toBe(false);
+  });
+
+  test("batchBoundaryGapReason names the batch provider on the same credential", () => {
+    const reason = batchBoundaryGapReason("deepgram-flux");
+    expect(reason).toBe(
+      'Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".',
+    );
+  });
+
+  test("batchBoundaryGapReason falls back to generic guidance for an unknown provider", () => {
+    // No catalog entry means no credential to search a batch-capable peer on.
+    const reason = batchBoundaryGapReason("nonexistent" as never);
+    expect(reason).toContain("nonexistent is streaming-only");
+    expect(reason).toContain("supports batch transcription");
   });
 
   test("supportsBoundary returns false for unknown provider IDs", () => {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "../../../__tests__/helpers/set-config.js";
 import { getConfig } from "../../../config/loader.js";
+import { SttError } from "../../../stt/types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before any subject imports
@@ -509,8 +510,9 @@ describe("telephony capability catalog alignment", () => {
 
   /**
    * Providers that deliberately sit out telephony (`telephonyMode: "none"`).
-   * `deepgram-flux` is a streaming-only spike: phone calls stay on the
-   * `deepgram` provider until Flux proves itself in live voice.
+   * `deepgram-flux` is a streaming-only spike, and telephony is out of its
+   * scope. Nothing reroutes a call to another provider, so opting out here
+   * means a Flux-configured assistant does not transcribe calls.
    */
   const TELEPHONY_OPT_OUT: ReadonlySet<SttProviderId> = new Set([
     "deepgram-flux",
@@ -1598,6 +1600,65 @@ describe("deepgram-flux streaming resolution", () => {
     });
 
     expect(transcriber).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: batch resolution against a streaming-only provider
+// ---------------------------------------------------------------------------
+
+describe("deepgram-flux batch resolution", () => {
+  beforeEach(() => {
+    mockVellumAvailable = false;
+    mockVelayConnection = null;
+    mockProviderKeys = {};
+    loggerWarnings.length = 0;
+  });
+
+  /**
+   * Every batch caller pairs a `null` resolve with "no speech-to-text
+   * provider is configured". Flux is configured, and the operator who set it
+   * needs to be told which of the two Deepgram entries batch runs on, so the
+   * resolver raises a typed error instead of returning that `null`.
+   */
+  test("throws a named error rather than resolving null", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    await expect(resolveBatchTranscriber()).rejects.toThrow(
+      'Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".',
+    );
+  });
+
+  test("marks the error user-facing so friendly copy does not overwrite it", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    const err = await resolveBatchTranscriber().catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SttError);
+    expect((err as SttError).category).toBe("provider-error");
+    expect((err as SttError).userFacing).toBe(true);
+  });
+
+  test("logs the gap so a degrading caller still leaves a daemon-side trace", async () => {
+    mockProviderKeys = { deepgram: "dg-key" };
+    applyConfig({ provider: "deepgram-flux" });
+
+    await resolveBatchTranscriber().catch(() => undefined);
+
+    expect(loggerWarnings).toHaveLength(1);
+    expect(
+      (loggerWarnings[0]!.data as { providerId?: unknown }).providerId,
+    ).toBe("deepgram-flux");
+  });
+
+  test("a provider that is absent from the catalog still resolves null", async () => {
+    // "Unknown provider" is a different situation from "known provider,
+    // wrong boundary", and only the latter has a fix worth naming.
+    applyConfig({ provider: "not-a-provider" });
+
+    expect(await resolveBatchTranscriber()).toBeNull();
   });
 });
 

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -177,7 +177,9 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
       credentialProvider: "deepgram",
       // Streaming only: Flux has no batch endpoint.
       supportedBoundaries: new Set<SttBoundaryId>(["daemon-streaming"]),
-      // Phone calls stay on the `deepgram` provider while Flux is a spike.
+      // Telephony is out of scope for the spike. Nothing reroutes a call to
+      // another provider, so a Flux-configured assistant does not transcribe
+      // calls at all.
       telephonyMode: "none",
       conversationStreamingMode: "realtime-ws",
       supportsDiarization: false,
@@ -331,6 +333,32 @@ export function supportsBoundary(
   boundary: SttBoundaryId,
 ): boolean {
   return CATALOG.get(id)?.supportedBoundaries.has(boundary) ?? false;
+}
+
+/**
+ * Message explaining why a provider cannot serve the `daemon-batch` boundary.
+ *
+ * Streaming-only providers are selected through the same
+ * `services.stt.provider` key as batch-capable ones, so a batch caller that
+ * reports only "nothing is configured" points the operator at the wrong
+ * problem. This names the provider and, where one exists, the batch-capable
+ * provider on the same credential, so acting on it needs no catalog reading.
+ */
+export function batchBoundaryGapReason(id: SttProviderId): string {
+  const entry = CATALOG.get(id);
+  const label = entry?.displayName ?? id;
+  const alternative = entry
+    ? [...CATALOG.values()].find(
+        (candidate) =>
+          candidate.id !== entry.id &&
+          candidate.credentialProvider === entry.credentialProvider &&
+          candidate.supportedBoundaries.has("daemon-batch"),
+      )
+    : undefined;
+  const remedy = alternative
+    ? `Batch transcription requires the ${alternative.id} provider: set services.stt.provider to "${alternative.id}".`
+    : "Set services.stt.provider to a provider that supports batch transcription.";
+  return `${label} is streaming-only. ${remedy}`;
 }
 
 /**

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -6,8 +6,10 @@ import type {
   StreamingTranscriber,
   SttProviderId,
 } from "../../stt/types.js";
+import { SttError } from "../../stt/types.js";
 import { getLogger } from "../../util/logger.js";
 import {
+  batchBoundaryGapReason,
   getCredentialProvider,
   getProviderEntry,
   supportsBoundary,
@@ -88,8 +90,13 @@ export function effectiveSttLanguage(
  *
  * Returns `null` when:
  * - The configured provider is not in the catalog.
- * - The configured provider doesn't support the `daemon-batch` boundary.
  * - No credentials are configured for the resolved provider.
+ *
+ * Throws an {@link SttError} when the configured provider is in the catalog
+ * but has no `daemon-batch` boundary. That is a configuration mismatch the
+ * resolver can name, and returning `null` for it would reach the user as the
+ * "no speech-to-text provider is configured" copy every caller pairs with
+ * `null`, which is the opposite of what happened.
  */
 export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null> {
   // Snapshot the stt config once, before any await, so a concurrent config
@@ -111,7 +118,9 @@ export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null
 
   // Verify the provider supports the daemon-batch boundary.
   if (!supportsBoundary(provider as SttProviderId, "daemon-batch")) {
-    return null;
+    const reason = batchBoundaryGapReason(provider as SttProviderId);
+    log.warn({ providerId: provider }, reason);
+    throw new SttError("provider-error", reason, { userFacing: true });
   }
 
   if (provider === "vellum") {

--- a/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/stt-routes.test.ts
@@ -288,6 +288,31 @@ describe("stt-routes", () => {
     expect(err.message).toContain("not available");
   });
 
+  test("surfaces a typed resolver error verbatim instead of the generic copy", async () => {
+    // A streaming-only provider IS configured, so the "nothing configured"
+    // and "not available" strings would both send the caller looking for a
+    // problem that does not exist.
+    const reason =
+      'Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".';
+    mockResolveError = new SttError("provider-error", reason, {
+      userFacing: true,
+    });
+
+    const { handler } = getRoute("stt/transcribe");
+    const err = await expectRouteError(
+      () =>
+        handler(
+          makeArgs({
+            audioBase64: toBase64("audio-data"),
+            mimeType: "audio/wav",
+          }),
+        ),
+      503,
+      "SERVICE_UNAVAILABLE",
+    );
+    expect(err.message).toBe(reason);
+  });
+
   // -- Timeout --------------------------------------------------------------
 
   test("throws 504 when transcription times out", async () => {

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -223,6 +223,35 @@ const STT_ERROR_MAP: Record<SttErrorCategory, () => RouteError> = {
   "provider-error": () => new BadGatewayError("STT provider error"),
 };
 
+/**
+ * Resolve the configured batch transcriber, or fail the request with a 503
+ * naming which kind of unavailability this is.
+ *
+ * A typed {@link SttError} already names the situation and its fix (a
+ * configured provider that cannot batch transcribe), so its message is
+ * surfaced verbatim. `null` means nothing is configured at all, and any other
+ * throw is an unexpected resolver failure.
+ */
+async function resolveBatchTranscriberOrUnavailable(): Promise<BatchTranscriber> {
+  let transcriber: BatchTranscriber | null;
+  try {
+    transcriber = await resolveBatchTranscriber();
+  } catch (err) {
+    if (err instanceof SttError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    log.error({ err }, "Failed to resolve STT transcriber");
+    throw new ServiceUnavailableError("STT provider is not available");
+  }
+
+  if (!transcriber) {
+    throw new ServiceUnavailableError(
+      "No speech-to-text provider is configured",
+    );
+  }
+  return transcriber;
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -288,19 +317,7 @@ async function handleTranscribe({ body }: RouteHandlerArgs) {
   }
 
   // -- Resolve transcriber --------------------------------------------------
-  let transcriber;
-  try {
-    transcriber = await resolveBatchTranscriber();
-  } catch (err) {
-    log.error({ err }, "Failed to resolve STT transcriber");
-    throw new ServiceUnavailableError("STT provider is not available");
-  }
-
-  if (!transcriber) {
-    throw new ServiceUnavailableError(
-      "No speech-to-text provider is configured",
-    );
-  }
+  const transcriber = await resolveBatchTranscriberOrUnavailable();
 
   // -- Transcribe with timeout ----------------------------------------------
   const abortController = new AbortController();
@@ -358,18 +375,7 @@ async function handleTranscribeFile({ body }: RouteHandlerArgs) {
     );
   }
 
-  let transcriber;
-  try {
-    transcriber = await resolveBatchTranscriber();
-  } catch (err) {
-    log.error({ err }, "Failed to resolve STT transcriber");
-    throw new ServiceUnavailableError("STT provider is not available");
-  }
-  if (!transcriber) {
-    throw new ServiceUnavailableError(
-      "No speech-to-text provider is configured",
-    );
-  }
+  const transcriber = await resolveBatchTranscriberOrUnavailable();
 
   const startTime = Date.now();
   let wavPath: string | null = null;

--- a/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
+++ b/assistant/src/stt/__tests__/daemon-batch-transcriber.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { batchBoundaryGapReason } from "../../providers/speech-to-text/provider-catalog.js";
 import { SttError } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -618,5 +619,26 @@ describe("vellum factory case", () => {
 
   test("still returns null for key-based providers without a key", () => {
     expect(createDaemonBatchTranscriber(null, "deepgram")).toBeNull();
+  });
+});
+
+describe("deepgram-flux factory case", () => {
+  // The copy itself is pinned in provider-catalog.test.ts; what matters here
+  // is that the factory speaks with the catalog's voice rather than its own.
+  test("throws the catalog's streaming-only reason", () => {
+    expect(() =>
+      createDaemonBatchTranscriber("dg-test-key", "deepgram-flux"),
+    ).toThrow(batchBoundaryGapReason("deepgram-flux"));
+  });
+
+  test("marks the error user-facing so friendly copy does not overwrite it", () => {
+    try {
+      createDaemonBatchTranscriber("dg-test-key", "deepgram-flux");
+      throw new Error("expected the factory to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SttError);
+      expect((err as SttError).category).toBe("provider-error");
+      expect((err as SttError).userFacing).toBe(true);
+    }
   });
 });

--- a/assistant/src/stt/daemon-batch-transcriber.ts
+++ b/assistant/src/stt/daemon-batch-transcriber.ts
@@ -13,6 +13,7 @@
  * - xAI (`xai`)
  */
 
+import { batchBoundaryGapReason } from "../providers/speech-to-text/provider-catalog.js";
 import type {
   BatchTranscriber,
   SttProviderId,
@@ -245,6 +246,9 @@ class VellumManagedBatchTranscriber implements BatchTranscriber {
  * language code), and the vellum managed path, whose platform proxy passes
  * it to Deepgram server-side. Whisper and Gemini auto-detect natively and
  * take no language parameter, so it is silently ignored for them.
+ *
+ * Throws an {@link SttError} for a provider with no batch endpoint at all,
+ * which no key can fix and `null` would understate.
  */
 export function createDaemonBatchTranscriber(
   apiKey: string | null | undefined,
@@ -269,10 +273,11 @@ export function createDaemonBatchTranscriber(
     case "xai":
       return new XAIBatchTranscriber(apiKey, language);
     case "deepgram-flux":
-      throw new SttError(
-        "provider-error",
-        "Flux is streaming-only; use the deepgram provider for batch transcription",
-      );
+      // Same copy the resolver raises, so a direct factory caller and a
+      // config-driven one report the mismatch identically.
+      throw new SttError("provider-error", batchBoundaryGapReason(providerId), {
+        userFacing: true,
+      });
     default: {
       // Exhaustive check — compile error if a new SttProviderId is added
       // without a corresponding case here.


### PR DESCRIPTION
## Summary

- `resolveBatchTranscriber` threw away the reason a configured provider could not batch transcribe: `deepgram-flux` has no `daemon-batch` boundary, so the boundary check returned `null`, and every batch caller pairs `null` with "No speech-to-text provider is configured". One IS configured, so the operator following the Flux spike runbook was sent after a problem that did not exist.
- The resolver now throws a typed `SttError` for a catalog provider with no batch boundary, carrying copy that names the situation and its fix: `Deepgram Flux is streaming-only. Batch transcription requires the deepgram provider: set services.stt.provider to "deepgram".` It is marked `userFacing` so `describeSttFailure` does not rewrite it to the generic BYOK copy.
- The copy is derived from the catalog (`batchBoundaryGapReason`), which finds the batch-capable provider sharing the streaming-only one's credential. Nothing is Flux-specific, so the next streaming-only provider gets the same message for free.
- `createDaemonBatchTranscriber`'s Flux case raised its own separately worded message that no user could reach, since the boundary check short-circuited first. It now raises the same catalog copy, so a direct factory caller and a config-driven one report the mismatch identically.
- Callers surface it: `/v1/stt/transcribe` and `/v1/stt/transcribe-file` share one resolve helper that passes a typed error's message through the 503 instead of flattening it to "STT provider is not available"; the `transcribe` skill returns it to the model; inbound attachment transcription already routes through `describeSttFailure`. `media-processing` preprocess degrades to transcript-less segments as it does for an absent provider, reporting the reason on the progress stream rather than killing the run.
- An unknown provider id still resolves to `null`. "Not in the catalog" is a different situation from "in the catalog, wrong boundary", and only the latter has a fix worth naming.

## Deliberately not done: credential-sharing fallback

`resolveBatchTranscriber` could have silently substituted `deepgram` when the configured provider shares its credential and lacks the batch boundary. Rejected:

- `services.stt.provider` is documented as the single source of truth for all STT routing (`stt-provider-onboarding.md` step 7). Substitution breaks that: `/v1/stt/transcribe` would answer `providerId: "deepgram"` while config says `deepgram-flux`, and clients read that field.
- The catalog has no concept of a batch peer. The rule would be "any provider sharing my credential", which is a coincidence of credential layout, not a declared relationship, and it would silently pick an arbitrary sibling as the set grows.
- It would hide exactly the misconfiguration this PR exists to report, and the spike is temporary and explicit. A loud message plus a runbook warning is the honest behavior.

## Runbook

`flux-turn-detection-spike.md` claimed a batch request on `deepgram-flux` "fails with an explicit streaming-only message". It did not. Corrected, plus a warning where the operator is told to set the provider, listing every surface this takes down workspace-wide and how to restore it.

Also corrected: the runbook and two code comments said phone calls "stay on the `deepgram` provider" under Flux. Nothing reroutes them. A Flux-configured assistant does not transcribe calls at all.

## Testing

Ran individually (STT suites leak `mock.module` when batched): `resolve.test.ts`, `provider-catalog.test.ts`, `daemon-batch-transcriber.test.ts`, `stt-routes.test.ts`, `transcribe-media.test.ts`, `audio-transcribe.test.ts`, `preprocess.test.ts`, `preprocess-audio.test.ts`, `transcribe-audio.test.ts`, `media-stream-stt-session.test.ts`, `media-stream-server-integration.test.ts`. All pass. Typecheck clean; circular-dependency count unchanged at the pre-existing 188.

Fixes a gap found during plan review for flux-turn-detection.md.