### PR TITLE
feat(assistant): add a documents-changed sync broadcast

### DIFF
--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -15,6 +15,7 @@ export const SYNC_TAGS = {
   assistantSchedules: "assistant:self:schedules",
   assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
+  documentsList: "documents:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -67,6 +67,10 @@ export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
 }
 
+export function publishDocumentsChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.documentsList], originClientId);
+}
+
 export function publishPluginsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.pluginsList], originClientId);
 }

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -6,6 +6,7 @@ export const SYNC_TAGS = {
   assistantSchedules: "assistant:self:schedules",
   assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
+  documentsList: "documents:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",

--- a/clients/web/src/utils/sandbox-sync-filter.test.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.test.ts
@@ -23,6 +23,7 @@ describe("forwardableSyncTags", () => {
       "conversation:conv-1:messages",
       "conversations:list",
       "apps:list",
+      "documents:list",
       "plugins:list",
       "feature-flags:client",
     ];
@@ -37,6 +38,15 @@ describe("forwardableSyncTags", () => {
       forwardableSyncTags(
         ["show:state", "apps:list"],
         ["show:state", "apps:list"],
+      ),
+    ).toEqual(["show:state"]);
+  });
+
+  test("drops the documents list tag while keeping a custom tag alongside it", () => {
+    expect(
+      forwardableSyncTags(
+        ["show:state", "documents:list"],
+        ["show:state", "documents:list"],
       ),
     ).toEqual(["show:state"]);
   });

--- a/clients/web/src/utils/sandbox-sync-filter.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.ts
@@ -5,10 +5,10 @@
  * A sandboxed app may only receive `sync_changed` invalidations for the tags
  * it explicitly subscribed to, and never for the host's reserved sync
  * namespaces — forwarding those would leak host activity (conversation
- * traffic, config/theme/schedule changes, the apps/plugins lists) into
- * untrusted app code. Custom tags an app's own routes emit pass through, so an
- * app can drive live refreshes off its own `publishSyncInvalidation` without
- * polling.
+ * traffic, config/theme/schedule changes, the apps/documents/plugins lists)
+ * into untrusted app code. Custom tags an app's own routes emit pass through,
+ * so an app can drive live refreshes off its own `publishSyncInvalidation`
+ * without polling.
  *
  * `sync_changed` carries no payload — only which resource went stale — and the
  * authenticated fetch proxy remains the real access gate; this filter is
@@ -21,6 +21,7 @@ export const RESERVED_SYNC_TAG_PREFIXES = [
   "conversation:",
   "conversations:",
   "apps:",
+  "documents:",
   "plugins:",
   "feature-flags:",
 ] as const;


### PR DESCRIPTION
## Summary
- Add `publishDocumentsChanged()` mirroring the existing apps broadcast.
- Add the `documents:list` sync tag to the web SYNC_TAGS registry.
- Additive scaffolding only: no callers yet, no behavior change.

Part of plan: document-update-discoverability.md (PR 1 of 12)