### PR TITLE
Stop a clipboard write that resolves after unmount

### DIFF
--- a/clients/web/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/clients/web/src/hooks/use-copy-to-clipboard.test.tsx
@@ -6,7 +6,7 @@
  *      then, so anything scheduled from the resolution outlives the component.
  *   2. A write that resolves while mounted still runs its caller's callback.
  *
- * The failure this guards is quiet: React no longer warns on a setState after
+ * The failure this guards is quiet: React does not warn on a setState after
  * unmount, so the leak is a timer nothing will clear rather than an error
  * anyone would see.
  */

--- a/clients/web/src/hooks/use-copy-to-clipboard.test.tsx
+++ b/clients/web/src/hooks/use-copy-to-clipboard.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for `useCopyToClipboard`'s lifecycle:
+ *
+ *   1. A write that resolves after unmount does no work. The clipboard promise
+ *      resolves on its own schedule, and the effect cleanup has already run by
+ *      then, so anything scheduled from the resolution outlives the component.
+ *   2. A write that resolves while mounted still runs its caller's callback.
+ *
+ * The failure this guards is quiet: React no longer warns on a setState after
+ * unmount, so the leak is a timer nothing will clear rather than an error
+ * anyone would see.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render } from "@testing-library/react";
+
+import * as toastModule from "@vellumai/design-library/components/toast";
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: { ...toastModule.toast, success: () => {}, error: () => {} },
+}));
+mock.module("@/lib/sentry/capture-error", () => ({ captureError: () => {} }));
+
+const { useCopyToClipboard } = await import("@/hooks/use-copy-to-clipboard");
+
+let resolveWrite: (() => void) | null = null;
+
+beforeEach(() => {
+  resolveWrite = null;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    },
+  });
+});
+
+afterEach(cleanup);
+
+function Harness({ onCopied }: { onCopied: () => void }) {
+  const { copy, copied } = useCopyToClipboard({ errorMessage: "nope" });
+  return (
+    <button type="button" onClick={() => copy("payload", onCopied)}>
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}
+
+describe("useCopyToClipboard", () => {
+  test("does no work when the write resolves after unmount", async () => {
+    const calls: string[] = [];
+    const { getByRole, unmount } = render(
+      <Harness onCopied={() => calls.push("copied")} />,
+    );
+
+    getByRole("button").click();
+    unmount();
+
+    await act(async () => {
+      resolveWrite?.();
+      await Promise.resolve();
+    });
+
+    // Reaching the callback means the transient flag was set and a reset timer
+    // armed, both after the cleanup that was supposed to have ended this.
+    expect(calls).toEqual([]);
+  });
+
+  test("runs the caller's callback when the write resolves while mounted", async () => {
+    const calls: string[] = [];
+    const { getByRole } = render(
+      <Harness onCopied={() => calls.push("copied")} />,
+    );
+
+    getByRole("button").click();
+
+    await act(async () => {
+      resolveWrite?.();
+      await Promise.resolve();
+    });
+
+    expect(calls).toEqual(["copied"]);
+    expect(getByRole("button").textContent).toBe("Copied!");
+  });
+});

--- a/clients/web/src/hooks/use-copy-to-clipboard.ts
+++ b/clients/web/src/hooks/use-copy-to-clipboard.ts
@@ -27,9 +27,15 @@ export function useCopyToClipboard({
 }: UseCopyToClipboardOptions) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mounted = useRef(true);
 
   useEffect(() => {
+    // Set on the way in as well as cleared on the way out: StrictMode mounts,
+    // cleans up, and mounts again, so a flag only cleared on unmount would
+    // leave the second mount believing it had already gone.
+    mounted.current = true;
     return () => {
+      mounted.current = false;
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
@@ -41,6 +47,12 @@ export function useCopyToClipboard({
       copyToClipboard(text, {
         errorMessage,
         onCopied: () => {
+          // The write resolves on its own schedule. If the drawer closed in
+          // the meantime the cleanup has already run, so arming a timer here
+          // would leave one nothing will clear.
+          if (!mounted.current) {
+            return;
+          }
           setCopied(true);
           if (timerRef.current) {
             clearTimeout(timerRef.current);


### PR DESCRIPTION
## TL;DR

`useCopyToClipboard` kept working after the component using it had gone. A clipboard write that resolves post-unmount set state and armed a fresh reset timer, after the cleanup that was supposed to clear it had already run.

Split out of #40239 (LUM-3077). It has nothing to do with Telegram setup, and two of the three components it affects live nowhere near that feature.

## The bug

`copy()` hands the write to `copyToClipboard`, which resolves a promise and calls back. That callback sets the transient `copied` flag and schedules a 1.5s reset. Both happen whenever the promise resolves, which is on the browser's schedule, not the component's.

Close the drawer between the click and the resolution and the order is:

1. Component unmounts. The cleanup effect runs and clears the pending timer.
2. The clipboard promise resolves.
3. The callback sets state on a component that is gone, and arms a **new** timer.
4. Nothing will ever clear that timer.

React stopped warning on setState-after-unmount, so there is no error and no console noise. The symptom is a stray timer holding a closure.

## Who this affects

Three components share the hook:

| Component | Where |
| -- | -- |
| `CopyButton` | chat inspector |
| `PairDeviceCard` | settings, device pairing |
| `SlackSetupWizard` | channel setup |

The first two are why this is its own PR rather than riding along in a Telegram setup change. Nobody reviewing that would think to check the inspector's copy button.

## The fix

A `mounted` ref, checked before the callback does anything.

It is set on the way **in** as well as cleared on the way out. StrictMode mounts, runs effects, cleans up, and mounts again, so a flag only cleared on unmount leaves the second mount believing it had already gone, and copying would silently stop working in development.

## Why this is safe

- Additive guard. The mounted path is unchanged, which the second test pins.
- No call-site changes. No public API change.
- 869/870 web test files pass. The one failure is `daily-reset-time.test.ts`, which asserts a locale-formatted string that varies by ICU version; it fails on this machine and passes in CI on main.

## Tests

The test controls the clipboard promise directly so it can unmount in the window between the click and the resolution, which is the only place the two behaviours differ. Mutation-checked: removing the guard fails it, and the mounted-path test keeps the guard from being over-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->