### PR TITLE
feat(web): show an unseen-changes dot on the assets pill

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -33,15 +33,24 @@ const { appsGetOptions, documentsGetOptions } =
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
 const SURFACE_ID = "surface-1";
+const OTHER_CONVERSATION_ID = "conv-2";
+const OTHER_SURFACE_ID = "surface-2";
+
+const DOC_TITLE = "Roadmap";
+const OTHER_DOC_TITLE = "Backlog";
 
 const SEEN_LABEL = "Conversation assets, 1 items";
 const UNSEEN_LABEL = "Conversation assets, 1 items (unseen changes)";
 
-function makeDocument(): DocumentSummary {
+function makeDocument(
+  conversationId = CONVERSATION_ID,
+  surfaceId = SURFACE_ID,
+  title = DOC_TITLE,
+): DocumentSummary {
   return {
-    surfaceId: SURFACE_ID,
-    conversationId: CONVERSATION_ID,
-    title: "Roadmap",
+    surfaceId,
+    conversationId,
+    title,
     wordCount: 12,
     createdAt: 1_700_000_000_000,
     updatedAt: 1_700_000_000_001,
@@ -60,30 +69,51 @@ function makeQueryClient() {
   });
 }
 
-function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
-  const client = makeQueryClient();
+function seedConversation(
+  client: QueryClient,
+  documents: DocumentSummary[],
+  conversationId: string,
+) {
   const queryArgs = {
     path: { assistant_id: ASSISTANT_ID },
-    query: { conversationId: CONVERSATION_ID },
+    query: { conversationId },
   };
   client.setQueryData(appsGetOptions(queryArgs).queryKey, { apps: [] });
-  client.setQueryData(documentsGetOptions(queryArgs).queryKey, {
-    documents: withAssets ? [makeDocument()] : [],
-  });
-  render(
+  client.setQueryData(documentsGetOptions(queryArgs).queryKey, { documents });
+}
+
+function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
+  const client = makeQueryClient();
+  seedConversation(client, withAssets ? [makeDocument()] : [], CONVERSATION_ID);
+  seedConversation(
+    client,
+    [makeDocument(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID, OTHER_DOC_TITLE)],
+    OTHER_CONVERSATION_ID,
+  );
+
+  const pill = (conversationId: string) => (
     <QueryClientProvider client={client}>
       <ConversationAssetsPill
         assistantId={ASSISTANT_ID}
-        conversationId={CONVERSATION_ID}
+        conversationId={conversationId}
       />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+
+  const view = render(pill(CONVERSATION_ID));
+
+  return {
+    /** Swap the prop on the already-mounted pill, as the chat header does. */
+    switchConversation: (conversationId: string) => {
+      view.rerender(pill(conversationId));
+    },
+  };
 }
 
-function markUnseen() {
+function markUnseen(conversationId = CONVERSATION_ID, surfaceId = SURFACE_ID) {
   useUnseenDocumentChangesStore
     .getState()
-    .markDocumentChanged(CONVERSATION_ID, SURFACE_ID);
+    .markDocumentChanged(conversationId, surfaceId);
 }
 
 function unseenConversations(): string[] {
@@ -155,6 +185,46 @@ describe("mobile trigger", () => {
 
     expect(unseenConversations()).toEqual([]);
     expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+});
+
+describe("conversation switch while the disclosure is open", () => {
+  /**
+   * The chat header renders one unkeyed pill and swaps `conversationId` on it,
+   * so `open` survives the switch and `onOpenChange` never fires for it. The
+   * pill closes its own disclosure on that swap: the incoming conversation's
+   * assets are never put on screen unasked, and its changes stay marked unseen
+   * until the user opens the list.
+   */
+  test("closes the popover and keeps the incoming dot", () => {
+    markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
+    const { switchConversation } = renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
+
+    switchConversation(OTHER_CONVERSATION_ID);
+
+    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+    expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+
+  test("closes the sheet and keeps the incoming dot on mobile", () => {
+    isMobileRef.value = true;
+    markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
+    const { switchConversation } = renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
+
+    switchConversation(OTHER_CONVERSATION_ID);
+
+    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+    expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
   });
 });
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Tests for `ConversationAssetsPill`'s unseen-document-changes affordance.
+ *
+ * The pill's asset list comes from two TanStack queries, so the suite seeds
+ * the cache with `staleTime: Infinity` instead of mocking the SDK: nothing
+ * refetches on mount and the rendered list is exactly what a test asks for.
+ *
+ * Class strings are deliberately not asserted (happy-dom makes those brittle);
+ * the dot is located by its `data-testid` and the state it communicates is
+ * asserted through the trigger's accessible name.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DocumentSummary } from "@/types/document-types";
+
+const isMobileRef = { value: false };
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const { ConversationAssetsPill, ASSETS_PILL_UNSEEN_DOT_TESTID } =
+  await import("@/domains/chat/components/conversation-assets-pill");
+const { useUnseenDocumentChangesStore } =
+  await import("@/domains/chat/unseen-document-changes-store");
+const { appsGetOptions, documentsGetOptions } =
+  await import("@/generated/daemon/@tanstack/react-query.gen");
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+const SURFACE_ID = "surface-1";
+
+const SEEN_LABEL = "Conversation assets, 1 items";
+const UNSEEN_LABEL = "Conversation assets, 1 items (unseen changes)";
+
+function makeDocument(): DocumentSummary {
+  return {
+    surfaceId: SURFACE_ID,
+    conversationId: CONVERSATION_ID,
+    title: "Roadmap",
+    wordCount: 12,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_001,
+  };
+}
+
+/**
+ * `staleTime: Infinity` keeps the seeded entries fresh, so the queries resolve
+ * from cache and never reach the generated SDK.
+ */
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+    },
+  });
+}
+
+function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
+  const client = makeQueryClient();
+  const queryArgs = {
+    path: { assistant_id: ASSISTANT_ID },
+    query: { conversationId: CONVERSATION_ID },
+  };
+  client.setQueryData(appsGetOptions(queryArgs).queryKey, { apps: [] });
+  client.setQueryData(documentsGetOptions(queryArgs).queryKey, {
+    documents: withAssets ? [makeDocument()] : [],
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ConversationAssetsPill
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function markUnseen() {
+  useUnseenDocumentChangesStore
+    .getState()
+    .markDocumentChanged(CONVERSATION_ID, SURFACE_ID);
+}
+
+function unseenConversations(): string[] {
+  return Object.keys(useUnseenDocumentChangesStore.getState().changedDocuments);
+}
+
+beforeEach(() => {
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  isMobileRef.value = false;
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+describe("desktop pill", () => {
+  test("shows the dot and names the state when a change is unseen", () => {
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+  });
+
+  test("shows no dot and the plain name when nothing is unseen", () => {
+    renderPill();
+
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
+  });
+
+  test("opening the popover clears the conversation", () => {
+    markUnseen();
+    renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
+
+    expect(unseenConversations()).toEqual([]);
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+});
+
+describe("mobile trigger", () => {
+  beforeEach(() => {
+    isMobileRef.value = true;
+  });
+
+  test("shows the dot and names the state when a change is unseen", () => {
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+  });
+
+  test("shows no dot and the plain name when nothing is unseen", () => {
+    renderPill();
+
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
+  });
+
+  test("opening the sheet clears the conversation", () => {
+    markUnseen();
+    renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
+
+    expect(unseenConversations()).toEqual([]);
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+});
+
+describe("empty asset list", () => {
+  /**
+   * Pins the deliberate trade-off: the pill renders nothing at all without
+   * assets, so there is no Layers icon to carry a dot. An unseen change in
+   * that window stays recorded in the store and the dot appears as soon as
+   * the documents query reports the asset, rather than the pill being forced
+   * to render an empty disclosure.
+   */
+  test("renders nothing even when a change is unseen", () => {
+    markUnseen();
+    renderPill({ withAssets: false });
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(unseenConversations()).toEqual([CONVERSATION_ID]);
+  });
+});

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -21,10 +21,16 @@ import {
   AppAssetActions,
   DocumentAssetActions,
 } from "@/domains/chat/components/conversation-asset-actions";
+import {
+  useHasUnseenDocumentChanges,
+  useUnseenDocumentChangesStore,
+} from "@/domains/chat/unseen-document-changes-store";
 import { useAppDelete } from "@/hooks/use-app-delete";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
+
+export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
 
 interface ConversationAsset {
   id: string;
@@ -119,6 +125,21 @@ export function ConversationAssetsPill({
 
   const [open, setOpen] = useState(false);
   const isMobile = useIsMobile();
+  const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
+  const clearConversation =
+    useUnseenDocumentChangesStore.use.clearConversation();
+
+  // Opening the disclosure is the user looking at the asset list, so whatever
+  // changed is no longer unseen.
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        clearConversation(conversationId);
+      }
+    },
+    [clearConversation, conversationId],
+  );
 
   const handleSelect = useCallback(
     (asset: ConversationAsset) => {
@@ -139,7 +160,24 @@ export function ConversationAssetsPill({
   }
 
   const label = assets.length === 1 ? "1 asset" : `${assets.length} assets`;
-  const ariaLabel = `Conversation assets, ${assets.length} items`;
+  const ariaLabel = hasUnseenChanges
+    ? `Conversation assets, ${assets.length} items (unseen changes)`
+    : `Conversation assets, ${assets.length} items`;
+
+  // Same dot as the notifications bell in this header cluster: ringed in the
+  // color of the surface behind it so the ring reads as a gap carved out of
+  // the icon.
+  const layersIcon = (
+    <span className="relative flex" aria-hidden>
+      <Layers />
+      {hasUnseenChanges ? (
+        <span
+          data-testid={ASSETS_PILL_UNSEEN_DOT_TESTID}
+          className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+        />
+      ) : null}
+    </span>
+  );
 
   const assetItems = assets.map((asset) => (
     <PanelItem
@@ -170,12 +208,12 @@ export function ConversationAssetsPill({
   if (isMobile) {
     return (
       <>
-        <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Root open={open} onOpenChange={handleOpenChange}>
           <BottomSheet.Trigger asChild>
             <Button
               variant="ghost"
               active
-              iconOnly={<Layers />}
+              iconOnly={layersIcon}
               tintColor="var(--content-default)"
               aria-label={ariaLabel}
             />
@@ -199,12 +237,12 @@ export function ConversationAssetsPill({
 
   return (
     <>
-      <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Root open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
           <Button
             variant="ghost"
             active
-            leftIcon={<Layers />}
+            leftIcon={layersIcon}
             className="rounded-full"
             tintColor="var(--content-default)"
             aria-label={ariaLabel}

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -1,6 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AppWindow, FileText, Layers } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   BottomSheet,
@@ -124,6 +130,17 @@ export function ConversationAssetsPill({
   const assets = useMemo(() => toAssets(apps, docs), [apps, docs]);
 
   const [open, setOpen] = useState(false);
+
+  // The chat header swaps `conversationId` on this same mounted pill, so an
+  // open disclosure would otherwise carry over and list the incoming
+  // conversation's assets without the user asking to see them, leaving that
+  // conversation's changes marked unseen behind a sheet that is already open.
+  // Layout effect: the outgoing conversation's disclosure must never paint
+  // over the incoming conversation, not even for one frame.
+  useLayoutEffect(() => {
+    setOpen(false);
+  }, [conversationId]);
+
   const isMobile = useIsMobile();
   const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
   const clearConversation =


### PR DESCRIPTION
## Summary
- Show a dot on the Layers assets icon when the conversation has document changes the user has not seen.
- Clear it when the assets disclosure opens.
- Matches the notifications bell dot treatment in the same header cluster.

Part of plan: document-update-discoverability.md (PR 7 of 12)