### PR TITLE
feat(web): derive changed document ids from a turn's tool calls

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
@@ -235,4 +235,60 @@ describe("resolveChangedDocuments", () => {
     });
     expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
   });
+
+  test("ignores a replace that succeeded without changing content", () => {
+    // document_replace_text succeeds with content_changed: false when `find`
+    // matched nothing, so the document is unchanged.
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      result: JSON.stringify({
+        success: true,
+        surface_id: "doc-1",
+        replacements_made: 0,
+        content_changed: false,
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("resolves a replace that reports content_changed", () => {
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      result: JSON.stringify({
+        success: true,
+        surface_id: "doc-1",
+        replacements_made: 2,
+        content_changed: true,
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("resolves create and update results, which omit content_changed", () => {
+    const calls = [
+      call({
+        id: "tc-a",
+        name: "document_create",
+        input: { title: "Notes" },
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-1",
+          message: "Document created",
+        }),
+      }),
+      call({
+        id: "tc-b",
+        name: "document_update",
+        input: { surface_id: "doc-2" },
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          mode: "append",
+          message: "Document content updated",
+        }),
+      }),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([
+      "doc-1",
+      "doc-2",
+    ]);
+  });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import {
   computeCardBackedWorkflowRunIds,
+  resolveChangedDocuments,
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -126,5 +127,112 @@ describe("computeCardBackedWorkflowRunIds", () => {
       result: "Failed to start workflow: agent cap exceeded",
     });
     expect(computeCardBackedWorkflowRunIds([tc], backingState()).size).toBe(0);
+  });
+});
+
+/** A document tool call whose surface id is recoverable from its result. */
+function docCall(
+  id: string,
+  tool: string,
+  surfaceId: string,
+  overrides: Partial<ChatMessageToolCall> = {},
+): ChatMessageToolCall {
+  return call({
+    id,
+    name: tool,
+    input: { surface_id: surfaceId },
+    result: JSON.stringify({ success: true, surface_id: surfaceId }),
+    ...overrides,
+  });
+}
+
+describe("resolveChangedDocuments", () => {
+  test("resolves the surface id a single update wrote to", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1");
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("resolves a call delivered inside a skill_execute envelope", () => {
+    const tc = call({
+      id: "tc-a",
+      name: "skill_execute",
+      input: { tool: "document_update", surface_id: "doc-1" },
+      result: JSON.stringify({ success: true, surface_id: "doc-1" }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("collapses a create then an update of the same document to one entry", () => {
+    const calls = [
+      docCall("tc-a", "document_create", "doc-1"),
+      docCall("tc-b", "document_update", "doc-1"),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual(["doc-1"]);
+  });
+
+  test("returns two different documents in first-changed order", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-2"),
+      docCall("tc-b", "document_replace_text", "doc-1"),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([
+      "doc-2",
+      "doc-1",
+    ]);
+  });
+
+  test("a shared claimed Set stops a second group anchoring the same document", () => {
+    const claimed = new Set<string>();
+    const first = docCall("tc-a", "document_update", "doc-1");
+    const second = docCall("tc-b", "document_update", "doc-1");
+    expect(resolveChangedDocuments([first], claimed)).toEqual(["doc-1"]);
+    expect(resolveChangedDocuments([second], claimed)).toEqual([]);
+  });
+
+  test("ignores a malformed, non-JSON result without throwing", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: "Failed to update document: no document is open",
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores a result whose JSON carries no surface_id", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: JSON.stringify({ success: true }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores a call whose result has not landed yet", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: undefined,
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores non-document tool calls", () => {
+    const calls = [
+      call({ id: "tc-a", name: "document_read", result: "{}" }),
+      call({
+        id: "tc-b",
+        name: "file_write",
+        result: JSON.stringify({ surface_id: "doc-1" }),
+      }),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([]);
+  });
+
+  test("ignores an errored call even when its result carries a surface id", () => {
+    // A failed document_replace_text still echoes the surface id it targeted,
+    // but nothing changed, so there is no document to reopen.
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      isError: true,
+      result: JSON.stringify({
+        success: false,
+        surface_id: "doc-1",
+        error: "text not found",
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -424,6 +424,86 @@ export function resolveBackgroundTaskIds(
   return ids;
 }
 
+/** The document tools that change a document's content. */
+const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
+  "document_create",
+  "document_update",
+  "document_replace_text",
+]);
+
+/**
+ * Detect a call to a document tool that changes content. Document tools ship in
+ * the bundled `document-editor` skill, so a call arrives either under its raw
+ * tool name or inside a `skill_execute` envelope whose `input.tool` names it.
+ */
+function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
+  if (DOCUMENT_MUTATION_TOOLS.has(toolCall.name)) {
+    return true;
+  }
+  if (toolCall.name !== "skill_execute") {
+    return false;
+  }
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") {
+    return false;
+  }
+  const tool = (input as Record<string, unknown>).tool;
+  return typeof tool === "string" && DOCUMENT_MUTATION_TOOLS.has(tool);
+}
+
+/**
+ * Extract the `surface_id` a mutating document tool call wrote to. The
+ * executors return `JSON.stringify({ ..., surface_id })` (see
+ * `assistant/src/tools/document/document-tool.ts`). Returns `undefined` for a
+ * non-document call, a call that failed, or a non-JSON/malformed result, so
+ * callers anchor only on documents that really changed.
+ */
+function extractDocumentSurfaceIdFromResult(
+  toolCall: ChatMessageToolCall,
+): string | undefined {
+  if (!isDocumentMutationCall(toolCall) || toolCall.isError === true) {
+    return undefined;
+  }
+  if (typeof toolCall.result !== "string" || !toolCall.result) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(toolCall.result) as { surface_id?: unknown };
+    return typeof parsed.surface_id === "string" && parsed.surface_id !== ""
+      ? parsed.surface_id
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the ids of the documents `toolCalls` changed, in first-changed order.
+ * Each id rides on its call's persisted `result`, so it survives a history
+ * reseed, unlike the ephemeral `document_editor_update` event.
+ *
+ * The caller owns the `claimed` Set so it persists across every invocation
+ * within a single message. That collapses repeated edits of one document into a
+ * single entry and stops two non-consecutive tool-call groups from both
+ * anchoring the same document.
+ */
+export function resolveChangedDocuments(
+  toolCalls: ChatMessageToolCall[],
+  claimed: Set<string>,
+): string[] {
+  const surfaceIds: string[] = [];
+
+  for (const tc of toolCalls) {
+    const surfaceId = extractDocumentSurfaceIdFromResult(tc);
+    if (surfaceId && !claimed.has(surfaceId)) {
+      surfaceIds.push(surfaceId);
+      claimed.add(surfaceId);
+    }
+  }
+
+  return surfaceIds;
+}
+
 /**
  * The `acpSessionId` a single `acp_spawn` tool call resolves to — its
  * `byToolUseId` anchor (from the `acp_session_spawned` event), else the id

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -455,8 +455,15 @@ function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
  * Extract the `surface_id` a mutating document tool call wrote to. The
  * executors return `JSON.stringify({ ..., surface_id })` (see
  * `assistant/src/tools/document/document-tool.ts`). Returns `undefined` for a
- * non-document call, a call that failed, or a non-JSON/malformed result, so
- * callers anchor only on documents that really changed.
+ * non-document call, a call that failed, a replace that matched nothing, or a
+ * non-JSON/malformed result, so callers anchor only on documents that really
+ * changed.
+ *
+ * Only `document_replace_text` reports `content_changed`, and it succeeds with
+ * `content_changed: false` when `find` matched nothing. `document_create` and
+ * `document_update` omit the field and always write, so an absent field reads
+ * as changed and only an explicit `false` rejects the call. That matches the
+ * daemon, which emits `document_editor_update` on the same condition.
  */
 function extractDocumentSurfaceIdFromResult(
   toolCall: ChatMessageToolCall,
@@ -468,7 +475,13 @@ function extractDocumentSurfaceIdFromResult(
     return undefined;
   }
   try {
-    const parsed = JSON.parse(toolCall.result) as { surface_id?: unknown };
+    const parsed = JSON.parse(toolCall.result) as {
+      surface_id?: unknown;
+      content_changed?: unknown;
+    };
+    if (parsed.content_changed === false) {
+      return undefined;
+    }
     return typeof parsed.surface_id === "string" && parsed.surface_id !== ""
       ? parsed.surface_id
       : undefined;


### PR DESCRIPTION
## Summary
- Add `resolveChangedDocuments`, reading `surface_id` out of the persisted document tool results.
- Deduplicate within a turn using the existing claimed-set idiom.
- No consumers yet.

Part of plan: document-update-discoverability.md (PR 9 of 12)