### PR TITLE
Add a theme-aware Android launch screen

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -51,8 +51,9 @@ For local development, pick the `devDebug` variant in Android Studio. If you
 sync a different `VELLUM_ENVIRONMENT`, build the matching flavor so the WebView
 origin and native auth host agree.
 
-Launcher and splash colors also distinguish production, staging, and dev
-installs.
+Launcher colors distinguish production, staging, and dev installs. The launch
+screen follows the saved app appearance, falling back to the Android light or
+dark setting until the web app has stored a preference.
 
 ## HTTPS App Links
 
@@ -203,6 +204,7 @@ clients/
     │       │   ├── MainActivity.java
     │       │   ├── NativeAuthPlugin.java
     │       │   ├── NativeBiometricPlugin.java
+    │       │   ├── NativeLaunchScreenPlugin.java
     │       │   ├── BiometricTokenStore.java
     │       │   ├── SelfHostedServer.java
     │       │   ├── VoiceAudioSessionPlugin.java

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -54,7 +54,9 @@ origin and native auth host agree.
 Launcher colors distinguish production, staging, and dev installs. The launch
 screen follows the saved app appearance, falling back to the Android light or
 dark setting until the web app has stored a preference. Android's app night
-mode keeps the OS splash and native overlay on the same theme.
+mode keeps the OS splash and native overlay on the same theme. Android 11 and
+older skip the OS preview window so the themed native overlay is the first app
+frame.
 
 ## HTTPS App Links
 

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -53,7 +53,8 @@ origin and native auth host agree.
 
 Launcher colors distinguish production, staging, and dev installs. The launch
 screen follows the saved app appearance, falling back to the Android light or
