### PR TITLE
fix(web): scope the Conversations bulk actions to what the header contains

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -222,7 +222,11 @@ describe("AssistantSideMenu · All view", () => {
   });
 
   const conversations = [
-    makeConversation({ conversationId: "p1", title: "Pin one", isPinned: true }),
+    makeConversation({
+      conversationId: "p1",
+      title: "Pin one",
+      isPinned: true,
+    }),
     makeConversation({ conversationId: "r1", title: "Recent one" }),
     makeConversation({
       conversationId: "s1",
@@ -351,7 +355,9 @@ describe("AssistantSideMenu · scrollport top inset", () => {
   // glyphs. So the inset lives on the cluster rather than the scrollport.
   test("the rail's scrollport carries no top inset", () => {
     const container = parse(
-      renderMenu({ conversations: [makeConversation({ conversationId: "r1" })] }),
+      renderMenu({
+        conversations: [makeConversation({ conversationId: "r1" })],
+      }),
     );
     const body = container.querySelector<HTMLElement>(
       '[data-slot="side-menu-body"]',
@@ -824,7 +830,10 @@ describe("AssistantSideMenu · section header menus", () => {
     }),
   ];
 
-  function renderWithGroupActions() {
+  function renderWithGroupActions(capture?: {
+    markAllRead?: (conversations: Conversation[]) => void;
+    archiveAll?: (label: string, conversations: Conversation[]) => void;
+  }) {
     return render(
       createElement(AssistantSideMenu, {
         assistantId: "asst-1",
@@ -832,8 +841,8 @@ describe("AssistantSideMenu · section header menus", () => {
         variant: "rail" as const,
         conversations,
         onSelectConversation: () => {},
-        onMarkAllReadInGroup: () => {},
-        onArchiveAllInGroup: () => {},
+        onMarkAllReadInGroup: capture?.markAllRead ?? (() => {}),
+        onArchiveAllInGroup: capture?.archiveAll ?? (() => {}),
       }),
     );
   }
@@ -851,8 +860,83 @@ describe("AssistantSideMenu · section header menus", () => {
     return match;
   }
 
-  // Every section header carries the same bulk actions, Pinned and Chats
-  // included — not just the channel sections.
+  /**
+   * Fire a header's Archive All and return the conversation ids it was handed.
+   *
+   * Asserting on the payload rather than the menu's text is the point: a
+   * presence check passes whether the action covers the right conversations,
+   * none of them, or the entire database. Archive All rather than Mark All as
+   * Read because it is enabled for any non-empty section, so the assertion
+   * turns on scope alone.
+   */
+  async function archiveScopeOf(
+    container: HTMLElement,
+    label: string,
+    received: Array<[string, Conversation[]]>,
+  ): Promise<string[]> {
+    act(() => {
+      headerFor(container, label).dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, button: 2 }),
+      );
+    });
+    let item: HTMLElement | undefined;
+    await waitFor(() => {
+      item = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).find((el) => el.textContent?.includes("Archive All"));
+      expect(item).toBeDefined();
+    });
+    act(() => {
+      item!.click();
+    });
+    const last = received.at(-1);
+    if (!last) {
+      throw new Error(`Archive All under "${label}" fired no handler`);
+    }
+    return last[1].map((c) => c.conversationId).sort();
+  }
+
+  test("the Conversations header covers the same set in either view", async () => {
+    // The header sits above Chats and the channel sections, so its bulk
+    // actions have to reach every conversation it contains. Scoping them to
+    // the `all` view's flat list drops the channel sections in `grouped`,
+    // where those conversations have moved into sections of their own, and a
+    // user who archives "all conversations" is told their Slack threads are
+    // handled when they are not.
+    const scopes: Record<string, string[]> = {};
+    for (const mode of ["all", "grouped"] as const) {
+      localStorage.setItem("vellum:sidebar-view-mode:asst-1", mode);
+      const received: Array<[string, Conversation[]]> = [];
+      const { container, unmount } = renderWithGroupActions({
+        archiveAll: (label, c) => received.push([label, c]),
+      });
+      scopes[mode] = await archiveScopeOf(container, "Conversations", received);
+      unmount();
+      cleanup();
+    }
+
+    expect(scopes.grouped).toContain("s1");
+    expect(scopes.grouped).toEqual(scopes.all);
+  });
+
+  test("a section header covers only that section", async () => {
+    localStorage.setItem("vellum:sidebar-view-mode:asst-1", "grouped");
+    const received: Array<[string, Conversation[]]> = [];
+    const { container } = renderWithGroupActions({
+      archiveAll: (label, c) => received.push([label, c]),
+    });
+    try {
+      expect(await archiveScopeOf(container, "Slack", received)).toEqual([
+        "s1",
+      ]);
+      expect(await archiveScopeOf(container, "Pinned", received)).toEqual([
+        "p1",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
   test.each(["Pinned", "Chats", "Slack"])(
     "%s exposes the same bulk actions on right-click",
     async (label) => {
@@ -920,7 +1004,11 @@ const LAYOUT_CONVERSATIONS = [
     originChannel: "slack",
     groupId: "system:all",
   }),
-  makeConversation({ conversationId: "g1", title: "Group one", groupId: "grp-a" }),
+  makeConversation({
+    conversationId: "g1",
+    title: "Group one",
+    groupId: "grp-a",
+  }),
 ];
 
 const LAYOUT_GROUPS = [
@@ -1280,9 +1368,9 @@ describe("AssistantSideMenu · section reordering", () => {
       (_, index) => labels[index] !== "Conversations",
     );
     expect(draggable).toHaveLength(4);
-    expect(
-      draggable.every((h) => h.getAttribute("draggable") === "true"),
-    ).toBe(true);
+    expect(draggable.every((h) => h.getAttribute("draggable") === "true")).toBe(
+      true,
+    );
   });
 
   test("a lone section isn't draggable - there's nothing to reorder against", () => {
@@ -1302,9 +1390,9 @@ describe("AssistantSideMenu · section reordering", () => {
       ),
     );
     expect(headers).toHaveLength(2);
-    expect(
-      headers.every((h) => h.getAttribute("draggable") !== "true"),
-    ).toBe(true);
+    expect(headers.every((h) => h.getAttribute("draggable") !== "true")).toBe(
+      true,
+    );
   });
 
   // Regression guard. The handlers first sat on the section root, where
@@ -1333,7 +1421,11 @@ describe("AssistantSideMenu · section reordering", () => {
 
       // Minimal DataTransfer stand-in: `onDragStart` only sets an effect and
       // a payload (Firefox needs the latter to begin a drag at all).
-      const dataTransfer = { effectAllowed: "", dropEffect: "", setData: () => {} };
+      const dataTransfer = {
+        effectAllowed: "",
+        dropEffect: "",
+        setData: () => {},
+      };
       const fire = (el: HTMLElement, type: string) => {
         const event = new Event(type, { bubbles: true, cancelable: true });
         Object.assign(event, { dataTransfer, clientY: 10 });

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,6 +1,7 @@
 import { Search, X } from "lucide-react";
 import {
   useCallback,
+  useMemo,
   useState,
   type CSSProperties,
   type ReactNode,
@@ -404,13 +405,38 @@ export function AssistantSideMenu({
     />
   );
 
+  // Everything the persistent "Conversations" header contains, which is
+  // whatever its body renders: the flat list in `all`, and the sections below
+  // the curated tier in `grouped`.
+  //
+  // Both branches describe the same set of conversations, just partitioned
+  // differently, so the header's bulk actions reach the same rows either way.
+  // Reading `flatList` in both views would not: it is the `all` view's list,
+  // so in `grouped` it holds only what is left once the channel sections take
+  // their conversations, and the actions would silently skip every Slack and
+  // Telegram row the header visibly contains.
+  const governedConversations = useMemo(
+    () =>
+      sidebar.viewMode === "all"
+        ? sidebar.flatList
+        : sidebar.sections
+            .slice(sidebar.curatedSectionCount)
+            .flatMap((section) => section.all),
+    [
+      sidebar.viewMode,
+      sidebar.flatList,
+      sidebar.sections,
+      sidebar.curatedSectionCount,
+    ],
+  );
+
   // The persistent "Conversations" header: same bulk-action menu shape as a
   // section's, minus move-up/down since it isn't a member of
-  // `sidebar.sections`. Scoped to `flatList` regardless of view mode:
-  // that's every conversation neither pinned nor in a custom group, the same
-  // set whether it's currently rendered as one list (grouped by None) or
-  // split into Chats + channel sub-sections (grouped by Channel).
-  const conversationsMenu = buildGroupMenu("Conversations", sidebar.flatList);
+  // `sidebar.sections`.
+  const conversationsMenu = buildGroupMenu(
+    "Conversations",
+    governedConversations,
+  );
 
   // Rendered in the rail's non-scrolling header, or at the top of the
   // overlay's body so the whole menu scrolls as one surface; the block's
@@ -524,7 +550,7 @@ export function AssistantSideMenu({
                whole scrollport rather than any one section. */
             <>
               <SidebarListContextMenu onCreateGroup={onCreateGroup}>
-              {/* Every section - Pinned, Chats, channels, custom groups -
+                {/* Every section - Pinned, Chats, channels, custom groups -
                   shares one accordion root, so its gap is the only thing
                   between any two of them and the spacing is uniform by
                   construction. Their open state lives in three storage buckets
@@ -532,20 +558,20 @@ export function AssistantSideMenu({
                   `use-sidebar-state` merges and re-splits it. New Chat lives in
                   the assistant cluster above, not as a section-header
                   action. */}
-              <CollapsibleNavSection.Root
-                type="multiple"
-                className="gap-3"
-                value={sidebar.effectiveOpenSections}
-                onValueChange={sidebar.onOpenSectionsChange}
-              >
-                {/* Pinned and the custom groups: the user's own curation,
+                <CollapsibleNavSection.Root
+                  type="multiple"
+                  className="gap-3"
+                  value={sidebar.effectiveOpenSections}
+                  onValueChange={sidebar.onOpenSectionsChange}
+                >
+                  {/* Pinned and the custom groups: the user's own curation,
                     identical in both views. Nothing between them - they flow
                     together as one curated block, and only the block's own
                     rule below marks the boundary to Conversations. */}
-                {sidebar.sections
-                  .slice(0, sidebar.curatedSectionCount)
-                  .map(renderSection)}
-                {/* The list's one rule, marking where curation ends and the
+                  {sidebar.sections
+                    .slice(0, sidebar.curatedSectionCount)
+                    .map(renderSection)}
+                  {/* The list's one rule, marking where curation ends and the
                     conversations begin. Absent when nothing is curated yet, so
                     a fresh sidebar never opens on a stray line. Sits on the
                     root's own gap, pulled up 2px so the curated block's last
@@ -553,16 +579,16 @@ export function AssistantSideMenu({
                     Static: Pinned no longer caps/scrolls (it's `unbounded`
                     now, see `ConversationRowList`), so there's nothing left
                     to resize here. */}
-                {sidebar.curatedSectionCount > 0 ? (
-                  <div
-                    data-slot="sidebar-section-rule"
-                    role="separator"
-                    aria-orientation="horizontal"
-                    style={{ marginTop: -2 }}
-                    className="h-px w-full bg-[var(--border-base)]"
-                  />
-                ) : null}
-                {/* "Conversations" is the persistent header for everything
+                  {sidebar.curatedSectionCount > 0 ? (
+                    <div
+                      data-slot="sidebar-section-rule"
+                      role="separator"
+                      aria-orientation="horizontal"
+                      style={{ marginTop: -2 }}
+                      className="h-px w-full bg-[var(--border-base)]"
+                    />
+                  ) : null}
+                  {/* "Conversations" is the persistent header for everything
                     that isn't Pinned or a custom group: it never swaps out
                     for "Chats". Grouped by All, its content is the flat
                     list; grouped by Channels, Chats and each channel
@@ -571,36 +597,36 @@ export function AssistantSideMenu({
                     behavior. Same bulk-action menu machinery as a
                     section's, minus move-up/down since it isn't a member
                     of `sidebar.sections`. */}
-                <ConversationNavSection
-                  value="conversations"
-                  label="Conversations"
-                  collapsible={false}
-                  trailing={
-                    <GroupActionsMenu
-                      label="Conversations"
-                      footer={groupByFooter}
-                      {...conversationsMenu}
-                    />
-                  }
-                  groupMenu={conversationsMenu}
-                  items={sidebar.flatList}
-                >
-                  {sidebar.viewMode === "all" ? (
-                    bodyElement ? (
-                      <ConversationRowList
-                        items={sidebar.flatList}
-                        scrollParent={bodyElement}
+                  <ConversationNavSection
+                    value="conversations"
+                    label="Conversations"
+                    collapsible={false}
+                    trailing={
+                      <GroupActionsMenu
+                        label="Conversations"
+                        footer={groupByFooter}
+                        {...conversationsMenu}
                       />
-                    ) : null
-                  ) : (
-                    <div className="flex flex-col gap-3">
-                      {sidebar.sections
-                        .slice(sidebar.curatedSectionCount)
-                        .map(renderSection)}
-                    </div>
-                  )}
-                </ConversationNavSection>
-              </CollapsibleNavSection.Root>
+                    }
+                    groupMenu={conversationsMenu}
+                    items={sidebar.flatList}
+                  >
+                    {sidebar.viewMode === "all" ? (
+                      bodyElement ? (
+                        <ConversationRowList
+                          items={sidebar.flatList}
+                          scrollParent={bodyElement}
+                        />
+                      ) : null
+                    ) : (
+                      <div className="flex flex-col gap-3">
+                        {sidebar.sections
+                          .slice(sidebar.curatedSectionCount)
+                          .map(renderSection)}
+                      </div>
+                    )}
+                  </ConversationNavSection>
+                </CollapsibleNavSection.Root>
               </SidebarListContextMenu>
               <SidebarBackToTop
                 visible={scrolledPast}


### PR DESCRIPTION
## TL;DR

"Archive All" on the **Conversations** header silently skips every Slack and Telegram thread when you're in Grouped view, and reports success. Twelve lines fix the scope; the rest of the diff is a test that can actually detect it.

Fixes [LUM-3008](https://linear.app/vellum/issue/LUM-3008).

## What changes for the user

| Action | Before | After |
| -- | -- | -- |
| Archive All / Mark All as Read on **Conversations**, All view | Covers everything | Unchanged |
| Same action, **Grouped** view | **Silently skips all channel conversations** | Covers them |
| Any individual section's own menu (Pinned, Chats, Slack) | Correct already | Unchanged |

## Why it happened

The header renders above Chats and the channel sections, but its menu was built from `sidebar.flatList`. That is the *All* view's list. In Grouped view the channel conversations have moved into sections of their own, so `flatList` holds only what is left, and the menu on the header that visibly contains them covered a strict subset.

The fix scopes the menu to what the header's body actually renders: `flatList` in All, and the sections below the curated tier in Grouped. Same conversations either way, partitioned differently.

## Why the existing test did not catch it

`assistant-side-menu.test.tsx` right-clicks a header and asserts the menu's text contains "Mark All as Read", with `onMarkAllReadInGroup: () => {}` as the handler. It captures nothing and never fires the action, so it passes whether the scope is correct, empty, or the entire database.

The new tests assert the array the action receives:

* the header's scope is identical in All and Grouped, and contains the channel conversation
* a section's own menu covers only that section

Both were mutation-checked: reverting to the original `flatList` scoping turns the first one red.

## One thing worth knowing about the fix

My first version scoped to `sections.slice(curatedSectionCount)` in both views. It reads correctly and is right in Grouped. But in All the sidebar puts only the curated tier in `sections` and renders everything else as `flatList`, so the slice was empty, the menu went **disabled**, and Archive All would have done nothing at all.

The payload test caught that. The old test passed against the original bug, against that broken fix, and against the correct one, which is the argument for asserting on what an action receives rather than on what a menu says.

## The underlying shape problem, deliberately not fixed here

`useSidebarState` returns the same conversations in two shapes: `SidebarSection` objects for every section, and a bare `flatList` for the All view's non-curated rows. Consumers wanting "everything not pinned or grouped" therefore have to know which view they are in. Two people reached for the obvious answer and got opposite halves of it wrong.

The clean shape is that Chats is a section like the others, with presentation deciding whether it draws as a card or a bare virtualized list. That is not worth doing here: LUM-2443 and LUM-3061 replace `useSidebarState` and this component outright, and in the card design Chats *is* a card, so the asymmetry disappears by construction rather than by patch. Recorded as an invariant on LUM-2443 instead.

The test, unlike the fix, is not tied to this implementation. It states that a header's bulk action covers what the header contains, so it carries into the rebuild unchanged.

## Validation

Typecheck and lint clean. 57/57 in `assistant-side-menu.test.tsx`, 16/16 in `use-sidebar-state.test.tsx`, and the full isolated web suite passes apart from `daily-reset-time.test.ts`, which fails on this machine with `"GMT"` vs `"GMT+0"`, an ICU/timezone difference unrelated to this change: the diff touches two files and that test imports neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->