### PR TITLE
feat(web): add a reopen link for documents a turn changed

### DIFF
--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for the end-of-turn link back to a document the assistant changed.
+ *
+ * Covers the two things the link owes its caller: it names the document from
+ * the documents query (with a neutral label when the query has no title for
+ * it), and it is present exactly when its own document is not the one open in
+ * the viewer.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { DocumentReopenLink } from "@/domains/chat/transcript/document-reopen-link";
+import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useViewerStore } from "@/stores/viewer-store";
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+const SURFACE_ID = "surf-notes";
+
+const onOpenDocument = mock((_surfaceId: string) => {});
+
+type SeededDocument = { surfaceId: string; title: string };
+
+/**
+ * Render the link with the documents query already answered. `staleTime` is
+ * infinite so the seeded entry is never refetched and the test needs no network.
+ */
+function renderLink(documents: SeededDocument[]): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(
+    documentsGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID },
+      query: { conversationId: CONVERSATION_ID },
+    }),
+    {
+      documents: documents.map((doc) => ({
+        surfaceId: doc.surfaceId,
+        conversationId: CONVERSATION_ID,
+        title: doc.title,
+        wordCount: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      })),
+    },
+  );
+  const ui: ReactNode = (
+    <DocumentReopenLink
+      surfaceId={SURFACE_ID}
+      assistantId={ASSISTANT_ID}
+      conversationId={CONVERSATION_ID}
+      onOpenDocument={onOpenDocument}
+    />
+  );
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+/** Put the viewer store where it would be with `surfaceId` open in the drawer. */
+function openDocument(surfaceId: string): void {
+  useViewerStore.setState({
+    mainView: "document",
+    openedDocumentState: {
+      source: "document",
+      surfaceId,
+      conversationId: CONVERSATION_ID,
+      documentName: "Quarterly notes",
+      content: "# notes",
+    },
+  });
+}
+
+beforeEach(() => {
+  onOpenDocument.mockClear();
+  useViewerStore.setState({ mainView: "chat", openedDocumentState: null });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DocumentReopenLink", () => {
+  test("names the document from the documents query", () => {
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("falls back to a neutral label when the query has no title", () => {
+    renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
+
+    expect(screen.getByText("Untitled document")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("hides itself while its own document is open", () => {
+    openDocument(SURFACE_ID);
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("stays visible while a different document is open", () => {
+    openDocument("surf-other");
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+  });
+
+  test("clicking opens the document it names", () => {
+    renderLink([
+      { surfaceId: "surf-other", title: "Some other doc" },
+      { surfaceId: SURFACE_ID, title: "Quarterly notes" },
+    ]);
+
+    fireEvent.click(screen.getByTestId("document-reopen-link"));
+
+    expect(onOpenDocument).toHaveBeenCalledTimes(1);
+    expect(onOpenDocument.mock.calls[0]).toEqual([SURFACE_ID]);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -1,0 +1,96 @@
+/**
+ * A link back to a document the assistant changed during a turn, rendered at
+ * the end of that turn's response.
+ *
+ * The link is derived durably from the turn's tool calls, which persist on the
+ * message, and is hidden reactively while the document is visible. It does not
+ * depend on point-in-time closed-ness captured when the turn finished: that
+ * does not survive a reload, and on mobile the editor is a full-screen overlay,
+ * so a visible transcript already means the editor is closed.
+ *
+ * The name comes from the documents query rather than the tool result, so the
+ * link reads the same title the assets list and the Library show, including
+ * after a rename. A document the query cannot name still gets a link, under a
+ * neutral label.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { ArrowUpRight, FileText } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+
+/** Label for a document the documents query has no title for. */
+const FALLBACK_DOCUMENT_NAME = "Untitled document";
+
+/**
+ * Title of the document `surfaceId`, or {@link FALLBACK_DOCUMENT_NAME} when the
+ * documents query has not named it. Keyed the same way the assets pill keys its
+ * list, so both read one cache entry and one invalidation refreshes both.
+ */
+function useDocumentDisplayName(
+  surfaceId: string,
+  assistantId?: string | null,
+  conversationId?: string | null,
+): string {
+  const { data: title } = useQuery({
+    ...documentsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+      query: { conversationId: conversationId ?? undefined },
+    }),
+    enabled: Boolean(assistantId),
+    select: (response) =>
+      response.documents.find((doc) => doc.surfaceId === surfaceId)?.title,
+  });
+  if (title === undefined || title.trim() === "") {
+    return FALLBACK_DOCUMENT_NAME;
+  }
+  return title;
+}
+
+export interface DocumentReopenLinkProps {
+  /** Surface id of the document the turn changed. */
+  surfaceId: string;
+  /** Assistant the documents query reads through. */
+  assistantId?: string | null;
+  /** Conversation the document belongs to. */
+  conversationId?: string | null;
+  onOpenDocument: (surfaceId: string) => void;
+}
+
+export function DocumentReopenLink({
+  surfaceId,
+  assistantId,
+  conversationId,
+  onOpenDocument,
+}: DocumentReopenLinkProps) {
+  const isOpen = useIsDocumentOpen(surfaceId);
+  const displayName = useDocumentDisplayName(
+    surfaceId,
+    assistantId,
+    conversationId,
+  );
+
+  if (isOpen) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="compact"
+      className="mt-2 max-w-full gap-2 rounded-lg"
+      aria-label={`Open ${displayName}`}
+      data-testid="document-reopen-link"
+      onClick={() => onOpenDocument(surfaceId)}
+    >
+      <FileText className="h-4 w-4 shrink-0 text-[var(--content-quiet)]" />
+      <span className="min-w-0 truncate text-title-small text-[var(--content-strong)]">
+        {displayName}
+      </span>
+      <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-[var(--content-faint)]" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a link that reopens a document the assistant changed during a turn.
- Hides itself while that document is already open.
- Mounted into the transcript by the next PR in this plan.

Part of plan: document-update-discoverability.md (PR 11 of 12)