### PR TITLE
Cover the router's latency with a View Transition instead of a blank screen

### DIFF
--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -63,6 +63,7 @@ export function SidebarShell({
     onBack: handleSwipeBack,
     enabled: isMobile,
     navKey: pathname,
+    prefetchHref: mobileBackHref,
   });
 
   // In the Electron shell the macOS window controls (traffic lights) sit in an

--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -7,6 +7,7 @@ import { RuntimeUpgradeBanner } from "@/components/runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
 import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { navigateWithPageTransition } from "@/lib/page-transition";
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
 
@@ -85,7 +86,9 @@ export function SidebarShell({
       iconOnly={<ArrowLeft />}
       aria-label={mobileBackLabel}
       tintColor="var(--content-secondary)"
-      onClick={() => navigate(mobileBackHref)}
+      onClick={() =>
+        navigateWithPageTransition(navigate, mobileBackHref, "pop")
+      }
     />
   );
 

--- a/clients/web/src/components/sidebar-tree.tsx
+++ b/clients/web/src/components/sidebar-tree.tsx
@@ -3,6 +3,7 @@ import { Fragment } from "react";
 import { useLocation, useNavigate } from "react-router";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { navigateWithPageTransition } from "@/lib/page-transition";
 import { isModifiedLinkClick } from "@/utils/link-click";
 import { SideMenu } from "@vellumai/design-library";
 
@@ -73,7 +74,7 @@ export function SidebarTree({
                     return;
                   }
                   e.preventDefault();
-                  navigate(href);
+                  navigateWithPageTransition(navigate, href, "push");
                 }
           }
         />

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -81,6 +81,9 @@ export function SkillDetailPage() {
     onBack: handleBack,
     enabled: isMobile,
     navKey: pathname,
+    // Path only: the list's search params are carried by `handleBack` and
+    // play no part in matching the route branch to warm.
+    prefetchHref: routes.superpowers,
   });
 
   const {

--- a/clients/web/src/domains/library/library-detail-page.tsx
+++ b/clients/web/src/domains/library/library-detail-page.tsx
@@ -88,6 +88,7 @@ export function LibraryDetailPage() {
     onBack: handleClose,
     enabled: isMobile,
     navKey: pathname,
+    prefetchHref: routes.library.root,
   });
 
   const editApp = useEditApp();

--- a/clients/web/src/hooks/use-edge-swipe-back.ts
+++ b/clients/web/src/hooks/use-edge-swipe-back.ts
@@ -7,6 +7,7 @@ import {
   EDGE_SWIPE_SLIDE_MS,
 } from "@/hooks/edge-swipe-motion";
 import { computeVisualOffset, useEdgeSwipe } from "@/hooks/use-edge-swipe";
