### PR TITLE
fix(assistant): record one comparable end-of-turn latency on both paths

### DIFF
--- a/assistant/docs/flux-turn-detection-spike.md
+++ b/assistant/docs/flux-turn-detection-spike.md
@@ -8,7 +8,15 @@ Flux is a spike. `liveVoice.flux.turnEnd.enabled` defaults to `false`, the exist
 
 ## Read this before you read any number
 
-**The two paths do not measure the same span.** If you compare `endpointDecisionMaxLatencyMs` between a Flux run and a front-door run without correcting for it, you will get a number that flatters Flux by roughly a full second, and nothing in the output will tell you.
+**`endpointCommitLatencyMs` is the headline, and it is the only endpoint field that is like-for-like across the two arms.** It measures the local VAD speech-stop mark to the moment the turn committed. Take its median per arm and compare the two medians. There is no arithmetic to do and no source-specific semantics to remember.
+
+It is stamped in `releaseUtterance` (`live-voice-session.ts`), which every committed turn passes through whichever decider released it, from the same speech-stop anchor on both. So the two arms are one population measured over one span. It is absent only on a turn that never committed, and in push-to-talk, which this spike does not run.
+
+### Why the other endpoint fields are not the comparison
+
+`endpointDecisionMaxLatencyMs`, `endpointHoldCount`, and `endpointDecisionSource` all still exist and are all still worth reading. But `endpointDecisionMaxLatencyMs` is **not** comparable between arms, in two independent ways, and comparing it flatters Flux by roughly a full second with nothing in the output to tell you.
+
+**It spans different things.**
 
 | Path                                   | What `endpointDecisionMaxLatencyMs` actually spans                                                                                                                                                                                     |
 | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -17,32 +25,17 @@ Flux is a spike. `liveVoice.flux.turnEnd.enabled` defaults to `false`, the exist
 
 Source: `handleFluxTurnEnd` passes `this.msSinceLocalSpeechStop()` (`live-voice-session.ts`), while `holdSpeculativeTurn` passes `Date.now() - turn.speculativeDispatchedAtMs`, and the dispatch happens at the silence boundary.
 
-### The correction to apply
+**It samples different populations.** `markEndpointDecision` is called from exactly two places: the Flux commit, and the hold verdict. A front-door turn that committed straight through the boundary emits **no** `endpoint_decision` at all, and its metrics frame carries none of the three endpoint fields. So the front-door sample is "turns the model judged mid-thought", the slow tail by construction, while the Flux sample is every turn. Two denominators that cannot be reconciled after the fact is exactly why `endpointCommitLatencyMs` exists.
 
-Do this arithmetic on every front-door number before you put it next to a Flux number:
+Read `endpointDecisionMaxLatencyMs` as a **breakdown of** the headline, not against the other arm: on a Flux turn it isolates how much of the commit latency was Flux's own decision, and on a held front-door turn it isolates the decider LLM roundtrip.
 
-```
-front_door_end_of_turn_ms  >=  silenceThresholdMs
-                             + (endpointHoldCount * endpointExtensionMs)
-                             + endpointDecisionMaxLatencyMs
-```
+### What the front door actually costs
 
-- `silenceThresholdMs` is the trailing-silence wait the boundary cost. Its value is, in precedence order: the client's explicit "pause before reply" setting sent on the start frame, else `liveVoice.vad.silenceThresholdMs` (schema default **1200**, `config/schemas/live-voice.ts`), else the in-code `DEFAULT_SILENCE_THRESHOLD_MS` of **800** (`live-voice-session.ts`). In a real daemon run the factory always seeds the config value, so **1200 is the number to use** unless you set the web client's pause slider or overrode the config key. The 800 constant only governs a session built with no `liveVoice` config at all, which in practice means tests. A code comment near `createLiveVoiceSession` still claims the schema default is 800; the schema is the authority and it says 1200.
-- `endpointExtensionMs` defaults to **1500** and `endpointMaxExtensions` to **2**, so a fully held turn can absorb up to 3000ms of extension on top of everything else.
-- It is `>=`, not `=`, because `endpointDecisionMaxLatencyMs` is the **worst single** roundtrip in the turn, not their sum. A turn with two holds paid two roundtrips and the frame reports one of them.
+You do not need this to read the headline. You need it when a front-door number surprises you.
 
