### PR TITLE
fix(web): put the nudge banner in flow instead of measuring it (React error 185)

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -711,6 +711,34 @@ imperative write.
 Reference: `lib/commit-pressure.ts` — the probe that measures this
 traffic and attaches it to error-185 Sentry events.
 
+### Never key an effect on a `ReactNode` prop
+
+An element is a fresh object on every render of whoever created it, so
+`useEffect(fn, [someNode])` re-runs `fn` in _every_ commit for as long as
+that node is mounted. When `fn` measures the DOM, swaps an observer, or
+calls `setState`, that is per-commit work landing in the commit stream,
+and it feeds the same counter described above (LUM-3062, LUM-2927).
+
+Key on what actually changed instead: a boolean for "is it mounted", an
+id for "which one is it". Content that changes _inside_ a mounted node
+changes its size, not its identity, so a `ResizeObserver` (or the
+relevant observer) already reports it.
+
+The same reasoning applies one level up, to any hook returning an object:
+
+```ts
+// Avoid: a fresh object every render busts every downstream useMemo,
+// which remints the elements built from it, which re-runs any effect
+// keyed on those elements.
+return { bannerShouldShow, handleDismiss };
+
+// Good
+return useMemo(
+  () => ({ bannerShouldShow, handleDismiss }),
+  [bannerShouldShow, handleDismiss],
+);
+```
+
 ---
 
 ## Framework strategy

--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -711,6 +711,33 @@ imperative write.
 Reference: `lib/commit-pressure.ts` — the probe that measures this
 traffic and attaches it to error-185 Sentry events.
 
+### Don't measure an element to give back the space you took from it
+
+If you position something absolutely and then reserve its measured height
+as padding somewhere else, the absolute positioning bought nothing: the
+element ends up occupying exactly the space normal flow would have given
+it. What you have built is flow layout, reimplemented in JavaScript, at
+the cost of a `ResizeObserver`, a piece of state, an effect, and usually
+a prop threaded through someone else's component. `ChatBody`'s nudge
+banner did this for six weeks and put the component in the error-185
+family (LUM-2927).
+
+Ask which of the two things you actually want:
+
+- **It needs space.** Make it a flow sibling and let flexbox size it. A
+  `flex-1` neighbour gives back exactly the right height at every
+  viewport, for free, with nothing to keep in sync.
+- **It floats over content.** Reserve nothing, like the scroll-to-latest
+  pill. Measure only when content must scroll _behind_ it and the
+  scrollport's own padding is what keeps the tail reachable, which is the
+  one case that genuinely needs a number
+  (`side-menu-overlay-bottom-column.tsx`).
+
+Putting both kinds in one positioned container is what forces the
+measurement, because the container can only have one layout behavior.
+
+When you do need a live box, `hooks/use-element-size.ts` already exists.
+
 ### Never key an effect on a `ReactNode` prop
 
 An element is a fresh object on every render of whoever created it, so
@@ -720,9 +747,10 @@ calls `setState`, that is per-commit work landing in the commit stream,
 and it feeds the same counter described above (LUM-3062, LUM-2927).
 
 Key on what actually changed instead: a boolean for "is it mounted", an
-id for "which one is it". Content that changes _inside_ a mounted node
-changes its size, not its identity, so a `ResizeObserver` (or the
-relevant observer) already reports it.
+id for "which one is it". Note that re-keying alone is not a fix if the
+node can be swapped underneath you: sibling slots in one parent are
+matched by index and element type, so mounting an unkeyed sibling can
+hand your observed node to a different subtree while the effect sleeps.
 
 The same reasoning applies one level up, to any hook returning an object:
 

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -289,6 +289,57 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
       cleanup();
     }
   });
+
+  test("re-rendering with a fresh bannerSlot element does not re-run the measuring effect", () => {
+    // The failure shape behind the error-185 family (LUM-2927): keying the
+    // measuring layout effect on `bannerSlot` re-runs it on every parent
+    // render, because the slot is a fresh element each time. That is a
+    // synchronous reflow plus an observer teardown and re-observe in every
+    // commit for the whole life of the banner, each queueing a setState into
+    // the commit stream. Counting observer constructions pins the invariant:
+    // one mounted banner, one observer, however often the parent renders.
+    // A `[bannerSlot]`-keyed effect constructs one per render and fails this.
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let observersConstructed = 0;
+
+    globalThis.ResizeObserver = class {
+      constructor() {
+        observersConstructed += 1;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+
+    try {
+      const { rerender } = render(
+        <ChatBody
+          {...baseProps({
+            bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
+          })}
+        />,
+      );
+      const afterMount = observersConstructed;
+
+      const parentRenders = 3;
+      for (let i = 0; i < parentRenders; i += 1) {
+        // A fresh element each time, exactly like a re-rendering parent.
+        rerender(
+          <ChatBody
+            {...baseProps({
+              bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
+            })}
+          />,
+        );
+      }
+
+      expect(afterMount).toBe(1);
+      expect(observersConstructed - afterMount).toBe(0);
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+      cleanup();
+    }
+  });
 });
 
 describe("ChatBody — banner-visibility store mirroring", () => {

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -230,75 +230,46 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
     expect(html).toContain("BANNER_CONTENT");
   });
 
