### PR TITLE
feat(web): track unseen document changes from editor updates

### DIFF
--- a/clients/web/src/domains/chat/document-viewer-page.test.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * The standalone `/assistant/documents/:surfaceId` route is a second way into
+ * a document, so opening one there clears its unseen-change record just as the
+ * in-chat viewer does.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import type { DocumentsByIdGetResponse } from "@/generated/daemon/types.gen";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
+
+const daemonSdk = await import("@/generated/daemon/sdk.gen");
+
+type DocumentResult = { data: DocumentsByIdGetResponse | null };
+
+let documentResult: () => Promise<DocumentResult> = () =>
+  Promise.reject(new Error("not stubbed"));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  documentsByIdGet: () => documentResult(),
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: { use: { activeAssistantId: () => "asst-1" } },
+}));
+
+// The editor is a heavy Tiptap tree with nothing to say about the record.
+mock.module("./components/document-viewer-container", () => ({
+  DocumentViewerContainer: () => <div data-testid="viewer" />,
+}));
+
+const { DocumentViewerPage } = await import(
+  "@/domains/chat/document-viewer-page"
+);
+
+function documentSurface(
+  overrides: Partial<DocumentsByIdGetResponse> = {},
+): DocumentsByIdGetResponse {
+  return {
+    success: true,
+    surfaceId: "surf-1",
+    conversationId: "conv-1",
+    title: "Notes",
+    content: "# Notes",
+    wordCount: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    workspacePath: null,
+    ...overrides,
+  };
+}
+
+function renderPage(surfaceId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/assistant/documents/${surfaceId}`]}>
+      <Routes>
+        <Route
+          path="/assistant/documents/:surfaceId"
+          element={<DocumentViewerPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
+beforeEach(() => {
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DocumentViewerPage", () => {
+  test("clears the unseen change for the document it loaded", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("leaves the conversation's other unseen documents alone", async () => {
+    const unseen = useUnseenDocumentChangesStore.getState();
+    unseen.markDocumentChanged("conv-1", "surf-1");
+    unseen.markDocumentChanged("conv-1", "surf-2");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("keeps the unseen change when the load fails", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.reject(new Error("boom"));
+
+    renderPage("surf-1");
+    await waitFor(() => {
+      expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -33,6 +33,7 @@ import {
   type DocumentViewerContainerHandle,
 } from "./components/document-viewer-container";
 import { useDocumentCommentEvents } from "./hooks/use-document-comment-events";
+import { useUnseenDocumentChangesStore } from "./unseen-document-changes-store";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -75,6 +76,11 @@ export function DocumentViewerPage() {
           return;
         }
         setDoc(result);
+        // This route is a second way into a document, separate from the
+        // in-chat viewer, so it clears the unseen record itself.
+        useUnseenDocumentChangesStore
+          .getState()
+          .clearDocument(result.conversationId, surfaceId);
       } catch {
         if (!cancelled) {
           setError("Failed to load document.");

--- a/clients/web/src/hooks/use-document-editor-sync.test.tsx
+++ b/clients/web/src/hooks/use-document-editor-sync.test.tsx
@@ -1,15 +1,30 @@
 /**
  * `useDocumentEditorSync` applies a streamed document edit to the viewer and
  * records the change as unseen unless the user is watching that very document.
+ *
+ * "Watching" is the route as well as the viewer store, so these render the
+ * hook under a router positioned on the route being exercised.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
 
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import { useViewerStore } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
+
+/** Mount the hook on `pathname`, defaulting to the conversation chat route. */
+function renderSyncAt(pathname: string = routes.conversation("conv-1")) {
+  return renderHook(() => useDocumentEditorSync(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={[pathname]}>{children}</MemoryRouter>
+    ),
+  });
+}
 
 function publishDocumentEdit(options: {
   conversationId?: string;
@@ -62,7 +77,7 @@ afterEach(() => {
 
 describe("useDocumentEditorSync", () => {
   test("records an unseen change when the document is not open", () => {
-    renderHook(() => useDocumentEditorSync());
+    renderSyncAt();
 
     publishDocumentEdit({ surfaceId: "surf-1" });
 
@@ -71,7 +86,7 @@ describe("useDocumentEditorSync", () => {
 
   test("records nothing when that document is the one on screen", () => {
     openInViewer("surf-1");
-    renderHook(() => useDocumentEditorSync());
+    renderSyncAt();
 
     publishDocumentEdit({ surfaceId: "surf-1" });
 
@@ -80,7 +95,7 @@ describe("useDocumentEditorSync", () => {
 
   test("records an unseen change when a different document is on screen", () => {
     openInViewer("surf-1");
-    renderHook(() => useDocumentEditorSync());
+    renderSyncAt();
 
     publishDocumentEdit({ surfaceId: "surf-2" });
 
@@ -88,7 +103,7 @@ describe("useDocumentEditorSync", () => {
   });
 
   test("records against the conversation the edit came from", () => {
-    renderHook(() => useDocumentEditorSync());
+    renderSyncAt();
 
     publishDocumentEdit({ conversationId: "conv-2", surfaceId: "surf-1" });
 
@@ -98,7 +113,37 @@ describe("useDocumentEditorSync", () => {
 
   test("applies the streamed content to the open document", () => {
     openInViewer("surf-1");
-    renderHook(() => useDocumentEditorSync());
+    renderSyncAt();
+
+    publishDocumentEdit({ surfaceId: "surf-1", markdown: "# Rewritten" });
+
+    expect(useViewerStore.getState().openedDocumentState).toMatchObject({
+      surfaceId: "surf-1",
+      content: "# Rewritten",
+    });
+  });
+
+  test("records an unseen change when the drawer is open but the route is not chat", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("records an unseen change on the standalone document route", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.document("surf-1"));
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("still applies the streamed content off the chat route", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.settings.general);
 
     publishDocumentEdit({ surfaceId: "surf-1", markdown: "# Rewritten" });
 

--- a/clients/web/src/hooks/use-document-editor-sync.test.tsx
+++ b/clients/web/src/hooks/use-document-editor-sync.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * `useDocumentEditorSync` applies a streamed document edit to the viewer and
+ * records the change as unseen unless the user is watching that very document.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
+import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
+import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useViewerStore } from "@/stores/viewer-store";
+
+function publishDocumentEdit(options: {
+  conversationId?: string;
+  surfaceId: string;
+  markdown?: string;
+}) {
+  act(() => {
+    publish("sse.event", {
+      id: "evt-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "document_editor_update",
+        conversationId: options.conversationId ?? "conv-1",
+        surfaceId: options.surfaceId,
+        markdown: options.markdown ?? "# Edited",
+        mode: "replace",
+      },
+    });
+  });
+}
+
+/** Put the in-chat viewer on `surfaceId`, the way `loadDocument` leaves it. */
+function openInViewer(surfaceId: string) {
+  useViewerStore.getState().openDocument();
+  useViewerStore.getState().setLoadedDocument({
+    source: "document",
+    surfaceId,
+    conversationId: "conv-1",
+    documentName: "Notes",
+    content: "# Notes",
+  });
+}
+
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
+beforeEach(() => {
+  __resetForTesting();
+  useViewerStore.getState().reset();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useDocumentEditorSync", () => {
+  test("records an unseen change when the document is not open", () => {
+    renderHook(() => useDocumentEditorSync());
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("records nothing when that document is the one on screen", () => {
+    openInViewer("surf-1");
+    renderHook(() => useDocumentEditorSync());
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("records an unseen change when a different document is on screen", () => {
+    openInViewer("surf-1");
+    renderHook(() => useDocumentEditorSync());
+
+    publishDocumentEdit({ surfaceId: "surf-2" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("records against the conversation the edit came from", () => {
+    renderHook(() => useDocumentEditorSync());
+
+    publishDocumentEdit({ conversationId: "conv-2", surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual([]);
+    expect(unseenFor("conv-2")).toEqual(["surf-1"]);
+  });
+
+  test("applies the streamed content to the open document", () => {
+    openInViewer("surf-1");
+    renderHook(() => useDocumentEditorSync());
+
+    publishDocumentEdit({ surfaceId: "surf-1", markdown: "# Rewritten" });
+
+    expect(useViewerStore.getState().openedDocumentState).toMatchObject({
+      surfaceId: "surf-1",
+      content: "# Rewritten",
+    });
+  });
+});

--- a/clients/web/src/hooks/use-document-editor-sync.ts
+++ b/clients/web/src/hooks/use-document-editor-sync.ts
@@ -10,16 +10,32 @@
  * as unseen here. An edit to the document already on screen is not: the user
  * is watching it happen.
  *
+ * "On screen" is the route as well as the viewer store. The store keeps
+ * `mainView === "document"` and its opened document while the user is away on
+ * Library or Settings, but both surfaces that render a document beside the
+ * chat (the desktop drawer in `chat-content-layout.tsx` and the mobile
+ * overlay in `mobile-chat-overlays.tsx`) mount under `ActiveChatView`, which
+ * only the conversation chat route renders. Off that route the document is
+ * not visible, so its edit is unseen.
+ *
+ * The standalone `/assistant/documents/:surfaceId` route is not a live surface
+ * either: it renders the content it fetched on mount and never applies these
+ * updates, so an edit arriving while it is open is unseen there too. That page
+ * clears its own record when the user next loads it.
+ *
  * References:
  * - EVENT_BUS.md: bus subscription contract
  * - stores/viewer-store.ts: document editor state
  * - domains/chat/unseen-document-changes-store.ts: unseen-change records
  */
 
+import { useLocation } from "react-router";
+
 import { isDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useViewerStore } from "@/stores/viewer-store";
+import { isConversationChatPath } from "@/utils/routes";
 
 /**
  * Subscribes to `document_editor_update` SSE events via the event bus
@@ -29,6 +45,7 @@ import { useViewerStore } from "@/stores/viewer-store";
  * store is global and document surface ids are globally unique.
  */
 export function useDocumentEditorSync(): void {
+  const location = useLocation();
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "document_editor_update") {
@@ -36,11 +53,13 @@ export function useDocumentEditorSync(): void {
     }
     // An event handler, so the viewer is read rather than subscribed to.
     const viewer = useViewerStore.getState();
-    const watchingLive = isDocumentOpen(
-      viewer.mainView,
-      viewer.openedDocumentState,
-      event.surfaceId,
-    );
+    const watchingLive =
+      isConversationChatPath(location.pathname) &&
+      isDocumentOpen(
+        viewer.mainView,
+        viewer.openedDocumentState,
+        event.surfaceId,
+      );
     viewer.updateDocumentContent(event.surfaceId, event.markdown, event.mode);
     if (watchingLive) {
       return;

--- a/clients/web/src/hooks/use-document-editor-sync.ts
+++ b/clients/web/src/hooks/use-document-editor-sync.ts
@@ -5,11 +5,19 @@
  * The daemon sends incremental markdown content (append or replace
  * mode) as the assistant edits a document surface.
  *
+ * The same event is also the only signal that a document changed at all, so an
+ * edit that lands while the user is not looking at that document is recorded
+ * as unseen here. An edit to the document already on screen is not: the user
+ * is watching it happen.
+ *
  * References:
- * - EVENT_BUS.md — bus subscription contract
- * - stores/viewer-store.ts — document editor state
+ * - EVENT_BUS.md: bus subscription contract
+ * - stores/viewer-store.ts: document editor state
+ * - domains/chat/unseen-document-changes-store.ts: unseen-change records
  */
 
+import { isDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useViewerStore } from "@/stores/viewer-store";
 
@@ -26,8 +34,19 @@ export function useDocumentEditorSync(): void {
     if (event.type !== "document_editor_update") {
       return;
     }
-    useViewerStore
+    // An event handler, so the viewer is read rather than subscribed to.
+    const viewer = useViewerStore.getState();
+    const watchingLive = isDocumentOpen(
+      viewer.mainView,
+      viewer.openedDocumentState,
+      event.surfaceId,
+    );
+    viewer.updateDocumentContent(event.surfaceId, event.markdown, event.mode);
+    if (watchingLive) {
+      return;
+    }
+    useUnseenDocumentChangesStore
       .getState()
-      .updateDocumentContent(event.surfaceId, event.markdown, event.mode);
+      .markDocumentChanged(event.conversationId, event.surfaceId);
   });
 }

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -5,9 +5,13 @@ import type {
   MessageFilesPayload,
   ToolDetailPayload,
 } from "@/stores/viewer-store";
-import type { DocumentsForworkspacefilePostResponse } from "@/generated/daemon/types.gen";
+import type {
+  DocumentsByIdGetResponse,
+  DocumentsForworkspacefilePostResponse,
+} from "@/generated/daemon/types.gen";
 import { ApiError } from "@/utils/api-errors";
 import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 
 // The store opens file-backed documents through the daemon SDK. Spread the
 // real module so the actions this file does not exercise keep their real
@@ -18,12 +22,20 @@ type FileDocumentResult = {
   data: DocumentsForworkspacefilePostResponse | null;
 };
 
+type DocumentResult = {
+  data: DocumentsByIdGetResponse | null;
+};
+
 let fileDocumentResult: () => Promise<FileDocumentResult> = () =>
   Promise.reject(new Error("not stubbed"));
 const fileDocumentCalls: unknown[] = [];
 
+let documentResult: () => Promise<DocumentResult> = () =>
+  Promise.reject(new Error("not stubbed"));
+
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...daemonSdk,
+  documentsByIdGet: () => documentResult(),
   documentsForworkspacefilePost: (options: unknown) => {
     fileDocumentCalls.push(options);
     return fileDocumentResult();
@@ -54,11 +66,19 @@ function getState() {
   return useViewerStore.getState();
 }
 
+/** The surface ids a conversation currently holds unseen changes for. */
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
 beforeEach(() => {
   getState().reset();
   fileDocumentCalls.length = 0;
   toastError.mockClear();
   openWorkspaceFile.mockClear();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
 
 const SAMPLE_APP = {
@@ -1042,6 +1062,64 @@ describe("openWorkspaceFilePreview", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Document viewer: document surfaces
+// ---------------------------------------------------------------------------
+
+/** The daemon's answer for a document surface fetched by id. */
+function documentSurface(
+  overrides: Partial<DocumentsByIdGetResponse> = {},
+): DocumentsByIdGetResponse {
+  return {
+    success: true,
+    surfaceId: "surf-1",
+    conversationId: "conv-1",
+    title: "Notes",
+    content: "# Notes",
+    wordCount: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    workspacePath: null,
+    ...overrides,
+  };
+}
+
+describe("loadDocument", () => {
+  it("clears the unseen change for the document it opened", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(getState().mainView).toBe("document");
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  it("leaves the conversation's other unseen documents alone", async () => {
+    const unseen = useUnseenDocumentChangesStore.getState();
+    unseen.markDocumentChanged("conv-1", "surf-1");
+    unseen.markDocumentChanged("conv-1", "surf-2");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  it("keeps the unseen change when the open fails", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.reject(new ApiError(404, "Not found"));
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Document viewer: workspace files
 // ---------------------------------------------------------------------------
 
@@ -1095,6 +1173,21 @@ describe("loadWorkspaceFileDocument", () => {
       body: { path: "drafts/notes.md", conversationId: "conv-1" },
     });
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("clears the unseen change for the document it opened", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-file");
+    fileDocumentResult = () => Promise.resolve({ data: fileDocument() });
+
+    await getState().loadWorkspaceFileDocument(
+      "asst-1",
+      "drafts/notes.md",
+      "conv-1",
+    );
+
+    expect(unseenFor("conv-1")).toEqual([]);
   });
 
   it("names an untitled document rather than showing an empty navbar", async () => {

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -46,6 +46,7 @@ import { ApiError } from "@/utils/api-errors";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { workspaceBasenameOf } from "@/domains/chat/utils/workspace-path-links";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import { createSelectors } from "@/utils/create-selectors";
@@ -1170,6 +1171,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
           workspacePath: result.workspacePath,
         },
       });
+      useUnseenDocumentChangesStore
+        .getState()
+        .clearDocument(result.conversationId, result.surfaceId);
     } catch {
       if (!sameDocumentTarget(get().activeDocumentTarget, target)) {
         return;
@@ -1244,6 +1248,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
           workspacePath: result.workspacePath,
         },
       });
+      useUnseenDocumentChangesStore
+        .getState()
+        .clearDocument(result.conversationId, result.surfaceId);
     } catch (err) {
       giveUp(err);
     }


### PR DESCRIPTION
## Summary
- Record an unseen change when a document editor update lands for a document that is not open.
- Clear the record when the document is opened through the in-chat viewer or the standalone route.

Part of plan: document-update-discoverability.md (PR 6 of 12)