### PR TITLE
macOS: floating voice-session surface (LUM-3073)

### DIFF
--- a/clients/macos/electron.vite.config.1786040987340.mjs
+++ b/clients/macos/electron.vite.config.1786040987340.mjs
@@ -1,0 +1,83 @@
+// electron.vite.config.ts
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+var __electron_vite_injected_dirname = "/Users/alex/vellum/workspace/vellum-assistant/clients/macos";
+var DEPS_TO_INLINE = [
+  "electron-log",
+  "electron-store",
+  "electron-updater",
+  "conf",
+  "@vellumai/electron-utils",
+  "@vellumai/ipc-contract",
+  "@vellumai/local-mode",
+  "@vellumai/environments"
+];
+var resolveBuildSha = () => {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA.slice(0, 7);
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+};
+var resolveBunVersion = () => {
+  try {
+    const toolVersions = readFileSync(
+      path.resolve(__electron_vite_injected_dirname, "../../.tool-versions"),
+      "utf8"
+    );
+    return toolVersions.match(/^bun\s+(\S+)/m)?.[1] ?? "";
+  } catch {
+    return "";
+  }
+};
+var LOCAL_CLI_ENTRY = (process.env.VELLUM_ENVIRONMENT || "local") === "local" ? path.resolve(__electron_vite_injected_dirname, "../../cli/src/index.ts") : "";
+var BUILD_DEFINES = {
+  __VELLUM_BUILD_SHA__: JSON.stringify(resolveBuildSha()),
+  __VELLUM_ENVIRONMENT__: JSON.stringify(
+    process.env.VELLUM_ENVIRONMENT || "local"
+  ),
+  __VELLUM_LOCAL_CLI_ENTRY__: JSON.stringify(LOCAL_CLI_ENTRY),
+  __VELLUM_BUN_VERSION__: JSON.stringify(resolveBunVersion()),
+  __VELLUM_ENABLE_CHROME_DEVTOOLS__: JSON.stringify(
+    process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "true" || process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1"
+  ),
+  __SENTRY_DSN_MACOS__: JSON.stringify(process.env.SENTRY_DSN_MACOS || ""),
+  // Root hostname (leading dot) shared with the web bundle's
+  // VITE_ROOT_HOSTNAME; baked into the CSP source lists (see src/main/csp.ts).
+  __VELLUM_ROOT_HOSTNAME__: JSON.stringify(
+    process.env.VITE_ROOT_HOSTNAME || ".vellum.ai"
+  )
+};
+var electron_vite_config_default = defineConfig({
+  main: {
+    plugins: [externalizeDepsPlugin({ exclude: DEPS_TO_INLINE })],
+    define: BUILD_DEFINES,
+    build: {
+      outDir: "out/main",
+      lib: {
+        entry: "src/main/index.ts"
+      },
+      rollupOptions: {
+        external: ["electron"]
+      }
+    }
+  },
+  preload: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      outDir: "out/preload",
+      lib: {
+        entry: "src/preload/index.ts"
+      },
+      rollupOptions: {
+        external: ["electron"]
+      }
+    }
+  }
+});
+export {
+  electron_vite_config_default as default
+};

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -92,6 +92,7 @@ import { installIdentityIpc } from "./identity";
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
+import { installVoiceActivityWindow } from "./voice-activity-window";
 import { hardenedWebPreferences } from "./windows";
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the
@@ -471,6 +472,7 @@ app
     installApplicationMenu();
     installQuickInput();
     installDictationOverlay({ onRecordingLifecycle: setDictationRecording });
+    installVoiceActivityWindow();
     installPopoutWindows();
     installGlobalShortcuts();
     // Register the avatar channel before the Dock and Tray install so their

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -92,7 +92,11 @@ import { installIdentityIpc } from "./identity";
 import { installConnectivityIpc, installStatusIpc } from "./status";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
-import { installVoiceActivityWindow } from "./voice-activity-window";
+import {
+  installVoiceActivityWindow,
+  isVoiceActivityRunning,
+  reopenVoiceActivityPanel,
+} from "./voice-activity-window";
 import { hardenedWebPreferences } from "./windows";
 
 // Dev-only: override the workspace `name` (`@vellumai/macos`) so the
@@ -504,6 +508,8 @@ app
       toggleMainWindow: toggleMainWindowVisibility,
       ensureMainWindow: ensureMainWindowVisible,
       openAbout: openAboutWindow,
+      isVoicePanelAvailable: isVoiceActivityRunning,
+      showVoicePanel: reopenVoiceActivityPanel,
     });
     installNativeAuth();
     installMainWindow();

--- a/clients/macos/src/main/main-window.ts
+++ b/clients/macos/src/main/main-window.ts
@@ -198,6 +198,9 @@ const createMainWindow = (): BrowserWindow => {
     // renderer content extends up to the top edge behind them.
     browserWindow: { ...sizing, titleBarStyle: "hidden", show: false },
     navigation: { installGuard: installSameOriginNavigationGuard },
+    // This window owns the live-voice session, which now keeps running — and
+    // keeps a floating panel on screen — while the user works in another app.
+    backgroundThrottling: false,
   });
 
   // Main owns the window title (the active assistant's name). Block the

--- a/clients/macos/src/main/main-window.ts
+++ b/clients/macos/src/main/main-window.ts
@@ -198,8 +198,8 @@ const createMainWindow = (): BrowserWindow => {
     // renderer content extends up to the top edge behind them.
     browserWindow: { ...sizing, titleBarStyle: "hidden", show: false },
     navigation: { installGuard: installSameOriginNavigationGuard },
-    // This window owns the live-voice session, which now keeps running — and
-    // keeps a floating panel on screen — while the user works in another app.
+    // This window owns the live-voice session, which keeps running (and keeps
+    // a floating panel on screen) while the user works in another app.
     backgroundThrottling: false,
   });
 

--- a/clients/macos/src/main/popout-window.ts
+++ b/clients/macos/src/main/popout-window.ts
@@ -76,8 +76,8 @@ const openPopout = (conversationId: string): void => {
       title: "Vellum",
       show: false,
     },
