### PR TITLE
fix(assistant): native origin-channel filter matches unattributed rows

### DIFF
--- a/assistant/src/__tests__/conversation-origin-channel-filter.test.ts
+++ b/assistant/src/__tests__/conversation-origin-channel-filter.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Filtering the conversation list by origin channel.
+ *
+ * "Native" has two spellings in the column and both are live: inserts leave
+ * `origin_channel` NULL, and migration 288 rewrites NULL to `"vellum"` only
+ * at daemon startup. So every conversation created while the daemon runs is
+ * NULL until the next boot, and the native filter has to match both or the
+ * sidebar's Chats section silently loses its newest rows.
+ *
+ * The over-matching cases below are as load-bearing as the rest: a reader
+ * that accepts NULL for every channel would file unstamped conversations
+ * into Slack's section too.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { createConversation } from "../persistence/conversation-crud.js";
+import { listConversations } from "../persistence/conversation-queries.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { rawRun } from "../persistence/raw-query.js";
+import { conversations } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+/**
+ * A conversation as `createConversation` actually writes one: no
+ * `origin_channel`. Migration 288 already ran during `initializeDb`, so this
+ * row stays NULL exactly as it would in a running daemon.
+ */
+function seedUnstamped(title: string) {
+  return createConversation({ title });
+}
+
+function seedStamped(title: string, channel: string) {
+  const conv = createConversation({ title });
+  rawRun(
+    "test:stampOriginChannel",
+    "UPDATE conversations SET origin_channel = ? WHERE id = ?",
+    channel,
+    conv.id,
+  );
+  return conv;
+}
+
+function titlesForChannel(originChannel: string): string[] {
+  return listConversations({ limit: 100, originChannel }).map(
+    (c) => c.title ?? "",
+  );
+}
+
+beforeEach(() => {
+  getDb().delete(conversations).run();
+});
+
+describe("the native channel filter", () => {
+  test("returns a conversation created since the last daemon boot", () => {
+    seedUnstamped("created-just-now");
+
+    expect(titlesForChannel("vellum")).toEqual(["created-just-now"]);
+  });
+
+  test("returns a conversation migration 288 already normalized", () => {
+    seedStamped("normalized-at-boot", "vellum");
+
+    expect(titlesForChannel("vellum")).toEqual(["normalized-at-boot"]);
+  });
+
+  test("returns both spellings together, without duplicating either", () => {
+    seedStamped("normalized-at-boot", "vellum");
+    seedUnstamped("created-just-now");
+
+    expect(titlesForChannel("vellum").sort()).toEqual([
+      "created-just-now",
+      "normalized-at-boot",
+    ]);
+  });
+
+  test("excludes conversations that arrived over an external channel", () => {
+    seedStamped("from-slack", "slack");
+    seedUnstamped("created-just-now");
+
+    expect(titlesForChannel("vellum")).toEqual(["created-just-now"]);
+  });
+});
+
+describe("an external channel filter", () => {
+  test("returns only its own conversations", () => {
+    seedStamped("from-slack", "slack");
+    seedStamped("from-email", "email");
+
+    expect(titlesForChannel("slack")).toEqual(["from-slack"]);
+  });
+
+  test("does not claim unstamped conversations", () => {
+    // The native branch must be reachable only for the native channel.
+    // Accepting NULL unconditionally would put every in-app conversation
+    // into every channel's section at once.
+    seedUnstamped("created-just-now");
+
+    expect(titlesForChannel("slack")).toEqual([]);
+  });
+});

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -1,4 +1,14 @@
-import { and, count, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import {
   parseExternalContentEnvelope,
@@ -16,6 +26,7 @@ import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { searchMessageIdsLexical } from "./conversation-search-lexical.js";
 import {
   type ConversationType,
+  NATIVE_ORIGIN_CHANNEL,
   PINNED_GROUP_ID,
   UNGROUPED_GROUP_ID,
 } from "./conversation-types.js";
@@ -319,6 +330,33 @@ function isUserOrderedGroup(groupId: string | undefined): boolean {
   return groupId === PINNED_GROUP_ID || !groupId.startsWith("system:");
 }
 
+/**
+ * Select one channel's conversations.
+ *
+ * The native channel matches an unstamped row as well as an explicit
+ * `"vellum"`. Inserts leave `origin_channel` NULL so a channel can still
+ * claim the row on its first inbound message, and migration 288 settles
+ * whatever is still unclaimed to `"vellum"` at startup. A strict equality
+ * would therefore drop every conversation created since the last daemon
+ * boot: the newest ones, and the ones a user is most likely to want.
+ *
+ * See {@link NATIVE_ORIGIN_CHANNEL} for why stamping at insert instead is
+ * not an option.
+ *
+ * External channel ids are only ever set by attribution, so they compare
+ * directly. Widening this branch to them would hand every unattributed
+ * conversation to every channel at once.
+ */
+function originChannelClause(originChannel: string) {
+  if (originChannel === NATIVE_ORIGIN_CHANNEL) {
+    return or(
+      isNull(conversations.originChannel),
+      eq(conversations.originChannel, NATIVE_ORIGIN_CHANNEL),
+    );
+  }
+  return eq(conversations.originChannel, originChannel);
+}
+
 function conversationListWhere(filter: ConversationListFilter) {
   const {
     conversationType = "standard",
@@ -329,7 +367,7 @@ function conversationListWhere(filter: ConversationListFilter) {
   return and(
     conversationTypeClause(conversationType),
     archiveStatusClause(archiveStatus) ?? undefined,
-    originChannel ? eq(conversations.originChannel, originChannel) : undefined,
+    originChannel ? originChannelClause(originChannel) : undefined,
     groupId ? groupIdClause(groupId) : undefined,
   );
 }

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -267,3 +267,22 @@ export function isReplyPushIneligibleUserMessage(
  */
 export const UNGROUPED_GROUP_ID = "system:all";
 export const PINNED_GROUP_ID = "system:pinned";
+
+/**
+ * The `origin_channel` value for a conversation that started in the app
+ * rather than arriving over an external channel.
+ *
+ * Two spellings mean this, and both are live, because NULL is a third
+ * state rather than a missing value: it means "not yet attributed".
+ * Channel conversations are stamped on their first inbound message by
+ * `setConversationOriginChannelIfUnset`, which fires only while the column
+ * is still NULL, so inserts deliberately leave it unset. Do not stamp this
+ * value at creation time: it would claim the row before the channel could,
+ * and every external conversation would report itself as native.
+ *
+ * A row still NULL once its attribution window has passed is native, which
+ * is the reading migration 288 applies at startup. Readers must apply the
+ * same reading in between. See `originChannelClause` in
+ * `conversation-queries.ts`.
+ */
+export const NATIVE_ORIGIN_CHANNEL = "vellum";


### PR DESCRIPTION
## TL;DR

Listing conversations by `originChannel=vellum` used a strict equality, so it returned only rows explicitly stamped `"vellum"` and silently skipped every row whose `origin_channel` is still NULL. In practice that means **every conversation created since the last daemon restart**. The native filter now matches both spellings.

## What changes for the user

| | Before | After |
| -- | -- | -- |
| Asking for native conversations | Returns only rows a daemon restart has already normalized | Returns those plus everything created since |
| A conversation you just started | Missing from the native filter until you restart the daemon | Present immediately |
| Asking for a channel (`slack`, `telegram`, …) | Unchanged | Unchanged |

No user-visible behavior changes today, because nothing ships a `?originChannel=vellum` consumer yet. This lands ahead of the Grouped-view Chats card in LUM-2443, which is that consumer.

## Why NULL is not a bug to be stamped out

`origin_channel` carries three states, and NULL means "not yet attributed" rather than "no channel":

| Value | Meaning |
| -- | -- |
| NULL | not yet attributed, still claimable by an inbound channel |
| `'vellum'` | attributed native |
| `'slack'`, `'telegram'`, … | attributed to that channel |

Inserts deliberately leave the column unset so an inbound message can claim the conversation for its channel: `setConversationOriginChannelIfUnset` is guarded on `isNull(origin_channel)` and no-ops once anything has claimed the row. Migration 288 then settles whatever was never claimed to `'vellum'`, but only at daemon startup.

So the gap this fixes is the window between one boot and the next, and a strict equality drops exactly the newest conversations in it.

**Stamping `'vellum'` at insert is not the fix**, and would be actively wrong: it claims the row before its channel can, so every Slack, email, and SMS conversation would permanently report itself as native and channel routing would break silently.

## Why it is safe

- The tolerant branch is reachable **only** for the native channel. External channel ids are written solely by attribution, so they keep comparing directly. A test covers this: filtering by `slack` must not return unattributed rows, or every in-app conversation would land in every channel's section at once.
- Pure read-side change. No schema change, no migration, no writes, no wire-format change.
- The clause is shared by `listConversations` and `countConversations` through `conversationListWhere`, so a list and its count cannot disagree about what they describe.

## Tests

New `assistant/src/__tests__/conversation-origin-channel-filter.test.ts`, 6 cases covering both spellings, their union without duplication, and both over-matching directions.

Sensitivity-checked rather than assumed: with the native branch disabled, exactly the 3 NULL-dependent cases fail and the other 3 still pass, which is the correct discrimination. Also re-ran `conversation-list-source`, `conversation-placement-promotion`, `conversation-group-tools`, `wake-schedule-trust`, and `call-pointer-messages` (76 tests total, all passing), plus typecheck.

## Deferred, and why

This fix is a read-side bridge. The underlying problem is that conversation provenance has no owner: five separate mechanisms maintain one fact, including a side effect stubbed in ~45 test files and a migration that re-runs on every boot. Filed as JARVIS-1466 with this predicate listed as an explicit deletion target, so the bridge is removed rather than left behind.

Deferred because it is a 33-call-site daemon refactor whose blast radius reaches channel reply routing, and it does not block the sidebar work. It is queued to be done on its own.

Part of LUM-2443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->