### PR TITLE
feat(web): GA queue steering, remove the queue-steering feature flag

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20880,6 +20880,10 @@ paths:
       responses:
         "200":
           description: Successful response
+        "403":
+          description: The queued message was enqueued by a different actor principal.
+        "404":
+          description: Conversation or queued message not found.
   /v1/migrations/export:
     post:
       operationId: migrations_export_post

--- a/assistant/src/__tests__/queued-message-steer-actor-scoping.test.ts
+++ b/assistant/src/__tests__/queued-message-steer-actor-scoping.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Authorization for steering to a queued message.
+ *
+ * Steering aborts the in-flight generation and promotes the named queued
+ * message to the head of the queue, so it is scoped to the actor principal
+ * that enqueued the message the same way deletion is: every subscriber sees
+ * every `message_queued` ack, so requestIds are not secrets and cannot stand
+ * in for authorization. The caller identity is normalized exactly as the send
+ * path normalizes it before recording `sourceActorPrincipalId`.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  MessageQueue,
+  type QueuedMessage,
+} from "../daemon/conversation-queue-manager.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../daemon/conversation-registry.js";
+import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
+
+const steerRoute = ROUTES.find(
+  (route) => route.operationId === "messages_queued_steer",
+)!;
+
+const registered: string[] = [];
+
+interface QueuedFixture {
+  requestId: string;
+  sourceActorPrincipalId?: string;
+}
+
+/**
+ * Register a live, mid-turn conversation holding `items`. The steer path
+ * reads the in-memory registry and touches no persistence, so a queue-only
+ * stand-in exercises the real code.
+ */
+function seedProcessingConversation(
+  conversationId: string,
+  items: QueuedFixture[],
+): { queue: MessageQueue; aborted: () => boolean } {
+  const queue = new MessageQueue();
+  for (const item of items) {
+    queue.push({
+      content: `content for ${item.requestId}`,
+      attachments: [],
+      requestId: item.requestId,
+      onEvent: () => {},
+      sentAt: Date.now(),
+      sourceActorPrincipalId: item.sourceActorPrincipalId,
+    } as QueuedMessage);
+  }
+  const abortController = new AbortController();
+  const conversation = {
+    conversationId,
+    queue,
+    isProcessing: () => true,
+    pendingSteerRepair: false,
+    abortController,
+    denyAllPendingConfirmations: () => {},
+  };
+  setConversation(conversationId, conversation as never);
+  registered.push(conversationId);
+  return { queue, aborted: () => abortController.signal.aborted };
+}
+
+function dispatchSteer(args: {
+  conversationId: string;
+  requestId: string;
+  actorPrincipalId?: string;
+}) {
+  return Promise.resolve(
+    steerRoute.handler({
+      pathParams: { id: args.requestId },
+      queryParams: { conversationId: args.conversationId },
+      headers:
+        args.actorPrincipalId !== undefined
+          ? { "x-vellum-actor-principal-id": args.actorPrincipalId }
+          : {},
+    }),
+  );
+}
+
+afterEach(() => {
+  for (const conversationId of registered.splice(0)) {
+    deleteConversation(conversationId);
+  }
+  delete process.env.DISABLE_HTTP_AUTH;
+});
+
+describe("queued message steer: actor scoping", () => {
+  test("a different actor principal cannot steer to someone else's queued message", async () => {
+    const { queue, aborted } = seedProcessingConversation("conv-steer-1", [
+      { requestId: "r-head", sourceActorPrincipalId: "actor-owner" },
+      { requestId: "r-target", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    await expect(
+      dispatchSteer({
+        conversationId: "conv-steer-1",
+        requestId: "r-target",
+        actorPrincipalId: "actor-bystander",
+      }),
+    ).rejects.toThrow("sent by a different user");
+
+    // The queue order is untouched and the live generation kept running.
+    expect(queue.peek(0)?.requestId).toBe("r-head");
+    expect(aborted()).toBe(false);
+  });
+
+  test("the enqueuing actor principal can steer to its own queued message", async () => {
+    const { queue, aborted } = seedProcessingConversation("conv-steer-2", [
+      { requestId: "r-head", sourceActorPrincipalId: "actor-owner" },
+      { requestId: "r-target", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    expect(
+      await dispatchSteer({
+        conversationId: "conv-steer-2",
+        requestId: "r-target",
+        actorPrincipalId: "actor-owner",
+      }),
+    ).toEqual({
+      ok: true,
+      conversationId: "conv-steer-2",
+      requestId: "r-target",
+    });
+
+    expect(queue.peek(0)?.requestId).toBe("r-target");
+    expect(aborted()).toBe(true);
+  });
+
+  test("a caller with no actor principal is the guardian by construction", async () => {
+    const { queue } = seedProcessingConversation("conv-steer-3", [
+      { requestId: "r-head", sourceActorPrincipalId: "actor-owner" },
+      { requestId: "r-target", sourceActorPrincipalId: "actor-owner" },
+    ]);
+
+    // Local/IPC and service principals carry no actorPrincipalId; the CLI
+    // must keep being able to steer.
+    await dispatchSteer({
+      conversationId: "conv-steer-3",
+      requestId: "r-target",
+    });
+
+    expect(queue.peek(0)?.requestId).toBe("r-target");
+  });
+
+  test("a daemon-internal enqueue with no recorded requester stays steerable", async () => {
+    const { queue } = seedProcessingConversation("conv-steer-4", [
+      { requestId: "r-head" },
+      { requestId: "r-target" },
+    ]);
+
+    await dispatchSteer({
+      conversationId: "conv-steer-4",
+      requestId: "r-target",
+      actorPrincipalId: "actor-anyone",
+    });
+
+    expect(queue.peek(0)?.requestId).toBe("r-target");
+  });
+});

--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -30,14 +30,15 @@ interface ParkedTurn {
 /**
  * Register a fake conversation whose in-flight turn is parked. The fake exposes
  * just the surface `steerToMessage` touches: a processing flag, a queue whose
- * head can be promoted, an abort controller that records aborts, and the
- * confirmation-deny hook.
+ * messages can be looked up and promoted, an abort controller that records
+ * aborts, and the confirmation-deny hook.
  */
 function registerParkedTurn(id: string): ParkedTurn {
   let abortCount = 0;
   const fake = {
     isProcessing: () => true,
     queue: {
+      findByRequestId: (requestId: string) => ({ requestId }),
       promoteToHead: (requestId: string) => ({ requestId }),
     },
     pendingSteerRepair: false,

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -242,16 +242,18 @@ export async function resolveMetaSlashCommand(
 // ---------------------------------------------------------------------------
 
 /**
- * Whether the caller behind a delete request may cancel this queued message.
+ * Whether the caller may cancel or steer to this queued message.
  *
  * A queued message records the verified requester that enqueued it
- * (`sourceActorPrincipalId`); the delete route receives the caller's verified
- * identity in the `x-vellum-actor-principal-id` header, which both adapters
- * derive from the auth context rather than from anything the caller sent. When
- * both are present they must match: `message_queued` is broadcast to every
- * subscriber of the assistant, so every requestId in a conversation is visible
- * to every connected client, and without this check one actor principal could
- * cancel another's pending message just by echoing the id back.
+ * (`sourceActorPrincipalId`); the delete and steer routes receive the caller's
+ * verified identity in the `x-vellum-actor-principal-id` header, which both
+ * adapters derive from the auth context rather than from anything the caller
+ * sent. When both are present they must match: `message_queued` is broadcast
+ * to every subscriber of the assistant, so every requestId in a conversation
+ * is visible to every connected client, and without this check one actor
+ * principal could cancel another's pending message, or abort the live
+ * generation and jump another's message to the head of the queue, just by
+ * echoing the id back.
  *
  * Two cases stay open, both deliberately:
  *
@@ -263,7 +265,7 @@ export async function resolveMetaSlashCommand(
  *   wake, subagent notifications, surface actions) have no enqueuing actor to
  *   compare against, and cancelling one from the queue UI is intended.
  */
-function mayCancelQueuedMessage(
+function mayActOnQueuedMessage(
   queued: QueuedMessage,
   callerActorPrincipalId: string | undefined,
 ): boolean {
@@ -311,7 +313,7 @@ export function deleteQueuedMessage(
     );
     return { removed: false, reason: "message_not_found" };
   }
-  if (!mayCancelQueuedMessage(queued, options.actorPrincipalId)) {
+  if (!mayActOnQueuedMessage(queued, options.actorPrincipalId)) {
     log.warn(
       {
         conversationId,
@@ -347,11 +349,16 @@ export function deleteQueuedMessage(
 export function steerToMessage(
   conversationId: string,
   requestId: string,
+  options: { actorPrincipalId?: string } = {},
 ):
   | { steered: true }
   | {
       steered: false;
-      reason: "conversation_not_found" | "message_not_found" | "not_processing";
+      reason:
+        | "conversation_not_found"
+        | "message_not_found"
+        | "not_processing"
+        | "forbidden";
     } {
   const conversation = findConversation(conversationId);
   if (!conversation) {
@@ -368,6 +375,26 @@ export function steerToMessage(
       "Cannot steer: conversation is not processing",
     );
     return { steered: false, reason: "not_processing" };
+  }
+
+  const queued = conversation.queue.findByRequestId(requestId);
+  if (!queued) {
+    log.warn(
+      { conversationId, requestId },
+      "Queued message not found for steering",
+    );
+    return { steered: false, reason: "message_not_found" };
+  }
+  if (!mayActOnQueuedMessage(queued, options.actorPrincipalId)) {
+    log.warn(
+      {
+        conversationId,
+        requestId,
+        callerActorPrincipalId: options.actorPrincipalId,
+      },
+      "Refusing to steer to a queued message enqueued by a different actor principal",
+    );
+    return { steered: false, reason: "forbidden" };
   }
 
   const promoted = conversation.queue.promoteToHead(requestId);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -2144,13 +2144,20 @@ async function handleDeleteQueuedMessage(args: RouteHandlerArgs) {
   throw new NotFoundError("Queued message not found");
 }
 
-function handleSteerToMessage(args: RouteHandlerArgs) {
-  const { pathParams = {} } = args;
+async function handleSteerToMessage(args: RouteHandlerArgs) {
+  const { pathParams = {}, headers = {} } = args;
   const conversationId = resolveQueuedMessageConversationId(args);
   if (!conversationId) {
     throw new BadRequestError("Missing required parameter: conversationId");
   }
-  const result = steerToMessage(conversationId, pathParams.id ?? "");
+  // Verified caller identity, normalized exactly as the delete path above
+  // (see the comment in `handleDeleteQueuedMessage`).
+  const actorPrincipalId = await resolveActorPrincipalIdForLocalGuardian(
+    headers["x-vellum-actor-principal-id"]?.trim() || undefined,
+  );
+  const result = steerToMessage(conversationId, pathParams.id ?? "", {
+    actorPrincipalId,
+  });
   if (result.steered) {
     return { ok: true, conversationId, requestId: pathParams.id };
   }
@@ -2160,6 +2167,11 @@ function handleSteerToMessage(args: RouteHandlerArgs) {
   if (result.reason === "not_processing") {
     throw new BadRequestError(
       "Cannot steer: conversation is not currently processing",
+    );
+  }
+  if (result.reason === "forbidden") {
+    throw new ForbiddenError(
+      "Queued message was sent by a different user and cannot be steered to here",
     );
   }
   throw new NotFoundError("Queued message not found");
@@ -2528,6 +2540,15 @@ export const ROUTES: RouteDefinition[] = [
         description: "Conversation ID (required)",
       },
     ],
+    additionalResponses: {
+      "403": {
+        description:
+          "The queued message was enqueued by a different actor principal.",
+      },
+      "404": {
+        description: "Conversation or queued message not found.",
+      },
+    },
     handler: handleSteerToMessage,
   },
 ];

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -118,7 +118,6 @@ import type {
   DisplayAttachment,
   DisplayMessage,
 } from "@/domains/chat/types/types";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
 import type { UIContext } from "@/domains/chat/turn-selectors";
@@ -547,11 +546,6 @@ export function ChatMainPanel({
     () => void sendMessage("/clean"),
     [sendMessage],
   );
-
-  // -------------------------------------------------------------------------
-  // Feature flags
-  // -------------------------------------------------------------------------
-  const queueSteering = useAssistantFeatureFlagStore.use.queueSteering();
 
   // -------------------------------------------------------------------------
   // Draft secret detection: owns the composer warning's matches/dismissal
@@ -1118,7 +1112,6 @@ export function ChatMainPanel({
     onCancelAllQueued: handleCancelAllQueued,
     onSteerMessage: handleSteerMessage,
     onEditQueueTail: handleEditQueueTail,
-    queueSteering,
   });
 
   // -------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
+++ b/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
@@ -14,7 +14,6 @@ export interface QueuedMessagesDrawerProps {
   onCancelMessage: (messageId: string) => void;
   onCancelAll: () => void;
   onSteer: (messageId: string) => void;
-  showSteer: boolean;
   onEditTail: () => void;
 }
 
@@ -28,7 +27,6 @@ interface QueuedMessageRowProps {
   isTail: boolean;
   onCancel: () => void;
   onSteer: () => void;
-  showSteer: boolean;
   onEdit: () => void;
 }
 
@@ -38,7 +36,6 @@ function QueuedMessageRow({
   isTail,
   onCancel,
   onSteer,
-  showSteer,
   onEdit,
 }: QueuedMessageRowProps) {
   const preview = useMemo(() => messagePlainText(message), [message]);
@@ -59,16 +56,14 @@ function QueuedMessageRow({
 
       {/* Action icons */}
       <div className="flex shrink-0 items-center gap-0.5">
-        {showSteer && (
-          <Button
-            variant="ghost"
-            size="compact"
-            className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
-            iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
-            onClick={onSteer}
-            aria-label="Push to agent"
-          />
-        )}
+        <Button
+          variant="ghost"
+          size="compact"
+          className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+          iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
+          onClick={onSteer}
+          aria-label="Push to agent"
+        />
         {isTail && (
           <Button
             variant="ghost"
@@ -101,7 +96,6 @@ export function QueuedMessagesDrawer({
   onCancelMessage,
   onCancelAll,
   onSteer,
-  showSteer,
   onEditTail,
 }: QueuedMessagesDrawerProps): ReactNode {
   const handleCancelMessage = useCallback(
@@ -143,7 +137,6 @@ export function QueuedMessagesDrawer({
               isTail={idx === queuedMessages.length - 1}
               onCancel={() => handleCancelMessage(msg.id)}
               onSteer={() => onSteer(msg.id)}
-              showSteer={showSteer}
               onEdit={onEditTail}
             />
           ))}

--- a/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
+++ b/clients/web/src/domains/chat/components/queued-messages-drawer.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, type ReactNode } from "react";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
+import { useSupportsQueueSteering } from "@/lib/backwards-compat/use-supports-queue-steering";
 import { Button } from "@vellumai/design-library";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,7 @@ function QueuedMessageRow({
   onEdit,
 }: QueuedMessageRowProps) {
   const preview = useMemo(() => messagePlainText(message), [message]);
+  const supportsSteer = useSupportsQueueSteering();
   return (
     <div className="flex items-center gap-1.5 rounded-md py-0.5 md:gap-2 md:px-2 md:py-1.5">
       {/* Accent bar */}
@@ -56,14 +58,16 @@ function QueuedMessageRow({
 
       {/* Action icons */}
       <div className="flex shrink-0 items-center gap-0.5">
-        <Button
-          variant="ghost"
-          size="compact"
-          className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
-          iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
-          onClick={onSteer}
-          aria-label="Push to agent"
-        />
+        {supportsSteer && (
+          <Button
+            variant="ghost"
+            size="compact"
+            className="max-md:h-6 max-md:w-6 max-md:bg-transparent max-md:rounded-md"
+            iconOnly={<ArrowUp className="h-3.5 w-3.5" />}
+            onClick={onSteer}
+            aria-label="Push to agent"
+          />
+        )}
         {isTail && (
           <Button
             variant="ghost"

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
@@ -73,7 +73,6 @@ function makeParams(nudges: Nudges): UseChatBannerSlotsParams {
     onCancelAllQueued: noop,
     onSteerMessage: noop,
     onEditQueueTail: noop,
-    queueSteering: false,
   };
 }
 

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
@@ -27,7 +27,6 @@ export interface UseChatBannerSlotsParams {
   onCancelAllQueued: () => void;
   onSteerMessage: (messageId: string) => void;
   onEditQueueTail: () => void;
-  queueSteering: boolean;
 }
 
 export interface ChatBannerSlots {
@@ -46,7 +45,6 @@ export function useChatBannerSlots({
   onCancelAllQueued,
   onSteerMessage,
   onEditQueueTail,
-  queueSteering,
 }: UseChatBannerSlotsParams): ChatBannerSlots {
   const {
     showBanner,
@@ -115,7 +113,6 @@ export function useChatBannerSlots({
         onCancelMessage={onCancelQueuedMessage}
         onCancelAll={onCancelAllQueued}
         onSteer={onSteerMessage}
-        showSteer={queueSteering}
         onEditTail={onEditQueueTail}
       />
     ),
@@ -124,7 +121,6 @@ export function useChatBannerSlots({
       onCancelQueuedMessage,
       onCancelAllQueued,
       onSteerMessage,
-      queueSteering,
       onEditQueueTail,
     ],
   );

--- a/clients/web/src/lib/backwards-compat/use-supports-queue-steering.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-queue-steering.ts
@@ -1,0 +1,24 @@
+/**
+ * Backwards-compat gate: the "Push to agent" steer button on queued
+ * messages.
+ *
+ * Vellum Assistant 0.8.4 added `POST /v1/messages/queued/:id/steer` (the
+ * endpoint that promotes a queued message to the head of the queue and
+ * aborts the in-flight generation; PR #31307). Older assistants 404 that
+ * route, so the web app hides the steer arrow on queued-message rows —
+ * the queue drawer renders with only the edit and cancel affordances, as
+ * it does today, with no error surfaced.
+ *
+ * This is a write action: the endpoint aborts the assistant's live
+ * generation. It gates inside `queued-messages-drawer.tsx`, the only
+ * render site of the steer button. A render hook (not the
+ * `assistantSupports` snapshot) so the button appears the moment the
+ * version hydrates.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.8.4";
+
+export function useSupportsQueueSteering(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -198,14 +198,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "queue-steering",
-      "scope": "assistant",
-      "key": "queue-steering",
-      "label": "Queue Steering",
-      "description": "Enable the 'Push to agent' button on queued messages, allowing users to steer the assistant to a specific queued message by aborting the current generation and promoting the message to the head of the queue.",
-      "defaultEnabled": false
-    },
-    {
       "id": "chat-pull-to-refresh-enabled",
       "scope": "client",
       "key": "chat-pull-to-refresh-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -198,14 +198,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "queue-steering",
-      "scope": "assistant",
-      "key": "queue-steering",
-      "label": "Queue Steering",
-      "description": "Enable the 'Push to agent' button on queued messages, allowing users to steer the assistant to a specific queued message by aborting the current generation and promoting the message to the head of the queue.",
-      "defaultEnabled": false
-    },
-    {
       "id": "chat-pull-to-refresh-enabled",
       "scope": "client",
       "key": "chat-pull-to-refresh-enabled",


### PR DESCRIPTION
## Why

The `queue-steering` flag shipped `defaultEnabled: false` in May 2026 (#31307) and was never enabled on the platform, so the "Push to agent" arrow on queued messages has been dark for every user for ~2.5 months while the rest of the queue UI (edit, cancel, cancel all) shipped unflagged. The daemon steer endpoint (`POST /v1/messages/queued/:id/steer`) is already ungated; the flag only hid the button.

## What

- Remove `queue-steering` from `meta/feature-flags/feature-flag-registry.json` and re-sync the bundled copies (`bun run meta/sync-bundled-copies.ts`; only the tracked web copy diffs, the assistant/gateway copies are untracked build artifacts).
- Render the steer button unconditionally: drop the `showSteer` prop from `QueuedMessagesDrawer` and the `queueSteering` plumbing through `useChatBannerSlots` and `chat-route-content`.

## Companion

Platform-side Terraform removal of the flag: companion PR in `vellum-assistant-platform` (linked in comments once open).

## Testing

- `bunx tsc --noEmit` in `clients/web` clean
- `bun test src/domains/chat/hooks/use-chat-banner-slots.test.tsx src/stores/assistant-feature-flag-store.test.ts` 9 pass
- `bun run lint` 0 errors, no warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->