+import { prefetchRoute } from "@/lib/prefetch-route";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,14 @@ export interface UseEdgeSwipeBackArgs {
    * briefly show the outgoing page.
    */
   navKey: string;
+  /**
+   * Where `onBack()` will navigate. Its lazy chunks are requested the moment
+   * the gesture is recognised as horizontal, which is a few hundred
+   * milliseconds of head start on the drag: a chunk still in flight when the
+   * finger lifts holds the navigation open, and the transition shows an empty
+   * screen for the whole wait. Optional, and purely an optimisation.
+   */
+  prefetchHref?: string;
 }
 
 /**
@@ -72,11 +81,17 @@ export function useEdgeSwipeBack({
   onBack,
   enabled,
   navKey,
+  prefetchHref,
 }: UseEdgeSwipeBackArgs): void {
   const onBackRef = useRef(onBack);
   useLayoutEffect(() => {
     onBackRef.current = onBack;
   }, [onBack]);
+
+  const prefetchHrefRef = useRef(prefetchHref);
+  useLayoutEffect(() => {
+    prefetchHrefRef.current = prefetchHref;
+  }, [prefetchHref]);
 
   // Set true the instant a swipe commits; the entrance layout effect consumes
   // it on the next `navKey` change so the reveal is synced to the route swap.
@@ -185,6 +200,10 @@ export function useEdgeSwipeBack({
   useEdgeSwipe({
     enabled,
     onConfirm: () => {
+      // Ahead of the element check: a detail page still on its loading branch
+      // has no container to drag, but its committed swipe still navigates
+      // (see the null-container path in `onCommit`).
+      prefetchRoute(prefetchHrefRef.current);
       const el = containerRef.current;
       if (!el) {
         return;

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -115,6 +115,64 @@ body {
   height: 100%;
 }
 
+/* Page transitions — the two snapshots the View Transitions API creates for a
+   router navigation, driven by `lib/page-transition.ts`, which writes the
+   direction attribute and asks React Router for the transition.
+
+   Both snapshots are live at once, so the pages travel together: the arriving
+   one crosses the full viewport while the departing one drifts a quarter of
+   it, the parallax that reads as one page sitting behind another. `z-index`
+   gives the arriving page the top layer on a push and the departing page the
+   top layer on a pop, matching which one a finger would be dragging.
+
+   Duration and easing mirror the edge-swipe gestures
+   (`hooks/edge-swipe-motion.ts`) so a tapped navigation and a swiped one land
+   on the same motion. Keep the two in step.
+
+   Inert wherever nothing requests a view transition: the pseudo-elements are
+   only created for a navigation that asked for one. */
+:root {
+  --page-transition-duration: 200ms;
+}
+
+/* Drop the default cross-fade. These are opaque pages sliding past each
+   other, not two images blending through one another. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+html[data-page-transition="push"]::view-transition-old(root) {
+  animation: page-depart-leading var(--page-transition-duration) ease-out both;
+}
+html[data-page-transition="push"]::view-transition-new(root) {
+  z-index: 1;
+  animation: page-arrive-trailing var(--page-transition-duration) ease-out both;
+}
+html[data-page-transition="pop"]::view-transition-old(root) {
+  z-index: 1;
+  animation: page-depart-trailing var(--page-transition-duration) ease-out both;
+}
+html[data-page-transition="pop"]::view-transition-new(root) {
+  animation: page-arrive-leading var(--page-transition-duration) ease-out both;
+}
+
+@keyframes page-arrive-trailing { from { transform: translateX(100%); } }
+@keyframes page-depart-leading { to { transform: translateX(-25%); } }
+@keyframes page-arrive-leading { from { transform: translateX(-25%); } }
+@keyframes page-depart-trailing { to { transform: translateX(100%); } }
+
+/* Snap to the destination. The transition still runs, so React Router's
+   snapshot still covers the router's own latency; only the travel is dropped. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(root),
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 @keyframes typing-dot-pulse {
   0%, 100% { opacity: 0.45; transform: scale(0.6); }
   50% { opacity: 1; transform: scale(1); }

--- a/clients/web/src/lib/page-transition.test.ts
+++ b/clients/web/src/lib/page-transition.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const isNativeMobile = mock(() => true);
+mock.module("@/runtime/platform-detection", () => ({ isNativeMobile }));
+
+const {
+  navigateWithPageTransition,
+  pageTransitionsEnabled,
+  resetPageTransitionState,
+} = await import("@/lib/page-transition");
+
+/**
+ * The real `startViewTransition` is non-optional in `lib.dom`, so stubbing and
+ * unstubbing it goes through an index signature rather than the typed member.
+ */
+const documentRecord = document as unknown as Record<string, unknown>;
+
+function installViewTransitionApi(): void {
+  documentRecord.startViewTransition = () => ({});
+}
+
+function removeViewTransitionApi(): void {
+  delete documentRecord.startViewTransition;
+}
+
+function directionAttribute(): string | null {
+  return document.documentElement.getAttribute("data-page-transition");
+}
+
+describe("navigateWithPageTransition", () => {
+  let navigate: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    navigate = mock(() => {});
+    isNativeMobile.mockReturnValue(true);
+    installViewTransitionApi();
+    resetPageTransitionState();
+  });
+
+  afterEach(() => {
+    removeViewTransitionApi();
+    resetPageTransitionState();
+  });
+
+  test("asks for a view transition and records the direction", () => {
+    navigateWithPageTransition(navigate as never, "/assistant/settings", "pop");
+    expect(navigate).toHaveBeenCalledWith("/assistant/settings", {
+      viewTransition: true,
+    });
+    expect(directionAttribute()).toBe("pop");
+  });
+
+  test("carries the caller's own navigate options through", () => {
+    navigateWithPageTransition(navigate as never, "/a", "push", {
+      replace: true,
+    });
+    expect(navigate).toHaveBeenCalledWith("/a", {
+      replace: true,
+      viewTransition: true,
+    });
+  });
+
+  test("navigates plainly off the native mobile shells", () => {
+    isNativeMobile.mockReturnValue(false);
+    navigateWithPageTransition(navigate as never, "/a", "push");
+    expect(navigate).toHaveBeenCalledWith("/a", undefined);
+    expect(directionAttribute()).toBeNull();
+  });
+
+  test("navigates plainly when the engine has no View Transitions API", () => {
+    removeViewTransitionApi();
+    navigateWithPageTransition(navigate as never, "/a", "pop");
+    expect(navigate).toHaveBeenCalledWith("/a", undefined);
+    expect(directionAttribute()).toBeNull();
+  });
+
+  test("the latest direction wins when navigations land back to back", () => {
+    navigateWithPageTransition(navigate as never, "/a", "push");
+    navigateWithPageTransition(navigate as never, "/b", "pop");
+    expect(directionAttribute()).toBe("pop");
+  });
+});
+
+describe("pageTransitionsEnabled", () => {
+  afterEach(() => {
+    removeViewTransitionApi();
+    isNativeMobile.mockReturnValue(true);
+  });
+
+  test("requires both a mobile shell and the API", () => {
+    installViewTransitionApi();
+    isNativeMobile.mockReturnValue(true);
+    expect(pageTransitionsEnabled()).toBe(true);
+
+    isNativeMobile.mockReturnValue(false);
+    expect(pageTransitionsEnabled()).toBe(false);
+
+    isNativeMobile.mockReturnValue(true);
+    removeViewTransitionApi();
+    expect(pageTransitionsEnabled()).toBe(false);
+  });
+});

