### PR TITLE
fix(android): contain startup and notification failures

### DIFF
--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -149,6 +149,7 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/clients/android/app/src/main/AndroidManifest.xml
+++ b/clients/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="false"
@@ -156,6 +157,17 @@
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name="com.capacitorjs.plugins.pushnotifications.MessagingService"
+            tools:node="remove" />
+        <service
+            android:name=".SafeMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
@@ -1,0 +1,40 @@
+package ai.vellum.assistant;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "AndroidNotificationChannels")
+public class AndroidNotificationChannelsPlugin extends Plugin {
+    private static final String ALERTS_CHANNEL_ID = "vellum-alerts";
+    private static final String FAILURE_CODE = "NOTIFICATION_CHANNEL_FAILED";
+    private static final String FAILURE_MESSAGE = "Android notification channels are unavailable";
+
+    @PluginMethod
+    public void ensureAlertsChannel(PluginCall call) {
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                call.resolve();
+                return;
+            }
+            NotificationManager manager = (NotificationManager) getContext()
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+            if (manager == null) {
+                call.reject(FAILURE_MESSAGE, FAILURE_CODE);
+                return;
+            }
+            NotificationChannel channel = new NotificationChannel(
+                ALERTS_CHANNEL_ID,
+                "Alerts",
+                NotificationManager.IMPORTANCE_DEFAULT
+            );
+            manager.createNotificationChannel(channel);
+            call.resolve();
+        });
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
@@ -20,7 +20,7 @@ public class AndroidPushRegistrationPlugin extends Plugin {
     }
 
     private void invokeSafely(PluginCall call, Consumer<PushNotificationsPlugin> operation) {
-        PushRegistrationGuard.run(call, () -> {
+        PushRegistrationGuard.call(call, () -> {
             PushNotificationsPlugin plugin = PushNotificationsPlugin.getPushNotificationsInstance();
             if (plugin == null) {
                 PushRegistrationGuard.reject(call);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -46,32 +46,61 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        NativeLaunchScreenPlugin.applySavedTheme(this);
-        boolean recoveredProcess = VoiceLiveActivityPlugin.clearRecoveredStatus(this);
-        if (
-            VoiceDeepLink.shouldSuppressRecoveredStatusLaunch(
-                recoveredProcess,
-                VoiceDeepLink.isStatusNotificationIntent(getIntent())
+        NativeFailureGuard.run(
+            "Unable to apply the Android launch theme",
+            () -> NativeLaunchScreenPlugin.applySavedTheme(this)
+        );
+        boolean recoveredProcess = NativeFailureGuard.get(
+            "Unable to clear the recovered voice status",
+            () -> VoiceLiveActivityPlugin.clearRecoveredStatus(this),
+            false
+        );
+        NativeFailureGuard.run("Unable to normalize the Android launch intent", () -> {
+            if (
+                VoiceDeepLink.shouldSuppressRecoveredStatusLaunch(
+                    recoveredProcess,
+                    VoiceDeepLink.isStatusNotificationIntent(getIntent())
+                )
+            ) {
+                setIntent(VoiceDeepLink.clearedCommandIntent(getIntent()));
+            }
+        });
+        NativeFailureGuard.run(
+            "Unable to prepare the Android voice launch",
+            () -> prepareVoiceLaunch(getIntent())
+        );
+        pendingConnect = NativeFailureGuard.get(
+            "Unable to read the Android connect launch",
+            () -> {
+                ConnectDeepLink connect = takeRecreationConnect();
+                return connect == null ? consumeConnectIntent(getIntent()) : connect;
+            },
+            null
+        );
+        URI selectedServer = pendingConnect == null
+            ? NativeFailureGuard.get(
+                "Unable to read the saved self-hosted server",
+                () -> SelfHostedServer.configured(this),
+                null
             )
-        ) {
-            setIntent(VoiceDeepLink.clearedCommandIntent(getIntent()));
-        }
-        prepareVoiceLaunch(getIntent());
-        pendingConnect = takeRecreationConnect();
-        if (pendingConnect == null) {
-            pendingConnect = consumeConnectIntent(getIntent());
-        }
-        configureServer(pendingConnect == null ? SelfHostedServer.configured(this) : pendingConnect.server());
-        pendingAppLink = consumeAppLinkIntent(getIntent());
+            : pendingConnect.server();
+        configureServer(selectedServer);
+        pendingAppLink = NativeFailureGuard.get(
+            "Unable to read the Android app link",
+            () -> consumeAppLinkIntent(getIntent()),
+            null
+        );
         super.onCreate(savedInstanceState);
-        showLaunchScreen();
-        deliverPendingVoiceLaunch();
-        if (bridge != null) {
-            bridge.setWebViewClient(new SelfHostedWebViewClient(bridge, this));
-        }
-        deliverPendingAppLink();
-        deliverPendingConnect();
-        deliverPendingNewChat();
+        NativeFailureGuard.run("Unable to show the Android launch screen", this::showLaunchScreen);
+        NativeFailureGuard.run("Unable to deliver the Android voice launch", this::deliverPendingVoiceLaunch);
+        NativeFailureGuard.run("Unable to configure the Android WebView", () -> {
+            if (bridge != null) {
+                bridge.setWebViewClient(new SelfHostedWebViewClient(bridge, this));
+            }
+        });
+        NativeFailureGuard.run("Unable to deliver the Android app link", this::deliverPendingAppLink);
+        NativeFailureGuard.run("Unable to deliver the Android connect launch", this::deliverPendingConnect);
+        NativeFailureGuard.run("Unable to deliver the Android new chat launch", this::deliverPendingNewChat);
     }
 
     @Override
@@ -88,6 +117,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
         registerPlugin(NativeLaunchScreenPlugin.class);
+        registerPlugin(AndroidNotificationChannelsPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
         registerPlugin(AndroidPushRegistrationPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
@@ -202,16 +232,19 @@ public class MainActivity extends BridgeActivity {
 
     private void configureServer(URI selectedServer) {
         effectiveServer = selectedServer;
-        if (selectedServer == null) {
-            config = CapConfig.loadDefault(this);
-            return;
-        }
         try {
-            config = SelfHostedServer.overrideCapacitorConfig(this, selectedServer);
-        } catch (IOException | JSONException exception) {
+            config = selectedServer == null
+                ? CapConfig.loadDefault(this)
+                : SelfHostedServer.overrideCapacitorConfig(this, selectedServer);
+        } catch (IOException | JSONException | RuntimeException exception) {
             Logger.error("Unable to apply the self-hosted server configuration", exception);
             effectiveServer = null;
-            config = CapConfig.loadDefault(this);
+            try {
+                config = CapConfig.loadDefault(this);
+            } catch (RuntimeException fallbackException) {
+                Logger.error("Unable to load the Android app configuration", fallbackException);
+                config = new CapConfig.Builder(this).create();
+            }
         }
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -19,7 +19,6 @@ import com.getcapacitor.Bridge;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.BridgeWebViewClient;
 import com.getcapacitor.CapConfig;
-import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginLoadException;
 import com.getcapacitor.PluginManager;
@@ -46,6 +45,7 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        NativeFailureGuard.initialize(this);
         NativeFailureGuard.run(
             "Unable to apply the Android launch theme",
             () -> NativeLaunchScreenPlugin.applySavedTheme(this)
@@ -110,12 +110,13 @@ public class MainActivity extends BridgeActivity {
             plugins = new PluginManager(getAssets()).loadPluginClasses();
             plugins.removeIf(PushNotificationsPlugin.class::equals);
         } catch (PluginLoadException exception) {
-            Logger.error("Unable to load Capacitor plugins", exception);
+            NativeFailureGuard.record("Unable to load Capacitor plugins", exception);
             plugins = new ArrayList<>();
         }
         bridgeBuilder.setPlugins(plugins);
         registerPlugin(NativeAuthPlugin.class);
         registerPlugin(NativeBiometricPlugin.class);
+        registerPlugin(NativeFailureReportsPlugin.class);
         registerPlugin(NativeLaunchScreenPlugin.class);
         registerPlugin(AndroidNotificationChannelsPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
@@ -237,12 +238,18 @@ public class MainActivity extends BridgeActivity {
                 ? CapConfig.loadDefault(this)
                 : SelfHostedServer.overrideCapacitorConfig(this, selectedServer);
         } catch (IOException | JSONException | RuntimeException exception) {
-            Logger.error("Unable to apply the self-hosted server configuration", exception);
+            NativeFailureGuard.record(
+                "Unable to apply the self-hosted server configuration",
+                exception
+            );
             effectiveServer = null;
             try {
                 config = CapConfig.loadDefault(this);
             } catch (RuntimeException fallbackException) {
-                Logger.error("Unable to load the Android app configuration", fallbackException);
+                NativeFailureGuard.record(
+                    "Unable to load the Android app configuration",
+                    fallbackException
+                );
                 config = new CapConfig.Builder(this).create();
             }
         }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
@@ -1,0 +1,39 @@
+package ai.vellum.assistant;
+
+import com.getcapacitor.Logger;
+import com.getcapacitor.PluginCall;
+import java.util.function.Supplier;
+
+final class NativeFailureGuard {
+    private NativeFailureGuard() {}
+
+    static void call(
+        PluginCall call,
+        String failureMessage,
+        String failureCode,
+        Runnable operation
+    ) {
+        try {
+            operation.run();
+        } catch (RuntimeException exception) {
+            call.reject(failureMessage, failureCode, exception);
+        }
+    }
+
+    static void run(String logMessage, Runnable operation) {
+        try {
+            operation.run();
+        } catch (RuntimeException exception) {
+            Logger.error(logMessage, exception);
+        }
+    }
+
+    static <T> T get(String logMessage, Supplier<T> operation, T fallback) {
+        try {
+            return operation.get();
+        } catch (RuntimeException exception) {
+            Logger.error(logMessage, exception);
+            return fallback;
+        }
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
@@ -1,11 +1,18 @@
 package ai.vellum.assistant;
 
+import android.content.Context;
 import com.getcapacitor.Logger;
 import com.getcapacitor.PluginCall;
 import java.util.function.Supplier;
 
 final class NativeFailureGuard {
+    private static volatile Context applicationContext;
+
     private NativeFailureGuard() {}
+
+    static void initialize(Context context) {
+        applicationContext = context.getApplicationContext();
+    }
 
     static void call(
         PluginCall call,
@@ -24,7 +31,7 @@ final class NativeFailureGuard {
         try {
             operation.run();
         } catch (RuntimeException exception) {
-            Logger.error(logMessage, exception);
+            record(logMessage, exception);
         }
     }
 
@@ -32,8 +39,25 @@ final class NativeFailureGuard {
         try {
             return operation.get();
         } catch (RuntimeException exception) {
-            Logger.error(logMessage, exception);
+            record(logMessage, exception);
             return fallback;
+        }
+    }
+
+    static void record(String logMessage, Throwable exception) {
+        Logger.error(logMessage, exception);
+        Context context = applicationContext;
+        if (context == null) {
+            return;
+        }
+        try {
+            if (!NativeFailureReportStore.isEnabled(context)) {
+                return;
+            }
+            NativeFailureReportStore.enqueue(context, logMessage, exception);
+            NativeFailureReportsPlugin.notifyReportAvailable();
+        } catch (RuntimeException storageException) {
+            Logger.error("Unable to store the Android failure report", storageException);
         }
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureReportStore.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureReportStore.java
@@ -1,0 +1,107 @@
+package ai.vellum.assistant;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+final class NativeFailureReportStore {
+    private static final int MAX_REPORTS = 20;
+    private static final int MAX_STACK_TRACE_LENGTH = 12_000;
+    private static final String ENABLED_KEY = "enabled";
+    private static final String PREFERENCES = "vellum_native_failure_reports";
+    private static final String REPORTS_KEY = "reports";
+
+    private NativeFailureReportStore() {}
+
+    static synchronized boolean isEnabled(Context context) {
+        return preferences(context).getBoolean(ENABLED_KEY, false);
+    }
+
+    static synchronized void setEnabled(Context context, boolean enabled) {
+        SharedPreferences.Editor editor = preferences(context)
+            .edit()
+            .putBoolean(ENABLED_KEY, enabled);
+        if (!enabled) {
+            editor.remove(REPORTS_KEY);
+        }
+        if (!editor.commit()) {
+            throw new IllegalStateException("Unable to update Android failure reporting");
+        }
+    }
+
+    static synchronized void enqueue(Context context, String message, Throwable exception) {
+        SharedPreferences preferences = preferences(context);
+        JSONArray reports = readReports(preferences);
+        while (reports.length() >= MAX_REPORTS) {
+            reports.remove(0);
+        }
+
+        JSONObject report = new JSONObject();
+        try {
+            report.put("message", message);
+            report.put("exceptionType", exception.getClass().getName());
+            report.put("stackTrace", stackTrace(exception));
+            report.put("timestamp", System.currentTimeMillis());
+            reports.put(report);
+        } catch (JSONException jsonException) {
+            throw new IllegalStateException(
+                "Unable to serialize the Android failure report",
+                jsonException
+            );
+        }
+
+        preferences.edit().putString(REPORTS_KEY, reports.toString()).apply();
+    }
+
+    static synchronized JSONArray drain(Context context) {
+        SharedPreferences preferences = preferences(context);
+        JSONArray reports = readReports(preferences);
+        if (!preferences.edit().remove(REPORTS_KEY).commit()) {
+            throw new IllegalStateException("Unable to clear Android failure reports");
+        }
+        return reports;
+    }
+
+    private static SharedPreferences preferences(Context context) {
+        return context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    private static JSONArray readReports(SharedPreferences preferences) {
+        String serialized = preferences.getString(REPORTS_KEY, "[]");
+        try {
+            return new JSONArray(serialized == null ? "[]" : serialized);
+        } catch (JSONException exception) {
+            return new JSONArray();
+        }
+    }
+
+    private static String stackTrace(Throwable exception) {
+        StringBuilder trace = new StringBuilder();
+        Throwable current = exception;
+        int causeDepth = 0;
+        while (
+            current != null &&
+            causeDepth < 4 &&
+            trace.length() < MAX_STACK_TRACE_LENGTH
+        ) {
+            if (causeDepth > 0) {
+                trace.append("Caused by: ");
+            }
+            trace.append(current.getClass().getName()).append('\n');
+            for (StackTraceElement frame : current.getStackTrace()) {
+                trace.append("  at ").append(frame).append('\n');
+                if (trace.length() >= MAX_STACK_TRACE_LENGTH) {
+                    break;
+                }
+            }
+            current = current.getCause();
+            causeDepth += 1;
+        }
+        if (trace.length() > MAX_STACK_TRACE_LENGTH) {
+            return trace.substring(0, MAX_STACK_TRACE_LENGTH);
+        }
+        return trace.toString();
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureReportsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureReportsPlugin.java
@@ -1,0 +1,71 @@
+package ai.vellum.assistant;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "NativeFailureReports")
+public class NativeFailureReportsPlugin extends Plugin {
+    private static final String EVENT_REPORT_AVAILABLE = "reportAvailable";
+    private static final String FAILURE_CODE = "FAILURE_REPORTS_UNAVAILABLE";
+    private static volatile NativeFailureReportsPlugin instance;
+
+    @Override
+    public void load() {
+        instance = this;
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (instance == this) {
+            instance = null;
+        }
+    }
+
+    @PluginMethod
+    public void drain(PluginCall call) {
+        NativeFailureGuard.call(
+            call,
+            "Unable to read Android failure reports",
+            FAILURE_CODE,
+            () -> {
+                JSObject result = new JSObject();
+                result.put("reports", NativeFailureReportStore.drain(getContext()));
+                call.resolve(result);
+            }
+        );
+    }
+
+    @PluginMethod
+    public void setEnabled(PluginCall call) {
+        Boolean enabled = call.getBoolean("enabled");
+        if (enabled == null) {
+            call.reject("enabled must be a boolean");
+            return;
+        }
+        NativeFailureGuard.call(
+            call,
+            "Unable to update Android failure reporting",
+            FAILURE_CODE,
+            () -> {
+                NativeFailureReportStore.setEnabled(getContext(), enabled);
+                call.resolve();
+            }
+        );
+    }
+
+    static void notifyReportAvailable() {
+        NativeFailureReportsPlugin plugin = instance;
+        if (plugin == null) {
+            return;
+        }
+        try {
+            plugin.notifyListeners(EVENT_REPORT_AVAILABLE, new JSObject());
+        } catch (RuntimeException exception) {
+            Logger.error("Unable to announce the Android failure report", exception);
+        }
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeLaunchScreenPlugin.java
@@ -1,5 +1,6 @@
 package ai.vellum.assistant;
 
+import android.app.Activity;
 import android.app.UiModeManager;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -14,26 +15,38 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 public class NativeLaunchScreenPlugin extends Plugin {
     private static final int APPLICATION_NIGHT_MODE_UNSPECIFIED =
         Configuration.UI_MODE_NIGHT_UNDEFINED >> 4;
+    private static final String FAILURE_CODE = "LAUNCH_SCREEN_FAILED";
+    private static final String FAILURE_MESSAGE = "Android launch screen is unavailable";
     private static final String PREFERENCES = "vellum_launch_screen";
     private static final String THEME_KEY = "theme";
 
     @PluginMethod
     public void ready(PluginCall call) {
-        if (!storeTheme(call)) {
-            return;
-        }
-        getActivity().runOnUiThread(() -> {
-            MainActivity activity = (MainActivity) getActivity();
-            activity.hideLaunchScreen();
-            call.resolve();
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+            if (!storeTheme(call)) {
+                return;
+            }
+            Activity activity = getActivity();
+            if (!(activity instanceof MainActivity)) {
+                call.reject(FAILURE_MESSAGE, FAILURE_CODE);
+                return;
+            }
+            activity.runOnUiThread(() -> {
+                NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+                    ((MainActivity) activity).hideLaunchScreen();
+                    call.resolve();
+                });
+            });
         });
     }
 
     @PluginMethod
     public void setTheme(PluginCall call) {
-        if (storeTheme(call)) {
-            call.resolve();
-        }
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+            if (storeTheme(call)) {
+                call.resolve();
+            }
+        });
     }
 
     static int backgroundColor(Context context) {
@@ -71,7 +84,9 @@ public class NativeLaunchScreenPlugin extends Plugin {
     private static void applyTheme(Context context, String theme) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             UiModeManager uiModeManager = context.getSystemService(UiModeManager.class);
-            uiModeManager.setApplicationNightMode(platformNightMode(theme));
+            if (uiModeManager != null) {
+                uiModeManager.setApplicationNightMode(platformNightMode(theme));
+            }
             return;
         }
         AppCompatDelegate.setDefaultNightMode(appCompatNightMode(theme));

--- a/clients/android/app/src/main/java/ai/vellum/assistant/PushRegistrationGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/PushRegistrationGuard.java
@@ -3,17 +3,13 @@ package ai.vellum.assistant;
 import com.getcapacitor.PluginCall;
 
 final class PushRegistrationGuard {
+    static final String FAILURE_MESSAGE = "Android push notifications are unavailable";
     private static final String FAILURE_CODE = "PUSH_REGISTRATION_FAILED";
-    private static final String FAILURE_MESSAGE = "Android push notifications are unavailable";
 
     private PushRegistrationGuard() {}
 
-    static void run(PluginCall call, Runnable operation) {
-        try {
-            operation.run();
-        } catch (RuntimeException exception) {
-            call.reject(FAILURE_MESSAGE, FAILURE_CODE, exception);
-        }
+    static void call(PluginCall call, Runnable operation) {
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, operation);
     }
 
     static void reject(PluginCall call) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
@@ -1,0 +1,27 @@
+package ai.vellum.assistant;
+
+import androidx.annotation.NonNull;
+import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+public class SafeMessagingService extends FirebaseMessagingService {
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        NativeFailureGuard.run(
+            "Unable to receive the Android push notification",
+            () -> {
+                super.onMessageReceived(remoteMessage);
+                PushNotificationsPlugin.sendRemoteMessage(remoteMessage);
+            }
+        );
+    }
+
+    @Override
+    public void onNewToken(@NonNull String token) {
+        NativeFailureGuard.run("Unable to receive the Android push token", () -> {
+            super.onNewToken(token);
+            PushNotificationsPlugin.onNewToken(token);
+        });
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.RemoteMessage;
 public class SafeMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        NativeFailureGuard.initialize(this);
         NativeFailureGuard.run(
             "Unable to receive the Android push notification",
             () -> {
@@ -19,6 +20,7 @@ public class SafeMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onNewToken(@NonNull String token) {
+        NativeFailureGuard.initialize(this);
         NativeFailureGuard.run("Unable to receive the Android push token", () -> {
             super.onNewToken(token);
             PushNotificationsPlugin.onNewToken(token);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
@@ -16,6 +16,7 @@ import com.google.firebase.messaging.RemoteMessage;
 public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
     @Override
     public void load() {
+        NativeFailureGuard.initialize(getContext());
         NativeFailureGuard.run("Unable to load Android push notifications", () -> super.load());
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafePushNotificationsPlugin.java
@@ -6,6 +6,8 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.RemoteMessage;
 
 @CapacitorPlugin(
     name = "PushNotifications",
@@ -13,26 +15,76 @@ import com.getcapacitor.annotation.Permission;
 )
 public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
     @Override
+    public void load() {
+        NativeFailureGuard.run("Unable to load Android push notifications", () -> super.load());
+    }
+
+    @Override
     @PluginMethod
     public void checkPermissions(PluginCall call) {
-        PushRegistrationGuard.run(call, () -> super.checkPermissions(call));
+        guard(call, () -> super.checkPermissions(call));
     }
 
     @Override
     @PluginMethod
     public void requestPermissions(PluginCall call) {
-        PushRegistrationGuard.run(call, () -> super.requestPermissions(call));
+        guard(call, () -> super.requestPermissions(call));
     }
 
     @Override
     @PluginMethod
     public void register(PluginCall call) {
-        PushRegistrationGuard.run(call, () -> super.register(call));
+        guard(call, () -> {
+            FirebaseMessaging messaging = FirebaseMessaging.getInstance();
+            messaging.setAutoInitEnabled(true);
+            messaging.getToken().addOnCompleteListener(task -> {
+                NativeFailureGuard.run("Unable to finish Android push registration", () -> {
+                    if (!task.isSuccessful()) {
+                        Exception exception = task.getException();
+                        sendError(
+                            exception == null || exception.getLocalizedMessage() == null
+                                ? PushRegistrationGuard.FAILURE_MESSAGE
+                                : exception.getLocalizedMessage()
+                        );
+                        return;
+                    }
+                    String token = task.getResult();
+                    if (token == null) {
+                        sendError(PushRegistrationGuard.FAILURE_MESSAGE);
+                        return;
+                    }
+                    sendToken(token);
+                });
+            });
+            call.resolve();
+        });
     }
 
     @Override
     @PluginMethod
     public void unregister(PluginCall call) {
-        PushRegistrationGuard.run(call, () -> super.unregister(call));
+        guard(call, () -> super.unregister(call));
+    }
+
+    @Override
+    public void sendToken(String token) {
+        NativeFailureGuard.run("Unable to deliver the Android push token", () -> super.sendToken(token));
+    }
+
+    @Override
+    public void sendError(String error) {
+        NativeFailureGuard.run("Unable to deliver the Android push error", () -> super.sendError(error));
+    }
+
+    @Override
+    public void fireNotification(RemoteMessage remoteMessage) {
+        NativeFailureGuard.run(
+            "Unable to process the Android push notification",
+            () -> super.fireNotification(remoteMessage)
+        );
+    }
+
+    private void guard(PluginCall call, Runnable operation) {
+        PushRegistrationGuard.call(call, operation);
     }
 }

--- a/clients/android/variables.gradle
+++ b/clients/android/variables.gradle
@@ -14,4 +14,5 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
+    firebaseMessagingVersion = '25.0.1'
 }

--- a/clients/web/src/components/startup-failure.tsx
+++ b/clients/web/src/components/startup-failure.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+import { markNativeLaunchScreenReady } from "@/runtime/native-launch-screen";
+
+export const STARTUP_FAILURE_TITLE = "Vellum couldn't start";
+export const STARTUP_FAILURE_MESSAGE =
+  "Reload the app to try again. If this keeps happening, update or reinstall the app.";
+
+export function StartupFailure() {
+  useEffect(() => {
+    void markNativeLaunchScreenReady("system");
+  }, []);
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-[var(--background)] p-6 text-[var(--content-primary)]">
+      <div role="alert" className="max-w-md text-center">
+        <h1 className="text-xl font-semibold">{STARTUP_FAILURE_TITLE}</h1>
+        <p className="mt-2 text-sm text-[var(--content-secondary)]">
+          {STARTUP_FAILURE_MESSAGE}
+        </p>
+        <button
+          type="button"
+          className="mt-5 rounded-md bg-[var(--background-brand)] px-4 py-2 text-sm font-medium text-white"
+          onClick={() => window.location.reload()}
+        >
+          Reload app
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/clients/web/src/lib/sentry/consent-gate.ts
+++ b/clients/web/src/lib/sentry/consent-gate.ts
@@ -33,3 +33,12 @@ export function diagnosticsConsentGranted(): boolean {
   }
   return readConsentHydrated();
 }
+
+/** Whether native diagnostics can be destructively disabled. */
+export function diagnosticsReportingResolvedOff(): boolean {
+  const { platformSession } = useAuthStore.getState();
+  return (
+    platformSession === "absent" ||
+    getDeviceSetting("diagnosticsReporting", "") === "false"
+  );
+}

--- a/clients/web/src/lib/sentry/flavor-capacitor.test.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.test.ts
@@ -7,10 +7,27 @@ import type { BrowserOptions, ErrorEvent } from "@sentry/react";
 // ---------------------------------------------------------------------------
 
 let lastInitOptions: BrowserOptions | undefined;
-const initMock = mock((options: BrowserOptions) => {
-  lastInitOptions = options;
+let siblingInit: ((options: BrowserOptions) => void) | undefined;
+const shutdownOrder: string[] = [];
+const initMock = mock(
+  (
+    options: BrowserOptions,
+    originalInit?: (options: BrowserOptions) => void,
+  ) => {
+    lastInitOptions = options;
+    siblingInit = originalInit;
+  },
+);
+const closeMock = mock(() => {
+  shutdownOrder.push("sentry");
+  return Promise.resolve();
 });
-const closeMock = mock(() => Promise.resolve());
+const reactInitMock = mock((_options: BrowserOptions) => {});
+const startNativeFailureReportForwardingMock = mock(() => Promise.resolve());
+const stopNativeFailureReportForwardingMock = mock(() => {
+  shutdownOrder.push("reports");
+  return Promise.resolve();
+});
 let client: { getOptions: () => { enabled?: boolean } } | undefined;
 
 mock.module("@sentry/capacitor", () => ({
@@ -18,7 +35,11 @@ mock.module("@sentry/capacitor", () => ({
   close: closeMock,
   getClient: () => client,
 }));
-mock.module("@sentry/react", () => ({ init: mock(() => {}) }));
+mock.module("@sentry/react", () => ({ init: reactInitMock }));
+mock.module("@/runtime/native-failure-reports", () => ({
+  startNativeFailureReportForwarding: startNativeFailureReportForwardingMock,
+  stopNativeFailureReportForwarding: stopNativeFailureReportForwardingMock,
+}));
 
 // Controllable composed gate the flavor's beforeSend reads.
 let consent = false;
@@ -35,7 +56,12 @@ const anEvent = (): ErrorEvent =>
 beforeEach(() => {
   initMock.mockClear();
   closeMock.mockClear();
+  reactInitMock.mockClear();
+  startNativeFailureReportForwardingMock.mockClear();
+  stopNativeFailureReportForwardingMock.mockClear();
+  shutdownOrder.length = 0;
   lastInitOptions = undefined;
+  siblingInit = undefined;
   client = undefined;
   consent = false;
 });
@@ -46,6 +72,16 @@ describe("capacitorFlavor.init", () => {
     expect(initMock).toHaveBeenCalledTimes(1);
     expect(lastInitOptions?.enabled).toBe(true);
     expect(lastInitOptions?.dsn).toBe(OPTIONS.dsn);
+  });
+
+  test("starts native failure forwarding after the Sentry client initializes", () => {
+    capacitorFlavor.init(OPTIONS);
+    expect(startNativeFailureReportForwardingMock).not.toHaveBeenCalled();
+
+    siblingInit?.(OPTIONS);
+
+    expect(reactInitMock).toHaveBeenCalledWith(OPTIONS);
+    expect(startNativeFailureReportForwardingMock).toHaveBeenCalledTimes(1);
   });
 
   test("beforeSend drops JS-bridged events when consent is off", () => {
@@ -98,9 +134,11 @@ describe("capacitorFlavor.init", () => {
 });
 
 describe("capacitorFlavor.close", () => {
-  test("shuts down both JS and native via Capacitor.close", () => {
-    void capacitorFlavor.close();
+  test("disables queued reports before shutting down Sentry", async () => {
+    await capacitorFlavor.close();
+    expect(stopNativeFailureReportForwardingMock).toHaveBeenCalledTimes(1);
     expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(shutdownOrder).toEqual(["reports", "sentry"]);
   });
 });
 

--- a/clients/web/src/lib/sentry/flavor-capacitor.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.ts
@@ -3,6 +3,10 @@ import { init as reactInit } from "@sentry/react";
 
 import type { SentryFlavor } from "@/lib/sentry/flavor";
 import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
+import {
+  startNativeFailureReportForwarding,
+  stopNativeFailureReportForwarding,
+} from "@/runtime/native-failure-reports";
 
 /**
  * `SentryFlavor` backed by `@sentry/capacitor`, used inside native mobile
@@ -57,14 +61,18 @@ export const capacitorFlavor: SentryFlavor = {
           return enrich ? enrich(event, hint) : event;
         },
       },
-      reactInit,
+      (browserOptions) => {
+        reactInit(browserOptions);
+        void startNativeFailureReportForwarding();
+      },
     );
   },
-  close() {
+  async close() {
     // Use the Capacitor SDK's own close routine, which shuts down BOTH the JS
     // client and the native SDK. Closing only the JS client would leave native
     // crash reporting running after an opt-out.
-    return Capacitor.close();
+    await stopNativeFailureReportForwarding();
+    await Capacitor.close();
   },
   getClientEnabled() {
     const client = Capacitor.getClient();

--- a/clients/web/src/lib/sentry/flavor.test.ts
+++ b/clients/web/src/lib/sentry/flavor.test.ts
@@ -11,6 +11,7 @@ mock.module("@/runtime/is-electron", () => ({ isElectron: () => electron }));
 // the capacitor flavor here does not drag in the auth store's runtime deps.
 mock.module("@/lib/sentry/consent-gate", () => ({
   diagnosticsConsentGranted: () => false,
+  diagnosticsReportingResolvedOff: () => false,
 }));
 
 const { selectSentryFlavor } = await import("@/lib/sentry/flavor");

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -97,7 +97,8 @@ mock.module("@/stores/auth-store", () => ({
 
 const { syncSentryClient, installSentryControlListeners } =
   await import("@/lib/sentry/sentry-control");
-const { diagnosticsConsentGranted } = await import("@/lib/sentry/consent-gate");
+const { diagnosticsConsentGranted, diagnosticsReportingResolvedOff } =
+  await import("@/lib/sentry/consent-gate");
 
 const OPTIONS: BrowserOptions = { dsn: "https://public@example.test/1" };
 
@@ -173,6 +174,33 @@ describe("diagnosticsConsentGranted (composed gate)", () => {
     expect(diagnosticsConsentGranted()).toBe(true);
     deviceDiagnostics = false;
     expect(diagnosticsConsentGranted()).toBe(false);
+  });
+});
+
+describe("diagnosticsReportingResolvedOff", () => {
+  test("preserves native reports while the platform session is unresolved", () => {
+    platformSession = "unknown";
+    deviceDiagnostics = null;
+    expect(diagnosticsReportingResolvedOff()).toBe(false);
+  });
+
+  test("clears native reports after an explicit opt-out", () => {
+    platformSession = "unknown";
+    deviceDiagnostics = false;
+    expect(diagnosticsReportingResolvedOff()).toBe(true);
+  });
+
+  test("clears native reports after the platform session settles absent", () => {
+    platformSession = "absent";
+    deviceDiagnostics = true;
+    expect(diagnosticsReportingResolvedOff()).toBe(true);
+  });
+
+  test("preserves native reports during an offline-restored session", () => {
+    platformSession = "present";
+    restoredOffline = true;
+    deviceDiagnostics = true;
+    expect(diagnosticsReportingResolvedOff()).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -50,6 +50,7 @@ let authSubscriber:
   | null = null;
 
 const syncDiagnosticsToMainMock = mock((_enabled: boolean) => {});
+const disableNativeFailureReportForwardingMock = mock(() => Promise.resolve());
 
 mock.module("@/utils/device-settings", () => ({
   getDeviceBool: (name: string, fallback: boolean) => {
@@ -71,6 +72,10 @@ mock.module("@/utils/device-settings", () => ({
 
 mock.module("@/runtime/diagnostics", () => ({
   syncDiagnosticsToMain: syncDiagnosticsToMainMock,
+}));
+mock.module("@/runtime/native-failure-reports", () => ({
+  disableNativeFailureReportForwarding:
+    disableNativeFailureReportForwardingMock,
 }));
 
 // Whether a consent sync (or explicit acceptance) has hydrated the flags —
@@ -107,6 +112,7 @@ beforeEach(() => {
   closeMock.mockClear();
   selectSentryFlavorMock.mockClear();
   syncDiagnosticsToMainMock.mockReset();
+  disableNativeFailureReportForwardingMock.mockClear();
   readNames.length = 0;
   watchedNames.length = 0;
   deviceWatchCallback = null;
@@ -212,12 +218,13 @@ describe("syncSentryClient", () => {
     expect(selectSentryFlavorMock).toHaveBeenCalled();
   });
 
-  test("no-ops when dsn is absent (never touches the flavor)", () => {
+  test("dsn absent disables native reporting without touching the flavor", () => {
     deviceDiagnostics = true;
     platformSession = "present";
     syncSentryClient({});
     expect(initMock).not.toHaveBeenCalled();
     expect(closeMock).not.toHaveBeenCalled();
+    expect(disableNativeFailureReportForwardingMock).toHaveBeenCalledTimes(1);
   });
 
   test("confirmed-live session + gate on: inits the flavor when no client is enabled", () => {

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -31,6 +31,7 @@ import { selectSentryFlavor } from "@/lib/sentry/flavor";
 import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
 import { watchDeviceSetting } from "@/utils/device-settings";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
+import { disableNativeFailureReportForwarding } from "@/runtime/native-failure-reports";
 import { useAuthStore } from "@/stores/auth-store";
 
 function tryInit(options: BrowserOptions): void {
@@ -52,6 +53,7 @@ function tryClose(): void {
  */
 export function syncSentryClient(options: BrowserOptions): void {
   if (!options.dsn) {
+    void disableNativeFailureReportForwarding();
     return;
   }
   if (diagnosticsConsentGranted()) {

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -19,6 +19,7 @@ import { isChunkLoadError } from "@/lib/chunk-errors";
 import { setupClientFlagScopeSync } from "@/lib/feature-flags/client-flag-scope";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
 import { isLocalClient, loadLockfile } from "@/lib/local-mode";
+import { captureError } from "@/lib/sentry/capture-error";
 import { initSentry } from "@/lib/sentry/sentry-init";
 import { markBoot } from "@/lib/telemetry/boot-telemetry";
 import { installTranslateDomGuard } from "@/lib/translate-dom-guard";
@@ -121,9 +122,9 @@ async function boot() {
 
 function showBootFailure(error: unknown): void {
   try {
-    Sentry.captureException(error, { tags: { boundary: "app-boot" } });
-  } catch {
-    console.error("Vellum failed to start", error);
+    captureError(error, { context: "app_boot" });
+  } catch (captureFailure) {
+    console.error("Unable to report the startup failure", captureFailure);
   }
   void markNativeLaunchScreenReady("system");
 

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -9,6 +9,11 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
 
 import { AppProviders } from "@/components/providers";
+import {
+  STARTUP_FAILURE_MESSAGE,
+  STARTUP_FAILURE_TITLE,
+  StartupFailure,
+} from "@/components/startup-failure";
 import { WindowDragRegion } from "@/components/window-drag-region";
 import { isChunkLoadError } from "@/lib/chunk-errors";
 import { setupClientFlagScopeSync } from "@/lib/feature-flags/client-flag-scope";
@@ -30,6 +35,7 @@ import { initNativeKeyboard } from "@/runtime/native-keyboard";
 import { initNativePlatformAttributes } from "@/runtime/native-platform-attributes";
 import { initSafeAreaBridge } from "@/runtime/native-safe-area";
 import { restorePendingNativeLogin } from "@/runtime/native-auth";
+import { markNativeLaunchScreenReady } from "@/runtime/native-launch-screen";
 import { initInputModality } from "@vellumai/design-library";
 
 async function boot() {
@@ -82,28 +88,69 @@ async function boot() {
   markBoot("react_mount");
   createRoot(rootEl).render(
     <StrictMode>
-      <AppProviders>
-        <WindowDragRegion />
-        <RouterProvider
-          router={router}
-          onError={(error) => {
-            // Single Sentry capture point for every router error.
-            // `RouteErrorBoundary` (used at every layer of the tree) owns
-            // only the UI variant and intentionally does NOT capture again
-            // to avoid duplicate events.
-            Sentry.captureException(error, {
-              tags: {
-                context: "RouterProvider",
-                boundary: isChunkLoadError(error)
-                  ? "lazy-route"
-                  : "route-render",
-              },
-            });
-          }}
-        />
-      </AppProviders>
+      <Sentry.ErrorBoundary
+        beforeCapture={(scope) => {
+          scope.setTag("boundary", "app-startup");
+        }}
+        fallback={<StartupFailure />}
+      >
+        <AppProviders>
+          <WindowDragRegion />
+          <RouterProvider
+            router={router}
+            onError={(error) => {
+              // Single Sentry capture point for every router error.
+              // `RouteErrorBoundary` (used at every layer of the tree) owns
+              // only the UI variant and intentionally does NOT capture again
+              // to avoid duplicate events.
+              Sentry.captureException(error, {
+                tags: {
+                  context: "RouterProvider",
+                  boundary: isChunkLoadError(error)
+                    ? "lazy-route"
+                    : "route-render",
+                },
+              });
+            }}
+          />
+        </AppProviders>
+      </Sentry.ErrorBoundary>
     </StrictMode>,
   );
 }
 
-boot();
+function showBootFailure(error: unknown): void {
+  try {
+    Sentry.captureException(error, { tags: { boundary: "app-boot" } });
+  } catch {
+    console.error("Vellum failed to start", error);
+  }
+  void markNativeLaunchScreenReady("system");
+
+  try {
+    const root = document.getElementById("root");
+    if (!root) {
+      return;
+    }
+    const container = document.createElement("main");
+    container.setAttribute("role", "alert");
+    container.style.cssText =
+      "min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;text-align:center;font-family:system-ui,sans-serif";
+    const content = document.createElement("div");
+    const heading = document.createElement("h1");
+    heading.textContent = STARTUP_FAILURE_TITLE;
+    const message = document.createElement("p");
+    message.textContent = STARTUP_FAILURE_MESSAGE;
+    const reload = document.createElement("button");
+    reload.type = "button";
+    reload.textContent = "Reload app";
+    reload.addEventListener("click", () => window.location.reload());
+    content.append(heading, message, reload);
+    container.append(content);
+    root.replaceChildren(container);
+  } catch (renderError) {
+    console.error("Unable to show the startup error", renderError);
+  }
+}
+
+void boot().catch(showBootFailure);

--- a/clients/web/src/runtime/android-notification-channels.test.ts
+++ b/clients/web/src/runtime/android-notification-channels.test.ts
@@ -3,6 +3,7 @@ import { expect, mock, test } from "bun:test";
 let isAndroid = false;
 let isAvailable = true;
 const ensureAlertsChannelMock = mock(async () => {});
+const createChannelMock = mock(async () => {});
 
 mock.module("@/runtime/platform-detection", () => ({
   isNativeAndroid: () => isAndroid,
@@ -17,23 +18,29 @@ mock.module("@capacitor/core", () => ({
   }),
 }));
 
+mock.module("@capacitor/local-notifications", () => ({
+  LocalNotifications: {
+    createChannel: createChannelMock,
+  },
+}));
+
 const { ensureAndroidAlertsChannel } =
   await import("./android-notification-channels");
 
-test("uses the guarded native channel plugin when available", async () => {
+test("creates the Android channel across native shell versions", async () => {
   await ensureAndroidAlertsChannel();
   expect(ensureAlertsChannelMock).not.toHaveBeenCalled();
+  expect(createChannelMock).not.toHaveBeenCalled();
 
   isAndroid = true;
   isAvailable = false;
-  await ensureAndroidAlertsChannel();
-  expect(ensureAlertsChannelMock).not.toHaveBeenCalled();
+  createChannelMock.mockRejectedValueOnce(new Error("unavailable"));
+  await expect(ensureAndroidAlertsChannel()).rejects.toThrow("unavailable");
+  expect(createChannelMock).toHaveBeenCalledTimes(1);
 
   isAvailable = true;
-  ensureAlertsChannelMock.mockRejectedValueOnce(new Error("unavailable"));
-  await expect(ensureAndroidAlertsChannel()).rejects.toThrow("unavailable");
   await ensureAndroidAlertsChannel();
   await ensureAndroidAlertsChannel();
 
-  expect(ensureAlertsChannelMock).toHaveBeenCalledTimes(2);
+  expect(ensureAlertsChannelMock).toHaveBeenCalledTimes(1);
 });

--- a/clients/web/src/runtime/android-notification-channels.test.ts
+++ b/clients/web/src/runtime/android-notification-channels.test.ts
@@ -1,0 +1,39 @@
+import { expect, mock, test } from "bun:test";
+
+let isAndroid = false;
+let isAvailable = true;
+const ensureAlertsChannelMock = mock(async () => {});
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeAndroid: () => isAndroid,
+}));
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isPluginAvailable: () => isAvailable,
+  },
+  registerPlugin: () => ({
+    ensureAlertsChannel: ensureAlertsChannelMock,
+  }),
+}));
+
+const { ensureAndroidAlertsChannel } =
+  await import("./android-notification-channels");
+
+test("uses the guarded native channel plugin when available", async () => {
+  await ensureAndroidAlertsChannel();
+  expect(ensureAlertsChannelMock).not.toHaveBeenCalled();
+
+  isAndroid = true;
+  isAvailable = false;
+  await ensureAndroidAlertsChannel();
+  expect(ensureAlertsChannelMock).not.toHaveBeenCalled();
+
+  isAvailable = true;
+  ensureAlertsChannelMock.mockRejectedValueOnce(new Error("unavailable"));
+  await expect(ensureAndroidAlertsChannel()).rejects.toThrow("unavailable");
+  await ensureAndroidAlertsChannel();
+  await ensureAndroidAlertsChannel();
+
+  expect(ensureAlertsChannelMock).toHaveBeenCalledTimes(2);
+});

--- a/clients/web/src/runtime/android-notification-channels.ts
+++ b/clients/web/src/runtime/android-notification-channels.ts
@@ -1,6 +1,18 @@
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
 import { isNativeAndroid } from "@/runtime/platform-detection";
 
 export const ANDROID_ALERTS_CHANNEL_ID = "vellum-alerts";
+const ANDROID_NOTIFICATION_CHANNELS_PLUGIN = "AndroidNotificationChannels";
+
+interface AndroidNotificationChannelsPlugin {
+  ensureAlertsChannel(): Promise<void>;
+}
+
+const AndroidNotificationChannels =
+  registerPlugin<AndroidNotificationChannelsPlugin>(
+    ANDROID_NOTIFICATION_CHANNELS_PLUGIN,
+  );
 
 let channelPromise: Promise<void> | null = null;
 
@@ -8,19 +20,16 @@ export async function ensureAndroidAlertsChannel(): Promise<void> {
   if (!isNativeAndroid()) {
     return;
   }
+  if (!Capacitor.isPluginAvailable(ANDROID_NOTIFICATION_CHANNELS_PLUGIN)) {
+    return;
+  }
   if (!channelPromise) {
-    channelPromise = (async () => {
-      const { LocalNotifications } =
-        await import("@capacitor/local-notifications");
-      await LocalNotifications.createChannel({
-        id: ANDROID_ALERTS_CHANNEL_ID,
-        name: "Alerts",
-        importance: 3,
-      });
-    })().catch((error) => {
-      channelPromise = null;
-      throw error;
-    });
+    channelPromise = AndroidNotificationChannels.ensureAlertsChannel().catch(
+      (error) => {
+        channelPromise = null;
+        throw error;
+      },
+    );
   }
   await channelPromise;
 }

--- a/clients/web/src/runtime/android-notification-channels.ts
+++ b/clients/web/src/runtime/android-notification-channels.ts
@@ -20,16 +20,22 @@ export async function ensureAndroidAlertsChannel(): Promise<void> {
   if (!isNativeAndroid()) {
     return;
   }
-  if (!Capacitor.isPluginAvailable(ANDROID_NOTIFICATION_CHANNELS_PLUGIN)) {
-    return;
-  }
   if (!channelPromise) {
-    channelPromise = AndroidNotificationChannels.ensureAlertsChannel().catch(
-      (error) => {
-        channelPromise = null;
-        throw error;
-      },
-    );
+    channelPromise = (
+      Capacitor.isPluginAvailable(ANDROID_NOTIFICATION_CHANNELS_PLUGIN)
+        ? AndroidNotificationChannels.ensureAlertsChannel()
+        : import("@capacitor/local-notifications").then(
+            ({ LocalNotifications }) =>
+              LocalNotifications.createChannel({
+                id: ANDROID_ALERTS_CHANNEL_ID,
+                name: "Alerts",
+                importance: 3,
+              }),
+          )
+    ).catch((error) => {
+      channelPromise = null;
+      throw error;
+    });
   }
   await channelPromise;
 }

--- a/clients/web/src/runtime/native-failure-reports.test.ts
+++ b/clients/web/src/runtime/native-failure-reports.test.ts
@@ -1,0 +1,113 @@
+import { expect, mock, test } from "bun:test";
+
+let isAndroid = false;
+let isAvailable = false;
+let consent = false;
+let reports: Array<{
+  message: string;
+  exceptionType: string;
+  stackTrace: string;
+  timestamp: number;
+}> = [];
+let reportAvailable: (() => void) | undefined;
+
+const drainMock = mock(async () => {
+  const drained = reports;
+  reports = [];
+  return { reports: drained };
+});
+const setEnabledMock = mock(async (_options: { enabled: boolean }) => {});
+const addListenerMock = mock(
+  async (_eventName: string, listener: () => void) => {
+    reportAvailable = listener;
+    return { remove: async () => {} };
+  },
+);
+const captureErrorMock = mock((_error: unknown, _options: unknown) => {});
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeAndroid: () => isAndroid,
+}));
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isPluginAvailable: () => isAvailable,
+  },
+  registerPlugin: () => ({
+    drain: drainMock,
+    setEnabled: setEnabledMock,
+    addListener: addListenerMock,
+  }),
+}));
+mock.module("@/lib/sentry/consent-gate", () => ({
+  diagnosticsConsentGranted: () => consent,
+}));
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const {
+  flushPendingNativeFailureReports,
+  startNativeFailureReportForwarding,
+  stopNativeFailureReportForwarding,
+} = await import("./native-failure-reports");
+
+test("forwards queued Android failures only while diagnostics reporting is enabled", async () => {
+  await startNativeFailureReportForwarding();
+  expect(drainMock).not.toHaveBeenCalled();
+
+  isAndroid = true;
+  isAvailable = true;
+  reports = [
+    {
+      message: "Unable to prepare the Android voice launch",
+      exceptionType: "java.lang.IllegalStateException",
+      stackTrace: "java.lang.IllegalStateException\n  at Example.call(Example.java:1)",
+      timestamp: 123,
+    },
+  ];
+  await startNativeFailureReportForwarding();
+  expect(drainMock).not.toHaveBeenCalled();
+
+  consent = true;
+  await startNativeFailureReportForwarding();
+
+  expect(setEnabledMock).toHaveBeenCalledWith({ enabled: true });
+  expect(addListenerMock).toHaveBeenCalledWith(
+    "reportAvailable",
+    expect.any(Function),
+  );
+  expect(drainMock).toHaveBeenCalledTimes(1);
+  const [error, options] = captureErrorMock.mock.calls[0]!;
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).name).toBe("java.lang.IllegalStateException");
+  expect(options).toEqual({
+    context: "android_native_failure",
+    tags: { native_exception_type: "java.lang.IllegalStateException" },
+    extra: {
+      nativeStackTrace:
+        "java.lang.IllegalStateException\n  at Example.call(Example.java:1)",
+      occurredAt: "1970-01-01T00:00:00.123Z",
+    },
+  });
+
+  reports = [
+    {
+      message: "Unable to receive the Android push token",
+      exceptionType: "java.lang.RuntimeException",
+      stackTrace: "java.lang.RuntimeException\n  at Example.push(Example.java:2)",
+      timestamp: 456,
+    },
+  ];
+  reportAvailable?.();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(drainMock).toHaveBeenCalledTimes(2);
+  expect(captureErrorMock).toHaveBeenCalledTimes(2);
+
+  consent = false;
+  reportAvailable?.();
+  await flushPendingNativeFailureReports();
+  expect(drainMock).toHaveBeenCalledTimes(2);
+
+  await stopNativeFailureReportForwarding();
+  expect(setEnabledMock).toHaveBeenLastCalledWith({ enabled: false });
+});

--- a/clients/web/src/runtime/native-failure-reports.test.ts
+++ b/clients/web/src/runtime/native-failure-reports.test.ts
@@ -3,6 +3,7 @@ import { expect, mock, test } from "bun:test";
 let isAndroid = false;
 let isAvailable = false;
 let consent = false;
+let reportingResolvedOff = false;
 let reports: Array<{
   message: string;
   exceptionType: string;
@@ -40,6 +41,7 @@ mock.module("@capacitor/core", () => ({
 }));
 mock.module("@/lib/sentry/consent-gate", () => ({
   diagnosticsConsentGranted: () => consent,
+  diagnosticsReportingResolvedOff: () => reportingResolvedOff,
 }));
 mock.module("@/lib/sentry/capture-error", () => ({
   captureError: captureErrorMock,
@@ -108,6 +110,10 @@ test("forwards queued Android failures only while diagnostics reporting is enabl
   await flushPendingNativeFailureReports();
   expect(drainMock).toHaveBeenCalledTimes(2);
 
+  await stopNativeFailureReportForwarding();
+  expect(setEnabledMock).not.toHaveBeenCalledWith({ enabled: false });
+
+  reportingResolvedOff = true;
   await stopNativeFailureReportForwarding();
   expect(setEnabledMock).toHaveBeenLastCalledWith({ enabled: false });
 });

--- a/clients/web/src/runtime/native-failure-reports.test.ts
+++ b/clients/web/src/runtime/native-failure-reports.test.ts
@@ -48,6 +48,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 const {
+  disableNativeFailureReportForwarding,
   flushPendingNativeFailureReports,
   startNativeFailureReportForwarding,
   stopNativeFailureReportForwarding,
@@ -112,6 +113,9 @@ test("forwards queued Android failures only while diagnostics reporting is enabl
 
   await stopNativeFailureReportForwarding();
   expect(setEnabledMock).not.toHaveBeenCalledWith({ enabled: false });
+
+  await disableNativeFailureReportForwarding();
+  expect(setEnabledMock).toHaveBeenLastCalledWith({ enabled: false });
 
   reportingResolvedOff = true;
   await stopNativeFailureReportForwarding();

--- a/clients/web/src/runtime/native-failure-reports.ts
+++ b/clients/web/src/runtime/native-failure-reports.ts
@@ -4,7 +4,10 @@ import {
   type PluginListenerHandle,
 } from "@capacitor/core";
 
-import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
+import {
+  diagnosticsConsentGranted,
+  diagnosticsReportingResolvedOff,
+} from "@/lib/sentry/consent-gate";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isNativeAndroid } from "@/runtime/platform-detection";
 
@@ -107,7 +110,7 @@ export async function startNativeFailureReportForwarding(): Promise<void> {
 }
 
 export async function stopNativeFailureReportForwarding(): Promise<void> {
-  if (!isAvailable()) {
+  if (!isAvailable() || !diagnosticsReportingResolvedOff()) {
     return;
   }
   try {

--- a/clients/web/src/runtime/native-failure-reports.ts
+++ b/clients/web/src/runtime/native-failure-reports.ts
@@ -1,0 +1,118 @@
+import {
+  Capacitor,
+  registerPlugin,
+  type PluginListenerHandle,
+} from "@capacitor/core";
+
+import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativeAndroid } from "@/runtime/platform-detection";
+
+interface NativeFailureReport {
+  message: string;
+  exceptionType: string;
+  stackTrace: string;
+  timestamp: number;
+}
+
+interface NativeFailureReportsPlugin {
+  drain(): Promise<{ reports: NativeFailureReport[] }>;
+  setEnabled(options: { enabled: boolean }): Promise<void>;
+  addListener(
+    eventName: "reportAvailable",
+    listener: () => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+const PLUGIN_NAME = "NativeFailureReports";
+const NativeFailureReports =
+  registerPlugin<NativeFailureReportsPlugin>(PLUGIN_NAME);
+
+let listenerPromise: Promise<void> | null = null;
+
+function isAvailable(): boolean {
+  return isNativeAndroid() && Capacitor.isPluginAvailable(PLUGIN_NAME);
+}
+
+function reportNativeFailure(report: NativeFailureReport): void {
+  const error = new Error(report.message);
+  error.name = report.exceptionType;
+  captureError(error, {
+    context: "android_native_failure",
+    tags: { native_exception_type: report.exceptionType },
+    extra: {
+      nativeStackTrace: report.stackTrace,
+      occurredAt: new Date(report.timestamp).toISOString(),
+    },
+  });
+}
+
+export async function flushPendingNativeFailureReports(): Promise<void> {
+  if (!isAvailable() || !diagnosticsConsentGranted()) {
+    return;
+  }
+  try {
+    const { reports } = await NativeFailureReports.drain();
+    for (const report of reports) {
+      reportNativeFailure(report);
+    }
+  } catch (error) {
+    captureError(error, {
+      context: "android_native_failure_drain",
+      bestEffort: true,
+    });
+  }
+}
+
+function ensureListener(): Promise<void> {
+  if (listenerPromise === null) {
+    listenerPromise = NativeFailureReports.addListener(
+      "reportAvailable",
+      () => {
+        void flushPendingNativeFailureReports();
+      },
+    )
+      .then(() => {
+        return undefined;
+      })
+      .catch((error) => {
+        listenerPromise = null;
+        throw error;
+      });
+  }
+  return listenerPromise;
+}
+
+export async function startNativeFailureReportForwarding(): Promise<void> {
+  if (!isAvailable() || !diagnosticsConsentGranted()) {
+    return;
+  }
+  try {
+    await ensureListener();
+    if (!diagnosticsConsentGranted()) {
+      return;
+    }
+    await NativeFailureReports.setEnabled({ enabled: true });
+    if (!diagnosticsConsentGranted()) {
+      await NativeFailureReports.setEnabled({ enabled: false });
+      return;
+    }
+    await flushPendingNativeFailureReports();
+  } catch (error) {
+    captureError(error, {
+      context: "android_native_failure_listener",
+      bestEffort: true,
+    });
+  }
+}
+
+export async function stopNativeFailureReportForwarding(): Promise<void> {
+  if (!isAvailable()) {
+    return;
+  }
+  try {
+    await NativeFailureReports.setEnabled({ enabled: false });
+  } catch (error) {
+    console.error("Unable to disable Android failure reporting", error);
+  }
+}

--- a/clients/web/src/runtime/native-failure-reports.ts
+++ b/clients/web/src/runtime/native-failure-reports.ts
@@ -113,6 +113,13 @@ export async function stopNativeFailureReportForwarding(): Promise<void> {
   if (!isAvailable() || !diagnosticsReportingResolvedOff()) {
     return;
   }
+  await disableNativeFailureReportForwarding();
+}
+
+export async function disableNativeFailureReportForwarding(): Promise<void> {
+  if (!isAvailable()) {
+    return;
+  }
   try {
     await NativeFailureReports.setEnabled({ enabled: false });
   } catch (error) {

--- a/clients/web/src/utils/storage-migration.test.ts
+++ b/clients/web/src/utils/storage-migration.test.ts
@@ -458,4 +458,26 @@ describe("runStorageMigrations", () => {
     runStorageMigrations();
     expect(localStorage.getItem("vellum:ai:imageGenProvider")).toBe("gemini");
   });
+
+  test("continues when image provider storage is unavailable", () => {
+    const originalGetItem = localStorage.getItem;
+    Object.defineProperty(localStorage, "getItem", {
+      value(key: string) {
+        if (key === "vellum:ai:imageGenProvider") {
+          throw new DOMException("Storage unavailable", "SecurityError");
+        }
+        return originalGetItem.call(localStorage, key);
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(() => runStorageMigrations()).not.toThrow();
+    } finally {
+      Object.defineProperty(localStorage, "getItem", {
+        value: originalGetItem,
+        configurable: true,
+      });
+    }
+  });
 });

--- a/clients/web/src/utils/storage-migration.ts
+++ b/clients/web/src/utils/storage-migration.ts
@@ -267,13 +267,17 @@ export function runStorageMigrations(): void {
   // legacy mode into the equivalent provider so a previously-managed
   // browser does not fall back to the BYOK default before the daemon
   // config loads.
-  if (localStorage.getItem("vellum:ai:imageGenProvider") === null) {
-    const legacyImageGenMode = localStorage.getItem("vellum:ai:imageGenMode");
-    if (legacyImageGenMode === "managed") {
-      localStorage.setItem("vellum:ai:imageGenProvider", "vellum");
-    } else if (legacyImageGenMode === "your-own") {
-      localStorage.setItem("vellum:ai:imageGenProvider", "gemini");
+  try {
+    if (localStorage.getItem("vellum:ai:imageGenProvider") === null) {
+      const legacyImageGenMode = localStorage.getItem("vellum:ai:imageGenMode");
+      if (legacyImageGenMode === "managed") {
+        localStorage.setItem("vellum:ai:imageGenProvider", "vellum");
+      } else if (legacyImageGenMode === "your-own") {
+        localStorage.setItem("vellum:ai:imageGenProvider", "gemini");
+      }
     }
+  } catch {
+    // Storage unavailable. Retry on next load.
   }
   migrateKey("vellum_web_search_mode", "vellum:ai:webSearchMode");
   migrateKey("vellum_web_search_provider", "vellum:ai:webSearchProvider");


### PR DESCRIPTION
## Summary
- contain synchronous and asynchronous Android push failures inside native crash guards
- create notification channels through a guarded native plugin and make optional cold-start work best-effort
- add web boot and provider recovery UI while making startup storage migrations failure-safe

## Original prompt
The Android internal-test app could still stop after sign-in, and the startup audit identified five unguarded crash paths across push registration, notification channels, cold-start setup, the native launch screen, and web bootstrap. This change fixes items 1 through 5 so optional notification or startup failures degrade gracefully instead of terminating or blanking the app.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->