-Worked example with the defaults, one hold, and an 800ms decider roundtrip:
-
-```
-1200 + (1 * 1500) + 800  =  3500 ms
-```
-
-A Flux turn reporting `endpointDecisionMaxLatencyMs: 450` is being compared against 3500ms, not against 800ms.
-
-### Two more reasons the raw comparison misleads
-
-- **The front door only records a decision when it holds.** `markEndpointDecision` is called from exactly two places: the Flux commit, and the hold verdict. A front-door turn that committed straight through the boundary emits **no** `endpoint_decision` at all, and the metrics frame carries none of the three endpoint fields. So the population of front-door samples is "turns the model judged mid-thought", which is the slow tail by construction, while the Flux population is every turn. Do not read a mean across the two as if they were the same denominator.
-- **On a non-held front-door turn the roundtrip is not added latency.** The speculative leg dispatched at the boundary _is_ the assistant turn. If the model does not return the hold token, generation has already been running since the boundary. So an unheld front-door turn's added end-of-turn cost is just `silenceThresholdMs`. That is the real bar Flux has to beat on the common case, and it is a lower bar than the held-turn arithmetic above.
+- On an **unheld** turn the added end-of-turn cost is `silenceThresholdMs` alone. The speculative leg dispatched at the boundary _is_ the assistant turn, so if the model does not return the hold token, generation has been running since the boundary and the decider roundtrip is not added latency. That is the common case, and the real bar Flux has to beat.
+- On a **held** turn, add `endpointExtensionMs` (default **1500**) per hold, capped at `endpointMaxExtensions` (default **2**), so up to 3000ms on top.
+- `silenceThresholdMs` is the trailing-silence wait the boundary cost. Its value is, in precedence order: the client's explicit "pause before reply" setting sent on the start frame, else `liveVoice.vad.silenceThresholdMs` (schema default **1200**, `config/schemas/live-voice.ts`), else the in-code `DEFAULT_SILENCE_THRESHOLD_MS` of **800** (`live-voice-session.ts`). In a real daemon run the factory always seeds the config value, so **1200 is the number in force** unless you moved the web client's pause slider or overrode the config key. The 800 constant governs only a session built with no `liveVoice` config at all, which in practice means tests.
 
 ### The cross-check that needs no correction
 
@@ -52,7 +45,7 @@ The per-turn timestamps in the metrics snapshot are absolute and come from one c
 utteranceEndAtMs - speechStartAtMs
 ```
 
-Say the **same scripted sentence** on both arms, and the difference between the arms in that figure is the endpointing cost, with no arithmetic and no source-specific semantics. Use this to sanity-check whatever the corrected `endpointDecisionMaxLatencyMs` comparison tells you. If the two disagree, trust this one.
+Say the **same scripted sentence** on both arms, and the difference between the arms in that figure is the endpointing cost. It is an independent path to the same answer as `endpointCommitLatencyMs`: that field anchors at the speech-stop mark and this one at the VAD speech onset, so a run where the two disagree means the mic was picking up something the script did not say. Use it to sanity-check the headline.
 
 ---
 
@@ -89,12 +82,12 @@ Restart the daemon so the config is reloaded, then start a live-voice session **
 
 The rest of `liveVoice.flux` is optional and defaulted (`config/schemas/live-voice.ts`):
 
-| Key                 | Default           | Range        | Notes                                                                    |
-| ------------------- | ----------------- | ------------ | ------------------------------------------------------------------------ |
-| `model`             | `flux-general-en` | any string   | English only in this spike.                                              |
-| `eotThreshold`      | `0.7`             | 0.5 to 0.9   | Lower commits sooner and cuts speakers off more; higher adds latency.    |
-| `eagerEotThreshold` | _unset_           | 0.3 to 0.9   | Leave it unset. See "Known gaps".                                        |
-| `eotTimeoutMs`      | `5000`            | 500 to 60000 | Silence after which Flux force-ends a turn it never got confident about. |
+| Key                 | Default           | Range        | Notes                                                                                                                                   |
+| ------------------- | ----------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`             | `flux-general-en` | any string   | English only in this spike.                                                                                                             |
+| `eotThreshold`      | `0.7`             | 0.5 to 0.9   | Lower commits sooner and cuts speakers off more; higher adds latency.                                                                   |
+| `eagerEotThreshold` | _unset_           | 0.3 to 0.9   | Leave it unset. See "Known gaps".                                                                                                       |
+| `eotTimeoutMs`      | `5000`            | 500 to 60000 | Silence after which Flux force-ends a turn it never got confident about. Lower it to 1500 to 2000 for a measurement run; see section 4. |
 
 ## 3. Run the A/B
 
@@ -116,15 +109,16 @@ With Flux as the provider in both arms, the transcript **final** arrives at diff
 
 ## 4. Read the numbers
 
-The daemon sends a `metrics` frame over the live-voice WebSocket on `turn_completed`, `turn_cancelled`, and `session_ended`. The three endpoint fields are flattened onto that frame by `getLiveVoiceMetricsAggregateFields`:
+The daemon sends a `metrics` frame over the live-voice WebSocket on `turn_completed`, `turn_cancelled`, and `session_ended`. The endpoint fields are flattened onto that frame by `getLiveVoiceMetricsAggregateFields`:
 
