### PR TITLE
Publish Android with workload identity federation

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2245,6 +2245,9 @@ jobs:
   release-android:
     needs: [compute-version, register-release, build-chrome-extension]
     if: vars.ANDROID_RELEASE_ENABLED == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/release-android.yaml
     with:
       environment: dev

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ inputs.environment }}
     timeout-minutes: 30
+    outputs:
+      artifact_name: ${{ steps.config.outputs.artifact_name }}
+      package_id: ${{ steps.config.outputs.package_id }}
+      version_name: ${{ steps.config.outputs.version_name }}
     permissions:
       contents: read
     steps:
@@ -54,7 +58,9 @@ jobs:
             exit 1
           fi
           echo "version_name=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "version_code=$(($(date +%s) / 10))" >> "$GITHUB_OUTPUT"
+          version_code=$(($(date +%s) / 10))
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=android-aab-${ENVIRONMENT}-${version_code}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -133,17 +139,54 @@ jobs:
       - name: Upload signed app bundle artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: android-aab-${{ inputs.environment }}-${{ steps.config.outputs.version_code }}
+          name: ${{ steps.config.outputs.artifact_name }}
           path: clients/android/app/build/outputs/bundle/${{ inputs.environment }}Release/*.aab
           if-no-files-found: error
 
+      - name: Remove sensitive build material
+        if: ${{ always() }}
+        run: |
+          rm -f /tmp/vellum-android-upload.jks
+          rm -f clients/android/app/google-services.json
+
+  publish:
+    needs: [build-and-upload]
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install publisher dependencies
+        working-directory: clients/web
+        run: bun install --frozen-lockfile --filter=@vellumai/web --ignore-scripts
+
+      - name: Download signed app bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.build-and-upload.outputs.artifact_name }}
+          path: android-bundle
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to Google Play internal track
-        env:
-          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           set -euo pipefail
           shopt -s nullglob
-          bundles=(clients/android/app/build/outputs/bundle/${{ inputs.environment }}Release/*.aab)
+          bundles=(android-bundle/*.aab)
           if [ "${#bundles[@]}" -ne 1 ]; then
             echo "::error::Expected exactly one signed Android App Bundle, found ${#bundles[@]}"
             exit 1
@@ -151,11 +194,5 @@ jobs:
 
           bun clients/web/scripts/publish-android-play.ts \
             --bundle "${bundles[0]}" \
-            --package-id "${{ steps.config.outputs.package_id }}" \
-            --release-name "${{ steps.config.outputs.version_name }}"
-
-      - name: Remove sensitive build material
-        if: ${{ always() }}
-        run: |
-          rm -f /tmp/vellum-android-upload.jks
-          rm -f clients/android/app/google-services.json
+            --package-id "${{ needs.build-and-upload.outputs.package_id }}" \
+            --release-name "${{ needs.build-and-upload.outputs.version_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2712,6 +2712,9 @@ jobs:
         && (needs.publish-plugin-api-prod.result == 'success' || needs.publish-plugin-api-prod.result == 'skipped')
         && (needs.push-dockerhub-image.result == 'success' || needs.push-dockerhub-image.result == 'skipped')
       }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/release-android.yaml
     with:
       environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -275,27 +275,33 @@ remains manual.
 When Firebase configuration is available, the workflow validates that it
 matches the selected flavor before including it in the build.
 
-Configure these environment-scoped GitHub secrets independently for `dev`,
-`staging`, and `production`:
+Configure these shared repository-level GitHub secrets once:
 
 | Secret | Format |
 |--------|--------|
-| `ANDROID_FIREBASE_CONFIG_B64` | Optional base64-encoded `google-services.json` for the environment's package |
 | `ANDROID_UPLOAD_KEYSTORE_B64` | Base64-encoded Play upload keystore |
 | `ANDROID_UPLOAD_KEYSTORE_PASSWORD` | Upload keystore password |
 | `ANDROID_UPLOAD_KEY_ALIAS` | Upload key alias |
 | `ANDROID_UPLOAD_KEY_PASSWORD` | Upload key password |
-| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Raw Play service account JSON |
 
-Never commit Firebase configuration, the keystore, credentials, or decoded
-secret material. The workflow removes restored files even when a build fails.
+Configure the optional `ANDROID_FIREBASE_CONFIG_B64` secret independently on
+the `dev`, `staging`, and `production` GitHub environments. Each value must be
+the base64-encoded `google-services.json` for that environment's package.
+
+The publish job authenticates without a JSON key by using the existing
+environment-scoped `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT`
+GitHub variables. `GCP_SERVICE_ACCOUNT` must match the environment's
+`assistant_deploy_service_account_email` Terraform output.
+
+Never commit Firebase configuration, the keystore, or decoded secret material.
+The workflow removes restored files even when a build fails.
 
 `ANDROID_FIREBASE_CONFIG_B64` remains optional so signing and internal
 distribution do not depend on push setup. When it is absent, the workflow emits
 a warning and the resulting AAB has no native push support. When it is present,
 malformed base64, invalid JSON, or a package mismatch fails the build.
 
-After all prerequisites and environment secrets are ready, set the repository
+After completing the prerequisites and GitHub configuration, set the repository
 variable `ANDROID_RELEASE_ENABLED` to `true`. Until then, both orchestrators
 skip Android distribution so existing releases remain unaffected.
 
@@ -303,16 +309,20 @@ skip Android distribution so existing releases remain unaffected.
 
 Complete the following setup before enabling internal-track uploads:
 
-1. Create Play Console apps for `ai.vellum.assistant`,
+1. Apply the platform Terraform stacks that enable the Android Publisher API
+   in the dev, staging, and production GCP projects.
+2. Create Play Console apps for `ai.vellum.assistant`,
    `ai.vellum.assistant.staging`, and
    `ai.vellum.assistant.dev`.
-2. Enable Play App Signing for each app and create one controlled upload key.
-3. Upload and roll out one signed AAB to each app's internal track manually.
+3. Enable Play App Signing for each app and create one controlled upload key.
+4. Upload and roll out one signed AAB to each app's internal track manually.
    Google Play requires this initial release before the Publisher API can
    upload a completed release.
-4. Grant the release service account permission to publish to each app's
-   internal track, then configure the environment-scoped secrets above.
-5. Complete each Play listing, privacy policy, Data Safety form, content rating,
+5. In Play Console, grant each environment's `GCP_SERVICE_ACCOUNT` access only
+   to its matching app, with **View app information (read-only)** and
+   **Release apps to testing tracks**. Do not grant production publishing.
+6. Configure the repository and environment secrets above.
+7. Complete each Play listing, privacy policy, Data Safety form, content rating,
    and the declarations required for microphone permissions.
 
 Before wider rollout, test the internal-track AAB on a physical device and

--- a/clients/web/scripts/publish-android-play.ts
+++ b/clients/web/scripts/publish-android-play.ts
@@ -28,14 +28,8 @@ async function main(): Promise<void> {
   const bundlePath = requireArgument("bundle", values.bundle);
   const packageId = requireArgument("package-id", values["package-id"]);
   const releaseName = requireArgument("release-name", values["release-name"]);
-  const credentialsJson = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON;
-
-  if (!credentialsJson) {
-    throw new Error("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is required");
-  }
 
   const auth = new androidpublisher.auth.GoogleAuth({
-    credentials: parseCredentials(credentialsJson),
     scopes: [ANDROID_PUBLISHER_SCOPE],
   });
   const publisher = androidpublisher.androidpublisher({
@@ -106,34 +100,6 @@ function requireArgument(name: string, value: string | undefined): string {
   }
 
   return value;
-}
-
-interface ServiceAccountCredentials {
-  type: "service_account";
-  client_email: string;
-  private_key: string;
-}
-
-function parseCredentials(value: string): ServiceAccountCredentials {
-  let credentials: Partial<ServiceAccountCredentials>;
-
-  try {
-    credentials = JSON.parse(value) as Partial<ServiceAccountCredentials>;
-  } catch {
-    throw new Error("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not valid JSON");
-  }
-
-  if (
-    credentials.type !== "service_account" ||
-    !credentials.client_email ||
-    !credentials.private_key
-  ) {
-    throw new Error(
-      "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON must contain service account credentials"
-    );
-  }
-
-  return credentials as ServiceAccountCredentials;
 }
 
 async function deleteEdit(


### PR DESCRIPTION
## Summary
- split Android builds from the OIDC-enabled Play publishing job
- authenticate with each environment's existing GCP Workload Identity configuration and use ADC in the publisher
- remove the service-account JSON secret path and document shared signing secrets plus app-scoped Play permissions

## Original prompt
Replace Android Play JSON-key authentication with the existing per-environment GitHub Actions deploy identities. Keep the build job away from cloud credentials, reuse the existing GCP variables, and remove the obsolete JSON secret requirement.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->