### PR TITLE
feat(web): pulse the assets dot when a change lands

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -7,12 +7,15 @@
  *
  * Class strings are deliberately not asserted (happy-dom makes those brittle);
  * the dot is located by its `data-testid` and the state it communicates is
- * asserted through the trigger's accessible name.
+ * asserted through the trigger's accessible name. The one exception is the
+ * appearance pulse, which has no accessible surface at all: those tests check
+ * for the single animation class token on the dot and nothing else.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as motionReact from "motion/react";
 
 import type { DocumentSummary } from "@/types/document-types";
 
@@ -23,8 +26,20 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
-const { ConversationAssetsPill, ASSETS_PILL_UNSEEN_DOT_TESTID } =
-  await import("@/domains/chat/components/conversation-assets-pill");
+// `useReducedMotion` reads a cached media-query singleton, so a per-test
+// `matchMedia` stub can't flip it. Override just that export and drive it
+// through this toggle instead.
+let reducedMotion = false;
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
+const {
+  ConversationAssetsPill,
+  ASSETS_PILL_UNSEEN_DOT_TESTID,
+  ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS,
+} = await import("@/domains/chat/components/conversation-assets-pill");
 const { useUnseenDocumentChangesStore } =
   await import("@/domains/chat/unseen-document-changes-store");
 const { appsGetOptions, documentsGetOptions } =
@@ -127,8 +142,15 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   isMobileRef.value = false;
+  reducedMotion = false;
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
+
+function dotHasPulse(): boolean {
+  return screen
+    .getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)
+    .classList.contains(ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS);
+}
 
 describe("desktop pill", () => {
   test("shows the dot and names the state when a change is unseen", () => {
@@ -225,6 +247,26 @@ describe("conversation switch while the disclosure is open", () => {
     expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
     expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
     expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+});
+
+describe("appearance pulse", () => {
+  // One `layersIcon` node feeds both the mobile trigger and the desktop pill,
+  // so the pulse has a single render site and needs no per-platform case.
+  test("pulses the dot when a change lands", () => {
+    markUnseen();
+    renderPill();
+
+    expect(dotHasPulse()).toBe(true);
+  });
+
+  test("appears without animating when reduced motion is preferred", () => {
+    reducedMotion = true;
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(dotHasPulse()).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AppWindow, FileText, Layers } from "lucide-react";
+import { useReducedMotion } from "motion/react";
 import {
   useCallback,
   useEffect,
@@ -35,8 +36,12 @@ import { useAppDelete } from "@/hooks/use-app-delete";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
+import { cn } from "@/utils/misc";
 
 export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
+
+/** Bounded attention pulse defined in `src/index.css`. */
+export const ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS = "unseen-dot-pulse";
 
 interface ConversationAsset {
   id: string;
@@ -142,6 +147,7 @@ export function ConversationAssetsPill({
   }, [conversationId]);
 
   const isMobile = useIsMobile();
+  const reduceMotion = useReducedMotion();
   const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
   const clearConversation =
     useUnseenDocumentChangesStore.use.clearConversation();
@@ -183,14 +189,18 @@ export function ConversationAssetsPill({
 
   // Same dot as the notifications bell in this header cluster: ringed in the
   // color of the surface behind it so the ring reads as a gap carved out of
-  // the icon.
+  // the icon. The dot mounts only while changes are unseen, so the CSS pulse
+  // runs on appearance and needs no restart bookkeeping.
   const layersIcon = (
     <span className="relative flex" aria-hidden>
       <Layers />
       {hasUnseenChanges ? (
         <span
           data-testid={ASSETS_PILL_UNSEEN_DOT_TESTID}
-          className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+          className={cn(
+            "absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]",
+            !reduceMotion && ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS,
+          )}
         />
       ) : null}
     </span>

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -185,6 +185,28 @@ body {
   border-radius: var(--radius-lg);
 }
 
+/* Unseen-changes dot attention pulse, applied when the dot appears so a
+ * change landing while the user reads the transcript is noticeable. Bounded
+ * on purpose: this dot lives in a persistent header, where anything looping
+ * forever reads as noise. It needs no fill mode because the last keyframe is
+ * already the resting style. The consumer also holds it static via
+ * useReducedMotion; the media query is defense-in-depth for callers that
+ * don't. */
+@keyframes unseen-dot-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.35); }
+}
+
+.unseen-dot-pulse {
+  animation: unseen-dot-pulse 0.6s ease-in-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .unseen-dot-pulse {
+    animation: none;
+  }
+}
+
 /* Streamed word fade — applied by `rehypeStreamWordFade` to each word of the
  * actively-streaming assistant message's trailing text. The plugin grades the
  * words nearest the reveal edge with inline opacities; this transition is


### PR DESCRIPTION
## Summary
- Pulse the unseen-changes dot briefly when it appears so a change landing on screen is noticeable.
- Respects reduced motion, where the dot appears with no animation.

## Implementation notes
- The pulse is a bounded CSS keyframe (`unseen-dot-pulse`, two 0.6s beats, transform only) defined in `src/index.css` next to the existing one-shot `.message-highlighted` flash. No `motion/react` components are mounted for a 6px dot; only the `useReducedMotion()` hook is used, matching `domains/intelligence/components/identity-overview.tsx`.
- The dot mounts only while changes are unseen, so the animation runs on appearance and needs no restart bookkeeping.
- Reduced motion is handled twice: the component drops the class, and the stylesheet carries a `prefers-reduced-motion` override as defense-in-depth, mirroring `.voice-caret-blink` and `.stream-word-fade`.
- `src/index.css` is a third file beyond the plan's list. Tailwind ships only infinite `animate-pulse`/`animate-ping`, and the plan rules out a bare infinite loop, so the bounded keyframe has to live in the stylesheet.

Part of plan: document-update-discoverability.md (PR 8 of 12)