### PR TITLE
feat(skills): recent revisions on the skill detail page

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29182,6 +29182,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Maximum revisions to return, newest first. Defaults to 20 and is clamped to 100.
       responses:
         "200":
           description: Successful response

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29166,6 +29166,67 @@ paths:
                   - isBinary
                   - content
                 additionalProperties: false
+  /v1/skills/{id}/history:
+    get:
+      operationId: skills_by_id_history_get
+      summary: Get skill revision history
+      description:
+        "Return a skill's recent updates, newest first, each with a combined diff across the skill directory.
+        Read-only: revisions come from the workspace git repository, which already retains prior content. Commits whose
+        only in-skill change is the `lastUsedAt` usage stamp are omitted, so entries are edits rather than loads."
+      tags:
+        - skills
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skillId:
+                    type: string
+                    description: The skill these revisions belong to
+                  revisions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: Opaque revision identifier
+                        changedAt:
+                          type: string
+                          description: ISO-8601 time of the update
+                        files:
+                          type: array
+                          items:
+                            type: string
+                          description: Paths changed, relative to the skill directory
+                        diff:
+                          type: string
+                          description: Unified diff of this update, scoped to the skill
+                      required:
+                        - id
+                        - changedAt
+                        - files
+                        - diff
+                      additionalProperties: false
+                    description: Recent updates, newest first
+                  truncatedByCompaction:
+                    type: boolean
+                    description: Older history was squashed away, so the oldest entry is a floor rather than the skill's creation
+                required:
+                  - skillId
+                  - revisions
+                  - truncatedByCompaction
+                additionalProperties: false
   /v1/skills/{id}/inspect:
     get:
       operationId: skills_by_id_inspect_get

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -646,6 +646,16 @@ function findSkillById(
   return { item, summary: r.summary };
 }
 
+/**
+ * Whether a skill currently resolves locally (bundled, managed, workspace, or
+ * extra). Callers that serve data ABOUT a skill use this to keep to the same
+ * current-resource boundary as the file routes, so a deleted skill stops
+ * answering even when durable artifacts about it survive elsewhere.
+ */
+export function skillExistsLocally(skillId: string): boolean {
+  return findSkillById(skillId) !== undefined;
+}
+
 export async function getSkill(
   skillId: string,
 ): Promise<{ skill: SkillDetailResponse } | { error: string; status: number }> {

--- a/assistant/src/runtime/routes/__tests__/skill-history-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/skill-history-route.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the `getSkillHistory` route's current-resource boundary.
+ *
+ * The service layer reads retained git history, which outlives the skill it
+ * describes: a deleted skill's commits stay in the workspace repository
+ * forever. The route is therefore the only place that can decide whether an id
+ * still names something, and it must reach the same answer as the sibling file
+ * routes rather than serving history for a resource the rest of the API
+ * reports as gone.
+ *
+ * Both collaborators are mocked, because what is under test is the ordering
+ * between them: the existence check has to gate the history read, not run
+ * alongside it.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const skillExistsLocallyMock = mock((_id: string): boolean => true);
+const getSkillHistoryMock = mock(async (_id: string, _opts?: unknown) => ({
+  skillId: _id,
+  revisions: [{ id: "abc1234", changedAt: "", files: ["SKILL.md"], diff: "" }],
+  truncatedByCompaction: false,
+}));
+
+mock.module("../../../daemon/handlers/skills.js", () => ({
+  skillExistsLocally: skillExistsLocallyMock,
+  // The route module imports the whole handler surface; the rest is unused
+  // here and only needs to exist.
+  checkSkillUpdates: mock(),
+  configureSkill: mock(),
+  createSkill: mock(),
+  disableSkill: mock(),
+  draftSkill: mock(),
+  enableSkill: mock(),
+  getSkill: mock(),
+  getSkillFileContent: mock(),
+  getSkillFiles: mock(),
+  getSkillLocalDetail: mock(),
+  inspectSkill: mock(),
+  installSkill: mock(),
+  listSkills: mock(),
+  listSkillsFiltered: mock(),
+  searchSkills: mock(),
+  uninstallSkill: mock(),
+  updateSkill: mock(),
+}));
+
+mock.module("../../../skills/skill-history.js", () => ({
+  getSkillHistory: getSkillHistoryMock,
+}));
+
+const { ROUTES } = await import("../skills-routes.js");
+
+const handler = ROUTES.find(
+  (r) => r.operationId === "getSkillHistory",
+)!.handler;
+
+beforeEach(() => {
+  skillExistsLocallyMock.mockClear();
+  getSkillHistoryMock.mockClear();
+  skillExistsLocallyMock.mockImplementation(() => true);
+});
+
+describe("getSkillHistory route", () => {
+  test("returns history for a skill that currently exists", async () => {
+    const result = (await handler({
+      pathParams: { id: "release-triage" },
+    })) as {
+      revisions: unknown[];
+    };
+
+    expect(result.revisions).toHaveLength(1);
+    expect(getSkillHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("404s for a deleted skill whose commits are still in the repository", async () => {
+    // The skill is gone from the resolver, but git would still answer.
+    skillExistsLocallyMock.mockImplementation(() => false);
+
+    await expect(
+      handler({ pathParams: { id: "release-triage" } }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("does not read history at all when the skill is gone", async () => {
+    skillExistsLocallyMock.mockImplementation(() => false);
+
+    await Promise.resolve(
+      handler({ pathParams: { id: "release-triage" } }),
+    ).catch(() => {});
+
+    // Ordering is the point: a check that ran after the read would still
+    // reject, but would have spent the git traversal to do it.
+    expect(getSkillHistoryMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed id as the caller's error, not a server fault", async () => {
+    getSkillHistoryMock.mockImplementation(() => {
+      throw new Error("Invalid skill id: contains a path separator");
+    });
+
+    await expect(handler({ pathParams: { id: "bad" } })).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  test("surfaces an unexpected service failure as a server error", async () => {
+    getSkillHistoryMock.mockImplementation(() => {
+      throw new Error("git exploded");
+    });
+
+    await expect(handler({ pathParams: { id: "ok" } })).rejects.toMatchObject({
+      statusCode: 500,
+    });
+  });
+});

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -364,6 +364,15 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Return a skill's recent updates, newest first, each with a combined diff across the skill directory. Read-only: revisions come from the workspace git repository, which already retains prior content. Commits whose only in-skill change is the `lastUsedAt` usage stamp are omitted, so entries are edits rather than loads.",
     tags: ["skills"],
+    queryParams: [
+      {
+        name: "limit",
+        schema: { type: "integer" },
+        required: false,
+        description:
+          "Maximum revisions to return, newest first. Defaults to 20 and is clamped to 100.",
+      },
+    ],
     responseBody: z.object({
       skillId: z.string().describe("The skill these revisions belong to"),
       revisions: z
@@ -393,15 +402,22 @@ export const ROUTES: RouteDefinition[] = [
           ? Number.parseInt(rawLimit, 10)
           : undefined;
       try {
+        // An id with no recorded revisions resolves to an empty list rather
+        // than a 404. Revisions are a workspace-git concept, and a bundled or
+        // catalog skill legitimately has none, so "nothing recorded" is the
+        // honest answer for every id the workspace has never tracked.
         return await getSkillHistory(pathParams!.id, {
           ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
         });
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         // The id reaches a git pathspec, so a malformed one is the caller's
-        // error rather than a server fault.
-        throw new BadRequestError(
-          err instanceof Error ? err.message : "Invalid skill id",
-        );
+        // error. Anything else escaping the service is a server fault: the
+        // read is otherwise fail-soft and returns an empty history.
+        if (message.startsWith("Invalid skill id")) {
+          throw new BadRequestError(message);
+        }
+        throw new InternalError(message);
       }
     },
   },

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -23,6 +23,7 @@ import {
   listSkills,
   listSkillsFiltered,
   searchSkills,
+  skillExistsLocally,
   uninstallSkill,
   updateSkill,
 } from "../../daemon/handlers/skills.js";
@@ -402,14 +403,22 @@ export const ROUTES: RouteDefinition[] = [
           ? Number.parseInt(rawLimit, 10)
           : undefined;
       try {
-        // An id with no recorded revisions resolves to an empty list rather
-        // than a 404. Revisions are a workspace-git concept, and a bundled or
-        // catalog skill legitimately has none, so "nothing recorded" is the
-        // honest answer for every id the workspace has never tracked.
+        // Same current-resource boundary as the file routes. Git retains a
+        // deleted skill's commits, so without this a removed skill keeps
+        // answering with history for something the rest of the API reports as
+        // gone. An existing skill with nothing recorded still gets an empty
+        // list, which is the honest answer for a bundled skill or one the
+        // workspace has not committed yet.
+        if (!skillExistsLocally(pathParams!.id)) {
+          throw new NotFoundError(`Skill "${pathParams!.id}" not found`);
+        }
         return await getSkillHistory(pathParams!.id, {
           ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
         });
       } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw err;
+        }
         const message = err instanceof Error ? err.message : String(err);
         // The id reaches a git pathspec, so a malformed one is the caller's
         // error. Anything else escaping the service is a server fault: the

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -27,6 +27,7 @@ import {
   updateSkill,
 } from "../../daemon/handlers/skills.js";
 import { getCategories } from "../../skills/categories-cache.js";
+import { getSkillHistory } from "../../skills/skill-history.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -349,6 +350,59 @@ export const ROUTES: RouteDefinition[] = [
         throw new InternalError(result.error);
       }
       return result;
+    },
+  },
+  {
+    operationId: "getSkillHistory",
+    endpoint: "skills/:id/history",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get skill revision history",
+    description:
+      "Return a skill's recent updates, newest first, each with a combined diff across the skill directory. Read-only: revisions come from the workspace git repository, which already retains prior content. Commits whose only in-skill change is the `lastUsedAt` usage stamp are omitted, so entries are edits rather than loads.",
+    tags: ["skills"],
+    responseBody: z.object({
+      skillId: z.string().describe("The skill these revisions belong to"),
+      revisions: z
+        .array(
+          z.object({
+            id: z.string().describe("Opaque revision identifier"),
+            changedAt: z.string().describe("ISO-8601 time of the update"),
+            files: z
+              .array(z.string())
+              .describe("Paths changed, relative to the skill directory"),
+            diff: z
+              .string()
+              .describe("Unified diff of this update, scoped to the skill"),
+          }),
+        )
+        .describe("Recent updates, newest first"),
+      truncatedByCompaction: z
+        .boolean()
+        .describe(
+          "Older history was squashed away, so the oldest entry is a floor rather than the skill's creation",
+        ),
+    }),
+    handler: async ({ pathParams, queryParams }: RouteHandlerArgs) => {
+      const rawLimit = queryParams?.limit;
+      const limit =
+        typeof rawLimit === "string" && rawLimit.trim().length > 0
+          ? Number.parseInt(rawLimit, 10)
+          : undefined;
+      try {
+        return await getSkillHistory(pathParams!.id, {
+          ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
+        });
+      } catch (err) {
+        // The id reaches a git pathspec, so a malformed one is the caller's
+        // error rather than a server fault.
+        throw new BadRequestError(
+          err instanceof Error ? err.message : "Invalid skill id",
+        );
+      }
     },
   },
   {

--- a/assistant/src/skills/skill-history.test.ts
+++ b/assistant/src/skills/skill-history.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for `skill-history.ts`, run against a REAL git repository rather than
+ * a mocked git.
+ *
+ * The behavior worth protecting is entirely about how git actually responds to
+ * a pathspec: that a commit touching 100 unrelated files still yields a diff
+ * scoped to one skill, that `:(exclude)` really drops the usage stamp, and
+ * that a commit whose only in-skill change was excluded disappears from the
+ * list. A stubbed git would let all three regress while the tests stayed
+ * green, so each test builds commits in a temp repo and reads them back.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let repoDir = "";
+
+// The module resolves the workspace through `getWorkspaceDir()`; point it at
+// the temp repository. `getWorkspaceGitService` is left real so the git
+// invocations under test are the ones that ship.
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => repoDir,
+}));
+
+import { getSkillHistory } from "./skill-history.js";
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repoDir,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+  });
+}
+
+/** Write a file under the repo, creating parents. */
+function write(relPath: string, content: string): void {
+  const full = join(repoDir, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+}
+
+function commit(message: string): void {
+  git("add", "-A");
+  git("commit", "--no-verify", "-m", message);
+}
+
+beforeEach(() => {
+  repoDir = mkdtempSync(join(tmpdir(), "skill-history-"));
+  git("init", "-b", "main");
+});
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true });
+  repoDir = "";
+});
+
+describe("getSkillHistory", () => {
+  test("returns one entry per update, with the diff scoped to that skill", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n\nStep one.\n");
+    write("skills/beta/SKILL.md", "# Beta\n\nUnrelated.\n");
+    commit("initial");
+
+    // A batched commit, the way the workspace heartbeat writes them: this
+    // skill, an unrelated skill, and a conversation file all at once.
+    write("skills/alpha/SKILL.md", "# Alpha\n\nStep one, corrected.\n");
+    write("skills/beta/SKILL.md", "# Beta\n\nAlso changed.\n");
+    write("conversations/whatever.jsonl", "{}\n");
+    commit("auto-commit: heartbeat safety net (3 files)");
+
+    const history = await getSkillHistory("alpha");
+
+    expect(history.skillId).toBe("alpha");
+    expect(history.revisions).toHaveLength(2);
+    // Newest first.
+    const [latest] = history.revisions;
+    expect(latest!.files).toEqual(["SKILL.md"]);
+    expect(latest!.diff).toContain("Step one, corrected.");
+    // The other skill and the conversation file are absent even though the
+    // same commit changed them.
+    expect(latest!.diff).not.toContain("Also changed.");
+    expect(latest!.diff).not.toContain("conversations/");
+  });
+
+  test("combines SKILL.md and companion changes from one update into a single entry", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    commit("initial");
+
+    write("skills/alpha/SKILL.md", "# Alpha\n\nRun the script.\n");
+    write("skills/alpha/scripts/export.py", "print('v1')\n");
+    write("skills/alpha/references/gotchas.md", "Watch the rate limit.\n");
+    commit("auto-commit: heartbeat safety net (3 files)");
+
+    const history = await getSkillHistory("alpha");
+
+    // One update, not three per-file entries.
+    const [latest] = history.revisions;
+    expect(latest!.files.sort()).toEqual([
+      "SKILL.md",
+      "references/gotchas.md",
+      "scripts/export.py",
+    ]);
+    expect(latest!.diff).toContain("Run the script.");
+    expect(latest!.diff).toContain("print('v1')");
+    expect(latest!.diff).toContain("Watch the rate limit.");
+  });
+
+  test("a load-only commit does not appear as an update", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    write(
+      "skills/alpha/install-meta.json",
+      JSON.stringify({ origin: "custom", lastUsedAt: "2026-08-04" }),
+    );
+    commit("initial");
+
+    // The skill was loaded, so only the usage stamp moved. Roughly half of a
+    // real skill's commits look like this.
+    write(
+      "skills/alpha/install-meta.json",
+      JSON.stringify({ origin: "custom", lastUsedAt: "2026-08-05" }),
+    );
+    commit("auto-commit: heartbeat safety net (1 file)");
+
+    const history = await getSkillHistory("alpha");
+
+    // Only the creating commit counts; the stamp bump is not an update.
+    expect(history.revisions).toHaveLength(1);
+    expect(history.revisions[0]!.files).toEqual(["SKILL.md"]);
+  });
+
+  test("a real edit alongside a stamp bump keeps the edit and drops the stamp", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    write(
+      "skills/alpha/install-meta.json",
+      JSON.stringify({ lastUsedAt: "1" }),
+    );
+    commit("initial");
+
+    write("skills/alpha/SKILL.md", "# Alpha\n\nRefined.\n");
+    write(
+      "skills/alpha/install-meta.json",
+      JSON.stringify({ lastUsedAt: "2" }),
+    );
+    commit("auto-commit: heartbeat safety net (2 files)");
+
+    const history = await getSkillHistory("alpha");
+
+    const [latest] = history.revisions;
+    expect(latest!.files).toEqual(["SKILL.md"]);
+    expect(latest!.diff).toContain("Refined.");
+    expect(latest!.diff).not.toContain("lastUsedAt");
+  });
+
+  test("respects the limit after filtering, not before", async () => {
+    write("skills/alpha/SKILL.md", "v0\n");
+    commit("initial");
+    // Interleave real edits with load-only commits, so a naive
+    // `--max-count=limit` would return mostly stamps.
+    for (let i = 1; i <= 4; i++) {
+      write(
+        "skills/alpha/install-meta.json",
+        JSON.stringify({ lastUsedAt: `stamp-${i}` }),
+      );
+      commit(`stamp ${i}`);
+      write("skills/alpha/SKILL.md", `v${i}\n`);
+      commit(`edit ${i}`);
+    }
+
+    const history = await getSkillHistory("alpha", { limit: 3 });
+
+    expect(history.revisions).toHaveLength(3);
+    // Every returned entry is a real edit.
+    for (const revision of history.revisions) {
+      expect(revision.files).toEqual(["SKILL.md"]);
+    }
+  });
+
+  test("reports when older history was squashed away", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    commit("Compacted workspace history (14667 commits squashed)");
+    write("skills/alpha/SKILL.md", "# Alpha\n\nMore.\n");
+    commit("auto-commit: heartbeat safety net (1 file)");
+
+    const history = await getSkillHistory("alpha");
+
+    // The caller needs this to avoid presenting the oldest entry as creation.
+    expect(history.truncatedByCompaction).toBe(true);
+  });
+
+  test("an untracked skill has empty history rather than an error", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    commit("initial");
+
+    const history = await getSkillHistory("never-committed");
+
+    expect(history.revisions).toEqual([]);
+    expect(history.skillId).toBe("never-committed");
+  });
+
+  test("a traversal-shaped id is rejected before it reaches a pathspec", async () => {
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    commit("initial");
+
+    await expect(getSkillHistory("../../etc")).rejects.toThrow(
+      /Invalid skill id/,
+    );
+  });
+
+  test("a workspace that is not a repository yields empty history, not a throw", async () => {
+    const bare = mkdtempSync(join(tmpdir(), "skill-history-norepo-"));
+    const previous = repoDir;
+    repoDir = bare;
+    try {
+      const history = await getSkillHistory("alpha");
+      expect(history.revisions).toEqual([]);
+    } finally {
+      repoDir = previous;
+      rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});

--- a/assistant/src/skills/skill-history.test.ts
+++ b/assistant/src/skills/skill-history.test.ts
@@ -11,7 +11,14 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -214,13 +221,20 @@ describe("getSkillHistory", () => {
     );
   });
 
