### PR TITLE
feat(web): surface changed documents at the end of a response

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -34,6 +34,34 @@ mock.module(
   }),
 );
 
+// The reopen link names its own document from the documents query and hides
+// itself while that document is open; both are covered by
+// `document-reopen-link.test`. Stub it to a bare button so these tests assert
+// what the transcript owns: which documents a turn anchors, in what order,
+// where in the message the links land, and what the click reaches.
+mock.module("@/domains/chat/transcript/document-reopen-link", () => ({
+  DocumentReopenLink: ({
+    surfaceId,
+    assistantId,
+    conversationId,
+    onOpenDocument,
+  }: {
+    surfaceId: string;
+    assistantId?: string | null;
+    conversationId?: string | null;
+    onOpenDocument: (surfaceId: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="document-reopen-link"
+      data-surface-id={surfaceId}
+      data-assistant-id={assistantId ?? ""}
+      data-conversation-id={conversationId ?? ""}
+      onClick={() => onOpenDocument(surfaceId)}
+    />
+  ),
+}));
+
 // The ACP-run and background-task rows wire their transcript stop button to
 // these standalone actions; stub them so clicking Stop records the call without
 // pulling in the daemon SDK / store wiring.
@@ -2196,5 +2224,183 @@ describe("TranscriptMessageBody — redacted-credential chip version gate", () =
   test("user messages never enable chips, even at the gated version", () => {
     hydrateIdentity(REDACTED_CHIPS_MIN_VERSION);
     expect(chipFlag("user")).toBe("false");
+  });
+});
+
+describe("TranscriptMessageBody: changed-document reopen links", () => {
+  const DOC_ASSISTANT_ID = "asst-doc";
+  const DOC_CONVERSATION_ID = "conv-doc";
+  const onOpenDocumentMock = mock((_surfaceId: string) => {});
+
+  /** A settled `document_update` whose result carries the surface it wrote. */
+  function documentUpdateCall(
+    id: string,
+    surfaceId: string,
+  ): ChatMessageToolCall {
+    return {
+      id,
+      name: "document_update",
+      input: { surface_id: surfaceId, content: "notes" },
+      result: JSON.stringify({ success: true, surface_id: surfaceId }),
+      completedAt: 1,
+    };
+  }
+
+  /**
+   * A turn that narrates, runs `toolCalls`, then answers. The lead-in and the
+   * tool run collapse into "Earlier activity", so any reopen link that renders
+   * has to sit outside that disclosure to still be visible.
+   */
+  function turnElement(
+    toolCalls: ChatMessageToolCall[],
+    onOpenDocument: ((surfaceId: string) => void) | undefined,
+  ) {
+    return (
+      <TranscriptMessageBody
+        message={{
+          id: "m-doc-turn",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Updating your notes."),
+            ...toolCalls.map(toolUseBlock),
+            textBlock("Done."),
+          ],
+          toolCalls,
+          timestamp: 1_000,
+        }}
+        conversationId={DOC_CONVERSATION_ID}
+        assistantId={DOC_ASSISTANT_ID}
+        onOpenDocument={onOpenDocument}
+        onSurfaceAction={noop}
+      />
+    );
+  }
+
+  function renderTurn(toolCalls: ChatMessageToolCall[]) {
+    return render(turnElement(toolCalls, onOpenDocumentMock));
+  }
+
+  function reopenLinks(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+      container.querySelectorAll<HTMLElement>(
+        "[data-testid='document-reopen-link']",
+      ),
+    );
+  }
+
+  function reopenSurfaceIds(container: HTMLElement): (string | null)[] {
+    return reopenLinks(container).map((link) =>
+      link.getAttribute("data-surface-id"),
+    );
+  }
+
+  beforeEach(() => {
+    onOpenDocumentMock.mockClear();
+  });
+
+  test("renders one reopen link for a turn that changed a document", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    const links = reopenLinks(container);
+    expect(links.length).toBe(1);
+    expect(links[0]!.getAttribute("data-surface-id")).toBe("surf-notes");
+    expect(links[0]!.getAttribute("data-assistant-id")).toBe(DOC_ASSISTANT_ID);
+    expect(links[0]!.getAttribute("data-conversation-id")).toBe(
+      DOC_CONVERSATION_ID,
+    );
+  });
+
+  test("places the reopen link after the response body and above the footer", () => {
+    const { container, getByText } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    const link = reopenLinks(container)[0]!;
+    // A direct child of the message column, so it is a sibling of the
+    // "Earlier activity" disclosure rather than something inside it.
+    const column = link.parentElement!;
+    expect(column.parentElement!.getAttribute("data-message-id")).toBe(
+      "m-doc-turn",
+    );
+    expect(
+      screen.getByRole("button", { name: "Earlier activity" }).contains(link),
+    ).toBe(false);
+    expect(
+      getByText("Done.").compareDocumentPosition(link) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+    // The hover-action footer is the column's last row.
+    expect(
+      link.compareDocumentPosition(column.lastElementChild!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
+  test("renders a reopen link for each document a turn changed", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc-a", "surf-notes"),
+      documentUpdateCall("tc-doc-b", "surf-plan"),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
+  });
+
+  test("collapses repeated edits of one document into a single reopen link", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc-a", "surf-notes"),
+      documentUpdateCall("tc-doc-b", "surf-notes"),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("renders no reopen link for a turn that changed no document", () => {
+    const { container } = renderTurn([
+      {
+        id: "tc-read",
+        name: "file_read",
+        input: { path: "/tmp/notes.md" },
+        result: JSON.stringify({ surface_id: "surf-notes" }),
+        completedAt: 1,
+      },
+    ]);
+
+    expect(reopenLinks(container).length).toBe(0);
+  });
+
+  test("clicking the reopen link opens that document", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    fireEvent.click(reopenLinks(container)[0]!);
+
+    expect(onOpenDocumentMock).toHaveBeenCalledTimes(1);
+    expect(onOpenDocumentMock).toHaveBeenCalledWith("surf-notes");
+  });
+
+  test("keeps the reopen link when the transcript reseeds from history", () => {
+    const toolCall = documentUpdateCall("tc-doc", "surf-notes");
+    const { container, rerender } = renderTurn([toolCall]);
+    expect(reopenLinks(container).length).toBe(1);
+
+    // A reseed from `/messages` rebuilds the row out of the persisted wire
+    // payload: fresh object identities, none of the live stream state.
+    const reseeded = JSON.parse(
+      JSON.stringify(toolCall),
+    ) as ChatMessageToolCall;
+    rerender(turnElement([reseeded], onOpenDocumentMock));
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("renders no reopen link without a handler to open the document", () => {
+    const { container } = render(
+      turnElement([documentUpdateCall("tc-doc", "surf-notes")], undefined),
+    );
+
+    expect(reopenLinks(container).length).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -2403,4 +2403,105 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
 
     expect(reopenLinks(container).length).toBe(0);
   });
+
+  /** A settled `document_create` whose result names the document it opened. */
+  function documentCreateCall(
+    id: string,
+    surfaceId: string,
+  ): ChatMessageToolCall {
+    return {
+      id,
+      name: "document_create",
+      input: { title: "Notes" },
+      result: JSON.stringify({ surface_id: surfaceId, opened: true }),
+      completedAt: 1,
+    };
+  }
+
+  /**
+   * The inline `document_preview` surface `document_create` emits alongside its
+   * result. The card carries its own `preview-` surface id; the document it
+   * opens rides in `data.surfaceId`.
+   */
+  function documentPreviewBlock(surfaceId: string): ConversationContentBlock {
+    return {
+      type: "surface",
+      surface: {
+        surfaceId: `preview-${surfaceId}`,
+        surfaceType: "document_preview",
+        title: "Notes",
+        data: { title: "Notes", surfaceId, subtitle: "Document" },
+      },
+    };
+  }
+
+  /** A turn that runs `toolCalls` and renders `surfaceBlocks` between them. */
+  function surfaceTurn(
+    toolCalls: ChatMessageToolCall[],
+    surfaceBlocks: ConversationContentBlock[],
+  ) {
+    return render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-doc-surface-turn",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Writing your notes."),
+            ...toolCalls.map(toolUseBlock),
+            ...surfaceBlocks,
+            textBlock("Done."),
+          ],
+          toolCalls,
+          timestamp: 1_000,
+        }}
+        conversationId={DOC_CONVERSATION_ID}
+        assistantId={DOC_ASSISTANT_ID}
+        onOpenDocument={onOpenDocumentMock}
+        onSurfaceAction={noop}
+      />,
+    );
+  }
+
+  test("renders no reopen link for a document its inline preview card already opens", () => {
+    const { container } = surfaceTurn(
+      [documentCreateCall("tc-doc", "surf-notes")],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    // The card is the turn's only affordance for this document.
+    expect(
+      container.querySelector("[data-surface-id='preview-surf-notes']"),
+    ).not.toBeNull();
+    expect(reopenLinks(container).length).toBe(0);
+  });
+
+  test("renders a reopen link for a changed document no preview card covers", () => {
+    const { container } = surfaceTurn(
+      [
+        documentCreateCall("tc-doc-a", "surf-notes"),
+        documentUpdateCall("tc-doc-b", "surf-plan"),
+      ],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-plan"]);
+  });
+
+  test("keeps the reopen link when a non-preview surface names the same id", () => {
+    const { container } = surfaceTurn(
+      [documentUpdateCall("tc-doc", "surf-notes")],
+      [
+        {
+          type: "surface",
+          surface: {
+            surfaceId: "card-1",
+            surfaceType: "card",
+            data: { surfaceId: "surf-notes" },
+          },
+        },
+      ],
+    );
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -42,6 +42,7 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
+import { DocumentReopenLink } from "@/domains/chat/transcript/document-reopen-link";
 import { hasRenderableAnswer } from "@/domains/chat/answered-question";
 import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
@@ -76,6 +77,7 @@ import {
   acpRunIdForCall,
   resolveAcpRunIds,
   resolveBackgroundTaskIds,
+  resolveChangedDocuments,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -374,6 +376,9 @@ export function TranscriptMessageBody({
   const claimedWorkflowIds = new Set<string>();
   const claimedAcpIds = new Set<string>();
   const claimedBackgroundTaskIds = new Set<string>();
+  // Document surface ids claim in their own namespace. Sharing a Set with the
+  // process kinds above would let an unrelated id suppress a reopen link.
+  const claimedDocumentIds = new Set<string>();
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -1102,6 +1107,25 @@ export function TranscriptMessageBody({
         })
       : renderedGroups;
 
+  // Resolved after the group render pass, so every inline affordance has taken
+  // its claims first. Without a handler the link opens nothing, so it does not
+  // render.
+  const documentReopenLinks =
+    isAssistant && onOpenDocument
+      ? resolveChangedDocuments(
+          message.toolCalls ?? [],
+          claimedDocumentIds,
+        ).map((surfaceId) => (
+          <DocumentReopenLink
+            key={`document-reopen-${surfaceId}`}
+            surfaceId={surfaceId}
+            assistantId={assistantId}
+            conversationId={conversationId}
+            onOpenDocument={onOpenDocument}
+          />
+        ))
+      : null;
+
   return (
     <div
       ref={wrapperRef}
@@ -1128,6 +1152,9 @@ export function TranscriptMessageBody({
             messageId={message.id}
           />
         )}
+        {/* Outside the `AssistantContentDisclosure` collapse, so a turn whose
+            document edit lands in "Earlier activity" still ends with the link. */}
+        {documentReopenLinks}
         {trailer}
       </div>
       {vellumFileModal}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -743,19 +743,33 @@ export function TranscriptMessageBody({
   const renderSurfaceNode = (
     surface: ConversationMessageSurface,
     key: string,
-  ): ReactNode => (
-    <div key={key} className="w-full">
-      <SurfaceRouter
-        surface={wireSurfaceToDisplay(surface)}
-        onAction={onSurfaceAction}
-        onOpenApp={onOpenApp}
-        onOpenDocument={onOpenDocument}
-        assistantId={assistantId}
-        toolCalls={message.toolCalls}
-        onVellumLinkClick={handleVellumLinkClick}
-      />
-    </div>
-  );
+  ): ReactNode => {
+    // A `document_preview` card opens its own document, so claim that document
+    // before the end-of-message resolution runs and the reopen link would
+    // otherwise repeat the same affordance right beside the card. The preview's
+    // own `surfaceId` is the surface (`preview-<doc id>`); the document it
+    // opens rides in `data.surfaceId`, which is what a document tool call
+    // reports in its result.
+    if (surface.surfaceType === "document_preview") {
+      const documentSurfaceId = surface.data?.surfaceId;
+      if (typeof documentSurfaceId === "string" && documentSurfaceId !== "") {
+        claimedDocumentIds.add(documentSurfaceId);
+      }
+    }
+    return (
+      <div key={key} className="w-full">
+        <SurfaceRouter
+          surface={wireSurfaceToDisplay(surface)}
+          onAction={onSurfaceAction}
+          onOpenApp={onOpenApp}
+          onOpenDocument={onOpenDocument}
+          assistantId={assistantId}
+          toolCalls={message.toolCalls}
+          onVellumLinkClick={handleVellumLinkClick}
+        />
+      </div>
+    );
+  };
 
   // Render one `activity` group (a contiguous thinking + tool run) into its
   // combined `MultiActivityGroup`, a lone inline link, or a bare thinking


### PR DESCRIPTION
## Summary
- Render a reopen link for each document an assistant turn changed, at the end of the response.
- Derived from the turn's persisted tool calls, so the link survives a transcript reseed.

Part of plan: document-update-discoverability.md (PR 12 of 12)