--- a/clients/web/src/lib/page-transition.ts
+++ b/clients/web/src/lib/page-transition.ts
@@ -1,0 +1,96 @@
+/**
+ * Directional page transitions for the native mobile shells, driven by the
+ * View Transitions API.
+ *
+ * A router navigation is asynchronous: middleware runs, lazy chunks resolve,
+ * and React renders the new subtree before anything can paint. Animating
+ * around that by hand means hiding the outgoing page first and exposing the
+ * whole wait as an empty screen. `document.startViewTransition` inverts it —
+ * React Router calls it at the *commit* point, and the browser holds a
+ * snapshot of the outgoing page until the incoming one has rendered, so the
+ * wait is covered rather than displayed.
+ *
+ * The motion itself is CSS: `::view-transition-old(root)` and
+ * `::view-transition-new(root)` in `index.css`, keyed off the
+ * `data-page-transition` attribute this module writes. Both snapshots exist at
+ * once, so the two pages move together rather than one after the other.
+ *
+ * Degrades silently. Off the mobile shells, and on any engine without the API
+ * (it needs iOS 18), the navigation runs exactly as it does today: React
+ * Router checks for `startViewTransition` itself and falls back to a plain
+ * state update.
+ */
+
+import type { NavigateFunction, NavigateOptions, To } from "react-router";
+
+import { EDGE_SWIPE_SLIDE_MS } from "@/hooks/edge-swipe-motion";
+import { isNativeMobile } from "@/runtime/platform-detection";
+
+/**
+ * Which way the pages travel. `push` moves deeper into a section (the new page
+ * arrives from the trailing edge); `pop` returns toward the root.
+ */
+export type PageTransitionDirection = "push" | "pop";
+
+/** Read by the `::view-transition-*` rules in `index.css`. */
+const DIRECTION_ATTRIBUTE = "data-page-transition";
+
+/**
+ * How long the attribute outlives the navigation. Only the pseudo-elements
+ * read it and they exist only mid-transition, so a stale value is inert; the
+ * cleanup keeps the DOM honest rather than guarding anything.
+ */
+const ATTRIBUTE_CLEANUP_MS = EDGE_SWIPE_SLIDE_MS * 2;
+
+let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+
+function supportsViewTransitions(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    typeof document.startViewTransition === "function"
+  );
+}
+
+/** Whether a navigation from here would animate, for callers that need to know. */
+export function pageTransitionsEnabled(): boolean {
+  return isNativeMobile() && supportsViewTransitions();
+}
+
+/**
+ * Navigate with a directional slide where the platform supports one, and
+ * exactly like `navigate()` everywhere else.
+ *
+ * `viewTransition` is per-navigation rather than global so a route change that
+ * should not animate (a redirect, a same-page param update) simply omits it.
+ */
+export function navigateWithPageTransition(
+  navigate: NavigateFunction,
+  to: To,
+  direction: PageTransitionDirection,
+  options?: NavigateOptions,
+): void {
+  if (!pageTransitionsEnabled()) {
+    void navigate(to, options);
+    return;
+  }
+
+  document.documentElement.setAttribute(DIRECTION_ATTRIBUTE, direction);
+  if (cleanupTimer !== undefined) {
+    clearTimeout(cleanupTimer);
+  }
+  cleanupTimer = setTimeout(() => {
+    cleanupTimer = undefined;
+    document.documentElement.removeAttribute(DIRECTION_ATTRIBUTE);
+  }, ATTRIBUTE_CLEANUP_MS);
+
+  void navigate(to, { ...options, viewTransition: true });
+}
+
+/** @internal Exposed for test isolation only. */
+export function resetPageTransitionState(): void {
+  if (cleanupTimer !== undefined) {
+    clearTimeout(cleanupTimer);
+    cleanupTimer = undefined;
+  }
+  document.documentElement.removeAttribute(DIRECTION_ATTRIBUTE);
+}

