### PR TITLE
Fix Android push permission crash in release builds

### DIFF
--- a/clients/android/app/proguard-rules.pro
+++ b/clients/android/app/proguard-rules.pro
@@ -14,6 +14,9 @@
 
 -keepattributes RuntimeVisibleAnnotations,AnnotationDefault,SourceFile,LineNumberTable
 
+# Capacitor reads permission annotations through this handle at runtime.
+-keep class com.getcapacitor.PluginHandle { *; }
+
 -keep @com.getcapacitor.annotation.CapacitorPlugin class * { *; }
 -keepclassmembers class * {
     @com.getcapacitor.PluginMethod <methods>;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
@@ -14,6 +14,18 @@ import com.getcapacitor.annotation.Permission;
 public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
     @Override
     @PluginMethod
+    public void checkPermissions(PluginCall call) {
+        PushRegistrationGuard.run(call, () -> super.checkPermissions(call));
+    }
+
+    @Override
+    @PluginMethod
+    public void requestPermissions(PluginCall call) {
+        PushRegistrationGuard.run(call, () -> super.requestPermissions(call));
+    }
+
+    @Override
+    @PluginMethod
     public void register(PluginCall call) {
         PushRegistrationGuard.run(call, () -> super.register(call));
     }


### PR DESCRIPTION
## Summary

- Preserve the Capacitor plugin handle fields that runtime permission checks read after R8 optimization.
- Guard push permission checks and requests so native failures reject the plugin call instead of terminating the app process.

## Original prompt

The dev Play build installed successfully but crashed immediately after sign-in. Device logs and compiled APK inspection traced the failure to R8 replacing Capacitor permission metadata access with a null throw, so the request was to fix it through the normal isolated worktree and PR flow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->