-| Field                          | Meaning                                                                                          |
-| ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `endpointDecisionSource`       | `"flux"` or `"front-door"`. Present only when an endpoint decision was recorded.                 |
-| `endpointDecisionMaxLatencyMs` | The headline number, subject to the correction above. Worst single decision latency in the turn. |
-| `endpointHoldCount`            | Hold verdicts in the turn. Always 0 on a Flux-committed turn.                                    |
+| Field                          | Meaning                                                                                                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpointCommitLatencyMs`      | **The headline.** Local VAD speech-stop mark to the commit. Present on every committed turn on both arms. Compare medians across arms. |
+| `endpointDecisionSource`       | `"flux"` or `"front-door"`. Present only when an endpoint decision was recorded.                                                       |
+| `endpointDecisionMaxLatencyMs` | Worst single decision latency in the turn. A breakdown of the headline, never a cross-arm comparison. See the first section.           |
+| `endpointHoldCount`            | Hold verdicts in the turn. Always 0 on a Flux-committed turn.                                                                          |
 
-All three are **absent** unless a decision was recorded, which is deliberate: the absence is itself the signal.
+The last three are **absent** unless a decision was recorded, which is deliberate: the absence is itself the signal, and it is what makes them useless as a cross-arm comparison. `endpointCommitLatencyMs` is absent only on a turn that never committed.
 
 **How to see them.** The web client stores the whole frame but its `console.debug("[live-voice] turn latency", ...)` line does not print the endpoint fields. Read them from the raw frame instead: DevTools, Network, WS, select the live-voice socket, filter frames for `"type":"metrics"`, and read the `turn_completed` frames. The per-turn `metrics.recentTurns[]` array in the same frame carries the `timestamps` you need for the cross-check in the first section.
 
@@ -144,9 +138,25 @@ No Flux end-of-turn is coming; falling back to the silence boundary for this utt
 
 The deadline is `liveVoice.flux.eotTimeoutMs` plus a 1000ms margin (`FLUX_TURN_END_FALLBACK_MARGIN_MS`), measured from the local speech-stop mark. If you see these routinely, you are measuring the fallback path, not Flux.
 
+#### Lower `eotTimeoutMs` for the run
+
+With the shipped defaults the fail-open budget is `eotTimeoutMs` (**5000**) plus `FLUX_TURN_END_FALLBACK_MARGIN_MS` (**1000**), so **6000ms from the local speech-stop mark**. The local silence boundary fires at ~1200ms and then hands the turn to Flux, so a stalled turn is roughly **4.8 seconds of dead air** before the utterance replays onto the hold path and anyone answers.
+
+That is the worst case by design (the budget has to clear Flux's own force-end), but it is a bad property to carry through a measurement run. It makes a stall expensive to sit through, which biases you toward not reproducing one, and it means arm B's slow turns are dominated by a timeout rather than by turn detection.
+
+Set `liveVoice.flux.eotTimeoutMs` to **1500 to 2000** for the duration of the run. The budget drops to 2500 to 3000ms, a stall costs about 1.3 to 1.8 seconds past the silence boundary instead of 4.8, and arm B stays representative of what Flux does rather than of what the deadline does. Put it back before drawing any conclusion about the shipped configuration: it also changes how long Flux itself waits before force-ending a turn it never got confident about.
+
 ### Prefer medians, and do not chase a single bad sample
 
-Per-turn Flux latency has a known outlier mode. If the caller resumes speaking and stops again before a delayed `turn-end` lands, the second boundary re-stamps `fluxBoundaryGeneration`, so `isStaleFluxTurnEnd` no longer recognizes the in-flight event as stale and accepts it. The **commit is still correct** (the caller has finished, and the transcript is the accumulated one), but `msSinceLocalSpeechStop()` measures from the newer speech-stop, so the recorded latency is wrong for that turn.
+Per-turn Flux latency has a known outlier mode. If the caller resumes speaking and stops again before a delayed `turn-end` lands, the second boundary re-stamps `fluxBoundaryGeneration`, so `isStaleFluxTurnEnd` no longer recognizes the in-flight event as stale and accepts it. The **commit is still correct** (the caller has finished, and the transcript is the accumulated one), but the speech-stop mark is the newer one, so the recorded latency is wrong for that turn. This affects `endpointCommitLatencyMs` and `endpointDecisionMaxLatencyMs` alike: they share the anchor.
+
+The nearby case, where the event **is** recognized as stale and dropped, logs at `info` and so is visible at the default log level:
+
+```
+Dropping a stale Flux end-of-turn: the caller resumed speaking past the boundary it closed
+```
+
+A drop is not itself an error (the turn still commits, on the end-of-turn for the resumed speech or on the fail-open deadline), but the two cases are the same race and only one of them announces itself. Count the drops in your run: if they are frequent, assume the silent variant is skewing individual samples too.
 
 This is not fixable session-side. It needs Flux's turn id carried on the `turn-end` event so the session can match the event to the boundary it closed. Until then, report medians over a run of turns and ignore individual extremes.
 
@@ -164,12 +174,7 @@ Check the URL is `/v2/listen` and contains `model=flux-general-en`, `eot_thresho
 
 ### Seeing the debug lines
 
-The pino level is hardcoded to `info` in `src/util/logger.ts`. Two useful lines are at `debug` and will **not** appear in a normal run:
-
-- The per-session chunk cadence line (below).
-- `Dropping a stale Flux end-of-turn: the caller resumed speaking past the boundary it closed`.
-
-To see them, temporarily change the `level: "info"` values in `getRootLogger` / `buildRotatingLogger` to `"debug"`. There is no config key or env var for it.
+The pino level is hardcoded to `info` in `src/util/logger.ts`, with no config key and no env var. Every diagnostic this runbook tells you to read is at `info` or `warn` and needs no change. The per-session chunk cadence line (section 6) is the one at `debug`; to see it, temporarily change the `level: "info"` values in `getRootLogger` / `buildRotatingLogger` to `"debug"`.
 
 ## 6. Chunk cadence
 
@@ -199,7 +204,7 @@ Do not rediscover these.
 Both are fixed on this branch. They matter only if you are measuring on an older build.
 
 - **A first utterance during a slow STT dial used to run the old path while looking like a Flux session.** `start()` sends `ready` without waiting on the transcriber resolve, so the caller could speak and close a whole silence boundary while the handshake was still in flight, with the latch still on its default `false`. The latch is now seeded from the **configured** provider before the dial and reconciled against the resolved one afterwards. Symptom on an older build: the session's opening turn silently uses the front door.