-  test("reserves the measured bottom banner height", async () => {
-    const originalGetBoundingClientRect =
-      HTMLElement.prototype.getBoundingClientRect;
-    const originalResizeObserver = globalThis.ResizeObserver;
-    let measuredHeight = 137;
-    let resizeCallback: ResizeObserverCallback | null = null;
-
-    HTMLElement.prototype.getBoundingClientRect =
-      function getBoundingClientRect() {
-        if (this.querySelector('[data-testid="banner"]')) {
-          return {
-            bottom: measuredHeight,
-            height: measuredHeight,
-            left: 0,
-            right: 0,
-            top: 0,
-            width: 0,
-            x: 0,
-            y: 0,
-            toJSON: () => ({}),
-          };
-        }
-        return originalGetBoundingClientRect.call(this);
-      };
-    globalThis.ResizeObserver = class {
-      constructor(callback: ResizeObserverCallback) {
-        resizeCallback = callback;
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as typeof ResizeObserver;
-
+  test("the banner takes its space in flow, and only the pill floats", () => {
+    // The banner is an opaque full-width card that always occupies its own
+    // height, so it belongs in the flex column: the `flex-1` scroll area
+    // gives back exactly that height at every viewport size. Positioning it
+    // absolutely removes it from flow and forces the space to be measured
+    // and reserved in JS, which is what put this component in the error-185
+    // family (LUM-2927) and cost a ResizeObserver, a state, and a prop on
+    // ChatScrollArea. The pill is the opposite: it genuinely floats over the
+    // transcript and reserves nothing.
+    const { container } = render(
+      <ChatBody
+        {...baseProps({
+          showScrollToLatest: true,
+          bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
+        })}
+      />,
+    );
     try {
-      const { container } = render(
-        <ChatBody
-          {...baseProps({
-            bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
-          })}
-        />,
-      );
-      await waitFor(() => {
-        expect(container.innerHTML).toContain("padding-bottom: 137px");
-      });
+      const banner = container.querySelector('[data-testid="banner"]');
+      const pill = container.querySelector('[data-testid="scroll-to-latest"]');
+      expect(banner).not.toBeNull();
+      expect(pill).not.toBeNull();
 
-      measuredHeight = 164;
-      act(() => {
-        resizeCallback?.([], {} as ResizeObserver);
-      });
-      await waitFor(() => {
-        expect(container.innerHTML).toContain("padding-bottom: 164px");
-      });
+      // In flow: no positioned ancestor between the banner and the root.
+      expect(banner?.closest(".absolute")).toBeNull();
+      // Floating: the pill still lives in a positioned, click-through layer.
+      expect(pill?.closest(".absolute")).not.toBeNull();
+      expect(pill?.closest(".pointer-events-none")).not.toBeNull();
     } finally {
-      HTMLElement.prototype.getBoundingClientRect =
-        originalGetBoundingClientRect;
-      globalThis.ResizeObserver = originalResizeObserver;
       cleanup();
     }
   });
 
-  test("re-rendering with a fresh bannerSlot element does not re-run the measuring effect", () => {
-    // The failure shape behind the error-185 family (LUM-2927): keying the
-    // measuring layout effect on `bannerSlot` re-runs it on every parent
-    // render, because the slot is a fresh element each time. That is a
-    // synchronous reflow plus an observer teardown and re-observe in every
-    // commit for the whole life of the banner, each queueing a setState into
-    // the commit stream. Counting observer constructions pins the invariant:
-    // one mounted banner, one observer, however often the parent renders.
-    // A `[bannerSlot]`-keyed effect constructs one per render and fails this.
+  test("measures nothing: no ResizeObserver, at mount or across re-renders", () => {
+    // The structural invariant. Any reintroduction of measure-to-reserve
+    // here (a ref'd node, an observer, a height in state) fails this, as
+    // does the subtler regression Codex caught on the first attempt: two
+    // unkeyed sibling divs in one overlay, where mounting the pill lets
+    // React reuse the observed banner node and leaves the observer on the
+    // wrong element.
     const originalResizeObserver = globalThis.ResizeObserver;
     let observersConstructed = 0;
 
@@ -319,22 +290,20 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
           })}
         />,
       );
-      const afterMount = observersConstructed;
 
-      const parentRenders = 3;
-      for (let i = 0; i < parentRenders; i += 1) {
-        // A fresh element each time, exactly like a re-rendering parent.
+      // Toggle the pill on and off under a live banner: the case that broke.
+      for (const showScrollToLatest of [true, false, true]) {
         rerender(
           <ChatBody
             {...baseProps({
+              showScrollToLatest,
               bannerSlot: <div data-testid="banner">BANNER_CONTENT</div>,
             })}
           />,
         );
       }
 
-      expect(afterMount).toBe(1);
-      expect(observersConstructed - afterMount).toBe(0);
+      expect(observersConstructed).toBe(0);
     } finally {
       globalThis.ResizeObserver = originalResizeObserver;
       cleanup();

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -305,17 +305,15 @@ export function ChatBody({
   // `trailingStarters` lets the docked layout render the starters elsewhere
   // (its own bottom dock) instead of directly below the composer.
   const renderComposerStack = (trailingStarters: ReactNode) => (
-    // The banner is a flow child of this group, not an overlay: it is an
-    // opaque full-width card that always occupies its own height, so letting
-    // the flex column size it is what reserves the transcript's space. The
-    // scroll area is the `flex-1` sibling, so it gives back exactly the
-    // banner's height at every viewport size, with nothing measured.
-    // Only the scroll-to-latest pill floats, and it anchors to the top of
-    // this group so it clears the banner.
+    // The banner is a flow child here because it is an opaque full-width
+    // card that always occupies its own height: the `flex-1` scroll area
+    // then gives back exactly that height at every viewport size, with
+    // nothing measured. The pill is the opposite and floats, so it anchors
+    // to the top of this group to clear the banner.
     <div className="relative">
       {showScrollToLatest && !isEmptyState && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2.5">
-          <div className="pointer-events-auto">
+        <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center">
+          <div className="pointer-events-auto pb-2.5">
             <ScrollToLatestButton
               onClick={onScrollToLatest}
               isAssistantBusy={isAssistantBusy}
@@ -335,27 +333,27 @@ export function ChatBody({
           </div>
         )}
         <div className="mx-auto max-w-[var(--chat-max-width)]">
-        {genericChatError && (
-          <div className="mb-2">
-            <Notice
-              tone={genericChatError.tone ?? "error"}
-              onDismiss={onDismissChatError}
-              actions={genericChatError.actions}
-            >
-              {genericChatError.message}
-            </Notice>
-          </div>
-        )}
-        {queuedDrawerSlot}
-        <QuestionPromptSlot />
-        {channelFooterSlot}
-        <StagedQuotesStrip />
-        {composerSlot}
-        {pluginPillsSlot &&
-          renderKeyboardCollapse(
-            "new-chat-plugins",
-            <div className="mt-4">{pluginPillsSlot}</div>,
+          {genericChatError && (
+            <div className="mb-2">
+              <Notice
+                tone={genericChatError.tone ?? "error"}
+                onDismiss={onDismissChatError}
+                actions={genericChatError.actions}
+              >
+                {genericChatError.message}
+              </Notice>
+            </div>
           )}
+          {queuedDrawerSlot}
+          <QuestionPromptSlot />
+          {channelFooterSlot}
+          <StagedQuotesStrip />
+          {composerSlot}
+          {pluginPillsSlot &&
+            renderKeyboardCollapse(
+              "new-chat-plugins",
+              <div className="mt-4">{pluginPillsSlot}</div>,
+            )}
           {trailingStarters}
         </div>
       </div>
@@ -394,9 +392,7 @@ export function ChatBody({
           <div
             className={`flex flex-1 flex-col ${keyboardOpen ? "justify-end" : "[justify-content:safe_center]"}`}
           >
-            <ChatScrollArea
-              {...scrollAreaProps}
-            />
+            <ChatScrollArea {...scrollAreaProps} />
             {renderComposerStack(null)}
           </div>
           {startersSlot &&
@@ -431,9 +427,7 @@ export function ChatBody({
       onDrop={dragHandlers.onDrop}
     >
       <div className={nonDockedInnerClass}>
-        <ChatScrollArea
-          {...scrollAreaProps}
-        />
+        <ChatScrollArea {...scrollAreaProps} />
 
         {!isEmptyState && activeProcessOverlaysSlot && (
           <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center gap-2 px-3 pt-2">

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -225,8 +225,28 @@ export function ChatBody({
   const bottomBannerOverlayRef = useRef<HTMLDivElement | null>(null);
   const [bottomBannerOverlayHeight, setBottomBannerOverlayHeight] = useState(0);
 
+  // Suppress the absolutely-positioned overlay on the empty state: its
+  // `bottom-full` positioning would overlap the greeting when the outer
+  // container centers greeting + composer + starters as a group.
+  // Banners (app-download nudge, GitHub star, Discord) show once the
+  // user sends a message and the empty state clears. `showScrollToLatest`
+  // is already false on the empty state (gated on `messages.length > 0`
+  // at the call site), so this only affects `bannerSlot`.
+  const bannerRendered = !isEmptyState && Boolean(bannerSlot);
+
+  // Measures the banner overlay so the transcript can reserve its height.
+  //
+  // Keyed on whether a banner is mounted, never on `bannerSlot` itself: that
+  // prop is a fresh element on most parent renders, and a ReactNode-keyed
+  // effect would re-run this whole body (a synchronous `getBoundingClientRect`
+  // reflow plus a `ResizeObserver` teardown and re-observe) in every commit
+  // for as long as a banner is up, queueing a setState whose eager bailout is
+  // skipped exactly when the fiber already has pending lanes. Enough such
+  // commits back to back trip React's nested-update limit under streaming load
+  // (error 185, LUM-2927). Content swaps within a mounted banner change its
+  // height, not its identity, and the observer already reports those.
   useLayoutEffect(() => {
-    if (isEmptyState || !bannerSlot) {
+    if (!bannerRendered) {
       setBottomBannerOverlayHeight(0);
       return;
     }
@@ -252,7 +272,7 @@ export function ChatBody({
     const observer = new ResizeObserver(updateHeight);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [bannerSlot, isEmptyState]);
+  }, [bannerRendered]);
 
   // When the empty state is visible, center greeting + composer + starters
   // as one group. `safe center` falls back to start-alignment when the
@@ -292,14 +312,6 @@ export function ChatBody({
     ? `flex min-h-full flex-col ${nonDockedAlignmentClass}`
     : "flex min-h-0 flex-1 flex-col";
 
-  // Suppress the absolutely-positioned overlay on the empty state: its
-  // `bottom-full` positioning would overlap the greeting when the outer
-  // container centers greeting + composer + starters as a group.
-  // Banners (app-download nudge, GitHub star, Discord) show once the
-  // user sends a message and the empty state clears. `showScrollToLatest`
-  // is already false on the empty state (gated on `messages.length > 0`
-  // at the call site), so this only affects `bannerSlot`.
-  const bannerRendered = !isEmptyState && Boolean(bannerSlot);
   const hasOverlay = bannerRendered || (!isEmptyState && showScrollToLatest);
   const bottomOverlayReservePx =
     bannerRendered && bottomBannerOverlayHeight > 0

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -1,10 +1,4 @@
-import {
-  useLayoutEffect,
-  useRef,
-  useState,
-  type DragEventHandler,
-  type ReactNode,
-} from "react";
+import { useLayoutEffect, type DragEventHandler, type ReactNode } from "react";
 
 import { Paperclip } from "lucide-react";
 
@@ -125,8 +119,8 @@ export interface ChatBodyProps {
 
   /**
    * Optional pre-rendered banner stack (mobile-app nudge / GitHub / Discord)
-   * rendered alongside the scroll-to-latest button in the absolute-positioned
-   * overlay above the composer. Omitted by the app-editing side panel.
+   * rendered in flow directly above the composer, so the flex column sizes
+   * the transcript around it. Omitted by the app-editing side panel.
    * While mounted (non-empty state), visibility is mirrored into the shared
    * banner-visibility store so tip surfaces can stay mutually exclusive.
    */
@@ -222,57 +216,11 @@ export function ChatBody({
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
   const keyboardOpen = useKeyboardOpen();
-  const bottomBannerOverlayRef = useRef<HTMLDivElement | null>(null);
-  const [bottomBannerOverlayHeight, setBottomBannerOverlayHeight] = useState(0);
-
-  // Suppress the absolutely-positioned overlay on the empty state: its
-  // `bottom-full` positioning would overlap the greeting when the outer
-  // container centers greeting + composer + starters as a group.
-  // Banners (app-download nudge, GitHub star, Discord) show once the
-  // user sends a message and the empty state clears. `showScrollToLatest`
-  // is already false on the empty state (gated on `messages.length > 0`
-  // at the call site), so this only affects `bannerSlot`.
+  // Banners (app-download nudge, GitHub star, Discord) show once the user
+  // sends a message and the empty state clears. They stay out of the empty
+  // state, where the outer container centers greeting + composer + starters
+  // as one group and a banner above the composer would split it.
   const bannerRendered = !isEmptyState && Boolean(bannerSlot);
-
-  // Measures the banner overlay so the transcript can reserve its height.
-  //
-  // Keyed on whether a banner is mounted, never on `bannerSlot` itself: that
-  // prop is a fresh element on most parent renders, and a ReactNode-keyed
-  // effect would re-run this whole body (a synchronous `getBoundingClientRect`
-  // reflow plus a `ResizeObserver` teardown and re-observe) in every commit
-  // for as long as a banner is up, queueing a setState whose eager bailout is
-  // skipped exactly when the fiber already has pending lanes. Enough such
-  // commits back to back trip React's nested-update limit under streaming load
-  // (error 185, LUM-2927). Content swaps within a mounted banner change its
-  // height, not its identity, and the observer already reports those.
-  useLayoutEffect(() => {
-    if (!bannerRendered) {
-      setBottomBannerOverlayHeight(0);
-      return;
-    }
-
-    const el = bottomBannerOverlayRef.current;
-    if (!el) {
-      return;
-    }
-
-    const updateHeight = () => {
-      const nextHeight = Math.ceil(el.getBoundingClientRect().height);
-      setBottomBannerOverlayHeight((currentHeight) =>
-        currentHeight === nextHeight ? currentHeight : nextHeight,
-      );
-    };
-
-    updateHeight();
-
-    if (typeof ResizeObserver === "undefined") {
-      return;
-    }
-
-    const observer = new ResizeObserver(updateHeight);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [bannerRendered]);
 
   // When the empty state is visible, center greeting + composer + starters
   // as one group. `safe center` falls back to start-alignment when the
@@ -311,12 +259,6 @@ export function ChatBody({
   const nonDockedInnerClass = isEmptyState
     ? `flex min-h-full flex-col ${nonDockedAlignmentClass}`
     : "flex min-h-0 flex-1 flex-col";
-
-  const hasOverlay = bannerRendered || (!isEmptyState && showScrollToLatest);
-  const bottomOverlayReservePx =
-    bannerRendered && bottomBannerOverlayHeight > 0
-      ? bottomBannerOverlayHeight
-      : undefined;
 
   // Mirror the mounted banner — not the candidate slot — into the shared
   // store so tip surfaces stay mutually exclusive with nudge banners.
@@ -363,34 +305,36 @@ export function ChatBody({
   // `trailingStarters` lets the docked layout render the starters elsewhere
   // (its own bottom dock) instead of directly below the composer.
   const renderComposerStack = (trailingStarters: ReactNode) => (
-    <div className="relative px-3 pt-1 pb-2 sm:px-6 sm:pb-0">
-      {refreshFeedback && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2">
-          <RefreshFeedbackPill
-            feedback={refreshFeedback}
-            onDismiss={onDismissRefreshFeedback}
-            onRetry={onRetryRefresh}
-          />
+    // The banner is a flow child of this group, not an overlay: it is an
+    // opaque full-width card that always occupies its own height, so letting
+    // the flex column size it is what reserves the transcript's space. The
+    // scroll area is the `flex-1` sibling, so it gives back exactly the
+    // banner's height at every viewport size, with nothing measured.
+    // Only the scroll-to-latest pill floats, and it anchors to the top of
+    // this group so it clears the banner.
+    <div className="relative">
+      {showScrollToLatest && !isEmptyState && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2.5">
+          <div className="pointer-events-auto">
+            <ScrollToLatestButton
+              onClick={onScrollToLatest}
+              isAssistantBusy={isAssistantBusy}
+            />
+          </div>
         </div>
       )}
-      {hasOverlay && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex flex-col items-center">
-          {showScrollToLatest && (
-            <div className="pointer-events-auto pb-2.5">
-              <ScrollToLatestButton
-                onClick={onScrollToLatest}
-                isAssistantBusy={isAssistantBusy}
-              />
-            </div>
-          )}
-          {bannerSlot && (
-            <div ref={bottomBannerOverlayRef} className="w-full">
-              {bannerSlot}
-            </div>
-          )}
-        </div>
-      )}
-      <div className="mx-auto max-w-[var(--chat-max-width)]">
+      {bannerRendered && bannerSlot}
+      <div className="relative px-3 pt-1 pb-2 sm:px-6 sm:pb-0">
+        {refreshFeedback && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex justify-center pb-2">
+            <RefreshFeedbackPill
+              feedback={refreshFeedback}
+              onDismiss={onDismissRefreshFeedback}
+              onRetry={onRetryRefresh}
+            />
+          </div>
+        )}
+        <div className="mx-auto max-w-[var(--chat-max-width)]">
         {genericChatError && (
           <div className="mb-2">
             <Notice
@@ -412,7 +356,8 @@ export function ChatBody({
             "new-chat-plugins",
             <div className="mt-4">{pluginPillsSlot}</div>,
           )}
-        {trailingStarters}
+          {trailingStarters}
+        </div>
       </div>
     </div>
   );
@@ -451,7 +396,6 @@ export function ChatBody({
           >
             <ChatScrollArea
               {...scrollAreaProps}
-              bottomOverlayReservePx={bottomOverlayReservePx}
             />
             {renderComposerStack(null)}
           </div>
@@ -489,7 +433,6 @@ export function ChatBody({
       <div className={nonDockedInnerClass}>
         <ChatScrollArea
           {...scrollAreaProps}
-          bottomOverlayReservePx={bottomOverlayReservePx}
         />
 
         {!isEmptyState && activeProcessOverlaysSlot && (

--- a/clients/web/src/domains/chat/components/chat-scroll-area.tsx
+++ b/clients/web/src/domains/chat/components/chat-scroll-area.tsx
@@ -57,8 +57,6 @@ export interface ChatScrollAreaProps {
   transcriptRef: ForwardedRef<TranscriptHandle>;
   /** {@link TranscriptProps} forwarded to {@link Transcript}. */
   transcriptProps: TranscriptProps;
-  /** Space reserved below the scrollable transcript for bottom floating UI. */
-  bottomOverlayReservePx?: number;
 }
 
 export function ChatScrollArea({
@@ -69,21 +67,22 @@ export function ChatScrollArea({
   emptyStateProps,
   transcriptRef,
   transcriptProps,
-  bottomOverlayReservePx,
 }: ChatScrollAreaProps) {
   // When the empty state is shown, this wrapper must NOT take `flex-1` so
   // the parent `ChatBody` can center it together with the composer +
   // starters as a single group. In all other states (skeleton, maintenance,
   // transcript), `flex-1` lets the content fill the available height.
+  //
+  // Bottom UI that needs space (the nudge banner) is a flow sibling in
+  // `ChatBody`, so `flex-1` gives that height back here with nothing
+  // measured. Only genuinely floating UI (the scroll-to-latest pill) is
+  // positioned over this area, and it reserves nothing by design.
   const wrapperClass = showEmptyState
     ? "relative flex min-h-0 flex-col"
     : "relative flex min-h-0 flex-1 flex-col";
-  const wrapperStyle = bottomOverlayReservePx
-    ? { paddingBottom: bottomOverlayReservePx }
-    : undefined;
 
   return (
-    <div className={wrapperClass} style={wrapperStyle}>
+    <div className={wrapperClass}>
       {isLoadingHistory && messageCount === 0 && <ChatSkeleton />}
       {showMaintenanceRecoveryCard && <MaintenanceRecoveryCard />}
       {showEmptyState && <ChatEmptyState {...emptyStateProps} />}

--- a/clients/web/src/domains/chat/components/chat-scroll-area.tsx
+++ b/clients/web/src/domains/chat/components/chat-scroll-area.tsx
@@ -71,12 +71,11 @@ export function ChatScrollArea({
   // When the empty state is shown, this wrapper must NOT take `flex-1` so
   // the parent `ChatBody` can center it together with the composer +
   // starters as a single group. In all other states (skeleton, maintenance,
-  // transcript), `flex-1` lets the content fill the available height.
-  //
-  // Bottom UI that needs space (the nudge banner) is a flow sibling in
-  // `ChatBody`, so `flex-1` gives that height back here with nothing
-  // measured. Only genuinely floating UI (the scroll-to-latest pill) is
-  // positioned over this area, and it reserves nothing by design.
+  // transcript), `flex-1` lets the content fill the available height, which
+  // is also how bottom UI that needs space gets it: the nudge banner is a
+  // flow sibling in `ChatBody`, so nothing here has to reserve room for it.
+  // Only genuinely floating UI (the scroll-to-latest pill) overlays this
+  // area, and that reserves nothing by design.
   const wrapperClass = showEmptyState
     ? "relative flex min-h-0 flex-col"
     : "relative flex min-h-0 flex-1 flex-col";

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
@@ -61,7 +61,7 @@ export function useChatBannerSlots({
   const mainBannerSlot = useMemo((): ReactNode => {
     if (showBanner) {
       return (
-        <div className="pointer-events-auto w-full px-3 pb-2 sm:px-6">
+        <div className="w-full px-3 pb-2 sm:px-6">
           {nativeAppPlatform ? (
             <NativeAppBanner
               platform={nativeAppPlatform}
@@ -79,7 +79,7 @@ export function useChatBannerSlots({
     }
     if (showGitHubBanner) {
       return (
-        <div className="pointer-events-auto w-full px-3 pb-2 sm:px-6">
+        <div className="w-full px-3 pb-2 sm:px-6">
           <GitHubNudgeBanner
             onStar={githubNudge.handleStar}
             onDismiss={githubNudge.handleBannerDismiss}
@@ -89,7 +89,7 @@ export function useChatBannerSlots({
     }
     if (showDiscordBanner) {
       return (
-        <div className="pointer-events-auto w-full px-3 pb-1 sm:px-6">
+        <div className="w-full px-3 pb-1 sm:px-6">
           <DiscordNudgeBanner
             onJoin={discordNudge.handleJoin}
             onDismiss={discordNudge.handleBannerDismiss}

--- a/clients/web/src/hooks/use-discord-nudge.ts
+++ b/clients/web/src/hooks/use-discord-nudge.ts
@@ -6,7 +6,7 @@
  * cascade, conversation count).
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useNudgeStore } from "@/stores/nudge-store";
 import {
@@ -158,11 +158,23 @@ export function useDiscordNudgeState(
     useNudgeStore.getState().dismissDiscordBanner();
   }, []);
 
-  return {
-    bannerShouldShow: prerequisitesMet && !joined && !bannerDismissed,
-    handleJoin,
-    handleBannerDismiss,
-  };
+  // Stable identity: consumers feed this into `useMemo` deps that build
+  // banner elements. See docs/CONVENTIONS.md, "Never key an effect on a
+  // ReactNode prop".
+  return useMemo(
+    () => ({
+      bannerShouldShow: prerequisitesMet && !joined && !bannerDismissed,
+      handleJoin,
+      handleBannerDismiss,
+    }),
+    [
+      prerequisitesMet,
+      joined,
+      bannerDismissed,
+      handleJoin,
+      handleBannerDismiss,
+    ],
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/hooks/use-github-nudge.ts
+++ b/clients/web/src/hooks/use-github-nudge.ts
@@ -10,7 +10,7 @@
  * a minimum number of user messages sent.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useNudgeStore } from "@/stores/nudge-store";
 
@@ -109,11 +109,17 @@ export function useGitHubNudgeState(): GitHubNudgeState {
     useNudgeStore.getState().dismissGitHubBanner();
   }, []);
 
-  return {
-    bannerShouldShow: !starred && !bannerDismissed && engagementMet,
-    handleStar,
-    handleBannerDismiss,
-  };
+  // Stable identity: consumers feed this into `useMemo` deps that build
+  // banner elements. See docs/CONVENTIONS.md, "Never key an effect on a
+  // ReactNode prop".
+  return useMemo(
+    () => ({
+      bannerShouldShow: !starred && !bannerDismissed && engagementMet,
+      handleStar,
+      handleBannerDismiss,
+    }),
+    [starred, bannerDismissed, engagementMet, handleStar, handleBannerDismiss],
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/hooks/use-macos-app-nudge.ts
+++ b/clients/web/src/hooks/use-macos-app-nudge.ts
@@ -6,7 +6,7 @@
  * banner behind a minimum age (it surfaces ~24h after first observation).
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   getLocalBool,
@@ -139,15 +139,27 @@ export function useMacOsNudgeState(): {
     setBannerDismissed(true);
   }, []);
 
-  return {
-    // Drives the iOS/macOS → GitHub → Discord cascade: true until the user
-    // downloads or dismisses.
-    bannerShouldShow: !downloaded && !bannerDismissed,
-    // True once the banner has waited the minimum age (24h) to render.
-    ageEligible,
-    handleDownload,
-    handleBannerDismiss,
-  };
+  // Stable identity: consumers feed this into `useMemo` deps that build
+  // banner elements. See docs/CONVENTIONS.md, "Never key an effect on a
+  // ReactNode prop".
+  return useMemo(
+    () => ({
+      // Drives the iOS/macOS → GitHub → Discord cascade: true until the user
+      // downloads or dismisses.
+      bannerShouldShow: !downloaded && !bannerDismissed,
+      // True once the banner has waited the minimum age (24h) to render.
+      ageEligible,
+      handleDownload,
+      handleBannerDismiss,
+    }),
+    [
+      downloaded,
+      bannerDismissed,
+      ageEligible,
+      handleDownload,
+      handleBannerDismiss,
+    ],
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/hooks/use-native-app-nudge.ts
+++ b/clients/web/src/hooks/use-native-app-nudge.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   getLocalBool,
@@ -170,12 +170,23 @@ export function useNativeAppNudgeState(platform: NativeAppPlatform): {
     setBannerDismissed(true);
   }, [platform]);
 
-  return {
-    bannerShouldShow:
-      promotionAvailable && !downloaded && !bannerDismissed,
-    handleDownload,
-    handleBannerDismiss,
-  };
+  // Stable identity: consumers feed this into `useMemo` deps that build
+  // banner elements. See docs/CONVENTIONS.md, "Never key an effect on a
+  // ReactNode prop".
+  return useMemo(
+    () => ({
+      bannerShouldShow: promotionAvailable && !downloaded && !bannerDismissed,
+      handleDownload,
+      handleBannerDismiss,
+    }),
+    [
+      promotionAvailable,
+      downloaded,
+      bannerDismissed,
+      handleDownload,
+      handleBannerDismiss,
+    ],
+  );
 }
 
 export const __testing = {


### PR DESCRIPTION
## TL;DR

The nudge banner was positioned absolutely, which took it out of flow and made it cover the transcript. The existing fix for that overlap measured the banner with a `ResizeObserver` and reserved its height as padding on the scroll area. But reserving *exactly* the measured height puts the element back in the space normal flow would have given it, so the absolute positioning bought nothing and cost a `ResizeObserver`, a piece of state, a layout effect, and a prop threaded through `ChatScrollArea`. And it put this component in the [LUM-2927](https://linear.app/vellum/issue/LUM-2927) error-185 family, because the effect ran in every commit for the life of the banner.

This deletes the measurement instead of making it cheaper. **113 insertions, 174 deletions.**

Found while triaging [LUM-3079](https://linear.app/vellum/issue/LUM-3079).

## Why the measurement existed

[#36183](https://github.com/vellum-ai/vellum-assistant/pull/36183) ("fix chat nudge banner overlap", June 25) hit the overlap and reached for measurement. The deeper cause is one line up: the banner had been put in the same positioned overlay as the scroll-to-latest pill.

Those two want opposite things. The pill genuinely floats over the transcript and correctly reserves nothing. The banner is an opaque full-width card ([nudge-chat-banner.tsx:48](clients/web/src/components/nudges/nudge-chat-banner.tsx:48)) that always occupies its own height. A positioned container can only have one layout behavior, so once they shared it, the banner's space had to be re-derived in JavaScript.

## The fix

The banner is a flow sibling of the composer stack. The scroll area is the `flex-1` neighbour, so it gives back exactly the banner's height at every viewport size, for free, with nothing to keep in sync. The pill keeps its float and now anchors to the top of that group so it still clears the banner.

Gone: `bottomBannerOverlayRef`, `bottomBannerOverlayHeight`, the measuring `useLayoutEffect`, `bottomOverlayReservePx` at both call sites, and the `bottomOverlayReservePx` prop on `ChatScrollArea`.

## Why it is safe

Geometry is unchanged, and it works out to the same numbers because the reservation was always exactly the flow height:

| | Before | After |
| -- | -- | -- |
| Banner horizontal inset | `inset-x-0` on the composer container, banner's own `px-3 sm:px-6` insets it | flow child of an unpadded group, same `px-3 sm:px-6` |
| Banner → composer gap | `pb-2` (8px) + container `pt-1` (4px) | same 8px + 4px |
| Pill → banner gap | `pb-2.5` (10px) | same 10px |
| Transcript height | shortened by measured banner height | shortened by the banner's flow height |
| Empty state | banner suppressed | unchanged, same `bannerRendered` guard |

One deliberate change: the refresh-feedback pill is anchored `bottom-full` on the inner composer container, which used to be the *same* anchor line as the banner overlay, so the two collided when both were visible. It now renders between the banner and the composer. That is a collision fixed, not a regression, but it is a visible difference worth knowing about.

## Tests

Two tests replace the two that covered the deleted mechanism:

- **the banner takes its space in flow, and only the pill floats** — asserts the banner has no positioned ancestor while the pill is still inside a `pointer-events-none` positioned layer. Pins the distinction rather than the implementation.
- **measures nothing: no ResizeObserver, at mount or across re-renders** — toggles the pill on and off under a live banner and requires zero observer constructions.

Both sensitivity-checked: they fail against the previous structure (2 fail / 36 pass).

Full web suite: 867 pass. The one failure, `src/utils/daily-reset-time.test.ts`, is a pre-existing ICU label mismatch (`GMT` vs `GMT+0`) in a file this branch does not touch.

I did not verify in a browser: there is no `ChatBody` story, and reaching a visible banner in the running app requires the nudge eligibility gates (24h account age or 5 user messages sent). The geometry above is derived from the class lists, and the existing 38 `chat-body` tests cover the empty-state, docked, non-docked, and keyboard-collapse layouts.

## Also in here

The four nudge-state hooks memoize their returned objects. That is no longer load-bearing (nothing is keyed on the element's identity anymore), but it is what makes `mainBannerSlot`'s `useMemo` actually hold instead of reminting the banner element on every render.

`clients/web/docs/CONVENTIONS.md` gains "Don't measure an element to give back the space you took from it", which is the general rule, and keeps the effect-key rule as its corollary. It also points at `hooks/use-element-size.ts`, which already existed and which this component ignored in favour of a hand-rolled observer.

## On LUM-3079 itself

Its stack names a 1 Hz timer in `use-tool-call-card-data.ts`. That is a bystander: error 185 throws from whatever `setState` runs after the limit is already breached. Its `commit_pressure` payload recorded 51 commits in 1466 ms with only 2 attributed updates, i.e. an uninstrumented per-commit updater. That event came from release `6af6bfe`, which predates [#40173](https://github.com/vellum-ai/vellum-assistant/pull/40173), so its specific cause is most likely already fixed. This PR removes a second, still-live source of the same traffic.

## Deferred

- Of ~22 `ResizeObserver`s in the web client I classified four closely. `side-menu-overlay-bottom-column.tsx` is the legitimate shape (content scrolls behind a floating column, padding keeps the tail reachable) and `use-chat-header-bottom.ts` is legitimate and well documented (a Radix dialog portals to `body` and cannot inherit its position). `personality-page`'s `bottomReserve` and `create-personality-step`'s `eyesReserve` look like the same measure-to-reserve shape but are unread; worth a sweep.
- LUM-3064 (a lint rule for effects keyed on `ReactNode` props) stays that ticket's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)