### PR TITLE
feat(assistant): state conversation provenance at creation

### DIFF
--- a/assistant/src/__tests__/conversation-key-store-origin.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-origin.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The key store attributes a channel conversation when it materializes it.
+ *
+ * This is the principal inbound seam: a new Slack, Telegram, or phone
+ * conversation gets its row here, before the daemon's own creation path is
+ * ever consulted. Stamping only in `createConversation` therefore misses the
+ * case that matters most, which is why these cases exist separately.
+ *
+ * The trust assertion at the end is the one worth protecting. `origin_channel`
+ * is what `recoverRestingTrustContext` reads, and the native channel recovers
+ * INTERNAL_GUARDIAN_TRUST_CONTEXT on every later wake and boot-resume. A
+ * remote conversation that reached this seam unattributed, or attributed as
+ * native, would resume as the guardian's own.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { recoverRestingTrustContext } from "../daemon/conversation-resting-trust.js";
+import { setConversationOriginChannelIfUnset } from "../persistence/conversation-crud.js";
+import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { conversations } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+function rawOriginChannel(id: string): string | null {
+  const row = getDb()
+    .all(`SELECT origin_channel FROM conversations WHERE id = '${id}'`)
+    .at(0) as { origin_channel: string | null } | undefined;
+  return row?.origin_channel ?? null;
+}
+
+beforeEach(() => {
+  getDb().delete(conversations).run();
+});
+
+describe("materializing a conversation from a channel key", () => {
+  test("stamps the channel at creation, before any message", () => {
+    const { conversationId, created } = getOrCreateConversation(
+      "default:slack:slack",
+      { origin: "slack" },
+    );
+
+    expect(created).toBe(true);
+    expect(rawOriginChannel(conversationId)).toBe("slack");
+  });
+
+  test("the first message does not change what creation established", () => {
+    // Attribution is guarded on `IS NULL`, so a row attributed at creation is
+    // never re-claimed. Before and after the first message agree.
+    const { conversationId } = getOrCreateConversation("default:slack:slack", {
+      origin: "slack",
+    });
+    const atCreation = rawOriginChannel(conversationId);
+
+    setConversationOriginChannelIfUnset(conversationId, "telegram");
+
+    expect(rawOriginChannel(conversationId)).toBe(atCreation);
+    expect(rawOriginChannel(conversationId)).toBe("slack");
+  });
+
+  test("reusing an existing key does not re-attribute it", () => {
+    const first = getOrCreateConversation("default:slack:slack", {
+      origin: "slack",
+    });
+
+    const second = getOrCreateConversation("default:slack:slack", {
+      origin: "vellum",
+    });
+
+    expect(second.created).toBe(false);
+    expect(second.conversationId).toBe(first.conversationId);
+    expect(rawOriginChannel(first.conversationId)).toBe("slack");
+  });
+
+  test("a caller that states no origin leaves the column unset", () => {
+    const { conversationId } = getOrCreateConversation("some:other:key");
+
+    expect(rawOriginChannel(conversationId)).toBeNull();
+  });
+});
+
+describe("what the attribution protects", () => {
+  test("a channel conversation recovers no resting trust", () => {
+    // The property the whole change exists to hold. Driven through the
+    // creation seam rather than a raw column write, so it fails if creation
+    // ever stops attributing the row.
+    const { conversationId } = getOrCreateConversation("default:slack:slack", {
+      origin: "slack",
+    });
+
+    expect(recoverRestingTrustContext(conversationId)).toBeNull();
+  });
+
+  test("a native conversation still recovers guardian trust", () => {
+    // The other half: attributing at creation must not withdraw trust from
+    // the guardian's own conversations, or every local wake regresses.
+    const { conversationId } = getOrCreateConversation("native-key", {
+      origin: "vellum",
+    });
+
+    expect(recoverRestingTrustContext(conversationId)).not.toBeNull();
+  });
+});

--- a/assistant/src/__tests__/conversation-origin-at-creation.test.ts
+++ b/assistant/src/__tests__/conversation-origin-at-creation.test.ts
@@ -83,7 +83,21 @@ describe("inheriting the origin from a parent", () => {
     expect(rawOriginChannel(fork.id)).toBe("vellum");
   });
 
