### PR TITLE
test(web): fold the duplicate FeedItem builders into the shared fixture

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -23,6 +23,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { FeedItem } from "@vellumai/assistant-api";
 
+import { feedItem } from "../feed-test-fixtures";
+
 const isMobileRef = { value: false };
 
 mock.module("@/hooks/use-is-mobile", () => ({
@@ -77,18 +79,16 @@ const READ_LABEL = 'aria-label="Notifications"';
 
 const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
 
-function feedItem(overrides: Partial<FeedItem>): FeedItem {
+function bellItem(overrides: Partial<FeedItem>): FeedItem {
+  // Relative so the bell's recency treatment is exercised.
   const timestamp = new Date(Date.now() - THREE_HOURS_MS).toISOString();
-  return {
+  return feedItem({
     id: "item-1",
-    type: "notification",
-    priority: 50,
     summary: "Something happened",
     timestamp,
     createdAt: timestamp,
-    status: "new",
     ...overrides,
-  };
+  });
 }
 
 function renderBell(): string {
@@ -113,7 +113,7 @@ afterEach(() => {
 
 describe("NotificationsBell unread dot", () => {
   test("shows the dot when an unread notification exists", () => {
-    feedRef.items = [feedItem({ status: "new" })];
+    feedRef.items = [bellItem({ status: "new" })];
     const html = renderBell();
     expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
@@ -121,8 +121,8 @@ describe("NotificationsBell unread dot", () => {
 
   test("hides the dot when every notification has been read", () => {
     feedRef.items = [
-      feedItem({ id: "a", status: "seen" }),
-      feedItem({ id: "b", status: "acted_on" }),
+      bellItem({ id: "a", status: "seen" }),
+      bellItem({ id: "b", status: "acted_on" }),
     ];
     const html = renderBell();
     expect(html).not.toContain(UNREAD_DOT);
@@ -140,8 +140,8 @@ describe("NotificationsBell unread dot", () => {
     // Dismissed and high-urgency items are filtered out of the list, so
     // they must not light a dot the panel can't explain.
     feedRef.items = [
-      feedItem({ id: "a", status: "dismissed" }),
-      feedItem({ id: "b", status: "new", urgency: "high" }),
+      bellItem({ id: "a", status: "dismissed" }),
+      bellItem({ id: "b", status: "new", urgency: "high" }),
     ];
     const html = renderBell();
     expect(html).not.toContain(UNREAD_DOT);
@@ -150,7 +150,7 @@ describe("NotificationsBell unread dot", () => {
 
   test("mobile trigger carries the same dot", () => {
     isMobileRef.value = true;
-    feedRef.items = [feedItem({ status: "new" })];
+    feedRef.items = [bellItem({ status: "new" })];
     const html = renderBell();
     expect(html).toContain(UNREAD_DOT);
     expect(html).toContain(UNREAD_LABEL);
@@ -160,7 +160,7 @@ describe("NotificationsBell unread dot", () => {
 describe("NotificationsBell panel", () => {
   test("renders each row with title, timestamp, and preview", async () => {
     feedRef.items = [
-      feedItem({
+      bellItem({
         category: "background",
         title: "Watcher job failed",
         summary: "The watcher job could not reach the upstream service.",
@@ -178,7 +178,7 @@ describe("NotificationsBell panel", () => {
 
   test("rows drop the category chip and the source label", async () => {
     feedRef.items = [
-      feedItem({
+      bellItem({
         category: "background",
         sourceLabel: "Heartbeat",
         title: "Watcher job failed",
@@ -192,7 +192,7 @@ describe("NotificationsBell panel", () => {
   });
 
   test("keeps its own unread dot distinct from the rows'", async () => {
-    feedRef.items = [feedItem({ status: "new" })];
+    feedRef.items = [bellItem({ status: "new" })];
 
     await openBell();
 
@@ -201,7 +201,7 @@ describe("NotificationsBell panel", () => {
   });
 
   test("keeps the panel header and bulk actions", async () => {
-    feedRef.items = [feedItem({ status: "new" })];
+    feedRef.items = [bellItem({ status: "new" })];
 
     await openBell();
 

--- a/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-detail-panel.stories.tsx
@@ -155,8 +155,21 @@ export const FromSchedule: Story = {
   },
 };
 
-/** The mobile layout, which the panel branches to before its desktop shell. */
+/**
+ * The mobile layout, which the panel branches to before its desktop shell.
+ *
+ * Framed at a fixed height because that branch is `h-full`: inside a
+ * height-less wrapper its scroll region has nothing to overflow against, so
+ * the treatment under test would not render.
+ */
 export const Mobile: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-[32rem]">
+        <Story />
+      </div>
+    ),
+  ],
   args: {
     isMobile: true,
     item: feedItem({

--- a/clients/web/src/domains/home/detail-panel/home-tool-permission-card.test.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-tool-permission-card.test.tsx
@@ -16,19 +16,18 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { FeedItem } from "@vellumai/assistant-api";
 
+import { feedItem } from "../feed-test-fixtures";
+
 import { HomeToolPermissionCard } from "./home-tool-permission-card";
 
-function feedItem(overrides: Partial<FeedItem> = {}): FeedItem {
-  return {
+function permissionItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return feedItem({
     id: "notif:1",
-    type: "notification",
-    priority: 50,
     summary: "Gmail lost access to the mailbox scope.",
     timestamp: "2026-01-01T00:00:00.000Z",
-    status: "new",
     createdAt: "2026-01-01T00:00:00.000Z",
     ...overrides,
-  } as FeedItem;
+  });
 }
 
 function render(item: FeedItem): string {
@@ -38,7 +37,7 @@ function render(item: FeedItem): string {
 describe("HomeToolPermissionCard without a provider", () => {
   test("renders the summary, not the title", () => {
     const html = render(
-      feedItem({
+      permissionItem({
         title: "Gmail Access Lost",
         summary: "Gmail lost access to the mailbox scope.",
       }),
@@ -53,7 +52,7 @@ describe("HomeToolPermissionCard without a provider", () => {
     // survives, so the two can legitimately be identical. The card must still
     // render the string once.
     const shared = "Gmail lost access to the mailbox scope.";
-    const html = render(feedItem({ title: shared, summary: shared }));
+    const html = render(permissionItem({ title: shared, summary: shared }));
 
     expect(html.split(shared).length - 1).toBe(1);
   });
@@ -61,7 +60,7 @@ describe("HomeToolPermissionCard without a provider", () => {
   test("still renders when the daemon omits a title", () => {
     // Older daemons omit `title`; web ships always-latest, so this path stays
     // reachable.
-    const html = render(feedItem({ title: undefined }));
+    const html = render(permissionItem({ title: undefined }));
 
     expect(html).toContain("Gmail lost access to the mailbox scope.");
   });
@@ -70,7 +69,7 @@ describe("HomeToolPermissionCard without a provider", () => {
 describe("HomeToolPermissionCard with a provider", () => {
   test("renders the provider detail view instead of the summary", () => {
     const html = render(
-      feedItem({
+      permissionItem({
         title: "Gmail Access Lost",
         metadata: {
           provider: "gmail",

--- a/clients/web/src/domains/home/home-recap-row.test.tsx
+++ b/clients/web/src/domains/home/home-recap-row.test.tsx
@@ -13,24 +13,23 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 
 import { HomeRecapRow, type HomeRecapRowProps } from "./home-recap-row";
+import { feedItem } from "./feed-test-fixtures";
 
 const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 
 function makeItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  // Relative so the row's date formatting renders a real "3d ago".
   const timestamp = new Date(Date.now() - THREE_DAYS_MS).toISOString();
-  return {
+  return feedItem({
     id: "feed-1",
-    type: "notification",
-    priority: 50,
     category: "background",
-    status: "new",
     title: "Watcher job failed",
     summary: "The watcher job could not reach the upstream service.",
     timestamp,
     createdAt: timestamp,
     conversationId: "conversation-1",
     ...overrides,
-  };
+  });
 }
 
 function renderRow(props: Partial<HomeRecapRowProps> = {}) {


### PR DESCRIPTION
Follow-up to #40222, which merged before its review feedback was addressed.

## What this fixes

**Four copies of the same builder.** #40222 introduced a shared `feedItem` fixture but left three near-identical local builders in place, so the base `FeedItem` shape lived in four spots at once. The Single Source of Truth rule asks for the originals to be deleted in the same change; this is that half.

Each local builder now delegates to the shared one and keeps only what makes its case distinct:

- `home-recap-row.test.tsx` and `notifications-bell.test.tsx` keep **relative** timestamps, because their date-formatting and recency treatments are precisely what those tests exercise. Folding them onto the fixture's fixed timestamp would have quietly changed what they assert.
- `home-tool-permission-card.test.tsx` keeps its own summary, and loses its `as FeedItem` cast, so the type system now checks that fixture the way it checks the others.

**The mobile story rendered nothing meaningful.** `HomeDetailPanel`'s `isMobile` branch is `h-full`, so inside a height-less decorator its scroll region had nothing to overflow against and the treatment under test never appeared. Framed at a fixed height.

## Why this is safe

Test and story files only. No production code, no behavior change. The three migrated test files pass (43 tests), and the delegation preserves each test's original semantics rather than normalizing them onto shared defaults.

## Correction

An earlier revision of this description reported a pre-existing typecheck failure in `src/domains/settings/ai/`. That was wrong: it came from running bare `bunx tsc --noEmit`, which skips the `openapi-ts` codegen step that `bun run typecheck` runs first, so it checked against stale generated API types. Running the real command reports nothing, and CI agrees. There is no such failure on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
