### PR TITLE
fix(web): clear unseen document changes by surface id

### DIFF
--- a/clients/web/src/domains/chat/components/local-file/open-local-file.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.ts
@@ -210,12 +210,22 @@ export function isDocumentOpen(
   openedDocument: OpenedDocumentState | null,
   surfaceId: string,
 ): boolean {
-  return (
-    mainView === "document" &&
-    openedDocument !== null &&
-    openedDocument.source === "document" &&
-    openedDocument.surfaceId === surfaceId
-  );
+  return openedDocumentSurfaceId(mainView, openedDocument) === surfaceId;
+}
+
+/**
+ * The document surface the drawer is showing, or `null` when it shows nothing
+ * or a read-only preview. The identity behind {@link isDocumentOpen}, for
+ * callers that need to know *which* document rather than ask about one.
+ */
+export function openedDocumentSurfaceId(
+  mainView: MainView,
+  openedDocument: OpenedDocumentState | null,
+): string | null {
+  if (mainView !== "document" || openedDocument?.source !== "document") {
+    return null;
+  }
+  return openedDocument.surfaceId;
 }
 
 /**

--- a/clients/web/src/domains/chat/document-viewer-page.test.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.test.tsx
@@ -105,6 +105,19 @@ describe("DocumentViewerPage", () => {
     expect(unseenFor("conv-1")).toEqual(["surf-2"]);
   });
 
+  test("clears a change recorded against a conversation other than the document's", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-1");
+    documentResult = () =>
+      Promise.resolve({ data: documentSurface({ conversationId: "conv-1" }) });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
   test("keeps the unseen change when the load fails", async () => {
     useUnseenDocumentChangesStore
       .getState()

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -80,7 +80,7 @@ export function DocumentViewerPage() {
         // in-chat viewer, so it clears the unseen record itself.
         useUnseenDocumentChangesStore
           .getState()
-          .clearDocument(result.conversationId, surfaceId);
+          .clearDocumentEverywhere(surfaceId);
       } catch {
         if (!cancelled) {
           setError("Failed to load document.");

--- a/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
@@ -152,6 +152,66 @@ describe("unseen document changes", () => {
     expect(unseen("conv-1")).toBe(false);
   });
 
+  test("clearing everywhere clears a conversation the reader never opened", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-2", "doc-a");
+      useUnseenDocumentChangesStore.getState().clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-2")).toBe(false);
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
+  });
+
+  test("clearing everywhere clears the surface from every conversation", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-2", "doc-a");
+      store.markDocumentChanged("conv-3", "doc-b");
+      store.clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(unseen("conv-2")).toBe(false);
+    expect(unseen("conv-3")).toBe(true);
+  });
+
+  test("clearing everywhere leaves the conversation's other documents unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toEqual(new Set(["doc-b"]));
+  });
+
+  test("clearing everywhere for an unmarked surface is a no-op", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    const before = useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocumentEverywhere("doc-b");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      before,
+    );
+    expect(unseen("conv-1")).toBe(true);
+  });
+
   test("a null conversation id is never unseen", () => {
     act(() => {
       useUnseenDocumentChangesStore

--- a/clients/web/src/domains/chat/unseen-document-changes-store.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.ts
@@ -7,6 +7,12 @@
  * Entries are keyed by conversation so a change in a background conversation
  * cannot light the affordance on the conversation currently on screen.
  *
+ * A document is reachable from every conversation it is linked to, and an edit
+ * is recorded against the conversation the assistant made it from, which need
+ * not be the one the reader opens it from. Opening a document therefore clears
+ * it from every conversation, which surface ids being globally unique makes
+ * unambiguous.
+ *
  * Wrapped with `createSelectors` for auto-generated per-field hooks.
  *
  * @see {@link https://zustand.docs.pmnd.rs/}
@@ -29,8 +35,14 @@ export interface UnseenDocumentChangesState {
 export interface UnseenDocumentChangesActions {
   /** Record that a document changed while the user was not looking at it. */
   markDocumentChanged: (conversationId: string, surfaceId: string) => void;
