### PR TITLE
fix(web): say why the profile editor blocks Save (LUM-3076)

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -120,28 +120,16 @@ export function ProfileEditorFields({
   );
 
   const keyField = (
-    <div className="space-y-1">
-      <label className="block text-body-small-default text-[var(--content-tertiary)]">
-        Key
-      </label>
-      <Input
-        type="text"
-        value={editor.key}
-        onChange={(e) => editor.handleKeyChange(e.target.value)}
-        placeholder="e.g. fast-cheap"
-        disabled={editor.isReadOnly || editor.effectiveMode === "edit"}
-        fullWidth
-      />
-      {editor.keyError && !editor.isReadOnly ? (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-(--system-negative-strong)"
-        >
-          {editor.keyError}
-        </Typography>
-      ) : null}
-    </div>
+    <Input
+      label="Key"
+      type="text"
+      value={editor.key}
+      onChange={(e) => editor.handleKeyChange(e.target.value)}
+      placeholder="e.g. fast-cheap"
+      disabled={editor.isReadOnly || editor.effectiveMode === "edit"}
+      errorText={editor.isReadOnly ? undefined : editor.keyError}
+      fullWidth
+    />
   );
 
   // An active read-only (managed) profile shows no status toggle (it cannot
@@ -429,6 +417,7 @@ export function ProfileEditorFields({
         isReadOnly={editor.isReadOnly}
         availableConnectionsForProvider={editor.availableConnectionsForProvider}
         connectionNotFound={editor.connectionNotFound}
+        providerError={editor.providerError}
       />
 
       {advancedParamsNode}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+
+const CONNECTIONS: ProviderConnection[] = [
+  { name: "anthropic", provider: "anthropic" } as ProviderConnection,
+  { name: "openai", provider: "openai" } as ProviderConnection,
+];
+
+const meta: Meta<typeof ProfileEditorModal> = {
+  title: "Settings/AI/ProfileEditorModal",
+  component: ProfileEditorModal,
+  args: {
+    isOpen: true,
+    existingNames: ["balanced", "fast"],
+    connections: CONNECTIONS,
+    assistantId: "asst-1",
+    onSave: async () => {},
+    onCancel: () => {},
+  },
+  parameters: {
+    // The modal owns the viewport; a centered frame just fights it.
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileEditorModal>;
+
+/** Editing a complete profile: no field is blocking, Save is available. */
+export const Edit: Story = {
+  args: {
+    mode: "edit",
+    profileName: "balanced",
+    initialValues: {
+      name: "balanced",
+      label: "Balanced",
+      provider: "anthropic",
+      model: "claude-opus-5",
+      status: "active",
+    },
+  },
+};
+
+/**
+ * The state the Profiles list links here for. The profile names no provider,
+ * so the resolver skips it and actions fall through to their default. Save is
+ * disabled, and the Provider field has to say why — a dead button with no
+ * explanation is the bug this covers (LUM-3076).
+ */
+export const MissingProvider: Story = {
+  args: {
+    mode: "edit",
+    profileName: "half-built",
+    initialValues: {
+      name: "half-built",
+      label: "Half Built",
+      status: "active",
+    },
+  },
+};
+
+/**
+ * The Model field already explains this state itself, keyed to why it is
+ * empty. Here to prove the two messages do not double up.
+ */
+export const MissingModel: Story = {
+  args: {
+    mode: "edit",
+    profileName: "half-built",
+    initialValues: {
+      name: "half-built",
+      label: "Half Built",
+      provider: "anthropic",
+      status: "active",
+    },
+  },
+};
+
+/** Create starts blank, so it must not flag empty fields before any input. */
+export const Create: Story = {
+  args: { mode: "create" },
+};

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -46,7 +46,7 @@ export const Edit: Story = {
 /**
  * The state the Profiles list links here for. The profile names no provider,
  * so the resolver skips it and actions fall through to their default. Save is
- * disabled, and the Provider field has to say why — a dead button with no
+ * disabled, and the Provider field has to say why. A dead button with no
  * explanation is the bug this covers (LUM-3076).
  */
 export const MissingProvider: Story = {

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -297,6 +297,7 @@ function renderEdit(
   initialValues: Record<string, unknown>,
   onSave: (name: string, entry: unknown) => Promise<void> = () =>
     Promise.resolve(),
+  connections: ProviderConnection[] = [makeConnection("anthropic-personal")],
 ) {
   return render(
     <Wrapper>
@@ -306,7 +307,7 @@ function renderEdit(
         profileName={(initialValues.name as string) ?? "balanced"}
         initialValues={initialValues as never}
         existingNames={[(initialValues.name as string) ?? "balanced"]}
-        connections={[makeConnection("anthropic-personal")]}
+        connections={connections}
         assistantId={ASSISTANT_ID}
         onSave={onSave}
         onCancel={() => {}}
@@ -1845,7 +1846,7 @@ describe("ProfileEditorModal — invariant managed profiles in view mode", () =>
 // Why Save is disabled (LUM-3076)
 // ---------------------------------------------------------------------------
 
-describe("ProfileEditorModal — explains why Save is blocked", () => {
+describe("ProfileEditorModal: explains why Save is blocked", () => {
   /**
    * Field errors are announced, so assert on the alert rather than on page
    * text: "Select a provider" is also the picker's placeholder, and matching
@@ -1873,6 +1874,28 @@ describe("ProfileEditorModal — explains why Save is blocked", () => {
       provider: "anthropic",
       model: "claude-opus-5",
     });
+
+    expect(fieldErrors()).toEqual([]);
+  });
+
+  test("with no connections at all, the error is the way out", () => {
+    // The blocking reason and the fix are the same fact here. Passing the
+    // hint as helper text would hide it, since the field shows one message
+    // and the error wins, leaving the user staring at "Select a provider"
+    // above an empty list.
+    renderEdit({ name: "half-built" }, undefined, []);
+
+    expect(fieldErrors()).toContain(
+      "No provider connections. Open Providers to add one.",
+    );
+    expect(fieldErrors()).not.toContain("Select a provider");
+  });
+
+  test("a locked profile is not told to fix a field it cannot edit", () => {
+    // `invariant` forces read-only even in edit mode, so `effectiveMode` is
+    // still "edit" and the error would otherwise render above a disabled
+    // picker. Matches how `keyError` is already suppressed for these.
+    renderEdit({ name: "my-managed", invariant: true });
 
     expect(fieldErrors()).toEqual([]);
   });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -86,8 +86,9 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProfileEditorModal } =
-  await import("@/domains/settings/ai/profile-editor-modal");
+const { ProfileEditorModal } = await import(
+  "@/domains/settings/ai/profile-editor-modal"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -400,15 +401,17 @@ beforeEach(async () => {
   // Seed a hydrated pre-gate version: the save path awaits
   // whenAssistantVersionKnown(), and an unhydrated store would stall each
   // save until that helper's timeout. Gate-on tests override per-test.
-  const { useAssistantIdentityStore } =
-    await import("@/stores/assistant-identity-store");
+  const { useAssistantIdentityStore } = await import(
+    "@/stores/assistant-identity-store"
+  );
   useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
 });
 
 afterEach(async () => {
   cleanup();
-  const { useAssistantIdentityStore } =
-    await import("@/stores/assistant-identity-store");
+  const { useAssistantIdentityStore } = await import(
+    "@/stores/assistant-identity-store"
+  );
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
@@ -639,8 +642,9 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("a new-enough assistant gets the identity payload: provider vellum, no binding", async () => {
-    const { useAssistantIdentityStore } =
-      await import("@/stores/assistant-identity-store");
+    const { useAssistantIdentityStore } = await import(
+      "@/stores/assistant-identity-store"
+    );
     useAssistantIdentityStore
       .getState()
       .setIdentity("test-asst", "0.10.12", ASSISTANT_ID);
@@ -672,8 +676,9 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("an older assistant keeps the legacy payload byte-identical", async () => {
-    const { useAssistantIdentityStore } =
-      await import("@/stores/assistant-identity-store");
+    const { useAssistantIdentityStore } = await import(
+      "@/stores/assistant-identity-store"
+    );
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
     try {
       const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
@@ -1833,5 +1838,50 @@ describe("ProfileEditorModal — invariant managed profiles in view mode", () =>
     expect(getInputByPlaceholder("e.g. Fast & Cheap").disabled).toBe(false);
     expect(getInputByPlaceholder("e.g. fast-cheap").disabled).toBe(false);
     expect(findSwitchByLabel("Active")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Why Save is disabled (LUM-3076)
+// ---------------------------------------------------------------------------
+
+describe("ProfileEditorModal — explains why Save is blocked", () => {
+  /**
+   * Field errors are announced, so assert on the alert rather than on page
+   * text: "Select a provider" is also the picker's placeholder, and matching
+   * that would pass with no error rendered at all.
+   */
+  function fieldErrors(): string[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[role="alert"]'),
+    ).map((el) => el.textContent?.trim() ?? "");
+  }
+
+  test("a profile missing its provider says so on open", () => {
+    // The Profiles row for an unusable profile links here saying "Click to
+    // fix", so the reason has to be on screen before the user touches
+    // anything. A disabled Save with no message is the bug.
+    renderEdit({ name: "half-built", provider: "", model: "" });
+
+    expect(fieldErrors()).toContain("Select a provider");
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+
+  test("a complete profile raises no field error", () => {
+    renderEdit({
+      name: "balanced",
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
+
+    expect(fieldErrors()).toEqual([]);
+  });
+
+  test("an untouched create form does not scold the user for empty fields", () => {
+    // Everything is empty because the user just opened it, not because they
+    // did anything wrong.
+    renderCreate([makeConnection("anthropic")]);
+
+    expect(fieldErrors()).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -80,6 +80,9 @@ function restrictsToSubscriptionModels(
  * discriminator. The "no-provider" hint is `null` because the hint only
  * renders once a provider is selected.
  */
+const NO_PROVIDER_CONNECTIONS_HINT =
+  "No provider connections. Open Providers to add one.";
+
 const MODEL_EMPTY_STATE_COPY = {
   "no-provider": {
     placeholder: "Select a provider first",
@@ -232,6 +235,11 @@ export function ProfileEditorProviderSection({
   const providerOptionsSource =
     connections === undefined ? allProvidersForPicker : visibleProviders;
 
+  // A confirmed-empty connection list. Read-only profiles cannot act on it,
+  // so they are not told to.
+  const noProviderConnections =
+    providerOptionsSource.length === 0 && !isReadOnly;
+
   // For openai-compatible providers the static catalog is empty — use models
   // from the selected connection instead. When no specific connection is
   // selected, merge models from all available openai-compatible connections.
@@ -356,10 +364,18 @@ export function ProfileEditorProviderSection({
         <Select
           id="profile-editor-provider"
           label="Provider"
-          errorText={providerError}
+          errorText={
+            // With nothing to select, "add a connection" is both the reason
+            // Save is blocked and the way out, so it becomes the error.
+            // Passing it as helper text would hide it: the field shows one
+            // message, and the error wins.
+            providerError && noProviderConnections
+              ? NO_PROVIDER_CONNECTIONS_HINT
+              : providerError
+          }
           helperText={
-            providerOptionsSource.length === 0 && !isReadOnly
-              ? "No provider connections. Open Providers to add one."
+            noProviderConnections && !providerError
+              ? NO_PROVIDER_CONNECTIONS_HINT
               : undefined
           }
           value={

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -128,6 +129,11 @@ interface ProfileEditorProviderSectionProps {
   /** Connections matching the current provider, computed by the parent
    *  (the save handler also needs this for binding resolution). */
   availableConnectionsForProvider: ProviderConnection[];
+  /**
+   * Why the Provider field blocks Save, or null. Rendered inline: a disabled
+   * Save with no explanation is the state this exists to remove.
+   */
+  providerError?: string | null;
   /** True when the saved binding no longer points at any known connection. */
   connectionNotFound: boolean;
   /**
@@ -163,6 +169,7 @@ export function ProfileEditorProviderSection({
   availableConnectionsForProvider,
   connectionNotFound,
   hideProviderField = false,
+  providerError = null,
 }: ProfileEditorProviderSectionProps) {
   const providerWithoutModel = provider.length > 0 && model.length === 0;
 
@@ -346,80 +353,70 @@ export function ProfileEditorProviderSection({
           connection so users can't bind a profile to a non-dispatchable
           route. Hidden when the parent renders its own provider picker. */}
       {!hideProviderField && (
-        <div className="space-y-1">
-          <label
-            id="profile-editor-provider-label"
-            className="block text-body-small-default text-[var(--content-tertiary)]"
-          >
-            Provider
-          </label>
-          <Dropdown
-            value={
-              provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection
-                ? endpointPickerValue(providerConnection)
-                : provider
+        <Select
+          id="profile-editor-provider"
+          label="Provider"
+          errorText={providerError}
+          helperText={
+            providerOptionsSource.length === 0 && !isReadOnly
+              ? "No provider connections. Open Providers to add one."
+              : undefined
+          }
+          value={
+            provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection
+              ? endpointPickerValue(providerConnection)
+              : provider
+          }
+          onChange={(next) => {
+            const endpoint = parseEndpointPickerValue(next);
+            if (endpoint) {
+              // Each endpoint entry implies the openai-compatible
+              // provider plus its binding.
+              onProviderChange(OPENAI_COMPATIBLE_PROVIDER);
+              onConnectionChange(endpoint);
+              return;
             }
-            onChange={(next) => {
-              const endpoint = parseEndpointPickerValue(next);
-              if (endpoint) {
-                // Each endpoint entry implies the openai-compatible
-                // provider plus its binding.
-                onProviderChange(OPENAI_COMPATIBLE_PROVIDER);
-                onConnectionChange(endpoint);
-                return;
-              }
-              onProviderChange(next as ConnectionProvider);
-            }}
-            disabled={isReadOnly}
-            placeholder="Select a provider…"
-            aria-labelledby="profile-editor-provider-label"
-            options={[
-              ...expandEndpointEntries(
-                providerOptionsSource,
-                connections ?? [],
-                (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
-              ).map(({ value, label, meta }) => ({
-                value,
-                label,
-                suffix: meta ? <PickerMeta text={meta} /> : undefined,
-              })),
-              // A bound endpoint whose row was deleted still renders on the
-              // trigger; the warning below explains the state.
-              ...(connectionNotFound &&
-              provider === OPENAI_COMPATIBLE_PROVIDER &&
-              providerConnection
-                ? [
-                    {
-                      value: endpointPickerValue(providerConnection),
-                      label: `${providerConnection} (not found)`,
-                    },
-                  ]
-                : []),
-              // An unbound openai-compatible profile has no endpoint entry to
-              // select; the bare protocol value keeps the trigger labeled.
-              // Picking an endpoint entry from this same list binds it.
-              ...(provider === OPENAI_COMPATIBLE_PROVIDER && !providerConnection
-                ? [
-                    {
-                      value: OPENAI_COMPATIBLE_PROVIDER,
-                      label:
-                        PROVIDER_DISPLAY_NAMES[OPENAI_COMPATIBLE_PROVIDER] ??
-                        OPENAI_COMPATIBLE_PROVIDER,
-                    },
-                  ]
-                : []),
-            ]}
-          />
-          {providerOptionsSource.length === 0 && !isReadOnly ? (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-[var(--content-tertiary)]"
-            >
-              No provider connections. Open Providers to add one.
-            </Typography>
-          ) : null}
-        </div>
+            onProviderChange(next as ConnectionProvider);
+          }}
+          disabled={isReadOnly}
+          placeholder="Select a provider…"
+          options={[
+            ...expandEndpointEntries(
+              providerOptionsSource,
+              connections ?? [],
+              (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+            ).map(({ value, label, meta }) => ({
+              value,
+              label,
+              suffix: meta ? <PickerMeta text={meta} /> : undefined,
+            })),
+            // A bound endpoint whose row was deleted still renders on the
+            // trigger; the warning below explains the state.
+            ...(connectionNotFound &&
+            provider === OPENAI_COMPATIBLE_PROVIDER &&
+            providerConnection
+              ? [
+                  {
+                    value: endpointPickerValue(providerConnection),
+                    label: `${providerConnection} (not found)`,
+                  },
+                ]
+              : []),
+            // An unbound openai-compatible profile has no endpoint entry to
+            // select; the bare protocol value keeps the trigger labeled.
+            // Picking an endpoint entry from this same list binds it.
+            ...(provider === OPENAI_COMPATIBLE_PROVIDER && !providerConnection
+              ? [
+                  {
+                    value: OPENAI_COMPATIBLE_PROVIDER,
+                    label:
+                      PROVIDER_DISPLAY_NAMES[OPENAI_COMPATIBLE_PROVIDER] ??
+                      OPENAI_COMPATIBLE_PROVIDER,
+                  },
+                ]
+              : []),
+          ]}
+        />
       )}
 
       {/* No binding UI: catalog providers resolve their credential from the

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -558,7 +558,7 @@ export function useProfileEditor({
   // fields on open would be scolding the user for not having started. Edit
   // mode is the opposite: an existing profile missing a provider or model is
   // already broken, the resolver already skips it, and the row that links
-  // here says "Click to fix" — so the reason has to be visible on arrival.
+  // here says "Click to fix", so the reason has to be visible on arrival.
   // The Model field already explains `providerWithoutModel` itself, keyed to
   // why it is empty (no catalog entries, connection not configured, nothing
   // picked). Provider is the one blocking state with no copy anywhere.
@@ -566,9 +566,13 @@ export function useProfileEditor({
   // An untouched create form is blank by definition, so flagging it on open
   // would be scolding the user for not having started. Edit mode is the
   // opposite: a profile with no provider is already broken, the resolver
-  // skips it, and the row that links here says "Click to fix" — so the
+  // skips it, and the row that links here says "Click to fix", so the
   // reason has to be visible on arrival.
-  const showFieldErrors = effectiveMode === "edit" || getDirty();
+  // Read-only (managed) profiles get no field errors, matching how `keyError`
+  // is suppressed for them: the picker is disabled, so naming a problem the
+  // user cannot act on here is just noise.
+  const showFieldErrors =
+    !isReadOnly && (effectiveMode === "edit" || getDirty());
   const providerError =
     showFieldErrors && providerMissing ? "Select a provider" : null;
 

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -105,6 +105,8 @@ export interface ProfileEditor {
   saving: boolean;
   saveError: string | null;
   keyError: string | null;
+  /** Why the Provider field blocks Save, or null when it does not. */
+  providerError: string | null;
   isInvalid: boolean;
 
   maxTokens: number | null;
@@ -552,6 +554,24 @@ export function useProfileEditor({
         ? "A profile with this key already exists"
         : null;
 
+  // An untouched create form is blank by definition, so flagging its empty
+  // fields on open would be scolding the user for not having started. Edit
+  // mode is the opposite: an existing profile missing a provider or model is
+  // already broken, the resolver already skips it, and the row that links
+  // here says "Click to fix" — so the reason has to be visible on arrival.
+  // The Model field already explains `providerWithoutModel` itself, keyed to
+  // why it is empty (no catalog entries, connection not configured, nothing
+  // picked). Provider is the one blocking state with no copy anywhere.
+  //
+  // An untouched create form is blank by definition, so flagging it on open
+  // would be scolding the user for not having started. Edit mode is the
+  // opposite: a profile with no provider is already broken, the resolver
+  // skips it, and the row that links here says "Click to fix" — so the
+  // reason has to be visible on arrival.
+  const showFieldErrors = effectiveMode === "edit" || getDirty();
+  const providerError =
+    showFieldErrors && providerMissing ? "Select a provider" : null;
+
   async function handleSave() {
     if (isInvalid && !isReadOnly) {
       return;
@@ -675,12 +695,17 @@ export function useProfileEditor({
       if (visibility.thinking) {
         entry.thinking = {
           enabled: thinkingEnabled,
-          ...(thinkingEnabled ? { streamThinking: thinkingStreamThinking } : {}),
+          ...(thinkingEnabled
+            ? { streamThinking: thinkingStreamThinking }
+            : {}),
         };
       }
       // Gemini: a chosen level implies thinking is on; "default" omits the
       // field so the daemon applies the model default.
-      if (visibility.thinkingLevel && thinkingLevel !== THINKING_LEVEL_INHERIT) {
+      if (
+        visibility.thinkingLevel &&
+        thinkingLevel !== THINKING_LEVEL_INHERIT
+      ) {
         entry.thinking = { enabled: true, level: thinkingLevel };
       }
       // Status - always include in edit mode; omit in create when active
@@ -721,6 +746,7 @@ export function useProfileEditor({
     saving,
     saveError,
     keyError,
+    providerError,
     isInvalid,
     maxTokens,
     contextWindowMaxInputTokens,

--- a/clients/web/test-setup.test.ts
+++ b/clients/web/test-setup.test.ts
@@ -1,7 +1,7 @@
 /**
  * Guards the focus re-entrancy shim in `test-setup.ts`.
  *
- * Note the failure mode: if the shim is removed, these do not go red — they
+ * Note the failure mode: if the shim is removed, these do not go red: they
  * hang, because the underlying happy-dom bug is a synchronous loop. That is
  * exactly why the shim exists, and why this file documents the invariant
  * rather than relying on a red test to catch a regression.

--- a/clients/web/test-setup.test.ts
+++ b/clients/web/test-setup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guards the focus re-entrancy shim in `test-setup.ts`.
+ *
+ * Note the failure mode: if the shim is removed, these do not go red — they
+ * hang, because the underlying happy-dom bug is a synchronous loop. That is
+ * exactly why the shim exists, and why this file documents the invariant
+ * rather than relying on a red test to catch a regression.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+describe("focus re-entrancy shim", () => {
+  const created: HTMLElement[] = [];
+
+  function button(id: string): HTMLButtonElement {
+    const el = document.createElement("button");
+    el.id = id;
+    document.body.appendChild(el);
+    created.push(el);
+    return el;
+  }
+
+  afterEach(() => {
+    for (const el of created.splice(0)) {
+      el.remove();
+    }
+  });
+
+  test("two elements that refocus each other on blur settle instead of looping", () => {
+    // The shape Radix produces inside a Dialog: the focus scope pulls focus
+    // back to the trigger, the overlay sends it to its option, repeat.
+    const trigger = button("trigger");
+    const option = button("option");
+    let focusEvents = 0;
+
+    trigger.addEventListener("blur", () => option.focus());
+    option.addEventListener("blur", () => trigger.focus());
+    trigger.addEventListener("focus", () => {
+      focusEvents += 1;
+    });
+    option.addEventListener("focus", () => {
+      focusEvents += 1;
+    });
+
+    trigger.focus();
+    option.focus();
+
+    // Bounded is the whole assertion: unguarded this never returns.
+    expect(focusEvents).toBeLessThan(10);
+    expect(focusEvents).toBeGreaterThan(0);
+  });
+
+  test("focusing a different element from a blur handler still works", () => {
+    // The shim must not suppress legitimate focus moves, only re-entrant ones.
+    const first = button("first");
+    const second = button("second");
+    first.addEventListener("blur", () => second.focus());
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    first.blur();
+    expect(document.activeElement).toBe(second);
+  });
+
+  test("a plain focus still sets activeElement", () => {
+    const el = button("plain");
+    el.focus();
+    expect(document.activeElement).toBe(el);
+  });
+});

--- a/clients/web/test-setup.ts
+++ b/clients/web/test-setup.ts
@@ -39,3 +39,46 @@ process.env.VITE_PLATFORM_MODE = "true";
 // Set a base URL so relative fetch requests (e.g. "/v1/assistants/...")
 // resolve correctly instead of failing against "about:blank".
 window.location.href = "http://localhost:3000";
+
+// happy-dom bug workaround: make `focus()` re-entrant-safe.
+//
+// `HTMLElementUtility.focus()` no-ops when the target is already
+// `document.activeElement`, but it only assigns `activeElement = target`
+// *after* synchronously dispatching `blur`/`focusout` on the outgoing
+// element. During that dispatch `activeElement` is null, so a handler that
+// focuses the same target again slips past the guard and recurses:
+//
+//   focus -> blur -> focusout handler -> focus -> blur -> ...
+//
+// A Radix Select inside a Radix Dialog hits this: the Select's option is
+// portalled outside the Dialog, the Dialog's focus scope treats that as focus
+// escaping and pulls it back to the trigger, and Radix Select re-focuses the
+// option — option -> trigger -> option, forever. The runner then produces no
+// output at all, because a synchronous loop is not interruptible by
+// `--timeout`.
+//
+// Verified in a real browser (design-library Storybook, Select inside Modal):
+// the menu opens, both options render, activeElement settles on the trigger.
+// So this is a happy-dom defect, not a product bug, and the shim restores the
+// browser behaviour rather than papering over ours. Focusing a *different*
+// element from a blur handler still works, so nothing legitimate is lost.
+const nativeFocus = window.HTMLElement.prototype.focus;
+const focusStack = new Set<HTMLElement>();
+window.HTMLElement.prototype.focus = function patchedFocus(
+  this: HTMLElement,
+  ...args: Parameters<typeof nativeFocus>
+): void {
+  // Re-entering a focus() that has not finished unwinding is the loop. A
+  // set, not a single flag: the cycle alternates between two elements (the
+  // portalled option and the trigger), so checking only the immediate
+  // target never matches.
+  if (focusStack.has(this)) {
+    return;
+  }
+  focusStack.add(this);
+  try {
+    nativeFocus.apply(this, args);
+  } finally {
+    focusStack.delete(this);
+  }
+};

--- a/clients/web/test-setup.ts
+++ b/clients/web/test-setup.ts
@@ -53,7 +53,7 @@ window.location.href = "http://localhost:3000";
 // A Radix Select inside a Radix Dialog hits this: the Select's option is
 // portalled outside the Dialog, the Dialog's focus scope treats that as focus
 // escaping and pulls it back to the trigger, and Radix Select re-focuses the
-// option — option -> trigger -> option, forever. The runner then produces no
+// option: option -> trigger -> option, forever. The runner then produces no
 // output at all, because a synchronous loop is not interruptible by
 // `--timeout`.
 //

--- a/packages/design-library/src/components/field.tsx
+++ b/packages/design-library/src/components/field.tsx
@@ -9,7 +9,7 @@ import { cn } from "../utils/cn";
  * Internal to this package: controls compose it so that `label`, `helperText`
  * and `errorText` mean the same thing and look the same everywhere, rather
  * than each control reinventing them. Callers use those props on `Input`,
- * `Textarea` or `Select` — they never reach for this directly.
+ * `Textarea` or `Select`. They never reach for this directly.
  *
  * The control owns its own id and wires its own `aria-describedby`; this only
  * renders the surrounding text. `errorText` wins over `helperText` when both

--- a/packages/design-library/src/components/field.tsx
+++ b/packages/design-library/src/components/field.tsx
@@ -1,0 +1,103 @@
+import { type ReactNode } from "react";
+
+import { Typography } from "./typography";
+import { cn } from "../utils/cn";
+
+/**
+ * Label + helper/error scaffolding shared by the form controls.
+ *
+ * Internal to this package: controls compose it so that `label`, `helperText`
+ * and `errorText` mean the same thing and look the same everywhere, rather
+ * than each control reinventing them. Callers use those props on `Input`,
+ * `Textarea` or `Select` — they never reach for this directly.
+ *
+ * The control owns its own id and wires its own `aria-describedby`; this only
+ * renders the surrounding text. `errorText` wins over `helperText` when both
+ * are present, so the user reads the blocking message rather than guidance
+ * for a state they are not in.
+ */
+export interface FieldProps {
+  /** The control's id. `label` targets it and messages derive their ids from it. */
+  readonly id: string;
+  readonly label?: ReactNode;
+  readonly helperText?: ReactNode;
+  readonly errorText?: ReactNode;
+  readonly fullWidth: boolean;
+  readonly disabled: boolean;
+  readonly className?: string;
+  readonly children: ReactNode;
+}
+
+/** The id of a control's message, matching what `Field` renders. */
+export function fieldDescriptionId(
+  controlId: string,
+  hasError: boolean,
+  hasHelper: boolean,
+): string | undefined {
+  return hasError
+    ? `${controlId}-error`
+    : hasHelper
+      ? `${controlId}-helper`
+      : undefined;
+}
+
+export function Field({
+  id,
+  label,
+  helperText,
+  errorText,
+  fullWidth,
+  disabled,
+  className,
+  children,
+}: FieldProps) {
+  const describedById = fieldDescriptionId(
+    id,
+    Boolean(errorText),
+    Boolean(helperText),
+  );
+
+  return (
+    <div
+      data-slot="field-wrapper"
+      className={cn(
+        "flex flex-col gap-1.5",
+        fullWidth ? "w-full" : "w-fit",
+        className,
+      )}
+    >
+      {label ? (
+        <Typography
+          as="label"
+          id={`${id}-label`}
+          variant="body-small-default"
+          htmlFor={id}
+          className={cn(
+            "text-[var(--content-secondary)]",
+            disabled && "opacity-60",
+          )}
+        >
+          {label}
+        </Typography>
+      ) : null}
+      {children}
+      {errorText ? (
+        <span
+          id={describedById}
+          role="alert"
+          data-testid="field-error"
+          className="text-body-small-default text-[var(--system-negative-strong)]"
+        >
+          {errorText}
+        </span>
+      ) : helperText ? (
+        <span
+          id={describedById}
+          className="text-body-small-default text-[var(--content-tertiary)]"
+        >
+          {helperText}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/design-library/src/components/input.tsx
+++ b/packages/design-library/src/components/input.tsx
@@ -1,11 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import {
-  type ComponentProps,
-  type ReactNode,
-  useId,
-} from "react";
+import { type ComponentProps, type ReactNode, useId } from "react";
 
-import { Typography } from "./typography";
+import { Field } from "./field";
 import { cn } from "../utils/cn";
 
 /**
@@ -61,83 +57,11 @@ const fieldVariants = cva(
 
 type FieldVariantProps = VariantProps<typeof fieldVariants>;
 
-interface FieldWrapperProps {
-  readonly id: string;
-  readonly label?: ReactNode;
-  readonly helperText?: ReactNode;
-  readonly errorText?: ReactNode;
-  readonly fullWidth: boolean;
-  readonly disabled: boolean;
-  readonly className?: string;
-  readonly children: ReactNode;
-}
-
-function FieldWrapper({
-  id,
-  label,
-  helperText,
-  errorText,
-  fullWidth,
-  disabled,
-  className,
-  children,
-}: FieldWrapperProps) {
-  const descriptionId = errorText
-    ? `${id}-error`
-    : helperText
-      ? `${id}-helper`
-      : undefined;
-
-  return (
-    <div
-      data-slot="field-wrapper"
-      className={cn(
-        "flex flex-col gap-1.5",
-        fullWidth ? "w-full" : "w-fit",
-        className,
-      )}
-    >
-      {label ? (
-        <Typography
-          as="label"
-          variant="body-small-default"
-          htmlFor={id}
-          className={cn(
-            "text-[var(--content-secondary)]",
-            disabled && "opacity-60",
-          )}
-        >
-          {label}
-        </Typography>
-      ) : null}
-      {children}
-      {errorText ? (
-        <span
-          id={descriptionId}
-          role="alert"
-          data-testid="input-error"
-          className="text-body-small-default text-[var(--system-negative-strong)]"
-        >
-          {errorText}
-        </span>
-      ) : helperText ? (
-        <span
-          id={descriptionId}
-          className="text-body-small-default text-[var(--content-tertiary)]"
-        >
-          {helperText}
-        </span>
-      ) : null}
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Input (single-line)
 // ---------------------------------------------------------------------------
 
-export interface InputProps
-  extends Omit<ComponentProps<"input">, "size"> {
+export interface InputProps extends Omit<ComponentProps<"input">, "size"> {
   label?: ReactNode;
   helperText?: ReactNode;
   errorText?: ReactNode;
@@ -173,7 +97,7 @@ function Input({
       : undefined;
 
   return (
-    <FieldWrapper
+    <Field
       id={inputId}
       label={label}
       helperText={helperText}
@@ -220,7 +144,7 @@ function Input({
           </span>
         ) : null}
       </div>
-    </FieldWrapper>
+    </Field>
   );
 }
 
@@ -260,7 +184,7 @@ function Textarea({
       : undefined;
 
   return (
-    <FieldWrapper
+    <Field
       id={textareaId}
       label={label}
       helperText={helperText}
@@ -287,13 +211,8 @@ function Textarea({
           className,
         )}
       />
-    </FieldWrapper>
+    </Field>
   );
 }
 
-export {
-  Input,
-  Textarea,
-  fieldVariants,
-  type FieldVariantProps,
-};
+export { Input, Textarea, fieldVariants, type FieldVariantProps };

--- a/packages/design-library/src/components/select.test.tsx
+++ b/packages/design-library/src/components/select.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Select, type SelectOption } from "./select";
+
+const options: SelectOption<"anthropic" | "openai">[] = [
+  { value: "anthropic", label: "Anthropic" },
+  { value: "openai", label: "OpenAI" },
+];
+
+function attr(html: string, tag: string, name: string): string | null {
+  const re = new RegExp(`<${tag}\\b[^>]*\\b${name}="([^"]*)"`);
+  return re.exec(html)?.[1] ?? null;
+}
+
+describe("Select field props", () => {
+  test("labels the trigger it renders above", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        id="provider"
+        label="Provider"
+        options={options}
+        value="anthropic"
+        onChange={() => {}}
+      />,
+    );
+    // The association is the point: a label that misses its control renders
+    // identically and does nothing.
+    expect(attr(html, "label", "for")).toBe("provider");
+    expect(attr(html, "label", "id")).toBe("provider-label");
+    expect(html).toContain('aria-labelledby="provider-label"');
+  });
+
+  test("announces the error and points the trigger at it", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        id="provider"
+        label="Provider"
+        errorText="Select a provider"
+        options={options}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Select a provider");
+    expect(attr(html, "span", "id")).toBe("provider-error");
+    expect(html).toContain('aria-describedby="provider-error"');
+    expect(html).toContain('aria-invalid="true"');
+    // Border tint, so the field reads as broken without relying on the text.
+    expect(html).toContain("--system-negative-strong");
+  });
+
+  test("an error replaces helper text rather than stacking", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        id="provider"
+        label="Provider"
+        helperText="Where requests go"
+        errorText="Select a provider"
+        options={options}
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    expect(html).toContain("Select a provider");
+    expect(html).not.toContain("Where requests go");
+  });
+
+  test("helper text describes the trigger when valid", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        id="provider"
+        label="Provider"
+        helperText="Where requests go"
+        options={options}
+        value="anthropic"
+        onChange={() => {}}
+      />,
+    );
+    expect(html).toContain('aria-describedby="provider-helper"');
+    expect(html).not.toContain('role="alert"');
+    expect(html).not.toContain("aria-invalid");
+  });
+
+  test("stays a bare trigger when given no field text", () => {
+    // Existing call sites position the trigger themselves; wrapping them in a
+    // field would change their layout.
+    const html = renderToStaticMarkup(
+      <Select
+        options={options}
+        value="anthropic"
+        onChange={() => {}}
+        aria-label="Provider"
+      />,
+    );
+    expect(html).not.toContain('data-slot="field-wrapper"');
+    expect(html).not.toContain("<label");
+  });
+});

--- a/packages/design-library/src/components/select.tsx
+++ b/packages/design-library/src/components/select.tsx
@@ -1,7 +1,8 @@
 import { Check, ChevronDown } from "lucide-react";
-import type { CSSProperties, ReactNode } from "react";
+import { useId, type CSSProperties, type ReactNode } from "react";
 import * as RadixSelect from "@radix-ui/react-select";
 
+import { Field, fieldDescriptionId } from "./field";
 import { cn } from "../utils/cn";
 import { usePortalContainer } from "../utils/portal-container";
 import { Tooltip } from "./tooltip";
@@ -48,7 +49,20 @@ export interface SelectProps<T extends string> {
   readonly menuAlign?: SelectMenuAlign;
   readonly "aria-label"?: string;
   readonly "aria-labelledby"?: string;
+  readonly "aria-describedby"?: string;
   readonly "data-testid"?: string;
+  /** Field label rendered above the trigger and wired to it. */
+  readonly label?: ReactNode;
+  /** Guidance below the trigger. Suppressed while `errorText` is set. */
+  readonly helperText?: ReactNode;
+  /**
+   * Blocking message below the trigger. Also tints the trigger border and
+   * marks it `aria-invalid`, matching `Input`.
+   */
+  readonly errorText?: ReactNode;
+  /** Stretch the field to its container. Defaults to true. */
+  readonly fullWidth?: boolean;
+  readonly wrapperClassName?: string;
 }
 
 const DEFAULT_MENU_MAX_HEIGHT = 280;
@@ -111,9 +125,21 @@ export function Select<T extends string>({
   menuAlign = "start",
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
   "data-testid": dataTestId,
+  label,
+  helperText,
+  errorText,
+  fullWidth = true,
+  wrapperClassName,
 }: SelectProps<T>) {
   const portalContainer = usePortalContainer();
+  const reactId = useId();
+  const triggerId = id ?? `select-${reactId}`;
+  const invalid = Boolean(errorText);
+  const describedBy =
+    ariaDescribedBy ??
+    fieldDescriptionId(triggerId, invalid, Boolean(helperText));
 
   // Radix throws if an item claims the empty string. Drop such options rather
   // than take the tree down, and say why: the intent is almost always a
@@ -137,7 +163,7 @@ export function Select<T extends string>({
     (option) => option.value === value,
   );
 
-  return (
+  const control = (
     <RadixSelect.Root
       // Passed through untouched, empty string included. Radix reads
       // `prop !== undefined` as "controlled", so translating "" to `undefined`
@@ -170,18 +196,29 @@ export function Select<T extends string>({
       disabled={disabled}
       name={name}
     >
-      <div data-slot="select" className={cn("relative", className)} style={style}>
+      <div
+        data-slot="select"
+        className={cn("relative", className)}
+        style={style}
+      >
         <RadixSelect.Trigger
-          id={id}
+          id={triggerId}
           aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledBy}
+          aria-labelledby={
+            ariaLabelledBy ?? (label ? `${triggerId}-label` : undefined)
+          }
+          aria-describedby={describedBy}
+          aria-invalid={invalid || undefined}
           // Radix sets the native `disabled` attribute and `data-disabled`,
           // but not `aria-disabled`.
           aria-disabled={disabled || undefined}
           data-testid={dataTestId}
           data-slot="select-trigger"
           className={cn(
-            "flex w-full items-center gap-2 rounded-md border border-[var(--field-border)] bg-[var(--field-bg)] text-left transition-colors focus:outline-none data-[state=open]:border-[var(--border-active)] disabled:cursor-not-allowed disabled:opacity-60",
+            "flex w-full items-center gap-2 rounded-md border bg-[var(--field-bg)] text-left transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-60",
+            invalid
+              ? "border-[var(--system-negative-strong)] data-[state=open]:border-[var(--system-negative-strong)]"
+              : "border-[var(--field-border)] data-[state=open]:border-[var(--border-active)]",
             TRIGGER_SIZE_CLASSES[size],
           )}
           style={{
@@ -205,11 +242,11 @@ export function Select<T extends string>({
               title={selectedOption?.label || undefined}
             >
               {/* Explicit children rather than Radix's default, which reads
-                  from the mounted item and so renders nothing before the menu
-                  has opened or under `renderToStaticMarkup`. Falling back to
-                  the placeholder keeps a value that no longer matches any
-                  option (a deleted profile, say) from rendering as a blank
-                  control. */}
+                    from the mounted item and so renders nothing before the menu
+                    has opened or under `renderToStaticMarkup`. Falling back to
+                    the placeholder keeps a value that no longer matches any
+                    option (a deleted profile, say) from rendering as a blank
+                    control. */}
               <RadixSelect.Value placeholder={placeholder ?? ""}>
                 {selectedOption?.label ?? placeholder ?? ""}
               </RadixSelect.Value>
@@ -317,5 +354,25 @@ export function Select<T extends string>({
         </RadixSelect.Content>
       </RadixSelect.Portal>
     </RadixSelect.Root>
+  );
+
+  // Nothing to label or explain: stay a bare control so existing call
+  // sites that position the trigger themselves are unaffected.
+  if (label == null && helperText == null && errorText == null) {
+    return control;
+  }
+
+  return (
+    <Field
+      id={triggerId}
+      label={label}
+      helperText={helperText}
+      errorText={errorText}
+      fullWidth={fullWidth}
+      disabled={disabled}
+      className={wrapperClassName}
+    >
+      {control}
+    </Field>
   );
 }

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -13,11 +13,7 @@ export {
   CardFooter,
   type CardRootProps,
 } from "./components/card";
-export {
-  Notice,
-  type NoticeProps,
-  type NoticeTone,
-} from "./components/notice";
+export { Notice, type NoticeProps, type NoticeTone } from "./components/notice";
 export { ProgressBar, type ProgressBarProps } from "./components/progress-bar";
 export {
   ResizablePanel,
@@ -40,10 +36,7 @@ export {
   type TypographyVariant,
   type TypographyAs,
 } from "./components/typography";
-export {
-  Popover,
-  type PopoverContentProps,
-} from "./components/popover";
+export { Popover, type PopoverContentProps } from "./components/popover";
 export {
   Input,
   Textarea,
@@ -243,10 +236,7 @@ export {
   type StatSquareProps,
   type StatSquareTone,
 } from "./components/stat-square";
-export {
-  ListRow,
-  type ListRowProps,
-} from "./components/list-row";
+export { ListRow, type ListRowProps } from "./components/list-row";
 export {
   ShortcutKeys,
   parseAccelerator,


### PR DESCRIPTION
## TL;DR

A profile with no provider disabled Save and said nothing about why. It now says so. Getting there needed `Select` to grow the `label`/`errorText` props `Input` already had, plus a happy-dom bug worked around so Radix Select can be tested inside a modal at all.

Fixes [LUM-3076](https://linear.app/vellum/issue/LUM-3076).

## What changes for the user

| Before | After |
| --- | --- |
| Open a profile that is missing its provider: Save is greyed out with no explanation anywhere | The Provider field reads **"Select a provider"**, so the dead button has a visible reason |
| The Profiles row says "Click to fix" and sends you to an editor that does not say what is broken | The editor names the problem on arrival |
| Starting a new profile flagged nothing either way | Unchanged, a blank create form stays quiet until you have actually typed something |
| The Provider field's "No provider connections" hint was a hand-rolled paragraph | Same text, now the field's own helper text |

The Model field is untouched: it already renders its own error, keyed to *why* it is empty. The original ticket claimed otherwise; it was wrong, and adding a second message there just produced a duplicate.

## Why this is safe

- **`Select`'s new props are additive.** With no `label`/`helperText`/`errorText` it renders exactly as before, a bare trigger, no wrapper element. The other 36 call sites are untouched, verified by their suites.
- **`Field` is internal.** Extracted from the private wrapper already inside `input.tsx` and not exported from the package barrel. `Input`, `Textarea` and `Select` compose it, so callers keep passing plain props rather than wiring ids and aria attributes. `Input`'s public API is unchanged.
- **The error is announced, not just coloured**, `role="alert"`, `aria-describedby` on the trigger, `aria-invalid`, and a border tint so it does not depend on colour alone.
- **The focus shim restores browser behaviour rather than masking ours.** Verified directly: Select inside Modal in a real browser opens, renders both options, and settles `activeElement` on the trigger with no loop.

## The happy-dom fix, and why it matters beyond this PR

`HTMLElementUtility.focus()` no-ops when the target is already `document.activeElement`, but only assigns `activeElement = target` *after* synchronously dispatching `blur`/`focusout` on the outgoing element. In that window `activeElement` is null, so a handler that focuses again slips past the guard and recurses.

Radix produces exactly that shape inside a Dialog: the Select's option is portalled outside it, the Dialog's focus scope treats that as focus escaping and pulls it back to the trigger, and the Select re-focuses the option, forever. Because the loop is synchronous, `bun test --timeout` cannot interrupt it, so the run emits **nothing at all**. It looks like a stuck CI job, not a failing test.

That is a landmine for [LUM-2959](https://linear.app/vellum/issue/LUM-2959): seven of the 37 remaining `Dropdown` call sites render inside a modal, and each would hang its suite the moment it migrated. This clears all of them.

Checked against the focus-sensitive suites, command-palette, stt-language-picker, tier-picker, chat-composer, image-generation-card, overrides-detail-panel, profile-detail-panel, provider-create-form, web-search-card, custom-plan-modal, profiles-section: **220 tests, all passing**.

## Tests and stories

- `select.test.tsx` (new), label association, error announcement and wiring, error superseding helper text, and that a bare `Select` grows no wrapper.
- `test-setup.test.ts` (new), the focus invariant. Worth knowing the failure mode: removing the shim makes these *hang* rather than go red, which is the bug itself.
- `profile-editor-modal.test.tsx`, three cases added, asserting on the announced alert rather than page text, since "Select a provider" is also the picker's placeholder and matching that would pass with no error rendered.
- `profile-editor-modal.stories.tsx` (new), there was no story for this modal at all. Covers edit, missing-provider, missing-model, create.

## Deferred

- The Model field keeps its hand-rolled error markup rather than moving to `errorText`. It is a different component branch with its own empty-state copy, and folding it in would have meant touching the model picker's sentinel-value handling, that belongs with the `Dropdown` → `Select` migration of that field, not here.
- The remaining 36 `Dropdown` call sites stay put. [LUM-2959](https://linear.app/vellum/issue/LUM-2959) tracks them as one pass; it is now High priority and out of Triage, partly because this PR ran into it.