-- **The first turn's latency used to be anchored at zero rather than the real speech-stop,** inflating it. `msSinceLocalSpeechStop()` now returns 0 when no speech has been heard, and `fluxLastSpeechAtMs` is stamped on every above-gate chunk.
+- **The first turn's latency used to be anchored at zero rather than the real speech-stop,** inflating it. `msSinceLocalSpeechStop()` returns 0 when no speech has been heard, and `localSpeechStopAtMs` is stamped on every above-gate chunk in every server-VAD session, so both arms share the anchor.
 
 ## 8. Falling back
 
@@ -211,9 +216,9 @@ Runtime fallback needs no action. A Flux stream that never emits `turn-end` is c
 
 The follow-up cleanup is not small: `HOLD_VERDICT_TOKEN`, the `includeHold` branch of `frontDoorDecisionRule`, the `holdEnabled` parameter on `classifyFrontDoorLeading`, six pieces of speculative-dispatch state in the session, and the `endpointExtensionMs` / `endpointMaxExtensions` config surface. It is worth doing only if Flux clears a real bar. Deepgram claims Flux decides in under 400ms; that claim is the hypothesis under test here, not an input.
 
-Suggested bar, all measured on the corrected basis from the first section, over enough turns for a median to mean something:
+Suggested bar, all measured on `endpointCommitLatencyMs` over enough turns for a median to mean something:
 
-1. **Median end-of-turn latency beats the unheld front-door case.** That is `silenceThresholdMs` alone, so about 1200ms with the defaults. Beating the held case is easy and proves nothing, because most turns are not held.
+1. **Median `endpointCommitLatencyMs` in arm B beats the median in arm A.** Most arm-A turns are unheld, so that median sits near `silenceThresholdMs`, about 1200ms with the defaults. Do not set the bar against arm A's held turns: beating those is easy and proves nothing, because most turns are not held.
 2. **No regression on thinking pauses.** The hold path exists so a mid-sentence pause does not trigger a premature reply. Count premature commits on the scripted pause utterances in both arms. Flux has to be at least as good, not merely faster. A fast path that interrupts people is worse than the slow one.
 3. **The fallback is rare.** If `warn`-level fallback lines appear on a meaningful fraction of turns, the hold path is not dead code, it is the live path, and deleting it removes the thing keeping the feature usable.
 4. **Escalate and the spoken ack / progress phrasing still behave.** Flux bypasses only the `[0]` hold branch. Confirm `[1]` escalate still fires and acks still land before concluding the front door has nothing left to do.

--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -241,6 +241,26 @@ function countFrames(
   return frames.filter((frame) => frame.type === type).length;
 }
 
+// Waits for the completed turn's metrics frame and hands it back narrowed, so
+// the assertions below read the endpoint fields without a type guard.
+async function waitForTurnMetrics(
+  frames: LiveVoiceServerFrame[],
+): Promise<Extract<LiveVoiceServerFrame, { type: "metrics" }>> {
+  const isTurnMetrics = (
+    frame: LiveVoiceServerFrame,
+  ): frame is Extract<LiveVoiceServerFrame, { type: "metrics" }> =>
+    frame.type === "metrics" && frame.event === "turn_completed";
+  await waitFor(
+    () => frames.some(isTurnMetrics),
+    "The completed turn never reported its metrics",
+  );
+  const metricsFrame = frames.find(isTurnMetrics);
+  if (!metricsFrame) {
+    throw new Error("The completed turn never reported its metrics");
+  }
+  return metricsFrame;
+}
+
 // Long enough for the 40 ms local silence timer to fire and hand the boundary
 // to Flux (which arms the fail-open deadline and commits nothing).
 const PAST_SILENCE_BOUNDARY_MS = 150;
@@ -355,22 +375,86 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
     await waitFor(() => transcribers.length > 0);
     transcribers[0]?.endOfTurn("hello there");
     await waitFor(() => turnCalls.length === 1);
-    await waitFor(() =>
-      frames.some(
-        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
-      ),
-    );
 
-    const metricsFrame = frames.find(
-      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
-    );
-    expect(metricsFrame).toBeDefined();
-    if (metricsFrame?.type === "metrics") {
-      expect(metricsFrame.endpointDecisionSource).toBe("flux");
-      expect(metricsFrame.endpointHoldCount).toBe(0);
-    }
+    const metricsFrame = await waitForTurnMetrics(frames);
+    expect(metricsFrame.endpointDecisionSource).toBe("flux");
+    expect(metricsFrame.endpointHoldCount).toBe(0);
 
     await session.close("client_end");