--- a/clients/web/src/lib/prefetch-route.test.ts
+++ b/clients/web/src/lib/prefetch-route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const componentLoad = mock(() => Promise.resolve({ Component: () => null }));
+const rejectingLoad = mock(() => Promise.reject(new Error("chunk failed")));
+
+mock.module("@/routes", () => ({
+  routeTree: [
+    {
+      path: "/assistant",
+      children: [
+        { path: "library", lazy: { Component: componentLoad } },
+        { path: "boom", lazy: { Component: rejectingLoad } },
+      ],
+    },
+  ],
+}));
+
+const { prefetchRoute, resetPrefetchedRoutes } =
+  await import("@/lib/prefetch-route");
+
+/**
+ * The helper never awaits. Its first call also resolves a dynamic import,
+ * which needs a real task, not just a drained microtask queue.
+ */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("prefetchRoute", () => {
+  beforeEach(() => {
+    resetPrefetchedRoutes();
+    componentLoad.mockClear();
+    rejectingLoad.mockClear();
+  });
+
+  test("requests the lazy chunk on the matching route branch", async () => {
+    prefetchRoute("/assistant/library");
+    await settle();
+    expect(componentLoad).toHaveBeenCalledTimes(1);
+  });
+
+  test("requests each path only once", async () => {
+    prefetchRoute("/assistant/library");
+    await settle();
+    prefetchRoute("/assistant/library");
+    await settle();
+    expect(componentLoad).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores an empty href", async () => {
+    prefetchRoute(undefined);
+    prefetchRoute("");
+    await settle();
+    expect(componentLoad).not.toHaveBeenCalled();
+  });
+
+  test("loads nothing for a path that matches no route", async () => {
+    prefetchRoute("/assistant/nope");
+    await settle();
+    expect(componentLoad).not.toHaveBeenCalled();
+  });
+
+  test("swallows a failed chunk request", async () => {
+    prefetchRoute("/assistant/boom");
+    await settle();
+    expect(rejectingLoad).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/lib/prefetch-route.ts
+++ b/clients/web/src/lib/prefetch-route.ts
@@ -1,0 +1,71 @@
+/**
+ * Warm the lazy chunks a path will need, before anything navigates to it.
+ *
+ * Route components are code-split (`lazy: { Component: () => import(...) }` in
+ * `routes.tsx`), so a navigation to a path whose chunk is not resolved yet
+ * cannot commit until the network round trip finishes. Nothing paints during
+ * that window, which is most visible behind an animated transition: the
+ * outgoing view is already gone and the incoming one does not exist.
+ *
+ * Calling this ahead of the navigation moves the fetch off the critical path.
+ * The dynamic imports are idempotent and module-cached by the bundler, so an
+ * already-resolved chunk costs nothing and a warmed path is skipped outright.
+ *
+ * Best-effort by contract: a failure here must never surface, because the real
+ * navigation will request the same chunk again and own the error handling.
+ */
+
+import { matchRoutes } from "react-router";
+
+/** Paths whose chunks have already been requested. */
+const warmed = new Set<string>();
+
+/** The `lazy` shapes a route may carry: a single loader or one per property. */
+type LazyRouteValue =
+  (() => Promise<unknown>) | Record<string, () => Promise<unknown>>;
+
+function warmLazy(lazy: LazyRouteValue): void {
+  if (typeof lazy === "function") {
+    void lazy().catch(() => {});
+    return;
+  }
+  for (const load of Object.values(lazy)) {
+    if (typeof load === "function") {
+      void load().catch(() => {});
+    }
+  }
+}
+
+/**
+ * Request every lazy chunk on the route branch matching `href`. Safe to call
+ * repeatedly and from event handlers; it never throws and never awaits.
+ */
+export function prefetchRoute(href: string | undefined): void {
+  if (!href || warmed.has(href)) {
+    return;
+  }
+  warmed.add(href);
+
+  // `routes.tsx` builds the router out of the whole component tree, so a
+  // static import here would be a cycle. The same lazy-import escape hatch
+  // `auth-middleware.ts` uses for the router.
+  void import("@/routes")
+    .then(({ routeTree }) => {
+      const matches = matchRoutes(routeTree as never, href);
+      for (const match of matches ?? []) {
+        const lazy = (match.route as { lazy?: LazyRouteValue }).lazy;
+        if (lazy) {
+          warmLazy(lazy);
+        }
+      }
+    })
+    .catch(() => {
+      // Let a later call retry rather than leaving the path marked warm.
+      warmed.delete(href);
+    });
+}
+
+/** @internal Exposed for test isolation only. */
+export function resetPrefetchedRoutes(): void {
+  warmed.clear();
+}


### PR DESCRIPTION
Follow-up to #40211. Two commits: a chunk prefetch, then the fix that actually closes the gap.

## The problem, measured

Frame-stepping a 120fps capture of a Privacy → Settings back-swipe:

| | |
|---|---|
| 0ms | finger releases |
| 0 → 130ms | exit slide (good) |
| 130 → 280ms | **blank white screen** |
| 280 → 430ms | entrance |

A third of the transition is nothing on screen. The animation is not the cause. `useEdgeSwipeBack` hides the container and *then* navigates:

```js
el.style.opacity = "0";
void el.offsetWidth;
onBackRef.current();   // async: middleware, lazy chunk, React render
```

Router navigations in data mode are asynchronous, so that window is the router's latency with the page already blanked. The middleware is not the cost on a warm navigation (`resolveWithGuard` only awaits when it returns `"wait"`, which happens at boot); it is mostly the lazy chunk plus React rendering the new subtree. The chat drawer has no equivalent gap because it never navigates.

## Commit 2: View Transitions (the fix)

`document.startViewTransition` inverts the ordering. React Router calls it at the **commit** point, after loaders and lazy imports resolve, and its non-flushSync path is:

```js
startViewTransition(async () => {
  startTransition(() => setStateImpl(newState));
  await renderPromise;      // waits for React to render
});
```

The browser holds a snapshot of the outgoing page through the router latency **and** React's render. Nothing is ever hidden, so there is no blank. Both snapshots are live simultaneously, so the pages travel together rather than one after the other — the parallax that reads as native.

The motion is CSS on `::view-transition-old(root)` / `::view-transition-new(root)`, keyed off a `data-page-transition` attribute, reusing the edge-swipe duration and easing so a tapped navigation and a swiped one match. Wired to the settings nav rows (push) and the mobile back arrow (pop) — the exact flow captured above.

**Degradation is free.** React Router checks for `startViewTransition` itself and falls back to a plain state update. Combined with an `isNativeMobile()` gate, macOS, desktop web, and iOS before 18 all behave exactly as they do today. There is no parallel implementation to maintain.

The swipe gesture keeps its own imperative animation for now; unifying it onto view transitions is a separate change.

## Commit 1: chunk prefetch

`prefetchRoute(href)` matches a path against `routeTree` and calls the lazy loaders on that branch. `useEdgeSwipeBack` invokes it from `onConfirm`, which fires as soon as the gesture reads as horizontal, so the fetch overlaps the remaining drag. Wired into `SidebarShell`, `LibraryDetailPage`, and `SkillDetailPage`; `DocumentViewerPage` opts out because it calls `navigate(-1)` with no statically known destination.

This only helps when the destination chunk is cold — a first visit, or a swipe soon after launch. It does not close the gap above, where the chunk was already resolved. Kept because it is small, cannot regress, and removes one of the two contributors outright.

## Test plan

- `bun run typecheck` clean, `bun run build` clean
- Verified the view-transition selectors and keyframes survive minification in `dist/assets/index-*.css` (they are non-standard pseudo-elements, so worth confirming rather than assuming)
- `eslint` on touched files clean, aside from one pre-existing warning on `main`
- `page-transition.test.ts` 6 pass: opts in and records direction, forwards caller options, falls back off the shells, falls back without the API, latest direction wins
- `prefetch-route.test.ts` 5 pass, `use-edge-swipe.test.ts` 30 pass, `sidebar-shell.test.tsx` 3 pass
- `index.css` was hand-formatted to the file's existing style; running Prettier over it reflows the whole file

Device check on iOS 18+: tap into a settings sub-page and back out. There should be no blank frame, and the two pages should move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