-  /** Clear one document, for "the user opened that document". */
+  /** Clear one document within one conversation. */
   clearDocument: (conversationId: string, surfaceId: string) => void;
+  /**
+   * Clear one document from every conversation, for "the user opened that
+   * document". The reader may have opened it from a conversation other than
+   * the one the edit was recorded against.
+   */
+  clearDocumentEverywhere: (surfaceId: string) => void;
   /** Clear a whole conversation, for "the user opened the assets sheet". */
   clearConversation: (conversationId: string) => void;
 }
@@ -69,6 +81,31 @@ const useUnseenDocumentChangesStoreBase = create<UnseenDocumentChangesStore>()(
           delete changedDocuments[conversationId];
         } else {
           changedDocuments[conversationId] = next;
+        }
+        return { changedDocuments };
+      });
+    },
+
+    clearDocumentEverywhere: (surfaceId) => {
+      set((s) => {
+        const changedDocuments: Record<string, ReadonlySet<string>> = {};
+        let found = false;
+        for (const [conversationId, surfaces] of Object.entries(
+          s.changedDocuments,
+        )) {
+          if (!surfaces.has(surfaceId)) {
+            changedDocuments[conversationId] = surfaces;
+            continue;
+          }
+          found = true;
+          const next = new Set(surfaces);
+          next.delete(surfaceId);
+          if (next.size > 0) {
+            changedDocuments[conversationId] = next;
+          }
+        }
+        if (!found) {
+          return s;
         }
         return { changedDocuments };
       });

--- a/clients/web/src/hooks/use-document-editor-sync.test.tsx
+++ b/clients/web/src/hooks/use-document-editor-sync.test.tsx
@@ -8,8 +8,8 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router";
+import { useEffect, type ReactNode } from "react";
+import { MemoryRouter, useNavigate, type NavigateFunction } from "react-router";
 
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
@@ -17,12 +17,33 @@ import { __resetForTesting, publish } from "@/lib/event-bus";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
+/** Drives the router from a test, since `MemoryRouter` ignores entry changes. */
+let navigate: NavigateFunction | null = null;
+
+function NavigationProbe() {
+  const navigateFn = useNavigate();
+  useEffect(() => {
+    navigate = navigateFn;
+  }, [navigateFn]);
+  return null;
+}
+
 /** Mount the hook on `pathname`, defaulting to the conversation chat route. */
 function renderSyncAt(pathname: string = routes.conversation("conv-1")) {
   return renderHook(() => useDocumentEditorSync(), {
     wrapper: ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={[pathname]}>{children}</MemoryRouter>
+      <MemoryRouter initialEntries={[pathname]}>
+        <NavigationProbe />
+        {children}
+      </MemoryRouter>
     ),
+  });
+}
+
+/** Navigate the mounted router, the way a click in the sidebar would. */
+function navigateTo(pathname: string) {
+  act(() => {
+    navigate?.(pathname);
   });
 }
 
