### PR TITLE
refactor(assistant): drop dead Flux adapter surface and its duplicated frame parse

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-frames.test.ts
@@ -430,19 +430,4 @@ describe("buildFluxQueryParams", () => {
       expect(new URLSearchParams(query).has("eager_eot_threshold")).toBe(false);
     }
   });
-
-  test("repeats language_hint once per hint", () => {
-    const params = new URLSearchParams(
-      buildFluxQueryParams({
-        model: "flux-general-multi",
-        languageHint: ["en", "es"],
-      }),
-    );
-    expect(params.getAll("language_hint")).toEqual(["en", "es"]);
-
-    const single = new URLSearchParams(
-      buildFluxQueryParams({ model: "flux-general-multi", languageHint: "fr" }),
-    );
-    expect(single.getAll("language_hint")).toEqual(["fr"]);
-  });
 });

--- a/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/deepgram-flux-realtime.test.ts
@@ -11,8 +11,7 @@ import { SttError } from "../../../stt/types.js";
 // Logger mock: must be declared before the subject import
 //
 // The adapter's only observable output for the chunk-cadence measurement is a
-// debug log line, and the Configure-failure contract is "warn, never a stream
-// error", so both are asserted through captured logs.
+// log line, so it is asserted through captured logs.
 // ---------------------------------------------------------------------------
 
 interface CapturedLog {
@@ -20,8 +19,7 @@ interface CapturedLog {
   message: string;
 }
 
-const debugLogs: CapturedLog[] = [];
-const warnLogs: CapturedLog[] = [];
+const infoLogs: CapturedLog[] = [];
 
 function capture(sink: CapturedLog[]) {
   return (data: unknown, message?: string) => {
@@ -35,9 +33,9 @@ function capture(sink: CapturedLog[]) {
 
 mock.module("../../../util/logger.js", () => {
   const logger = {
-    debug: capture(debugLogs),
-    warn: capture(warnLogs),
-    info: () => {},
+    info: capture(infoLogs),
+    debug: () => {},
+    warn: () => {},
     error: () => {},
     trace: () => {},
     fatal: () => {},
@@ -160,8 +158,7 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
     mockWs = new MockWebSocket();
     dialedUrls = [];
     dialedOptions = [];
-    debugLogs.length = 0;
-    warnLogs.length = 0;
+    infoLogs.length = 0;
 
     originalWebSocket = (globalThis as Record<string, unknown>).WebSocket;
     (globalThis as Record<string, unknown>).WebSocket = class {
@@ -285,14 +282,16 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       expect(mockWs.sentData).toHaveLength(0);
     });
 
-    test("logs the observed chunk duration once per session", async () => {
+    test("logs the observed chunk duration once per session at info", async () => {
       const { transcriber } = await startSession({ sampleRate: 16_000 });
 
       // 2560 bytes of mono linear16 at 16kHz is exactly 80ms.
       transcriber.sendAudio(Buffer.alloc(2560), "audio/pcm");
       transcriber.sendAudio(Buffer.alloc(2560), "audio/pcm");
 
-      const cadenceLogs = debugLogs.filter((entry) =>
+      // The runbook reads this line off a default daemon, whose pino level is
+      // `info`: at debug it would never reach the log it is read from.
+      const cadenceLogs = infoLogs.filter((entry) =>
         entry.message.includes("chunk cadence"),
       );
       expect(cadenceLogs).toHaveLength(1);
@@ -366,9 +365,11 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       expect(events[0]).toMatchObject({ type: "error", category: "auth" });
     });
 
-    test("malformed frames are dropped rather than surfaced", async () => {
+    test("unrecognized and malformed frames leave the session transcribing", async () => {
       const { events } = await startSession();
 
+      // Deepgram can add frame types without warning, so anything the parser
+      // does not recognize is dropped rather than raised as a stream failure.
       mockWs.simulateMessage("not json at all");
       mockWs.simulateMessage(JSON.stringify([1, 2, 3]));
       mockWs.simulateMessage(
@@ -376,67 +377,14 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       );
 
       expect(events).toEqual([]);
-    });
-  });
 
-  // ─────────────────────────────────────────────────────────────────
-  // Configure acknowledgements
-  // ─────────────────────────────────────────────────────────────────
-
-  describe("Configure acknowledgements", () => {
-    test("ConfigureSuccess logs the authoritative thresholds and emits nothing", async () => {
-      const { events } = await startSession();
-
-      mockWs.simulateMessage(
-        JSON.stringify({
-          type: "ConfigureSuccess",
-          thresholds: {
-            eot_threshold: 0.8,
-            eager_eot_threshold: 0.4,
-            eot_timeout_ms: 6_000,
-          },
-        }),
-      );
-
-      expect(events).toEqual([]);
-      const ack = debugLogs.find((entry) =>
-        entry.message.includes("accepted a Configure"),
-      );
-      expect(ack).toBeDefined();
-      expect(ack!.data).toMatchObject({
-        thresholds: { eot_threshold: 0.8, eot_timeout_ms: 6_000 },
-      });
-    });
-
-    test("ConfigureFailure warns and leaves the session usable", async () => {
-      const { transcriber, events } = await startSession();
-
-      mockWs.simulateMessage(
-        JSON.stringify({
-          type: "ConfigureFailure",
-          sequence_id: 42,
-          code: "INVALID_THRESHOLD",
-          description:
-            "eager_eot_threshold must be less than or equal to eot_threshold",
-        }),
-      );
-
-      // A rejected Configure leaves the stream on its previous settings, so
-      // it must not become a stream error that tears the session down.
-      expect(events).toEqual([]);
-      const rejection = warnLogs.find((entry) =>
-        entry.message.includes("rejected a Configure"),
-      );
-      expect(rejection).toBeDefined();
-      expect(rejection!.data).toMatchObject({ code: "INVALID_THRESHOLD" });
-
-      // The session still transcribes.
       mockWs.simulateMessage(
         turnInfoFrame("EndOfTurn", { transcript: "still here" }),
       );
-      expect(events.map((event) => event.type)).toEqual(["final", "turn-end"]);
-
-      transcriber.stop();
+      expect(events).toEqual([
+        { type: "final", text: "still here" },
+        { type: "turn-end", text: "still here", turnIndex: 0 },
+      ]);
     });
   });
 
@@ -635,13 +583,15 @@ describe("DeepgramFluxRealtimeTranscriber", () => {
       expect(keepalives.length).toBeGreaterThanOrEqual(2);
     });
 
-    test("finalizeUtterance is deliberately absent, Flux owns turn boundaries", async () => {
+    test("finalizeUtterance is absent, Flux has no mid-stream flush", async () => {
       const { transcriber } = await startSession();
 
-      // Callers feature-detect this method and fall back to stop(), which is
-      // the correct semantics for a provider whose model ends the turn. The
-      // contract type is where the optional method lives, so the check goes
-      // through it. The class not declaring it at all is the point.
+      // Flux commits a transcript only on EndOfTurn and its protocol has no
+      // flush that keeps the socket open, so a finalizeUtterance here could
+      // only claim a commit that never happened and lose the tail of every
+      // turn released on a caller-side boundary. Callers feature-detect the
+      // method and fall back to stop(). The contract type is where the
+      // optional method lives, so the check goes through it.
       const asContract: StreamingTranscriber = transcriber;
       expect(asContract.finalizeUtterance).toBeUndefined();
     });

--- a/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-frames.ts
@@ -47,25 +47,6 @@ export type FluxFrameKind =
   | "EndOfTurn"
   | "Error";
 
-/** A single word within a Flux turn frame, with timings and confidence. */
-export interface FluxWord {
-  /** The recognized word. */
-  word?: string;
-  /** Per-word recognition confidence in [0, 1]. */
-  confidence?: number;
-  /** Word start offset in seconds from the beginning of the stream. */
-  start?: number;
-  /** Word end offset in seconds from the beginning of the stream. */
-  end?: number;
-}
-
-/** Session-established frame, sent once after the socket opens. */
-export interface FluxConnectedFrame {
-  type: "Connected";
-  request_id?: string;
-  sequence_id?: number;
-}
-
 /**
  * A turn-state frame.
  *
@@ -88,8 +69,6 @@ export interface FluxTurnFrame {
   audio_window_end?: number;
   /** Transcript for the turn so far. */
   transcript?: string;
-  /** Per-word timings and confidences backing {@link transcript}. */
-  words?: FluxWord[];
   /** Flux's end-of-turn confidence in [0, 1]. */
   end_of_turn_confidence?: number;
 }
@@ -107,8 +86,6 @@ export interface FluxErrorFrame {
   /** Prose explanation of the failure. */
   description?: string;
 }
-
-export type FluxFrame = FluxConnectedFrame | FluxTurnFrame | FluxErrorFrame;
 
 /**
  * A payload that has been confirmed to be an object but whose frame kind is
@@ -339,11 +316,6 @@ export interface FluxQueryParamOptions {
   eagerEotThreshold?: number;
   /** Silence (ms) after which Flux force-ends a turn. */
   eotTimeoutMs?: number;
-  /**
-   * Language hints for the multilingual model. Repeatable: each entry is sent
-   * as its own `language_hint` parameter. Ignored by monolingual models.
-   */
-  languageHint?: string | string[];
 }
 
 /**
@@ -405,13 +377,6 @@ export function buildFluxQueryParams(opts: FluxQueryParamOptions): string {
   const eotTimeoutMs = clamp(opts.eotTimeoutMs, EOT_TIMEOUT_MS_RANGE);
   if (eotTimeoutMs !== undefined) {
     params.set("eot_timeout_ms", String(Math.round(eotTimeoutMs)));
-  }
-
-  const hints = opts.languageHint;
-  for (const hint of typeof hints === "string" ? [hints] : (hints ?? [])) {
-    if (hint) {
-      params.append("language_hint", hint);
-    }
   }
 
   return params.toString();

--- a/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
+++ b/assistant/src/providers/speech-to-text/deepgram-flux-realtime.ts
@@ -16,10 +16,13 @@
  * 4. The `onEvent` callback receives `partial`, `final`, the four
  *    turn-detection events, `error`, and finally `closed`.
  *
- * There is deliberately **no `finalizeUtterance`**. Flux owns turn
- * boundaries, so there is nothing for a caller to flush mid-stream; leaving
- * the optional method off makes callers feature-detect and fall back to
- * {@link stop}, which is the correct semantics for this provider.
+ * There is **no `finalizeUtterance`**. Flux commits a transcript only when
+ * its model closes a turn, and its wire protocol offers no mid-stream flush:
+ * `CloseStream` is the only way to make it answer for a turn still in
+ * progress. A method that returned `finalized` without flushing would claim a
+ * commit the provider never made and lose the tail of every turn released on
+ * a caller-side boundary, so the optional method is left off and callers
+ * feature-detect it and fall back to {@link stop}.
  *
  * Error handling mirrors `deepgram-realtime.ts`: socket closes and errors map
  * onto {@link SttErrorCategory} values (`auth`, `rate-limit`, `timeout`,
@@ -30,15 +33,14 @@
  */
 
 import { getConfig } from "../../config/loader.js";
+import type { LiveVoiceFluxConfig } from "../../config/schemas/live-voice.js";
 import type {
   StreamingTranscriber,
   SttErrorCategory,
   SttStreamServerEvent,
 } from "../../stt/types.js";
 import { SttError } from "../../stt/types.js";
-import { parseJsonSafe } from "../../util/json.js";
 import { getLogger } from "../../util/logger.js";
-import { isPlainObject } from "../../util/object.js";
 import type { FluxEncoding } from "./deepgram-flux-frames.js";
 import {
   buildFluxQueryParams,
@@ -51,7 +53,7 @@ const log = getLogger("deepgram-flux-realtime");
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_WS_BASE_URL = "wss://api.deepgram.com";
+const WS_BASE_URL = "wss://api.deepgram.com";
 
 /** Flux lives on the v2 listen route; the v1 route speaks a different protocol. */
 const FLUX_PATH = "/v2/listen";
@@ -80,8 +82,8 @@ const MAX_BUFFERED_AMOUNT = 1024 * 1024; // 1 MiB
 /** Grace (ms) after `CloseStream` before the socket is force-closed. */
 const CLOSE_GRACE_MS = 5_000;
 
-/** Default raw-audio encoding: clients send linear16 PCM. */
-const DEFAULT_ENCODING: FluxEncoding = "linear16";
+/** Raw-audio encoding of the stream: clients send linear16 PCM. */
+const AUDIO_ENCODING: FluxEncoding = "linear16";
 
 /** Default sample rate (Hz) when the client negotiates none. */
 const DEFAULT_SAMPLE_RATE = 16_000;
@@ -99,26 +101,15 @@ const RECOMMENDED_CHUNK_MS = 80;
 // Options
 // ---------------------------------------------------------------------------
 
+/**
+ * Transport-level wiring for a Flux session. Turn-detection tuning (model,
+ * thresholds, force-end timeout) is not here: it comes from `liveVoice.flux`,
+ * which the adapter reads itself, so there is exactly one place to turn those
+ * dials.
+ */
 export interface DeepgramFluxRealtimeOptions {
-  /** Flux model. Defaults to `liveVoice.flux.model`. */
-  model?: string;
-  /** End-of-turn confidence. Defaults to `liveVoice.flux.eotThreshold`. */
-  eotThreshold?: number;
-  /**
-   * Eager end-of-turn confidence. Defaults to
-   * `liveVoice.flux.eagerEotThreshold`, which is unset by default, and
-   * leaving it unset is what stops Deepgram emitting `EagerEndOfTurn` /
-   * `TurnResumed` at all.
-   */
-  eagerEotThreshold?: number;
-  /** Force-end silence (ms). Defaults to `liveVoice.flux.eotTimeoutMs`. */
-  eotTimeoutMs?: number;
   /** Audio sample rate in Hz (default: 16000). */
   sampleRate?: number;
-  /** Raw audio encoding (default: linear16). */
-  encoding?: FluxEncoding;
-  /** Override the WebSocket base URL (proxies, on-prem). */
-  baseUrl?: string;
   /** Connect timeout in milliseconds. Default: 10_000. */
   connectTimeoutMs?: number;
   /** Inactivity timeout in milliseconds. Default: 30_000. */
@@ -173,13 +164,9 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   readonly boundaryId = "daemon-streaming" as const;
 
   private readonly apiKey: string;
-  private readonly model: string;
-  private readonly eotThreshold: number | undefined;
-  private readonly eagerEotThreshold: number | undefined;
-  private readonly eotTimeoutMs: number | undefined;
+  /** Turn-detection tuning, snapshotted when the transcriber is built. */
+  private readonly flux: LiveVoiceFluxConfig;
   private readonly sampleRate: number;
-  private readonly encoding: FluxEncoding;
-  private readonly baseUrl: string;
   private readonly connectTimeoutMs: number;
   private readonly inactivityTimeoutMs: number;
   private readonly keepaliveIntervalMs: number;
@@ -225,19 +212,9 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(apiKey: string, options: DeepgramFluxRealtimeOptions = {}) {
-    // Tuning comes from `liveVoice.flux` so the spike has one place to turn
-    // the dials; explicit options win for callers that already know better.
-    const flux = getConfig().liveVoice.flux;
-
     this.apiKey = apiKey;
-    this.model = options.model ?? flux.model;
-    this.eotThreshold = options.eotThreshold ?? flux.eotThreshold;
-    this.eagerEotThreshold =
-      options.eagerEotThreshold ?? flux.eagerEotThreshold;
-    this.eotTimeoutMs = options.eotTimeoutMs ?? flux.eotTimeoutMs;
+    this.flux = getConfig().liveVoice.flux;
     this.sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE;
-    this.encoding = options.encoding ?? DEFAULT_ENCODING;
-    this.baseUrl = (options.baseUrl ?? DEFAULT_WS_BASE_URL).replace(/\/+$/, "");
     this.connectTimeoutMs =
       options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
     this.inactivityTimeoutMs =
@@ -325,7 +302,7 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     this.resetInactivityTimer();
     this.startKeepaliveTimer();
 
-    log.info({ model: this.model }, "Deepgram Flux session opened");
+    log.info({ model: this.flux.model }, "Deepgram Flux session opened");
   }
 
   sendAudio(audio: Buffer, _mimeType: string): void {
@@ -427,8 +404,9 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
   /**
    * Normalize one inbound Flux frame into daemon events.
    *
-   * Everything except the `Configure*` acknowledgements goes straight to
-   * {@link parseFluxFrame}: the wire shapes live there, not here.
+   * Frames go straight to {@link parseFluxFrame}, which owns JSON decoding,
+   * the wire shapes, and the graceful handling of anything it does not
+   * recognize.
    */
   private handleProviderMessage(data: unknown): void {
     if (this.closed) {
@@ -448,63 +426,12 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
       return;
     }
 
-    const frame = parseJsonSafe(raw);
-    if (!isPlainObject(frame)) {
-      log.debug("Dropped a Deepgram Flux payload that is not a frame object");
-      return;
-    }
-
-    if (this.handleConfigureAck(frame)) {
-      return;
-    }
-
-    for (const event of parseFluxFrame(frame)) {
+    for (const event of parseFluxFrame(raw)) {
       if (event.type === "error") {
         this.fatalErrorReported = true;
       }
       this.emitEvent(event);
     }
-  }
-
-  /**
-   * Absorb the acknowledgements for a mid-stream `Configure`, returning true
-   * when the frame was one. This adapter is the layer that knows whether a
-   * `Configure` is in flight, so the two frames are handled here rather than
-   * in the pure parser.
-   *
-   * Neither becomes a stream event. `ConfigureSuccess` echoes the
-   * configuration actually in force, which is the cheapest confirmation that
-   * the thresholds we clamped are the ones Deepgram is using, worth a debug
-   * line and nothing more. `ConfigureFailure` leaves the stream running on the
-   * previous settings, so raising an `error` event would tear down a session
-   * that is still perfectly usable.
-   */
-  private handleConfigureAck(frame: Record<string, unknown>): boolean {
-    if (frame.type === "ConfigureSuccess") {
-      log.debug(
-        {
-          thresholds: frame.thresholds,
-          keyterms: frame.keyterms,
-          languageHints: frame.language_hints,
-        },
-        "Deepgram Flux accepted a Configure, thresholds now in force",
-      );
-      return true;
-    }
-
-    if (frame.type === "ConfigureFailure") {
-      log.warn(
-        {
-          code: frame.code,
-          description: frame.description,
-          sequenceId: frame.sequence_id,
-        },
-        "Deepgram Flux rejected a Configure, the session continues at its previous settings",
-      );
-      return true;
-    }
-
-    return false;
   }
 
   /** Handle provider-side WebSocket close. */
@@ -599,20 +526,18 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
     }
     this.chunkCadenceLogged = true;
 
-    // Only linear16 has a byte length that maps to a duration without
-    // decoding the payload.
     const observedChunkMs =
-      this.encoding === "linear16" && this.sampleRate > 0
+      this.sampleRate > 0
         ? Math.round(
             (byteLength / LINEAR16_BYTES_PER_SAMPLE / this.sampleRate) * 1_000,
           )
         : undefined;
 
-    log.debug(
+    log.info(
       {
         byteLength,
         sampleRate: this.sampleRate,
-        encoding: this.encoding,
+        encoding: AUDIO_ENCODING,
         observedChunkMs,
         recommendedChunkMs: RECOMMENDED_CHUNK_MS,
       },
@@ -751,14 +676,14 @@ export class DeepgramFluxRealtimeTranscriber implements StreamingTranscriber {
    */
   private buildWebSocketUrl(): string {
     const query = buildFluxQueryParams({
-      model: this.model,
-      encoding: this.encoding,
+      model: this.flux.model,
+      encoding: AUDIO_ENCODING,
       sampleRate: this.sampleRate,
-      eotThreshold: this.eotThreshold,
-      eagerEotThreshold: this.eagerEotThreshold,
-      eotTimeoutMs: this.eotTimeoutMs,
+      eotThreshold: this.flux.eotThreshold,
+      eagerEotThreshold: this.flux.eagerEotThreshold,
+      eotTimeoutMs: this.flux.eotTimeoutMs,
     });
-    return `${this.baseUrl}${FLUX_PATH}?${query}`;
+    return `${WS_BASE_URL}${FLUX_PATH}?${query}`;
   }
 }
 


### PR DESCRIPTION
## Summary

- Delete `handleConfigureAck`. Nothing in the repo sends a Flux `Configure`, so Deepgram never answers with `ConfigureSuccess` / `ConfigureFailure` and both branches were unreachable.
- Collapse `handleProviderMessage` to decode binary to string and hand the raw payload to `parseFluxFrame`, which already does JSON decoding and object validation via `coerceFrame`. This removes a duplicated parse and a log line that existed verbatim in both files. Unknown frames fall through the parser's default arm, covered by a test that asserts the session keeps transcribing afterwards.
- Promote the once-per-session chunk-cadence line from `log.debug` to `log.info`. The pino level is hardcoded to `info`, so the runbook's instruction to read this line did not work without a source edit. It fires once per session and carries no PII.
- Drop the adapter options nothing passes: `model`, `eotThreshold`, `eagerEotThreshold`, `eotTimeoutMs`, `encoding`, `baseUrl`. The constructor already reads the tuning from `liveVoice.flux`, which is now the single configuration surface; the four config mirrors collapse into one snapshot field. Hardcoding linear16 also removes a dead ternary arm in the cadence log. `connectTimeoutMs`, `inactivityTimeoutMs`, `keepaliveIntervalMs` and `sampleRate` stay: they are real test seams and production wiring.
- Drop unreferenced protocol types: the `FluxFrame` union, `FluxConnectedFrame`, `FluxWord` and the `words` field no parser function reads.
- Drop `languageHint` from `buildFluxQueryParams`. No config key plumbs into it and the spike pins the monolingual `flux-general-en`.

## Not done: `finalizeUtterance`

Adding a no-op `finalizeUtterance` would take Flux into the session's persistent shared-transcriber mode and remove a per-turn socket teardown from the measured interval, but it is not correct for this provider. `parseFluxFrame` emits `final` only on `EndOfTurn`, and Flux offers no mid-stream flush: `CloseStream` is the only way to make it answer for a turn still in progress. A no-op would report `finalized` without a flush and drop the tail of every turn released on a caller-side boundary. With `liveVoice.flux.turnEnd.enabled` defaulting to false that is every turn. The adapter doc and its test now record that reason instead of the weaker "callers should feature-detect" one.

Fixes gaps found during plan review for flux-turn-detection.md.