### PR TITLE
test(web): stop the surface-router mock leaking into other test files

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
@@ -1,13 +1,43 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
-// Replace one surface renderer with a component that always throws so we can
-// assert the boundary contains the failure. Declared before importing
+const CARD_SURFACE_MODULE = "@/domains/chat/components/surfaces/card-surface";
+
+/**
+ * Whether the stubbed card surface throws on render.
+ *
+ * `mock.module` patches a module registry that a bun run shares across every
+ * test file, and there is no way to undo it: re-registering the real module
+ * afterwards does not restore it. So the stub stays installed for the rest of
+ * the run and has to be transparent by default, delegating to the real
+ * component. Only the boundary tests below flip this on. An unconditional
+ * `throw` here fails every card-surface test that runs after this file.
+ */
+let cardSurfaceThrows = false;
+
+// The component value, read out of the namespace before the mock replaces it.
+// Holding the namespace object instead would recurse: `mock.module` patches
+// that same object, so the stub would resolve `CardSurface` to itself.
+const { CardSurface: RealCardSurface } = await import(CARD_SURFACE_MODULE);
+
+// Replace one surface renderer with a component that throws on demand so we
+// can assert the boundary contains the failure. Declared before importing
 // `SurfaceRouter` so the mock is in place when the router resolves its imports.
-mock.module("@/domains/chat/components/surfaces/card-surface", () => ({
-  CardSurface: () => {
-    throw new Error("boom");
+mock.module(CARD_SURFACE_MODULE, () => ({
+  CardSurface: (props: Record<string, unknown>) => {
+    if (cardSurfaceThrows) {
+      throw new Error("boom");
+    }
+    return <RealCardSurface {...props} />;
   },
 }));
 
@@ -16,6 +46,10 @@ import type { Surface } from "@/domains/chat/types/types";
 
 afterEach(() => {
   cleanup();
+});
+
+afterAll(() => {
+  cardSurfaceThrows = false;
 });
 
 function makeSurface(overrides: Partial<Surface> = {}): Surface {
@@ -30,6 +64,14 @@ function makeSurface(overrides: Partial<Surface> = {}): Surface {
 }
 
 describe("SurfaceRouter error boundary", () => {
+  beforeEach(() => {
+    cardSurfaceThrows = true;
+  });
+
+  afterEach(() => {
+    cardSurfaceThrows = false;
+  });
+
   test("contains a surface render failure behind an inline fallback", () => {
     const { getByRole } = render(
       <SurfaceRouter surface={makeSurface()} onAction={() => {}} />,


### PR DESCRIPTION
Split out of #40266, where this surfaced. Independent of it.

## The bug

`surface-router.test.tsx` replaces `CardSurface` with a component that always throws, so it can assert the router's error boundary contains a failing surface:

```ts
mock.module("@/domains/chat/components/surfaces/card-surface", () => ({
  CardSurface: () => { throw new Error("boom"); },
}));
```

`mock.module` patches a module registry that a bun run **shares across every test file**, and re-registering the real module afterwards does not undo it. So the throwing stub outlives this file, and every one of the 17 tests in `card-surface.test.tsx` fails when they run after it:

```
bun test src/domains/chat/components/surfaces/
  168 pass, 17 fail
```

Latent rather than red today only because the default ordering happens to reach `card-surface.test.tsx` first. It becomes real the moment file ordering shifts, which is exactly the kind of failure that costs an afternoon: the error points at `card-surface.test.tsx`, which is not the file with the bug.

## The fix

The stub cannot be removed, so make it **transparent**: render the real component unless a test explicitly asks it to throw, which only the two boundary tests do.

One subtlety worth a look during review: the real component is captured as a value, not a namespace.

```ts
const { CardSurface: RealCardSurface } = await import(CARD_SURFACE_MODULE);
```

Holding `await import(...)` and reaching through it as `realCardSurface.CardSurface` **infinitely recurses** (`RangeError: Maximum call stack size exceeded`), because `mock.module` patches that very namespace object, so the stub resolves `CardSurface` back to itself. Destructuring reads the binding before the mock lands.

## Verification

```
bun test .../card-surface.test.tsx .../surface-router.test.tsx   ->  21 pass, 0 fail   (was 4 pass, 17 fail)
bun test src/domains/chat/components/surfaces/ src/utils/sandbox-bridge.test.ts -> 176 pass, 0 fail
bunx tsc --noEmit  ->  clean
bun run lint       ->  0 errors
```

The boundary tests still fail for the right reason: flipping the flag off makes them fail, so they are still exercising the throw rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->