### PR TITLE
fix(voice): skip workspace Git init for tool-less turns (JARVIS-1463)

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1191,14 +1191,17 @@ describe("session-agent-loop", () => {
 
     test("skips workspace Git initialization when tools are disabled", async () => {
       const ensureInitialized = mock(async () => {});
+      const commitTurnChanges = mock(async () => {});
       const ctx = makeCtx({
         toolsDisabledDepth: 1,
         getWorkspaceGitService: () => ({ ensureInitialized }),
+        commitTurnChanges,
       });
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
 
       expect(ensureInitialized).not.toHaveBeenCalled();
+      expect(commitTurnChanges).not.toHaveBeenCalled();
     });
 
     test("initializes workspace Git before hooks when tools can run", async () => {
@@ -1206,6 +1209,7 @@ describe("session-agent-loop", () => {
       const ensureInitialized = mock(async () => {
         initialized = true;
       });
+      const commitTurnChanges = mock(async () => {});
       const initializedDuringHook: boolean[] = [];
       registerPlugin({
         manifest: {
@@ -1220,11 +1224,13 @@ describe("session-agent-loop", () => {
       });
       const ctx = makeCtx({
         getWorkspaceGitService: () => ({ ensureInitialized }),
+        commitTurnChanges,
       });
 
       await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
 
       expect(ensureInitialized).toHaveBeenCalledTimes(1);
+      expect(commitTurnChanges).toHaveBeenCalledTimes(1);
       expect(initializedDuringHook).toEqual([true]);
     });
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -782,6 +782,7 @@ function makeCtx(
     channelCapabilities: undefined,
     commandIntent: undefined,
     trustContext: undefined,
+    toolsDisabledDepth: 0,
 
     allowedToolNames: undefined,
     preactivatedSkillIds: undefined,
@@ -1186,6 +1187,67 @@ describe("session-agent-loop", () => {
       await expect(
         runAgentLoopImpl(ctx, "hello", "msg-1", () => {}),
       ).rejects.toThrow("runAgentLoop called without prior persistUserMessage");
+    });
+
+    test("skips workspace Git initialization when tools are disabled", async () => {
+      const ensureInitialized = mock(async () => {});
+      const ctx = makeCtx({
+        toolsDisabledDepth: 1,
+        getWorkspaceGitService: () => ({ ensureInitialized }),
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(ensureInitialized).not.toHaveBeenCalled();
+    });
+
+    test("initializes workspace Git before hooks when tools can run", async () => {
+      let initialized = false;
+      const ensureInitialized = mock(async () => {
+        initialized = true;
+      });
+      const initializedDuringHook: boolean[] = [];
+      registerPlugin({
+        manifest: {
+          name: "test-workspace-git-ready-before-hook",
+          version: "1.0.0",
+        },
+        hooks: {
+          "user-prompt-submit": async () => {
+            initializedDuringHook.push(initialized);
+          },
+        },
+      });
+      const ctx = makeCtx({
+        getWorkspaceGitService: () => ({ ensureInitialized }),
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(ensureInitialized).toHaveBeenCalledTimes(1);
+      expect(initializedDuringHook).toEqual([true]);
+    });
+
+    test("continues a tool-capable turn when workspace Git initialization fails", async () => {
+      const ensureInitialized = mock(async () => {
+        throw new Error("simulated Git initialization failure");
+      });
+      const events: AssistantEvent[] = [];
+      const ctx = makeCtx({
+        getWorkspaceGitService: () => ({ ensureInitialized }),
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (event) =>
+        events.push(event),
+      );
+
+      expect(ensureInitialized).toHaveBeenCalledTimes(1);
+      expect(events.some((event) => event.type === "message_complete")).toBe(
+        true,
+      );
+      expect(events.some((event) => event.type === "conversation_error")).toBe(
+        false,
+      );
     });
   });
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1189,7 +1189,7 @@ describe("session-agent-loop", () => {
       ).rejects.toThrow("runAgentLoop called without prior persistUserMessage");
     });
 
-    test("skips workspace Git initialization when tools are disabled", async () => {
+    test("defers workspace Git work when tools are disabled", async () => {
       const ensureInitialized = mock(async () => {});
       const commitTurnChanges = mock(async () => {});
       const ctx = makeCtx({
@@ -1202,6 +1202,25 @@ describe("session-agent-loop", () => {
 
       expect(ensureInitialized).not.toHaveBeenCalled();
       expect(commitTurnChanges).not.toHaveBeenCalled();
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(commitTurnChanges).toHaveBeenCalledTimes(1);
+    });
+
+    test("leaves a deferred commit to an immediate follow-up turn", async () => {
+      const commitTurnChanges = mock(async () => {});
+      const ctx = makeCtx({
+        toolsDisabledDepth: 1,
+        commitTurnChanges,
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+      ctx.setProcessing(true);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(commitTurnChanges).not.toHaveBeenCalled();
+      ctx.setProcessing(false);
     });
 
     test("initializes workspace Git before hooks when tools can run", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1705,7 +1705,7 @@ export async function runAgentLoopImpl(
 
     if (turnStarted) {
       ctx.turnCount++;
-      if (!toolsDisabledForTurn) {
+      const runTurnCommit = async (): Promise<void> => {
         const config = getConfig();
         const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
         const deadlineMs = Date.now() + maxWait;
@@ -1729,6 +1729,21 @@ export async function runAgentLoopImpl(
             "Turn-boundary commit timed out; continuing without waiting (commit still runs in background)",
           );
         }
+      };
+
+      if (toolsDisabledForTurn) {
+        // Let the caller and queue drain claim an immediate follow-up turn
+        // before starting Git. That turn will commit the accumulated disk view.
+        setImmediate(() => {
+          if (ctx.isProcessing()) {
+            return;
+          }
+          void runTurnCommit().catch((err) => {
+            rlog.warn({ err }, "Deferred turn-boundary commit failed");
+          });
+        });
+      } else {
+        await runTurnCommit();
       }
 
       // Recompute relationship-state.json at turn boundary (fire-and-forget).

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -722,14 +722,20 @@ export async function runAgentLoopImpl(
       return;
     }
 
-    // Ensure workspace git repo is initialized before any tools run.
-    try {
-      const getWorkspaceGitServiceFn =
-        ctx.getWorkspaceGitService ?? getWorkspaceGitService;
-      const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
-      await gitService.ensureInitialized();
-    } catch (err) {
-      rlog.warn({ err }, "Failed to initialize workspace git repo (non-fatal)");
+    // Workspace Git readiness is required only when tools can run. Tool-less
+    // callers use the same depth gate consumed by tool resolution.
+    if (!(ctx.toolsDisabledDepth > 0)) {
+      try {
+        const getWorkspaceGitServiceFn =
+          ctx.getWorkspaceGitService ?? getWorkspaceGitService;
+        const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
+        await gitService.ensureInitialized();
+      } catch (err) {
+        rlog.warn(
+          { err },
+          "Failed to initialize workspace git repo (non-fatal)",
+        );
+      }
     }
 
     // Auto-complete stale interactive surfaces from previous turns.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -642,6 +642,7 @@ export async function runAgentLoopImpl(
   );
   ctx.diskPressureCleanupModeActive =
     diskPressureDecision.action === "allow-cleanup-mode";
+  const toolsDisabledForTurn = ctx.toolsDisabledDepth > 0;
 
   ctx.lastAssistantAttachments = [];
   ctx.lastAttachmentWarnings = [];
@@ -724,7 +725,7 @@ export async function runAgentLoopImpl(
 
     // Workspace Git readiness is required only when tools can run. Tool-less
     // callers use the same depth gate consumed by tool resolution.
-    if (!(ctx.toolsDisabledDepth > 0)) {
+    if (!toolsDisabledForTurn) {
       try {
         const getWorkspaceGitServiceFn =
           ctx.getWorkspaceGitService ?? getWorkspaceGitService;
@@ -1704,28 +1705,30 @@ export async function runAgentLoopImpl(
 
     if (turnStarted) {
       ctx.turnCount++;
-      const config = getConfig();
-      const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
-      const deadlineMs = Date.now() + maxWait;
+      if (!toolsDisabledForTurn) {
+        const config = getConfig();
+        const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
+        const deadlineMs = Date.now() + maxWait;
 
-      const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
-      const commitPromise = commitTurnChangesFn(
-        ctx.workingDir,
-        ctx.conversationId,
-        ctx.turnCount,
-        undefined,
-        deadlineMs,
-      );
-      const outcome = await raceWithTimeout(commitPromise, maxWait);
-      if (outcome === "timed_out") {
-        rlog.warn(
-          {
-            turnNumber: ctx.turnCount,
-            maxWaitMs: maxWait,
-            conversationId: ctx.conversationId,
-          },
-          "Turn-boundary commit timed out — continuing without waiting (commit still runs in background)",
+        const commitTurnChangesFn = ctx.commitTurnChanges ?? commitTurnChanges;
+        const commitPromise = commitTurnChangesFn(
+          ctx.workingDir,
+          ctx.conversationId,
+          ctx.turnCount,
+          undefined,
+          deadlineMs,
         );
+        const outcome = await raceWithTimeout(commitPromise, maxWait);
+        if (outcome === "timed_out") {
+          rlog.warn(
+            {
+              turnNumber: ctx.turnCount,
+              maxWaitMs: maxWait,
+              conversationId: ctx.conversationId,
+            },
+            "Turn-boundary commit timed out; continuing without waiting (commit still runs in background)",
+          );
+        }
       }
 
       // Recompute relationship-state.json at turn boundary (fire-and-forget).


### PR DESCRIPTION
## Summary

- Skip workspace Git initialization when the agent loop tool execution gate is disabled.
- Preserve Git readiness ordering and non-fatal behavior for tool-capable turns.
- Add regression coverage for both paths.

## Original prompt

Fix a reported live-voice turn that spent 31.178 seconds in local setup before an 809 ms provider first token by removing unnecessary workspace Git initialization from the tool-less front-door path.

Closes JARVIS-1463