### PR TITLE
feat(web): add a predicate for whether a document is open

### DIFF
--- a/clients/web/src/domains/chat/components/local-file/open-local-file.test.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
 
 import type { WorkspaceFilePreviewKind } from "@/stores/viewer-store";
 
@@ -6,11 +7,13 @@ const openWorkspaceFile = mock(async (_path: string) => {});
 mock.module("@/utils/open-workspace-file", () => ({ openWorkspaceFile }));
 
 const {
+  isDocumentOpen,
   isWorkspaceFileOpen,
   openLocalFile,
   opensInDocumentDrawer,
   previewKindFor,
   toggleLocalFile,
+  useIsDocumentOpen,
   usesDocumentDrawer,
 } = await import("@/domains/chat/components/local-file/open-local-file");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -325,6 +328,66 @@ describe("isWorkspaceFileOpen", () => {
         "data/rows.csv",
       ),
     ).toBe(true);
+  });
+});
+
+describe("isDocumentOpen", () => {
+  const drawer = openDrawerState("drafts/notes.md");
+  const preview = openPreviewState("data/rows.csv");
+
+  /** What the reactive hook reports for the store state currently set. */
+  function renderIsDocumentOpen(surfaceId: string): boolean {
+    const { result, unmount } = renderHook(() => useIsDocumentOpen(surfaceId));
+    const answer = result.current;
+    unmount();
+    return answer;
+  }
+
+  test("matches the document the viewer is showing", () => {
+    useViewerStore.setState(drawer);
+
+    expect(
+      isDocumentOpen("document", drawer.openedDocumentState, "surf-file"),
+    ).toBe(true);
+    expect(renderIsDocumentOpen("surf-file")).toBe(true);
+  });
+
+  test("does not match a different document", () => {
+    useViewerStore.setState(drawer);
+
+    expect(
+      isDocumentOpen("document", drawer.openedDocumentState, "surf-other"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-other")).toBe(false);
+  });
+
+  test("does not match while another view is on top", () => {
+    const behind = { ...drawer, mainView: "chat" as const };
+    useViewerStore.setState(behind);
+
+    expect(
+      isDocumentOpen("chat", behind.openedDocumentState, "surf-file"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
+  });
+
+  test("does not match while nothing is loaded", () => {
+    useViewerStore.setState({
+      mainView: "document",
+      openedDocumentState: null,
+    });
+
+    expect(isDocumentOpen("document", null, "surf-file")).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
+  });
+
+  test("does not match a preview, which is not a document surface", () => {
+    useViewerStore.setState(preview);
+
+    expect(
+      isDocumentOpen("document", preview.openedDocumentState, "surf-file"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/components/local-file/open-local-file.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.ts
@@ -193,6 +193,42 @@ export function useIsWorkspaceFileOpen(workspacePath: string | null): boolean {
 }
 
 /**
+ * Whether the document drawer is currently showing the document surface
+ * `surfaceId`. Pure predicate so an affordance that hides itself while its own
+ * document is visible and anything acting on that document can never disagree
+ * about what "open" means.
+ *
+ * A read-only preview carries no surface id, so it matches nothing.
+ *
+ * This answers for the in-chat viewer only. The standalone
+ * `/assistant/documents/:surfaceId` route is a separate surface that does not
+ * set `mainView`, so a consumer that needs "open anywhere" also matches the
+ * route.
+ */
+export function isDocumentOpen(
+  mainView: MainView,
+  openedDocument: OpenedDocumentState | null,
+  surfaceId: string,
+): boolean {
+  return (
+    mainView === "document" &&
+    openedDocument !== null &&
+    openedDocument.source === "document" &&
+    openedDocument.surfaceId === surfaceId
+  );
+}
+
+/**
+ * Reactive form of {@link isDocumentOpen}, composed over atomic selectors so a
+ * consumer only re-renders when the view or the opened document changes.
+ */
+export function useIsDocumentOpen(surfaceId: string): boolean {
+  const mainView = useViewerStore.use.mainView();
+  const openedDocument = useViewerStore.use.openedDocumentState();
+  return isDocumentOpen(mainView, openedDocument, surfaceId);
+}
+
+/**
  * Open a workspace file the assistant referenced: a document bound to the file
  * for markdown, the drawer's read-only preview for everything else.
  *


### PR DESCRIPTION
## Summary
- Add `isDocumentOpen` and `useIsDocumentOpen` beside the existing workspace-file pair.
- Hook composes atomic viewer-store selectors so consumers re-render narrowly.
- No consumers yet.

Part of plan: document-update-discoverability.md (PR 10 of 12)