-dark setting until the web app has stored a preference.
+dark setting until the web app has stored a preference. Android's app night
+mode keeps the OS splash and native overlay on the same theme.
 
 ## HTTPS App Links
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -4,11 +4,16 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.http.SslError;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
+import android.widget.ImageView;
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
@@ -25,14 +30,19 @@ import java.util.List;
 import org.json.JSONException;
 
 public class MainActivity extends BridgeActivity {
+    private static final long LAUNCH_SCREEN_LOAD_FALLBACK_MS = 2_000;
+    private static final long LAUNCH_SCREEN_TIMEOUT_MS = 15_000;
     private static ConnectDeepLink recreationConnect;
 
+    private final Handler launchScreenHandler = new Handler(Looper.getMainLooper());
     private AlertDialog unreachableDialog;
     private URI effectiveServer;
     private URI pendingAppLink;
     private ConnectDeepLink pendingConnect;
     private boolean pendingNewChat;
     private Intent pendingVoiceLaunch;
+    private View launchScreen;
+    private boolean launchScreenReady;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -53,6 +63,7 @@ public class MainActivity extends BridgeActivity {
         configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
         pendingAppLink = consumeAppLinkIntent(getIntent());
         super.onCreate(savedInstanceState);
+        showLaunchScreen();
         deliverPendingVoiceLaunch();
         if (bridge != null) {
             bridge.setWebViewClient(new SelfHostedWebViewClient(bridge, this));
@@ -75,12 +86,55 @@ public class MainActivity extends BridgeActivity {
         bridgeBuilder.setPlugins(plugins);
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
+        registerPlugin(NativeLaunchScreenPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
         registerPlugin(AndroidPushRegistrationPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);
         registerPlugin(SafePushNotificationsPlugin.class);
         super.load();
+    }
+
+    private void showLaunchScreen() {
+        if (launchScreenReady) {
+            return;
+        }
+        ImageView view = new ImageView(this);
+        view.setBackgroundColor(NativeLaunchScreenPlugin.backgroundColor(this));
+        view.setImageResource(R.drawable.vellum_mark);
+        view.setColorFilter(NativeLaunchScreenPlugin.foregroundColor(this));
+        view.setScaleType(ImageView.ScaleType.CENTER);
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        addContentView(
+            view,
+            new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        );
+        launchScreen = view;
+        scheduleLaunchScreenFallback(LAUNCH_SCREEN_TIMEOUT_MS);
+    }
+
+    void hideLaunchScreen() {
+        launchScreenReady = true;
+        launchScreenHandler.removeCallbacksAndMessages(null);
+        if (launchScreen == null) {
+            return;
+        }
+        ViewGroup parent = (ViewGroup) launchScreen.getParent();
+        if (parent != null) {
+            parent.removeView(launchScreen);
+        }
+        launchScreen = null;
+    }
+
+    private void scheduleLaunchScreenFallback(long delayMs) {
+        if (launchScreenReady) {
+            return;
+        }
+        launchScreenHandler.removeCallbacksAndMessages(null);
+        launchScreenHandler.postDelayed(this::hideLaunchScreen, delayMs);
     }
 
     @Override
@@ -137,6 +191,7 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onDestroy() {
+        launchScreenHandler.removeCallbacksAndMessages(null);
         if (unreachableDialog != null) {
             unreachableDialog.dismiss();
             unreachableDialog = null;
@@ -333,6 +388,7 @@ public class MainActivity extends BridgeActivity {
 
         @Override
         public void onPageStarted(WebView view, String url, android.graphics.Bitmap favicon) {
+            activity.scheduleLaunchScreenFallback(LAUNCH_SCREEN_TIMEOUT_MS);
             mainFrameUrl = url;
             mainFrameFailed = false;
             super.onPageStarted(view, url, favicon);
@@ -343,6 +399,7 @@ public class MainActivity extends BridgeActivity {
             super.onPageFinished(view, url);
             if (!mainFrameFailed) {
                 activity.finishPendingConnect(url);
+                activity.scheduleLaunchScreenFallback(LAUNCH_SCREEN_LOAD_FALLBACK_MS);
             }
         }
 
@@ -376,6 +433,7 @@ public class MainActivity extends BridgeActivity {
 
         private void fail(String url) {
             mainFrameFailed = true;
+            activity.hideLaunchScreen();
             activity.handleServerFailure(url);
         }
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -46,6 +46,7 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        NativeLaunchScreenPlugin.applySavedTheme(this);
         boolean recoveredProcess = VoiceLiveActivityPlugin.clearRecoveredStatus(this);
         if (
             VoiceDeepLink.shouldSuppressRecoveredStatusLaunch(

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -1,7 +1,11 @@
 package ai.vellum.assistant;
 
+import android.app.UiModeManager;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import androidx.appcompat.app.AppCompatDelegate;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -32,19 +36,15 @@ public class NativeLaunchScreenPlugin extends Plugin {
     }
 
     static int backgroundColor(Context context) {
-        return context.getColor(
-            isDark(context)
-                ? R.color.launch_screen_background_dark
-                : R.color.launch_screen_background_light
-        );
+        return context.getColor(R.color.launch_screen_background);
     }
 
     static int foregroundColor(Context context) {
-        return context.getColor(
-            isDark(context)
-                ? R.color.launch_screen_foreground_dark
-                : R.color.launch_screen_foreground_light
-        );
+        return context.getColor(R.color.launch_screen_foreground);
+    }
+
+    static void applySavedTheme(Context context) {
+        applyTheme(context, storedTheme(context));
     }
 
     private boolean storeTheme(PluginCall call) {
@@ -57,22 +57,47 @@ public class NativeLaunchScreenPlugin extends Plugin {
             .edit()
             .putString(THEME_KEY, theme)
             .apply();
+        applyTheme(getContext(), theme);
         return true;
     }
 
-    private static boolean isDark(Context context) {
-        String theme = context
+    private static String storedTheme(Context context) {
+        return context
             .getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
             .getString(THEME_KEY, "system");
+    }
+
+    private static void applyTheme(Context context, String theme) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            UiModeManager uiModeManager = context.getSystemService(UiModeManager.class);
+            uiModeManager.setApplicationNightMode(platformNightMode(theme));
+            return;
+        }
+        AppCompatDelegate.setDefaultNightMode(appCompatNightMode(theme));
+    }
+
+    private static int platformNightMode(String theme) {
         if ("dark".equals(theme)) {
-            return true;
+            return UiModeManager.MODE_NIGHT_YES;
         }
         if ("light".equals(theme)) {
-            return false;
+            return UiModeManager.MODE_NIGHT_NO;
         }
-        int nightMode = context.getResources().getConfiguration().uiMode
+        int nightMode = Resources.getSystem().getConfiguration().uiMode
             & Configuration.UI_MODE_NIGHT_MASK;
-        return nightMode == Configuration.UI_MODE_NIGHT_YES;
+        return nightMode == Configuration.UI_MODE_NIGHT_YES
+            ? UiModeManager.MODE_NIGHT_YES
+            : UiModeManager.MODE_NIGHT_NO;
+    }
+
+    private static int appCompatNightMode(String theme) {
+        if ("dark".equals(theme)) {
+            return AppCompatDelegate.MODE_NIGHT_YES;
+        }
+        if ("light".equals(theme)) {
+            return AppCompatDelegate.MODE_NIGHT_NO;
+        }
+        return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
     }
 
     private static boolean isTheme(String theme) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -2,8 +2,6 @@ package ai.vellum.assistant;
 
 import android.app.UiModeManager;
 import android.content.Context;
-import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Build;
 import androidx.appcompat.app.AppCompatDelegate;
 import com.getcapacitor.Plugin;
@@ -83,11 +81,7 @@ public class NativeLaunchScreenPlugin extends Plugin {
         if ("light".equals(theme)) {
             return UiModeManager.MODE_NIGHT_NO;
         }
-        int nightMode = Resources.getSystem().getConfiguration().uiMode
-            & Configuration.UI_MODE_NIGHT_MASK;
-        return nightMode == Configuration.UI_MODE_NIGHT_YES
-            ? UiModeManager.MODE_NIGHT_YES
-            : UiModeManager.MODE_NIGHT_NO;
+        return UiModeManager.MODE_NIGHT_AUTO;
     }
 
     private static int appCompatNightMode(String theme) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.content.res.Configuration;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import com.getcapacitor.annotation.PluginMethod;
 
 @CapacitorPlugin(name = "NativeLaunchScreen")
 public class NativeLaunchScreenPlugin extends Plugin {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -2,6 +2,7 @@ package ai.vellum.assistant;
 
 import android.app.UiModeManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Build;
 import androidx.appcompat.app.AppCompatDelegate;
 import com.getcapacitor.Plugin;
@@ -11,6 +12,8 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 
 @CapacitorPlugin(name = "NativeLaunchScreen")
 public class NativeLaunchScreenPlugin extends Plugin {
+    private static final int APPLICATION_NIGHT_MODE_UNSPECIFIED =
+        Configuration.UI_MODE_NIGHT_UNDEFINED >> 4;
     private static final String PREFERENCES = "vellum_launch_screen";
     private static final String THEME_KEY = "theme";
 
@@ -81,7 +84,7 @@ public class NativeLaunchScreenPlugin extends Plugin {
         if ("light".equals(theme)) {
             return UiModeManager.MODE_NIGHT_NO;
         }
-        return UiModeManager.MODE_NIGHT_AUTO;
+        return APPLICATION_NIGHT_MODE_UNSPECIFIED;
     }
 
     private static int appCompatNightMode(String theme) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -1,0 +1,81 @@
+package ai.vellum.assistant;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.PluginMethod;
+
+@CapacitorPlugin(name = "NativeLaunchScreen")
+public class NativeLaunchScreenPlugin extends Plugin {
+    private static final String PREFERENCES = "vellum_launch_screen";
+    private static final String THEME_KEY = "theme";
+
+    @PluginMethod
+    public void ready(PluginCall call) {
+        if (!storeTheme(call)) {
+            return;
+        }
+        getActivity().runOnUiThread(() -> {
+            MainActivity activity = (MainActivity) getActivity();
+            activity.hideLaunchScreen();
+            call.resolve();
+        });
+    }
+
+    @PluginMethod
+    public void setTheme(PluginCall call) {
+        if (storeTheme(call)) {
+            call.resolve();
+        }
+    }
+
+    static int backgroundColor(Context context) {
+        return context.getColor(
+            isDark(context)
+                ? R.color.launch_screen_background_dark
+                : R.color.launch_screen_background_light
+        );
+    }
+
+    static int foregroundColor(Context context) {
+        return context.getColor(
+            isDark(context)
+                ? R.color.launch_screen_foreground_dark
+                : R.color.launch_screen_foreground_light
+        );
+    }
+
+    private boolean storeTheme(PluginCall call) {
+        String theme = call.getString("theme");
+        if (!isTheme(theme)) {
+            call.reject("theme must be system, light, or dark");
+            return false;
+        }
+        getContext().getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+            .edit()
+            .putString(THEME_KEY, theme)
+            .apply();
+        return true;
+    }
+
+    private static boolean isDark(Context context) {
+        String theme = context
+            .getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+            .getString(THEME_KEY, "system");
+        if ("dark".equals(theme)) {
+            return true;
+        }
+        if ("light".equals(theme)) {
+            return false;
+        }
+        int nightMode = context.getResources().getConfiguration().uiMode
+            & Configuration.UI_MODE_NIGHT_MASK;
+        return nightMode == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    private static boolean isTheme(String theme) {
+        return "system".equals(theme) || "light".equals(theme) || "dark".equals(theme);
+    }
+}

--- a/clients/android/app/src/main/res/drawable/splash_screen.xml
+++ b/clients/android/app/src/main/res/drawable/splash_screen.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/launcher_background" />
+            <solid android:color="@color/launch_screen_background" />
         </shape>
     </item>
     <item

--- a/clients/android/app/src/main/res/drawable/vellum_mark.xml
+++ b/clients/android/app/src/main/res/drawable/vellum_mark.xml
@@ -5,6 +5,6 @@
     android:viewportWidth="92"
     android:viewportHeight="92">
     <path
-        android:fillColor="#FFFFFFFF"
+        android:fillColor="@color/launch_screen_foreground"
         android:pathData="M23.5,0L46,48.342L68.4107,0L91,0L45.8214,92L1,0L23.5,0Z" />
 </vector>

--- a/clients/android/app/src/main/res/values-night/colors.xml
+++ b/clients/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="launch_screen_background">@color/launch_screen_background_dark</color>
+    <color name="launch_screen_foreground">@color/launch_screen_foreground_dark</color>
+</resources>

--- a/clients/android/app/src/main/res/values-v31/styles.xml
+++ b/clients/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.NoActionBarLaunch" parent="@style/AppThemeNoActionBarLaunchBase">
+        <item name="android:windowDisablePreview">false</item>
+    </style>
+</resources>

--- a/clients/android/app/src/main/res/values/colors.xml
+++ b/clients/android/app/src/main/res/values/colors.xml
@@ -4,6 +4,12 @@
     <color name="colorPrimaryDark">#174B26</color>
     <color name="colorAccent">#F6C744</color>
     <color name="launcher_foreground">#FFFFFF</color>
+    <color name="launch_screen_background_light">#F6F5F4</color>
+    <color name="launch_screen_foreground_light">#17191C</color>
+    <color name="launch_screen_background_dark">#17191C</color>
+    <color name="launch_screen_foreground_dark">#FFFFFF</color>
+    <color name="launch_screen_background">@color/launch_screen_background_light</color>
+    <color name="launch_screen_foreground">@color/launch_screen_foreground_light</color>
     <color name="notification_icon_color">#F6C744</color>
     <color name="system_bar_scrim">#00000000</color>
 </resources>

--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/launcher_background</item>
+        <item name="windowSplashScreenBackground">@color/launch_screen_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/vellum_mark</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
         <item name="android:background">@drawable/splash_screen</item>

--- a/clients/android/app/src/main/res/values/styles.xml
+++ b/clients/android/app/src/main/res/values/styles.xml
@@ -20,10 +20,14 @@
     <style name="AppTheme.NoActionBar" parent="@style/AppThemeNoActionBarBase" />
 
 
-    <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
+    <style name="AppThemeNoActionBarLaunchBase" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/launch_screen_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/vellum_mark</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
         <item name="android:background">@drawable/splash_screen</item>
+    </style>
+
+    <style name="AppTheme.NoActionBarLaunch" parent="@style/AppThemeNoActionBarLaunchBase">
+        <item name="android:windowDisablePreview">true</item>
     </style>
 </resources>

--- a/clients/web/src/components/providers.tsx
+++ b/clients/web/src/components/providers.tsx
@@ -26,6 +26,7 @@ import { Toaster } from "@vellumai/design-library/components/toast";
 import { useEffect, useState, type ReactNode } from "react";
 
 import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider";
+import { useNativeLaunchScreenReady } from "@/hooks/use-native-launch-screen-ready";
 import { installQueryPressureProbe } from "@/lib/commit-pressure";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { useRequestOrganizationId } from "@/stores/organization-store";
@@ -93,6 +94,7 @@ function ScopeKeyedQueryClientProvider({ children }: { children: ReactNode }) {
 }
 
 export function AppProviders({ children }: { children: ReactNode }) {
+  useNativeLaunchScreenReady();
   const isAuthenticated = useIsAuthenticated();
   const user = useAuthStore.use.user();
   const authScopeKey = isAuthenticated

--- a/clients/web/src/hooks/use-native-launch-screen-ready.ts
+++ b/clients/web/src/hooks/use-native-launch-screen-ready.ts
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+
+import { markNativeLaunchScreenReady } from "@/runtime/native-launch-screen";
+import { readStoredThemePreference } from "@/utils/theme-preferences";
+
+/** Releases the Android launch screen after the first React tree commits. */
+export function useNativeLaunchScreenReady(): void {
+  useEffect(() => {
+    void markNativeLaunchScreenReady(
+      readStoredThemePreference({ velvetEnabled: true }),
+    );
+  }, []);
+}

--- a/clients/web/src/hooks/use-theme-preference.ts
+++ b/clients/web/src/hooks/use-theme-preference.ts
@@ -7,6 +7,7 @@ import {
   writeStoredThemePreference,
 } from "@/utils/theme-preferences";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { syncNativeLaunchScreenTheme } from "@/runtime/native-launch-screen";
 import { watchDeviceSetting } from "@/utils/device-settings";
 
 /**
@@ -40,6 +41,7 @@ export function useThemePreference() {
   const setThemePreference = (next: ThemePreference) => {
     setTheme(next);
     writeStoredThemePreference(next);
+    void syncNativeLaunchScreenTheme(next);
   };
 
   return { theme, setThemePreference } as const;

--- a/clients/web/src/runtime/native-launch-screen.ts
+++ b/clients/web/src/runtime/native-launch-screen.ts
@@ -1,0 +1,61 @@
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativeAndroid } from "@/runtime/platform-detection";
+import type { ThemePreference } from "@/utils/theme-preferences";
+
+type NativeLaunchTheme = "system" | "light" | "dark";
+
+interface NativeLaunchScreenPlugin {
+  ready(options: { theme: NativeLaunchTheme }): Promise<void>;
+  setTheme(options: { theme: NativeLaunchTheme }): Promise<void>;
+}
+
+const NATIVE_LAUNCH_SCREEN_PLUGIN = "NativeLaunchScreen";
+const NativeLaunchScreen =
+  registerPlugin<NativeLaunchScreenPlugin>(NATIVE_LAUNCH_SCREEN_PLUGIN);
+
+function nativeLaunchTheme(theme: ThemePreference): NativeLaunchTheme {
+  return theme === "velvet" ? "dark" : theme;
+}
+
+function isAvailable(): boolean {
+  return (
+    isNativeAndroid() &&
+    Capacitor.isPluginAvailable(NATIVE_LAUNCH_SCREEN_PLUGIN)
+  );
+}
+
+/** Stores the active theme and releases the Android launch screen. */
+export async function markNativeLaunchScreenReady(
+  theme: ThemePreference,
+): Promise<void> {
+  if (!isAvailable()) {
+    return;
+  }
+  try {
+    await NativeLaunchScreen.ready({ theme: nativeLaunchTheme(theme) });
+  } catch (error) {
+    captureError(error, {
+      context: "native_launch_screen_ready",
+      bestEffort: true,
+    });
+  }
+}
+
+/** Keeps the next Android launch screen aligned with the app preference. */
+export async function syncNativeLaunchScreenTheme(
+  theme: ThemePreference,
+): Promise<void> {
+  if (!isAvailable()) {
+    return;
+  }
+  try {
+    await NativeLaunchScreen.setTheme({ theme: nativeLaunchTheme(theme) });
+  } catch (error) {
+    captureError(error, {
+      context: "native_launch_screen_theme_sync",
+      bestEffort: true,
+    });
+  }
+}

--- a/clients/web/src/runtime/native-launch-screen.ts
+++ b/clients/web/src/runtime/native-launch-screen.ts
@@ -1,7 +1,6 @@
 import { Capacitor, registerPlugin } from "@capacitor/core";
 
 import { captureError } from "@/lib/sentry/capture-error";
-import { isNativeAndroid } from "@/runtime/platform-detection";
 import type { ThemePreference } from "@/utils/theme-preferences";
 
 type NativeLaunchTheme = "system" | "light" | "dark";
@@ -21,7 +20,8 @@ function nativeLaunchTheme(theme: ThemePreference): NativeLaunchTheme {
 
 function isAvailable(): boolean {
   return (
-    isNativeAndroid() &&
+    Capacitor.isNativePlatform() &&
+    Capacitor.getPlatform() === "android" &&
     Capacitor.isPluginAvailable(NATIVE_LAUNCH_SCREEN_PLUGIN)
   );
 }


### PR DESCRIPTION
## Summary

- Keep a branded Vellum launch layer visible until the remote web app mounts.
- Match the saved app appearance, with Android light and dark mode as the fallback.
- Preserve compatibility with older web bundles and failed or stalled page loads.

## Original prompt

The Android app showed a white screen while loading after launch. Replace that gap with a centered Vellum logo and make the background follow the user theme when known, otherwise the Android light or dark system setting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->