+  });
+
+  test("anchors the flux commit latency at the local speech-stop mark", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: { turnEnd: { enabled: true }, eotTimeoutMs: 30_000 },
+      // Long enough that the local silence boundary cannot be what commits,
+      // and that the fail-open deadline stays far away.
+      silenceThresholdMs: 10_000,
+      emitMetrics: true,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    // Silence between the caller's last above-gate chunk and the commit. A
+    // dispatch-anchored number would not see it; the speech-stop anchor must.
+    await sleep(250);
+    transcribers[0]?.endOfTurn("hello there");
+    await waitFor(() => turnCalls.length === 1);
+
+    const metricsFrame = await waitForTurnMetrics(frames);
+    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(250);
+
+    await session.close("client_end");
+  });
+
+  test("records the commit latency on the front-door path too, with no hold", async () => {
+    const { frames, session, transcribers, turnCalls } = createHarness({
+      // No flux config: the latch is down and the local silence boundary owns
+      // the commit, which is arm A of the measurement run.
+      silenceThresholdMs: 40,
+      emitMetrics: true,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.emit({ type: "partial", text: "hello there" });
+    await waitFor(() => turnCalls.length === 1);
+
+    // The turn committed straight through, so it records no endpoint decision
+    // at all. The commit latency is recorded regardless, which is what makes
+    // the two arms one population rather than two.
+    const metricsFrame = await waitForTurnMetrics(frames);
+    expect(metricsFrame.endpointDecisionSource).toBeUndefined();
+    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(40);
+
+    await session.close("client_end");
+  });
+
+  test("records no commit latency for a turn that never committed", async () => {
+    const { frames, session, transcribers } = createHarness({
+      fluxConfig: { turnEnd: { enabled: true }, eotTimeoutMs: 30_000 },
+      silenceThresholdMs: 10_000,
+      emitMetrics: true,
+      startVoiceTurn: autoCompletingTurn(),
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => transcribers.length > 0);
+    transcribers[0]?.emit({ type: "partial", text: "hello the" });
+    // Nothing ends this turn: no flux turn-end, no silence boundary, and the
+    // fail-open deadline is 30 s away.
+    await flushAsyncCallbacks();
+    await session.close("client_end");
+
+    const metricsFrames = frames.filter((frame) => frame.type === "metrics");
+    expect(metricsFrames.length).toBeGreaterThan(0);
+    for (const frame of metricsFrames) {
+      expect(frame).not.toHaveProperty("endpointCommitLatencyMs");
+    }
   });
 
   test("falls back to the silence-boundary path when no turn-end arrives", async () => {
@@ -521,21 +605,8 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
     expect(turnCalls[0]?.unifiedVerdict).toBeUndefined();
     expect(frames.some((frame) => frame.type === "utterance_end")).toBe(true);
 
-    await waitFor(
-      () =>
-        frames.some(
-          (frame) =>
-            frame.type === "metrics" && frame.event === "turn_completed",
-        ),
-      "The completed turn never reported its metrics",
-    );
-    const metricsFrame = frames.find(
-      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
-    );
-    expect(metricsFrame).toBeDefined();
-    if (metricsFrame?.type === "metrics") {
-      expect(metricsFrame.endpointDecisionSource).toBe("flux");
-    }
+    const metricsFrame = await waitForTurnMetrics(frames);
+    expect(metricsFrame.endpointDecisionSource).toBe("flux");
 
     await session.close("client_end");
   });

--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -437,6 +437,7 @@ describe("LiveVoiceMetricsCollector", () => {
     collector.markFirstAudio();
     const completed = collector.completeTurn();
 
+    expect(completed).not.toHaveProperty("endpointCommitLatencyMs");
     expect(completed).not.toHaveProperty("endpointHoldCount");
     expect(completed).not.toHaveProperty("endpointDecisionMaxLatencyMs");
     expect(completed).not.toHaveProperty("endpointDecisionSource");
@@ -447,11 +448,57 @@ describe("LiveVoiceMetricsCollector", () => {
       collector.getSnapshot(),
       "turn-off",
     );
+    expect(aggregateFields).not.toHaveProperty("endpointCommitLatencyMs");
     expect(aggregateFields).not.toHaveProperty("endpointHoldCount");
     expect(aggregateFields).not.toHaveProperty("endpointDecisionMaxLatencyMs");
     expect(aggregateFields).not.toHaveProperty("endpointDecisionSource");
     expect(aggregateFields).not.toHaveProperty("ackSpoken");
     expect(aggregateFields).not.toHaveProperty("progressUpdatesSpoken");
+  });
+
+  test("markEndpointCommit records the commit latency independently of the decision fields", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-commit",
+      conversationId: "conversation-commit",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-commit");
+    collector.markEndpointCommit("turn-commit", 1_340);
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({ endpointCommitLatencyMs: 1_340 });
+    // No decision was ever recorded, so the diagnostic trio stays absent: the
+    // comparable number does not depend on the decider having been consulted.
+    expect(completed).not.toHaveProperty("endpointDecisionMaxLatencyMs");
+    expect(
+      getLiveVoiceMetricsAggregateFields(
+        collector.getSnapshot(),
+        "turn-commit",
+      ),
+    ).toMatchObject({ endpointCommitLatencyMs: 1_340 });
+  });
+
+  test("the first commit latency wins and a non-finite one records zero", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-commit-first",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-first");
+    collector.markEndpointCommit("turn-first", 900);
+    collector.markEndpointCommit("turn-first", 4_000);
+    expect(collector.completeTurn()).toMatchObject({
+      endpointCommitLatencyMs: 900,
+    });
+
+    collector.startTurn("turn-nan");
+    collector.markEndpointCommit("turn-nan", Number.NaN);
+    expect(collector.completeTurn()).toMatchObject({
+      endpointCommitLatencyMs: 0,
+    });
   });
 
   test("markBargeIn records a first-wins timestamp on the active turn", () => {

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -15,6 +15,7 @@ export type LiveVoiceMetricsEvent =
   | "ptt_release"
   | "utterance_end"
   | "endpoint_decision"
+  | "endpoint_commit"
   | "barge_in"
   | "final_transcript"
   | "first_assistant_delta"
@@ -124,6 +125,11 @@ interface LiveVoiceTurnMetrics {
   cancellationReason: string | null;
   timestamps: LiveVoiceTurnTimestamps;
   durations: LiveVoiceTurnDurations;
+  // End of turn measured from the local VAD speech-stop mark to the commit,
+  // recorded on every committed turn whichever decider owned the boundary.
+  // Absent on a turn that never committed, and in push-to-talk mode, where
+  // there is no local speech-stop mark to anchor to.
+  endpointCommitLatencyMs?: number;
   // Present only when the semantic-endpointing decider was consulted for the
   // turn / when an ack actually spoke / when a progress narration spoke, so
   // turns that never touch the features carry no trace of them.
@@ -173,8 +179,10 @@ interface LiveVoiceMetricsAggregateFields {
   ttsFirstAudioMs: number | null;
   roundTripMs: number | null;
   totalMs: number | null;
-  // Optional so metrics frames stay byte-identical when the front-model
-  // features never engaged (see the matching fields on LiveVoiceTurnMetrics).
+  // Optional so metrics frames stay byte-identical when the turn never
+  // committed and when the front-model features never engaged (see the
+  // matching fields on LiveVoiceTurnMetrics).
+  endpointCommitLatencyMs?: number;
   endpointHoldCount?: number;
   endpointDecisionMaxLatencyMs?: number;
   endpointDecisionSource?: VoiceEndpointSource;
@@ -196,6 +204,8 @@ interface MutableTurn {
   status: LiveVoiceTurnStatus;
   cancellationReason: string | null;
   timestamps: LiveVoiceTurnTimestamps;
+  // Null means the turn never committed (see LiveVoiceTurnMetrics).
+  endpointCommitLatencyMs: number | null;
   endpointHoldCount: number;
   // Doubles as the "decider was consulted" latch: null means no endpoint
   // decision was ever recorded for the turn.
@@ -266,6 +276,7 @@ export class LiveVoiceMetricsCollector {
         completedAtMs: null,
         cancelledAtMs: null,
       },
+      endpointCommitLatencyMs: null,
       endpointHoldCount: 0,
       endpointDecisionMaxLatencyMs: null,
       endpointDecisionSource: null,
@@ -352,15 +363,24 @@ export class LiveVoiceMetricsCollector {
     if (decision.action === "hold") {
       turn.endpointHoldCount += 1;
     }
-    const latencyMs = Number.isFinite(decision.latencyMs)
-      ? Math.max(0, decision.latencyMs)
-      : 0;
     turn.endpointDecisionMaxLatencyMs = Math.max(
       turn.endpointDecisionMaxLatencyMs ?? 0,
-      latencyMs,
+      normalizeLatencyMs(decision.latencyMs),
     );
     turn.endpointDecisionSource = decision.source ?? DEFAULT_ENDPOINT_SOURCE;
     return this.emit("endpoint_decision", turn.turnId);
+  }
+
+  // First-wins, since an utterance commits once.
+  markEndpointCommit(
+    turnId: string | undefined,
+    latencyMs: number,
+  ): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.endpointCommitLatencyMs === null) {
+      turn.endpointCommitLatencyMs = normalizeLatencyMs(latencyMs);
+    }
+    return this.emit("endpoint_commit", turn.turnId);
   }
 
   markAckSpoken(
@@ -587,17 +607,19 @@ function aggregateFieldsForTurn(
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
     roundTripMs: turn.durations.roundTripMs,
     totalMs: turn.durations.totalTurnDurationMs,
-    ...frontModelFields(turn),
+    ...optionalTurnFields(turn),
   };
 }
 
-// Shared optional front-model fields for turn snapshots and aggregate
-// frame fields: absent unless the endpoint decider was consulted / an ack
-// spoke / a progress narration spoke, so turns that never touch the
-// features are unchanged.
-function frontModelFields(
+// Shared optional fields for turn snapshots and aggregate frame fields: the
+// commit latency is absent unless the turn committed against a local
+// speech-stop mark, and the front-model fields are absent unless the endpoint
+// decider was consulted / an ack spoke / a progress narration spoke, so turns
+// that never touch the features are unchanged.
+function optionalTurnFields(
   // Accepts both MutableTurn (null = unset) and snapshot (absent = unset).
   turn: {
+    endpointCommitLatencyMs?: number | null;
     endpointHoldCount?: number | null;
     endpointDecisionMaxLatencyMs?: number | null;
     endpointDecisionSource?: VoiceEndpointSource | null;
@@ -606,6 +628,7 @@ function frontModelFields(
   },
 ): Pick<
   LiveVoiceTurnMetrics,
+  | "endpointCommitLatencyMs"
   | "endpointHoldCount"
   | "endpointDecisionMaxLatencyMs"
   | "endpointDecisionSource"
@@ -614,6 +637,9 @@ function frontModelFields(
 > {
   const progressUpdatesSpoken = turn.progressUpdatesSpoken ?? 0;
   return {
+    ...(turn.endpointCommitLatencyMs != null
+      ? { endpointCommitLatencyMs: turn.endpointCommitLatencyMs }
+      : {}),
     ...(turn.endpointDecisionMaxLatencyMs != null
       ? {
           endpointHoldCount: turn.endpointHoldCount ?? 0,
@@ -666,6 +692,7 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     status: turn.status,
     cancellationReason: turn.cancellationReason,
     timestamps: { ...turn.timestamps },
+    endpointCommitLatencyMs: turn.endpointCommitLatencyMs,
     endpointHoldCount: turn.endpointHoldCount,
     endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
     endpointDecisionSource: turn.endpointDecisionSource,
@@ -681,7 +708,7 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
     status: turn.status,
     cancellationReason: turn.cancellationReason,
     timestamps,
-    ...frontModelFields(turn),
+    ...optionalTurnFields(turn),
     durations: {
       firstAudioToFirstPartialMs: duration(
         timestamps.firstAudioAtMs,
@@ -782,6 +809,10 @@ function percentile(
   }
   const index = Math.ceil(sortedValues.length * percentileValue) - 1;
   return sortedValues[Math.min(Math.max(index, 0), sortedValues.length - 1)];
+}
+
+function normalizeLatencyMs(latencyMs: number): number {
+  return Number.isFinite(latencyMs) ? Math.max(0, latencyMs) : 0;
 }
 
 function duration(startMs: number | null, endMs: number | null): number | null {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1157,10 +1157,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * the picture.
    */
   private fluxTurnEndActive = false;
-  // Wall-clock of the newest above-gate audio chunk, tracked only while the
-  // latch is active. It is the local VAD's speech-stop mark: the anchor for
-  // the end-of-turn latency this path reports, and for the fallback deadline.
-  private fluxLastSpeechAtMs: number | null = null;
+  // Wall-clock of the newest above-gate audio chunk, tracked in every
+  // server-VAD session. It is the local VAD's speech-stop mark: the one anchor
+  // the reported end-of-turn latency is measured from whichever decider
+  // commits the turn, and the anchor for the Flux fallback deadline. Null in
+  // push-to-talk, where no local VAD runs.
+  private localSpeechStopAtMs: number | null = null;
   // Fail-open deadline for a Flux end-of-turn that never arrives. On expiry
   // the utterance falls back to the silence-boundary path, so a dead Flux
   // stream degrades to today's behavior instead of a hung turn.
@@ -1706,8 +1708,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
-    if (this.fluxTurnEndActive && hasSpeech) {
-      this.fluxLastSpeechAtMs = Date.now();
+    if (hasSpeech) {
+      this.localSpeechStopAtMs = Date.now();
     }
 
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
@@ -3007,10 +3009,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // mark both the fallback deadline and the reported end-of-turn latency are
   // measured from. Zero when no speech has been heard at all.
   private msSinceLocalSpeechStop(): number {
-    if (this.fluxLastSpeechAtMs === null) {
+    if (this.localSpeechStopAtMs === null) {
       return 0;
     }
-    return Math.max(0, Date.now() - this.fluxLastSpeechAtMs);
+    return Math.max(0, Date.now() - this.localSpeechStopAtMs);
   }
 
   /**
@@ -3039,7 +3041,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     if (this.isStaleFluxTurnEnd(utterance, turnIndex)) {
-      log.debug(
+      // At `info`, not `debug`: a drop is rare and is the only signal of the
+      // one known latency-outlier mode, so an operator measuring the two
+      // paths has to be able to see it at the default log level.
+      log.info(
         {
           turnIndex,
           openTurnIndex: utterance.fluxOpenTurnIndex,
@@ -3305,6 +3310,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (utterance.phase === "transcriber_closed") {
       utterance.released = true;
       this.markUtteranceReleased(utterance);
+      this.markEndpointCommit(utterance);
       await this.startAssistantTurnIfReady();
       await this.drainOutboundFrames();
       return;
@@ -3316,6 +3322,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     utterance.released = true;
     this.markUtteranceReleased(utterance);
+    this.markEndpointCommit(utterance);
 
     if (utterance.phase === "pending") {
       // The transcriber is still starting; beginUtterance completes the release.
@@ -5618,6 +5625,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
   }
 
+  /**
+   * The turn's end-of-turn latency, stamped at the moment it commits. Called
+   * from `releaseUtterance`, which every committed turn passes through
+   * whichever decider released it, so the front-door and Flux samples span
+   * the same thing from the same anchor over the same population. That is
+   * what `endpointDecisionMaxLatencyMs` cannot offer, and why this exists
+   * alongside it.
+   *
+   * Skipped with no speech-stop mark, which is push-to-talk: there the
+   * client's release is the boundary and no local VAD runs.
+   */
+  private markEndpointCommit(utterance: UtteranceCycle): void {
+    if (this.localSpeechStopAtMs === null) {
+      return;
+    }
+    const turnId = this.ensureTurnId(utterance);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      return;
+    }
+    this.metrics.markEndpointCommit(turnId, this.msSinceLocalSpeechStop());
+  }
+
   private markAckSpoken(
     activeTurn: ActiveAssistantTurn,
     kind: LiveVoiceSpokenAckKind,
@@ -5982,11 +6011,13 @@ export function createLiveVoiceSession(
   options: LiveVoiceSessionOptions = {},
 ): LiveVoiceSession {
   // Workspace-tunable server-VAD thresholds. The `liveVoice.vad` schema
-  // defaults match the code defaults (800 energy / 800 ms silence / 30 s max
-  // turn / 60 ms barge-in guard), so an unset config leaves behavior
-  // unchanged. Optional-chained
-  // because hand-built test configs may predate the liveVoice namespace;
-  // absent config falls through to the in-code defaults.
+  // defaults are 800 energy / 1200 ms silence / 30 s max turn / 250 ms
+  // barge-in guard. Three of the four match their in-code fallback; the
+  // trailing-silence threshold does not, so a session built with a
+  // `liveVoice` config waits 1200 ms and one built without waits the in-code
+  // DEFAULT_SILENCE_THRESHOLD_MS of 800. Optional-chained because hand-built
+  // test configs may predate the liveVoice namespace; absent config falls
+  // through to the in-code defaults.
   const liveVoiceConfig = getConfig().liveVoice;
   const vadConfig = liveVoiceConfig?.vad;
   // Parsed once here into a complete config, shared by the decider and the

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -319,12 +319,26 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly roundTripMs: number | null;
   readonly totalMs: number | null;
   /**
+   * End-of-turn latency: the local VAD speech-stop mark to the moment the
+   * turn committed. Recorded on every committed turn, and measured from the
+   * same anchor whichever decider owned the boundary, so front-door and Flux
+   * turns are one comparable population. Absent on a turn that never
+   * committed and in push-to-talk mode, where there is no local VAD
+   * speech-stop mark.
+   */
+  readonly endpointCommitLatencyMs?: number;
+  /**
    * Semantic-endpointing "hold" decisions taken during the turn. Present only
    * when the endpoint decider was consulted (otherwise the field is absent,
    * keeping frames unchanged).
    */
   readonly endpointHoldCount?: number;
-  /** Worst endpoint-decision latency observed during the turn. */
+  /**
+   * Worst endpoint-decision latency observed during the turn. It spans only
+   * the decider's own work, and the two deciders start it at different
+   * moments, so it is a diagnostic rather than a cross-path comparison: read
+   * `endpointCommitLatencyMs` for that.
+   */
   readonly endpointDecisionMaxLatencyMs?: number;
   /**
    * Which path decided the turn's endpoint: the front-door hold verdict or

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -291,12 +291,26 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly roundTripMs?: number | null;
   readonly totalMs: number | null;
   /**
+   * End-of-turn latency: the local VAD speech-stop mark to the moment the
+   * turn committed. Recorded on every committed turn, and measured from the
+   * same anchor whichever decider owned the boundary, so front-door and Flux
+   * turns are one comparable population. Absent on a turn that never
+   * committed and in push-to-talk mode, where there is no local VAD
+   * speech-stop mark.
+   */
+  readonly endpointCommitLatencyMs?: number;
+  /**
    * Semantic-endpointing "hold" decisions taken during the turn. Present only
    * when the endpoint decider was consulted (with the
    * feature off the field is absent, keeping frames unchanged).
    */
   readonly endpointHoldCount?: number;
-  /** Worst endpoint-decision latency observed during the turn. */
+  /**
+   * Worst endpoint-decision latency observed during the turn. It spans only
+   * the decider's own work, and the two deciders start it at different
+   * moments, so it is a diagnostic rather than a cross-path comparison: read
+   * `endpointCommitLatencyMs` for that.
+   */
   readonly endpointDecisionMaxLatencyMs?: number;
   /**
    * Which path decided the turn's endpoint: the front-door hold verdict or


### PR DESCRIPTION
## Summary

- Add `endpointCommitLatencyMs`: the local VAD speech-stop mark to the moment the turn commits, stamped in `releaseUtterance`, which every committed turn passes through on both the front-door and Flux paths. Same span, same anchor, same population, so the A/B is a single-field median comparison.
- Track the local speech-stop mark in every server-VAD session instead of only while the Flux latch is up (`fluxLastSpeechAtMs` becomes `localSpeechStopAtMs`), so both arms measure from the same anchor.
- Surface the field on `LiveVoiceMetricsServerFrame` in both the daemon protocol and the web mirror, kept in sync.
- `endpointDecisionMaxLatencyMs`, `endpointHoldCount`, and `endpointDecisionSource` are unchanged and keep working; their docs now say they are a per-turn breakdown, not a cross-arm comparison.
- Promote the stale Flux turn-end drop line from `debug` to `info`. It fires rarely and is the only diagnostic for the known latency-outlier mode, and the pino level is hardcoded to `info` with no config key.
- Fix the `createLiveVoiceSession` comment: the `liveVoice.vad` schema defaults are 1200 ms silence and a 250 ms barge-in guard, and the silence threshold is the one value that does not match its in-code fallback of 800.
- Rewrite the runbook around the new headline: drop the arithmetic-correction instructions, keep the explanation of why the old fields differ, state the fail-open worst case (`eotTimeoutMs` 5000 plus `FLUX_TURN_END_FALLBACK_MARGIN_MS` 1000 = 6000 ms from the speech-stop mark, so roughly 4.8 s of dead air past the ~1200 ms silence boundary), and recommend lowering `eotTimeoutMs` to 1500 to 2000 for a measurement run.

Behavior with `liveVoice.flux.turnEnd.enabled: false` is unchanged. The hold machinery, the local-VAD barge-in trigger, the echo-adaptive gate, `forceEnd()` after a Flux commit, and the `isStaleFluxTurnEnd` turn-index logic are all untouched.

## Testing

- New: both paths emit `endpointCommitLatencyMs`; the Flux number includes a 250 ms silence a dispatch-anchored number would miss; a front-door turn that never held records it with no endpoint decision at all; a turn that never commits records nothing; collector-level first-wins and non-finite handling.
- Full `live-voice` suite run file by file, plus the web protocol test. Assistant and web typecheck clean.

Fixes gaps found during plan review for flux-turn-detection.md.