-  test("an unreadable parent fails the insert rather than defaulting", () => {
+  test("a parent whose own origin is unset yields an unset origin", () => {
+    // Faithful inheritance, not an error. Most rows sit unattributed until a
+    // message claims them or startup sweeps them, so treating this as a
+    // failure would break the majority of forks and subagent spawns.
+    const parent = createConversation({ title: "unattributed-parent" });
+
+    const fork = createConversation({
+      title: "fork",
+      origin: { inheritFrom: parent.id },
+    });
+
+    expect(rawOriginChannel(fork.id)).toBeNull();
+  });
+
+  test("a parent that does not exist fails the insert rather than defaulting", () => {
     // Defaulting here would be a trust grant, not a cosmetic guess:
     // `recoverRestingTrustContext` recovers INTERNAL_GUARDIAN_TRUST_CONTEXT
     // for the native channel, so a fork of a remote conversation whose parent

--- a/assistant/src/__tests__/conversation-origin-at-creation.test.ts
+++ b/assistant/src/__tests__/conversation-origin-at-creation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Conversation provenance is stated at creation.
+ *
+ * `createConversation` accepts the origin so the row is attributed from the
+ * moment it exists, rather than being patched afterward by
+ * `setConversationOriginChannelIfUnset` on the first inbound message. See
+ * JARVIS-1466 for why the post-hoc path leaves the column in a third
+ * "not yet attributed" state that different readers resolve in opposite
+ * directions.
+ *
+ * The omitted-origin case is pinned deliberately: while call sites are being
+ * migrated, omitting the argument has to behave exactly as it did before the
+ * parameter existed, or migrating them stops being safe to do piecemeal.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createConversation,
+  getConversationOriginChannel,
+  setConversationOriginChannelIfUnset,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { conversations } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+/** The raw column, not the parsed accessor, so NULL stays distinguishable. */
+function rawOriginChannel(id: string): string | null {
+  const row = getDb()
+    .all(`SELECT origin_channel FROM conversations WHERE id = '${id}'`)
+    .at(0) as { origin_channel: string | null } | undefined;
+  return row?.origin_channel ?? null;
+}
+
+beforeEach(() => {
+  getDb().delete(conversations).run();
+});
+
+describe("stating the origin at creation", () => {
+  test("stamps a native conversation", () => {
+    const conv = createConversation({ title: "in-app", origin: "vellum" });
+
+    expect(rawOriginChannel(conv.id)).toBe("vellum");
+  });
+
+  test("stamps an external channel", () => {
+    const conv = createConversation({ title: "from-slack", origin: "slack" });
+
+    expect(rawOriginChannel(conv.id)).toBe("slack");
+  });
+
+  test("a stamped row is attributed before any message arrives", () => {
+    // The point of the change: the row is already correct, so nothing has to
+    // run afterward to make it so.
+    const conv = createConversation({ title: "from-slack", origin: "slack" });
+
+    expect(getConversationOriginChannel(conv.id)).toBe("slack");
+  });
+});
+
+describe("inheriting the origin from a parent", () => {
+  test("a fork lands on its parent's channel", () => {
+    const parent = createConversation({ title: "parent", origin: "telegram" });
+
+    const fork = createConversation({
+      title: "fork",
+      origin: { inheritFrom: parent.id },
+    });
+
+    expect(rawOriginChannel(fork.id)).toBe("telegram");
+  });
+
+  test("inheriting from a native parent stays native", () => {
+    const parent = createConversation({ title: "parent", origin: "vellum" });
+
+    const fork = createConversation({
+      title: "fork",
+      origin: { inheritFrom: parent.id },
+    });
+
+    expect(rawOriginChannel(fork.id)).toBe("vellum");
+  });
+
+  test("an unreadable parent falls back to native rather than failing", () => {
+    // Creation is on the inbound critical path: a slightly wrong origin is
+    // recoverable, a thrown insert is not.
+    const fork = createConversation({
+      title: "orphan",
+      origin: { inheritFrom: "no-such-conversation" },
+    });
+
+    expect(rawOriginChannel(fork.id)).toBe("vellum");
+  });
+});
+
+describe("callers that have not been migrated yet", () => {
+  test("omitting the origin leaves the column unset", () => {
+    const conv = createConversation({ title: "unmigrated" });
+
+    expect(rawOriginChannel(conv.id)).toBeNull();
+  });
+
+  test("attribution still claims an unstamped row", () => {
+    const conv = createConversation({ title: "unmigrated" });
+
+    setConversationOriginChannelIfUnset(conv.id, "slack");
+
+    expect(rawOriginChannel(conv.id)).toBe("slack");
+  });
+
+  test("attribution does not overwrite an origin stated at creation", () => {
+    // The `isNull` guard is what makes stamping and attribution able to
+    // coexist during the migration: a row that already knows its origin is
+    // never re-claimed by a later message.
+    const conv = createConversation({ title: "from-slack", origin: "slack" });
+
+    setConversationOriginChannelIfUnset(conv.id, "telegram");
+
+    expect(rawOriginChannel(conv.id)).toBe("slack");
+  });
+});

--- a/assistant/src/__tests__/conversation-origin-at-creation.test.ts
+++ b/assistant/src/__tests__/conversation-origin-at-creation.test.ts
@@ -83,15 +83,31 @@ describe("inheriting the origin from a parent", () => {
     expect(rawOriginChannel(fork.id)).toBe("vellum");
   });
 
-  test("an unreadable parent falls back to native rather than failing", () => {
-    // Creation is on the inbound critical path: a slightly wrong origin is
-    // recoverable, a thrown insert is not.
+  test("an unreadable parent fails the insert rather than defaulting", () => {
+    // Defaulting here would be a trust grant, not a cosmetic guess:
+    // `recoverRestingTrustContext` recovers INTERNAL_GUARDIAN_TRUST_CONTEXT
+    // for the native channel, so a fork of a remote conversation whose parent
+    // we failed to read would come back as the guardian's own on every later
+    // wake and boot-resume.
+    expect(() =>
+      createConversation({
+        title: "orphan",
+        origin: { inheritFrom: "no-such-conversation" },
+      }),
+    ).toThrow(/Cannot inherit conversation origin/);
+  });
+
+  test("a remote parent's fork does not become native", () => {
+    // The property that matters for trust, stated directly.
+    const parent = createConversation({ title: "parent", origin: "slack" });
+
     const fork = createConversation({
-      title: "orphan",
-      origin: { inheritFrom: "no-such-conversation" },
+      title: "fork",
+      origin: { inheritFrom: parent.id },
     });
 
-    expect(rawOriginChannel(fork.id)).toBe("vellum");
+    expect(rawOriginChannel(fork.id)).not.toBe("vellum");
+    expect(rawOriginChannel(fork.id)).toBe("slack");
   });
 });
 

--- a/assistant/src/__tests__/conversation-store-ephemeral.test.ts
+++ b/assistant/src/__tests__/conversation-store-ephemeral.test.ts
@@ -175,8 +175,12 @@ describe("getOrCreateConversation ephemeral flag", () => {
 
     await getOrCreateConversation("real-conversation-id");
 
+    // No trust context on this call, so no origin is asserted: the row is
+    // left unattributed for the first inbound message to claim, rather than
+    // being guessed as native.
     expect(mockEnsureConversationExists).toHaveBeenCalledWith(
       "real-conversation-id",
+      undefined,
     );
   });
 });

--- a/assistant/src/__tests__/ensure-conversation-exists.test.ts
+++ b/assistant/src/__tests__/ensure-conversation-exists.test.ts
@@ -26,7 +26,7 @@ describe("ensureConversationExists", () => {
 
     // Reports that it inserted the row so callers can emit a one-time
     // conversations-list invalidation.
-    expect(ensureConversationExists(conversationId)).toBe(true);
+    expect(ensureConversationExists(conversationId, "vellum")).toBe(true);
 
     const row = getConversation(conversationId);
     expect(row?.id).toBe(conversationId);
@@ -48,8 +48,8 @@ describe("ensureConversationExists", () => {
 
     // Two extra ensures must be no-ops — return false (did not create), no
     // throw, no title/row change.
-    expect(ensureConversationExists(created.id)).toBe(false);
-    expect(ensureConversationExists(created.id)).toBe(false);
+    expect(ensureConversationExists(created.id, "vellum")).toBe(false);
+    expect(ensureConversationExists(created.id, "vellum")).toBe(false);
 
     const row = getConversation(created.id);
     expect(row?.id).toBe(created.id);
@@ -61,7 +61,7 @@ describe("ensureConversationExists", () => {
     // traversal value from an untrusted live-voice start frame must be refused
     // before createConversation() touches disk.
     for (const unsafe of ["../../tmp/x", "a/b", "..", "with space", ""]) {
-      expect(() => ensureConversationExists(unsafe)).toThrow(
+      expect(() => ensureConversationExists(unsafe, "vellum")).toThrow(
         /unsafe conversation id/,
       );
       expect(getConversation(unsafe)).toBeNull();
@@ -69,7 +69,10 @@ describe("ensureConversationExists", () => {
 
     // A plain uuid-shaped id is still accepted.
     expect(
-      ensureConversationExists("0f9c1e2a-3b4d-5e6f-7a8b-9c0d1e2f3a4b"),
+      ensureConversationExists(
+        "0f9c1e2a-3b4d-5e6f-7a8b-9c0d1e2f3a4b",
+        "vellum",
+      ),
     ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -52,7 +52,7 @@ mock.module("../daemon/conversation-store.js", () => ({
             | "background",
         });
       } else {
-        ensureConversationExists(conversationId);
+        ensureConversationExists(conversationId, "vellum");
       }
     }
     return {

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -19,6 +19,7 @@ import {
   ensureConversationExists,
   getConversation,
 } from "../persistence/conversation-crud.js";
+import type { ConversationOrigin } from "../persistence/conversation-types.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import {
   mainAgentResolutionError,
@@ -50,6 +51,27 @@ import { buildTransportHints } from "./transport-hints.js";
 // ── Per-conversation persistent options ────────────────────────────
 
 const conversationOptions = new Map<string, ConversationCreateOptions>();
+
+/**
+ * The channel a conversation created here belongs to.
+ *
+ * A trust context is stamped per inbound message from the gateway verdict,
+ * so `sourceChannel` names the channel the message creating this
+ * conversation actually arrived on. This is the moment that fact is known,
+ * and the caller is the only party that holds it.
+ *
+ * Its absence means no channel message is involved: a desktop, web, or CLI
+ * turn, which is native. That is the same conclusion migration 288 reaches
+ * at startup for a row nothing ever claimed, and the same one
+ * `recoverRestingTrustContext` reaches for an unset column, so recording it
+ * here changes no behavior. It states the fact when it is known instead of
+ * leaving it to be inferred twice, differently, later.
+ */
+function originFromStoredOptions(
+  storedOptions: ConversationCreateOptions | undefined,
+): ConversationOrigin {
+  return storedOptions?.trustContext?.sourceChannel ?? "vellum";
+}
 
 /**
  * Drops the transport fields that describe what the client had on screen for a
@@ -229,9 +251,13 @@ export async function getOrCreateConversation(
           createConversation({
             id: conversationId,
             conversationType: storedOptions.conversationType,
+            origin: originFromStoredOptions(storedOptions),
           });
         } else {
-          ensureConversationExists(conversationId);
+          ensureConversationExists(
+            conversationId,
+            originFromStoredOptions(storedOptions),
+          );
         }
       }
 

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -60,17 +60,27 @@ const conversationOptions = new Map<string, ConversationCreateOptions>();
  * conversation actually arrived on. This is the moment that fact is known,
  * and the caller is the only party that holds it.
  *
- * Its absence means no channel message is involved: a desktop, web, or CLI
- * turn, which is native. That is the same conclusion migration 288 reaches
- * at startup for a row nothing ever claimed, and the same one
- * `recoverRestingTrustContext` reaches for an unset column, so recording it
- * here changes no behavior. It states the fact when it is known instead of
- * leaving it to be inferred twice, differently, later.
+ * Returns `undefined` when there is no trust context, which does NOT mean
+ * native. `handleSendMessage` materializes a conversation before the route
+ * resolves trust, so a Slack or phone send reaches here with no
+ * `sourceChannel` yet. Assuming native there would stamp a remote
+ * conversation as the guardian's own, and nothing could repair it:
+ * `setConversationOriginChannelIfUnset` only writes over NULL, and
+ * `recoverRestingTrustContext` grants INTERNAL_GUARDIAN_TRUST_CONTEXT to the
+ * native channel on every later wake and boot-resume.
+ *
+ * `transport.channelId` is not a substitute. It is the external Slack
+ * conversation id, not a {@link ChannelId}.
+ *
+ * So this states the origin only where it is genuinely known, and leaves the
+ * rest to attribution exactly as before. The remaining callers get their
+ * origin when they are migrated with real knowledge of it, not by guessing
+ * here.
  */
 function originFromStoredOptions(
   storedOptions: ConversationCreateOptions | undefined,
-): ConversationOrigin {
-  return storedOptions?.trustContext?.sourceChannel ?? "vellum";
+): ConversationOrigin | undefined {
+  return storedOptions?.trustContext?.sourceChannel;
 }
 
 /**

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5794,7 +5794,14 @@ async function defaultStartVoiceTurn(
   // inside `startVoiceTurn` trips `FOREIGN KEY constraint failed`. Ensure it
   // exists (idempotent) before persisting. Lives in the production wiring, not
   // the session state machine, so session unit tests stay DB-free.
-  const createdConversation = ensureConversationExists(options.conversationId);
+  // Native: this is the local live-voice session, which adopts a conversation
+  // id the app supplied. Its trust context resolves through
+  // `resolveLocalLiveVoiceTrustContext`, and a phone call reaches the assistant
+  // through the telephony path rather than here.
+  const createdConversation = ensureConversationExists(
+    options.conversationId,
+    "vellum",
+  );
   if (createdConversation) {
     // The row was created outside the normal send-message route, which is where
     // sibling clients/sidebars learn about a new conversation. Emit the same

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -973,11 +973,10 @@ export function createConversation(
          * `origin_channel` at insert, so the row is attributed from the
          * moment it exists.
          *
-         * Optional only while the call sites are being migrated
-         * (JARVIS-1466). Omitting it leaves the column NULL for
-         * `setConversationOriginChannelIfUnset` to fill in on the first
-         * inbound message, which is the behavior every caller had before
-         * this parameter existed. New callers should always pass it.
+         * Pass it whenever the origin is known. Omitting it leaves the
+         * column unset, and the conversation is instead attributed by
+         * `setConversationOriginChannelIfUnset` when its first inbound
+         * message arrives.
          */
         origin?: ConversationOrigin;
         forkParentConversationId?: string;
@@ -1104,8 +1103,7 @@ export function createConversation(
  * would come back as the guardian's own. Parent ids here come from daemon
  * internals rather than user input, so a missing one is a programming error.
  *
- * `undefined` maps to NULL, for the callers that cannot yet state an origin.
- * See JARVIS-1466.
+ * `undefined` maps to NULL, leaving the row for first-message attribution.
  */
 function resolveConversationOrigin(
   origin: ConversationOrigin | undefined,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1088,12 +1088,16 @@ export function createConversation(
  * `origin_channel`.
  *
  * `inheritFrom` reads the parent's value, which is how a fork, a subagent
- * spawn, or a scheduled wake lands on the surface its parent belongs to. A
- * parent that cannot be read falls back to the native channel rather than
- * throwing: creation is on the critical path for inbound traffic, and a
- * conversation with a slightly wrong origin is recoverable where a failed
- * insert is not. It is logged because it means a caller named a parent that
- * does not exist.
+ * spawn, or a scheduled wake lands on the surface its parent belongs to.
+ *
+ * An unreadable parent throws rather than defaulting. Defaulting here would
+ * be a trust grant, not a cosmetic guess: `recoverRestingTrustContext` reads
+ * this column, and both the native channel and an unset column recover
+ * `INTERNAL_GUARDIAN_TRUST_CONTEXT` on every later wake and boot-resume. So
+ * a fork of a remote conversation whose parent we failed to read would come
+ * back as the guardian's own. Parent ids on this path come from daemon
+ * internals rather than user input, so a missing one is a programming error,
+ * and failing the insert is the fail-closed answer.
  *
  * `undefined` maps to NULL for now, preserving the pre-parameter behavior
  * for call sites still to be migrated. See JARVIS-1466.
@@ -1109,11 +1113,10 @@ function resolveConversationOrigin(
   }
   const inherited = getConversationOriginChannel(origin.inheritFrom);
   if (inherited === null) {
-    log.warn(
-      { parentConversationId: origin.inheritFrom },
-      "Cannot inherit conversation origin from unreadable parent, defaulting to vellum",
+    throw new Error(
+      `Cannot inherit conversation origin from ${origin.inheritFrom}: ` +
+        "parent is missing or its origin is unreadable",
     );
-    return "vellum";
   }
   return inherited;
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1076,8 +1076,7 @@ export function createConversation(
     throw err;
   }
 
-  // The row carries its own origin now, so the disk view records the same
-  // value the database holds rather than a hardcoded null.
+  // The disk view records the same origin the row holds.
   initConversationDir(conversation);
 
   return conversation;
@@ -1090,17 +1089,23 @@ export function createConversation(
  * `inheritFrom` reads the parent's value, which is how a fork, a subagent
  * spawn, or a scheduled wake lands on the surface its parent belongs to.
  *
- * An unreadable parent throws rather than defaulting. Defaulting here would
- * be a trust grant, not a cosmetic guess: `recoverRestingTrustContext` reads
- * this column, and both the native channel and an unset column recover
- * `INTERNAL_GUARDIAN_TRUST_CONTEXT` on every later wake and boot-resume. So
- * a fork of a remote conversation whose parent we failed to read would come
- * back as the guardian's own. Parent ids on this path come from daemon
- * internals rather than user input, so a missing one is a programming error,
- * and failing the insert is the fail-closed answer.
+ * A parent whose own origin is unset yields an unset origin: the child
+ * inherits the parent's state faithfully, including "not yet attributed".
+ * Most rows are in exactly that state until they are claimed by a message or
+ * swept at startup, so treating it as an error would fail the majority of
+ * forks and subagent spawns.
  *
- * `undefined` maps to NULL for now, preserving the pre-parameter behavior
- * for call sites still to be migrated. See JARVIS-1466.
+ * A parent that does not exist throws. That is not the same condition: it
+ * means a caller named a conversation that is not there, and guessing an
+ * origin for it would be a trust grant rather than a cosmetic default.
+ * `recoverRestingTrustContext` reads this column, and the native channel
+ * recovers `INTERNAL_GUARDIAN_TRUST_CONTEXT` on every later wake and
+ * boot-resume, so a fork of a remote conversation that silently defaulted
+ * would come back as the guardian's own. Parent ids here come from daemon
+ * internals rather than user input, so a missing one is a programming error.
+ *
+ * `undefined` maps to NULL, for the callers that cannot yet state an origin.
+ * See JARVIS-1466.
  */
 function resolveConversationOrigin(
   origin: ConversationOrigin | undefined,
@@ -1111,14 +1116,14 @@ function resolveConversationOrigin(
   if (typeof origin === "string") {
     return origin;
   }
-  const inherited = getConversationOriginChannel(origin.inheritFrom);
-  if (inherited === null) {
+  const parent = getConversation(origin.inheritFrom);
+  if (!parent) {
     throw new Error(
       `Cannot inherit conversation origin from ${origin.inheritFrom}: ` +
-        "parent is missing or its origin is unreadable",
+        "no such conversation",
     );
   }
-  return inherited;
+  return parent.originChannel;
 }
 
 /**
@@ -1152,7 +1157,7 @@ export const ADOPTABLE_CONVERSATION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
  */
 export function ensureConversationExists(
   id: string,
-  origin: ConversationOrigin,
+  origin: ConversationOrigin | undefined,
 ): boolean {
   if (getConversation(id)) {
     return false;

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1150,7 +1150,10 @@ export const ADOPTABLE_CONVERSATION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
  * is validated first — a value like `../../tmp/x` would otherwise write
  * `meta.json` outside the conversations directory.
  */
-export function ensureConversationExists(id: string): boolean {
+export function ensureConversationExists(
+  id: string,
+  origin: ConversationOrigin,
+): boolean {
   if (getConversation(id)) {
     return false;
   }
@@ -1160,7 +1163,7 @@ export function ensureConversationExists(id: string): boolean {
     );
   }
   try {
-    createConversation({ id });
+    createConversation({ id, origin });
     return true;
   } catch (err) {
     // A concurrent caller may have created the row between the check and the

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -74,6 +74,7 @@ import { deleteConversationRowsInBatches } from "./conversation-row-batch-delete
 import {
   BACKGROUND_CONVERSATION_TYPES,
   type ConversationCreateType,
+  type ConversationOrigin,
   isHiddenMessageMetadata,
   PINNED_GROUP_ID,
   UNGROUPED_GROUP_ID,
@@ -967,6 +968,18 @@ export function createConversation(
         source?: string;
         scheduleJobId?: string;
         groupId?: string;
+        /**
+         * Where this conversation came from. Stamped into
+         * `origin_channel` at insert, so the row is attributed from the
+         * moment it exists.
+         *
+         * Optional only while the call sites are being migrated
+         * (JARVIS-1466). Omitting it leaves the column NULL for
+         * `setConversationOriginChannelIfUnset` to fill in on the first
+         * inbound message, which is the behavior every caller had before
+         * this parameter existed. New callers should always pass it.
+         */
+        origin?: ConversationOrigin;
         forkParentConversationId?: string;
         /**
          * Id of the conversation that spawned this one (subagent spawns).
@@ -996,6 +1009,7 @@ export function createConversation(
     requestedConversationType ?? "standard";
   const source = opts.source ?? "user";
   const groupId = opts.groupId;
+  const originChannel = resolveConversationOrigin(opts.origin);
   // Time-ordered UUIDv7 for server-minted conversation ids (see message id).
   const id = opts.id ?? uuidv7();
 
@@ -1022,6 +1036,7 @@ export function createConversation(
     slackContextCompactionWatermarkAt: null as number | null,
     conversationType,
     source,
+    originChannel,
     scheduleJobId: opts.scheduleJobId ?? null,
     forkParentConversationId: opts.forkParentConversationId ?? null,
     parentConversationId: opts.parentConversationId ?? null,
@@ -1061,9 +1076,46 @@ export function createConversation(
     throw err;
   }
 
-  initConversationDir({ ...conversation, originChannel: null });
+  // The row carries its own origin now, so the disk view records the same
+  // value the database holds rather than a hardcoded null.
+  initConversationDir(conversation);
 
   return conversation;
+}
+
+/**
+ * Resolve a caller's {@link ConversationOrigin} to the string stored in
+ * `origin_channel`.
+ *
+ * `inheritFrom` reads the parent's value, which is how a fork, a subagent
+ * spawn, or a scheduled wake lands on the surface its parent belongs to. A
+ * parent that cannot be read falls back to the native channel rather than
+ * throwing: creation is on the critical path for inbound traffic, and a
+ * conversation with a slightly wrong origin is recoverable where a failed
+ * insert is not. It is logged because it means a caller named a parent that
+ * does not exist.
+ *
+ * `undefined` maps to NULL for now, preserving the pre-parameter behavior
+ * for call sites still to be migrated. See JARVIS-1466.
+ */
+function resolveConversationOrigin(
+  origin: ConversationOrigin | undefined,
+): string | null {
+  if (origin === undefined) {
+    return null;
+  }
+  if (typeof origin === "string") {
+    return origin;
+  }
+  const inherited = getConversationOriginChannel(origin.inheritFrom);
+  if (inherited === null) {
+    log.warn(
+      { parentConversationId: origin.inheritFrom },
+      "Cannot inherit conversation origin from unreadable parent, defaulting to vellum",
+    );
+    return "vellum";
+  }
+  return inherited;
 }
 
 /**

--- a/assistant/src/persistence/conversation-key-store.ts
+++ b/assistant/src/persistence/conversation-key-store.ts
@@ -10,6 +10,7 @@
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import type { ChannelId } from "../channels/types.js";
 import { cleanupBootstrapFiles } from "../prompts/bootstrap-cleanup.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { getLogger } from "../util/logger.js";
@@ -162,6 +163,17 @@ export function getOrCreateConversation(
      * untouched. Ignored when the conversation already exists.
      */
     title?: string;
+    /**
+     * The channel this conversation originates on, stamped into
+     * `origin_channel` when this call creates the row.
+     *
+     * This is the principal inbound materialization seam, so it is where a
+     * channel conversation gets its provenance. Callers that resolve a
+     * source channel before reaching here already hold the value; omitting
+     * it leaves the column unset for first-message attribution, which is
+     * what every caller did before this option existed.
+     */
+    origin?: ChannelId;
   },
 ): {
   conversationId: string;
@@ -259,6 +271,7 @@ export function getOrCreateConversation(
         contextCompactedMessageCount: 0,
         contextCompactedAt: null,
         conversationType,
+        originChannel: opts?.origin ?? null,
       })
       .run();
 
@@ -280,12 +293,13 @@ export function getOrCreateConversation(
         title,
         createdAt: now,
         conversationType,
+        originChannel: opts?.origin ?? null,
       },
     };
   });
 
   if (result.created) {
-    initConversationDir({ ...result.conversation, originChannel: null });
+    initConversationDir(result.conversation);
     // Attribution for every key-materialized conversation: this is the single
     // choke point through which all unseen-key creations flow, and the key
     // shape + caller frames identify the entry point from the log alone. The

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -7,7 +7,32 @@
 // `resolveConversationKind` classifier, and the pure predicates over a
 // persisted message's `metadata` record.
 
-import { parseChannelId, parseClientOs } from "../channels/types.js";
+import {
+  type ChannelId,
+  parseChannelId,
+  parseClientOs,
+} from "../channels/types.js";
+
+/**
+ * Where a conversation came from, stated by whoever creates it.
+ *
+ * `conversations.origin_channel` records this. It is the caller's job to
+ * supply it, because the caller is the only party that knows: an inbound
+ * Slack message creates a conversation *because* it is Slack, and nothing
+ * downstream can recover that fact once the moment has passed.
+ *
+ * A bare {@link ChannelId} covers the cases where the origin is known
+ * outright, including `"vellum"` for a conversation started in the app.
+ * `inheritFrom` covers the derived ones, where the conversation belongs to
+ * whatever surface its parent belongs to: forks, subagent spawns, and
+ * scheduled wakes.
+ *
+ * Deliberately closed, and deliberately not optional. An optional string
+ * would let a caller decline to answer, which is how the column came to
+ * carry a third "not yet attributed" state that different readers resolve
+ * in contradictory directions. See JARVIS-1466.
+ */
+export type ConversationOrigin = ChannelId | { readonly inheritFrom: string };
 
 /**
  * Canonical `conversations.source` string for background memory v2

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1715,6 +1715,11 @@ export async function handleSendMessage(
     mapping = getOrCreateConversation(resolvedConversationKey, {
       conversationType: "standard",
       title: onboardingTitle,
+      // This route already resolved the channel the message arrived on, and
+      // this is the seam that materializes the row, so the conversation is
+      // attributed from the moment it exists rather than on its first
+      // message.
+      origin: sourceChannel,
     });
   }
 


### PR DESCRIPTION
## TL;DR

A conversation can now say where it came from when it is created, instead of relying entirely on a side effect that patches `origin_channel` in later. Behavior-identical; this builds the seam that the rest of JARVIS-1466 needs.

## What changes for the user

| | Before | After |
| -- | -- | -- |
| A conversation created with a resolved trust context | Origin set after the first message is persisted | Origin set when the row is created |
| Every other conversation | Origin set later by attribution | Unchanged, still set later by attribution |
| Anything visible in the app | — | Unchanged |

## Why

`origin_channel` is maintained by five mechanisms that between them own one fact, and none owns it outright: 33 `createConversation` call sites that cannot state an origin, an `ensureConversationExists(id)` seam that accepted only an id, a side effect in message processing that patches the column later, a migration that re-runs every boot to sweep leftovers, and readers that each cope with the resulting ambiguity differently.

So NULL means "not yet attributed" rather than "no channel", and readers disagree about it. `calls/call-pointer-messages.ts:72` answers a different ownership question for the same conversation before and after a daemon restart. `persistence/conversation-attention-store.ts:670` filters with a strict equality that silently drops every unattributed row.

The caller is the only party that knows this fact. An inbound Slack message creates a conversation *because* it is Slack, and it had nowhere to say so.

## What this PR does

- Adds `ConversationOrigin`: a `ChannelId` when the origin is known outright, or `{ inheritFrom }` when it derives from a parent.
- `createConversation` accepts it and stamps `origin_channel` at insert.
- `ensureConversationExists` takes it and passes it through.
- `getOrCreateConversation` supplies it from `TrustContext.sourceChannel` **when a trust context is present**, and asserts nothing otherwise.

## Why it is safe

**It only states an origin where one is genuinely known.** Review caught the first version defaulting to native whenever no trust context was present, which is not the same as the conversation being native: `handleSendMessage` materializes a conversation before the route resolves trust, so a Slack or phone send arrives with no `sourceChannel` yet. That default was unrecoverable in both directions — `setConversationOriginChannelIfUnset` only writes over NULL, so the real channel could never claim the row, and `recoverRestingTrustContext` grants `INTERNAL_GUARDIAN_TRUST_CONTEXT` to the native channel on every later wake and boot-resume. A remote conversation would have resumed as the guardian's own. Fixed in 4ecb75e8f6; rows without a resolvable origin are simply left for attribution exactly as before.

(`transport.channelId` is not a usable substitute: it holds the external Slack conversation id, not a `ChannelId`.)

**Attribution still runs** and covers everything not stamped here. Its `isNull` guard means it no-ops on rows this PR does stamp, so the two cannot fight. A test pins that a row created with an origin is never re-claimed by a later message.

**`inheritFrom` distinguishes two conditions.** A parent whose own origin is unset yields an unset origin, so a child inherits its parent's state faithfully including "not yet attributed" — most rows are in that state, so treating it as an error would fail the majority of forks. A parent that does not exist throws, since guessing there would be a trust grant rather than a cosmetic default.

## Tests

11 cases in `conversation-origin-at-creation.test.ts`, sensitivity-checked: with stamping disabled, only the cases that genuinely depend on it fail.

Re-ran the suites that exercise this column — 76 tests, including `wake-schedule-trust` and `interrupted-turn-reconciler`, the two that drive trust recovery off `origin_channel`, where a wrong origin would surface.

## Deferred, and why

Remaining under JARVIS-1466: `inheritFrom` wired for forks/subagents/scheduler, making `origin` required on `createConversation` itself, deleting the attribution side effect with its ~45 test stubs, and fixing the two strict-equality readers.

Split out because the fork/subagent batch is trust-sensitive and deserves its own review rather than riding along with the mechanical part.

**A `NOT NULL` constraint was considered and dropped.** SQLite has no `ALTER COLUMN`, so it means rebuilding the `conversations` table and copying every row: a heavy migration on a mature instance for zero behavior change, since the column is already non-null in practice once creation states an origin.

Part of JARVIS-1466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)