-    // A pop-out thread can own a live-voice session too — that is why the
-    // session pill has a standalone variant for these windows — so it needs
+    // A pop-out thread can own a live-voice session too, which is why the
+    // session pill has a standalone variant for these windows, so it needs
     // the main window's exemption for the same reason.
     backgroundThrottling: false,
     navigation: {

--- a/clients/macos/src/main/popout-window.ts
+++ b/clients/macos/src/main/popout-window.ts
@@ -76,6 +76,10 @@ const openPopout = (conversationId: string): void => {
       title: "Vellum",
       show: false,
     },
+    // A pop-out thread can own a live-voice session too — that is why the
+    // session pill has a standalone variant for these windows — so it needs
+    // the main window's exemption for the same reason.
+    backgroundThrottling: false,
     navigation: {
       installGuard: (w) => {
         // Block top-level navigation (prevents navigating away from the pop-out

--- a/clients/macos/src/main/tray.test.ts
+++ b/clients/macos/src/main/tray.test.ts
@@ -194,6 +194,10 @@ const handlers = {
   toggleMainWindow: mock(() => undefined),
   ensureMainWindow: mock(() => Promise.resolve()),
   openAbout: mock(() => undefined),
+  // No call running by default, so the voice-panel item stays out of the menu
+  // for every case that is not about it.
+  isVoicePanelAvailable: mock(() => false),
+  showVoicePanel: mock(() => undefined),
 };
 
 // Swap in fake timers so the pulse loop and deferred restart are deterministic.
@@ -226,7 +230,8 @@ beforeEach(() => {
     intervalCallback = cb;
     return 1 as unknown as ReturnType<typeof setInterval>;
   }) as typeof setInterval;
-  globalThis.clearInterval = clearIntervalMock as unknown as typeof clearInterval;
+  globalThis.clearInterval =
+    clearIntervalMock as unknown as typeof clearInterval;
   timeoutCallbacks = [];
   globalThis.setTimeout = ((cb: () => void) => {
     timeoutCallbacks.push(cb);
@@ -294,9 +299,9 @@ describe("installTray", () => {
     expect(labels).toContain("Restart");
     expect(labels).toContain("About Vellum Electron");
     expect(labels).toContain("Quit Vellum Electron");
-    expect(
-      template.find((item) => item.label?.startsWith("Quit"))?.role,
-    ).toBe("quit");
+    expect(template.find((item) => item.label?.startsWith("Quit"))?.role).toBe(
+      "quit",
+    );
   });
 
   test("the Re-pair item appears only when status is authFailed", () => {
@@ -481,7 +486,10 @@ describe("assistant switcher", () => {
   });
 
   test("Remove from this Mac surfaces the window and dispatches removePairedAssistant", async () => {
-    watchedLockfile = { assistants: [pairedEntry], activeAssistant: "paired-1" };
+    watchedLockfile = {
+      assistants: [pairedEntry],
+      activeAssistant: "paired-1",
+    };
     const template = popMenu();
     const beforeEnsure = handlers.ensureMainWindow.mock.calls.length;
     const beforeDispatch = dispatchToMainMock.mock.calls.length;
@@ -621,5 +629,34 @@ describe("avatar and appearance updates", () => {
 
     expect(invalidateIconCacheMock).toHaveBeenCalledTimes(1);
     expect(tray?.setImage).toHaveBeenLastCalledWith({ id: "idle" });
+  });
+});
+
+describe("the voice panel item", () => {
+  test("is absent when no call is running", () => {
+    handlers.isVoicePanelAvailable.mockReturnValue(false);
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const template = buildFromTemplateMock.mock.calls[0]?.[0] as Array<{
+      label?: string;
+    }>;
+    const labels = template.map((item) => item.label).filter(Boolean);
+    expect(labels).not.toContain("Show Voice Panel");
+  });
+
+  test("appears while a call is running and reopens the panel", () => {
+    handlers.isVoicePanelAvailable.mockReturnValue(true);
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const template = buildFromTemplateMock.mock.calls[0]?.[0] as Array<{
+      label?: string;
+      click?: () => void;
+    }>;
+    // The way back from the panel's close button, which hides the window
+    // without ending the call.
+    const item = template.find((entry) => entry.label === "Show Voice Panel");
+    expect(item).toBeDefined();
+    item?.click?.();
+    expect(handlers.showVoicePanel).toHaveBeenCalled();
   });
 });

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -18,6 +18,10 @@ import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands";
 import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
+import {
+  isVoiceActivityRunning,
+  reopenVoiceActivityPanel,
+} from "./voice-activity-window";
 import { dispatchToMain } from "./main-window";
 import { menuIcon } from "./menu-icon";
 import { readSetting } from "./settings";
@@ -304,6 +308,18 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
       label: "Show / Hide Main Window",
       click: handlers.toggleMainWindow,
     },
+    // Only while a call is running, because reopening is meaningless
+    // otherwise. This is the way back from the panel's close button: closing
+    // it never ends the session, so without this a closed panel would leave a
+    // live microphone with no floating control until the call ended.
+    ...(isVoiceActivityRunning()
+      ? [
+          {
+            label: "Show Voice Panel",
+            click: reopenVoiceActivityPanel,
+          },
+        ]
+      : []),
     { type: "separator" },
     {
       label: "Settings\u2026",

--- a/clients/macos/src/main/tray.ts
+++ b/clients/macos/src/main/tray.ts
@@ -18,10 +18,6 @@ import { onAvatarChange } from "./avatar";
 import { acceleratorOption } from "./commands";
 import { getName, onNameChange } from "./identity";
 import { getWatchedLockfile } from "./lockfile-watcher";
-import {
-  isVoiceActivityRunning,
-  reopenVoiceActivityPanel,
-} from "./voice-activity-window";
 import { dispatchToMain } from "./main-window";
 import { menuIcon } from "./menu-icon";
 import { readSetting } from "./settings";
@@ -69,6 +65,20 @@ import { readOnboardingActive } from "./window-state";
  */
 
 export interface TrayHandlers {
+  /**
+   * Whether a live-voice session is running, which is the only time reopening
+   * the floating panel means anything.
+   *
+   * Injected like every other handler rather than imported: the tray is built
+   * on every menu open, and reaching into the panel module directly would pull
+   * its window and store dependencies into the tray's own graph.
+   */
+  isVoicePanelAvailable(): boolean;
+  /**
+   * Show the floating voice panel again. The way back from its close button,
+   * which hides the window without ending the call.
+   */
+  showVoicePanel(): void;
   /**
    * Bound to the tray's left click and the "Show / Hide Main Window"
    * menu item: if the main window is visible and focused, hide it;
@@ -134,7 +144,10 @@ const isDeveloperMenuEnabled = (): boolean => {
   return flags?.["developer-menu-items"] === true;
 };
 
-const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu => {
+const buildTrayMenu = (
+  handlers: TrayHandlers,
+  status: AssistantStatus,
+): Menu => {
   const onboarding = readOnboardingActive();
 
   const items: Electron.MenuItemConstructorOptions[] = [
@@ -312,11 +325,11 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
     // otherwise. This is the way back from the panel's close button: closing
     // it never ends the session, so without this a closed panel would leave a
     // live microphone with no floating control until the call ended.
-    ...(isVoiceActivityRunning()
+    ...(handlers.isVoicePanelAvailable()
       ? [
           {
             label: "Show Voice Panel",
-            click: reopenVoiceActivityPanel,
+            click: handlers.showVoicePanel,
           },
         ]
       : []),

--- a/clients/macos/src/main/voice-activity-window.test.ts
+++ b/clients/macos/src/main/voice-activity-window.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceActivityContent,
+  VoiceActivityStart,
+  VoiceActivityState,
+} from "@vellumai/ipc-contract";
+
+// The module under test reaches `window-state.ts` for the panel's remembered
+// position, which loads `electron-store` — a real module that imports the
+// Electron binary's default export and cannot resolve off-Electron. Only the
+// import chain needs satisfying here: these cases exercise the controller,
+// which touches no store. Same shape as `window-state.test.ts`, which mocks it
+// for the same reason.
+mock.module("electron-store", () => ({
+  default: class {
+    get(_key: string, fallback?: unknown) {
+      return fallback;
+    }
+    set() {}
+  },
+}));
+
+// Dynamic, so the mock above is installed before the module graph loads —
+// static imports hoist above it. Same pattern as `window-state.test.ts`.
+const { createVoiceActivityController } =
+  await import("./voice-activity-window");
+
+const CONTENT: VoiceActivityContent = {
+  phase: "listening",
+  label: "Listening…",
+  accentHex: "#7C5CFF",
+  muted: false,
+  outputMuted: false,
+  detail: "",
+  approvalRequestId: "",
+};
+
+const START: VoiceActivityStart = {
+  ...CONTENT,
+  assistantName: "Aria",
+  avatarBase64: "iVBORw0KGgo=",
+};
+
+type Harness = {
+  controller: ReturnType<typeof createVoiceActivityController>;
+  showPanel: ReturnType<typeof mock>;
+  hidePanel: ReturnType<typeof mock>;
+  sent: (VoiceActivityState | null)[];
+  setFrontmost: (frontmost: boolean) => void;
+  setNow: (now: number) => void;
+};
+
+const createHarness = (
+  options: { frontmost?: boolean; now?: number } = {},
+): Harness => {
+  let frontmost = options.frontmost ?? false;
+  let now = options.now ?? 1_000;
+  const showPanel = mock(() => undefined);
+  const hidePanel = mock(() => undefined);
+  const sent: (VoiceActivityState | null)[] = [];
+
+  const controller = createVoiceActivityController({
+    showPanel,
+    hidePanel,
+    sendState: (state) => {
+      sent.push(state);
+    },
+    isAppFrontmost: () => frontmost,
+    now: () => now,
+  });
+
+  return {
+    controller,
+    showPanel,
+    hidePanel,
+    sent,
+    setFrontmost: (next) => {
+      frontmost = next;
+    },
+    setNow: (next) => {
+      now = next;
+    },
+  };
+};
+
+describe("createVoiceActivityController", () => {
+  test("shows the panel for a session started while the app is in the background", () => {
+    const h = createHarness({ frontmost: false });
+
+    h.controller.start(START);
+
+    expect(h.showPanel).toHaveBeenCalledTimes(1);
+    expect(h.hidePanel).not.toHaveBeenCalled();
+    expect(h.sent.at(-1)).toMatchObject({
+      assistantName: "Aria",
+      phase: "listening",
+      startedAt: 1_000,
+    });
+  });
+
+  test("keeps the panel hidden while Vellum is frontmost", () => {
+    const h = createHarness({ frontmost: true });
+
+    h.controller.start(START);
+
+    expect(h.showPanel).not.toHaveBeenCalled();
+    expect(h.hidePanel).toHaveBeenCalledTimes(1);
+    // State is still published: the app being frontmost decides visibility,
+    // not whether the session is tracked.
+    expect(h.controller.currentState()).not.toBeNull();
+  });
+
+  test("shows and hides as the app loses and regains focus mid-session", () => {
+    const h = createHarness({ frontmost: true });
+    h.controller.start(START);
+
+    h.setFrontmost(false);
+    h.controller.focusChanged();
+    expect(h.showPanel).toHaveBeenCalledTimes(1);
+
+    h.setFrontmost(true);
+    h.controller.focusChanged();
+    expect(h.hidePanel).toHaveBeenCalledTimes(2);
+  });
+
+  test("a focus change with no session never shows the panel", () => {
+    const h = createHarness({ frontmost: false });
+
+    h.controller.focusChanged();
+
+    expect(h.showPanel).not.toHaveBeenCalled();
+  });
+
+  test("a redundant start updates the session without restarting the clock", () => {
+    const h = createHarness({ now: 1_000 });
+    h.controller.start(START);
+
+    h.setNow(60_000);
+    h.controller.start({ ...START, phase: "thinking", label: "Thinking…" });
+
+    // The session controller remounts across layout-level route changes while
+    // the store persists, so a second start is expected traffic — an elapsed
+    // timer that jumped back to zero there would be a visible lie.
+    expect(h.controller.currentState()).toMatchObject({
+      phase: "thinking",
+      startedAt: 1_000,
+    });
+  });
+
+  test("update merges content and leaves the session's fixed fields alone", () => {
+    const h = createHarness();
+    h.controller.start(START);
+
+    h.controller.update({ ...CONTENT, phase: "speaking", label: "Speaking…" });
+
+    expect(h.controller.currentState()).toMatchObject({
+      phase: "speaking",
+      label: "Speaking…",
+      assistantName: "Aria",
+      avatarBase64: "iVBORw0KGgo=",
+      startedAt: 1_000,
+    });
+  });
+
+  test("update with no running session is dropped rather than promoted", () => {
+    const h = createHarness();
+
+    h.controller.update(CONTENT);
+
+    // Content carries no assistant name or avatar, so honoring it would put an
+    // anonymous panel on screen.
+    expect(h.controller.currentState()).toBeNull();
+    expect(h.showPanel).not.toHaveBeenCalled();
+    expect(h.sent).toHaveLength(0);
+  });
+
+  test("end clears the session and pushes the clear before hiding", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.sent.length = 0;
+    h.hidePanel.mockClear();
+
+    h.controller.end();
+
+    // Null first: a panel shown again later in the same launch must never
+    // paint the previous session's phase for a frame.
+    expect(h.sent).toEqual([null]);
+    expect(h.hidePanel).toHaveBeenCalledTimes(1);
+    expect(h.controller.currentState()).toBeNull();
+  });
+
+  test("a focus change after the session ended keeps the panel hidden", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.end();
+    h.showPanel.mockClear();
+
+    h.setFrontmost(false);
+    h.controller.focusChanged();
+
+    expect(h.showPanel).not.toHaveBeenCalled();
+  });
+
+  test("carries the pending approval through to the panel", () => {
+    const h = createHarness();
+    h.controller.start(START);
+
+    h.controller.update({
+      ...CONTENT,
+      detail: "Waiting for your decision",
+      approvalRequestId: "req-42",
+    });
+
+    expect(h.sent.at(-1)).toMatchObject({ approvalRequestId: "req-42" });
+  });
+});

--- a/clients/macos/src/main/voice-activity-window.test.ts
+++ b/clients/macos/src/main/voice-activity-window.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "@vellumai/ipc-contract";
 
 // The module under test reaches `window-state.ts` for the panel's remembered
-// position, which loads `electron-store` — a real module that imports the
+// position, which loads `electron-store`, a real module that imports the
 // Electron binary's default export and cannot resolve off-Electron. Only the
 // import chain needs satisfying here: these cases exercise the controller,
 // which touches no store. Same shape as `window-state.test.ts`, which mocks it
@@ -21,7 +21,7 @@ mock.module("electron-store", () => ({
   },
 }));
 
-// Dynamic, so the mock above is installed before the module graph loads —
+// Dynamic, so the mock above is installed before the module graph loads:
 // static imports hoist above it. Same pattern as `window-state.test.ts`.
 const { createVoiceActivityController } =
   await import("./voice-activity-window");
@@ -140,7 +140,7 @@ describe("createVoiceActivityController", () => {
     h.controller.start({ ...START, phase: "thinking", label: "Thinking…" });
 
     // The session controller remounts across layout-level route changes while
-    // the store persists, so a second start is expected traffic — an elapsed
+    // the store persists, so a second start is expected traffic. An elapsed
     // timer that jumped back to zero there would be a visible lie.
     expect(h.controller.currentState()).toMatchObject({
       phase: "thinking",

--- a/clients/macos/src/main/voice-activity-window.test.ts
+++ b/clients/macos/src/main/voice-activity-window.test.ts
@@ -23,7 +23,7 @@ mock.module("electron-store", () => ({
 
 // Dynamic, so the mock above is installed before the module graph loads:
 // static imports hoist above it. Same pattern as `window-state.test.ts`.
-const { createVoiceActivityController } =
+const { createVoiceActivityController, createFrontmostTracker } =
   await import("./voice-activity-window");
 
 const CONTENT: VoiceActivityContent = {
@@ -213,5 +213,54 @@ describe("createVoiceActivityController", () => {
     });
 
     expect(h.sent.at(-1)).toMatchObject({ approvalRequestId: "req-42" });
+  });
+});
+
+describe("createFrontmostTracker", () => {
+  test("falls back to the window server before any activation event", () => {
+    const focused = createFrontmostTracker(() => true);
+    const unfocused = createFrontmostTracker(() => false);
+
+    expect(focused.isFrontmost()).toBe(true);
+    expect(unfocused.isFrontmost()).toBe(false);
+  });
+
+  test("a launch that activated before install still reads as frontmost", () => {
+    // The install runs before `installMainWindow`, so at install time there is
+    // no window to focus and the launch's `did-become-active` has already
+    // fired. A tracker that latched "not frontmost" there would open the panel
+    // over a focused app for the whole first session.
+    let windowExists = false;
+    const tracker = createFrontmostTracker(() => windowExists);
+
+    expect(tracker.isFrontmost()).toBe(false);
+
+    windowExists = true;
+
+    expect(tracker.isFrontmost()).toBe(true);
+  });
+
+  test("activation events win over the fallback once one lands", () => {
+    // The fallback asks which window holds key status, which is the question
+    // the events exist to stop this from depending on: a non-activating panel
+    // can hold key while the app is genuinely in the background.
+    const tracker = createFrontmostTracker(() => true);
+
+    tracker.resignedActive();
+
+    expect(tracker.isFrontmost()).toBe(false);
+  });
+
+  test("tracks activation back and forth", () => {
+    const tracker = createFrontmostTracker(() => false);
+
+    tracker.becameActive();
+    expect(tracker.isFrontmost()).toBe(true);
+
+    tracker.resignedActive();
+    expect(tracker.isFrontmost()).toBe(false);
+
+    tracker.becameActive();
+    expect(tracker.isFrontmost()).toBe(true);
   });
 });

--- a/clients/macos/src/main/voice-activity-window.test.ts
+++ b/clients/macos/src/main/voice-activity-window.test.ts
@@ -217,7 +217,7 @@ describe("createVoiceActivityController", () => {
 });
 
 describe("createFrontmostTracker", () => {
-  test("falls back to the window server before any activation event", () => {
+  test("falls back to the window server before any signal lands", () => {
     const focused = createFrontmostTracker(() => true);
     const unfocused = createFrontmostTracker(() => false);
 
@@ -230,37 +230,64 @@ describe("createFrontmostTracker", () => {
     // no window to focus and the launch's `did-become-active` has already
     // fired. A tracker that latched "not frontmost" there would open the panel
     // over a focused app for the whole first session.
-    let windowExists = false;
-    const tracker = createFrontmostTracker(() => windowExists);
+    let otherWindowFocused = false;
+    const tracker = createFrontmostTracker(() => otherWindowFocused);
 
     expect(tracker.isFrontmost()).toBe(false);
 
-    windowExists = true;
+    otherWindowFocused = true;
 
     expect(tracker.isFrontmost()).toBe(true);
   });
 
-  test("activation events win over the fallback once one lands", () => {
-    // The fallback asks which window holds key status, which is the question
-    // the events exist to stop this from depending on: a non-activating panel
-    // can hold key while the app is genuinely in the background.
-    const tracker = createFrontmostTracker(() => true);
-
+  test("clicking the panel does not count as the app coming forward", () => {
+    // Clicking the panel activates the app despite its non-activating window
+    // type, so an unguarded `did-become-active` hid the panel the instant the
+    // user touched it, including on a drag of its own header.
+    const tracker = createFrontmostTracker(() => false);
     tracker.resignedActive();
+
+    tracker.becameActive(true);
 
     expect(tracker.isFrontmost()).toBe(false);
   });
 
-  test("tracks activation back and forth", () => {
+  test("focus moving to a real window after a panel click still hides it", () => {
+    // macOS fires no second activation once the panel has already made the app
+    // active, so window focus is the only signal left to catch this.
+    const tracker = createFrontmostTracker(() => false);
+    tracker.resignedActive();
+    tracker.becameActive(true);
+
+    tracker.windowFocused(false);
+
+    expect(tracker.isFrontmost()).toBe(true);
+  });
+
+  test("the panel taking focus never marks the app frontmost", () => {
+    const tracker = createFrontmostTracker(() => false);
+    tracker.resignedActive();
+
+    tracker.windowFocused(true);
+
+    expect(tracker.isFrontmost()).toBe(false);
+  });
+
+  test("an activation with the panel unfocused marks the app frontmost", () => {
     const tracker = createFrontmostTracker(() => false);
 
-    tracker.becameActive();
+    tracker.becameActive(false);
+
+    expect(tracker.isFrontmost()).toBe(true);
+  });
+
+  test("resigning active always wins", () => {
+    const tracker = createFrontmostTracker(() => true);
+    tracker.windowFocused(false);
     expect(tracker.isFrontmost()).toBe(true);
 
     tracker.resignedActive();
-    expect(tracker.isFrontmost()).toBe(false);
 
-    tracker.becameActive();
-    expect(tracker.isFrontmost()).toBe(true);
+    expect(tracker.isFrontmost()).toBe(false);
   });
 });

--- a/clients/macos/src/main/voice-activity-window.test.ts
+++ b/clients/macos/src/main/voice-activity-window.test.ts
@@ -23,7 +23,7 @@ mock.module("electron-store", () => ({
 
 // Dynamic, so the mock above is installed before the module graph loads:
 // static imports hoist above it. Same pattern as `window-state.test.ts`.
-const { createVoiceActivityController, createFrontmostTracker } =
+const { createVoiceActivityController } =
   await import("./voice-activity-window");
 
 const CONTENT: VoiceActivityContent = {
@@ -46,27 +46,25 @@ type Harness = {
   controller: ReturnType<typeof createVoiceActivityController>;
   showPanel: ReturnType<typeof mock>;
   hidePanel: ReturnType<typeof mock>;
+  setCollapsed: ReturnType<typeof mock>;
   sent: (VoiceActivityState | null)[];
-  setFrontmost: (frontmost: boolean) => void;
   setNow: (now: number) => void;
 };
 
-const createHarness = (
-  options: { frontmost?: boolean; now?: number } = {},
-): Harness => {
-  let frontmost = options.frontmost ?? false;
+const createHarness = (options: { now?: number } = {}): Harness => {
   let now = options.now ?? 1_000;
   const showPanel = mock(() => undefined);
   const hidePanel = mock(() => undefined);
+  const setCollapsed = mock((_collapsed: boolean) => undefined);
   const sent: (VoiceActivityState | null)[] = [];
 
   const controller = createVoiceActivityController({
     showPanel,
     hidePanel,
+    setCollapsed,
     sendState: (state) => {
       sent.push(state);
     },
-    isAppFrontmost: () => frontmost,
     now: () => now,
   });
 
@@ -74,10 +72,8 @@ const createHarness = (
     controller,
     showPanel,
     hidePanel,
+    setCollapsed,
     sent,
-    setFrontmost: (next) => {
-      frontmost = next;
-    },
     setNow: (next) => {
       now = next;
     },
@@ -85,51 +81,18 @@ const createHarness = (
 };
 
 describe("createVoiceActivityController", () => {
-  test("shows the panel for a session started while the app is in the background", () => {
-    const h = createHarness({ frontmost: false });
+  test("shows the panel when a session starts", () => {
+    const h = createHarness();
 
     h.controller.start(START);
 
     expect(h.showPanel).toHaveBeenCalledTimes(1);
-    expect(h.hidePanel).not.toHaveBeenCalled();
     expect(h.sent.at(-1)).toMatchObject({
       assistantName: "Aria",
       phase: "listening",
       startedAt: 1_000,
+      collapsed: false,
     });
-  });
-
-  test("keeps the panel hidden while Vellum is frontmost", () => {
-    const h = createHarness({ frontmost: true });
-
-    h.controller.start(START);
-
-    expect(h.showPanel).not.toHaveBeenCalled();
-    expect(h.hidePanel).toHaveBeenCalledTimes(1);
-    // State is still published: the app being frontmost decides visibility,
-    // not whether the session is tracked.
-    expect(h.controller.currentState()).not.toBeNull();
-  });
-
-  test("shows and hides as the app loses and regains focus mid-session", () => {
-    const h = createHarness({ frontmost: true });
-    h.controller.start(START);
-
-    h.setFrontmost(false);
-    h.controller.focusChanged();
-    expect(h.showPanel).toHaveBeenCalledTimes(1);
-
-    h.setFrontmost(true);
-    h.controller.focusChanged();
-    expect(h.hidePanel).toHaveBeenCalledTimes(2);
-  });
-
-  test("a focus change with no session never shows the panel", () => {
-    const h = createHarness({ frontmost: false });
-
-    h.controller.focusChanged();
-
-    expect(h.showPanel).not.toHaveBeenCalled();
   });
 
   test("a redundant start updates the session without restarting the clock", () => {
@@ -190,18 +153,6 @@ describe("createVoiceActivityController", () => {
     expect(h.controller.currentState()).toBeNull();
   });
 
-  test("a focus change after the session ended keeps the panel hidden", () => {
-    const h = createHarness();
-    h.controller.start(START);
-    h.controller.end();
-    h.showPanel.mockClear();
-
-    h.setFrontmost(false);
-    h.controller.focusChanged();
-
-    expect(h.showPanel).not.toHaveBeenCalled();
-  });
-
   test("carries the pending approval through to the panel", () => {
     const h = createHarness();
     h.controller.start(START);
@@ -216,78 +167,112 @@ describe("createVoiceActivityController", () => {
   });
 });
 
-describe("createFrontmostTracker", () => {
-  test("falls back to the window server before any signal lands", () => {
-    const focused = createFrontmostTracker(() => true);
-    const unfocused = createFrontmostTracker(() => false);
+describe("closing the window", () => {
+  test("dismiss hides the window and leaves the session running", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.hidePanel.mockClear();
 
-    expect(focused.isFrontmost()).toBe(true);
-    expect(unfocused.isFrontmost()).toBe(false);
+    h.controller.dismiss();
+
+    // The button a user reaches for when a panel is in the way must never hang
+    // up on them.
+    expect(h.hidePanel).toHaveBeenCalledTimes(1);
+    expect(h.controller.currentState()).not.toBeNull();
   });
 
-  test("a launch that activated before install still reads as frontmost", () => {
-    // The install runs before `installMainWindow`, so at install time there is
-    // no window to focus and the launch's `did-become-active` has already
-    // fired. A tracker that latched "not frontmost" there would open the panel
-    // over a focused app for the whole first session.
-    let otherWindowFocused = false;
-    const tracker = createFrontmostTracker(() => otherWindowFocused);
+  test("updates keep flowing to a dismissed panel without reopening it", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.dismiss();
+    h.showPanel.mockClear();
 
-    expect(tracker.isFrontmost()).toBe(false);
+    h.controller.update({ ...CONTENT, phase: "thinking", label: "Thinking…" });
 
-    otherWindowFocused = true;
-
-    expect(tracker.isFrontmost()).toBe(true);
+    expect(h.showPanel).not.toHaveBeenCalled();
+    expect(h.controller.currentState()).toMatchObject({ phase: "thinking" });
   });
 
-  test("clicking the panel does not count as the app coming forward", () => {
-    // Clicking the panel activates the app despite its non-activating window
-    // type, so an unguarded `did-become-active` hid the panel the instant the
-    // user touched it, including on a drag of its own header.
-    const tracker = createFrontmostTracker(() => false);
-    tracker.resignedActive();
+  test("reopen brings it back for the session already running", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.dismiss();
+    h.showPanel.mockClear();
 
-    tracker.becameActive(true);
+    h.controller.reopen();
 
-    expect(tracker.isFrontmost()).toBe(false);
+    expect(h.showPanel).toHaveBeenCalledTimes(1);
   });
 
-  test("focus moving to a real window after a panel click still hides it", () => {
-    // macOS fires no second activation once the panel has already made the app
-    // active, so window focus is the only signal left to catch this.
-    const tracker = createFrontmostTracker(() => false);
-    tracker.resignedActive();
-    tracker.becameActive(true);
+  test("a new session reopens a panel closed during the last one", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.dismiss();
+    h.controller.end();
+    h.showPanel.mockClear();
 
-    tracker.windowFocused(false);
+    h.controller.start(START);
 
-    expect(tracker.isFrontmost()).toBe(true);
+    // A closed panel means a live microphone with no floating control, so a
+    // dismissal lasts only as long as the call it was aimed at.
+    expect(h.showPanel).toHaveBeenCalledTimes(1);
   });
 
-  test("the panel taking focus never marks the app frontmost", () => {
-    const tracker = createFrontmostTracker(() => false);
-    tracker.resignedActive();
+  test("a remount during a dismissed session does not reopen it", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.dismiss();
+    h.showPanel.mockClear();
 
-    tracker.windowFocused(true);
+    h.controller.start({ ...START, phase: "thinking", label: "Thinking…" });
 
-    expect(tracker.isFrontmost()).toBe(false);
+    // A redundant start is the mirror re-syncing, not the user changing their
+    // mind about a panel they closed.
+    expect(h.showPanel).not.toHaveBeenCalled();
+  });
+});
+
+describe("collapsing to the chip", () => {
+  test("resizes the window before telling the page", () => {
+    const h = createHarness();
+    h.controller.start(START);
+
+    h.controller.setCollapsed(true);
+
+    // The page must never draw a chip into a window still the size of the
+    // expanded panel.
+    expect(h.setCollapsed).toHaveBeenCalledWith(true);
+    expect(h.sent.at(-1)).toMatchObject({ collapsed: true });
   });
 
-  test("an activation with the panel unfocused marks the app frontmost", () => {
-    const tracker = createFrontmostTracker(() => false);
+  test("restoring expands it again", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.setCollapsed(true);
 
-    tracker.becameActive(false);
+    h.controller.setCollapsed(false);
 
-    expect(tracker.isFrontmost()).toBe(true);
+    expect(h.setCollapsed).toHaveBeenLastCalledWith(false);
+    expect(h.controller.currentState()).toMatchObject({ collapsed: false });
   });
 
-  test("resigning active always wins", () => {
-    const tracker = createFrontmostTracker(() => true);
-    tracker.windowFocused(false);
-    expect(tracker.isFrontmost()).toBe(true);
+  test("a redundant collapse does not resize the window again", () => {
+    const h = createHarness();
+    h.controller.start(START);
+    h.controller.setCollapsed(true);
+    h.setCollapsed.mockClear();
 
-    tracker.resignedActive();
+    h.controller.setCollapsed(true);
 
-    expect(tracker.isFrontmost()).toBe(false);
+    expect(h.setCollapsed).not.toHaveBeenCalled();
+  });
+
+  test("collapsing with no session does nothing", () => {
+    const h = createHarness();
+
+    h.controller.setCollapsed(true);
+
+    expect(h.setCollapsed).not.toHaveBeenCalled();
+    expect(h.sent).toHaveLength(0);
   });
 });

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -44,13 +44,14 @@ const PANEL_KIND = "voice-activity";
 const PANEL_PATH = "/floating/voice-activity";
 const WINDOW_STATE_KEY = "voice-activity";
 
-// Wide enough for the assistant's name over a phase line and a control row,
-// short enough to sit in a screen corner without covering work. The canvas is
-// the panel: unlike the dictation HUD there is no CSS shadow to leave room
+// Wide enough for the assistant's name beside its phase, short enough to sit
+// in a screen corner without covering work. The height carries three rows:
+// identity and phase, the turn's activity line, and the controls. The canvas
+// is the panel: unlike the dictation HUD there is no CSS shadow to leave room
 // for, because a window the user positions themselves is allowed the system's
 // own shadow (`hasShadow`).
 const PANEL_WIDTH = 300;
-const PANEL_HEIGHT = 116;
+const PANEL_HEIGHT = 96;
 
 /** Gap from the work area's top-right corner on the first ever launch. */
 const DEFAULT_MARGIN = 16;
@@ -253,54 +254,71 @@ const ensurePanel = (): BrowserWindow => {
 };
 
 /**
- * Whether Vellum is the frontmost app, tracked from the two macOS events that
- * mean exactly that.
+ * Whether **a window other than the panel** is frontmost, which is the real
+ * question this surface turns on.
  *
- * **Not derived from `BrowserWindow.getFocusedWindow()`.** That reports which
- * window holds *key* status, which is a different question, and for this
- * surface it answers wrongly in the one case that matters: the panel is an
- * always-on-top non-activating `NSPanel`, so it can keep key status while the
- * user brings the main window to the front. A frontmost check that excluded
- * the panel to avoid hiding on its own clicks then reported "not frontmost"
- * for the rest of the session, and the panel never went away.
+ * Three signals, because no single one answers it:
  *
- * `did-become-active` / `did-resign-active` describe the *application*, so
- * they need no such exclusion: the panel being non-activating means clicking
- * it does not activate the app, and therefore does not fire either event.
- * The behavior the exclusion was hand-rolling is what these give for free.
+ * - `did-resign-active`: the app went to the background. Definitive.
+ * - `browser-window-focus` on anything but the panel: a real window of the app
+ *   took focus, so the session has an on-screen control again.
+ * - `did-become-active`: the app came forward, but *only counts when the panel
+ *   is not the key window*. Clicking the panel activates the app despite its
+ *   non-activating window type, and treating that as "frontmost" hid the panel
+ *   the instant the user touched it, including on a drag of its own header.
  *
- * **Until the first of those events lands there is nothing to report**, and
- * the honest answer then is whatever the window server says right now. A
- * launch that macOS activated before this module was installed has already
- * missed its `did-become-active`, and nothing else will fire until the user
- * switches away and back, so a tracker that assumed "not frontmost" would open
- * the panel over a focused app for the whole first session. Asking at the
- * moment the question is put is what makes this independent of where in the
- * startup sequence the install happens to sit, and of whether a window existed
- * when it did.
+ * The app-level pair alone is not enough, and neither is window focus alone.
+ * Ignoring a panel-driven `did-become-active` leaves the app active with the
+ * panel still up, and macOS fires no second activation when focus then moves
+ * to the main window, so without the focus signal the panel would never hide
+ * again. Focus events alone were the original bug: the panel is an
+ * always-on-top `NSPanel` and keeps key status when the main window comes
+ * forward, so a focus-derived check reported "not frontmost" for the rest of
+ * the session.
+ *
+ * **Until one of those lands there is nothing to report**, and the honest
+ * answer then is whatever the window server says right now. A launch macOS
+ * activated before this module was installed has already missed its
+ * `did-become-active`, and nothing fires again until the user switches away
+ * and back, so a tracker that assumed "not frontmost" would open the panel
+ * over a focused app for the whole first session.
  *
  * Injected rather than read directly so the fallback has a seam to be tested
- * through, which the sequencing bug this replaces went unnoticed for want of.
+ * through, which the sequencing bug that needed it went unnoticed for want of.
  */
 export const createFrontmostTracker = (
-  anyWindowFocused: () => boolean,
+  anyOtherWindowFocused: () => boolean,
 ): {
   isFrontmost: () => boolean;
-  becameActive: () => void;
+  becameActive: (panelHasKey: boolean) => void;
   resignedActive: () => void;
+  windowFocused: (isPanel: boolean) => void;
 } => {
   let observed = false;
   let frontmost = false;
 
   return {
-    isFrontmost: () => (observed ? frontmost : anyWindowFocused()),
-    becameActive: () => {
+    isFrontmost: () => (observed ? frontmost : anyOtherWindowFocused()),
+    becameActive: (panelHasKey) => {
+      // A panel-driven activation says nothing about the rest of the app, so
+      // it is not allowed to answer the question either way: recording it
+      // would latch a value the next real focus change may never correct.
+      if (panelHasKey) {
+        return;
+      }
       observed = true;
       frontmost = true;
     },
     resignedActive: () => {
       observed = true;
       frontmost = false;
+    },
+    windowFocused: (isPanel) => {
+      if (isPanel) {
+        return;
+      }
+      observed = true;
+      frontmost = true;
     },
   };
 };
@@ -313,9 +331,15 @@ export const installVoiceActivityWindow = (): void => {
   }
   installed = true;
 
-  const frontmost = createFrontmostTracker(
-    () => BrowserWindow.getFocusedWindow() !== null,
-  );
+  const panelHasKey = (): boolean => {
+    const focused = BrowserWindow.getFocusedWindow();
+    return focused !== null && focused === panelWindow();
+  };
+
+  const frontmost = createFrontmostTracker(() => {
+    const focused = BrowserWindow.getFocusedWindow();
+    return focused !== null && focused !== panelWindow();
+  });
 
   const controller = createVoiceActivityController({
     showPanel: () => {
@@ -391,11 +415,15 @@ export const installVoiceActivityWindow = (): void => {
   // once per actual application activation, so there is no blur/focus gap to
   // ride out and nothing to coalesce.
   app.on("did-become-active", () => {
-    frontmost.becameActive();
+    frontmost.becameActive(panelHasKey());
     controller.focusChanged();
   });
   app.on("did-resign-active", () => {
     frontmost.resignedActive();
+    controller.focusChanged();
+  });
+  app.on("browser-window-focus", (_event, win) => {
+    frontmost.windowFocused(win === panelWindow());
     controller.focusChanged();
   });
 };

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -279,7 +279,9 @@ let appFrontmost = false;
 let installed = false;
 
 export const installVoiceActivityWindow = (): void => {
-  if (installed) return;
+  if (installed) {
+    return;
+  }
   installed = true;
 
   // Install runs after `app.whenReady()`, so a focused window here means the

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -1,0 +1,359 @@
+import { BrowserWindow, app, screen } from "electron";
+import { z } from "zod";
+
+import {
+  voiceActivityContentSchema,
+  voiceActivityControlSchema,
+  voiceActivityStartSchema,
+  type VoiceActivityContent,
+  type VoiceActivityControl,
+  type VoiceActivityStart,
+  type VoiceActivityState,
+} from "@vellumai/ipc-contract";
+
+import { createFloatingWindow, getFloatingWindow } from "./floating-window";
+import { handle, on } from "./ipc";
+import { restoreBounds, track } from "./window-state";
+
+/**
+ * The floating live-voice session surface — the desktop counterpart to the iOS
+ * Dynamic Island and Lock Screen activity.
+ *
+ * A small always-on-top panel carrying what those carry: the assistant's
+ * identity, the session phase, the turn's activity line, elapsed time, mute
+ * state, and the session's own controls. It exists for the same reason they
+ * do: a live microphone whose app is not on screen still needs a readout and
+ * a way to act on it.
+ *
+ * **The panel is its own renderer**, so it does not share the main window's
+ * live-voice store. State flows main-window renderer → here → panel renderer,
+ * which is why the payload is a flat serializable snapshot rather than a store
+ * subscription — the same shape the iOS bridge sends, for the same reason.
+ * `dictation-overlay-window.ts` is the closest sibling; this differs in living
+ * for the length of a call rather than a few seconds, which is what earns it a
+ * remembered position and a vibrancy material rather than a fixed HUD slot.
+ *
+ * **It shows only while Vellum is not frontmost.** The app already renders
+ * exactly one control for a live session — the voice room, the composer's
+ * voice bar, or the pill (see `voice-session-pill-host.tsx`) — so a panel on
+ * top of that would be a second control for the same session. Not-frontmost is
+ * the desktop reading of the state an island exists for.
+ */
+
+const PANEL_KIND = "voice-activity";
+const PANEL_PATH = "/floating/voice-activity";
+const WINDOW_STATE_KEY = "voice-activity";
+
+// Wide enough for the assistant's name over a phase line and a control row,
+// short enough to sit in a screen corner without covering work. The canvas is
+// the panel: unlike the dictation HUD there is no CSS shadow to leave room
+// for, because a window the user positions themselves is allowed the system's
+// own shadow (`hasShadow`).
+const PANEL_WIDTH = 300;
+const PANEL_HEIGHT = 116;
+
+/** Gap from the work area's top-right corner on the first ever launch. */
+const DEFAULT_MARGIN = 16;
+
+// ---------------------------------------------------------------------------
+// Session state machine
+// ---------------------------------------------------------------------------
+
+export type VoiceActivityDeps = {
+  showPanel: () => void;
+  hidePanel: () => void;
+  sendState: (state: VoiceActivityState | null) => void;
+  /**
+   * Whether Vellum is the frontmost app — the gate the whole surface turns on.
+   * Injected rather than read here so the visibility rules are testable
+   * without a window server.
+   */
+  isAppFrontmost: () => boolean;
+  now: () => number;
+};
+
+export type VoiceActivityController = {
+  start: (start: VoiceActivityStart) => void;
+  update: (content: VoiceActivityContent) => void;
+  end: () => void;
+  /** Re-evaluate visibility after the app's frontmost-ness may have changed. */
+  focusChanged: () => void;
+  /** The snapshot the panel renders, or `null` when no session is running. */
+  currentState: () => VoiceActivityState | null;
+};
+
+/**
+ * Session lifecycle and visibility, separated from the window plumbing so the
+ * rules are unit-testable — the same deps-injection shape as
+ * `createDictationOverlayController`.
+ *
+ * Two pieces of state, deliberately independent: whether a session exists at
+ * all, and whether the app is frontmost. The panel is on screen only when the
+ * first is true and the second is false, and every entry point routes through
+ * one reconcile so the two can never disagree about what is showing.
+ */
+export const createVoiceActivityController = (
+  deps: VoiceActivityDeps,
+): VoiceActivityController => {
+  let session: VoiceActivityState | null = null;
+
+  const reconcile = (): void => {
+    if (session === null || deps.isAppFrontmost()) {
+      deps.hidePanel();
+      return;
+    }
+    deps.showPanel();
+  };
+
+  const start = (start: VoiceActivityStart): void => {
+    // A redundant start updates the running session rather than restarting its
+    // clock. The mirror re-syncs on mount and the session controller remounts
+    // across layout-level route changes while the store persists, so a second
+    // start for a session already on screen is expected traffic — not a new
+    // call, and an elapsed timer that jumped back to zero on a route change
+    // would be a visible lie about a session that never stopped.
+    session =
+      session === null
+        ? { ...start, startedAt: deps.now() }
+        : { ...session, ...start };
+    reconcile();
+    deps.sendState(session);
+  };
+
+  const update = (content: VoiceActivityContent): void => {
+    // An update with no session is dropped rather than promoted into one: it
+    // carries no assistant name and no avatar, so honoring it would put an
+    // anonymous panel on screen. In practice this is the tail of a session
+    // that has already ended.
+    if (session === null) {
+      return;
+    }
+    session = { ...session, ...content };
+    deps.sendState(session);
+  };
+
+  const end = (): void => {
+    session = null;
+    // Pushed before the hide, so a panel shown again later in the same launch
+    // never paints the previous session's phase for a frame.
+    deps.sendState(null);
+    reconcile();
+  };
+
+  return {
+    start,
+    update,
+    end,
+    focusChanged: reconcile,
+    currentState: () => session,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Window plumbing
+// ---------------------------------------------------------------------------
+
+const panelWindow = (): BrowserWindow | null => getFloatingWindow(PANEL_KIND);
+
+/**
+ * Where a panel with no remembered position opens: the top-right of the
+ * display under the cursor, which is where the user is looking and the corner
+ * least likely to hold the window they are working in.
+ */
+const defaultPosition = (): { x: number; y: number } => {
+  const cursor = screen.getCursorScreenPoint();
+  const { workArea } = screen.getDisplayNearestPoint(cursor);
+  return {
+    x: Math.round(workArea.x + workArea.width - PANEL_WIDTH - DEFAULT_MARGIN),
+    y: Math.round(workArea.y + DEFAULT_MARGIN),
+  };
+};
+
+/**
+ * The panel's opening position: where the user last left it, or the default
+ * corner.
+ *
+ * Only the origin is taken from the saved state. `restoreBounds` also returns
+ * a size, and honoring it would let one launch's dimensions outlive a change
+ * to `PANEL_WIDTH` / `PANEL_HEIGHT` — the panel is not resizable, so its size
+ * is the build's to decide and only its placement is the user's. The saved
+ * origin is still clamped into a connected display's work area by
+ * `restoreBounds`, so a monitor unplugged between sessions cannot strand it
+ * off-screen.
+ */
+export const openingPosition = (): { x: number; y: number } => {
+  const saved = restoreBounds(WINDOW_STATE_KEY, {
+    width: PANEL_WIDTH,
+    height: PANEL_HEIGHT,
+  });
+  if (saved.x === undefined || saved.y === undefined) {
+    return defaultPosition();
+  }
+  return { x: saved.x, y: saved.y };
+};
+
+/** Whether the geometry tracker has been bound to the current panel window. */
+let tracked = false;
+
+const ensurePanel = (): BrowserWindow => {
+  const win = createFloatingWindow({
+    kind: PANEL_KIND,
+    route: PANEL_PATH,
+    width: PANEL_WIDTH,
+    height: PANEL_HEIGHT,
+    // Never steals focus from whatever the user is actually doing. `panel` is
+    // a non-activating panel on macOS, so the controls can be clicked without
+    // bringing Vellum forward — which for this surface is the entire point.
+    focusOnShow: false,
+    // Above ordinary windows, below the system's own overlays. The dictation
+    // HUD reaches for `screen-saver` because it is transient and modal in
+    // spirit; a panel that stays up for the length of a call should not
+    // outrank a screen saver.
+    alwaysOnTopLevel: "floating",
+    browserWindow: {
+      // Repositionable, which is the whole reason geometry is persisted. The
+      // drag itself comes from the route's `-webkit-app-region: drag`; this
+      // only permits it.
+      movable: true,
+      minimizable: false,
+      maximizable: false,
+      hasShadow: true,
+      // The glass. `under-window` samples what is behind the panel, which for
+      // a surface floating over *other apps* is the material that reads as
+      // glass rather than as a tinted rectangle. `active` keeps it live while
+      // Vellum is in the background — which, for this panel, is always.
+      vibrancy: "under-window",
+      visualEffectState: "active",
+      roundedCorners: true,
+    },
+    // Only on creation. Re-applying on every show would drag the panel back to
+    // its saved corner mid-session, undoing a move the user made minutes ago
+    // — the position is persisted precisely so it survives.
+    position: panelWindow() === null ? openingPosition() : undefined,
+  });
+
+  if (!tracked) {
+    tracked = true;
+    track(WINDOW_STATE_KEY, win);
+    win.on("closed", () => {
+      tracked = false;
+    });
+  }
+
+  return win;
+};
+
+/**
+ * Whether Vellum is the frontmost app.
+ *
+ * The panel is deliberately not counted. It is a non-activating panel, so
+ * clicking it does not make Vellum frontmost in the first place — but it can
+ * still take key focus, and treating that as "the app is frontmost" would hide
+ * the surface the moment the user reached for it.
+ */
+const isAppFrontmost = (): boolean => {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused === null || focused.isDestroyed()) {
+    return false;
+  }
+  return focused !== panelWindow();
+};
+
+let installed = false;
+
+export const installVoiceActivityWindow = (): void => {
+  if (installed) return;
+  installed = true;
+
+  const controller = createVoiceActivityController({
+    showPanel: () => {
+      ensurePanel();
+    },
+    hidePanel: () => {
+      const win = panelWindow();
+      if (win?.isVisible()) {
+        win.hide();
+      }
+    },
+    sendState: (state) => {
+      panelWindow()?.webContents.send("vellum:voiceActivity:state", state);
+    },
+    isAppFrontmost,
+    now: () => Date.now(),
+  });
+
+  /**
+   * Focus changes are reconciled on the next tick rather than inline.
+   *
+   * Moving between two Vellum windows fires `browser-window-blur` for the one
+   * being left before `browser-window-focus` for the one being entered, so a
+   * synchronous read of `getFocusedWindow()` inside that gap says "no Vellum
+   * window has focus" and the panel would flash into view mid-switch.
+   */
+  let reconcileTimer: NodeJS.Timeout | null = null;
+  const scheduleReconcile = (): void => {
+    if (reconcileTimer !== null) {
+      return;
+    }
+    reconcileTimer = setTimeout(() => {
+      reconcileTimer = null;
+      controller.focusChanged();
+    }, 0);
+  };
+
+  on(
+    "vellum:voiceActivity:start",
+    z.tuple([voiceActivityStartSchema]),
+    ([start]) => {
+      controller.start(start);
+    },
+  );
+
+  on(
+    "vellum:voiceActivity:update",
+    z.tuple([voiceActivityContentSchema]),
+    ([content]) => {
+      controller.update(content);
+    },
+  );
+
+  on("vellum:voiceActivity:end", z.tuple([]), () => {
+    controller.end();
+  });
+
+  /**
+   * Deliver a panel press to the session that can act on it.
+   *
+   * Broadcast rather than addressed, for the same reason the dictation overlay
+   * broadcasts its stop: main does not know which renderer owns the session,
+   * and the session's own listener is mounted for exactly the session's
+   * lifetime, so a press with no owner lands nowhere rather than being
+   * misrouted. The panel is excluded because it is the sender.
+   */
+  on(
+    "vellum:voiceActivity:control",
+    z.tuple([voiceActivityControlSchema]),
+    ([control]: [VoiceActivityControl]) => {
+      const panel = panelWindow();
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (
+          win === panel ||
+          win.isDestroyed() ||
+          win.webContents.isDestroyed()
+        ) {
+          continue;
+        }
+        win.webContents.send("vellum:voiceActivity:controlEvent", control);
+      }
+    },
+  );
+
+  // The panel route loads lazily, so states pushed before its subscription
+  // registers are dropped by Electron — it pulls this once subscribed.
+  handle("vellum:voiceActivity:getState", z.tuple([]), () =>
+    controller.currentState(),
+  );
+
+  app.on("browser-window-focus", scheduleReconcile);
+  app.on("browser-window-blur", scheduleReconcile);
+};

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -433,5 +433,4 @@ export const installVoiceActivityWindow = (): void => {
   handle("vellum:voiceActivity:getState", z.tuple([]), () =>
     controller.currentState(),
   );
-
 };

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -11,9 +11,10 @@ import {
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
-import { createFloatingWindow, getFloatingWindow } from "./floating-window";
 import { ensureVisible as ensureMainWindowVisible } from "./main-window";
+import { RENDERER_BASE_PROD, getDevRendererBase } from "./app-config";
 import { handle, on } from "./ipc";
+import { createWindow } from "./windows";
 import { restoreBounds, track } from "./window-state";
 
 /**
@@ -41,7 +42,6 @@ import { restoreBounds, track } from "./window-state";
  * the desktop reading of the state an island exists for.
  */
 
-const PANEL_KIND = "voice-activity";
 const PANEL_PATH = "/floating/voice-activity";
 const WINDOW_STATE_KEY = "voice-activity";
 
@@ -193,7 +193,17 @@ export const createVoiceActivityController = (
 // Window plumbing
 // ---------------------------------------------------------------------------
 
-const panelWindow = (): BrowserWindow | null => getFloatingWindow(PANEL_KIND);
+let panel: BrowserWindow | null = null;
+
+const panelWindow = (): BrowserWindow | null => {
+  if (panel === null) {
+    return null;
+  }
+  if (panel.isDestroyed() || panel.webContents.isDestroyed()) {
+    panel = null;
+  }
+  return panel;
+};
 
 /**
  * Where a panel with no remembered position opens: the top-right of the
@@ -232,81 +242,102 @@ export const openingPosition = (): { x: number; y: number } => {
   return { x: saved.x, y: saved.y };
 };
 
-/** Whether the geometry tracker has been bound to the current panel window. */
-let tracked = false;
+const panelUrl = (): string => {
+  const base = app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase();
+  return `${base}${PANEL_PATH}`;
+};
 
-const ensurePanel = (): BrowserWindow => {
-  const win = createFloatingWindow({
-    kind: PANEL_KIND,
-    route: PANEL_PATH,
-    width: PANEL_WIDTH,
-    height: PANEL_HEIGHT,
-    // Never steals focus from whatever the user is actually doing. `panel` is
-    // a non-activating panel on macOS, so the controls can be clicked without
-    // bringing Vellum forward, which for this surface is the entire point.
-    focusOnShow: false,
-    // Above ordinary windows, below the system's own overlays. The dictation
-    // HUD reaches for `screen-saver` because it is transient and modal in
-    // spirit; a panel that stays up for the length of a call should not
-    // outrank a screen saver.
-    alwaysOnTopLevel: "floating",
+/**
+ * The panel window, created on first use.
+ *
+ * **Built directly rather than through `createFloatingWindow`**, which fixes
+ * `frame: false`, `transparent: true` and `type: "panel"`. None of those can
+ * carry traffic lights: a transparent frameless panel has no window surface
+ * for macOS to draw them on, and a non-activating panel would leave them
+ * inert. This is a real window that happens to float.
+ *
+ * The traffic lights are the window controls, so the page draws none of its
+ * own. Red hides it (see the `close` interception below), yellow minimizes to
+ * the Dock, and green is disabled through `maximizable` and `fullscreenable`:
+ * a fixed-size readout has no meaningful zoom, and macOS grays the button out
+ * rather than needing it hidden.
+ */
+const createPanel = (): BrowserWindow => {
+  const { x, y } = openingPosition();
+  const win = createWindow({
     browserWindow: {
-      // Repositionable, which is the whole reason geometry is persisted. The
-      // drag itself comes from the route's `-webkit-app-region: drag`; this
-      // only permits the window to move.
-      movable: true,
-      minimizable: false,
+      width: PANEL_WIDTH,
+      height: PANEL_HEIGHT,
+      x,
+      y,
+      // Frameless *with* traffic lights, the standard macOS shape for a window
+      // that wants no title bar and still wants its controls.
+      titleBarStyle: "hidden",
+      trafficLightPosition: { x: 10, y: 10 },
+      resizable: false,
+      minimizable: true,
       maximizable: false,
+      fullscreenable: false,
+      movable: true,
+      show: false,
       hasShadow: true,
-      // **Without this, every control on this panel is dead on first press.**
-      // macOS defaults to swallowing the click that activates an inactive
-      // window, delivering only the second one to its content. That rule
-      // exists so a stray click on a background app cannot act on it. This
-      // panel is the exception the rule was not written for: it is *only ever*
-      // on screen while the app is inactive, so every press it receives is a
-      // first press, and "click once to wake it, again to mean it" is the
-      // whole interaction. The user aimed at Mute; the click is not stray.
+      // Focusable, unlike the panel this replaces: traffic lights on a window
+      // that cannot take key status are drawn inert.
+      focusable: true,
       acceptFirstMouse: true,
-      // The panel never takes key status, so it never activates the app. That
-      // is what stops a press on it from flickering the menu bar to Vellum
-      // while leaving every real window behind, and it keeps app activation
-      // meaning what the visibility gate reads it as: a real window came
-      // forward. Clicking the panel still reaches the page, and foregrounding
-      // is now something a click asks for explicitly rather than a side
-      // effect of touching the surface. The dictation overlay is non-focusable
-      // for the same reason and keeps a working control.
-      focusable: false,
-      // The glass. `under-window` samples what is behind the panel, which for
-      // a surface floating over *other apps* is the material that reads as
-      // glass rather than as a tinted rectangle. `active` keeps it live while
-      // Vellum is in the background, which for this panel is always.
+      // The glass. `under-window` samples what is behind the window, which for
+      // a surface floating over *other apps* reads as glass rather than as a
+      // tinted rectangle. `active` keeps it live while Vellum is in the
+      // background, which is most of this window's life.
       vibrancy: "under-window",
       visualEffectState: "active",
       roundedCorners: true,
     },
-    // Only on creation. Re-applying on every show would drag the panel back to
-    // its saved corner mid-session, undoing a move the user made minutes ago.
-    // The position is persisted precisely so it survives.
-    position: panelWindow() === null ? openingPosition() : undefined,
+    navigation: "deny-all",
   });
 
-  if (!tracked) {
-    tracked = true;
-    track(WINDOW_STATE_KEY, win);
-    win.on("closed", () => {
-      tracked = false;
-    });
-  }
+  win.setAlwaysOnTop(true, "floating");
+  win.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  });
 
+  // Red hides the window; it never destroys it and never ends the call. The
+  // button a user reaches for when a window is in the way must not hang up on
+  // them, and the tray offers the way back while a session is live.
+  win.on("close", (event) => {
+    if (win.isDestroyed()) {
+      return;
+    }
+    event.preventDefault();
+    win.hide();
+    voiceActivityController?.dismiss();
+  });
+
+  track(WINDOW_STATE_KEY, win);
+  panel = win;
+  win.on("closed", () => {
+    panel = null;
+  });
+
+  void win.loadURL(panelUrl());
   return win;
+};
+
+const ensurePanel = (): BrowserWindow => {
+  const existing = panelWindow();
+  if (existing !== null) {
+    return existing;
+  }
+  return createPanel();
 };
 
 /**
  * The live controller, for callers outside the IPC surface.
  *
- * The tray needs to reopen a panel the user closed, and the tray is built long
- * before any session exists, so it reaches the controller through this rather
- * than being handed one at install.
+ * The tray needs to reopen a window the user closed, and the tray is built
+ * long before any session exists, so it reaches the controller through this
+ * rather than being handed one at install.
  */
 let voiceActivityController: VoiceActivityController | null = null;
 
@@ -315,10 +346,10 @@ export const isVoiceActivityRunning = (): boolean =>
   voiceActivityController?.currentState() != null;
 
 /**
- * Show the panel again for a session already running.
+ * Show the window again for a session already running.
  *
- * The way back from the close button. Without one, closing the panel would
- * leave a live microphone with no floating control until the call ended.
+ * The way back from the red button, which hides the window without ending the
+ * call.
  */
 export const reopenVoiceActivityPanel = (): void => {
   voiceActivityController?.reopen();
@@ -334,7 +365,12 @@ export const installVoiceActivityWindow = (): void => {
 
   const controller = createVoiceActivityController({
     showPanel: () => {
-      ensurePanel();
+      const win = ensurePanel();
+      // `showInactive` rather than `show`: the window appears because the user
+      // left the app, so it must not pull them back into it.
+      if (!win.isVisible()) {
+        win.showInactive();
+      }
     },
     hidePanel: () => {
       const win = panelWindow();

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -12,6 +12,7 @@ import {
 } from "@vellumai/ipc-contract";
 
 import { createFloatingWindow, getFloatingWindow } from "./floating-window";
+import { ensureVisible as ensureMainWindowVisible } from "./main-window";
 import { handle, on } from "./ipc";
 import { restoreBounds, track } from "./window-state";
 
@@ -55,6 +56,9 @@ const PANEL_HEIGHT = 96;
 
 /** Gap from the work area's top-right corner on the first ever launch. */
 const DEFAULT_MARGIN = 16;
+
+/** Roughly one frame at 60Hz, the rate a hand-driven drag is repositioned at. */
+const DRAG_FRAME_MS = 16;
 
 // ---------------------------------------------------------------------------
 // Session state machine
@@ -193,6 +197,54 @@ export const openingPosition = (): { x: number; y: number } => {
   return { x: saved.x, y: saved.y };
 };
 
+/**
+ * Cursor-follow drag.
+ *
+ * The panel is moved by hand rather than by `-webkit-app-region: drag`,
+ * because a drag region swallows clicks outright and this surface needs the
+ * same pixels to answer two gestures: a press means "bring the app forward",
+ * a hold means "move me". The page decides which one happened and calls in.
+ *
+ * Main follows the cursor rather than applying deltas the page sends, so the
+ * window keeps up with a fast drag: per-move IPC would put a round trip in
+ * front of every frame, and the panel would lag behind the pointer.
+ */
+let dragTimer: NodeJS.Timeout | null = null;
+
+const endDrag = (): void => {
+  if (dragTimer !== null) {
+    clearInterval(dragTimer);
+    dragTimer = null;
+  }
+};
+
+const beginDrag = (): void => {
+  const win = panelWindow();
+  if (win === null) {
+    return;
+  }
+  const cursor = screen.getCursorScreenPoint();
+  const [windowX, windowY] = win.getPosition();
+  // Where in the panel the pointer grabbed it, so the window travels with the
+  // cursor instead of snapping its corner to it.
+  const offsetX = cursor.x - windowX;
+  const offsetY = cursor.y - windowY;
+
+  endDrag();
+  dragTimer = setInterval(() => {
+    const dragging = panelWindow();
+    // The pointer can leave the panel mid-drag, and a page that is torn down
+    // between press and release never sends its `endDrag`. Both would leave
+    // this running, so the window's own absence ends it.
+    if (dragging === null || !dragging.isVisible()) {
+      endDrag();
+      return;
+    }
+    const point = screen.getCursorScreenPoint();
+    dragging.setPosition(point.x - offsetX, point.y - offsetY);
+  }, DRAG_FRAME_MS);
+};
+
 /** Whether the geometry tracker has been bound to the current panel window. */
 let tracked = false;
 
@@ -213,8 +265,8 @@ const ensurePanel = (): BrowserWindow => {
     alwaysOnTopLevel: "floating",
     browserWindow: {
       // Repositionable, which is the whole reason geometry is persisted. The
-      // drag itself comes from the route's `-webkit-app-region: drag`; this
-      // only permits it.
+      // drag itself is driven by hand from the route (see `beginDrag`); this
+      // only permits the window to move.
       movable: true,
       minimizable: false,
       maximizable: false,
@@ -228,6 +280,15 @@ const ensurePanel = (): BrowserWindow => {
       // first press, and "click once to wake it, again to mean it" is the
       // whole interaction. The user aimed at Mute; the click is not stray.
       acceptFirstMouse: true,
+      // The panel never takes key status, so it never activates the app. That
+      // is what stops a press on it from flickering the menu bar to Vellum
+      // while leaving every real window behind, and it keeps app activation
+      // meaning what the visibility gate reads it as: a real window came
+      // forward. Clicking the panel still reaches the page, and foregrounding
+      // is now something a click asks for explicitly rather than a side
+      // effect of touching the surface. The dictation overlay is non-focusable
+      // for the same reason and keeps a working control.
+      focusable: false,
       // The glass. `under-window` samples what is behind the panel, which for
       // a surface floating over *other apps* is the material that reads as
       // glass rather than as a tinted rectangle. `active` keeps it live while
@@ -404,6 +465,22 @@ export const installVoiceActivityWindow = (): void => {
       }
     },
   );
+
+  on("vellum:voiceActivity:beginDrag", z.tuple([]), () => {
+    beginDrag();
+  });
+
+  on("vellum:voiceActivity:endDrag", z.tuple([]), () => {
+    endDrag();
+  });
+
+  on("vellum:voiceActivity:activate", z.tuple([]), () => {
+    // A press on the panel is a request to go back to the app, the desktop
+    // reading of the island's tap-through. Raising the main window focuses it,
+    // which the visibility gate sees as a real window coming forward, so the
+    // panel stands down on its own without this having to hide it.
+    void ensureMainWindowVisible();
+  });
 
   // The panel route loads lazily, so states pushed before its subscription
   // registers are dropped by Electron. It pulls this once subscribed.

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -16,7 +16,7 @@ import { handle, on } from "./ipc";
 import { restoreBounds, track } from "./window-state";
 
 /**
- * The floating live-voice session surface — the desktop counterpart to the iOS
+ * The floating live-voice session surface: the desktop counterpart to the iOS
  * Dynamic Island and Lock Screen activity.
  *
  * A small always-on-top panel carrying what those carry: the assistant's
@@ -28,14 +28,14 @@ import { restoreBounds, track } from "./window-state";
  * **The panel is its own renderer**, so it does not share the main window's
  * live-voice store. State flows main-window renderer → here → panel renderer,
  * which is why the payload is a flat serializable snapshot rather than a store
- * subscription — the same shape the iOS bridge sends, for the same reason.
+ * subscription. It is the same shape the iOS bridge sends, for the same reason.
  * `dictation-overlay-window.ts` is the closest sibling; this differs in living
  * for the length of a call rather than a few seconds, which is what earns it a
  * remembered position and a vibrancy material rather than a fixed HUD slot.
  *
  * **It shows only while Vellum is not frontmost.** The app already renders
- * exactly one control for a live session — the voice room, the composer's
- * voice bar, or the pill (see `voice-session-pill-host.tsx`) — so a panel on
+ * exactly one control for a live session (the voice room, the composer's
+ * voice bar, or the pill; see `voice-session-pill-host.tsx`), so a panel on
  * top of that would be a second control for the same session. Not-frontmost is
  * the desktop reading of the state an island exists for.
  */
@@ -64,7 +64,7 @@ export type VoiceActivityDeps = {
   hidePanel: () => void;
   sendState: (state: VoiceActivityState | null) => void;
   /**
-   * Whether Vellum is the frontmost app — the gate the whole surface turns on.
+   * Whether Vellum is the frontmost app: the gate the whole surface turns on.
    * Injected rather than read here so the visibility rules are testable
    * without a window server.
    */
@@ -84,7 +84,7 @@ export type VoiceActivityController = {
 
 /**
  * Session lifecycle and visibility, separated from the window plumbing so the
- * rules are unit-testable — the same deps-injection shape as
+ * rules are unit-testable, the same deps-injection shape as
  * `createDictationOverlayController`.
  *
  * Two pieces of state, deliberately independent: whether a session exists at
@@ -109,7 +109,7 @@ export const createVoiceActivityController = (
     // A redundant start updates the running session rather than restarting its
     // clock. The mirror re-syncs on mount and the session controller remounts
     // across layout-level route changes while the store persists, so a second
-    // start for a session already on screen is expected traffic — not a new
+    // start for a session already on screen is expected traffic, not a new
     // call, and an elapsed timer that jumped back to zero on a route change
     // would be a visible lie about a session that never stopped.
     session =
@@ -175,7 +175,7 @@ const defaultPosition = (): { x: number; y: number } => {
  *
  * Only the origin is taken from the saved state. `restoreBounds` also returns
  * a size, and honoring it would let one launch's dimensions outlive a change
- * to `PANEL_WIDTH` / `PANEL_HEIGHT` — the panel is not resizable, so its size
+ * to `PANEL_WIDTH` / `PANEL_HEIGHT`. The panel is not resizable, so its size
  * is the build's to decide and only its placement is the user's. The saved
  * origin is still clamped into a connected display's work area by
  * `restoreBounds`, so a monitor unplugged between sessions cannot strand it
@@ -203,7 +203,7 @@ const ensurePanel = (): BrowserWindow => {
     height: PANEL_HEIGHT,
     // Never steals focus from whatever the user is actually doing. `panel` is
     // a non-activating panel on macOS, so the controls can be clicked without
-    // bringing Vellum forward — which for this surface is the entire point.
+    // bringing Vellum forward, which for this surface is the entire point.
     focusOnShow: false,
     // Above ordinary windows, below the system's own overlays. The dictation
     // HUD reaches for `screen-saver` because it is transient and modal in
@@ -220,7 +220,7 @@ const ensurePanel = (): BrowserWindow => {
       hasShadow: true,
       // **Without this, every control on this panel is dead on first press.**
       // macOS defaults to swallowing the click that activates an inactive
-      // window, delivering only the second one to its content — a rule that
+      // window, delivering only the second one to its content. That rule
       // exists so a stray click on a background app cannot act on it. This
       // panel is the exception the rule was not written for: it is *only ever*
       // on screen while the app is inactive, so every press it receives is a
@@ -230,14 +230,14 @@ const ensurePanel = (): BrowserWindow => {
       // The glass. `under-window` samples what is behind the panel, which for
       // a surface floating over *other apps* is the material that reads as
       // glass rather than as a tinted rectangle. `active` keeps it live while
-      // Vellum is in the background — which, for this panel, is always.
+      // Vellum is in the background, which for this panel is always.
       vibrancy: "under-window",
       visualEffectState: "active",
       roundedCorners: true,
     },
     // Only on creation. Re-applying on every show would drag the panel back to
-    // its saved corner mid-session, undoing a move the user made minutes ago
-    // — the position is persisted precisely so it survives.
+    // its saved corner mid-session, undoing a move the user made minutes ago.
+    // The position is persisted precisely so it survives.
     position: panelWindow() === null ? openingPosition() : undefined,
   });
 
@@ -265,17 +265,26 @@ const ensurePanel = (): BrowserWindow => {
  * for the rest of the session, and the panel never went away.
  *
  * `did-become-active` / `did-resign-active` describe the *application*, so
- * they need no such exclusion — the panel being non-activating means clicking
+ * they need no such exclusion: the panel being non-activating means clicking
  * it does not activate the app, and therefore does not fire either event.
  * The behavior the exclusion was hand-rolling is what these give for free.
+ *
+ * Seeded in `installVoiceActivityWindow` rather than here. The seed reads an
+ * Electron API, and a module scope that calls one runs it at import time,
+ * before `app.whenReady()` and before any test has a chance to say what it
+ * should return.
  */
-let appFrontmost = BrowserWindow.getFocusedWindow() !== null;
+let appFrontmost = false;
 
 let installed = false;
 
 export const installVoiceActivityWindow = (): void => {
   if (installed) return;
   installed = true;
+
+  // Install runs after `app.whenReady()`, so a focused window here means the
+  // app is active. The two activation events correct it from then on.
+  appFrontmost = BrowserWindow.getFocusedWindow() !== null;
 
   const controller = createVoiceActivityController({
     showPanel: () => {
@@ -342,7 +351,7 @@ export const installVoiceActivityWindow = (): void => {
   );
 
   // The panel route loads lazily, so states pushed before its subscription
-  // registers are dropped by Electron — it pulls this once subscribed.
+  // registers are dropped by Electron. It pulls this once subscribed.
   handle("vellum:voiceActivity:getState", z.tuple([]), () =>
     controller.currentState(),
   );

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -218,6 +218,15 @@ const ensurePanel = (): BrowserWindow => {
       minimizable: false,
       maximizable: false,
       hasShadow: true,
+      // **Without this, every control on this panel is dead on first press.**
+      // macOS defaults to swallowing the click that activates an inactive
+      // window, delivering only the second one to its content — a rule that
+      // exists so a stray click on a background app cannot act on it. This
+      // panel is the exception the rule was not written for: it is *only ever*
+      // on screen while the app is inactive, so every press it receives is a
+      // first press, and "click once to wake it, again to mean it" is the
+      // whole interaction. The user aimed at Mute; the click is not stray.
+      acceptFirstMouse: true,
       // The glass. `under-window` samples what is behind the panel, which for
       // a surface floating over *other apps* is the material that reads as
       // glass rather than as a tinted rectangle. `active` keeps it live while
@@ -244,20 +253,23 @@ const ensurePanel = (): BrowserWindow => {
 };
 
 /**
- * Whether Vellum is the frontmost app.
+ * Whether Vellum is the frontmost app, tracked from the two macOS events that
+ * mean exactly that.
  *
- * The panel is deliberately not counted. It is a non-activating panel, so
- * clicking it does not make Vellum frontmost in the first place — but it can
- * still take key focus, and treating that as "the app is frontmost" would hide
- * the surface the moment the user reached for it.
+ * **Not derived from `BrowserWindow.getFocusedWindow()`.** That reports which
+ * window holds *key* status, which is a different question, and for this
+ * surface it answers wrongly in the one case that matters: the panel is an
+ * always-on-top non-activating `NSPanel`, so it can keep key status while the
+ * user brings the main window to the front. A frontmost check that excluded
+ * the panel to avoid hiding on its own clicks then reported "not frontmost"
+ * for the rest of the session, and the panel never went away.
+ *
+ * `did-become-active` / `did-resign-active` describe the *application*, so
+ * they need no such exclusion — the panel being non-activating means clicking
+ * it does not activate the app, and therefore does not fire either event.
+ * The behavior the exclusion was hand-rolling is what these give for free.
  */
-const isAppFrontmost = (): boolean => {
-  const focused = BrowserWindow.getFocusedWindow();
-  if (focused === null || focused.isDestroyed()) {
-    return false;
-  }
-  return focused !== panelWindow();
-};
+let appFrontmost = BrowserWindow.getFocusedWindow() !== null;
 
 let installed = false;
 
@@ -278,28 +290,9 @@ export const installVoiceActivityWindow = (): void => {
     sendState: (state) => {
       panelWindow()?.webContents.send("vellum:voiceActivity:state", state);
     },
-    isAppFrontmost,
+    isAppFrontmost: () => appFrontmost,
     now: () => Date.now(),
   });
-
-  /**
-   * Focus changes are reconciled on the next tick rather than inline.
-   *
-   * Moving between two Vellum windows fires `browser-window-blur` for the one
-   * being left before `browser-window-focus` for the one being entered, so a
-   * synchronous read of `getFocusedWindow()` inside that gap says "no Vellum
-   * window has focus" and the panel would flash into view mid-switch.
-   */
-  let reconcileTimer: NodeJS.Timeout | null = null;
-  const scheduleReconcile = (): void => {
-    if (reconcileTimer !== null) {
-      return;
-    }
-    reconcileTimer = setTimeout(() => {
-      reconcileTimer = null;
-      controller.focusChanged();
-    }, 0);
-  };
 
   on(
     "vellum:voiceActivity:start",
@@ -354,6 +347,15 @@ export const installVoiceActivityWindow = (): void => {
     controller.currentState(),
   );
 
-  app.on("browser-window-focus", scheduleReconcile);
-  app.on("browser-window-blur", scheduleReconcile);
+  // No debounce and no deferral: unlike per-window focus events, these fire
+  // once per actual application activation, so there is no blur/focus gap to
+  // ride out and nothing to coalesce.
+  app.on("did-become-active", () => {
+    appFrontmost = true;
+    controller.focusChanged();
+  });
+  app.on("did-resign-active", () => {
+    appFrontmost = false;
+    controller.focusChanged();
+  });
 };

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -303,6 +303,16 @@ const createPanel = (): BrowserWindow => {
       // a surface floating over *other apps* reads as glass rather than as a
       // tinted rectangle. `active` keeps it live while Vellum is in the
       // background, which is most of this window's life.
+      //
+      // The material is an NSVisualEffectView *behind* the web contents, so it
+      // is only ever as visible as those contents are transparent. Electron
+      // backs a window with an opaque colour by default, which hides it
+      // completely. `quick-input-window.ts` gets there through `transparent`,
+      // which this window cannot use without giving up its traffic lights, so
+      // it takes the command palette's route instead: a zero-alpha backing
+      // colour. The page then paints no background of its own, because the
+      // material is the background.
+      backgroundColor: "#00000000",
       vibrancy: "under-window",
       visualEffectState: "active",
       roundedCorners: true,

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -52,7 +52,17 @@ const WINDOW_STATE_KEY = "voice-activity";
 // for, because a window the user positions themselves is allowed the system's
 // own shadow (`hasShadow`).
 const PANEL_WIDTH = 320;
-const PANEL_HEIGHT = 124;
+
+// Two heights, because the activity line is usually absent. A window sized for
+// its tallest possible content spends most of a call showing a hole where that
+// line would be, which is what the first build looked like.
+const PANEL_HEIGHT = 96;
+const PANEL_HEIGHT_WITH_DETAIL = 116;
+
+const heightFor = (state: VoiceActivityState | null): number =>
+  state !== null && state.detail !== ""
+    ? PANEL_HEIGHT_WITH_DETAIL
+    : PANEL_HEIGHT;
 
 // The collapsed chip: identity, phase and elapsed time, which is what survives
 // when the panel is shrunk out of the way. Roughly the island's minimal
@@ -394,7 +404,22 @@ export const installVoiceActivityWindow = (): void => {
       });
     },
     sendState: (state) => {
-      panelWindow()?.webContents.send("vellum:voiceActivity:state", state);
+      const win = panelWindow();
+      if (win === null) {
+        return;
+      }
+      // Sized to the content before the content arrives, so the activity line
+      // never paints into a window too short for it, and its absence never
+      // leaves an empty strip. Collapsed windows keep the chip's height.
+      const current = state?.collapsed === true ? null : heightFor(state);
+      if (current !== null) {
+        const [x, y] = win.getPosition();
+        const [, height] = win.getSize();
+        if (height !== current) {
+          win.setBounds({ x, y, width: PANEL_WIDTH, height: current });
+        }
+      }
+      win.webContents.send("vellum:voiceActivity:state", state);
     },
     now: () => Date.now(),
   });

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -35,19 +35,23 @@ import { restoreBounds, track } from "./window-state";
  * for the length of a call rather than a few seconds, which is what earns it a
  * remembered position and a vibrancy material rather than a fixed HUD slot.
  *
- * **It shows only while Vellum is not frontmost.** The app already renders
- * exactly one control for a live session (the voice room, the composer's
- * voice bar, or the pill; see `voice-session-pill-host.tsx`), so a panel on
- * top of that would be a second control for the same session. Not-frontmost is
- * the desktop reading of the state an island exists for.
+ * **It shows for as long as the session runs, and the user decides when it
+ * goes.** An earlier build hid it whenever Vellum came forward, reasoning that
+ * the app already renders exactly one control for a live session (the voice
+ * room, the composer's voice bar, or the pill; see
+ * `voice-session-pill-host.tsx`). That rule cannot survive the window this
+ * became: a real window with live traffic lights activates the app when it is
+ * clicked, so every press on the panel was a press that hid it. A window the
+ * user placed and can close is the simpler contract, and the tray is the way
+ * back.
  */
 
 const PANEL_PATH = "/floating/voice-activity";
 const WINDOW_STATE_KEY = "voice-activity";
 
 // Wide enough for the assistant's name beside its phase, short enough to sit
-// in a screen corner without covering work. The height carries three rows:
-// identity and phase, the turn's activity line, and the controls. The canvas
+// in a screen corner without covering work. The height carries the title bar's
+// identity, the phase row, and the controls. The canvas
 // is the panel: unlike the dictation HUD there is no CSS shadow to leave room
 // for, because a window the user positions themselves is allowed the system's
 // own shadow (`hasShadow`).
@@ -291,8 +295,8 @@ const createPanel = (): BrowserWindow => {
       movable: true,
       show: false,
       hasShadow: true,
-      // Focusable, unlike the panel this replaces: traffic lights on a window
-      // that cannot take key status are drawn inert.
+      // Focusable: traffic lights on a window that cannot take key status are
+      // drawn inert.
       focusable: true,
       acceptFirstMouse: true,
       // The glass. `under-window` samples what is behind the window, which for
@@ -376,8 +380,9 @@ export const installVoiceActivityWindow = (): void => {
   const controller = createVoiceActivityController({
     showPanel: () => {
       const win = ensurePanel();
-      // `showInactive` rather than `show`: the window appears because the user
-      // left the app, so it must not pull them back into it.
+      // `showInactive` rather than `show`: the window appears because a
+      // session started, which is not a reason to take focus away from
+      // whatever the user is doing.
       if (!win.isVisible()) {
         win.showInactive();
       }
@@ -482,10 +487,10 @@ export const installVoiceActivityWindow = (): void => {
   });
 
   on("vellum:voiceActivity:activate", z.tuple([]), () => {
-    // A press on the panel is a request to go back to the app, the desktop
-    // reading of the island's tap-through. Raising the main window focuses it,
-    // which the visibility gate sees as a real window coming forward, so the
-    // panel stands down on its own without this having to hide it.
+    // The return button is a request to go back to the app, the desktop
+    // reading of the island's tap-through. The panel stays up behind it: it
+    // belongs to the session rather than to the app's backgrounded-ness, and
+    // the red button is how the user puts it away.
     void ensureMainWindowVisible();
   });
 

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -269,12 +269,41 @@ const ensurePanel = (): BrowserWindow => {
  * it does not activate the app, and therefore does not fire either event.
  * The behavior the exclusion was hand-rolling is what these give for free.
  *
- * Seeded in `installVoiceActivityWindow` rather than here. The seed reads an
- * Electron API, and a module scope that calls one runs it at import time,
- * before `app.whenReady()` and before any test has a chance to say what it
- * should return.
+ * **Until the first of those events lands there is nothing to report**, and
+ * the honest answer then is whatever the window server says right now. A
+ * launch that macOS activated before this module was installed has already
+ * missed its `did-become-active`, and nothing else will fire until the user
+ * switches away and back, so a tracker that assumed "not frontmost" would open
+ * the panel over a focused app for the whole first session. Asking at the
+ * moment the question is put is what makes this independent of where in the
+ * startup sequence the install happens to sit, and of whether a window existed
+ * when it did.
+ *
+ * Injected rather than read directly so the fallback has a seam to be tested
+ * through, which the sequencing bug this replaces went unnoticed for want of.
  */
-let appFrontmost = false;
+export const createFrontmostTracker = (
+  anyWindowFocused: () => boolean,
+): {
+  isFrontmost: () => boolean;
+  becameActive: () => void;
+  resignedActive: () => void;
+} => {
+  let observed = false;
+  let frontmost = false;
+
+  return {
+    isFrontmost: () => (observed ? frontmost : anyWindowFocused()),
+    becameActive: () => {
+      observed = true;
+      frontmost = true;
+    },
+    resignedActive: () => {
+      observed = true;
+      frontmost = false;
+    },
+  };
+};
 
 let installed = false;
 
@@ -284,9 +313,9 @@ export const installVoiceActivityWindow = (): void => {
   }
   installed = true;
 
-  // Install runs after `app.whenReady()`, so a focused window here means the
-  // app is active. The two activation events correct it from then on.
-  appFrontmost = BrowserWindow.getFocusedWindow() !== null;
+  const frontmost = createFrontmostTracker(
+    () => BrowserWindow.getFocusedWindow() !== null,
+  );
 
   const controller = createVoiceActivityController({
     showPanel: () => {
@@ -301,7 +330,7 @@ export const installVoiceActivityWindow = (): void => {
     sendState: (state) => {
       panelWindow()?.webContents.send("vellum:voiceActivity:state", state);
     },
-    isAppFrontmost: () => appFrontmost,
+    isAppFrontmost: frontmost.isFrontmost,
     now: () => Date.now(),
   });
 
@@ -362,11 +391,11 @@ export const installVoiceActivityWindow = (): void => {
   // once per actual application activation, so there is no blur/focus gap to
   // ride out and nothing to coalesce.
   app.on("did-become-active", () => {
-    appFrontmost = true;
+    frontmost.becameActive();
     controller.focusChanged();
   });
   app.on("did-resign-active", () => {
-    appFrontmost = false;
+    frontmost.resignedActive();
     controller.focusChanged();
   });
 };

--- a/clients/macos/src/main/voice-activity-window.ts
+++ b/clients/macos/src/main/voice-activity-window.ts
@@ -51,14 +51,17 @@ const WINDOW_STATE_KEY = "voice-activity";
 // is the panel: unlike the dictation HUD there is no CSS shadow to leave room
 // for, because a window the user positions themselves is allowed the system's
 // own shadow (`hasShadow`).
-const PANEL_WIDTH = 300;
-const PANEL_HEIGHT = 96;
+const PANEL_WIDTH = 320;
+const PANEL_HEIGHT = 124;
+
+// The collapsed chip: identity, phase and elapsed time, which is what survives
+// when the panel is shrunk out of the way. Roughly the island's minimal
+// presentation, and the reason minimize is not just a second close.
+const CHIP_WIDTH = 168;
+const CHIP_HEIGHT = 36;
 
 /** Gap from the work area's top-right corner on the first ever launch. */
 const DEFAULT_MARGIN = 16;
-
-/** Roughly one frame at 60Hz, the rate a hand-driven drag is repositioned at. */
-const DRAG_FRAME_MS = 16;
 
 // ---------------------------------------------------------------------------
 // Session state machine
@@ -67,13 +70,9 @@ const DRAG_FRAME_MS = 16;
 export type VoiceActivityDeps = {
   showPanel: () => void;
   hidePanel: () => void;
+  /** Resize the window between its expanded and collapsed shapes. */
+  setCollapsed: (collapsed: boolean) => void;
   sendState: (state: VoiceActivityState | null) => void;
-  /**
-   * Whether Vellum is the frontmost app: the gate the whole surface turns on.
-   * Injected rather than read here so the visibility rules are testable
-   * without a window server.
-   */
-  isAppFrontmost: () => boolean;
   now: () => number;
 };
 
@@ -81,29 +80,40 @@ export type VoiceActivityController = {
   start: (start: VoiceActivityStart) => void;
   update: (content: VoiceActivityContent) => void;
   end: () => void;
-  /** Re-evaluate visibility after the app's frontmost-ness may have changed. */
-  focusChanged: () => void;
+  /** Hide the window. The session keeps running. */
+  dismiss: () => void;
+  /** Show it again for the session already running. */
+  reopen: () => void;
+  setCollapsed: (collapsed: boolean) => void;
   /** The snapshot the panel renders, or `null` when no session is running. */
   currentState: () => VoiceActivityState | null;
 };
 
 /**
- * Session lifecycle and visibility, separated from the window plumbing so the
- * rules are unit-testable, the same deps-injection shape as
+ * Session lifecycle and window state, separated from the window plumbing so
+ * the rules are unit-testable, the same deps-injection shape as
  * `createDictationOverlayController`.
  *
- * Two pieces of state, deliberately independent: whether a session exists at
- * all, and whether the app is frontmost. The panel is on screen only when the
- * first is true and the second is false, and every entry point routes through
- * one reconcile so the two can never disagree about what is showing.
+ * **The window is the user's, and the session is the app's.** Closing the
+ * window hides a readout; it never ends a call, because the thing a user
+ * reaches for when a panel is in their way is the close button, and a close
+ * button that hung up would be a trap. The two pieces of state are therefore
+ * independent: whether a session exists, and whether the user wants to see it.
+ *
+ * Dismissal lasts only as long as the session it was aimed at. A closed panel
+ * means a live microphone with no floating control, which is the state this
+ * surface exists to prevent, so `start` clears it and the next call opens a
+ * fresh window rather than silently inheriting a preference the user set once
+ * and forgot.
  */
 export const createVoiceActivityController = (
   deps: VoiceActivityDeps,
 ): VoiceActivityController => {
   let session: VoiceActivityState | null = null;
+  let dismissed = false;
 
   const reconcile = (): void => {
-    if (session === null || deps.isAppFrontmost()) {
+    if (session === null || dismissed) {
       deps.hidePanel();
       return;
     }
@@ -111,6 +121,7 @@ export const createVoiceActivityController = (
   };
 
   const start = (start: VoiceActivityStart): void => {
+    const fresh = session === null;
     // A redundant start updates the running session rather than restarting its
     // clock. The mirror re-syncs on mount and the session controller remounts
     // across layout-level route changes while the store persists, so a second
@@ -119,8 +130,13 @@ export const createVoiceActivityController = (
     // would be a visible lie about a session that never stopped.
     session =
       session === null
-        ? { ...start, startedAt: deps.now() }
+        ? { ...start, startedAt: deps.now(), collapsed: false }
         : { ...session, ...start };
+    // Only a genuinely new call reopens a closed panel. A remount is not the
+    // user changing their mind.
+    if (fresh) {
+      dismissed = false;
+    }
     reconcile();
     deps.sendState(session);
   };
@@ -145,11 +161,30 @@ export const createVoiceActivityController = (
     reconcile();
   };
 
+  const setCollapsed = (collapsed: boolean): void => {
+    if (session === null || session.collapsed === collapsed) {
+      return;
+    }
+    session = { ...session, collapsed };
+    // The window resizes before the page is told, so the chip is never drawn
+    // into a window still the size of the expanded panel.
+    deps.setCollapsed(collapsed);
+    deps.sendState(session);
+  };
+
   return {
     start,
     update,
     end,
-    focusChanged: reconcile,
+    dismiss: () => {
+      dismissed = true;
+      reconcile();
+    },
+    reopen: () => {
+      dismissed = false;
+      reconcile();
+    },
+    setCollapsed,
     currentState: () => session,
   };
 };
@@ -197,54 +232,6 @@ export const openingPosition = (): { x: number; y: number } => {
   return { x: saved.x, y: saved.y };
 };
 
-/**
- * Cursor-follow drag.
- *
- * The panel is moved by hand rather than by `-webkit-app-region: drag`,
- * because a drag region swallows clicks outright and this surface needs the
- * same pixels to answer two gestures: a press means "bring the app forward",
- * a hold means "move me". The page decides which one happened and calls in.
- *
- * Main follows the cursor rather than applying deltas the page sends, so the
- * window keeps up with a fast drag: per-move IPC would put a round trip in
- * front of every frame, and the panel would lag behind the pointer.
- */
-let dragTimer: NodeJS.Timeout | null = null;
-
-const endDrag = (): void => {
-  if (dragTimer !== null) {
-    clearInterval(dragTimer);
-    dragTimer = null;
-  }
-};
-
-const beginDrag = (): void => {
-  const win = panelWindow();
-  if (win === null) {
-    return;
-  }
-  const cursor = screen.getCursorScreenPoint();
-  const [windowX, windowY] = win.getPosition();
-  // Where in the panel the pointer grabbed it, so the window travels with the
-  // cursor instead of snapping its corner to it.
-  const offsetX = cursor.x - windowX;
-  const offsetY = cursor.y - windowY;
-
-  endDrag();
-  dragTimer = setInterval(() => {
-    const dragging = panelWindow();
-    // The pointer can leave the panel mid-drag, and a page that is torn down
-    // between press and release never sends its `endDrag`. Both would leave
-    // this running, so the window's own absence ends it.
-    if (dragging === null || !dragging.isVisible()) {
-      endDrag();
-      return;
-    }
-    const point = screen.getCursorScreenPoint();
-    dragging.setPosition(point.x - offsetX, point.y - offsetY);
-  }, DRAG_FRAME_MS);
-};
-
 /** Whether the geometry tracker has been bound to the current panel window. */
 let tracked = false;
 
@@ -265,7 +252,7 @@ const ensurePanel = (): BrowserWindow => {
     alwaysOnTopLevel: "floating",
     browserWindow: {
       // Repositionable, which is the whole reason geometry is persisted. The
-      // drag itself is driven by hand from the route (see `beginDrag`); this
+      // drag itself comes from the route's `-webkit-app-region: drag`; this
       // only permits the window to move.
       movable: true,
       minimizable: false,
@@ -315,73 +302,26 @@ const ensurePanel = (): BrowserWindow => {
 };
 
 /**
- * Whether **a window other than the panel** is frontmost, which is the real
- * question this surface turns on.
+ * The live controller, for callers outside the IPC surface.
  *
- * Three signals, because no single one answers it:
- *
- * - `did-resign-active`: the app went to the background. Definitive.
- * - `browser-window-focus` on anything but the panel: a real window of the app
- *   took focus, so the session has an on-screen control again.
- * - `did-become-active`: the app came forward, but *only counts when the panel
- *   is not the key window*. Clicking the panel activates the app despite its
- *   non-activating window type, and treating that as "frontmost" hid the panel
- *   the instant the user touched it, including on a drag of its own header.
- *
- * The app-level pair alone is not enough, and neither is window focus alone.
- * Ignoring a panel-driven `did-become-active` leaves the app active with the
- * panel still up, and macOS fires no second activation when focus then moves
- * to the main window, so without the focus signal the panel would never hide
- * again. Focus events alone were the original bug: the panel is an
- * always-on-top `NSPanel` and keeps key status when the main window comes
- * forward, so a focus-derived check reported "not frontmost" for the rest of
- * the session.
- *
- * **Until one of those lands there is nothing to report**, and the honest
- * answer then is whatever the window server says right now. A launch macOS
- * activated before this module was installed has already missed its
- * `did-become-active`, and nothing fires again until the user switches away
- * and back, so a tracker that assumed "not frontmost" would open the panel
- * over a focused app for the whole first session.
- *
- * Injected rather than read directly so the fallback has a seam to be tested
- * through, which the sequencing bug that needed it went unnoticed for want of.
+ * The tray needs to reopen a panel the user closed, and the tray is built long
+ * before any session exists, so it reaches the controller through this rather
+ * than being handed one at install.
  */
-export const createFrontmostTracker = (
-  anyOtherWindowFocused: () => boolean,
-): {
-  isFrontmost: () => boolean;
-  becameActive: (panelHasKey: boolean) => void;
-  resignedActive: () => void;
-  windowFocused: (isPanel: boolean) => void;
-} => {
-  let observed = false;
-  let frontmost = false;
+let voiceActivityController: VoiceActivityController | null = null;
 
-  return {
-    isFrontmost: () => (observed ? frontmost : anyOtherWindowFocused()),
-    becameActive: (panelHasKey) => {
-      // A panel-driven activation says nothing about the rest of the app, so
-      // it is not allowed to answer the question either way: recording it
-      // would latch a value the next real focus change may never correct.
-      if (panelHasKey) {
-        return;
-      }
-      observed = true;
-      frontmost = true;
-    },
-    resignedActive: () => {
-      observed = true;
-      frontmost = false;
-    },
-    windowFocused: (isPanel) => {
-      if (isPanel) {
-        return;
-      }
-      observed = true;
-      frontmost = true;
-    },
-  };
+/** Whether a session is running, which is when reopening means anything. */
+export const isVoiceActivityRunning = (): boolean =>
+  voiceActivityController?.currentState() != null;
+
+/**
+ * Show the panel again for a session already running.
+ *
+ * The way back from the close button. Without one, closing the panel would
+ * leave a live microphone with no floating control until the call ended.
+ */
+export const reopenVoiceActivityPanel = (): void => {
+  voiceActivityController?.reopen();
 };
 
 let installed = false;
@@ -391,16 +331,6 @@ export const installVoiceActivityWindow = (): void => {
     return;
   }
   installed = true;
-
-  const panelHasKey = (): boolean => {
-    const focused = BrowserWindow.getFocusedWindow();
-    return focused !== null && focused === panelWindow();
-  };
-
-  const frontmost = createFrontmostTracker(() => {
-    const focused = BrowserWindow.getFocusedWindow();
-    return focused !== null && focused !== panelWindow();
-  });
 
   const controller = createVoiceActivityController({
     showPanel: () => {
@@ -412,12 +342,28 @@ export const installVoiceActivityWindow = (): void => {
         win.hide();
       }
     },
+    setCollapsed: (collapsed) => {
+      const win = panelWindow();
+      if (win === null) {
+        return;
+      }
+      // Anchored top-left, so a panel the user parked against the right edge
+      // of a display does not walk left every time it is collapsed.
+      const [x, y] = win.getPosition();
+      win.setBounds({
+        x,
+        y,
+        width: collapsed ? CHIP_WIDTH : PANEL_WIDTH,
+        height: collapsed ? CHIP_HEIGHT : PANEL_HEIGHT,
+      });
+    },
     sendState: (state) => {
       panelWindow()?.webContents.send("vellum:voiceActivity:state", state);
     },
-    isAppFrontmost: frontmost.isFrontmost,
     now: () => Date.now(),
   });
+
+  voiceActivityController = controller;
 
   on(
     "vellum:voiceActivity:start",
@@ -466,12 +412,12 @@ export const installVoiceActivityWindow = (): void => {
     },
   );
 
-  on("vellum:voiceActivity:beginDrag", z.tuple([]), () => {
-    beginDrag();
+  on("vellum:voiceActivity:dismiss", z.tuple([]), () => {
+    controller.dismiss();
   });
 
-  on("vellum:voiceActivity:endDrag", z.tuple([]), () => {
-    endDrag();
+  on("vellum:voiceActivity:setCollapsed", z.tuple([z.boolean()]), ([next]) => {
+    controller.setCollapsed(next);
   });
 
   on("vellum:voiceActivity:activate", z.tuple([]), () => {
@@ -488,19 +434,4 @@ export const installVoiceActivityWindow = (): void => {
     controller.currentState(),
   );
 
-  // No debounce and no deferral: unlike per-window focus events, these fire
-  // once per actual application activation, so there is no blur/focus gap to
-  // ride out and nothing to coalesce.
-  app.on("did-become-active", () => {
-    frontmost.becameActive(panelHasKey());
-    controller.focusChanged();
-  });
-  app.on("did-resign-active", () => {
-    frontmost.resignedActive();
-    controller.focusChanged();
-  });
-  app.on("browser-window-focus", (_event, win) => {
-    frontmost.windowFocused(win === panelWindow());
-    controller.focusChanged();
-  });
 };

--- a/clients/macos/src/main/windows.ts
+++ b/clients/macos/src/main/windows.ts
@@ -78,7 +78,7 @@ export interface CreateWindowOptions {
    * a battery win.
    *
    * Lives here rather than at the call site because `webPreferences` is the
-   * seam's to own — see {@link hardenedWebPreferences}. Off by default: every
+   * seam's to own (see {@link hardenedWebPreferences}). Off by default: every
    * other window should keep the battery saving.
    */
   backgroundThrottling?: boolean;

--- a/clients/macos/src/main/windows.ts
+++ b/clients/macos/src/main/windows.ts
@@ -63,6 +63,25 @@ export interface CreateWindowOptions {
    */
   browserWindow: Omit<BrowserWindowConstructorOptions, "webPreferences">;
   navigation: WindowNavigation;
+  /**
+   * Opt this window out of Chromium's background throttling, which otherwise
+   * clamps timers to roughly 1 Hz and suspends animation frames once the
+   * window is occluded or minimized.
+   *
+   * Reserved for windows that host a **live-voice session**, because that is
+   * the one thing the app does whose correctness depends on time passing
+   * normally in a window nobody is looking at: reconnect backoff, the
+   * assistant-audio idle timer behind the `speaking` → `thinking` relabel, and
+   * anything else pacing a real-time stream. Running a session with the app in
+   * the background used to be an odd corner; the floating voice panel makes it
+   * a designed state, so the throttle became a correctness problem rather than
+   * a battery win.
+   *
+   * Lives here rather than at the call site because `webPreferences` is the
+   * seam's to own — see {@link hardenedWebPreferences}. Off by default: every
+   * other window should keep the battery saving.
+   */
+  backgroundThrottling?: boolean;
 }
 
 const applyDenyAllNavigation = (win: BrowserWindow): void => {
@@ -91,6 +110,9 @@ export const createWindow = (opts: CreateWindowOptions): BrowserWindow => {
     webPreferences: {
       preload: preloadPath(),
       ...hardenedWebPreferences(),
+      ...(opts.backgroundThrottling === undefined
+        ? {}
+        : { backgroundThrottling: opts.backgroundThrottling }),
     },
   });
 

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -604,14 +604,14 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:voiceActivity:controlEvent", handler);
       };
     },
-    beginDrag: (): void => {
-      ipcRenderer.send("vellum:voiceActivity:beginDrag");
-    },
-    endDrag: (): void => {
-      ipcRenderer.send("vellum:voiceActivity:endDrag");
-    },
     activate: (): void => {
       ipcRenderer.send("vellum:voiceActivity:activate");
+    },
+    dismiss: (): void => {
+      ipcRenderer.send("vellum:voiceActivity:dismiss");
+    },
+    setCollapsed: (collapsed: boolean): void => {
+      ipcRenderer.send("vellum:voiceActivity:setCollapsed", collapsed);
     },
   },
   popout: {

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -604,6 +604,15 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:voiceActivity:controlEvent", handler);
       };
     },
+    beginDrag: (): void => {
+      ipcRenderer.send("vellum:voiceActivity:beginDrag");
+    },
+    endDrag: (): void => {
+      ipcRenderer.send("vellum:voiceActivity:endDrag");
+    },
+    activate: (): void => {
+      ipcRenderer.send("vellum:voiceActivity:activate");
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -38,6 +38,10 @@ import type {
   UpdateState,
   VellumBridge,
   VellumCommand,
+  VoiceActivityContent,
+  VoiceActivityControl,
+  VoiceActivityStart,
+  VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
 export type {
@@ -557,6 +561,48 @@ const bridge: VellumBridge = {
     },
     setInteractive: (interactive: boolean): void => {
       ipcRenderer.send("vellum:dictationOverlay:setInteractive", interactive);
+    },
+  },
+  voiceActivity: {
+    start: (state: VoiceActivityStart): void => {
+      ipcRenderer.send("vellum:voiceActivity:start", state);
+    },
+    update: (content: VoiceActivityContent): void => {
+      ipcRenderer.send("vellum:voiceActivity:update", content);
+    },
+    end: (): void => {
+      ipcRenderer.send("vellum:voiceActivity:end");
+    },
+    getState: (): Promise<VoiceActivityState | null> =>
+      ipcRenderer.invoke(
+        "vellum:voiceActivity:getState",
+      ) as Promise<VoiceActivityState | null>,
+    onState: (callback) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: VoiceActivityState | null,
+      ) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:voiceActivity:state", handler);
+      return () => {
+        ipcRenderer.off("vellum:voiceActivity:state", handler);
+      };
+    },
+    control: (control: VoiceActivityControl): void => {
+      ipcRenderer.send("vellum:voiceActivity:control", control);
+    },
+    onControl: (callback) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: VoiceActivityControl,
+      ) => {
+        callback(payload);
+      };
+      ipcRenderer.on("vellum:voiceActivity:controlEvent", handler);
+      return () => {
+        ipcRenderer.off("vellum:voiceActivity:controlEvent", handler);
+      };
     },
   },
   popout: {

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -80,35 +80,36 @@ export function VoiceActivityPanelPage() {
 
   return (
     // The whole panel drags, so the user can move it from anywhere that isn't
-    // a control. A 300×116 surface has no room for a dedicated grip.
+    // a control. A 300×96 surface has no room for a dedicated grip.
     <div
       className="relative flex h-screen w-screen flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={{ ["--voice-accent" as string]: accentColor(state.accentHex) }}
     >
-      <div className="flex min-w-0 items-center gap-2">
+      {/* Identity and state on one line: who is on the call and what the call
+          is doing are read together, and the name alone was a whole row spent
+          on the one fact that never changes. The name gives up its width first
+          (`shrink`), because a truncated name is still recognizable while a
+          truncated phase is not. */}
+      <div className="flex min-w-0 items-center gap-1.5">
         <Identity
           assistantName={state.assistantName}
           avatarBase64={state.avatarBase64}
         />
-        <span className="truncate text-[12px] font-medium text-[var(--content-primary)]">
+        <span className="shrink truncate text-[12px] font-medium text-[var(--content-primary)]">
           {state.assistantName}
+        </span>
+        <PhaseGlyph phase={state.phase} />
+        <span className="min-w-0 shrink-0 truncate text-[11px] text-[var(--content-secondary)]">
+          {state.label}
         </span>
         <Elapsed startedAt={state.startedAt} />
       </div>
 
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <PhaseGlyph phase={state.phase} />
-          <span className="truncate text-[11px] text-[var(--content-secondary)]">
-            {state.label}
-          </span>
-        </div>
-        {state.detail !== "" && (
-          <span className="truncate text-[10px] text-[var(--content-tertiary)]">
-            {state.detail}
-          </span>
-        )}
-      </div>
+      {state.detail !== "" && (
+        <span className="min-w-0 truncate text-[10px] text-[var(--content-tertiary)]">
+          {state.detail}
+        </span>
+      )}
 
       {pendingApproval ? (
         <ApprovalControls requestId={state.approvalRequestId} />

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -114,47 +114,50 @@ export function VoiceActivityPanelPage() {
   }
 
   return (
-    // The surface drags; every control opts out. With the window carrying its
-    // own close and minimize, and a button back to the conversation, dragging
-    // is the only thing left for the background to mean.
+    // The surface drags; every control opts out. The macOS traffic lights are
+    // the window's controls, so the page draws none of its own.
     <div
-      className="relative flex h-screen w-screen flex-col gap-1 overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 pb-2.5 pt-1.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+      className="relative flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={surfaceStyle}
     >
-      {/* No window chrome of its own: the macOS traffic lights are the
-          window's controls. Red hides it without ending the call, yellow
-          minimizes to the Dock, green is disabled because a fixed-size readout
-          has no meaningful zoom. The row below is inset to clear them. */}
-      {/* Identity and state on one line: who is on the call and what the call
-          is doing are read together. The name gives up its width first, since
-          a truncated name is still recognizable while a truncated phase is
-          not. */}
-      <div className="flex min-w-0 items-center gap-1.5 pl-[62px]">
+      {/* Identity titles the window, centered over the traffic lights rather
+          than sharing a row with the session's state. Who is on the call is the
+          one fact here that never changes, so it reads as the window's name;
+          everything that moves lives below. */}
+      <div className="relative flex h-[34px] shrink-0 items-center justify-center gap-1.5">
         <Identity
           assistantName={state.assistantName}
           avatarBase64={state.avatarBase64}
         />
-        <span className="shrink truncate text-[12px] font-medium text-[var(--content-primary)]">
+        <span className="max-w-[150px] truncate text-[13px] font-semibold tracking-[-0.01em] text-[var(--content-primary)]">
           {state.assistantName}
         </span>
-        <PhaseGlyph phase={state.phase} />
-        <span className="min-w-0 shrink-0 truncate text-[11px] text-[var(--content-secondary)]">
-          {state.label}
-        </span>
-        <Elapsed startedAt={state.startedAt} />
       </div>
 
-      {state.detail !== "" && (
-        <span className="min-w-0 truncate text-[10px] text-[var(--content-tertiary)]">
-          {state.detail}
-        </span>
-      )}
+      <div className="flex min-w-0 flex-col gap-2 px-3.5 pb-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <PhaseGlyph phase={state.phase} />
+          <span className="min-w-0 truncate text-[12px] text-[var(--content-secondary)]">
+            {state.label}
+          </span>
+          <Elapsed startedAt={state.startedAt} />
+        </div>
 
-      {pendingApproval ? (
-        <ApprovalControls requestId={state.approvalRequestId} />
-      ) : (
-        <SessionControls muted={state.muted} outputMuted={state.outputMuted} />
-      )}
+        {state.detail !== "" && (
+          <span className="min-w-0 truncate text-[11px] text-[var(--content-tertiary)]">
+            {state.detail}
+          </span>
+        )}
+
+        {pendingApproval ? (
+          <ApprovalControls requestId={state.approvalRequestId} />
+        ) : (
+          <SessionControls
+            muted={state.muted}
+            outputMuted={state.outputMuted}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -10,9 +10,17 @@ import {
   VolumeX,
   X,
 } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
 
 import {
+  activateVoiceActivityApp,
+  beginVoiceActivityDrag,
+  endVoiceActivityDrag,
   getVoiceActivityState,
   sendVoiceActivityControl,
   subscribeVoiceActivityState,
@@ -55,6 +63,89 @@ import type {
  * and a specular highlight along the top edge. Off-Electron the subscription
  * no-ops and the page stays blank.
  */
+/**
+ * How long a press may rest before it becomes a drag rather than a click.
+ *
+ * Long enough that an ordinary click never arms it, short enough that "grab
+ * and move" feels immediate to a hand that paused first.
+ */
+const HOLD_TO_DRAG_MS = 180;
+
+/**
+ * How far a press may travel before it becomes a drag regardless of time.
+ *
+ * A quick flick to reposition the panel should not have to wait out
+ * {@link HOLD_TO_DRAG_MS}, and a hand that has already moved four pixels is
+ * plainly not clicking. It also keeps a click from being lost to the tremor of
+ * pressing the button.
+ */
+const DRAG_SLOP_PX = 4;
+
+/**
+ * The panel's two gestures on one surface: press to bring the app forward,
+ * hold or drag to move the panel.
+ *
+ * They cannot be split by `-webkit-app-region: drag`, which swallows clicks in
+ * whatever region it covers, so the gestures are told apart here and the
+ * window is moved by main following the cursor.
+ *
+ * The pointer is captured for the whole press so the release is always
+ * delivered: a drag pulls the window along under the cursor, and without
+ * capture a pointer that outruns it lands the `pointerup` somewhere else and
+ * leaves main following the cursor forever.
+ */
+function handlePanelPointerDown(
+  event: ReactPointerEvent<HTMLDivElement>,
+): void {
+  // Secondary buttons open context menus and mean neither gesture.
+  if (event.button !== 0) {
+    return;
+  }
+
+  const target = event.currentTarget;
+  const startX = event.screenX;
+  const startY = event.screenY;
+  let dragging = false;
+
+  const startDragging = (): void => {
+    if (dragging) {
+      return;
+    }
+    dragging = true;
+    beginVoiceActivityDrag();
+  };
+
+  const holdTimer = setTimeout(startDragging, HOLD_TO_DRAG_MS);
+
+  const onMove = (moved: PointerEvent): void => {
+    if (
+      Math.abs(moved.screenX - startX) > DRAG_SLOP_PX ||
+      Math.abs(moved.screenY - startY) > DRAG_SLOP_PX
+    ) {
+      startDragging();
+    }
+  };
+
+  const onEnd = (): void => {
+    clearTimeout(holdTimer);
+    target.removeEventListener("pointermove", onMove);
+    target.removeEventListener("pointerup", onEnd);
+    target.removeEventListener("pointercancel", onEnd);
+    if (dragging) {
+      endVoiceActivityDrag();
+      return;
+    }
+    activateVoiceActivityApp();
+  };
+
+  target.setPointerCapture(event.pointerId);
+  target.addEventListener("pointermove", onMove);
+  target.addEventListener("pointerup", onEnd);
+  // A cancelled pointer (the window server taking over, a display change) must
+  // still stop main following the cursor, and must not be read as a click.
+  target.addEventListener("pointercancel", onEnd);
+}
+
 export function VoiceActivityPanelPage() {
   const [state, setState] = useState<VoiceActivityState | null>(null);
 
@@ -79,11 +170,13 @@ export function VoiceActivityPanelPage() {
   const pendingApproval = state.approvalRequestId !== "";
 
   return (
-    // The whole panel drags, so the user can move it from anywhere that isn't
-    // a control. A 300×96 surface has no room for a dedicated grip.
+    // One surface, two gestures: press to go back to the app, hold or drag to
+    // move the panel. A 300×96 surface has no room to spend on a dedicated
+    // grip, and `-webkit-app-region: drag` cannot share pixels with a click.
     <div
-      className="relative flex h-screen w-screen flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+      className="relative flex h-screen w-screen cursor-pointer flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={{ ["--voice-accent" as string]: accentColor(state.accentHex) }}
+      onPointerDown={handlePanelPointerDown}
     >
       {/* Identity and state on one line: who is on the call and what the call
           is doing are read together, and the name alone was a whole row spent
@@ -332,9 +425,13 @@ function ControlButton({
       type="button"
       aria-label={label}
       title={label}
-      // Opted out of the panel's drag region, or the press would be swallowed
-      // by a window move.
-      className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
+      className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
+      // A control is neither of the panel's two gestures, so the press stops
+      // here rather than reaching the surface and being read as "go back" or
+      // as the start of a drag.
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
       onClick={() => {
         sendVoiceActivityControl(
           requestId === undefined ? { action } : { action, requestId },

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -2,7 +2,6 @@ import {
   Brain,
   Check,
   CornerUpLeft,
-  Minus,
   Mic,
   MicOff,
   MessageSquareText,
@@ -16,7 +15,6 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import {
   activateVoiceActivityApp,
-  dismissVoiceActivityPanel,
   getVoiceActivityState,
   sendVoiceActivityControl,
   setVoiceActivityCollapsed,
@@ -123,31 +121,15 @@ export function VoiceActivityPanelPage() {
       className="relative flex h-screen w-screen flex-col gap-1 overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 pb-2.5 pt-1.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={surfaceStyle}
     >
-      {/* Window chrome. Minimize shrinks to the chip and close hides the
-          window; neither touches the call, because the button a user reaches
-          for when a panel is in the way must never hang up on them. */}
-      <div className="flex items-center gap-1">
-        <WindowButton
-          label="Minimize voice panel"
-          onClick={() => {
-            setVoiceActivityCollapsed(true);
-          }}
-        >
-          <Minus className="size-3" aria-hidden />
-        </WindowButton>
-        <WindowButton
-          label="Close voice panel"
-          onClick={dismissVoiceActivityPanel}
-        >
-          <X className="size-3" aria-hidden />
-        </WindowButton>
-      </div>
-
+      {/* No window chrome of its own: the macOS traffic lights are the
+          window's controls. Red hides it without ending the call, yellow
+          minimizes to the Dock, green is disabled because a fixed-size readout
+          has no meaningful zoom. The row below is inset to clear them. */}
       {/* Identity and state on one line: who is on the call and what the call
           is doing are read together. The name gives up its width first, since
           a truncated name is still recognizable while a truncated phase is
           not. */}
-      <div className="flex min-w-0 items-center gap-1.5">
+      <div className="flex min-w-0 items-center gap-1.5 pl-[62px]">
         <Identity
           assistantName={state.assistantName}
           avatarBase64={state.avatarBase64}
@@ -174,35 +156,6 @@ export function VoiceActivityPanelPage() {
         <SessionControls muted={state.muted} outputMuted={state.outputMuted} />
       )}
     </div>
-  );
-}
-
-/**
- * Minimize and close.
- *
- * Quieter than the session controls and set apart from them, because they act
- * on the window while everything below acts on the call. Confusing the two is
- * the one mistake this surface can make that a user cannot undo.
- */
-function WindowButton({
-  label,
-  onClick,
-  children,
-}: {
-  label: string;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      className="flex size-4 items-center justify-center rounded-full text-[var(--content-tertiary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/15 hover:text-[var(--content-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)]"
-      onClick={onClick}
-    >
-      {children}
-    </button>
   );
 }
 

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -27,8 +27,8 @@ import type {
 } from "@/runtime/is-electron";
 
 /**
- * The floating live-voice session surface, rendered inside the Electron panel
- * the main process shows while a session runs and the app is not frontmost
+ * The floating live-voice session surface, rendered inside the Electron window
+ * the main process shows for the length of a session
  * (`clients/macos/src/main/voice-activity-window.ts`).
  *
  * The desktop counterpart to the iOS Lock Screen card, and deliberately the
@@ -389,7 +389,6 @@ function ControlButton({
       aria-label={label}
       title={label}
       className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
-
       onClick={() => {
         sendVoiceActivityControl(
           requestId === undefined ? { action } : { action, requestId },

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -135,7 +135,10 @@ export function VoiceActivityPanelPage() {
         >
           <Minus className="size-3" aria-hidden />
         </WindowButton>
-        <WindowButton label="Close voice panel" onClick={dismissVoiceActivityPanel}>
+        <WindowButton
+          label="Close voice panel"
+          onClick={dismissVoiceActivityPanel}
+        >
           <X className="size-3" aria-hidden />
         </WindowButton>
       </div>

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -1,0 +1,357 @@
+import {
+  Brain,
+  Check,
+  Mic,
+  MicOff,
+  MessageSquareText,
+  PhoneOff,
+  RadioTower,
+  Volume2,
+  VolumeX,
+  X,
+} from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+
+import {
+  getVoiceActivityState,
+  sendVoiceActivityControl,
+  subscribeVoiceActivityState,
+} from "@/runtime/desktop-voice-activity";
+import type {
+  VoiceActivityControlAction,
+  VoiceActivityPhase,
+  VoiceActivityState,
+} from "@/runtime/is-electron";
+
+/**
+ * The floating live-voice session surface, rendered inside the Electron panel
+ * the main process shows while a session runs and the app is not frontmost
+ * (`clients/macos/src/main/voice-activity-window.ts`).
+ *
+ * The desktop counterpart to the iOS Lock Screen card, and deliberately the
+ * same handful of facts: identity (avatar and assistant name), the phase as
+ * both a glyph and passed-through wording, how long the call has been running,
+ * the turn's activity line, and the session's controls. Where the island has
+ * four sizes to drop facts between, this has one — a panel the user placed
+ * themselves — so nothing is dropped.
+ *
+ * Two rules carried over from `VoiceSessionIslandViews.swift`, for the same
+ * reasons:
+ *
+ * 1. **No phase copy of its own.** Every string describing the session is
+ *    `label` or `assistantName`, passed through from the session's own store.
+ *    `LIVE_VOICE_STATE_LABELS` / `liveVoiceSurfaceLabel` own the wording. This
+ *    page happens to ship in the same bundle as that store today — but the
+ *    payload it renders is a bridge contract shared with a native shell, and a
+ *    surface that re-words its own phases is how the two come to disagree.
+ * 2. **Accent is decoration, never the carrier.** `accentHex` is the user's
+ *    avatar color and can be any brightness, over a vibrancy material sampling
+ *    an unknown desktop. Text stays on the theme's own content tokens, which
+ *    adapt; the accent only fills shapes.
+ *
+ * Standalone (no auth, no RootLayout) like the dictation overlay and Quick
+ * Input. The window canvas is transparent with a vibrancy material behind it,
+ * so the page paints the glass itself: a translucent wash, a hairline border,
+ * and a specular highlight along the top edge. Off-Electron the subscription
+ * no-ops and the page stays blank.
+ */
+export function VoiceActivityPanelPage() {
+  const [state, setState] = useState<VoiceActivityState | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeVoiceActivityState(setState);
+    // This route chunk loads lazily after the window is created, so the
+    // session's first states can be pushed before the subscription above
+    // registers and be dropped. Pull the latest to catch up — pushed states
+    // are newer, so never overwrite one.
+    void getVoiceActivityState().then((initial) => {
+      if (initial) {
+        setState((current) => current ?? initial);
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  if (!state) {
+    return null;
+  }
+
+  const pendingApproval = state.approvalRequestId !== "";
+
+  return (
+    // The whole panel drags, so the user can move it from anywhere that isn't
+    // a control — a 300×116 surface has no room for a dedicated grip.
+    <div
+      className="relative flex h-screen w-screen flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+      style={{ ["--voice-accent" as string]: accentColor(state.accentHex) }}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Identity
+          assistantName={state.assistantName}
+          avatarBase64={state.avatarBase64}
+        />
+        <span className="truncate text-[12px] font-medium text-[var(--content-primary)]">
+          {state.assistantName}
+        </span>
+        <Elapsed startedAt={state.startedAt} />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <PhaseGlyph phase={state.phase} />
+          <span className="truncate text-[11px] text-[var(--content-secondary)]">
+            {state.label}
+          </span>
+        </div>
+        {state.detail !== "" && (
+          <span className="truncate text-[10px] text-[var(--content-tertiary)]">
+            {state.detail}
+          </span>
+        )}
+      </div>
+
+      {pendingApproval ? (
+        <ApprovalControls requestId={state.approvalRequestId} />
+      ) : (
+        <SessionControls muted={state.muted} outputMuted={state.outputMuted} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * The phase as a glyph.
+ *
+ * **A glyph is not copy, which is why this may switch on `phase` when nothing
+ * else here may.** The rule above exists because wording deploys continuously
+ * while a native shell ships on release cadence; a symbol has no second source
+ * to drift from, and the phase vocabulary itself is the contract — a new phase
+ * makes this switch a compile error.
+ *
+ * It earns its place by being legible at a glance from across a desk, which
+ * an 11px caption is not: someone who has put this panel in a screen corner
+ * reads its state peripherally, and the glyph is what survives that.
+ *
+ * Matches `phaseSymbol` in `VoiceSessionIslandViews.swift` one-for-one. Known
+ * corner: a `speaking` phase that has gone silent mid-turn relabels to
+ * "Thinking…" via `liveVoiceSurfaceLabel` while `phase` stays `speaking`, so
+ * the glyph reads as a speaker beside that word. The island has the same seam
+ * and it is not fixable on one surface alone — the daemon's APNs path composes
+ * the island's content from the raw phase, so remapping here would leave the
+ * two drivers disagreeing.
+ */
+function PhaseGlyph({ phase }: { phase: VoiceActivityPhase }) {
+  const className = "size-3.5 shrink-0 text-[var(--voice-accent)]";
+  switch (phase) {
+    case "connecting":
+      return <RadioTower className={className} aria-hidden />;
+    case "listening":
+      return <Mic className={className} aria-hidden />;
+    case "transcribing":
+      return <MessageSquareText className={className} aria-hidden />;
+    case "thinking":
+      return <Brain className={className} aria-hidden />;
+    case "speaking":
+      return <Volume2 className={className} aria-hidden />;
+    case "ending":
+      return <PhoneOff className={className} aria-hidden />;
+  }
+}
+
+/**
+ * The avatar, or the accent as a plain disc when there is none small enough to
+ * have crossed the bridge.
+ *
+ * The bytes arrive base64 without their type, so the data URL's is read back
+ * off the payload's own magic prefix. `<img>` would very likely sniff its way
+ * to the right decoder regardless, but "very likely" is not a thing to build
+ * an identity on.
+ */
+function Identity({
+  assistantName,
+  avatarBase64,
+}: {
+  assistantName: string;
+  avatarBase64?: string;
+}) {
+  if (avatarBase64 === undefined) {
+    return (
+      <span
+        className="size-5 shrink-0 rounded-full bg-[var(--voice-accent)]"
+        aria-hidden
+      />
+    );
+  }
+  const mime = avatarBase64.startsWith("/9j/") ? "image/jpeg" : "image/png";
+  return (
+    <img
+      src={`data:${mime};base64,${avatarBase64}`}
+      alt={assistantName}
+      className="size-5 shrink-0 rounded-full object-cover"
+    />
+  );
+}
+
+/**
+ * Elapsed call time, ticking from the timestamp the main process stamped.
+ *
+ * Anchored in main rather than here because this renderer can reload or be
+ * recreated mid-session, and a clock anchored in it would restart when that
+ * happened — the one fact on the panel a user would read as "the call dropped
+ * and came back".
+ */
+function Elapsed({ startedAt }: { startedAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const label = `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+
+  return (
+    <span className="ml-auto shrink-0 font-mono text-[11px] tabular-nums text-[var(--content-secondary)]">
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Mute the mic, mute the assistant, end the call.
+ *
+ * **Each mute sends the state its own label promised, not a toggle.** The
+ * panel renders content that can be a beat behind the session, so a toggle
+ * resolved against live state would be self-consistent and still wrong for the
+ * user — a button reading "Mute assistant" over an already-muted session would
+ * unmute it. Sending what the button said makes a stale press a no-op that the
+ * next push corrects. See `VoiceActivityControl` in the IPC contract.
+ */
+function SessionControls({
+  muted,
+  outputMuted,
+}: {
+  muted: boolean;
+  outputMuted: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <ControlButton
+        action={muted ? "unmuteMicrophone" : "muteMicrophone"}
+        label={muted ? "Unmute microphone" : "Mute microphone"}
+      >
+        {muted ? (
+          <MicOff className="size-3.5" aria-hidden />
+        ) : (
+          <Mic className="size-3.5" aria-hidden />
+        )}
+      </ControlButton>
+      <ControlButton
+        action={outputMuted ? "unmuteAssistantAudio" : "muteAssistantAudio"}
+        label={outputMuted ? "Unmute assistant" : "Mute assistant"}
+      >
+        {outputMuted ? (
+          <VolumeX className="size-3.5" aria-hidden />
+        ) : (
+          <Volume2 className="size-3.5" aria-hidden />
+        )}
+      </ControlButton>
+      <ControlButton
+        action="endSession"
+        label="End session"
+        className="ml-auto text-[var(--system-negative-strong)]"
+      >
+        <PhoneOff className="size-3.5" aria-hidden />
+      </ControlButton>
+    </div>
+  );
+}
+
+/**
+ * Approve or deny the confirmation the turn is blocked on.
+ *
+ * Takes the controls' place rather than crowding in beside them: the turn is
+ * stopped until this is answered, so it is the only thing on the panel worth
+ * pressing, and a 300pt row that tried to carry five buttons would make each
+ * of them a smaller target than the decision deserves.
+ *
+ * The request id travels with the press so the session answers the question
+ * the user was actually shown — see `VoiceActivityControl.requestId`.
+ */
+function ApprovalControls({ requestId }: { requestId: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <ControlButton
+        action="approveRequest"
+        requestId={requestId}
+        label="Approve"
+        className="flex-1 text-[var(--system-positive-strong)]"
+      >
+        <Check className="size-3.5" aria-hidden />
+        <span className="text-[11px] font-medium">Allow</span>
+      </ControlButton>
+      <ControlButton
+        action="denyRequest"
+        requestId={requestId}
+        label="Deny"
+        className="flex-1 text-[var(--system-negative-strong)]"
+      >
+        <X className="size-3.5" aria-hidden />
+        <span className="text-[11px] font-medium">Deny</span>
+      </ControlButton>
+    </div>
+  );
+}
+
+function ControlButton({
+  action,
+  requestId,
+  label,
+  className = "",
+  children,
+}: {
+  action: VoiceActivityControlAction;
+  requestId?: string;
+  label: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      // Opted out of the panel's drag region, or the press would be swallowed
+      // by a window move.
+      className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
+      onClick={() => {
+        sendVoiceActivityControl(
+          requestId === undefined ? { action } : { action, requestId },
+        );
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The accent to paint glyphs and focus rings with.
+ *
+ * `accentHex` is `""` while the avatar is still resolving, and the contract
+ * makes no promise it parses — so anything that isn't an obvious `#RRGGBB`
+ * falls back to the theme's own accent rather than being handed to CSS, where
+ * an invalid value would silently drop the custom property and take the
+ * glyph's color with it.
+ */
+function accentColor(accentHex: string): string {
+  return /^#[0-9a-f]{6}$/i.test(accentHex)
+    ? accentHex
+    : "var(--content-secondary)";
+}

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -1,6 +1,8 @@
 import {
   Brain,
   Check,
+  CornerUpLeft,
+  Minus,
   Mic,
   MicOff,
   MessageSquareText,
@@ -10,19 +12,14 @@ import {
   VolumeX,
   X,
 } from "lucide-react";
-import {
-  useEffect,
-  useState,
-  type PointerEvent as ReactPointerEvent,
-  type ReactNode,
-} from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import {
   activateVoiceActivityApp,
-  beginVoiceActivityDrag,
-  endVoiceActivityDrag,
+  dismissVoiceActivityPanel,
   getVoiceActivityState,
   sendVoiceActivityControl,
+  setVoiceActivityCollapsed,
   subscribeVoiceActivityState,
 } from "@/runtime/desktop-voice-activity";
 import type {
@@ -63,89 +60,6 @@ import type {
  * and a specular highlight along the top edge. Off-Electron the subscription
  * no-ops and the page stays blank.
  */
-/**
- * How long a press may rest before it becomes a drag rather than a click.
- *
- * Long enough that an ordinary click never arms it, short enough that "grab
- * and move" feels immediate to a hand that paused first.
- */
-const HOLD_TO_DRAG_MS = 180;
-
-/**
- * How far a press may travel before it becomes a drag regardless of time.
- *
- * A quick flick to reposition the panel should not have to wait out
- * {@link HOLD_TO_DRAG_MS}, and a hand that has already moved four pixels is
- * plainly not clicking. It also keeps a click from being lost to the tremor of
- * pressing the button.
- */
-const DRAG_SLOP_PX = 4;
-
-/**
- * The panel's two gestures on one surface: press to bring the app forward,
- * hold or drag to move the panel.
- *
- * They cannot be split by `-webkit-app-region: drag`, which swallows clicks in
- * whatever region it covers, so the gestures are told apart here and the
- * window is moved by main following the cursor.
- *
- * The pointer is captured for the whole press so the release is always
- * delivered: a drag pulls the window along under the cursor, and without
- * capture a pointer that outruns it lands the `pointerup` somewhere else and
- * leaves main following the cursor forever.
- */
-function handlePanelPointerDown(
-  event: ReactPointerEvent<HTMLDivElement>,
-): void {
-  // Secondary buttons open context menus and mean neither gesture.
-  if (event.button !== 0) {
-    return;
-  }
-
-  const target = event.currentTarget;
-  const startX = event.screenX;
-  const startY = event.screenY;
-  let dragging = false;
-
-  const startDragging = (): void => {
-    if (dragging) {
-      return;
-    }
-    dragging = true;
-    beginVoiceActivityDrag();
-  };
-
-  const holdTimer = setTimeout(startDragging, HOLD_TO_DRAG_MS);
-
-  const onMove = (moved: PointerEvent): void => {
-    if (
-      Math.abs(moved.screenX - startX) > DRAG_SLOP_PX ||
-      Math.abs(moved.screenY - startY) > DRAG_SLOP_PX
-    ) {
-      startDragging();
-    }
-  };
-
-  const onEnd = (): void => {
-    clearTimeout(holdTimer);
-    target.removeEventListener("pointermove", onMove);
-    target.removeEventListener("pointerup", onEnd);
-    target.removeEventListener("pointercancel", onEnd);
-    if (dragging) {
-      endVoiceActivityDrag();
-      return;
-    }
-    activateVoiceActivityApp();
-  };
-
-  target.setPointerCapture(event.pointerId);
-  target.addEventListener("pointermove", onMove);
-  target.addEventListener("pointerup", onEnd);
-  // A cancelled pointer (the window server taking over, a display change) must
-  // still stop main following the cursor, and must not be read as a click.
-  target.addEventListener("pointercancel", onEnd);
-}
-
 export function VoiceActivityPanelPage() {
   const [state, setState] = useState<VoiceActivityState | null>(null);
 
@@ -168,21 +82,68 @@ export function VoiceActivityPanelPage() {
   }
 
   const pendingApproval = state.approvalRequestId !== "";
+  const surfaceStyle = {
+    ["--voice-accent" as string]: accentColor(state.accentHex),
+  };
+
+  // Shrunk out of the way: identity, phase and elapsed time, which is what is
+  // still worth knowing at a glance. The avatar restores it, so the chip needs
+  // no chrome of its own.
+  if (state.collapsed) {
+    return (
+      <div
+        className="relative flex h-screen w-screen items-center gap-2 overflow-hidden rounded-full border border-white/15 bg-white/[0.07] px-2 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+        style={surfaceStyle}
+      >
+        <button
+          type="button"
+          aria-label="Expand voice panel"
+          title="Expand"
+          className="shrink-0 rounded-full [-webkit-app-region:no-drag] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)]"
+          onClick={() => {
+            setVoiceActivityCollapsed(false);
+          }}
+        >
+          <Identity
+            assistantName={state.assistantName}
+            avatarBase64={state.avatarBase64}
+          />
+        </button>
+        <PhaseGlyph phase={state.phase} />
+        <Elapsed startedAt={state.startedAt} />
+      </div>
+    );
+  }
 
   return (
-    // One surface, two gestures: press to go back to the app, hold or drag to
-    // move the panel. A 300×96 surface has no room to spend on a dedicated
-    // grip, and `-webkit-app-region: drag` cannot share pixels with a click.
+    // The surface drags; every control opts out. With the window carrying its
+    // own close and minimize, and a button back to the conversation, dragging
+    // is the only thing left for the background to mean.
     <div
-      className="relative flex h-screen w-screen cursor-pointer flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
-      style={{ ["--voice-accent" as string]: accentColor(state.accentHex) }}
-      onPointerDown={handlePanelPointerDown}
+      className="relative flex h-screen w-screen flex-col gap-1 overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 pb-2.5 pt-1.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+      style={surfaceStyle}
     >
+      {/* Window chrome. Minimize shrinks to the chip and close hides the
+          window; neither touches the call, because the button a user reaches
+          for when a panel is in the way must never hang up on them. */}
+      <div className="flex items-center gap-1">
+        <WindowButton
+          label="Minimize voice panel"
+          onClick={() => {
+            setVoiceActivityCollapsed(true);
+          }}
+        >
+          <Minus className="size-3" aria-hidden />
+        </WindowButton>
+        <WindowButton label="Close voice panel" onClick={dismissVoiceActivityPanel}>
+          <X className="size-3" aria-hidden />
+        </WindowButton>
+      </div>
+
       {/* Identity and state on one line: who is on the call and what the call
-          is doing are read together, and the name alone was a whole row spent
-          on the one fact that never changes. The name gives up its width first
-          (`shrink`), because a truncated name is still recognizable while a
-          truncated phase is not. */}
+          is doing are read together. The name gives up its width first, since
+          a truncated name is still recognizable while a truncated phase is
+          not. */}
       <div className="flex min-w-0 items-center gap-1.5">
         <Identity
           assistantName={state.assistantName}
@@ -210,6 +171,35 @@ export function VoiceActivityPanelPage() {
         <SessionControls muted={state.muted} outputMuted={state.outputMuted} />
       )}
     </div>
+  );
+}
+
+/**
+ * Minimize and close.
+ *
+ * Quieter than the session controls and set apart from them, because they act
+ * on the window while everything below acts on the call. Confusing the two is
+ * the one mistake this surface can make that a user cannot undo.
+ */
+function WindowButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="flex size-4 items-center justify-center rounded-full text-[var(--content-tertiary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/15 hover:text-[var(--content-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)]"
+      onClick={onClick}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -356,6 +346,20 @@ function SessionControls({
           <Volume2 className="size-3.5" aria-hidden />
         )}
       </ControlButton>
+      {/* Back to the conversation, the desktop reading of the island's
+          tap-through and of the pill's tappable middle. A button rather than
+          the surface itself: the background is the drag handle, and a region
+          cannot both drag and be clicked. */}
+      <button
+        type="button"
+        aria-label="Return to conversation"
+        title="Return to conversation"
+        className="ml-auto flex h-6 items-center justify-center rounded-md px-2 text-[var(--content-secondary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)]"
+        onClick={activateVoiceActivityApp}
+      >
+        <CornerUpLeft className="size-3.5" aria-hidden />
+      </button>
+
       {/* The room's own end control, at panel scale: the same ✕ at the same
           weight, in the same destructive tone, under the same label. Ending a
           call is the one irreversible thing on this surface, so it should look
@@ -363,7 +367,7 @@ function SessionControls({
       <ControlButton
         action="endSession"
         label="End voice session"
-        className="ml-auto text-[var(--system-negative-strong)]"
+        className="text-[var(--system-negative-strong)]"
       >
         <X className="size-3.5" strokeWidth={2.5} aria-hidden />
       </ControlButton>
@@ -425,13 +429,8 @@ function ControlButton({
       type="button"
       aria-label={label}
       title={label}
-      className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
-      // A control is neither of the panel's two gestures, so the press stops
-      // here rather than reaching the surface and being read as "go back" or
-      // as the start of a drag.
-      onPointerDown={(event) => {
-        event.stopPropagation();
-      }}
+      className={`flex h-6 items-center justify-center gap-1 rounded-md px-2 text-[var(--content-secondary)] transition-colors [-webkit-app-region:no-drag] hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--voice-accent)] ${className}`}
+
       onClick={() => {
         sendVoiceActivityControl(
           requestId === undefined ? { action } : { action, requestId },

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -54,9 +54,11 @@ import type {
  *
  * Standalone (no auth, no RootLayout) like the dictation overlay and Quick
  * Input. The window canvas is transparent with a vibrancy material behind it,
- * so the page paints the glass itself: a translucent wash, a hairline border,
- * and a specular highlight along the top edge. Off-Electron the subscription
- * no-ops and the page stays blank.
+ * and that material is the background. The page adds only what the material
+ * cannot draw for itself, a hairline border and a specular highlight along the
+ * top edge; a wash of its own would double-tint the glass, which is what made
+ * the first build read as a flat translucent rectangle. Off-Electron the
+ * subscription no-ops and the page stays blank.
  */
 export function VoiceActivityPanelPage() {
   const [state, setState] = useState<VoiceActivityState | null>(null);
@@ -90,7 +92,7 @@ export function VoiceActivityPanelPage() {
   if (state.collapsed) {
     return (
       <div
-        className="relative flex h-screen w-screen items-center gap-2 overflow-hidden rounded-full border border-white/15 bg-white/[0.07] px-2 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+        className="relative flex h-screen w-screen items-center gap-2 overflow-hidden rounded-full border border-white/15 px-2 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
         style={surfaceStyle}
       >
         <button
@@ -117,7 +119,7 @@ export function VoiceActivityPanelPage() {
     // The surface drags; every control opts out. The macOS traffic lights are
     // the window's controls, so the page draws none of its own.
     <div
-      className="relative flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
+      className="relative flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-white/15 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={surfaceStyle}
     >
       {/* Identity titles the window, centered over the traffic lights rather

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -32,8 +32,8 @@ import type {
  * same handful of facts: identity (avatar and assistant name), the phase as
  * both a glyph and passed-through wording, how long the call has been running,
  * the turn's activity line, and the session's controls. Where the island has
- * four sizes to drop facts between, this has one — a panel the user placed
- * themselves — so nothing is dropped.
+ * four sizes to drop facts between, this has one (a panel the user placed
+ * themselves), so nothing is dropped.
  *
  * Two rules carried over from `VoiceSessionIslandViews.swift`, for the same
  * reasons:
@@ -41,7 +41,7 @@ import type {
  * 1. **No phase copy of its own.** Every string describing the session is
  *    `label` or `assistantName`, passed through from the session's own store.
  *    `LIVE_VOICE_STATE_LABELS` / `liveVoiceSurfaceLabel` own the wording. This
- *    page happens to ship in the same bundle as that store today — but the
+ *    page happens to ship in the same bundle as that store today, but the
  *    payload it renders is a bridge contract shared with a native shell, and a
  *    surface that re-words its own phases is how the two come to disagree.
  * 2. **Accent is decoration, never the carrier.** `accentHex` is the user's
@@ -62,7 +62,7 @@ export function VoiceActivityPanelPage() {
     const unsubscribe = subscribeVoiceActivityState(setState);
     // This route chunk loads lazily after the window is created, so the
     // session's first states can be pushed before the subscription above
-    // registers and be dropped. Pull the latest to catch up — pushed states
+    // registers and be dropped. Pull the latest to catch up: pushed states
     // are newer, so never overwrite one.
     void getVoiceActivityState().then((initial) => {
       if (initial) {
@@ -80,7 +80,7 @@ export function VoiceActivityPanelPage() {
 
   return (
     // The whole panel drags, so the user can move it from anywhere that isn't
-    // a control — a 300×116 surface has no room for a dedicated grip.
+    // a control. A 300×116 surface has no room for a dedicated grip.
     <div
       className="relative flex h-screen w-screen flex-col justify-between overflow-hidden rounded-xl border border-white/15 bg-white/[0.07] px-3 py-2.5 [-webkit-app-region:drag] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent"
       style={{ ["--voice-accent" as string]: accentColor(state.accentHex) }}
@@ -125,7 +125,7 @@ export function VoiceActivityPanelPage() {
  * **A glyph is not copy, which is why this may switch on `phase` when nothing
  * else here may.** The rule above exists because wording deploys continuously
  * while a native shell ships on release cadence; a symbol has no second source
- * to drift from, and the phase vocabulary itself is the contract — a new phase
+ * to drift from, and the phase vocabulary itself is the contract: a new phase
  * makes this switch a compile error.
  *
  * It earns its place by being legible at a glance from across a desk, which
@@ -136,7 +136,7 @@ export function VoiceActivityPanelPage() {
  * corner: a `speaking` phase that has gone silent mid-turn relabels to
  * "Thinking…" via `liveVoiceSurfaceLabel` while `phase` stays `speaking`, so
  * the glyph reads as a speaker beside that word. The island has the same seam
- * and it is not fixable on one surface alone — the daemon's APNs path composes
+ * and it is not fixable on one surface alone. The daemon's APNs path composes
  * the island's content from the raw phase, so remapping here would leave the
  * two drivers disagreeing.
  */
@@ -197,7 +197,7 @@ function Identity({
  *
  * Anchored in main rather than here because this renderer can reload or be
  * recreated mid-session, and a clock anchored in it would restart when that
- * happened — the one fact on the panel a user would read as "the call dropped
+ * happened, the one fact on the panel a user would read as "the call dropped
  * and came back".
  */
 function Elapsed({ startedAt }: { startedAt: number }) {
@@ -229,7 +229,7 @@ function Elapsed({ startedAt }: { startedAt: number }) {
  * **Each mute sends the state its own label promised, not a toggle.** The
  * panel renders content that can be a beat behind the session, so a toggle
  * resolved against live state would be self-consistent and still wrong for the
- * user — a button reading "Mute assistant" over an already-muted session would
+ * user: a button reading "Mute assistant" over an already-muted session would
  * unmute it. Sending what the button said makes a stale press a no-op that the
  * next push corrects. See `VoiceActivityControl` in the IPC contract.
  */
@@ -286,7 +286,7 @@ function SessionControls({
  * of them a smaller target than the decision deserves.
  *
  * The request id travels with the press so the session answers the question
- * the user was actually shown — see `VoiceActivityControl.requestId`.
+ * the user was actually shown. See `VoiceActivityControl.requestId`.
  */
 function ApprovalControls({ requestId }: { requestId: string }) {
   return (
@@ -349,7 +349,7 @@ function ControlButton({
  * The accent to paint glyphs and focus rings with.
  *
  * `accentHex` is `""` while the avatar is still resolving, and the contract
- * makes no promise it parses — so anything that isn't an obvious `#RRGGBB`
+ * makes no promise it parses, so anything that isn't an obvious `#RRGGBB`
  * falls back to the theme's own accent rather than being handed to CSS, where
  * an invalid value would silently drop the custom property and take the
  * glyph's color with it.

--- a/clients/web/src/components/voice-activity-panel-page.tsx
+++ b/clients/web/src/components/voice-activity-panel-page.tsx
@@ -262,12 +262,16 @@ function SessionControls({
           <Volume2 className="size-3.5" aria-hidden />
         )}
       </ControlButton>
+      {/* The room's own end control, at panel scale: the same ✕ at the same
+          weight, in the same destructive tone, under the same label. Ending a
+          call is the one irreversible thing on this surface, so it should look
+          identical wherever the user meets it. */}
       <ControlButton
         action="endSession"
-        label="End session"
+        label="End voice session"
         className="ml-auto text-[var(--system-negative-strong)]"
       >
-        <PhoneOff className="size-3.5" aria-hidden />
+        <X className="size-3.5" strokeWidth={2.5} aria-hidden />
       </ControlButton>
     </div>
   );

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
@@ -21,8 +21,14 @@
  * exactly the session's; a press that arrives with no session mounted has
  * nothing listening and does nothing (nothing native queues them).
  *
- * No-ops off iOS and on a shell too old to send the events, through
- * `subscribeVoiceLiveActivityControl`'s skew contract.
+ * **Both out-of-app surfaces feed this one path.** The iOS island's App Intent
+ * presses and the macOS floating panel's button presses carry the same action
+ * vocabulary and mean the same thing, so they are applied by the same function
+ * rather than each growing its own handling — the drift this avoids is two
+ * surfaces disagreeing about what "mute" does mid-call.
+ *
+ * No-ops off iOS, off Electron, and on a shell too old to send the events,
+ * through each subscription's skew contract.
  */
 
 import { useEffect } from "react";
@@ -40,6 +46,7 @@ import {
   subscribeVoiceLiveActivityControl,
   type VoiceLiveActivityControlAction,
 } from "@/runtime/native-live-activity";
+import { subscribeVoiceActivityControl } from "@/runtime/desktop-voice-activity";
 import type { ConfirmationDecision } from "@/types/event-types";
 
 /**
@@ -133,10 +140,26 @@ export function applyLiveActivityControl(
 }
 
 export function useLiveActivityControls(): void {
-  useEffect(
-    () => subscribeVoiceLiveActivityControl(({ action, requestId }) => {
+  useEffect(() => {
+    const apply = ({
+      action,
+      requestId,
+    }: {
+      action: VoiceLiveActivityControlAction;
+      requestId?: string;
+    }): void => {
       applyLiveActivityControl(action, requestId);
-    }),
-    [],
-  );
+    };
+    // Both surfaces, one set of semantics. Each subscription no-ops off its own
+    // host, so at most one ever fires — but they are subscribed unconditionally
+    // rather than behind a platform branch, for the same reason the mirror
+    // pushes to both sinks: the host test belongs in the runtime module, not
+    // duplicated at every call site.
+    const unsubscribeIsland = subscribeVoiceLiveActivityControl(apply);
+    const unsubscribePanel = subscribeVoiceActivityControl(apply);
+    return () => {
+      unsubscribeIsland();
+      unsubscribePanel();
+    };
+  }, []);
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
@@ -24,7 +24,7 @@
  * **Both out-of-app surfaces feed this one path.** The iOS island's App Intent
  * presses and the macOS floating panel's button presses carry the same action
  * vocabulary and mean the same thing, so they are applied by the same function
- * rather than each growing its own handling — the drift this avoids is two
+ * rather than each growing its own handling. The drift this avoids is two
  * surfaces disagreeing about what "mute" does mid-call.
  *
  * No-ops off iOS, off Electron, and on a shell too old to send the events,
@@ -151,7 +151,7 @@ export function useLiveActivityControls(): void {
       applyLiveActivityControl(action, requestId);
     };
     // Both surfaces, one set of semantics. Each subscription no-ops off its own
-    // host, so at most one ever fires — but they are subscribed unconditionally
+    // host, so at most one ever fires, but they are subscribed unconditionally
     // rather than behind a platform branch, for the same reason the mirror
     // pushes to both sinks: the host test belongs in the runtime module, not
     // duplicated at every call site.

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for `useLiveActivityMirror` — the out-of-app mirror of a live-voice
+ * Tests for `useLiveActivityMirror`, the out-of-app mirror of a live-voice
  * session, feeding the iOS Live Activity and the macOS floating panel from one
  * snapshot.
  *
@@ -105,7 +105,7 @@ mock.module("@/runtime/native-live-activity", () => ({
   subscribeVoiceLiveActivityPushToken,
 }));
 
-// The desktop sink — the Electron floating panel's half of the same mirror.
+// The desktop sink: the Electron floating panel's half of the same mirror.
 // Stubbed at the same boundary as the mobile bridge, and for the same reason:
 // its own off-Electron behavior is the runtime module's to pin, while what
 // matters here is that both sinks are driven from one snapshot.
@@ -854,8 +854,8 @@ describe("registering the activity for server-driven updates", () => {
 
 /**
  * The floating panel is fed by the same mirror as the island, from the same
- * computed snapshot. These pin the fan-out itself — that both sinks see one
- * payload, on one schedule — rather than re-testing the content rules above,
+ * computed snapshot. These pin the fan-out itself (that both sinks see one
+ * payload, on one schedule) rather than re-testing the content rules above,
  * which are sink-agnostic by construction.
  */
 describe("the desktop panel sink", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -1,6 +1,7 @@
 /**
- * Tests for `useLiveActivityMirror` — the iOS Live Activity mirror of a
- * live-voice session.
+ * Tests for `useLiveActivityMirror` — the out-of-app mirror of a live-voice
+ * session, feeding the iOS Live Activity and the macOS floating panel from one
+ * snapshot.
  *
  * The `runtime/native-live-activity` bridge is stubbed at the module boundary
  * (rather than by faking `isNativeIOS`) so the mirror's own lifecycle and
@@ -32,6 +33,10 @@ import type {
   VoiceLiveActivityContent,
   VoiceLiveActivityStart,
 } from "@/runtime/native-live-activity";
+import type {
+  VoiceActivityContent,
+  VoiceActivityStart,
+} from "@/runtime/is-electron";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
 // Typed to the real bridge signatures so the recorded payloads stay checked.
@@ -98,6 +103,24 @@ mock.module("@/runtime/native-live-activity", () => ({
   updateVoiceLiveActivity,
   endVoiceLiveActivity,
   subscribeVoiceLiveActivityPushToken,
+}));
+
+// The desktop sink — the Electron floating panel's half of the same mirror.
+// Stubbed at the same boundary as the mobile bridge, and for the same reason:
+// its own off-Electron behavior is the runtime module's to pin, while what
+// matters here is that both sinks are driven from one snapshot.
+const startVoiceActivity = mock(
+  (_state: VoiceActivityStart): void => undefined,
+);
+const updateVoiceActivity = mock(
+  (_content: VoiceActivityContent): void => undefined,
+);
+const endVoiceActivity = mock((): void => undefined);
+
+mock.module("@/runtime/desktop-voice-activity", () => ({
+  startVoiceActivity,
+  updateVoiceActivity,
+  endVoiceActivity,
 }));
 
 mock.module(
@@ -190,6 +213,9 @@ beforeEach(() => {
   subscribeVoiceLiveActivityPushToken.mockClear();
   registerLiveActivityPushToken.mockClear();
   unregisterLiveActivityPushToken.mockClear();
+  startVoiceActivity.mockClear();
+  updateVoiceActivity.mockClear();
+  endVoiceActivity.mockClear();
   emitPushToken = null;
 });
 
@@ -819,5 +845,76 @@ describe("registering the activity for server-driven updates", () => {
     await emitToken("token-abc");
 
     expect(registerLiveActivityPushToken).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The desktop sink
+// ---------------------------------------------------------------------------
+
+/**
+ * The floating panel is fed by the same mirror as the island, from the same
+ * computed snapshot. These pin the fan-out itself — that both sinks see one
+ * payload, on one schedule — rather than re-testing the content rules above,
+ * which are sink-agnostic by construction.
+ */
+describe("the desktop panel sink", () => {
+  test("start reaches both sinks with the identical payload", async () => {
+    renderMirror();
+
+    await setPhase("connecting");
+
+    expect(startVoiceActivity).toHaveBeenCalledTimes(1);
+    expect(startVoiceActivity.mock.calls.at(-1)?.[0]).toEqual(
+      lastStartPayload() as VoiceActivityStart,
+    );
+  });
+
+  test("updates are pushed to the panel on the island's schedule", async () => {
+    renderMirror();
+    await setPhase("connecting");
+
+    await setPhase("listening");
+
+    expect(updateVoiceActivity).toHaveBeenCalledTimes(1);
+    expect(updateVoiceActivity.mock.calls.at(-1)?.[0]).toEqual(
+      lastUpdatePayload() as VoiceActivityContent,
+    );
+  });
+
+  test("content that would not move the island does not reach the panel either", async () => {
+    renderMirror();
+    await setPhase("connecting");
+    updateVoiceActivity.mockClear();
+
+    // A store write the mirror deliberately ignores: same phase, same label,
+    // same everything a surface renders.
+    await settled(() => {
+      useLiveVoiceStore.getState().setState("connecting");
+    });
+
+    expect(updateVoiceActivity).not.toHaveBeenCalled();
+  });
+
+  test("ending the session dismisses the panel", async () => {
+    renderMirror();
+    await setPhase("listening");
+
+    await setPhase("idle");
+
+    expect(endVoiceActivity).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmounting the mirror dismisses the panel", async () => {
+    const view = renderMirror();
+    await setPhase("listening");
+
+    await act(async () => {
+      view.unmount();
+    });
+
+    // A panel that outlives its mirror floats over the desktop showing a phase
+    // nothing is driving.
+    expect(endVoiceActivity).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -9,7 +9,7 @@
  * handed to whichever transport the host has: `runtime/native-live-activity`
  * (Capacitor → ActivityKit) and `runtime/desktop-voice-activity` (Electron IPC
  * → BrowserWindow). Each no-ops off its own host, so this hook needs no
- * platform branch of its own — a mirror that asked "which platform am I on"
+ * platform branch of its own. A mirror that asked "which platform am I on"
  * would have to be updated for each new surface, whereas a sink that answers
  * "not mine" degrades on its own.
  *
@@ -34,7 +34,7 @@
  * **Updates are pushed only when the content actually changes.** ActivityKit
  * rate-limits updates and silently drops the overflow, so an activity that
  * spends its budget on redundant pushes stops reflecting the session at all.
- * The desktop panel has no such budget — it is local IPC — but it is fed from
+ * The desktop panel has no such budget (it is local IPC), but it is fed from
  * the same comparison anyway: two sinks diverging on *when* they update is how
  * the two surfaces would come to show different things.
  * The mirror therefore reads only what a `ContentState` is built from (phase,
@@ -186,7 +186,7 @@ async function startWithAvatar(
   };
   // Handed to both sinks unchanged. `VoiceActivityStart`'s `phase` is the same
   // vocabulary as `ActiveLiveVoiceSessionState`, restated in the IPC contract
-  // rather than imported across the package boundary — this assignment is what
+  // rather than imported across the package boundary. This assignment is what
   // holds the two in step, so a phase added to the store without a matching
   // case in `@vellumai/ipc-contract` fails to compile here.
   startVoiceActivity(payload);
@@ -364,8 +364,8 @@ export function useLiveActivityMirror(): void {
     return () => {
       unsubscribe();
       unsubscribeToken();
-      // A surface that outlives its mirror sits on the Lock Screen — or floats
-      // over the desktop — showing a phase nothing is driving.
+      // A surface that outlives its mirror sits on the Lock Screen, or floats
+      // over the desktop, showing a phase nothing is driving.
       if (pushed !== null) {
         pushed = null;
         pushToken = null;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -1,15 +1,25 @@
 /**
  * `useLiveActivityMirror()` — mirrors the running live-voice session into the
- * iOS Live Activity (the Dynamic Island and Lock Screen presence for a session
- * that otherwise lives entirely in the web layer).
+ * platform's out-of-app session surface: the Dynamic Island and Lock Screen on
+ * iOS, the floating panel on macOS. Both are presence for a session that
+ * otherwise lives entirely in the web layer.
+ *
+ * **One snapshot, two sinks.** The payload is identical because the two
+ * surfaces show the same facts, so the content is computed once here and
+ * handed to whichever transport the host has: `runtime/native-live-activity`
+ * (Capacitor → ActivityKit) and `runtime/desktop-voice-activity` (Electron IPC
+ * → BrowserWindow). Each no-ops off its own host, so this hook needs no
+ * platform branch of its own — a mirror that asked "which platform am I on"
+ * would have to be updated for each new surface, whereas a sink that answers
+ * "not mine" degrades on its own.
  *
  * Mounted by {@link useLiveVoiceSessionController}, so the mirror's lifetime is
  * exactly the session's. It is deliberately a *separate module* from the
  * controller: the controller owns session lifecycle, this owns an optional
  * platform flourish. Nothing here may reach the session — every bridge call
- * goes through `runtime/native-live-activity`, which no-ops off iOS, on an
- * older App Store shell, and when the user has turned Live Activities off in
- * Settings (see that module's skew contract), and is then fired and forgotten.
+ * no-ops off its host, on an older shell, and when the user has turned Live
+ * Activities off in Settings (see each module's skew contract), and is then
+ * fired and forgotten.
  *
  * **Everything runs inside an effect**, reading the store through
  * {@link subscribeSettledLiveVoiceState} rather than a reactive selector. The
@@ -24,6 +34,9 @@
  * **Updates are pushed only when the content actually changes.** ActivityKit
  * rate-limits updates and silently drops the overflow, so an activity that
  * spends its budget on redundant pushes stops reflecting the session at all.
+ * The desktop panel has no such budget — it is local IPC — but it is fed from
+ * the same comparison anyway: two sinks diverging on *when* they update is how
+ * the two surfaces would come to show different things.
  * The mirror therefore reads only what a `ContentState` is built from (phase,
  * reconnecting, `assistantAudioActive` for the label remap, muted, accent) and
  * compares each candidate against the last payload it pushed. `inputAmplitude`
@@ -55,6 +68,11 @@ import {
   type VoiceLiveActivityContent,
   type VoiceLiveActivityStart,
 } from "@/runtime/native-live-activity";
+import {
+  endVoiceActivity,
+  startVoiceActivity,
+  updateVoiceActivity,
+} from "@/runtime/desktop-voice-activity";
 import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
 import type { AvatarRender } from "@/utils/avatar-render";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -162,10 +180,17 @@ async function startWithAvatar(
   if (start === null) {
     return;
   }
-  await startVoiceLiveActivity({
+  const payload = {
     ...start,
     ...(avatarBase64 ? { avatarBase64 } : {}),
-  });
+  };
+  // Handed to both sinks unchanged. `VoiceActivityStart`'s `phase` is the same
+  // vocabulary as `ActiveLiveVoiceSessionState`, restated in the IPC contract
+  // rather than imported across the package boundary — this assignment is what
+  // holds the two in step, so a phase added to the store without a matching
+  // case in `@vellumai/ipc-contract` fails to compile here.
+  startVoiceActivity(payload);
+  await startVoiceLiveActivity(payload);
 }
 
 /** Whether two payloads would render the same island. */
@@ -274,6 +299,7 @@ export function useLiveActivityMirror(): void {
         registeredKey = null;
         void unregisterLiveActivityPushToken();
         void endVoiceLiveActivity();
+        endVoiceActivity();
         return;
       }
 
@@ -309,6 +335,7 @@ export function useLiveActivityMirror(): void {
       }
       pushed = content;
       void updateVoiceLiveActivity(content);
+      updateVoiceActivity(content);
     };
 
     // A session can already be running when this mounts — the controller
@@ -337,14 +364,15 @@ export function useLiveActivityMirror(): void {
     return () => {
       unsubscribe();
       unsubscribeToken();
-      // An activity that outlives its mirror sits on the Lock Screen showing a
-      // phase nothing is driving.
+      // A surface that outlives its mirror sits on the Lock Screen — or floats
+      // over the desktop — showing a phase nothing is driving.
       if (pushed !== null) {
         pushed = null;
         pushToken = null;
         registeredKey = null;
         void unregisterLiveActivityPushToken();
         void endVoiceLiveActivity();
+        endVoiceActivity();
       }
     };
   }, []);

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -343,8 +343,8 @@ export const routeTree = [
   },
 
   // Voice activity panel: the floating live-voice session surface rendered
-  // inside the Electron panel that shows while a session runs and the app is
-  // not frontmost (the desktop counterpart to the iOS Dynamic Island).
+  // inside the Electron window that shows for the length of a session (the
+  // desktop counterpart to the iOS Dynamic Island).
   // Standalone like the dictation overlay: outside auth middleware and
   // RootLayout so it paints as soon as the window opens.
   {

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -342,6 +342,23 @@ export const routeTree = [
     },
   },
 
+  // Voice activity panel — the floating live-voice session surface rendered
+  // inside the Electron panel that shows while a session runs and the app is
+  // not frontmost (the desktop counterpart to the iOS Dynamic Island).
+  // Standalone like the dictation overlay: outside auth middleware and
+  // RootLayout so it paints as soon as the window opens.
+  {
+    path: "/assistant/floating/voice-activity",
+    ErrorBoundary: RouteErrorBoundary,
+    HydrateFallback: RootHydrateFallback,
+    lazy: {
+      Component: () =>
+        import("@/components/voice-activity-panel-page").then(
+          (m) => m.VoiceActivityPanelPage,
+        ),
+    },
+  },
+
   // Dictation overlay — live transcription pill rendered inside the
   // Electron dictation overlay BrowserWindow (a floating panel pinned
   // top-center of the screen while push-to-talk dictation is active).

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -342,7 +342,7 @@ export const routeTree = [
     },
   },
 
-  // Voice activity panel — the floating live-voice session surface rendered
+  // Voice activity panel: the floating live-voice session surface rendered
   // inside the Electron panel that shows while a session runs and the app is
   // not frontmost (the desktop counterpart to the iOS Dynamic Island).
   // Standalone like the dictation overlay: outside auth middleware and

--- a/clients/web/src/runtime/desktop-voice-activity.ts
+++ b/clients/web/src/runtime/desktop-voice-activity.ts
@@ -109,3 +109,24 @@ export async function getVoiceActivityState(): Promise<VoiceActivityState | null
 export function sendVoiceActivityControl(control: VoiceActivityControl): void {
   bridge()?.control(control);
 }
+
+/**
+ * Start moving the panel with the cursor, and stop.
+ *
+ * The panel drags by hand rather than through `-webkit-app-region: drag`: a
+ * drag region swallows clicks outright, and this surface needs the same pixels
+ * to answer a press (bring the app forward) and a hold (move me). The page
+ * tells these apart and calls in; main does the following.
+ */
+export function beginVoiceActivityDrag(): void {
+  bridge()?.beginDrag?.();
+}
+
+export function endVoiceActivityDrag(): void {
+  bridge()?.endDrag?.();
+}
+
+/** Bring the app forward. What a press on the panel asks for. */
+export function activateVoiceActivityApp(): void {
+  bridge()?.activate?.();
+}

--- a/clients/web/src/runtime/desktop-voice-activity.ts
+++ b/clients/web/src/runtime/desktop-voice-activity.ts
@@ -1,0 +1,111 @@
+/**
+ * Runtime wrapper for the desktop live-voice session surface — the floating
+ * panel the Electron main process shows while a session runs and the app is
+ * not frontmost (`clients/macos/src/main/voice-activity-window.ts`).
+ *
+ * The desktop counterpart to `native-live-activity.ts`. That module speaks to
+ * a Capacitor plugin and an ActivityKit activity; this one speaks to an
+ * Electron BrowserWindow. They are two transports for one payload, which is
+ * why {@link useLiveActivityMirror} can drive both from a single computed
+ * snapshot and why the payload types live in `@vellumai/ipc-contract` rather
+ * than being restated here.
+ *
+ * **Skew contract, same as its mobile sibling.** Every call no-ops off
+ * Electron and on a shell that predates the channel, and nothing here throws.
+ * The surface is optional and must never block or end a voice session.
+ *
+ * Two consumers use different halves. The main window drives
+ * {@link startVoiceActivity} / {@link updateVoiceActivity} /
+ * {@link endVoiceActivity} and listens through
+ * {@link subscribeVoiceActivityControl}; the panel's own route reads
+ * {@link getVoiceActivityState} / {@link subscribeVoiceActivityState} and
+ * sends through {@link sendVoiceActivityControl}.
+ */
+
+import {
+  isElectron,
+  type VoiceActivityContent,
+  type VoiceActivityControl,
+  type VoiceActivityStart,
+  type VoiceActivityState,
+} from "@/runtime/is-electron";
+
+type VoiceActivityBridge = NonNullable<
+  NonNullable<Window["vellum"]>["voiceActivity"]
+>;
+
+const bridge = (): VoiceActivityBridge | undefined => {
+  if (!isElectron()) {
+    return undefined;
+  }
+  return window.vellum?.voiceActivity;
+};
+
+/**
+ * Show the panel for a session that just became active, or update the one
+ * already showing.
+ *
+ * Safe to call when one is running: main updates it rather than opening a
+ * second, and deliberately does not restart the elapsed clock. Pair every call
+ * with {@link endVoiceActivity} — a panel that outlives its session floats
+ * over the desktop showing a phase nothing is driving.
+ */
+export function startVoiceActivity(state: VoiceActivityStart): void {
+  bridge()?.start(state);
+}
+
+/**
+ * Push new content to the running panel. A no-op when none is running.
+ *
+ * Unlike ActivityKit there is no update budget here — this is local IPC — but
+ * callers still push only on an actual content change, because the two sinks
+ * are driven from one comparison in the mirror.
+ */
+export function updateVoiceActivity(content: VoiceActivityContent): void {
+  bridge()?.update(content);
+}
+
+/** Dismiss the panel at the end of a session. A no-op when none is running. */
+export function endVoiceActivity(): void {
+  bridge()?.end();
+}
+
+/**
+ * Subscribe to panel button presses, returning an unsubscribe.
+ *
+ * The inbound path — the one that *acts on* the session rather than describing
+ * it. Main broadcasts each press to every renderer but the panel, so this
+ * fires in whichever window has the session mounted; a press that lands with
+ * no listener attached does nothing rather than queueing for the next session.
+ */
+export function subscribeVoiceActivityControl(
+  handler: (control: VoiceActivityControl) => void,
+): () => void {
+  return bridge()?.onControl(handler) ?? (() => undefined);
+}
+
+/**
+ * Subscribe to the state the panel should render, returning an unsubscribe.
+ * `null` means no session is running. Only the panel's own route consumes
+ * this.
+ */
+export function subscribeVoiceActivityState(
+  handler: (state: VoiceActivityState | null) => void,
+): () => void {
+  return bridge()?.onState(handler) ?? (() => undefined);
+}
+
+/**
+ * Read the current session snapshot.
+ *
+ * The panel route loads lazily, so states pushed before its subscription
+ * registers are dropped — pull this once subscribed to catch up.
+ */
+export async function getVoiceActivityState(): Promise<VoiceActivityState | null> {
+  return (await bridge()?.getState()) ?? null;
+}
+
+/** Send a panel button press toward the session. Called only by the panel route. */
+export function sendVoiceActivityControl(control: VoiceActivityControl): void {
+  bridge()?.control(control);
+}

--- a/clients/web/src/runtime/desktop-voice-activity.ts
+++ b/clients/web/src/runtime/desktop-voice-activity.ts
@@ -1,5 +1,5 @@
 /**
- * Runtime wrapper for the desktop live-voice session surface — the floating
+ * Runtime wrapper for the desktop live-voice session surface: the floating
  * panel the Electron main process shows while a session runs and the app is
  * not frontmost (`clients/macos/src/main/voice-activity-window.ts`).
  *
@@ -47,7 +47,7 @@ const bridge = (): VoiceActivityBridge | undefined => {
  *
  * Safe to call when one is running: main updates it rather than opening a
  * second, and deliberately does not restart the elapsed clock. Pair every call
- * with {@link endVoiceActivity} — a panel that outlives its session floats
+ * with {@link endVoiceActivity}. A panel that outlives its session floats
  * over the desktop showing a phase nothing is driving.
  */
 export function startVoiceActivity(state: VoiceActivityStart): void {
@@ -57,7 +57,7 @@ export function startVoiceActivity(state: VoiceActivityStart): void {
 /**
  * Push new content to the running panel. A no-op when none is running.
  *
- * Unlike ActivityKit there is no update budget here — this is local IPC — but
+ * Unlike ActivityKit there is no update budget here (this is local IPC), but
  * callers still push only on an actual content change, because the two sinks
  * are driven from one comparison in the mirror.
  */
@@ -73,7 +73,7 @@ export function endVoiceActivity(): void {
 /**
  * Subscribe to panel button presses, returning an unsubscribe.
  *
- * The inbound path — the one that *acts on* the session rather than describing
+ * The inbound path, the one that *acts on* the session rather than describing
  * it. Main broadcasts each press to every renderer but the panel, so this
  * fires in whichever window has the session mounted; a press that lands with
  * no listener attached does nothing rather than queueing for the next session.
@@ -99,7 +99,7 @@ export function subscribeVoiceActivityState(
  * Read the current session snapshot.
  *
  * The panel route loads lazily, so states pushed before its subscription
- * registers are dropped — pull this once subscribed to catch up.
+ * registers are dropped. Pull this once subscribed to catch up.
  */
 export async function getVoiceActivityState(): Promise<VoiceActivityState | null> {
   return (await bridge()?.getState()) ?? null;

--- a/clients/web/src/runtime/desktop-voice-activity.ts
+++ b/clients/web/src/runtime/desktop-voice-activity.ts
@@ -110,23 +110,19 @@ export function sendVoiceActivityControl(control: VoiceActivityControl): void {
   bridge()?.control(control);
 }
 
-/**
- * Start moving the panel with the cursor, and stop.
- *
- * The panel drags by hand rather than through `-webkit-app-region: drag`: a
- * drag region swallows clicks outright, and this surface needs the same pixels
- * to answer a press (bring the app forward) and a hold (move me). The page
- * tells these apart and calls in; main does the following.
- */
-export function beginVoiceActivityDrag(): void {
-  bridge()?.beginDrag?.();
-}
-
-export function endVoiceActivityDrag(): void {
-  bridge()?.endDrag?.();
-}
-
-/** Bring the app forward. What a press on the panel asks for. */
+/** Bring the app forward, the panel's way back to the conversation. */
 export function activateVoiceActivityApp(): void {
   bridge()?.activate?.();
+}
+
+/**
+ * Hide the window. The session keeps running, and the tray can bring it back.
+ */
+export function dismissVoiceActivityPanel(): void {
+  bridge()?.dismiss?.();
+}
+
+/** Shrink the window to its chip, or restore it. */
+export function setVoiceActivityCollapsed(collapsed: boolean): void {
+  bridge()?.setCollapsed?.(collapsed);
 }

--- a/clients/web/src/runtime/desktop-voice-activity.ts
+++ b/clients/web/src/runtime/desktop-voice-activity.ts
@@ -1,7 +1,7 @@
 /**
  * Runtime wrapper for the desktop live-voice session surface: the floating
- * panel the Electron main process shows while a session runs and the app is
- * not frontmost (`clients/macos/src/main/voice-activity-window.ts`).
+ * window the Electron main process shows for the length of a session
+ * (`clients/macos/src/main/voice-activity-window.ts`).
  *
  * The desktop counterpart to `native-live-activity.ts`. That module speaks to
  * a Capacitor plugin and an ActivityKit activity; this one speaks to an

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -320,9 +320,9 @@ declare global {
         ): () => void;
         control(control: VoiceActivityControl): void;
         onControl(callback: (control: VoiceActivityControl) => void): () => void;
-        beginDrag?(): void;
-        endDrag?(): void;
         activate?(): void;
+        dismiss?(): void;
+        setCollapsed?(collapsed: boolean): void;
       };
     };
   }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -320,6 +320,9 @@ declare global {
         ): () => void;
         control(control: VoiceActivityControl): void;
         onControl(callback: (control: VoiceActivityControl) => void): () => void;
+        beginDrag?(): void;
+        endDrag?(): void;
+        activate?(): void;
       };
     };
   }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -50,6 +50,12 @@ import type {
   UpdateState,
   UpdateStatus,
   VellumCommand,
+  VoiceActivityContent,
+  VoiceActivityControl,
+  VoiceActivityControlAction,
+  VoiceActivityPhase,
+  VoiceActivityStart,
+  VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
 export type {
@@ -79,6 +85,12 @@ export type {
   UpdateState,
   UpdateStatus,
   VellumCommand,
+  VoiceActivityContent,
+  VoiceActivityControl,
+  VoiceActivityControlAction,
+  VoiceActivityPhase,
+  VoiceActivityStart,
+  VoiceActivityState,
 };
 
 // Legacy aliases — existing consumers import these `Electron`-prefixed names.
@@ -297,6 +309,17 @@ declare global {
         check(): Promise<void>;
         install(): Promise<void>;
         onState(callback: (state: UpdateState) => void): () => void;
+      };
+      voiceActivity?: {
+        start(state: VoiceActivityStart): void;
+        update(content: VoiceActivityContent): void;
+        end(): void;
+        getState(): Promise<VoiceActivityState | null>;
+        onState(
+          callback: (state: VoiceActivityState | null) => void,
+        ): () => void;
+        control(control: VoiceActivityControl): void;
+        onControl(callback: (control: VoiceActivityControl) => void): () => void;
       };
     };
   }

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -40,6 +40,10 @@ import type {
   TextInsertionResult,
   UpdateState,
   VellumCommand,
+  VoiceActivityContent,
+  VoiceActivityControl,
+  VoiceActivityStart,
+  VoiceActivityState,
 } from "./types";
 
 /**
@@ -282,6 +286,21 @@ export interface VellumBridge {
     requestStop(): void;
     onStopRequested(callback: () => void): () => void;
     setInteractive(interactive: boolean): void;
+  };
+  /**
+   * The floating live-voice session surface (macOS). Two renderers use
+   * different halves: the main window drives `start`/`update`/`end` and
+   * listens for `onControl`; the panel's own route reads `getState`/`onState`
+   * and sends `control`.
+   */
+  voiceActivity: {
+    start(state: VoiceActivityStart): void;
+    update(content: VoiceActivityContent): void;
+    end(): void;
+    getState(): Promise<VoiceActivityState | null>;
+    onState(callback: (state: VoiceActivityState | null) => void): () => void;
+    control(control: VoiceActivityControl): void;
+    onControl(callback: (control: VoiceActivityControl) => void): () => void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -301,16 +301,12 @@ export interface VellumBridge {
     onState(callback: (state: VoiceActivityState | null) => void): () => void;
     control(control: VoiceActivityControl): void;
     onControl(callback: (control: VoiceActivityControl) => void): () => void;
-    /**
-     * Start moving the panel with the cursor. Main follows the pointer until
-     * `endDrag`, because the panel drags by hand rather than through
-     * `-webkit-app-region`: a drag region swallows clicks outright, and this
-     * surface needs the same pixels to answer both a press and a hold.
-     */
-    beginDrag(): void;
-    endDrag(): void;
-    /** Bring the app forward. What a click on the panel means. */
+    /** Bring the app forward, the panel's way back to the conversation. */
     activate(): void;
+    /** Hide the window. The session keeps running. */
+    dismiss(): void;
+    /** Shrink to the chip, or restore. */
+    setCollapsed(collapsed: boolean): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -301,6 +301,16 @@ export interface VellumBridge {
     onState(callback: (state: VoiceActivityState | null) => void): () => void;
     control(control: VoiceActivityControl): void;
     onControl(callback: (control: VoiceActivityControl) => void): () => void;
+    /**
+     * Start moving the panel with the cursor. Main follows the pointer until
+     * `endDrag`, because the panel drags by hand rather than through
+     * `-webkit-app-region`: a drag region swallows clicks outright, and this
+     * surface needs the same pixels to answer both a press and a hold.
+     */
+    beginDrag(): void;
+    endDrag(): void;
+    /** Bring the app forward. What a click on the panel means. */
+    activate(): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -141,6 +141,9 @@ export const VOICE_ACTIVITY_GET_STATE = "vellum:voiceActivity:getState";
 export const VOICE_ACTIVITY_STATE_EVENT = "vellum:voiceActivity:state";
 export const VOICE_ACTIVITY_CONTROL = "vellum:voiceActivity:control";
 export const VOICE_ACTIVITY_CONTROL_EVENT = "vellum:voiceActivity:controlEvent";
+export const VOICE_ACTIVITY_BEGIN_DRAG = "vellum:voiceActivity:beginDrag";
+export const VOICE_ACTIVITY_END_DRAG = "vellum:voiceActivity:endDrag";
+export const VOICE_ACTIVITY_ACTIVATE = "vellum:voiceActivity:activate";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -133,6 +133,15 @@ export const DICTATION_OVERLAY_STOP_REQUESTED =
 export const DICTATION_OVERLAY_SET_INTERACTIVE =
   "vellum:dictationOverlay:setInteractive";
 
+// Voice activity — the floating live-voice session surface
+export const VOICE_ACTIVITY_START = "vellum:voiceActivity:start";
+export const VOICE_ACTIVITY_UPDATE = "vellum:voiceActivity:update";
+export const VOICE_ACTIVITY_END = "vellum:voiceActivity:end";
+export const VOICE_ACTIVITY_GET_STATE = "vellum:voiceActivity:getState";
+export const VOICE_ACTIVITY_STATE_EVENT = "vellum:voiceActivity:state";
+export const VOICE_ACTIVITY_CONTROL = "vellum:voiceActivity:control";
+export const VOICE_ACTIVITY_CONTROL_EVENT = "vellum:voiceActivity:controlEvent";
+
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";
 

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -141,9 +141,10 @@ export const VOICE_ACTIVITY_GET_STATE = "vellum:voiceActivity:getState";
 export const VOICE_ACTIVITY_STATE_EVENT = "vellum:voiceActivity:state";
 export const VOICE_ACTIVITY_CONTROL = "vellum:voiceActivity:control";
 export const VOICE_ACTIVITY_CONTROL_EVENT = "vellum:voiceActivity:controlEvent";
-export const VOICE_ACTIVITY_BEGIN_DRAG = "vellum:voiceActivity:beginDrag";
-export const VOICE_ACTIVITY_END_DRAG = "vellum:voiceActivity:endDrag";
 export const VOICE_ACTIVITY_ACTIVATE = "vellum:voiceActivity:activate";
+export const VOICE_ACTIVITY_DISMISS = "vellum:voiceActivity:dismiss";
+export const VOICE_ACTIVITY_SET_COLLAPSED =
+  "vellum:voiceActivity:setCollapsed";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -133,7 +133,7 @@ export const DICTATION_OVERLAY_STOP_REQUESTED =
 export const DICTATION_OVERLAY_SET_INTERACTIVE =
   "vellum:dictationOverlay:setInteractive";
 
-// Voice activity — the floating live-voice session surface
+// Voice activity: the floating live-voice session surface
 export const VOICE_ACTIVITY_START = "vellum:voiceActivity:start";
 export const VOICE_ACTIVITY_UPDATE = "vellum:voiceActivity:update";
 export const VOICE_ACTIVITY_END = "vellum:voiceActivity:end";

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -15,7 +15,12 @@
  */
 import { z } from "zod";
 
-import { ASSISTANT_STATUSES, NOTIFICATION_CATEGORIES } from "./types";
+import {
+  ASSISTANT_STATUSES,
+  NOTIFICATION_CATEGORIES,
+  VOICE_ACTIVITY_CONTROL_ACTIONS,
+  VOICE_ACTIVITY_PHASES,
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // Status
@@ -37,4 +42,40 @@ export const showNotificationPayloadSchema = z.object({
   conversationId: z.string().optional(),
   toolCallId: z.string().optional(),
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Voice activity
+// ---------------------------------------------------------------------------
+
+/**
+ * Derived from the `as const` vocabularies in `./types.ts` rather than
+ * restated, so a phase or action added there is validated here without a
+ * second edit — and, more to the point, cannot be added there and silently
+ * rejected at this boundary.
+ */
+export const voiceActivityPhaseSchema = z.enum(VOICE_ACTIVITY_PHASES);
+
+export const voiceActivityContentSchema = z.object({
+  phase: voiceActivityPhaseSchema,
+  label: z.string(),
+  accentHex: z.string(),
+  muted: z.boolean(),
+  outputMuted: z.boolean(),
+  detail: z.string(),
+  approvalRequestId: z.string(),
+});
+
+export const voiceActivityStartSchema = voiceActivityContentSchema.extend({
+  assistantName: z.string(),
+  avatarBase64: z.string().optional(),
+});
+
+export const voiceActivityControlActionSchema = z.enum(
+  VOICE_ACTIVITY_CONTROL_ACTIONS,
+);
+
+export const voiceActivityControlSchema = z.object({
+  action: voiceActivityControlActionSchema,
+  requestId: z.string().optional(),
 });

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -51,7 +51,7 @@ export const showNotificationPayloadSchema = z.object({
 /**
  * Derived from the `as const` vocabularies in `./types.ts` rather than
  * restated, so a phase or action added there is validated here without a
- * second edit — and, more to the point, cannot be added there and silently
+ * second edit and, more to the point, cannot be added there and silently
  * rejected at this boundary.
  */
 export const voiceActivityPhaseSchema = z.enum(VOICE_ACTIVITY_PHASES);

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -98,8 +98,7 @@ export interface HotkeyEvent {
 }
 
 export type FnPushToTalkResult =
-  | { ok: true; enabled: boolean }
-  | { ok: false; reason: string };
+  { ok: true; enabled: boolean } | { ok: false; reason: string };
 
 // ---------------------------------------------------------------------------
 // System permissions
@@ -174,11 +173,7 @@ export type ConnectivityState = (typeof CONNECTIVITY_STATES)[number];
 // ---------------------------------------------------------------------------
 
 export type PowerEventKind =
-  | "suspend"
-  | "resume"
-  | "lock"
-  | "unlock"
-  | "active";
+  "suspend" | "resume" | "lock" | "unlock" | "active";
 
 export interface PowerEvent {
   kind: PowerEventKind;
@@ -216,8 +211,7 @@ export type DeepLink =
 // ---------------------------------------------------------------------------
 
 export type DictationPartialsResult =
-  | { ok: true; enabled: boolean }
-  | { ok: false; reason: string };
+  { ok: true; enabled: boolean } | { ok: false; reason: string };
 
 export interface DictationPartialEvent {
   text: string;
@@ -234,8 +228,7 @@ export type DictationOverlayState =
   | { kind: "error"; message: string };
 
 export type DictationOverlayMessage =
-  | DictationOverlayState
-  | { kind: "dismiss" };
+  DictationOverlayState | { kind: "dismiss" };
 
 // ---------------------------------------------------------------------------
 // Voice activity (the floating live-voice session surface)
@@ -466,12 +459,7 @@ export interface BundleScanData {
 // ---------------------------------------------------------------------------
 
 export type UpdateStatus =
-  | "idle"
-  | "checking"
-  | "available"
-  | "downloading"
-  | "downloaded"
-  | "error";
+  "idle" | "checking" | "available" | "downloading" | "downloaded" | "error";
 
 export interface UpdateState {
   status: UpdateStatus;
@@ -534,8 +522,7 @@ export interface Lockfile {
 }
 
 export type LockfileWriteResult =
-  | { ok: true; lockfile: Lockfile }
-  | { ok: false; error: string };
+  { ok: true; lockfile: Lockfile } | { ok: false; error: string };
 
 export type LocalAssistantRuntimeState =
   | "healthy"

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -318,6 +318,12 @@ export interface VoiceActivityStart extends VoiceActivityContent {
 export interface VoiceActivityState extends VoiceActivityStart {
   /** Epoch ms when main opened this surface. */
   startedAt: number;
+  /**
+   * Whether the window is shrunk to its chip. Main owns it because the window
+   * has to be resized around it, and the page must never draw a chip into a
+   * window still the size of the expanded panel.
+   */
+  collapsed: boolean;
 }
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -238,6 +238,131 @@ export type DictationOverlayMessage =
   | { kind: "dismiss" };
 
 // ---------------------------------------------------------------------------
+// Voice activity (the floating live-voice session surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * Phases of a *running* live-voice session, as the floating surface renders
+ * them.
+ *
+ * Mirrors the web layer's `ActiveLiveVoiceSessionState` — the phases a session
+ * has while it exists, so neither `idle` (no session) nor `failed` (which ends
+ * the surface rather than rendering as a phase) appears here. The two are kept
+ * in step structurally rather than by import: the mirror hands its own payload
+ * to this channel, so a phase added there without a case here fails to compile
+ * at that call site.
+ *
+ * The same vocabulary is decoded on iOS by
+ * `VoiceSessionAttributes.ContentState.Phase`. This surface and that one are
+ * two renderings of one contract.
+ */
+export const VOICE_ACTIVITY_PHASES = [
+  "connecting",
+  "listening",
+  "transcribing",
+  "thinking",
+  "speaking",
+  "ending",
+] as const;
+
+export type VoiceActivityPhase = (typeof VOICE_ACTIVITY_PHASES)[number];
+
+/** The mutable half of the surface — everything that can change mid-session. */
+export interface VoiceActivityContent {
+  phase: VoiceActivityPhase;
+  /**
+   * User-facing phase copy, passed through from the web layer verbatim
+   * (`liveVoiceSurfaceLabel`), so the panel shows exactly what the voice room
+   * shows. Main and the panel own no phase wording of their own — the wording
+   * deploys continuously with the web bundle while the shell ships on release
+   * cadence, so a `switch` over `phase` on this side would fossilize.
+   */
+  label: string;
+  /** Avatar accent as `#RRGGBB`, or `""` when the avatar has no color yet. */
+  accentHex: string;
+  muted: boolean;
+  /** Whether the assistant's audio is muted — what the speaker button renders against. */
+  outputMuted: boolean;
+  /** One short line describing what the turn is doing ("Reading a file"), or `""`. */
+  detail: string;
+  /**
+   * The confirmation the turn is waiting on, or `""` when it is waiting on
+   * none. Non-empty is what puts Approve/Deny on the panel, and the id travels
+   * with them so a decision answers the request the user was shown.
+   */
+  approvalRequestId: string;
+}
+
+/** {@link VoiceActivityContent} plus the fields fixed for the session's lifetime. */
+export interface VoiceActivityStart extends VoiceActivityContent {
+  assistantName: string;
+  /**
+   * The assistant's avatar as a base64 PNG or JPEG. Omitted when there is
+   * none, which the panel renders as its accent glyph instead.
+   *
+   * Sent once at `start` and never re-sent: it cannot change while a session
+   * runs, and it is the one field in this payload big enough for re-sending to
+   * be worth avoiding.
+   */
+  avatarBase64?: string;
+}
+
+/**
+ * What the panel's own renderer receives: everything the session sent, plus
+ * `startedAt`, which main stamps.
+ *
+ * `startedAt` is main's rather than the sender's because the panel is a
+ * separate renderer that can load, reload, or be recreated mid-session — an
+ * elapsed clock anchored in either renderer would restart when that happened.
+ */
+export interface VoiceActivityState extends VoiceActivityStart {
+  /** Epoch ms when main opened this surface. */
+  startedAt: number;
+}
+
+/**
+ * What a panel button asks of the session.
+ *
+ * Each mute is **absolute — the state the button's own label promised** — not
+ * a toggle. The panel renders content that can be a beat old, so a toggle
+ * resolved against live session state is self-consistent and still wrong for
+ * the user: a button reading "Mute assistant" over an already-muted session
+ * would unmute it. Sending what the button said makes that press a no-op,
+ * which the next push corrects.
+ *
+ * Mirrors `VoiceSessionControlAction` on iOS and the web layer's
+ * `VoiceLiveActivityControlAction`; all three are one vocabulary.
+ */
+export const VOICE_ACTIVITY_CONTROL_ACTIONS = [
+  "muteMicrophone",
+  "unmuteMicrophone",
+  "muteAssistantAudio",
+  "unmuteAssistantAudio",
+  "endSession",
+  "approveRequest",
+  "denyRequest",
+] as const;
+
+export type VoiceActivityControlAction =
+  (typeof VOICE_ACTIVITY_CONTROL_ACTIONS)[number];
+
+export interface VoiceActivityControl {
+  action: VoiceActivityControlAction;
+  /**
+   * The confirmation an `approveRequest` / `denyRequest` press was drawn
+   * against; absent on every other action.
+   *
+   * The absolute-mute principle carried one step further. A mute that arrives
+   * stale is a no-op the next push corrects; an approval that arrived stale
+   * would answer a *different question* than the one the user was shown — the
+   * request it named may since have been decided in the main window or timed
+   * out. So the press names its request, and the session answers that one or
+   * drops the press.
+   */
+  requestId?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Helper (native sidecar process)
 // ---------------------------------------------------------------------------
 

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -245,7 +245,7 @@ export type DictationOverlayMessage =
  * Phases of a *running* live-voice session, as the floating surface renders
  * them.
  *
- * Mirrors the web layer's `ActiveLiveVoiceSessionState` — the phases a session
+ * Mirrors the web layer's `ActiveLiveVoiceSessionState`: the phases a session
  * has while it exists, so neither `idle` (no session) nor `failed` (which ends
  * the surface rather than rendering as a phase) appears here. The two are kept
  * in step structurally rather than by import: the mirror hands its own payload
@@ -267,13 +267,13 @@ export const VOICE_ACTIVITY_PHASES = [
 
 export type VoiceActivityPhase = (typeof VOICE_ACTIVITY_PHASES)[number];
 
-/** The mutable half of the surface — everything that can change mid-session. */
+/** The mutable half of the surface: everything that can change mid-session. */
 export interface VoiceActivityContent {
   phase: VoiceActivityPhase;
   /**
    * User-facing phase copy, passed through from the web layer verbatim
    * (`liveVoiceSurfaceLabel`), so the panel shows exactly what the voice room
-   * shows. Main and the panel own no phase wording of their own — the wording
+   * shows. Main and the panel own no phase wording of their own. The wording
    * deploys continuously with the web bundle while the shell ships on release
    * cadence, so a `switch` over `phase` on this side would fossilize.
    */
@@ -281,7 +281,7 @@ export interface VoiceActivityContent {
   /** Avatar accent as `#RRGGBB`, or `""` when the avatar has no color yet. */
   accentHex: string;
   muted: boolean;
-  /** Whether the assistant's audio is muted — what the speaker button renders against. */
+  /** Whether the assistant's audio is muted: what the speaker button renders against. */
   outputMuted: boolean;
   /** One short line describing what the turn is doing ("Reading a file"), or `""`. */
   detail: string;
@@ -312,7 +312,7 @@ export interface VoiceActivityStart extends VoiceActivityContent {
  * `startedAt`, which main stamps.
  *
  * `startedAt` is main's rather than the sender's because the panel is a
- * separate renderer that can load, reload, or be recreated mid-session — an
+ * separate renderer that can load, reload, or be recreated mid-session, and an
  * elapsed clock anchored in either renderer would restart when that happened.
  */
 export interface VoiceActivityState extends VoiceActivityStart {
@@ -323,7 +323,7 @@ export interface VoiceActivityState extends VoiceActivityStart {
 /**
  * What a panel button asks of the session.
  *
- * Each mute is **absolute — the state the button's own label promised** — not
+ * Each mute is **absolute: the state the button's own label promised**, not
  * a toggle. The panel renders content that can be a beat old, so a toggle
  * resolved against live session state is self-consistent and still wrong for
  * the user: a button reading "Mute assistant" over an already-muted session
@@ -354,7 +354,7 @@ export interface VoiceActivityControl {
    *
    * The absolute-mute principle carried one step further. A mute that arrives
    * stale is a no-op the next push corrects; an approval that arrived stale
-   * would answer a *different question* than the one the user was shown — the
+   * would answer a *different question* than the one the user was shown. The
    * request it named may since have been decided in the main window or timed
    * out. So the press names its request, and the session answers that one or
    * drops the press.


### PR DESCRIPTION
A live microphone whose app is not on screen needs a readout and a way to act
on it. iOS has the Dynamic Island and the Lock Screen card for that; the
desktop had nothing, so a voice session moved to the background became an
invisible hot mic.

This adds the desktop equivalent: a small always-on-top window carrying the
same facts the island carries (identity, phase, the turn's activity line,
elapsed time, mute state) plus the session's own controls, a way back to the
conversation, and Approve / Deny when a turn is blocked on a confirmation.

## It is a window, not an overlay

The first build was an auto-hiding panel: a non-activating NSPanel that
appeared when Vellum went to the background and hid itself when Vellum came
forward. That reasoning was sound for a HUD and wrong for this. A surface that
lives for the length of a call is something the user positions, returns to and
puts away, and the appearing-and-vanishing rule kept taking that away from
them. It also could not survive its own controls: a window with live traffic
lights activates the app when clicked, so under the old rule every press on the
panel was a press that hid it.

So it is a real window that happens to float, and the visibility rule is gone.

- **Built directly rather than through `createFloatingWindow`**, which fixes
  `frame: false`, `transparent: true` and `type: "panel"`. None of those can
  carry traffic lights: a transparent frameless panel gives macOS no window
  surface to draw them on, and a non-activating panel leaves them inert.
  `titleBarStyle: "hidden"` with a positioned `trafficLightPosition` is the
  standard shape for a window that wants no title bar and still wants its
  controls.
- **Red hides, and never hangs up.** `close` is intercepted: the window hides,
  the call keeps running. The button a user reaches for when a window is in
  their way must not end their call. Yellow minimizes to the Dock; green is
  disabled through `maximizable` / `fullscreenable`, since a fixed-size readout
  has no meaningful zoom.
- **The way back is the tray**, which grows a "Show Voice Panel" item for
  exactly as long as a session is running.
- **A closed panel is forgotten at the end of the session that closed it.** A
  live mic with no floating control is the state this surface exists to
  prevent, so the next call opens a fresh window rather than inheriting a
  preference the user set once and forgot. A remount is not a new call, and is
  tested as such.
- **Position is the user's, size is the build's.** Only the saved origin is
  restored, so a change to the window's dimensions is not outlived by one
  launch's, and `restoreBounds` clamps it into a connected display so an
  unplugged monitor cannot strand it off screen.
- **The window sizes to its content**, 96pt and 116pt when the daemon has sent
  an activity line. Sizing for the tallest possible content meant spending most
  of a call showing a hole where that line would be.
- **Session-hosting windows opt out of background throttling.** A session
  running in a window nobody is looking at used to be an odd corner; this makes
  it a designed state, and clamping timers to 1 Hz distorts reconnect backoff
  and the assistant-audio idle timer behind the speaking to thinking relabel.

## Mostly a transport change

`useLiveActivityMirror` already computed the whole payload and already ran in
the Electron renderer; it no-opped at `native-live-activity`'s
`isNativeMobile()` gate. So the mirror now fans one computed snapshot out to
two sinks, the Capacitor bridge and a new Electron one, rather than growing a
platform branch of its own, and the inbound control path subscribes to both
sources and applies them through the one function that already existed.

Payload types move to `@vellumai/ipc-contract`. The phase vocabulary is
restated there rather than imported across the package boundary, and the
assignment at the mirror's call site is what holds the two in step: a phase
added to the store without a matching case in the contract fails to compile.

The panel is its own `BrowserWindow`, so it shares no store with the session.
State flows renderer -> main -> panel renderer. `startedAt` is stamped in main
(as `VoiceLiveActivityPlugin` does on iOS) because that renderer can reload
mid-session, and a clock anchored in it would restart, which is the one fact on
the panel a user would read as "the call dropped".

## Other decisions worth reviewing

- **The surface drags and every control opts out.** `-webkit-app-region: drag`
  swallows clicks entirely, so a region either drags or is clickable. That is
  why returning to the conversation is a button rather than a press on the
  panel itself.
- **Each mute sends the state its own label promised, not a toggle.** The panel
  can be a beat behind the session, so a toggle resolved against live state
  would be self-consistent and still wrong: a button reading "Mute assistant"
  over an already-muted session would unmute it. A stale press is a no-op the
  next push corrects.
- **Approve / Deny replaces the controls rather than crowding in beside them.**
  The turn is stopped until it is answered, and the request id travels with the
  press so the session answers the question the user was shown.
- **The page draws no phase copy of its own.** Every string is passed through
  from the session's store; only the glyph switches on `phase`, which is what
  makes a new phase a compile error here.
- **No amplitude in v1.** The band keys off phase alone. Throttled amplitude on
  a desktop-only channel is a follow-on if it reads dead.

## A seam left deliberately unfixed

A `speaking` phase that goes silent mid-turn relabels to "Thinking..." via
`liveVoiceSurfaceLabel` while `phase` stays `speaking`, so the panel shows a
speaker glyph beside that word. iOS has the identical seam. It is not fixable
on one surface alone: the daemon's APNs path composes the island's content from
the raw phase, so remapping in the mirror would leave the island's two drivers
disagreeing. Worth fixing on both at once, or not at all.

## Testing

- 15 cases on the main-process session/visibility controller, which is
  extracted behind injected deps (the `createDictationOverlayController` shape)
  so the rules are testable without a window server: close and reopen, a
  redundant start that must not restart the clock, a dismissed panel that keeps
  receiving updates without reopening.
- 5 cases on the mirror's fan-out: both sinks see one payload on one schedule,
  and content that would not move the island does not reach the panel either.
- 2 cases on the tray item appearing only while a call is running.
- Full macOS suite, web voice suites, both typechecks and eslint.

Verified by hand in the dev app: the window appears when a session starts,
drags, remembers where it was left, closes without ending the call and comes
back from the tray; mic mute, assistant mute and end session all round-trip;
and a backgrounded session still captures voice.

**Not yet exercised:** the Approve / Deny row, which needs a turn blocked on a
confirmation, and the resize when an activity line arrives mid-turn.

**Vestigial:** the collapse-to-chip path (contract field, IPC channel, and the
page's chip branch) is still wired but currently unreachable. It was entered by
the hand-drawn minimize button that the system's traffic lights replaced, and
yellow minimizes to the Dock rather than collapsing. Worth either giving it a
way in or deleting it before this lands.

Closes LUM-3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)