@@ -66,6 +87,7 @@ function unseenFor(conversationId: string): string[] {
 
 beforeEach(() => {
   __resetForTesting();
+  navigate = null;
   useViewerStore.getState().reset();
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
@@ -137,6 +159,49 @@ describe("useDocumentEditorSync", () => {
     renderSyncAt(routes.document("surf-1"));
 
     publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("clears the record when the user returns to chat with the document open", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("returning to chat clears a record made from another conversation", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ conversationId: "conv-2", surfaceId: "surf-1" });
+    expect(unseenFor("conv-2")).toEqual(["surf-1"]);
+
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
+  test("returning to chat leaves a document other than the open one unseen", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-2" });
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("returning to chat with no document open clears nothing", () => {
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+    navigateTo(routes.conversation("conv-1"));
 
     expect(unseenFor("conv-1")).toEqual(["surf-1"]);
   });

--- a/clients/web/src/hooks/use-document-editor-sync.ts
+++ b/clients/web/src/hooks/use-document-editor-sync.ts
@@ -23,15 +23,23 @@
  * updates, so an edit arriving while it is open is unseen there too. That page
  * clears its own record when the user next loads it.
  *
+ * Returning to the chat route puts a still-open document back on screen with
+ * no load of its own to clear the record it collected while away, so that
+ * clearing happens here too.
+ *
  * References:
  * - EVENT_BUS.md: bus subscription contract
  * - stores/viewer-store.ts: document editor state
  * - domains/chat/unseen-document-changes-store.ts: unseen-change records
  */
 
+import { useEffect } from "react";
 import { useLocation } from "react-router";
 
-import { isDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import {
+  isDocumentOpen,
+  openedDocumentSurfaceId,
+} from "@/domains/chat/components/local-file/open-local-file";
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -46,6 +54,23 @@ import { isConversationChatPath } from "@/utils/routes";
  */
 export function useDocumentEditorSync(): void {
   const location = useLocation();
+  const chatVisible = isConversationChatPath(location.pathname);
+
+  useEffect(() => {
+    if (!chatVisible) {
+      return;
+    }
+    const viewer = useViewerStore.getState();
+    const surfaceId = openedDocumentSurfaceId(
+      viewer.mainView,
+      viewer.openedDocumentState,
+    );
+    if (surfaceId === null) {
+      return;
+    }
+    useUnseenDocumentChangesStore.getState().clearDocumentEverywhere(surfaceId);
+  }, [chatVisible]);
+
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "document_editor_update") {
@@ -54,7 +79,7 @@ export function useDocumentEditorSync(): void {
     // An event handler, so the viewer is read rather than subscribed to.
     const viewer = useViewerStore.getState();
     const watchingLive =
-      isConversationChatPath(location.pathname) &&
+      chatVisible &&
       isDocumentOpen(
         viewer.mainView,
         viewer.openedDocumentState,

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -1107,6 +1107,20 @@ describe("loadDocument", () => {
     expect(unseenFor("conv-1")).toEqual(["surf-2"]);
   });
 
+  it("clears a change recorded against a conversation other than the document's", async () => {
+    // The daemon records the edit against the conversation the tool ran in,
+    // while the document row keeps the conversation that created it.
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-1");
+    documentResult = () =>
+      Promise.resolve({ data: documentSurface({ conversationId: "conv-1" }) });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
   it("keeps the unseen change when the open fails", async () => {
     useUnseenDocumentChangesStore
       .getState()
@@ -1188,6 +1202,24 @@ describe("loadWorkspaceFileDocument", () => {
     );
 
     expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  it("clears a change recorded against a conversation other than the document's", async () => {
+    // Opening the file from another conversation still answers with the
+    // conversation that created the document.
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-file");
+    fileDocumentResult = () =>
+      Promise.resolve({ data: fileDocument({ conversationId: "conv-1" }) });
+
+    await getState().loadWorkspaceFileDocument(
+      "asst-1",
+      "drafts/notes.md",
+      "conv-2",
+    );
+
+    expect(unseenFor("conv-2")).toEqual([]);
   });
 
   it("names an untitled document rather than showing an empty navbar", async () => {

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -1173,7 +1173,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       });
       useUnseenDocumentChangesStore
         .getState()
-        .clearDocument(result.conversationId, result.surfaceId);
+        .clearDocumentEverywhere(result.surfaceId);
     } catch {
       if (!sameDocumentTarget(get().activeDocumentTarget, target)) {
         return;
@@ -1250,7 +1250,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       });
       useUnseenDocumentChangesStore
         .getState()
-        .clearDocument(result.conversationId, result.surfaceId);
+        .clearDocumentEverywhere(result.surfaceId);
     } catch (err) {
       giveUp(err);
     }


### PR DESCRIPTION
## Summary
- Clear the unseen record by surface id across every conversation, so a document edited from a linked conversation clears when opened.
- Clear when returning to chat with the document already open.
- Narrow the watching-live route gate.

Fixes review findings on plan document-update-discoverability.md