### PR TITLE
feat(web): add a store for unseen document changes

### DIFF
--- a/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the unseen-document-changes store.
+ *
+ * Every case asserts the pure predicate and the reactive hook together, since
+ * the point of the pairing is that a badge and the clearing logic can never
+ * disagree about what "unseen" means.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import {
+  hasUnseenChanges,
+  useHasUnseenDocumentChanges,
+  useUnseenDocumentChangesStore,
+} from "@/domains/chat/unseen-document-changes-store";
+
+afterEach(() => {
+  cleanup();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+/** Assert the predicate and the hook agree, and return what they both say. */
+function unseen(conversationId: string | null): boolean {
+  const fromPredicate = hasUnseenChanges(
+    useUnseenDocumentChangesStore.getState(),
+    conversationId,
+  );
+  const { result } = renderHook(() =>
+    useHasUnseenDocumentChanges(conversationId),
+  );
+  expect(result.current).toBe(fromPredicate);
+  return fromPredicate;
+}
+
+describe("unseen document changes", () => {
+  test("starts with nothing unseen", () => {
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("marking a document makes its conversation unseen", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+  });
+
+  test("clearing the marked document clears the conversation", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toBeUndefined();
+  });
+
+  test("clearing one document leaves the other unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toEqual(new Set(["doc-b"]));
+  });
+
+  test("clearing a document that was never marked is a no-op", () => {
+    const before = useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      before,
+    );
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("conversations are isolated from each other", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(unseen("conv-2")).toBe(false);
+  });
+
+  test("clearing one conversation leaves the other unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-2", "doc-b");
+      store.clearConversation("conv-1");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(unseen("conv-2")).toBe(true);
+  });
+
+  test("clearing a conversation clears all of its documents", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearConversation("conv-1");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
+  });
+
+  test("marking the same document twice is idempotent", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    const afterFirst =
+      useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      afterFirst,
+    );
+    expect(unseen("conv-1")).toBe(true);
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("a null conversation id is never unseen", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen(null)).toBe(false);
+  });
+
+  test("the hook reacts to a mark and a clear while mounted", () => {
+    const { result } = renderHook(() => useHasUnseenDocumentChanges("conv-1"));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearConversation("conv-1");
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/unseen-document-changes-store.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Documents the assistant changed since the user last looked at them.
+ *
+ * Session-ephemeral: the flag lives only for the life of the tab, so a reload
+ * starts clean. There is no server-side "unseen" record to reconcile against.
+ *
+ * Entries are keyed by conversation so a change in a background conversation
+ * cannot light the affordance on the conversation currently on screen.
+ *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+export interface UnseenDocumentChangesState {
+  /**
+   * Conversation id to the surface ids of its documents with unseen changes.
+   *
+   * A conversation with nothing unseen carries no entry at all, so an empty
+   * set is never left behind for a predicate to have to interpret.
+   */
+  changedDocuments: Record<string, ReadonlySet<string>>;
+}
+
+export interface UnseenDocumentChangesActions {
+  /** Record that a document changed while the user was not looking at it. */
+  markDocumentChanged: (conversationId: string, surfaceId: string) => void;
+  /** Clear one document, for "the user opened that document". */
+  clearDocument: (conversationId: string, surfaceId: string) => void;
+  /** Clear a whole conversation, for "the user opened the assets sheet". */
+  clearConversation: (conversationId: string) => void;
+}
+
+export type UnseenDocumentChangesStore = UnseenDocumentChangesState &
+  UnseenDocumentChangesActions;
+
+const useUnseenDocumentChangesStoreBase = create<UnseenDocumentChangesStore>()(
+  (set) => ({
+    changedDocuments: {},
+
+    markDocumentChanged: (conversationId, surfaceId) => {
+      set((s) => {
+        const current = s.changedDocuments[conversationId];
+        if (current?.has(surfaceId)) {
+          return s;
+        }
+        const next = new Set(current);
+        next.add(surfaceId);
+        return {
+          changedDocuments: { ...s.changedDocuments, [conversationId]: next },
+        };
+      });
+    },
+
+    clearDocument: (conversationId, surfaceId) => {
+      set((s) => {
+        const current = s.changedDocuments[conversationId];
+        if (!current?.has(surfaceId)) {
+          return s;
+        }
+        const next = new Set(current);
+        next.delete(surfaceId);
+        const changedDocuments = { ...s.changedDocuments };
+        if (next.size === 0) {
+          delete changedDocuments[conversationId];
+        } else {
+          changedDocuments[conversationId] = next;
+        }
+        return { changedDocuments };
+      });
+    },
+
+    clearConversation: (conversationId) => {
+      set((s) => {
+        if (s.changedDocuments[conversationId] === undefined) {
+          return s;
+        }
+        const changedDocuments = { ...s.changedDocuments };
+        delete changedDocuments[conversationId];
+        return { changedDocuments };
+      });
+    },
+  }),
+);
+
+export const useUnseenDocumentChangesStore = createSelectors(
+  useUnseenDocumentChangesStoreBase,
+);
+
+/**
+ * Whether a conversation has any document changed since the user last looked.
+ *
+ * Pure predicate so the reactive affordance and the imperative clearing paths
+ * can never disagree about what "unseen" means. Takes the store state, so an
+ * event handler can pass `useUnseenDocumentChangesStore.getState()` directly.
+ */
+export function hasUnseenChanges(
+  state: UnseenDocumentChangesState,
+  conversationId: string | null,
+): boolean {
+  if (conversationId === null) {
+    return false;
+  }
+  return (state.changedDocuments[conversationId]?.size ?? 0) > 0;
+}
+
+/**
+ * Reactive form of {@link hasUnseenChanges}, composed over the atomic selector
+ * so a consumer only re-renders when the unseen map changes.
+ */
+export function useHasUnseenDocumentChanges(
+  conversationId: string | null,
+): boolean {
+  const changedDocuments = useUnseenDocumentChangesStore.use.changedDocuments();
+  return hasUnseenChanges({ changedDocuments }, conversationId);
+}


### PR DESCRIPTION
## Summary
- Add a conversation-scoped Zustand store tracking documents changed since the user last looked.
- Expose a pure predicate plus a reactive hook so the badge and the clearing logic agree on what unseen means.
- No consumers yet.

## Note for downstream PRs
The plan lists the file under `domains/chat/stores/`. It ships at the domain root instead (`clients/web/src/domains/chat/unseen-document-changes-store.ts`) because `clients/web/docs/CONVENTIONS.md` bans single-file directories, names this exact case as its example, and `docs/STATE_MANAGEMENT.md` specifies `domains/<x>/<x>-store.ts`. Every other chat store already sits at the domain root. Import from `@/domains/chat/unseen-document-changes-store`.

Part of plan: document-update-discoverability.md (PR 5 of 12)