### PR TITLE
Drop the story-only initialStepId prop from SlackSetupWizard

### DIFF
--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -32,7 +32,22 @@ const DIGITS = "0".repeat(10);
 const BOT_TOKEN = `xoxb-${DIGITS}-${DIGITS}-abcdefghij`;
 const APP_TOKEN = `xapp-1-A${DIGITS}-${DIGITS}-abcdefghij`;
 
+/**
+ * Walk to the token step the way a user does. There is no prop to jump
+ * straight there: a story that renders a screen no real path produces would
+ * assert against a state the wizard cannot actually reach.
+ */
+async function goToConnect(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+  await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+  await userEvent.click(
+    canvas.getByRole("button", { name: /I created the app/i }),
+  );
+}
+
 const fillTokens: Story["play"] = async ({ canvasElement }) => {
+  await goToConnect(canvasElement);
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByLabelText(/Bot Token/i), BOT_TOKEN);
   await userEvent.type(canvas.getByLabelText(/App Token/i), APP_TOKEN);
@@ -90,27 +105,32 @@ export const OpenSlackAfterCopy: Story = {
 
 /** Step 3: the in-Slack directions, with one way forward. */
 export const CreateApp: Story = {
-  args: { initialStepId: "create" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+  },
 };
 
 /** Step 4: both tokens, empty. */
 export const Connect: Story = {
-  args: { initialStepId: "connect" },
+  play: async ({ canvasElement }) => {
+    await goToConnect(canvasElement);
+  },
 };
 
 export const Saving: Story = {
-  args: { initialStepId: "connect", saveStatus: "pending" },
+  args: { saveStatus: "pending" },
   play: fillTokens,
 };
 
 export const Connected: Story = {
-  args: { initialStepId: "connect", saveStatus: "success" },
+  args: { saveStatus: "success" },
   play: fillTokens,
 };
 
 export const SaveFailed: Story = {
   args: {
-    initialStepId: "connect",
     saveStatus: "error",
     saveError: "Slack rejected the bot token (invalid_auth).",
   },
@@ -123,8 +143,8 @@ export const SaveFailed: Story = {
  * Connect stays disabled.
  */
 export const TokenFormatValidation: Story = {
-  args: { initialStepId: "connect" },
   play: async ({ canvasElement }) => {
+    await goToConnect(canvasElement);
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText(/Bot Token/i), APP_TOKEN);
     await userEvent.type(canvas.getByLabelText(/App Token/i), "xapp-123");

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -77,6 +77,17 @@ const nextButton = () => screen.getByRole("button", { name: /^Next$/i });
 const onOpenStep = () =>
   screen.queryByRole("button", { name: /Open Slack/i }) !== null;
 
+/**
+ * Walk to the token step the way a user does. The wizard exposes no way to
+ * start on a later step, so a test that needs one has to earn it: that also
+ * means these assertions run against a state the real flow can produce.
+ */
+function goToConnectStep() {
+  fireEvent.click(screen.getByRole("button", { name: /^Next$/i }));
+  fireEvent.click(screen.getByRole("button", { name: /^Next$/i }));
+  fireEvent.click(screen.getByRole("button", { name: /I created the app/i }));
+}
+
 describe("SlackSetupWizard step flow", () => {
   test("copying puts the live manifest on the clipboard without navigating", async () => {
     render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
@@ -232,10 +243,11 @@ describe("SlackSetupWizard step flow", () => {
     render(
       <SlackSetupWizard
         assistantName={ASSISTANT_NAME}
-        initialStepId="connect"
         onSave={(bot, app) => saved.push([bot, app])}
       />,
     );
+
+    goToConnectStep();
 
     fireEvent.change(screen.getByLabelText(/Bot Token/i), {
       target: { value: `  ${BOT_TOKEN}  ` },

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -29,11 +29,6 @@ const WIZARD_STEPS: StepperStep[] = [
 
 export interface SlackSetupWizardProps {
   assistantName: string;
-  /**
-   * Step to open on. Production always starts at the beginning; stories use
-   * this to render a later step without clicking through the earlier ones.
-   */
-  initialStepId?: SlackSetupStepId;
   onSave?: (botToken: string, appToken: string) => void;
   saveStatus?: MutationStatus;
   saveError?: string | null;
@@ -51,12 +46,11 @@ export interface SlackSetupWizardProps {
  */
 export function SlackSetupWizard({
   assistantName,
-  initialStepId = "name",
   onSave,
   saveStatus = "idle",
   saveError = null,
 }: SlackSetupWizardProps) {
-  const [stepId, setStepId] = useState<SlackSetupStepId>(initialStepId);
+  const [stepId, setStepId] = useState<SlackSetupStepId>("name");
   const [slackAppName, setSlackAppName] = useState(assistantName);
   const [description, setDescription] = useState("");
   const userEditedName = useRef(false);


### PR DESCRIPTION
## TL;DR

`SlackSetupWizard` exposed an `initialStepId` prop with no production caller. It existed so stories and tests could render a later step without walking to it. Removing it.

Follow-up to #40219 / #40223. No reviewer asked for this; it came out of a self-audit of that work.

## Why it should go

Two reasons, and the second matters more than the tidiness one.

**It is a test harness in the component's public API.** Both mounts (`channel-setup-panel.tsx` and `channel-panel.tsx`) always start at the beginning. Nothing else can pass it. It is API surface that exists for Storybook.

**It made the coverage dishonest.** Six stories and one test rendered the token step directly, asserting against a screen no real path produces. If step 1 or the handoff broke, every one of them still passed, because they stepped over the thing that broke. Walking there exercises the path a user takes.

## What changes

| Before | After |
| -- | -- |
| `args: { initialStepId: "connect" }` | `play: goToConnect(canvasElement)` |
| Token-step assertions skip steps 1 to 3 | They walk through them first |
| Prop on the public interface | Gone |

Stories and tests each get a small `goToConnect` helper, so the repetition is one line per case.

## Why this is safe

- No production caller existed, so no call site changes.
- Pure test and story refactor plus a prop deletion. No behaviour change to the wizard itself.
- 9/9 wizard tests pass, having grown to cover the walk. Lint and typecheck clean on merged main.

## Note

The equivalent prop on the new Telegram wizard is removed in the LUM-3077 branch, where that wizard is introduced, rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->