### PR TITLE
fix(design-library): cap tooltip width so long content wraps

### DIFF
--- a/packages/design-library/src/components/tooltip.stories.tsx
+++ b/packages/design-library/src/components/tooltip.stories.tsx
@@ -89,3 +89,32 @@ export const OnTextTrigger: Story = {
     </Tooltip>
   ),
 };
+
+/**
+ * A sentence-length tooltip wraps instead of stretching into one long line.
+ *
+ * Real copy reaches this length whenever a tooltip explains a problem and
+ * its fix, so the content is capped at 20rem and never exceeds the space
+ * Radix reports on the chosen side. Forced open so the wrapping is visible
+ * in a static screenshot.
+ */
+export const LongContent: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <TooltipProvider delayDuration={0}>
+      <div
+        style={{ padding: "6rem", display: "flex", justifyContent: "center" }}
+      >
+        <Tooltip.Root defaultOpen delayDuration={0}>
+          <Tooltip.Trigger asChild>
+            <Button variant="outlined">Needs attention</Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content side="bottom">
+            Missing a model, so actions using it fall back to another profile.
+            Click to fix.
+          </Tooltip.Content>
+        </Tooltip.Root>
+      </div>
+    </TooltipProvider>
+  ),
+};

--- a/packages/design-library/src/components/tooltip.tsx
+++ b/packages/design-library/src/components/tooltip.tsx
@@ -70,6 +70,12 @@ function Content({
         className={cn(
           "z-50 rounded-md bg-[var(--primary-base)] px-2 py-1 shadow-[var(--shadow-popover)]",
           "text-body-small-default text-[color:var(--content-inset)]",
+          // A sentence-length tooltip would otherwise render as one
+          // unbroken line the width of its text. Capped so it wraps, and
+          // never wider than the space Radix reports on the chosen side, so
+          // a trigger near a viewport edge does not force a reflow.
+          "max-w-[min(20rem,var(--radix-tooltip-content-available-width,20rem))]",
+          "text-pretty break-words",
           "data-[state=delayed-open]:animate-[popoverIn_120ms_ease-out]",
           "data-[state=instant-open]:animate-[popoverIn_60ms_ease-out]",
           className,
@@ -100,7 +106,13 @@ export interface TooltipProps {
  * `TooltipProvider` exists, the inner provider scopes its own subtree
  * with matching defaults so behaviour is consistent.
  */
-function Tooltip({ content, children, side, align, delayDuration }: TooltipProps) {
+function Tooltip({
+  content,
+  children,
+  side,
+  align,
+  delayDuration,
+}: TooltipProps) {
   return (
     <RadixTooltip.Provider delayDuration={200} skipDelayDuration={300}>
       <Root delayDuration={delayDuration}>


### PR DESCRIPTION
## TL;DR

`Tooltip` had no width constraint, so a sentence-length tooltip rendered as one unbroken line the width of its text. Capped at 20rem, and never wider than the space Radix reports available on the chosen side.

## What changes for the user

| Before | After |
| --- | --- |
| A tooltip explaining a problem stretches across most of the viewport in a single line, hard to read and overlapping whatever it covers | It wraps to a readable column |
| A trigger near a viewport edge pushes a long tooltip against the boundary | It is additionally capped by the space Radix reports on that side |

## Why now

The profile warnings in the Models and Services surface are full sentences by design (what is wrong, what it costs, what to do about it). That made the missing cap visible rather than theoretical, but the gap is in the primitive, so every tooltip in the app inherits the fix.

## Implementation

```
max-w-[min(20rem,var(--radix-tooltip-content-available-width,20rem))]
text-pretty break-words
```

The `min()` against Radix's own available-width variable means the cap tightens near a viewport edge rather than forcing a reflow, and the fallback keeps the plain 20rem cap if the variable is absent. `className` still merges last in `cn()`, so a call site that genuinely needs a wider or narrower tooltip can still say so.

## Verification

A `LongContent` story is added, forced open so the wrapping is visible in a static screenshot, using real warning copy rather than lorem text. Confirmed in Storybook that it wraps to two lines at a readable width.

`bunx tsc --noEmit` clean, 199 design-library component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->