### PR TITLE
Split Android release gates by environment

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2244,7 +2244,7 @@ jobs:
 
   release-android:
     needs: [compute-version, register-release, build-chrome-extension]
-    if: vars.ANDROID_RELEASE_ENABLED == 'true'
+    if: vars.ANDROID_DEV_RELEASE_ENABLED == 'true'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2699,7 +2699,10 @@ jobs:
     needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
     if: >-
       ${{
-        vars.ANDROID_RELEASE_ENABLED == 'true'
+        (
+          (needs.extract-version.outputs.is_staging == 'true' && vars.ANDROID_STAGING_RELEASE_ENABLED == 'true')
+          || (needs.extract-version.outputs.is_staging != 'true' && vars.ANDROID_PRODUCTION_RELEASE_ENABLED == 'true')
+        )
         && always() && !cancelled()
         && needs.extract-version.result == 'success'
         && needs.push-assistant-manifest.result == 'success'

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -301,9 +301,21 @@ distribution do not depend on push setup. When it is absent, the workflow emits
 a warning and the resulting AAB has no native push support. When it is present,
 malformed base64, invalid JSON, or a package mismatch fails the build.
 
-After completing the prerequisites and GitHub configuration, set the repository
-variable `ANDROID_RELEASE_ENABLED` to `true`. Until then, both orchestrators
-skip Android distribution so existing releases remain unaffected.
+After completing the prerequisites and GitHub configuration, enable Android
+distribution independently with these repository variables:
+
+| Variable | Release workflow |
+|----------|------------------|
+| `ANDROID_DEV_RELEASE_ENABLED` | Dev releases |
+| `ANDROID_STAGING_RELEASE_ENABLED` | Staging releases |
+| `ANDROID_PRODUCTION_RELEASE_ENABLED` | Production releases |
+
+Set only `ANDROID_DEV_RELEASE_ENABLED` to `true` to test the dev app on its Play
+internal track. Leave the staging and production variables unset or set to
+`false` until those apps are ready. A missing or non-`true` variable skips the
+matching Android distribution job. Manually dispatch the **Dev Release**
+workflow to run the dev release immediately instead of waiting for its hourly
+schedule.
 
 ### Manual Play Prerequisites
 


### PR DESCRIPTION
## Summary

- replace the global Android release gate with independent dev, staging, and production repository variables
- allow dev internal-track testing without enabling Android publishing in staging or production
- document the dev-only variable and manual Dev Release dispatch path

## Original prompt

Android publishing currently uses one repository-wide gate across all release workflows. The user wants to test the dev Play internal-track upload without enabling staging or production, so the release gates need to be independent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->