-  test("a workspace that is not a repository yields empty history, not a throw", async () => {
+  test("a workspace that is not a repository yields empty history, and stays not a repository", async () => {
     const bare = mkdtempSync(join(tmpdir(), "skill-history-norepo-"));
     const previous = repoDir;
     repoDir = bare;
     try {
       const history = await getSkillHistory("alpha");
+
       expect(history.revisions).toEqual([]);
+      // The empty result is not enough on its own: reading through
+      // `runReadOnlyGit` would ALSO return empty here, having quietly created
+      // the repository first. This route is a GET, so the absence of the
+      // write is the actual invariant.
+      expect(existsSync(join(bare, ".git"))).toBe(false);
+      expect(readdirSync(bare)).toEqual([]);
     } finally {
       repoDir = previous;
       rmSync(bare, { recursive: true, force: true });

--- a/assistant/src/skills/skill-history.ts
+++ b/assistant/src/skills/skill-history.ts
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------
+// Skill revision history, read from the workspace git repository.
+// ---------------------------------------------------------------------------
+//
+// The workspace is a git repo with an auto-committing heartbeat, and `skills/`
+// is tracked, so every managed-skill write already has its prior content
+// retained. This module reads that history rather than storing a second copy:
+// `createManagedSkill` writes through an atomic rename and keeps no version of
+// its own, but the commit underneath it does.
+//
+// A revision here is ONE UPDATE TO THE WHOLE SKILL, not a per-file log. A
+// single commit is diffed against the skill's directory, so `SKILL.md`,
+// `scripts/`, and `references/` changes made together appear as one entry with
+// one combined diff, which is what "what changed the last time this skill was
+// updated" means. The commit itself usually touches many unrelated files (the
+// heartbeat batches by count and age), so the pathspec is what makes the diff
+// legible.
+//
+// Two properties of that history shape the output, and both are load-bearing:
+//
+//   - `install-meta.json` is EXCLUDED. It carries a `lastUsedAt` stamp
+//     refreshed every time a skill is loaded, so roughly half of a skill's
+//     commits touch nothing else. Including it would report a skill as
+//     "updated" on days nobody edited it, which is worse than showing no
+//     history at all. Revisions left empty by the exclusion are dropped.
+//   - History is BOUNDED. The workspace periodically squashes
+//     ("Compacted workspace history"), so the oldest revision available is not
+//     necessarily the skill's creation. Callers should present the list as
+//     "recent changes", never as a complete record.
+//
+// Commit subjects are deliberately not surfaced: they read
+// `auto-commit: heartbeat safety net (164 files, changes older than 900s)`,
+// which describes the batch rather than the skill and would actively mislead.
+
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceGitService } from "../workspace/git-service.js";
+import { validateManagedSkillId } from "./managed-store.js";
+
+const log = getLogger("skill-history");
+
+/** How many revisions to return when the caller does not specify. */
+export const DEFAULT_SKILL_HISTORY_LIMIT = 20;
+
+/** Hard ceiling, so one request cannot walk an entire repository. */
+export const MAX_SKILL_HISTORY_LIMIT = 100;
+
+/** One update to a skill: a commit, diffed to that skill's directory. */
+export interface SkillRevision {
+  /** Abbreviated commit hash. Opaque to callers; useful for support. */
+  id: string;
+  /** ISO-8601 commit timestamp. */
+  changedAt: string;
+  /** Paths changed inside the skill, relative to the skill directory. */
+  files: string[];
+  /** Unified diff of this commit, restricted to the skill's directory. */
+  diff: string;
+}
+
+export interface SkillHistory {
+  skillId: string;
+  revisions: SkillRevision[];
+  /**
+   * Whether history may be incomplete because the workspace squashed older
+   * commits. When true the oldest revision listed is a floor, not the
+   * skill's creation.
+   */
+  truncatedByCompaction: boolean;
+}
+
+/**
+ * Field separator for the `git log` format: an ASCII unit separator, written
+ * as an escape so the source stays copy-paste safe. It cannot occur in a
+ * commit hash or an ISO timestamp.
+ */
+const FIELD = "\u001f";
+
+/**
+ * Read a skill's recent revisions from workspace git.
+ *
+ * Returns an empty history rather than throwing when git is unavailable, the
+ * workspace is not a repository, or the skill has no tracked changes: history
+ * is a read-only enrichment and must never be the reason a caller fails.
+ * An invalid skill id DOES throw, because it means the caller passed
+ * unvalidated input into a pathspec.
+ */
+export async function getSkillHistory(
+  skillId: string,
+  options: { limit?: number } = {},
+): Promise<SkillHistory> {
+  const invalid = validateManagedSkillId(skillId);
+  if (invalid) {
+    throw new Error(`Invalid skill id: ${invalid}`);
+  }
+  const limit = Math.min(
+    Math.max(1, options.limit ?? DEFAULT_SKILL_HISTORY_LIMIT),
+    MAX_SKILL_HISTORY_LIMIT,
+  );
+
+  const empty: SkillHistory = {
+    skillId,
+    revisions: [],
+    truncatedByCompaction: false,
+  };
+
+  let git: ReturnType<typeof getWorkspaceGitService>;
+  try {
+    git = getWorkspaceGitService(getWorkspaceDir());
+  } catch (err) {
+    log.warn({ err, skillId }, "workspace git unavailable; no skill history");
+    return empty;
+  }
+
+  const skillPath = `skills/${skillId}/`;
+  // Exclude the usage stamp so a skill that was merely LOADED does not read as
+  // edited. `:(exclude)` is git pathspec magic, applied to both the log and
+  // the per-commit diff so the two can never disagree about what counts.
+  const pathspec = [skillPath, `:(exclude)${skillPath}install-meta.json`];
+
+  let shas: Array<{ sha: string; changedAt: string }>;
+  try {
+    const { stdout } = await git.runReadOnlyGit([
+      "log",
+      `--format=%h${FIELD}%aI`,
+      // Ask for more than `limit`: commits whose only in-skill change is
+      // excluded by the pathspec still appear here, so the list is filtered
+      // down afterwards and would otherwise come up short.
+      `--max-count=${limit * 4}`,
+      "--",
+      ...pathspec,
+    ]);
+    shas = stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const [sha, changedAt] = line.split(FIELD);
+        return { sha: sha ?? "", changedAt: changedAt ?? "" };
+      })
+      .filter((entry) => entry.sha.length > 0);
+  } catch (err) {
+    log.warn({ err, skillId }, "git log failed; no skill history");
+    return empty;
+  }
+
+  const revisions: SkillRevision[] = [];
+  for (const { sha, changedAt } of shas) {
+    if (revisions.length >= limit) {
+      break;
+    }
+    let diff: string;
+    let files: string[];
+    try {
+      const [diffResult, nameResult] = await Promise.all([
+        git.runReadOnlyGit(["show", "--format=", sha, "--", ...pathspec]),
+        git.runReadOnlyGit([
+          "show",
+          "--format=",
+          "--name-only",
+          sha,
+          "--",
+          ...pathspec,
+        ]),
+      ]);
+      diff = diffResult.stdout.trim();
+      files = nameResult.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith(skillPath))
+        .map((line) => line.slice(skillPath.length))
+        .filter((line) => line.length > 0);
+    } catch (err) {
+      log.warn({ err, skillId, sha }, "git show failed; skipping revision");
+      continue;
+    }
+    // Nothing left once the usage stamp is excluded: the skill was loaded,
+    // not changed.
+    if (diff.length === 0 || files.length === 0) {
+      continue;
+    }
+    revisions.push({ id: sha, changedAt, files, diff });
+  }
+
+  return {
+    skillId,
+    revisions,
+    truncatedByCompaction: await hasCompactedHistory(git),
+  };
+}
+
+/**
+ * Whether the workspace has squashed older commits, which caps how far back
+ * any skill's history can reach. Best-effort: an error here only means the
+ * caller loses the caveat, never the history.
+ */
+async function hasCompactedHistory(
+  git: ReturnType<typeof getWorkspaceGitService>,
+): Promise<boolean> {
+  try {
+    const { stdout } = await git.runReadOnlyGit([
+      "log",
+      "--format=%s",
+      "--max-count=1",
+      "--grep=Compacted workspace history",
+    ]);
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/assistant/src/skills/skill-history.ts
+++ b/assistant/src/skills/skill-history.ts
@@ -129,7 +129,10 @@ export async function getSkillHistory(
   try {
     const { stdout } = await git.runReadOnlyGitWithoutInit([
       "log",
-      `--format=%h${FIELD}%aI`,
+      // Committer date, not author date. `git log` orders by commit date, so
+      // reporting the author date could label the list newest-first while its
+      // displayed dates disagree with that order.
+      `--format=%h${FIELD}%cI`,
       // Ask for more than `limit`: commits whose only in-skill change is
       // excluded by the pathspec still appear here, so the list is filtered
       // down afterwards and would otherwise come up short.

--- a/assistant/src/skills/skill-history.ts
+++ b/assistant/src/skills/skill-history.ts
@@ -31,6 +31,14 @@
 // Commit subjects are deliberately not surfaced: they read
 // `auto-commit: heartbeat safety net (164 files, changes older than 900s)`,
 // which describes the batch rather than the skill and would actively mislead.
+//
+// Every git call goes through `runReadOnlyGitWithoutInit`, NOT
+// `runReadOnlyGit`. The latter awaits `ensureInitialized()`, which creates the
+// repository, writes `.gitignore` and the hooks directory, makes an initial
+// commit, and schedules a history compaction when the workspace is not yet a
+// repo. This module is reached from an HTTP GET, which `src/runtime/AGENTS.md`
+// requires to be side-effect-free, so observing history must never be the
+// thing that brings a repository into existence.
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -119,7 +127,7 @@ export async function getSkillHistory(
 
   let shas: Array<{ sha: string; changedAt: string }>;
   try {
-    const { stdout } = await git.runReadOnlyGit([
+    const { stdout } = await git.runReadOnlyGitWithoutInit([
       "log",
       `--format=%h${FIELD}%aI`,
       // Ask for more than `limit`: commits whose only in-skill change is
@@ -152,8 +160,14 @@ export async function getSkillHistory(
     let files: string[];
     try {
       const [diffResult, nameResult] = await Promise.all([
-        git.runReadOnlyGit(["show", "--format=", sha, "--", ...pathspec]),
-        git.runReadOnlyGit([
+        git.runReadOnlyGitWithoutInit([
+          "show",
+          "--format=",
+          sha,
+          "--",
+          ...pathspec,
+        ]),
+        git.runReadOnlyGitWithoutInit([
           "show",
           "--format=",
           "--name-only",
@@ -197,7 +211,7 @@ async function hasCompactedHistory(
   git: ReturnType<typeof getWorkspaceGitService>,
 ): Promise<boolean> {
   try {
-    const { stdout } = await git.runReadOnlyGit([
+    const { stdout } = await git.runReadOnlyGitWithoutInit([
       "log",
       "--format=%s",
       "--max-count=1",

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1993,6 +1993,29 @@ export class WorkspaceGitService {
   }
 
   /**
+   * Run a read-only git command WITHOUT initializing the repository.
+   *
+   * `runReadOnlyGit` is read-only in the sense that its git command does not
+   * write, but it still awaits `ensureInitialized()`, which will create the
+   * repository, write `.gitignore` and the hooks directory, make the initial
+   * commit, and schedule a history compaction when the workspace is not yet a
+   * repo. That makes it unusable from an HTTP GET, which
+   * `src/runtime/AGENTS.md` requires to be side-effect-free.
+   *
+   * This variant skips initialization entirely and throws when the workspace
+   * is not a repository, so a caller that merely wants to *observe* history
+   * can degrade instead of bringing a repo into existence.
+   */
+  async runReadOnlyGitWithoutInit(
+    args: string[],
+  ): Promise<{ stdout: string; stderr: string }> {
+    if (!existsSync(join(this.workspaceDir, ".git"))) {
+      throw new Error("Workspace is not a git repository");
+    }
+    return this.execGit(args);
+  }
+
+  /**
    * Run a sequence of git commands atomically under the workspace mutex.
    * Use this for write operations that need serialization with other
    * git mutations (e.g. checkout + commit).

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
@@ -1,0 +1,227 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { SkillInfo } from "@/domains/intelligence/skills/types";
+import {
+  skillsByIdFilesContentGetQueryKey,
+  skillsByIdFilesGetQueryKey,
+  skillsByIdHistoryGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+
+import { SkillDetail } from "./skill-detail";
+
+/**
+ * The whole skill detail page as it renders at
+ * `/assistant/skills/:skillId`, the surface you land on from My
+ * Superpowers. Shows the History tab in place next to Files, with the real
+ * header, origin badge, and lineage link around it.
+ *
+ * Both the files and history queries are seeded into a story-local cache, so
+ * the stories exercise the shipped components with no network and no mocks.
+ */
+
+const ASSISTANT_ID = "asst_story";
+const SKILL_ID = "release-triage";
+
+const SKILL: SkillInfo = {
+  id: SKILL_ID,
+  name: "Release triage",
+  description:
+    "Check the release label, group failures by owning team, and post the summary in the release thread.",
+  emoji: "🚦",
+  kind: "installed",
+  status: "enabled",
+  origin: "assistant-memory",
+  category: "Engineering",
+};
+
+const SKILL_MD = `---
+name: Release triage
+description: Triage a release's failing checks.
+---
+
+# Release triage
+
+Read the release label first.
+Skip drafts unless the label is explicit.
+
+## Grouping
+
+Group the failures by owning team, not by file: one file often spans
+three teams. See references/owners.md.
+`;
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+const REVISIONS = [
+  {
+    id: "9c1f2ab",
+    changedAt: daysAgo(2),
+    files: ["SKILL.md", "references/owners.md"],
+    diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/skills/release-triage/SKILL.md
++++ b/skills/release-triage/SKILL.md
+@@ -18,3 +18,4 @@
+ ## Grouping
+-Group the failures by file.
++Group the failures by owning team, not by file: one file often spans
++three teams. See references/owners.md.
+diff --git a/skills/release-triage/references/owners.md b/skills/release-triage/references/owners.md
+new file mode 100644
+index 0000000..9999999
+--- /dev/null
++++ b/skills/release-triage/references/owners.md
+@@ -0,0 +1,2 @@
++Platform owns the gateway.
++Assistant owns the daemon.
+`,
+  },
+  {
+    id: "4de88b1",
+    changedAt: daysAgo(9),
+    files: ["SKILL.md"],
+    diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+index aaa1111..bbb2222 100644
+--- a/skills/release-triage/SKILL.md
++++ b/skills/release-triage/SKILL.md
+@@ -6,2 +6,3 @@
+ Read the release label first.
++Skip drafts unless the label is explicit.
+`,
+  },
+];
+
+const FILES = [
+  {
+    name: "SKILL.md",
+    path: "SKILL.md",
+    size: SKILL_MD.length,
+    mimeType: "text/markdown",
+    isBinary: false,
+  },
+  {
+    name: "references",
+    path: "references",
+    size: 0,
+    mimeType: "inode/directory",
+    isBinary: false,
+  },
+  {
+    name: "triage.py",
+    path: "scripts/triage.py",
+    size: 210,
+    mimeType: "text/x-python",
+    isBinary: false,
+  },
+];
+
+/**
+ * Build a cache seeded for one story. `historySupported: false` leaves the
+ * history query resolved to `null`, which is what an assistant without the
+ * route produces and what hides the tab strip.
+ */
+function seededClient(options: {
+  historySupported: boolean;
+  revisions?: typeof REVISIONS;
+  truncatedByCompaction?: boolean;
+}): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const path = { assistant_id: ASSISTANT_ID, id: SKILL_ID };
+
+  client.setQueryData(skillsByIdFilesGetQueryKey({ path }), {
+    skill: SKILL,
+    files: FILES,
+  });
+  client.setQueryData(
+    skillsByIdFilesContentGetQueryKey({ path, query: { path: "SKILL.md" } }),
+    {
+      path: "SKILL.md",
+      name: "SKILL.md",
+      size: SKILL_MD.length,
+      mimeType: "text/markdown",
+      isBinary: false,
+      content: SKILL_MD,
+    },
+  );
+  client.setQueryData(
+    skillsByIdHistoryGetQueryKey({ path }),
+    options.historySupported
+      ? {
+          skillId: SKILL_ID,
+          revisions: options.revisions ?? REVISIONS,
+          truncatedByCompaction: options.truncatedByCompaction ?? false,
+        }
+      : null,
+  );
+  return client;
+}
+
+const meta: Meta<typeof SkillDetail> = {
+  title: "Intelligence/Skills/SkillDetail",
+  component: SkillDetail,
+  parameters: { layout: "fullscreen" },
+  args: {
+    assistantId: ASSISTANT_ID,
+    skill: SKILL,
+    sourceConversationId: "conv_story",
+    onBack: () => {},
+    onRemove: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SkillDetail>;
+
+/**
+ * Decorator giving the page its usual viewport height. The router comes from
+ * Storybook's own preview wrapper, so this must not add another one.
+ */
+function withShell(client: QueryClient) {
+  return function Decorator(Story: () => React.ReactElement) {
+    return (
+      <QueryClientProvider client={client}>
+        <div className="h-screen p-6">
+          <Story />
+        </div>
+      </QueryClientProvider>
+    );
+  };
+}
+
+/**
+ * Landing on the page: Files is selected and History sits beside it. Click
+ * History to see the revision list inside the page's own card. Every story
+ * below opens on Files the same way, since the tab is uncontrolled.
+ */
+export const Default: Story = {
+  decorators: [withShell(seededClient({ historySupported: true }))],
+};
+
+/** Workspace history was squashed, so the list carries its caveat. */
+export const HistoryTruncated: Story = {
+  decorators: [
+    withShell(
+      seededClient({ historySupported: true, truncatedByCompaction: true }),
+    ),
+  ],
+};
+
+/** A skill that exists but has never been edited. */
+export const HistoryEmpty: Story = {
+  decorators: [
+    withShell(seededClient({ historySupported: true, revisions: [] })),
+  ],
+};
+
+/**
+ * An assistant that predates the history route. No tab strip renders at all,
+ * so the page looks exactly as it did before this feature.
+ */
+export const HistoryUnsupported: Story = {
+  decorators: [withShell(seededClient({ historySupported: false }))],
+};

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -85,7 +85,6 @@ export function SkillDetail({
   // Falling back to Files when history turns out to be unsupported keeps the
   // page coherent if the query answers after a tab was already chosen.
   const activeTab = isHistoryUnsupported ? "files" : selectedTab;
-  const setActiveTab = setSelectedTab;
 
   const header = (
     <div className="mb-4 flex items-start gap-3">
@@ -259,19 +258,15 @@ export function SkillDetail({
     <div className="flex h-[calc(100vh-14rem)] flex-col">
       {header}
       {/*
-        The files panel stays mounted across tab switches and across the
-        history query resolving. Radix unmounts an inactive panel by default,
-        and `SkillFileContent` holds the in-progress edit in local state, so a
-        remount would silently discard unsaved text. `forceMount` keeps it
-        alive and an inline `display` drives visibility, which beats fighting
-        class precedence between `hidden` and `flex`. The files panel is also
-        never moved between branches: only the tab strip and the history panel
-        appear once the query answers, so `isHistoryUnsupported` flipping
-        cannot remount the editor either.
+        `SkillFileContent` holds the in-progress edit in local state, and Radix
+        unmounts an inactive panel, so the files panel is force-mounted and
+        only the tab strip and history panel are conditional. Visibility rides
+        an inline `display` to avoid a precedence fight between `hidden` and
+        `flex`.
       */}
       <Tabs.Root
         value={activeTab}
-        onValueChange={setActiveTab}
+        onValueChange={setSelectedTab}
         className="flex min-h-0 flex-1 flex-col"
       >
         {!isHistoryUnsupported && (

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -20,16 +20,18 @@ import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
 import { SkillLineageLink } from "@/components/skill-lineage-link";
 import { SkillIcon } from "@/domains/intelligence/components/skills/skill-icon";
 import { SkillOriginBadge } from "@/domains/intelligence/components/skills/skill-origin-badge";
+import { SkillRevisionHistory } from "@/domains/intelligence/components/skills/skill-revision-history";
 import {
   isAvailableSkill,
   type SkillInfo,
 } from "@/domains/intelligence/skills/types";
 import { useWorkspaceWritePostMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useSkillDetailFiles } from "@/hooks/use-skill-detail-files";
+import { useSkillHistory } from "@/hooks/use-skill-history";
 import { captureError } from "@/lib/sentry/capture-error";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { invalidateSkillsList, isRemovableSkill } from "@/utils/skills";
-import { Button, Card } from "@vellumai/design-library";
+import { Button, Card, Tabs } from "@vellumai/design-library";
 
 interface SkillDetailProps {
   assistantId: string;
@@ -70,173 +72,212 @@ export function SkillDetail({
     isContentLoading,
   } = useSkillDetailFiles(assistantId, skill.id);
 
-  return (
-    <div className="flex h-[calc(100vh-14rem)] flex-col">
-      <div className="mb-4 flex items-start gap-3">
-        <Button
-          type="button"
-          variant="ghost"
-          iconOnly={<ArrowLeft aria-hidden />}
-          aria-label="Back to skills"
-          onClick={onBack}
-        />
-        <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            <SkillIcon skill={skill} className="h-8 w-8 text-3xl" />
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <h2
-                  className="text-title-medium"
-                  style={{ color: "var(--content-default)" }}
-                >
-                  {skill.name}
-                </h2>
-                <SkillOriginBadge origin={skill.origin} />
-              </div>
-              <p
-                className="mt-0.5 line-clamp-2 text-body-medium-lighter"
-                style={{ color: "var(--content-secondary)" }}
+  // An assistant without the history route reports `isUnsupported`, which
+  // hides the tab strip entirely so the page renders exactly as it did before
+  // revisions existed. Shares a query key with the panel, so this is one
+  // request, not two.
+  const { isUnsupported: isHistoryUnsupported } = useSkillHistory(
+    assistantId,
+    skill.id,
+  );
+
+  const header = (
+    <div className="mb-4 flex items-start gap-3">
+      <Button
+        type="button"
+        variant="ghost"
+        iconOnly={<ArrowLeft aria-hidden />}
+        aria-label="Back to skills"
+        onClick={onBack}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <SkillIcon skill={skill} className="h-8 w-8 text-3xl" />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <h2
+                className="text-title-medium"
+                style={{ color: "var(--content-default)" }}
               >
-                {skill.description}
-              </p>
-              <SkillLineageLink
-                skill={{ origin: skill.origin, sourceConversationId }}
-                className="mt-1"
+                {skill.name}
+              </h2>
+              <SkillOriginBadge origin={skill.origin} />
+            </div>
+            <p
+              className="mt-0.5 line-clamp-2 text-body-medium-lighter"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              {skill.description}
+            </p>
+            <SkillLineageLink
+              skill={{ origin: skill.origin, sourceConversationId }}
+              className="mt-1"
+            />
+          </div>
+        </div>
+        {available ? (
+          isInstalling ? (
+            <div className="flex h-9 items-center px-3">
+              <Loader2
+                className="h-4 w-4 animate-spin"
+                style={{ color: "var(--content-tertiary)" }}
               />
             </div>
-          </div>
-          {available ? (
-            isInstalling ? (
-              <div className="flex h-9 items-center px-3">
-                <Loader2
-                  className="h-4 w-4 animate-spin"
-                  style={{ color: "var(--content-tertiary)" }}
-                />
-              </div>
-            ) : (
-              <Button
-                type="button"
-                onClick={onInstall}
-                disabled={!onInstall}
-                leftIcon={<ArrowDownToLine aria-hidden />}
-              >
-                Install
-              </Button>
-            )
           ) : (
             <Button
               type="button"
-              variant={removable ? "dangerOutline" : "outlined"}
-              onClick={onRemove}
-              disabled={!removable || isRemoving || !onRemove}
-              leftIcon={
-                isRemoving ? (
-                  <Loader2 className="animate-spin" aria-hidden />
-                ) : (
-                  <Trash2 aria-hidden />
-                )
-              }
+              onClick={onInstall}
+              disabled={!onInstall}
+              leftIcon={<ArrowDownToLine aria-hidden />}
             >
-              Remove
+              Install
             </Button>
+          )
+        ) : (
+          <Button
+            type="button"
+            variant={removable ? "dangerOutline" : "outlined"}
+            onClick={onRemove}
+            disabled={!removable || isRemoving || !onRemove}
+            leftIcon={
+              isRemoving ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <Trash2 aria-hidden />
+              )
+            }
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  const filesCard = (
+    <Card.Root asChild noPadding>
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden sm:grid"
+        style={{
+          gridTemplateColumns: "240px 1fr",
+        }}
+      >
+        <div
+          className="max-h-40 shrink-0 overflow-y-auto border-b p-2 sm:max-h-none sm:border-b-0 sm:border-r"
+          style={{ borderColor: "var(--border-base)" }}
+        >
+          {isFilesLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2
+                className="h-4 w-4 animate-spin"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            </div>
+          ) : fileEntries.length === 0 ? (
+            <p
+              className="px-3 py-4 text-center text-body-medium-lighter"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              No files available.
+            </p>
+          ) : (
+            fileEntries.map((entry) => {
+              const isActive = activePath === entry.path;
+              const isDirectory = (entry.mimeType ?? "").endsWith("/directory");
+              return (
+                <button
+                  key={entry.path}
+                  type="button"
+                  onClick={() => setSelectedPath(entry.path)}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
+                  style={{
+                    color: isActive
+                      ? "var(--primary-base)"
+                      : "var(--content-default)",
+                    backgroundColor: isActive
+                      ? "color-mix(in oklab, var(--primary-base) 10%, transparent)"
+                      : undefined,
+                  }}
+                >
+                  {isDirectory ? (
+                    <Folder
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--system-mid-strong)" }}
+                    />
+                  ) : (
+                    <FileText
+                      className="h-4 w-4 shrink-0"
+                      style={{ color: "var(--content-secondary)" }}
+                    />
+                  )}
+                  <span className="truncate">{entry.name}</span>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-hidden">
+          {isContentLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader2
+                className="h-6 w-6 animate-spin"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            </div>
+          ) : activeFile ? (
+            <SkillFileContent
+              key={`${skill.id}/${activeFile.path}`}
+              assistantId={assistantId}
+              skillId={skill.id}
+              fileName={activeFile.name}
+              filePath={activeFile.path}
+              content={fileContent}
+              isBinary={isBinary}
+              editable={skill.kind === "installed"}
+            />
+          ) : (
+            <p
+              className="flex h-full items-center justify-center text-body-medium-lighter"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              Select a file to view its contents.
+            </p>
           )}
         </div>
       </div>
+    </Card.Root>
+  );
 
-      <Card.Root asChild noPadding>
-        <div
-          className="flex flex-1 flex-col overflow-hidden sm:grid"
-          style={{
-            gridTemplateColumns: "240px 1fr",
-          }}
+  return (
+    <div className="flex h-[calc(100vh-14rem)] flex-col">
+      {header}
+      {isHistoryUnsupported ? (
+        filesCard
+      ) : (
+        <Tabs.Root
+          defaultValue="files"
+          className="flex min-h-0 flex-1 flex-col"
         >
-          <div
-            className="max-h-40 shrink-0 overflow-y-auto border-b p-2 sm:max-h-none sm:border-b-0 sm:border-r"
-            style={{ borderColor: "var(--border-base)" }}
-          >
-            {isFilesLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2
-                  className="h-4 w-4 animate-spin"
-                  style={{ color: "var(--content-tertiary)" }}
+          <Tabs.List className="mb-3">
+            <Tabs.Trigger value="files">Files</Tabs.Trigger>
+            <Tabs.Trigger value="history">History</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Panel value="files" className="flex min-h-0 flex-1 flex-col">
+            {filesCard}
+          </Tabs.Panel>
+          <Tabs.Panel value="history" className="flex min-h-0 flex-1 flex-col">
+            <Card.Root asChild noPadding>
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <SkillRevisionHistory
+                  assistantId={assistantId}
+                  skillId={skill.id}
                 />
               </div>
-            ) : fileEntries.length === 0 ? (
-              <p
-                className="px-3 py-4 text-center text-body-medium-lighter"
-                style={{ color: "var(--content-tertiary)" }}
-              >
-                No files available.
-              </p>
-            ) : (
-              fileEntries.map((entry) => {
-                const isActive = activePath === entry.path;
-                const isDirectory = (entry.mimeType ?? "").endsWith(
-                  "/directory",
-                );
-                return (
-                  <button
-                    key={entry.path}
-                    type="button"
-                    onClick={() => setSelectedPath(entry.path)}
-                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
-                    style={{
-                      color: isActive
-                        ? "var(--primary-base)"
-                        : "var(--content-default)",
-                      backgroundColor: isActive
-                        ? "color-mix(in oklab, var(--primary-base) 10%, transparent)"
-                        : undefined,
-                    }}
-                  >
-                    {isDirectory ? (
-                      <Folder
-                        className="h-4 w-4 shrink-0"
-                        style={{ color: "var(--system-mid-strong)" }}
-                      />
-                    ) : (
-                      <FileText
-                        className="h-4 w-4 shrink-0"
-                        style={{ color: "var(--content-secondary)" }}
-                      />
-                    )}
-                    <span className="truncate">{entry.name}</span>
-                  </button>
-                );
-              })
-            )}
-          </div>
-
-          <div className="min-h-0 flex-1 overflow-hidden">
-            {isContentLoading ? (
-              <div className="flex h-full items-center justify-center">
-                <Loader2
-                  className="h-6 w-6 animate-spin"
-                  style={{ color: "var(--content-tertiary)" }}
-                />
-              </div>
-            ) : activeFile ? (
-              <SkillFileContent
-                key={`${skill.id}/${activeFile.path}`}
-                assistantId={assistantId}
-                skillId={skill.id}
-                fileName={activeFile.name}
-                filePath={activeFile.path}
-                content={fileContent}
-                isBinary={isBinary}
-                editable={skill.kind === "installed"}
-              />
-            ) : (
-              <p
-                className="flex h-full items-center justify-center text-body-medium-lighter"
-                style={{ color: "var(--content-tertiary)" }}
-              >
-                Select a file to view its contents.
-              </p>
-            )}
-          </div>
-        </div>
-      </Card.Root>
+            </Card.Root>
+          </Tabs.Panel>
+        </Tabs.Root>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -81,6 +81,12 @@ export function SkillDetail({
     skill.id,
   );
 
+  const [selectedTab, setSelectedTab] = useState("files");
+  // Falling back to Files when history turns out to be unsupported keeps the
+  // page coherent if the query answers after a tab was already chosen.
+  const activeTab = isHistoryUnsupported ? "files" : selectedTab;
+  const setActiveTab = setSelectedTab;
+
   const header = (
     <div className="mb-4 flex items-start gap-3">
       <Button
@@ -252,20 +258,37 @@ export function SkillDetail({
   return (
     <div className="flex h-[calc(100vh-14rem)] flex-col">
       {header}
-      {isHistoryUnsupported ? (
-        filesCard
-      ) : (
-        <Tabs.Root
-          defaultValue="files"
-          className="flex min-h-0 flex-1 flex-col"
-        >
+      {/*
+        The files panel stays mounted across tab switches and across the
+        history query resolving. Radix unmounts an inactive panel by default,
+        and `SkillFileContent` holds the in-progress edit in local state, so a
+        remount would silently discard unsaved text. `forceMount` keeps it
+        alive and an inline `display` drives visibility, which beats fighting
+        class precedence between `hidden` and `flex`. The files panel is also
+        never moved between branches: only the tab strip and the history panel
+        appear once the query answers, so `isHistoryUnsupported` flipping
+        cannot remount the editor either.
+      */}
+      <Tabs.Root
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        {!isHistoryUnsupported && (
           <Tabs.List className="mb-3">
             <Tabs.Trigger value="files">Files</Tabs.Trigger>
             <Tabs.Trigger value="history">History</Tabs.Trigger>
           </Tabs.List>
-          <Tabs.Panel value="files" className="flex min-h-0 flex-1 flex-col">
-            {filesCard}
-          </Tabs.Panel>
+        )}
+        <Tabs.Panel
+          value="files"
+          forceMount
+          className="min-h-0 flex-1 flex-col"
+          style={{ display: activeTab === "files" ? "flex" : "none" }}
+        >
+          {filesCard}
+        </Tabs.Panel>
+        {!isHistoryUnsupported && (
           <Tabs.Panel value="history" className="flex min-h-0 flex-1 flex-col">
             <Card.Root asChild noPadding>
               <div className="min-h-0 flex-1 overflow-y-auto">
@@ -276,8 +299,8 @@ export function SkillDetail({
               </div>
             </Card.Root>
           </Tabs.Panel>
-        </Tabs.Root>
-      )}
+        )}
+      </Tabs.Root>
     </div>
   );
 }

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -334,6 +334,15 @@ function SkillFileContent({
       void queryClient.invalidateQueries({
         queryKey: [{ _id: "skillsByIdFilesGet" }],
       });
+      // History has no push channel and its query disables focus refetches, so
+      // without this a History tab opened after a save keeps showing the
+      // pre-save list for the rest of the session. The new revision appears
+      // once the workspace heartbeat commits, not at save time, so this
+      // refetch is what eventually surfaces it rather than an immediate
+      // guarantee.
+      void queryClient.invalidateQueries({
+        queryKey: [{ _id: "skillsByIdHistoryGet" }],
+      });
       if (filePath === "SKILL.md") {
         invalidateSkillsList(queryClient, assistantId);
       }

--- a/clients/web/src/domains/intelligence/components/skills/skill-revision-history.stories.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-revision-history.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { SkillRevision } from "@/hooks/use-skill-history";
+
+import { SkillRevisionList } from "./skill-revision-history";
+
+/**
+ * Stories for the skill detail History tab.
+ *
+ * `SkillRevisionList` is the presentational half of
+ * {@link import("./skill-revision-history").SkillRevisionHistory}, so these
+ * render fixture revisions directly with no query cache to seed. The diffs are
+ * shaped like real `git show` output, including the index and mode lines the
+ * parser has to discard.
+ */
+
+const SKILL_ID = "release-triage";
+
+/** Relative-time copy is the point of the collapsed row, so dates are offsets. */
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+const MULTI_FILE: SkillRevision = {
+  id: "9c1f2ab",
+  changedAt: daysAgo(2),
+  files: ["SKILL.md", "references/owners.md"],
+  diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/skills/release-triage/SKILL.md
++++ b/skills/release-triage/SKILL.md
+@@ -18,3 +18,4 @@
+ ## Grouping
+-Group the failures by file.
++Group the failures by owning team, not by file: one file often spans
++three teams. See references/owners.md.
+diff --git a/skills/release-triage/references/owners.md b/skills/release-triage/references/owners.md
+new file mode 100644
+index 0000000..9999999
+--- /dev/null
++++ b/skills/release-triage/references/owners.md
+@@ -0,0 +1,2 @@
++Platform owns the gateway.
++Assistant owns the daemon.
+`,
+};
+
+const SINGLE_LINE: SkillRevision = {
+  id: "4de88b1",
+  changedAt: daysAgo(9),
+  files: ["SKILL.md"],
+  diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+index aaa1111..bbb2222 100644
+--- a/skills/release-triage/SKILL.md
++++ b/skills/release-triage/SKILL.md
+@@ -6,2 +6,3 @@
+ Read the release label first.
++Skip drafts unless the label is explicit.
+`,
+};
+
+const CREATION: SkillRevision = {
+  id: "01aa77c",
+  changedAt: daysAgo(24),
+  files: ["SKILL.md", "scripts/triage.py"],
+  diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/skills/release-triage/SKILL.md
+@@ -0,0 +1,3 @@
++# Release triage
++
++Read the release label first.
+diff --git a/skills/release-triage/scripts/triage.py b/skills/release-triage/scripts/triage.py
+new file mode 100644
+index 0000000..7654321
+--- /dev/null
++++ b/skills/release-triage/scripts/triage.py
+@@ -0,0 +1,2 @@
++import sys
++print(sys.argv)
+`,
+};
+
+const meta: Meta<typeof SkillRevisionList> = {
+  title: "Intelligence/Skills/SkillRevisionList",
+  component: SkillRevisionList,
+  parameters: { layout: "padded" },
+  args: { skillId: SKILL_ID, truncatedByCompaction: false },
+};
+
+export default meta;
+type Story = StoryObj<typeof SkillRevisionList>;
+
+/** The common case: a few updates, collapsed, newest first. */
+export const Default: Story = {
+  args: { revisions: [MULTI_FILE, SINGLE_LINE, CREATION] },
+};
+
+/**
+ * One update spanning `SKILL.md` and a companion file. Expanding it shows a
+ * single combined diff with a header per file, not two separate entries.
+ */
+export const SingleRevision: Story = {
+  args: { revisions: [MULTI_FILE] },
+};
+
+/**
+ * The caveat that matters most for trust: workspace history is periodically
+ * squashed, so the oldest entry is a floor and not the skill's creation.
+ */
+export const TruncatedByCompaction: Story = {
+  args: {
+    revisions: [MULTI_FILE, SINGLE_LINE],
+    truncatedByCompaction: true,
+  },
+};
+
+/**
+ * A skill that exists but has never been edited. Distinct from the tab being
+ * absent, which is what an assistant without the history route produces.
+ */
+export const NoChangesYet: Story = {
+  args: { revisions: [] },
+};
+
+/** A diff with more than one hunk, so the gap separator is visible. */
+export const MultipleHunks: Story = {
+  args: {
+    revisions: [
+      {
+        id: "77bb31e",
+        changedAt: daysAgo(1),
+        files: ["SKILL.md"],
+        diff: `diff --git a/skills/release-triage/SKILL.md b/skills/release-triage/SKILL.md
+index ccc3333..ddd4444 100644
+--- a/skills/release-triage/SKILL.md
++++ b/skills/release-triage/SKILL.md
+@@ -3,3 +3,3 @@
+ # Release triage
+-Read the label.
++Read the release label first.
+@@ -41,3 +41,4 @@
+ ## Posting
+-Post in the channel.
++Post in the release thread, not the channel.
++Tag the owning team.
+`,
+      },
+    ],
+  },
+};

--- a/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
@@ -11,59 +11,17 @@
  * recent changes and never presented as a complete record.
  */
 
-import { ChevronRight, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { useMemo } from "react";
 
+import { SkillsLoadingState } from "@/domains/intelligence/components/skills/skills-loading-state";
 import {
   parseUnifiedDiff,
   type DiffRow,
 } from "@/domains/intelligence/skills/parse-unified-diff";
 import { useSkillHistory, type SkillRevision } from "@/hooks/use-skill-history";
-import { cn } from "@/utils/misc";
-
-/** Absolute date, since a revision is a point in time worth citing exactly. */
-const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
-
-const RELATIVE_FORMAT = new Intl.RelativeTimeFormat(undefined, {
-  numeric: "auto",
-});
-
-const MINUTE = 60_000;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-
-/**
- * "2 days ago" for a recent change, falling back to nothing for anything the
- * absolute date already communicates better.
- */
-function formatRelative(iso: string, now: number): string | null {
-  const then = Date.parse(iso);
-  if (Number.isNaN(then)) {
-    return null;
-  }
-  const elapsed = now - then;
-  if (elapsed < MINUTE) {
-    return "just now";
-  }
-  if (elapsed < HOUR) {
-    return RELATIVE_FORMAT.format(-Math.floor(elapsed / MINUTE), "minute");
-  }
-  if (elapsed < DAY) {
-    return RELATIVE_FORMAT.format(-Math.floor(elapsed / HOUR), "hour");
-  }
-  if (elapsed < 30 * DAY) {
-    return RELATIVE_FORMAT.format(-Math.floor(elapsed / DAY), "day");
-  }
-  return null;
-}
-
-function formatAbsolute(iso: string): string {
-  const parsed = Date.parse(iso);
-  return Number.isNaN(parsed) ? iso : DATE_FORMAT.format(parsed);
-}
+import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
+import { Collapsible } from "@vellumai/design-library";
 
 export function SkillRevisionHistory({
   assistantId,
@@ -76,25 +34,11 @@ export function SkillRevisionHistory({
     useSkillHistory(assistantId, skillId);
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-10">
-        <Loader2
-          className="h-5 w-5 animate-spin"
-          style={{ color: "var(--content-tertiary)" }}
-        />
-      </div>
-    );
+    return <SkillsLoadingState />;
   }
 
   if (isError) {
-    return (
-      <p
-        className="px-3 py-10 text-center text-body-medium-lighter"
-        style={{ color: "var(--content-tertiary)" }}
-      >
-        Couldn&apos;t load revision history.
-      </p>
-    );
+    return <EmptyNote>Couldn&apos;t load revision history.</EmptyNote>;
   }
 
   return (
@@ -119,31 +63,14 @@ export function SkillRevisionList({
   revisions: SkillRevision[];
   truncatedByCompaction: boolean;
 }) {
-  // Read the clock once per mount rather than on each render: "2 days ago"
-  // only needs to be right when the list is opened, and a bare `Date.now()`
-  // in the render body is an impure call.
-  const [now] = useState(() => Date.now());
-
   if (revisions.length === 0) {
-    return (
-      <p
-        className="px-3 py-10 text-center text-body-medium-lighter"
-        style={{ color: "var(--content-tertiary)" }}
-      >
-        No changes recorded yet.
-      </p>
-    );
+    return <EmptyNote>No changes recorded yet.</EmptyNote>;
   }
 
   return (
-    <div className="flex flex-col gap-2 p-3">
+    <Collapsible.Root type="multiple" className="flex flex-col gap-2 p-3">
       {revisions.map((revision) => (
-        <RevisionRow
-          key={revision.id}
-          revision={revision}
-          skillId={skillId}
-          now={now}
-        />
+        <RevisionRow key={revision.id} revision={revision} skillId={skillId} />
       ))}
       {truncatedByCompaction && (
         <p
@@ -154,39 +81,44 @@ export function SkillRevisionList({
           this may not reach back to when the skill was created.
         </p>
       )}
-    </div>
+    </Collapsible.Root>
+  );
+}
+
+function EmptyNote({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="px-3 py-10 text-center text-body-medium-lighter"
+      style={{ color: "var(--content-tertiary)" }}
+    >
+      {children}
+    </p>
   );
 }
 
 function RevisionRow({
   revision,
   skillId,
-  now,
 }: {
   revision: SkillRevision;
   skillId: string;
-  now: number;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const parsed = parseUnifiedDiff(revision.diff, skillId);
-  const relative = formatRelative(revision.changedAt, now);
+  // Parsing walks the whole diff, and the collapsed row needs it only for the
+  // +/- counts, so keep it off the render path for a list that may hold 20.
+  const parsed = useMemo(
+    () => parseUnifiedDiff(revision.diff, skillId),
+    [revision.diff, skillId],
+  );
 
   return (
-    <div
+    <Collapsible.Item
+      value={revision.id}
       className="overflow-hidden rounded-md border"
       style={{ borderColor: "var(--border-base)" }}
     >
-      <button
-        type="button"
-        onClick={() => setIsOpen((open) => !open)}
-        aria-expanded={isOpen}
-        className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--surface-hover)]"
-      >
+      <Collapsible.Trigger className="group flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--surface-hover)]">
         <ChevronRight
-          className={cn(
-            "h-4 w-4 shrink-0 transition-transform",
-            isOpen && "rotate-90",
-          )}
+          className="h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-90"
           style={{ color: "var(--content-tertiary)" }}
           aria-hidden
         />
@@ -195,7 +127,7 @@ function RevisionRow({
             className="block truncate text-body-medium-default"
             style={{ color: "var(--content-default)" }}
           >
-            {relative ?? formatAbsolute(revision.changedAt)}
+            {formatRelativeDate(revision.changedAt)}
           </span>
           <span
             className="mt-0.5 block truncate text-body-small-lighter"
@@ -220,54 +152,55 @@ function RevisionRow({
             &minus;{parsed.removed}
           </span>
         )}
-      </button>
+      </Collapsible.Trigger>
 
-      {isOpen && (
-        <div className="border-t" style={{ borderColor: "var(--border-base)" }}>
+      <Collapsible.Content
+        className="border-t"
+        style={{ borderColor: "var(--border-base)" }}
+      >
+        <p
+          className="px-3 py-2 text-body-small-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {formatFullLocalDate(revision.changedAt)}
+        </p>
+        {parsed.files.length === 0 ? (
           <p
-            className="px-3 py-2 text-body-small-lighter"
+            className="px-3 pb-3 text-body-small-lighter"
             style={{ color: "var(--content-tertiary)" }}
           >
-            {formatAbsolute(revision.changedAt)}
+            No preview available for this change.
           </p>
-          {parsed.files.length === 0 ? (
-            <p
-              className="px-3 pb-3 text-body-small-lighter"
-              style={{ color: "var(--content-tertiary)" }}
-            >
-              No preview available for this change.
-            </p>
-          ) : (
-            parsed.files.map((file) => (
-              <div key={file.path}>
-                <p
-                  className="border-t px-3 py-1.5 font-mono text-body-small-default"
-                  style={{
-                    borderColor: "var(--border-base)",
-                    backgroundColor: "var(--surface-base)",
-                    color: "var(--content-secondary)",
-                  }}
-                >
-                  {file.path}
-                </p>
-                <div className="overflow-x-auto py-1 font-mono text-body-small-lighter">
-                  {file.rows.map((row, index) => (
-                    <DiffLine key={index} row={row} />
-                  ))}
-                </div>
+        ) : (
+          parsed.files.map((file) => (
+            <div key={file.path}>
+              <p
+                className="border-t px-3 py-1.5 font-mono text-body-small-default"
+                style={{
+                  borderColor: "var(--border-base)",
+                  backgroundColor: "var(--surface-base)",
+                  color: "var(--content-secondary)",
+                }}
+              >
+                {file.path}
+              </p>
+              <div className="overflow-x-auto py-1 font-mono text-body-small-lighter">
+                {file.rows.map((row, index) => (
+                  <DiffLine key={index} row={row} />
+                ))}
               </div>
-            ))
-          )}
-        </div>
-      )}
-    </div>
+            </div>
+          ))
+        )}
+      </Collapsible.Content>
+    </Collapsible.Item>
   );
 }
 
 /**
- * One diff line: two line-number gutters, a marker column, then the text.
- * Mirrors the gutter layout the chat file-diff view already uses so a diff
- * reads the same wherever it appears in the app.
+ * Mirrors the gutter layout of the chat file-diff view so a diff reads the same
+ * wherever it appears. That component computes its diff from two texts and
+ * keeps its row renderer private, so there is nothing to import here.
  */
 function DiffLine({ row }: { row: DiffRow }) {
   if (row.type === "meta") {

--- a/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-revision-history.tsx
@@ -1,0 +1,322 @@
+/**
+ * Recent revisions for one skill, rendered as a collapsible list.
+ *
+ * One entry is one update to the whole skill, not one file: the daemon diffs a
+ * commit against the skill's directory, so a change spanning `SKILL.md` and a
+ * companion file arrives as a single revision with a combined diff. Entries are
+ * shown newest first and collapsed by default, since the common question is
+ * "when did this last change" and the diff is the follow-up.
+ *
+ * The list is bounded by workspace history compaction, so it is labelled as
+ * recent changes and never presented as a complete record.
+ */
+
+import { ChevronRight, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import {
+  parseUnifiedDiff,
+  type DiffRow,
+} from "@/domains/intelligence/skills/parse-unified-diff";
+import { useSkillHistory, type SkillRevision } from "@/hooks/use-skill-history";
+import { cn } from "@/utils/misc";
+
+/** Absolute date, since a revision is a point in time worth citing exactly. */
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const RELATIVE_FORMAT = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+});
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * "2 days ago" for a recent change, falling back to nothing for anything the
+ * absolute date already communicates better.
+ */
+function formatRelative(iso: string, now: number): string | null {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) {
+    return null;
+  }
+  const elapsed = now - then;
+  if (elapsed < MINUTE) {
+    return "just now";
+  }
+  if (elapsed < HOUR) {
+    return RELATIVE_FORMAT.format(-Math.floor(elapsed / MINUTE), "minute");
+  }
+  if (elapsed < DAY) {
+    return RELATIVE_FORMAT.format(-Math.floor(elapsed / HOUR), "hour");
+  }
+  if (elapsed < 30 * DAY) {
+    return RELATIVE_FORMAT.format(-Math.floor(elapsed / DAY), "day");
+  }
+  return null;
+}
+
+function formatAbsolute(iso: string): string {
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? iso : DATE_FORMAT.format(parsed);
+}
+
+export function SkillRevisionHistory({
+  assistantId,
+  skillId,
+}: {
+  assistantId: string;
+  skillId: string;
+}) {
+  const { revisions, truncatedByCompaction, isLoading, isError } =
+    useSkillHistory(assistantId, skillId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <Loader2
+          className="h-5 w-5 animate-spin"
+          style={{ color: "var(--content-tertiary)" }}
+        />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p
+        className="px-3 py-10 text-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        Couldn&apos;t load revision history.
+      </p>
+    );
+  }
+
+  return (
+    <SkillRevisionList
+      skillId={skillId}
+      revisions={revisions}
+      truncatedByCompaction={truncatedByCompaction}
+    />
+  );
+}
+
+/**
+ * The rendered list, separated from the query so it can be exercised directly
+ * with fixture revisions.
+ */
+export function SkillRevisionList({
+  skillId,
+  revisions,
+  truncatedByCompaction,
+}: {
+  skillId: string;
+  revisions: SkillRevision[];
+  truncatedByCompaction: boolean;
+}) {
+  // Read the clock once per mount rather than on each render: "2 days ago"
+  // only needs to be right when the list is opened, and a bare `Date.now()`
+  // in the render body is an impure call.
+  const [now] = useState(() => Date.now());
+
+  if (revisions.length === 0) {
+    return (
+      <p
+        className="px-3 py-10 text-center text-body-medium-lighter"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        No changes recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      {revisions.map((revision) => (
+        <RevisionRow
+          key={revision.id}
+          revision={revision}
+          skillId={skillId}
+          now={now}
+        />
+      ))}
+      {truncatedByCompaction && (
+        <p
+          className="px-1 pt-1 text-body-small-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          Showing recent changes. Older history is periodically compacted, so
+          this may not reach back to when the skill was created.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RevisionRow({
+  revision,
+  skillId,
+  now,
+}: {
+  revision: SkillRevision;
+  skillId: string;
+  now: number;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const parsed = parseUnifiedDiff(revision.diff, skillId);
+  const relative = formatRelative(revision.changedAt, now);
+
+  return (
+    <div
+      className="overflow-hidden rounded-md border"
+      style={{ borderColor: "var(--border-base)" }}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-expanded={isOpen}
+        className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--surface-hover)]"
+      >
+        <ChevronRight
+          className={cn(
+            "h-4 w-4 shrink-0 transition-transform",
+            isOpen && "rotate-90",
+          )}
+          style={{ color: "var(--content-tertiary)" }}
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1">
+          <span
+            className="block truncate text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {relative ?? formatAbsolute(revision.changedAt)}
+          </span>
+          <span
+            className="mt-0.5 block truncate text-body-small-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {revision.files.join(" · ")}
+          </span>
+        </span>
+        {parsed.added > 0 && (
+          <span
+            className="shrink-0 text-body-small-default tabular-nums"
+            style={{ color: "var(--system-positive-strong)" }}
+          >
+            +{parsed.added}
+          </span>
+        )}
+        {parsed.removed > 0 && (
+          <span
+            className="shrink-0 text-body-small-default tabular-nums"
+            style={{ color: "var(--system-negative-strong)" }}
+          >
+            &minus;{parsed.removed}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="border-t" style={{ borderColor: "var(--border-base)" }}>
+          <p
+            className="px-3 py-2 text-body-small-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {formatAbsolute(revision.changedAt)}
+          </p>
+          {parsed.files.length === 0 ? (
+            <p
+              className="px-3 pb-3 text-body-small-lighter"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              No preview available for this change.
+            </p>
+          ) : (
+            parsed.files.map((file) => (
+              <div key={file.path}>
+                <p
+                  className="border-t px-3 py-1.5 font-mono text-body-small-default"
+                  style={{
+                    borderColor: "var(--border-base)",
+                    backgroundColor: "var(--surface-base)",
+                    color: "var(--content-secondary)",
+                  }}
+                >
+                  {file.path}
+                </p>
+                <div className="overflow-x-auto py-1 font-mono text-body-small-lighter">
+                  {file.rows.map((row, index) => (
+                    <DiffLine key={index} row={row} />
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One diff line: two line-number gutters, a marker column, then the text.
+ * Mirrors the gutter layout the chat file-diff view already uses so a diff
+ * reads the same wherever it appears in the app.
+ */
+function DiffLine({ row }: { row: DiffRow }) {
+  if (row.type === "meta") {
+    return (
+      <div
+        className="px-3 py-0.5"
+        style={{ color: "var(--content-faint)" }}
+        aria-hidden
+      >
+        ⋯
+      </div>
+    );
+  }
+
+  const isAdd = row.type === "add";
+  const isDel = row.type === "del";
+
+  return (
+    <div
+      className="flex whitespace-pre"
+      style={{
+        backgroundColor: isAdd
+          ? "var(--system-positive-weak)"
+          : isDel
+            ? "var(--system-negative-weak)"
+            : undefined,
+        color: isAdd
+          ? "var(--system-positive-strong)"
+          : isDel
+            ? "var(--system-negative-strong)"
+            : "var(--content-secondary)",
+      }}
+    >
+      <span
+        className="w-10 shrink-0 pr-2 text-right tabular-nums"
+        style={{ color: "var(--content-faint)" }}
+      >
+        {row.oldNo ?? ""}
+      </span>
+      <span
+        className="w-10 shrink-0 pr-2 text-right tabular-nums"
+        style={{ color: "var(--content-faint)" }}
+      >
+        {row.newNo ?? ""}
+      </span>
+      <span className="w-4 shrink-0 text-center">
+        {isAdd ? "+" : isDel ? "-" : " "}
+      </span>
+      <span className="flex-1 pr-3">{row.text}</span>
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseUnifiedDiff } from "./parse-unified-diff";
+
+/**
+ * The input here is shaped like real `git show` output, because the parser's
+ * whole job is to survive the parts of that format the renderer does not care
+ * about (index lines, mode changes, multiple files, multiple hunks).
+ */
+
+const TWO_FILES = `diff --git a/skills/triage/SKILL.md b/skills/triage/SKILL.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/skills/triage/SKILL.md
++++ b/skills/triage/SKILL.md
+@@ -18,3 +18,4 @@
+ ## Grouping
+-Group the failures by file.
++Group the failures by owning team.
++See references/owners.md.
+diff --git a/skills/triage/references/owners.md b/skills/triage/references/owners.md
+new file mode 100644
+index 0000000..9999999
+--- /dev/null
++++ b/skills/triage/references/owners.md
+@@ -0,0 +1,2 @@
++Platform owns the gateway.
++Assistant owns the daemon.
+`;
+
+describe("parseUnifiedDiff", () => {
+  test("splits a combined diff into one entry per file", () => {
+    const parsed = parseUnifiedDiff(TWO_FILES, "triage");
+
+    expect(parsed.files.map((f) => f.path)).toEqual([
+      "SKILL.md",
+      "references/owners.md",
+    ]);
+  });
+
+  test("strips the skill directory prefix from file paths", () => {
+    const parsed = parseUnifiedDiff(TWO_FILES, "triage");
+
+    // The path a reader sees should match the revision's `files` list, which
+    // the daemon reports relative to the skill directory.
+    expect(parsed.files[0]!.path).toBe("SKILL.md");
+    expect(parsed.files[0]!.path).not.toContain("skills/");
+  });
+
+  test("tags each row and counts additions and removals", () => {
+    const parsed = parseUnifiedDiff(TWO_FILES, "triage");
+
+    expect(parsed.added).toBe(4);
+    expect(parsed.removed).toBe(1);
+
+    const skillMd = parsed.files[0]!;
+    expect(skillMd.rows.map((r) => r.type)).toEqual([
+      "ctx",
+      "del",
+      "add",
+      "add",
+    ]);
+    expect(skillMd.rows[1]!.text).toBe("Group the failures by file.");
+  });
+
+  test("numbers rows from the hunk header, advancing each side separately", () => {
+    const parsed = parseUnifiedDiff(TWO_FILES, "triage");
+    const rows = parsed.files[0]!.rows;
+
+    // Context occupies line 18 on both sides; the deletion consumes only an
+    // old-side number, the additions only new-side ones.
+    expect(rows[0]).toMatchObject({ type: "ctx", oldNo: 18, newNo: 18 });
+    expect(rows[1]).toMatchObject({ type: "del", oldNo: 19 });
+    expect(rows[1]!.newNo).toBeUndefined();
+    expect(rows[2]).toMatchObject({ type: "add", newNo: 19 });
+    expect(rows[3]).toMatchObject({ type: "add", newNo: 20 });
+    expect(rows[2]!.oldNo).toBeUndefined();
+  });
+
+  test("drops file metadata that the rendered header already conveys", () => {
+    const parsed = parseUnifiedDiff(TWO_FILES, "triage");
+    const text = parsed.files
+      .flatMap((f) => f.rows.map((r) => r.text))
+      .join("\n");
+
+    for (const noise of ["index 1a2b3c4", "new file mode", "--- ", "+++ "]) {
+      expect(text).not.toContain(noise);
+    }
+  });
+
+  test("keeps a separator between hunks so a gap does not read as contiguous", () => {
+    const twoHunks = `diff --git a/skills/triage/SKILL.md b/skills/triage/SKILL.md
+--- a/skills/triage/SKILL.md
++++ b/skills/triage/SKILL.md
+@@ -1,2 +1,2 @@
+-first
++FIRST
+@@ -40,2 +40,2 @@
+-fortieth
++FORTIETH
+`;
+
+    const rows = parseUnifiedDiff(twoHunks, "triage").files[0]!.rows;
+
+    expect(rows.filter((r) => r.type === "meta")).toHaveLength(1);
+    // The separator sits between the two hunks, never at the top.
+    expect(rows[0]!.type).not.toBe("meta");
+    expect(rows[2]!.type).toBe("meta");
+    // Numbering restarts from the second hunk header rather than running on.
+    expect(rows[4]).toMatchObject({ type: "add", newNo: 40 });
+  });
+
+  test("leaves a path alone when it is not under the expected skill directory", () => {
+    const odd = `diff --git a/elsewhere/notes.md b/elsewhere/notes.md
+@@ -1 +1 @@
+-a
++b
+`;
+
+    expect(parseUnifiedDiff(odd, "triage").files[0]!.path).toBe(
+      "elsewhere/notes.md",
+    );
+  });
+
+  test("returns no files for an empty diff instead of throwing", () => {
+    expect(parseUnifiedDiff("", "triage")).toEqual({
+      files: [],
+      added: 0,
+      removed: 0,
+    });
+  });
+});

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
@@ -121,6 +121,48 @@ describe("parseUnifiedDiff", () => {
     );
   });
 
+  test("keeps content lines that look like file headers", () => {
+    // A skill script holding SQL or Lua comments: removing `-- old note`
+    // emits `-` + `-- old note` = `--- old note`, which is indistinguishable
+    // from a `--- a/path` header by prefix alone. Dropping it would both hide
+    // the change and, since a dropped row never advances its side's counter,
+    // shift every line number after it.
+    const looksLikeHeaders = `diff --git a/skills/triage/scripts/q.sql b/skills/triage/scripts/q.sql
+index ccc3333..ddd4444 100644
+--- a/skills/triage/scripts/q.sql
++++ b/skills/triage/scripts/q.sql
+@@ -1,4 +1,4 @@
+ SELECT 1;
+--- old note
++++ new note
+ SELECT 2;
+`;
+
+    const parsed = parseUnifiedDiff(looksLikeHeaders, "triage");
+    const rows = parsed.files[0]!.rows;
+
+    expect(parsed.added).toBe(1);
+    expect(parsed.removed).toBe(1);
+    expect(rows.map((r) => r.type)).toEqual(["ctx", "del", "add", "ctx"]);
+    expect(rows[1]!.text).toBe("-- old note");
+    expect(rows[2]!.text).toBe("++ new note");
+    // The trailing context keeps its true position on both sides.
+    expect(rows[3]).toMatchObject({ type: "ctx", oldNo: 3, newNo: 3 });
+  });
+
+  test("drops the no-newline marker wherever it appears", () => {
+    const noNewline = `diff --git a/skills/triage/SKILL.md b/skills/triage/SKILL.md
+@@ -1,2 +1,2 @@
+-first
+\\ No newline at end of file
++FIRST
+`;
+
+    const rows = parseUnifiedDiff(noNewline, "triage").files[0]!.rows;
+
+    expect(rows.map((r) => r.type)).toEqual(["del", "add"]);
+  });
+
   test("returns no files for an empty diff instead of throwing", () => {
     expect(parseUnifiedDiff("", "triage")).toEqual({
       files: [],

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts
@@ -163,6 +163,42 @@ index ccc3333..ddd4444 100644
     expect(rows.map((r) => r.type)).toEqual(["del", "add"]);
   });
 
+  test("recovers a path containing spaces", () => {
+    // Verbatim `git show` output for a tracked file named `my file.md`. Git
+    // does not quote a space, and appends a tab to the ---/+++ headers, so
+    // splitting the `diff --git` line on whitespace yields `file.md`.
+    const spaced = `diff --git a/skills/triage/my file.md b/skills/triage/my file.md
+index 7898192..6178079 100644
+--- a/skills/triage/my file.md\t
++++ b/skills/triage/my file.md\t
+@@ -1 +1 @@
+-a
++b
+`;
+
+    const parsed = parseUnifiedDiff(spaced, "triage");
+
+    expect(parsed.files[0]!.path).toBe("my file.md");
+    expect(parsed.files[0]!.rows).toHaveLength(2);
+  });
+
+  test("uses the surviving side's path when a file is deleted", () => {
+    const deleted = `diff --git a/skills/triage/gone.md b/skills/triage/gone.md
+deleted file mode 100644
+index 7898192..0000000
+--- a/skills/triage/gone.md
++++ /dev/null
+@@ -1 +0,0 @@
+-a
+`;
+
+    const parsed = parseUnifiedDiff(deleted, "triage");
+
+    // `/dev/null` must never become the displayed name.
+    expect(parsed.files[0]!.path).toBe("gone.md");
+    expect(parsed.removed).toBe(1);
+  });
+
   test("returns no files for an empty diff instead of throwing", () => {
     expect(parseUnifiedDiff("", "triage")).toEqual({
       files: [],

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
@@ -65,6 +65,13 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
   let current: DiffFile | null = null;
   let oldNo = 0;
   let newNo = 0;
+  // File metadata only ever appears BEFORE the first hunk header. Inside a
+  // hunk every line is content prefixed with a marker, so a deleted line whose
+  // own text begins with `--` arrives as `--- ...` and a added one beginning
+  // with `++` as `+++ ...`. Matching those against the header prefixes would
+  // drop real content rows and, because a dropped row never advances its side's
+  // counter, desynchronise every line number after it.
+  let inHunk = false;
 
   for (const line of diff.split("\n")) {
     if (line.startsWith("diff --git ")) {
@@ -81,6 +88,7 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
       files.push(current);
       oldNo = 0;
       newNo = 0;
+      inHunk = false;
       continue;
     }
 
@@ -92,6 +100,7 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
     if (hunk) {
       oldNo = Number(hunk[1]);
       newNo = Number(hunk[2]);
+      inHunk = true;
       // Hunk boundaries matter visually once a file has more than one; the
       // gap between them is not contiguous text.
       if (current.rows.length > 0) {
@@ -100,20 +109,26 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
       continue;
     }
 
+    // A "no newline at end of file" marker can appear inside a hunk, but it is
+    // notation rather than content, so it is dropped wherever it occurs.
+    if (line.startsWith("\\ No newline")) {
+      continue;
+    }
+
     // Everything between the `diff --git` line and the first hunk is file
     // metadata (index, mode, ---/+++ headers) that the header already conveys.
     if (
-      line.startsWith("index ") ||
-      line.startsWith("--- ") ||
-      line.startsWith("+++ ") ||
-      line.startsWith("new file mode ") ||
-      line.startsWith("deleted file mode ") ||
-      line.startsWith("similarity index ") ||
-      line.startsWith("rename ") ||
-      line.startsWith("old mode ") ||
-      line.startsWith("new mode ") ||
-      line.startsWith("Binary files ") ||
-      line.startsWith("\\ No newline")
+      !inHunk &&
+      (line.startsWith("index ") ||
+        line.startsWith("--- ") ||
+        line.startsWith("+++ ") ||
+        line.startsWith("new file mode ") ||
+        line.startsWith("deleted file mode ") ||
+        line.startsWith("similarity index ") ||
+        line.startsWith("rename ") ||
+        line.startsWith("old mode ") ||
+        line.startsWith("new mode ") ||
+        line.startsWith("Binary files "))
     ) {
       continue;
     }

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
@@ -41,6 +41,14 @@ export interface ParsedDiff {
 const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
 /**
+ * `diff --git a/<path> b/<path>` for the common case where both sides name the
+ * same file. The backreference is what makes a path containing spaces
+ * recoverable: splitting on whitespace cannot tell `a/my file.md b/my file.md`
+ * apart from four separate tokens.
+ */
+const DIFF_GIT_SAME_PATH = /^diff --git a\/(.+) b\/\1$/;
+
+/**
  * Strip the `a/`/`b/` diff prefix and the `skills/<id>/` directory so a file
  * reads the way the revision's `files` list spells it. A path that doesn't sit
  * under the expected directory is left alone rather than mangled.
@@ -51,6 +59,16 @@ function toSkillRelativePath(rawPath: string, skillId: string): string {
   return withoutDiffPrefix.startsWith(skillPrefix)
     ? withoutDiffPrefix.slice(skillPrefix.length)
     : withoutDiffPrefix;
+}
+
+/**
+ * Path from a `--- a/<path>` or `+++ b/<path>` header, which runs to the end of
+ * the line and so survives spaces. Git appends a tab to these when the path
+ * contains one. Returns null for the `/dev/null` side of an add or delete.
+ */
+function pathFromFileHeader(line: string): string | null {
+  const raw = line.slice(4).replace(/\t$/, "");
+  return raw === "/dev/null" ? null : raw;
 }
 
 /**
@@ -72,13 +90,18 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
   // drop real content rows and, because a dropped row never advances its side's
   // counter, desynchronise every line number after it.
   let inHunk = false;
+  // Whether the b-side path has been taken for the current file, so a later
+  // a-side header cannot overwrite it.
+  let seenNewPath = false;
 
   for (const line of diff.split("\n")) {
     if (line.startsWith("diff --git ")) {
-      // `diff --git a/x b/x`; take the b-side, which names the file after the
-      // change (and is the only side present for an addition).
-      const parts = line.split(" ");
-      const rawPath = parts[3] ?? parts[2] ?? "";
+      // Provisional: a rename has two different paths and no backreference
+      // match, so fall back to the last whitespace token. The `+++`/`---`
+      // headers below correct both cases before any row is rendered.
+      const samePath = DIFF_GIT_SAME_PATH.exec(line);
+      const rawPath =
+        samePath?.[1] ?? (line.split(" ").slice(3).join(" ") || "");
       current = {
         path: toSkillRelativePath(rawPath, skillId),
         rows: [],
@@ -89,6 +112,7 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
       oldNo = 0;
       newNo = 0;
       inHunk = false;
+      seenNewPath = false;
       continue;
     }
 
@@ -115,13 +139,24 @@ export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
       continue;
     }
 
+    // The `---`/`+++` headers carry the authoritative path: it runs to the end
+    // of the line, so unlike the `diff --git` line it is unambiguous when the
+    // path contains spaces. Prefer the b-side, falling back to the a-side for
+    // a deletion, where the b-side is `/dev/null`.
+    if (!inHunk && (line.startsWith("+++ ") || line.startsWith("--- "))) {
+      const headerPath = pathFromFileHeader(line);
+      if (headerPath !== null && (line.startsWith("+++ ") || !seenNewPath)) {
+        current.path = toSkillRelativePath(headerPath, skillId);
+        seenNewPath = line.startsWith("+++ ");
+      }
+      continue;
+    }
+
     // Everything between the `diff --git` line and the first hunk is file
-    // metadata (index, mode, ---/+++ headers) that the header already conveys.
+    // metadata (index, mode) that the header already conveys.
     if (
       !inHunk &&
       (line.startsWith("index ") ||
-        line.startsWith("--- ") ||
-        line.startsWith("+++ ") ||
         line.startsWith("new file mode ") ||
         line.startsWith("deleted file mode ") ||
         line.startsWith("similarity index ") ||

--- a/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
+++ b/clients/web/src/domains/intelligence/skills/parse-unified-diff.ts
@@ -1,0 +1,142 @@
+/**
+ * Parse the unified diff a skill revision carries into per-file rows the
+ * revision history can render.
+ *
+ * The daemon returns one combined `git show` diff per revision, scoped to the
+ * skill's directory, so a single string may describe several files. Rendering
+ * needs them split by file (each with its own header) and each line tagged with
+ * the old/new line numbers from its hunk header.
+ *
+ * The sibling diff utilities in the app compute a diff from two texts
+ * (`compute-line-diff.ts`, `inspector/cache-diff.ts`); this one reads a diff
+ * that already exists, which is why it parses rather than diffs.
+ */
+
+/** A single rendered line of a diff. */
+export interface DiffRow {
+  type: "add" | "del" | "ctx" | "meta";
+  text: string;
+  /** Line number in the pre-change file, when the row exists there. */
+  oldNo?: number;
+  /** Line number in the post-change file, when the row exists there. */
+  newNo?: number;
+}
+
+/** The rows belonging to one file within a revision's combined diff. */
+export interface DiffFile {
+  /** Path relative to the skill directory, e.g. `references/owners.md`. */
+  path: string;
+  rows: DiffRow[];
+  added: number;
+  removed: number;
+}
+
+export interface ParsedDiff {
+  files: DiffFile[];
+  added: number;
+  removed: number;
+}
+
+/** `@@ -12,7 +12,9 @@`, capturing the two starting line numbers. */
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * Strip the `a/`/`b/` diff prefix and the `skills/<id>/` directory so a file
+ * reads the way the revision's `files` list spells it. A path that doesn't sit
+ * under the expected directory is left alone rather than mangled.
+ */
+function toSkillRelativePath(rawPath: string, skillId: string): string {
+  const withoutDiffPrefix = rawPath.replace(/^[ab]\//, "");
+  const skillPrefix = `skills/${skillId}/`;
+  return withoutDiffPrefix.startsWith(skillPrefix)
+    ? withoutDiffPrefix.slice(skillPrefix.length)
+    : withoutDiffPrefix;
+}
+
+/**
+ * Split a revision's combined unified diff into per-file row lists.
+ *
+ * Returns no files for an empty or unrecognisable diff. Callers render that
+ * as "no preview" rather than treating it as an error, since the diff is
+ * presentational and a revision row still stands on its date and file list.
+ */
+export function parseUnifiedDiff(diff: string, skillId: string): ParsedDiff {
+  const files: DiffFile[] = [];
+  let current: DiffFile | null = null;
+  let oldNo = 0;
+  let newNo = 0;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      // `diff --git a/x b/x`; take the b-side, which names the file after the
+      // change (and is the only side present for an addition).
+      const parts = line.split(" ");
+      const rawPath = parts[3] ?? parts[2] ?? "";
+      current = {
+        path: toSkillRelativePath(rawPath, skillId),
+        rows: [],
+        added: 0,
+        removed: 0,
+      };
+      files.push(current);
+      oldNo = 0;
+      newNo = 0;
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      oldNo = Number(hunk[1]);
+      newNo = Number(hunk[2]);
+      // Hunk boundaries matter visually once a file has more than one; the
+      // gap between them is not contiguous text.
+      if (current.rows.length > 0) {
+        current.rows.push({ type: "meta", text: line });
+      }
+      continue;
+    }
+
+    // Everything between the `diff --git` line and the first hunk is file
+    // metadata (index, mode, ---/+++ headers) that the header already conveys.
+    if (
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("new file mode ") ||
+      line.startsWith("deleted file mode ") ||
+      line.startsWith("similarity index ") ||
+      line.startsWith("rename ") ||
+      line.startsWith("old mode ") ||
+      line.startsWith("new mode ") ||
+      line.startsWith("Binary files ") ||
+      line.startsWith("\\ No newline")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      current.rows.push({ type: "add", text: line.slice(1), newNo });
+      current.added += 1;
+      newNo += 1;
+    } else if (line.startsWith("-")) {
+      current.rows.push({ type: "del", text: line.slice(1), oldNo });
+      current.removed += 1;
+      oldNo += 1;
+    } else if (line.startsWith(" ")) {
+      current.rows.push({ type: "ctx", text: line.slice(1), oldNo, newNo });
+      oldNo += 1;
+      newNo += 1;
+    }
+    // A trailing empty string from the final newline falls through here.
+  }
+
+  return {
+    files,
+    added: files.reduce((sum, f) => sum + f.added, 0),
+    removed: files.reduce((sum, f) => sum + f.removed, 0),
+  };
+}

--- a/clients/web/src/hooks/use-skill-history.ts
+++ b/clients/web/src/hooks/use-skill-history.ts
@@ -1,0 +1,84 @@
+/**
+ * Read a skill's recent revisions for the skill detail view.
+ *
+ * Deliberately not version-gated. This is a read whose only fallback is "the
+ * feature is absent", which is exactly what an assistant without the route
+ * produces: `fetchSkillHistory` maps its 404 to `null`, the History tab hides,
+ * and the detail page renders the way it did before revisions existed. That is
+ * the documented exemption in BACKWARDS_COMPAT.md ("When a gate is
+ * unnecessary"), and it lets same-source self-hosted setups (which report the
+ * last released version while running unreleased code) get the tab without a
+ * debug override.
+ *
+ * `null` and an empty `revisions` array mean different things and must stay
+ * distinct: `null` is "this assistant cannot report history", while `[]` is
+ * "history is available and this skill has no recorded edits".
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { skillsByIdHistoryGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { skillsByIdHistoryGet } from "@/generated/daemon/sdk.gen";
+import type { SkillsByIdHistoryGetResponse } from "@/generated/daemon/types.gen";
+import { toApiError } from "@/utils/api-errors";
+
+export type SkillHistory = SkillsByIdHistoryGetResponse;
+export type SkillRevision = SkillHistory["revisions"][number];
+
+/**
+ * Fetch a skill's history, mapping a missing route to the feature-off value.
+ *
+ * Other HTTP failures throw a status-carrying error via {@link toApiError}:
+ * the `throwOnError: false` read bypasses the client's error interceptor, so
+ * the status has to be attached here for the global no-retry-4xx predicate to
+ * apply. A network error (no response at all) rethrows raw so it retries as a
+ * transient failure.
+ */
+export async function fetchSkillHistory(
+  assistantId: string,
+  skillId: string,
+  signal?: AbortSignal,
+): Promise<SkillHistory | null> {
+  const { data, error, response } = await skillsByIdHistoryGet({
+    path: { assistant_id: assistantId, id: skillId },
+    throwOnError: false,
+    signal,
+  });
+  if (!response || !response.ok) {
+    if (response?.status === 404) {
+      return null;
+    }
+    if (response) {
+      throw toApiError(error, response);
+    }
+    throw error ?? new Error("Failed to fetch skill history.");
+  }
+  return data ?? null;
+}
+
+export function useSkillHistory(assistantId: string | null, skillId: string) {
+  const enabled = Boolean(assistantId && skillId);
+
+  const query = useQuery({
+    queryKey: skillsByIdHistoryGetQueryKey({
+      path: { assistant_id: assistantId ?? "", id: skillId },
+    }),
+    queryFn: ({ signal }) =>
+      fetchSkillHistory(assistantId ?? "", skillId, signal),
+    enabled,
+    // Revisions change only when the workspace commits, which no client
+    // action triggers; a focus refetch would just re-issue the request (and,
+    // against an older assistant, the 404).
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    history: query.data ?? null,
+    revisions: query.data?.revisions ?? [],
+    truncatedByCompaction: query.data?.truncatedByCompaction ?? false,
+    /** The connected assistant cannot report history, so hide the surface. */
+    isUnsupported: query.isSuccess && query.data === null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}


### PR DESCRIPTION
## TL;DR

Adds a **History** tab to the skill detail page showing a skill's recent updates, newest first, each expandable to a diff. Read-only. Answers "what changed in this skill, and when" — which today is unanswerable from the UI for a skill the assistant edited on its own in the background.

## Why this rather than storing revisions

The workspace is already a git repository with an auto-committing heartbeat, and `skills/` is tracked, so every managed-skill write already retains its prior content. This reads that history instead of adding a second copy of it. `createManagedSkill` writes through an atomic rename and keeps no version of its own; the commit underneath it does.

Two properties of that history shape the output, and both are load-bearing:

- **`install-meta.json` is excluded.** It carries a `lastUsedAt` stamp refreshed every time a skill is *loaded*, so a large share of a skill's commits touch nothing else. Including it would report a skill as "updated" on days nobody edited it, which is worse than showing no history at all. Revisions left empty by the exclusion are dropped, and `--max-count` over-fetches so the caller's limit applies *after* filtering rather than before.
- **History is bounded.** The workspace periodically squashes ("Compacted workspace history"), so the oldest available revision is not necessarily the skill's creation. `truncatedByCompaction` drives a caveat under the list, and the section is labelled recent changes rather than a complete record.

Commit subjects are deliberately not surfaced: they read `auto-commit: heartbeat safety net (164 files, changes older than 900s)`, which describes the batch rather than the skill.

## A revision is one update to the whole skill

The daemon diffs each commit against the skill's directory, so changes made together to `SKILL.md`, `scripts/`, and `references/` arrive as **one** entry with one combined diff, not three per-file entries. That matches what "what changed the last time this skill was updated" means. The commit itself usually touches many unrelated files, so the pathspec is what makes the diff legible.

## What the user sees

| | Before | After |
|---|---|---|
| Skill detail page | Header + file browser | Same, plus a Files / History tab strip |
| A skill the assistant edited in the background | No indication it ever changed | Dated list of updates, each expandable to a diff |
| Multi-file update | n/a | One entry, one combined diff, a header per file |
| Skill never edited | n/a | "No changes recorded yet" |
| Older assistant without the route | Header + file browser | Identical — no tab strip, no error |

## Why it's safe

- **Read-only end to end.** No write path, no mutation, no revert. `GET skills/:id/history` shells out to `git log` / `git show` through the existing `runReadOnlyGit`.
- **Fail-soft.** Git unavailable, workspace not a repository, or a skill with no tracked changes all resolve to an empty history rather than an error. History is an enrichment and must never be the reason a caller fails. An invalid id *does* throw, because it means unvalidated input reached a git pathspec — `validateManagedSkillId` runs before the id is ever interpolated.
- **No new registration surface.** The gateway has no daemon-route allowlist; its catch-all proxy rewrites `/v1/assistants/{id}/skills/{id}/history` to the daemon path, and the IPC fast path reads its policy from the daemon's own route schema at runtime. The policy (`settings.read`, `ACTOR_PRINCIPALS`) is identical to all six sibling skill reads.
- **No version gate, deliberately.** This is the documented "When a gate is unnecessary" case in `BACKWARDS_COMPAT.md`: a read whose 404 maps to exactly the feature-off value in its `queryFn` (so a rollback can't strand a stale success), with `refetchOnWindowFocus` disabled so a missing route produces one unretried 404 rather than a stream of them. `null` (assistant can't report history) and `[]` (no edits recorded) stay distinct.

## Route corrections included

- `limit` is now declared as a query parameter. The handler already read it, but the route definition didn't expose it, so it never reached the OpenAPI spec and the generated client typed the query as `never` — the service-layer clamping (`DEFAULT_SKILL_HISTORY_LIMIT` / `MAX_SKILL_HISTORY_LIMIT`) was unreachable from any typed client.
- Error mapping narrowed. Every throw was surfaced as a 400; now only a malformed id is, and anything else escaping the otherwise fail-soft read is an `InternalError`.

An id with no recorded revisions returns an empty list rather than a 404, unlike the sibling `files` routes. That is intentional and commented: revisions are a workspace-git concept, and a bundled or catalog skill legitimately has none, so "nothing recorded" is the honest answer for every id the workspace has never tracked.

## Tests

- `assistant/src/skills/skill-history.test.ts` — 9 tests against **real git repositories** in temp dirs, not a mocked git. The behaviour worth protecting is entirely about how git actually responds to a pathspec: that a commit touching many unrelated files still yields a scoped diff, that `:(exclude)` really drops the usage stamp, and that a commit whose only in-skill change was excluded disappears from the list. A stubbed git would let all three regress while the tests stayed green.
- `clients/web/src/domains/intelligence/skills/parse-unified-diff.test.ts` — 8 tests over the diff parser: file splitting, prefix stripping, per-side line numbering, metadata rejection, hunk separators, empty input.
- `skill-revision-history.stories.tsx` — 5 stories covering the multi-file revision, the compaction caveat, the empty state, and a multi-hunk diff.

## Deliberately out of scope

- **Revert.** History answers "what changed"; undoing a background edit is a write path with its own questions (whole directory or one file, what happens if the assistant edits it again), and belongs in its own change.
- **Per-revision provenance.** The detail header already links to the source conversation via the existing `SkillLineageLink`, which tracks the most recent update. Attributing *each* revision to a conversation would require the retrospective to record conversation → commit at write time, since the batching heartbeat's commit messages can't be mined for it.

- **Mobile.** `skill-detail-mobile.tsx` is a separate layout with its own chrome (a portaled full-screen overlay, a file `Menu`, and a Preview/Source `SegmentControl` rather than a tab strip), so the History tab is desktop-only for now. Adding it needs a call on whether History becomes a third segment or a different affordance, which is a design question rather than a port.
