### PR TITLE
feat(assistant): broadcast a change when a document tool mutates

### DIFF
--- a/assistant/src/__tests__/tool-side-effects-documents.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-documents.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the document post-execution hooks that publish a documents-changed
+ * broadcast so client asset lists and the Library refresh after a mutation.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { createMockLoggerModule } from "./helpers/mock-logger.js";
+
+// ---------------------------------------------------------------------------
+// Mocks. Must be set up before importing the module under test.
+// ---------------------------------------------------------------------------
+
+const mockPublishDocumentsChanged = mock(() => {});
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishAppsChanged: mock(() => {}),
+  publishDocumentsChanged: mockPublishDocumentsChanged,
+}));
+
+mock.module("../util/logger.js", () => createMockLoggerModule());
+
+// Stub the transitive imports so the module graph under test stops at
+// tool-side-effects.ts and never reaches the real sync publisher.
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  findActiveSession: mock(() => Promise.resolve(null)),
+}));
+mock.module("../runtime/verification-outbound-actions.js", () => ({
+  deliverVerificationSlack: mock(() => {}),
+}));
+mock.module("../media/app-icon-generator.js", () => ({
+  generateAppIcon: mock(() => Promise.resolve()),
+}));
+mock.module("../apps/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => ""),
+  getAppsDir: mock(() => ""),
+  resolveAppIdFromPath: mock(() => null),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppDir: mock(() => ({ dirName: "", dirPath: "" })),
+  slugify: mock((s: string) => s),
+  validateDirName: mock(() => {}),
+  generateAppDirName: mock(() => ""),
+  listApps: mock(() => []),
+  createApp: mock(() => ({})),
+  updateApp: mock(() => {}),
+  deleteApp: mock(() => {}),
+  getAppPreview: mock(() => null),
+  createAppRecord: mock(() => ({})),
+  getAppRecord: mock(() => null),
+  queryAppRecords: mock(() => []),
+  updateAppRecord: mock(() => {}),
+  deleteAppRecord: mock(() => {}),
+  listAppFiles: mock(() => []),
+  appFileExists: mock(() => false),
+  readAppFile: mock(() => ""),
+  writeAppFile: mock(() => {}),
+  editAppFile: mock(() => ({})),
+  inlineDistAssets: mock((_: unknown, html: string) => html),
+  addAppConversationId: mock(() => false),
+  linkAppToConversationLineage: mock(() => {}),
+}));
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: mock(() => Promise.resolve({ ok: true })),
+}));
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+}));
+mock.module("../daemon/doordash-steps.js", () => ({
+  isDoordashCommand: mock(() => false),
+  updateDoordashProgress: mock(() => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks. The dynamic import ensures the mock.module() calls above
+// are registered before tool-side-effects.ts evaluates its top-level imports.
+// ---------------------------------------------------------------------------
+
+import type { SideEffectContext } from "../daemon/tool-side-effects.js";
+
+const { runPostExecutionSideEffects } =
+  await import("../daemon/tool-side-effects.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummySideEffectCtx = {
+  ctx: {} as SideEffectContext["ctx"],
+} satisfies SideEffectContext;
+
+const MUTATING_TOOLS = [
+  "document_create",
+  "document_update",
+  "document_replace_text",
+  "document_delete",
+];
+
+const READ_ONLY_TOOLS = [
+  "document_read",
+  "document_list",
+  "document_find",
+  "document_open",
+];
+
+// The content is deliberately not JSON: the hook fires on the executed tool
+// name alone and must never depend on the shape of the LLM-facing result.
+async function runTool(name: string, isError = false): Promise<void> {
+  await runPostExecutionSideEffects(
+    name,
+    { surface_id: "doc-1" },
+    { content: "Document saved.", isError },
+    dummySideEffectCtx,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("document hooks: documents-changed broadcast", () => {
+  beforeEach(() => {
+    mockPublishDocumentsChanged.mockReset();
+  });
+
+  for (const toolName of MUTATING_TOOLS) {
+    test(`${toolName} publishes exactly one documents change`, async () => {
+      await runTool(toolName);
+      expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  for (const toolName of READ_ONLY_TOOLS) {
+    test(`${toolName} publishes no documents change`, async () => {
+      await runTool(toolName);
+      expect(mockPublishDocumentsChanged).not.toHaveBeenCalled();
+    });
+  }
+
+  test("a failed mutation publishes no documents change", async () => {
+    await runTool("document_update", true);
+    expect(mockPublishDocumentsChanged).not.toHaveBeenCalled();
+  });
+
+  test("two mutations in one turn publish once each", async () => {
+    await runTool("document_update");
+    await runTool("document_replace_text");
+    expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -18,7 +18,10 @@ import { invalidateEdgeIndex } from "../plugins/defaults/memory/substrate/edge-i
 import { invalidatePageIndex } from "../plugins/defaults/memory/substrate/page-index.js";
 import { getConceptsDir } from "../plugins/defaults/memory/substrate/page-store.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
-import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
+import {
+  publishAppsChanged,
+  publishDocumentsChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -178,6 +181,23 @@ function registerAppSurfaceRefreshHook(toolName: string): void {
 }
 registerAppSurfaceRefreshHook("app_refresh");
 registerAppSurfaceRefreshHook("app_update");
+
+// The mutating document tools carry no list-level change signal of their own,
+// so the conversation assets pill and the Library keep serving a cached list
+// after an edit, and a deleted document lingers as a ghost row. `skill_execute`
+// calls reach the runner already unwrapped to the inner tool name, so the
+// bundled document-editor skill needs no separate registration.
+registerHook(
+  [
+    "document_create",
+    "document_update",
+    "document_replace_text",
+    "document_delete",
+  ],
+  () => {
+    publishDocumentsChanged();
+  },
+);
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;


### PR DESCRIPTION
## Summary
- Register post-execution hooks for the four mutating document tools so each publishes a documents-changed broadcast.
- Covers document_delete, which previously emitted nothing and left deleted documents in client lists.

Part of plan: document-update-discoverability.md (PR 2 of 12)