### PR TITLE
fix(web): refresh documents on the documents-changed sync tag

### DIFF
--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Client-initiated document writes must invalidate the `documents:list` tag so
+ * the Library and the per-conversation assets list converge on every surface.
+ * Read routes and rejected writes must stay silent.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AssistantEventEnvelope } from "../api/index.js";
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { createConversation } from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { ROUTES as DOCUMENT_ROUTES } from "../runtime/routes/documents-routes.js";
+import type { RouteDefinition } from "../runtime/routes/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+await initializeDb();
+
+const workspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+const notesDir = join(workspaceDir, "sync-notes");
+
+const CONVERSATION_ID = "conv-doc-sync";
+const OTHER_CONVERSATION_ID = "conv-doc-sync-other";
+const MISSING_CONVERSATION_ID = "conv-doc-sync-missing";
+
+function getRoute(operationId: string): RouteDefinition {
+  const route = DOCUMENT_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`No document route found for operationId: ${operationId}`);
+  }
+  return route;
+}
+
+/**
+ * Run `action` and return every `sync_changed` event it produced.
+ *
+ * The hub dispatches asynchronously, so the capture window stays open for a
+ * few ticks past the action. That window is what lets a "publishes nothing"
+ * assertion be meaningful and what catches a stray second publish.
+ */
+async function captureSyncEvents(
+  action: () => unknown | Promise<unknown>,
+): Promise<AssistantEventEnvelope[]> {
+  const received: AssistantEventEnvelope[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      if (event.message.type === "sync_changed") {
+        received.push(event);
+      }
+    },
+  });
+  try {
+    await action();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+function expectDocumentsChanged(events: AssistantEventEnvelope[]): void {
+  expect(events).toHaveLength(1);
+  expect(events[0].message).toMatchObject({
+    type: "sync_changed",
+    tags: [SYNC_TAGS.documentsList],
+  });
+}
+
+/** Run a route handler so its synchronous throws surface as rejections. */
+async function invoke(
+  operationId: string,
+  args: Parameters<RouteDefinition["handler"]>[0],
+): Promise<unknown> {
+  return await getRoute(operationId).handler(args);
+}
+
+async function saveViaRoute(
+  overrides: Record<string, unknown> = {},
+): Promise<unknown> {
+  return await invoke("saveDocument", {
+    body: {
+      surfaceId: "doc-sync",
+      conversationId: CONVERSATION_ID,
+      title: "Notes",
+      content: "hello world",
+      wordCount: 2,
+      ...overrides,
+    },
+  });
+}
+
+async function openWorkspaceFile(
+  path: string,
+  conversationId = CONVERSATION_ID,
+): Promise<unknown> {
+  return await invoke("documentForWorkspaceFile", {
+    body: { path, conversationId },
+  });
+}
+
+async function linkViaRoute(
+  surfaceId: string,
+  conversationId: string,
+): Promise<unknown> {
+  return await invoke("linkDocumentConversation", {
+    pathParams: { id: surfaceId },
+    body: { conversationId },
+  });
+}
+
+beforeEach(() => {
+  const db = getDb();
+  db.run("DELETE FROM document_conversations");
+  db.run("DELETE FROM documents");
+  db.run("DELETE FROM conversations");
+  createConversation({ id: CONVERSATION_ID });
+  createConversation({ id: OTHER_CONVERSATION_ID });
+  rmSync(notesDir, { recursive: true, force: true });
+  mkdirSync(notesDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(notesDir, { recursive: true, force: true });
+  resetDbForTesting();
+});
+
+describe("document write routes publish documents:list", () => {
+  test("a successful save publishes exactly one documents-changed event", async () => {
+    const events = await captureSyncEvents(() => saveViaRoute());
+    expectDocumentsChanged(events);
+  });
+
+  test("an upsert over an existing document publishes again", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("the save carries the caller's client id so it can suppress its own echo", async () => {
+    const events = await captureSyncEvents(() =>
+      invoke("saveDocument", {
+        body: {
+          surfaceId: "doc-sync-origin",
+          conversationId: CONVERSATION_ID,
+          title: "Notes",
+          content: "hello world",
+          wordCount: 2,
+        },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({
+      type: "sync_changed",
+      tags: [SYNC_TAGS.documentsList],
+      originClientId: "client-abc",
+    });
+  });
+
+  test("linking a document to a conversation publishes", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      linkViaRoute("doc-sync", OTHER_CONVERSATION_ID),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("binding a workspace file to a new document publishes", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("reopening the file from another conversation publishes the new link", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md", OTHER_CONVERSATION_ID),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("refreshing a document whose file changed on disk publishes", async () => {
+    const filePath = join(notesDir, "plan.md");
+    writeFileSync(filePath, "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+    writeFileSync(filePath, "# Plan\n\nedited outside the editor");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expectDocumentsChanged(events);
+  });
+});
+
+describe("document routes that write nothing stay silent", () => {
+  test("reopening an unchanged, already-linked file publishes nothing", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expect(events).toEqual([]);
+  });
+
+  test("a save rejected by validation publishes nothing", async () => {
+    const events = await captureSyncEvents(async () => {
+      await expect(saveViaRoute({ title: undefined })).rejects.toThrow(
+        /title is required/,
+      );
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("a save the store refuses publishes nothing", async () => {
+    // The conversation row is absent, so the insert trips the foreign key and
+    // the store reports failure instead of persisting.
+    const events = await captureSyncEvents(async () => {
+      await expect(
+        saveViaRoute({ conversationId: MISSING_CONVERSATION_ID }),
+      ).rejects.toThrow();
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("a link to a document that does not exist publishes nothing", async () => {
+    const events = await captureSyncEvents(async () => {
+      await expect(
+        linkViaRoute("doc-missing", OTHER_CONVERSATION_ID),
+      ).rejects.toThrow(/Document not found/);
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("listing documents publishes nothing", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() => invoke("listDocuments", {}));
+    expect(events).toEqual([]);
+  });
+
+  test("reading a single document publishes nothing", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      invoke("getDocument", { pathParams: { id: "doc-sync" } }),
+    );
+    expect(events).toEqual([]);
+  });
+});

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -16,12 +16,17 @@ import {
   getDocumentById,
   getDocumentByWorkspacePath,
   getDocumentsForConversation,
+  isDocumentAssociatedWithConversation,
   refreshDocumentContentFromFile,
   saveDocument,
 } from "../../documents/document-store.js";
 import { rawAll } from "../../persistence/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  getOriginClientId,
+  publishDocumentsChanged,
+} from "../sync/resource-sync-events.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import {
   BadRequestError,
@@ -162,6 +167,7 @@ function loadDocumentPayload(surfaceId: string): Record<string, unknown> {
  */
 function handleDocumentForWorkspaceFile({
   body,
+  headers,
 }: RouteHandlerArgs): Record<string, unknown> {
   const { path, conversationId } = (body ?? {}) as {
     path?: string;
@@ -194,8 +200,13 @@ function handleDocumentForWorkspaceFile({
   if (existing) {
     // Opening the file from another conversation grants that conversation
     // access, the same association the link route writes.
+    const alreadyLinked = isDocumentAssociatedWithConversation(
+      existing.surfaceId,
+      conversationId,
+    );
     addDocumentConversation(existing.surfaceId, conversationId);
 
+    let refreshed = false;
     if (existing.content !== fileText) {
       const refresh = refreshDocumentContentFromFile(
         existing.surfaceId,
@@ -204,10 +215,17 @@ function handleDocumentForWorkspaceFile({
       if (!refresh.success) {
         throw new InternalError(refresh.error);
       }
+      refreshed = true;
       log.info(
         { surfaceId: existing.surfaceId, workspacePath: relativePath },
         "Refreshed file-backed document from disk",
       );
+    }
+
+    // Reopening an unchanged, already-linked file writes nothing, so it must
+    // not invalidate every client's document list on each open.
+    if (!alreadyLinked || refreshed) {
+      publishDocumentsChanged(getOriginClientId(headers));
     }
     return loadDocumentPayload(existing.surfaceId);
   }
@@ -227,7 +245,14 @@ function handleDocumentForWorkspaceFile({
     if (!raced) {
       throw new InternalError(created.error);
     }
+    const racedAlreadyLinked = isDocumentAssociatedWithConversation(
+      raced.surfaceId,
+      conversationId,
+    );
     addDocumentConversation(raced.surfaceId, conversationId);
+    if (!racedAlreadyLinked) {
+      publishDocumentsChanged(getOriginClientId(headers));
+    }
     return loadDocumentPayload(raced.surfaceId);
   }
 
@@ -235,6 +260,7 @@ function handleDocumentForWorkspaceFile({
     { surfaceId, workspacePath: relativePath, conversationId },
     "Bound workspace file to a new document",
   );
+  publishDocumentsChanged(getOriginClientId(headers));
   return loadDocumentPayload(surfaceId);
 }
 
@@ -325,7 +351,7 @@ export const ROUTES: RouteDefinition[] = [
       success: z.literal(true),
       surfaceId: z.string(),
     }),
-    handler: ({ body }) => {
+    handler: ({ body, headers }) => {
       const { surfaceId, conversationId, title, content, wordCount } = (body ??
         {}) as {
         surfaceId?: string;
@@ -362,6 +388,7 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
+      publishDocumentsChanged(getOriginClientId(headers));
       return result;
     },
   },
@@ -412,7 +439,7 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string().describe("Conversation to link"),
     }),
     responseBody: z.object({ success: z.literal(true) }),
-    handler: ({ pathParams, body }) => {
+    handler: ({ pathParams, body, headers }) => {
       const { conversationId } = (body ?? {}) as { conversationId?: string };
       if (!conversationId) {
         throw new BadRequestError("conversationId is required");
@@ -426,6 +453,7 @@ export const ROUTES: RouteDefinition[] = [
         { surfaceId: pathParams!.id, conversationId },
         "Linked document to conversation",
       );
+      publishDocumentsChanged(getOriginClientId(headers));
       return { success: true as const };
     },
   },

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -9,6 +9,7 @@ import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memo
 import {
   appsGetQueryKey,
   configGetQueryKey,
+  documentsGetQueryKey,
   homeFeedGetQueryKey,
   homeStateGetQueryKey,
   inferenceProfilesGetQueryKey,
@@ -39,6 +40,35 @@ function freshQueryClient(): QueryClient {
     defaultOptions: { queries: { retry: false } },
   });
 }
+
+type QueryPredicate = (query: { queryKey: readonly unknown[] }) => boolean;
+
+/**
+ * Swaps `invalidateQueries` for a capture that records every predicate handed
+ * to it, so a test can ask which query keys the hook claimed.
+ */
+function capturePredicates(queryClient: QueryClient): QueryPredicate[] {
+  const predicates: QueryPredicate[] = [];
+  queryClient.invalidateQueries = ((arg: unknown) => {
+    const predicate = (arg as { predicate?: QueryPredicate }).predicate;
+    if (predicate) {
+      predicates.push(predicate);
+    }
+    return Promise.resolve();
+  }) as never;
+  return predicates;
+}
+
+/** The shape `domains/library/use-library-data.ts` reads documents under. */
+const LIBRARY_DOCUMENTS_KEY = documentsGetQueryKey({
+  path: { assistant_id: "asst-1" },
+});
+
+/** The shape `domains/chat/components/conversation-assets-pill.tsx` reads under. */
+const CONVERSATION_DOCUMENTS_KEY = documentsGetQueryKey({
+  path: { assistant_id: "asst-1" },
+  query: { conversationId: "convo-1" },
+});
 
 function syncEvent(tags: string[]): SyncChangedEvent {
   return { type: "sync_changed", tags };
@@ -296,6 +326,46 @@ describe("useAssistantResourceSync", () => {
       }),
     ).toBe(true);
     expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
+  });
+
+  // The Library keys the documents read by assistant alone while the
+  // conversation assets pill adds `query.conversationId`. Covering only the
+  // conversation-scoped key leaves the Library serving a pre-edit list.
+  test("invalidates both documents key shapes on documents:list sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const predicates = capturePredicates(queryClient);
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.documentsList]) as unknown as AssistantEvent);
+
+    const claims = (queryKey: readonly unknown[]) =>
+      predicates.some((p) => p({ queryKey }));
+    await waitFor(() => {
+      expect(claims(LIBRARY_DOCUMENTS_KEY)).toBe(true);
+    });
+    expect(claims(CONVERSATION_DOCUMENTS_KEY)).toBe(true);
+    expect(claims(appsGetQueryKey({ path: { assistant_id: "asst-1" } }))).toBe(
+      false,
+    );
+  });
+
+  test("reconciles both documents key shapes on non-fresh sse.opened reconnect", async () => {
+    const queryClient = freshQueryClient();
+    const predicates = capturePredicates(queryClient);
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+
+    const claims = (queryKey: readonly unknown[]) =>
+      predicates.some((p) => p({ queryKey }));
+    await waitFor(() => {
+      expect(claims(LIBRARY_DOCUMENTS_KEY)).toBe(true);
+    });
+    expect(claims(CONVERSATION_DOCUMENTS_KEY)).toBe(true);
   });
 
   test("invalidates plugin list / catalog / open-detail queries on plugins:list sync tag", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -2,7 +2,7 @@
  * Bus consumer for assistant-level resource cache invalidation.
  *
  * Routes `sync_changed` tags (avatar, identity, config, sounds, schedules,
- * apps, plugins) and discrete SSE events (`home_feed_updated`,
+ * apps, documents, plugins) and discrete SSE events (`home_feed_updated`,
  * `relationship_state_updated`, `identity_changed`, `avatar_updated`) into
  * TanStack Query cache invalidations.
  *
@@ -133,6 +133,15 @@ export function useAssistantResourceSync(
                   isGeneratedQueryKey(query.queryKey, "appsGet"),
               });
               break;
+            case SYNC_TAGS.documentsList:
+              // The assets pill keys by `query.conversationId` and the Library
+              // by the assistant path alone, so match on the operation id to
+              // cover both key shapes.
+              void queryClient.invalidateQueries({
+                predicate: (query) =>
+                  isGeneratedQueryKey(query.queryKey, "documentsGet"),
+              });
+              break;
             case SYNC_TAGS.pluginsList:
               invalidatePluginQueries(queryClient, assistantId);
               break;
@@ -215,6 +224,9 @@ export function useAssistantResourceSync(
     });
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
+    });
+    void queryClient.invalidateQueries({
+      predicate: (query) => isGeneratedQueryKey(query.queryKey, "documentsGet"),
     });
     invalidatePluginQueries(queryClient, assistantId);
     void queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- Invalidate the documents query on the documents-changed sync tag and on reconnect.
- Covers both the conversation-scoped and assistant-scoped key shapes so the Library list refreshes too.

Part of plan: document-update-discoverability.md (PR 3 of 12)