### PR TITLE
fix(web): keep the reopen link on turns that edit a created document

### DIFF
--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -2,9 +2,9 @@
  * Tests for the end-of-turn link back to a document the assistant changed.
  *
  * Covers the two things the link owes its caller: it names the document from
- * the documents query (with a neutral label when the query has no title for
- * it), and it is present exactly when its own document is not the one open in
- * the viewer.
+ * the documents query, rendering only once that query resolves with the
+ * document in it, and it is present exactly when its own document is not the
+ * one open in the viewer.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -24,39 +24,52 @@ const onOpenDocument = mock((_surfaceId: string) => {});
 
 type SeededDocument = { surfaceId: string; title: string };
 
-/**
- * Render the link with the documents query already answered. `staleTime` is
- * infinite so the seeded entry is never refetched and the test needs no network.
- */
-function renderLink(documents: SeededDocument[]): void {
-  const queryClient = new QueryClient({
+function seededPayload(documents: SeededDocument[]) {
+  return {
+    documents: documents.map((doc) => ({
+      surfaceId: doc.surfaceId,
+      conversationId: CONVERSATION_ID,
+      title: doc.title,
+      wordCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    })),
+  };
+}
+
+/** A client that never refetches, so a seeded entry needs no network. */
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   });
+}
+
+function renderWithClient(
+  queryClient: QueryClient,
+  conversationId: string | null,
+): void {
+  const ui: ReactNode = (
+    <DocumentReopenLink
+      surfaceId={SURFACE_ID}
+      assistantId={ASSISTANT_ID}
+      conversationId={conversationId}
+      onOpenDocument={onOpenDocument}
+    />
+  );
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+/** Render the link with the conversation-scoped documents query answered. */
+function renderLink(documents: SeededDocument[]): void {
+  const queryClient = makeQueryClient();
   queryClient.setQueryData(
     documentsGetQueryKey({
       path: { assistant_id: ASSISTANT_ID },
       query: { conversationId: CONVERSATION_ID },
     }),
-    {
-      documents: documents.map((doc) => ({
-        surfaceId: doc.surfaceId,
-        conversationId: CONVERSATION_ID,
-        title: doc.title,
-        wordCount: 0,
-        createdAt: 0,
-        updatedAt: 0,
-      })),
-    },
+    seededPayload(documents),
   );
-  const ui: ReactNode = (
-    <DocumentReopenLink
-      surfaceId={SURFACE_ID}
-      assistantId={ASSISTANT_ID}
-      conversationId={CONVERSATION_ID}
-      onOpenDocument={onOpenDocument}
-    />
-  );
-  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  renderWithClient(queryClient, CONVERSATION_ID);
 }
 
 /** Put the viewer store where it would be with `surfaceId` open in the drawer. */
@@ -73,12 +86,20 @@ function openDocument(surfaceId: string): void {
   });
 }
 
+const realFetch = globalThis.fetch;
+
 beforeEach(() => {
   onOpenDocument.mockClear();
   useViewerStore.setState({ mainView: "chat", openedDocumentState: null });
+  // An unseeded query leaves the link in its loading state for the whole test
+  // instead of reaching the network.
+  globalThis.fetch = Object.assign(() => new Promise<Response>(() => {}), {
+    preconnect: () => {},
+  }) as typeof globalThis.fetch;
 });
 
 afterEach(() => {
+  globalThis.fetch = realFetch;
   cleanup();
 });
 
@@ -90,11 +111,35 @@ describe("DocumentReopenLink", () => {
     expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
   });
 
-  test("falls back to a neutral label when the query has no title", () => {
+  test("renders nothing until the documents query resolves", () => {
+    renderWithClient(makeQueryClient(), CONVERSATION_ID);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+    expect(screen.queryByText("Untitled document")).toBeNull();
+  });
+
+  test("renders nothing for a document the resolved list does not carry", () => {
     renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("falls back to a neutral label for a document with an empty title", () => {
+    renderLink([{ surfaceId: SURFACE_ID, title: "  " }]);
 
     expect(screen.getByText("Untitled document")).toBeTruthy();
     expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("reads the assistant-wide list when there is no conversation", () => {
+    const queryClient = makeQueryClient();
+    queryClient.setQueryData(
+      documentsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+      seededPayload([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]),
+    );
+    renderWithClient(queryClient, null);
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
   });
 
   test("hides itself while its own document is open", () => {

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -10,8 +10,9 @@
  *
  * The name comes from the documents query rather than the tool result, so the
  * link reads the same title the assets list and the Library show, including
- * after a rename. A document the query cannot name still gets a link, under a
- * neutral label.
+ * after a rename. The link waits for that query and stays away from a document
+ * the resolved list does not carry, so it never offers to open something that
+ * has been deleted.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -22,31 +23,39 @@ import { Button } from "@vellumai/design-library/components/button";
 import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
-/** Label for a document the documents query has no title for. */
+/** Label for a document the documents query lists under an empty title. */
 const FALLBACK_DOCUMENT_NAME = "Untitled document";
 
 /**
- * Title of the document `surfaceId`, or {@link FALLBACK_DOCUMENT_NAME} when the
- * documents query has not named it. Keyed the same way the assets pill keys its
- * list, so both read one cache entry and one invalidation refreshes both.
+ * Title of the document `surfaceId`: `undefined` until the documents query
+ * resolves, `null` once a resolved list does not carry the document, and
+ * otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when that title is empty).
+ *
+ * With a conversation the key matches the assets pill's, so both read one cache
+ * entry and one invalidation refreshes both. Without one the key drops the
+ * filter and reads the assistant-wide list, which no pill shares.
  */
 function useDocumentDisplayName(
   surfaceId: string,
   assistantId?: string | null,
   conversationId?: string | null,
-): string {
+): string | null | undefined {
   const { data: title } = useQuery({
     ...documentsGetOptions({
       path: { assistant_id: assistantId ?? "" },
-      query: { conversationId: conversationId ?? undefined },
+      ...(conversationId ? { query: { conversationId } } : {}),
     }),
     enabled: Boolean(assistantId),
-    select: (response) =>
-      response.documents.find((doc) => doc.surfaceId === surfaceId)?.title,
+    select: (response) => {
+      const found = response.documents.find(
+        (doc) => doc.surfaceId === surfaceId,
+      );
+      if (!found) {
+        return null;
+      }
+      return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
+    },
   });
-  if (title === undefined || title.trim() === "") {
-    return FALLBACK_DOCUMENT_NAME;
-  }
   return title;
 }
 
@@ -73,7 +82,7 @@ export function DocumentReopenLink({
     conversationId,
   );
 
-  if (isOpen) {
+  if (isOpen || displayName == null) {
     return null;
   }
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import {
   computeCardBackedWorkflowRunIds,
   resolveChangedDocuments,
+  resolveEditedDocuments,
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -290,5 +291,58 @@ describe("resolveChangedDocuments", () => {
       "doc-1",
       "doc-2",
     ]);
+  });
+});
+
+describe("resolveEditedDocuments", () => {
+  test("returns the documents an update and a replace wrote to", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-1"),
+      docCall("tc-b", "document_replace_text", "doc-2", {
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          content_changed: true,
+        }),
+      }),
+    ];
+    expect([...resolveEditedDocuments(calls)]).toEqual(["doc-1", "doc-2"]);
+  });
+
+  test("omits a document the turn only created", () => {
+    const calls = [docCall("tc-a", "document_create", "doc-1")];
+    expect(resolveEditedDocuments(calls).size).toBe(0);
+  });
+
+  test("includes a created document the turn goes on to write into", () => {
+    const calls = [
+      docCall("tc-a", "document_create", "doc-1"),
+      docCall("tc-b", "document_update", "doc-1"),
+    ];
+    expect([...resolveEditedDocuments(calls)]).toEqual(["doc-1"]);
+  });
+
+  test("resolves an edit delivered inside a skill_execute envelope", () => {
+    const tc = call({
+      id: "tc-a",
+      name: "skill_execute",
+      input: { tool: "document_update", surface_id: "doc-1" },
+      result: JSON.stringify({ success: true, surface_id: "doc-1" }),
+    });
+    expect([...resolveEditedDocuments([tc])]).toEqual(["doc-1"]);
+  });
+
+  test("omits an errored edit and a replace that changed nothing", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-1", { isError: true }),
+      docCall("tc-b", "document_replace_text", "doc-2", {
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          content_changed: false,
+        }),
+      }),
+    ];
+    expect(resolveEditedDocuments(calls).size).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -431,13 +431,22 @@ const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
   "document_replace_text",
 ]);
 
+/** The mutating document tools that write into an already-created document. */
+const DOCUMENT_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  "document_update",
+  "document_replace_text",
+]);
+
 /**
- * Detect a call to a document tool that changes content. Document tools ship in
- * the bundled `document-editor` skill, so a call arrives either under its raw
- * tool name or inside a `skill_execute` envelope whose `input.tool` names it.
+ * Detect a call to one of `tools`. Document tools ship in the bundled
+ * `document-editor` skill, so a call arrives either under its raw tool name or
+ * inside a `skill_execute` envelope whose `input.tool` names it.
  */
-function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
-  if (DOCUMENT_MUTATION_TOOLS.has(toolCall.name)) {
+function isDocumentToolCall(
+  toolCall: ChatMessageToolCall,
+  tools: ReadonlySet<string>,
+): boolean {
+  if (tools.has(toolCall.name)) {
     return true;
   }
   if (toolCall.name !== "skill_execute") {
@@ -448,15 +457,15 @@ function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
     return false;
   }
   const tool = (input as Record<string, unknown>).tool;
-  return typeof tool === "string" && DOCUMENT_MUTATION_TOOLS.has(tool);
+  return typeof tool === "string" && tools.has(tool);
 }
 
 /**
- * Extract the `surface_id` a mutating document tool call wrote to. The
- * executors return `JSON.stringify({ ..., surface_id })` (see
+ * Extract the `surface_id` a call to one of `tools` wrote to. The executors
+ * return `JSON.stringify({ ..., surface_id })` (see
  * `assistant/src/tools/document/document-tool.ts`). Returns `undefined` for a
- * non-document call, a call that failed, a replace that matched nothing, or a
- * non-JSON/malformed result, so callers anchor only on documents that really
+ * call outside `tools`, a call that failed, a replace that matched nothing, or
+ * a non-JSON/malformed result, so callers anchor only on documents that really
  * changed.
  *
  * Only `document_replace_text` reports `content_changed`, and it succeeds with
@@ -467,8 +476,9 @@ function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
  */
 function extractDocumentSurfaceIdFromResult(
   toolCall: ChatMessageToolCall,
+  tools: ReadonlySet<string>,
 ): string | undefined {
-  if (!isDocumentMutationCall(toolCall) || toolCall.isError === true) {
+  if (!isDocumentToolCall(toolCall, tools) || toolCall.isError === true) {
     return undefined;
   }
   if (typeof toolCall.result !== "string" || !toolCall.result) {
@@ -507,10 +517,40 @@ export function resolveChangedDocuments(
   const surfaceIds: string[] = [];
 
   for (const tc of toolCalls) {
-    const surfaceId = extractDocumentSurfaceIdFromResult(tc);
+    const surfaceId = extractDocumentSurfaceIdFromResult(
+      tc,
+      DOCUMENT_MUTATION_TOOLS,
+    );
     if (surfaceId && !claimed.has(surfaceId)) {
       surfaceIds.push(surfaceId);
       claimed.add(surfaceId);
+    }
+  }
+
+  return surfaceIds;
+}
+
+/**
+ * The ids of the documents `toolCalls` wrote into with `document_update` or
+ * `document_replace_text`, ignoring the create that opened them.
+ *
+ * An inline `document_preview` card renders where its tool ran, so it stands in
+ * for the end-of-response reopen link only on a document the turn leaves alone
+ * afterwards. A document the turn keeps writing to is changed below its card
+ * and still owes a link at the end.
+ */
+export function resolveEditedDocuments(
+  toolCalls: ChatMessageToolCall[],
+): Set<string> {
+  const surfaceIds = new Set<string>();
+
+  for (const tc of toolCalls) {
+    const surfaceId = extractDocumentSurfaceIdFromResult(
+      tc,
+      DOCUMENT_EDIT_TOOLS,
+    );
+    if (surfaceId) {
+      surfaceIds.add(surfaceId);
     }
   }
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -2475,6 +2475,22 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     expect(reopenLinks(container).length).toBe(0);
   });
 
+  test("renders a reopen link for a created document the turn then edits", () => {
+    const { container } = surfaceTurn(
+      [
+        documentCreateCall("tc-doc-a", "surf-notes"),
+        documentUpdateCall("tc-doc-b", "surf-notes"),
+      ],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    // The card renders where the create ran, above the writes that followed.
+    expect(
+      container.querySelector("[data-surface-id='preview-surf-notes']"),
+    ).not.toBeNull();
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
   test("renders a reopen link for a changed document no preview card covers", () => {
     const { container } = surfaceTurn(
       [

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -78,6 +78,7 @@ import {
   resolveAcpRunIds,
   resolveBackgroundTaskIds,
   resolveChangedDocuments,
+  resolveEditedDocuments,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -379,6 +380,12 @@ export function TranscriptMessageBody({
   // Document surface ids claim in their own namespace. Sharing a Set with the
   // process kinds above would let an unrelated id suppress a reopen link.
   const claimedDocumentIds = new Set<string>();
+  // Resolved before the render pass so a `document_preview` card knows whether
+  // the turn writes to its document past the point where the card renders.
+  const editedDocumentIds = useMemo(
+    () => resolveEditedDocuments(message.toolCalls ?? []),
+    [message.toolCalls],
+  );
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -746,13 +753,19 @@ export function TranscriptMessageBody({
   ): ReactNode => {
     // A `document_preview` card opens its own document, so claim that document
     // before the end-of-message resolution runs and the reopen link would
-    // otherwise repeat the same affordance right beside the card. The preview's
-    // own `surfaceId` is the surface (`preview-<doc id>`); the document it
-    // opens rides in `data.surfaceId`, which is what a document tool call
-    // reports in its result.
+    // otherwise repeat the same affordance right beside the card. A document
+    // the turn also edits is left unclaimed: the card sits where its tool ran,
+    // above the edits, so that turn still ends with a link. The preview's own
+    // `surfaceId` is the surface (`preview-<doc id>`); the document it opens
+    // rides in `data.surfaceId`, which is what a document tool call reports in
+    // its result.
     if (surface.surfaceType === "document_preview") {
       const documentSurfaceId = surface.data?.surfaceId;
-      if (typeof documentSurfaceId === "string" && documentSurfaceId !== "") {
+      if (
+        typeof documentSurfaceId === "string" &&
+        documentSurfaceId !== "" &&
+        !editedDocumentIds.has(documentSurfaceId)
+      ) {
         claimedDocumentIds.add(documentSurfaceId);
       }
     }


### PR DESCRIPTION
## Summary
- Suppress the end-of-response reopen link only for a bare create whose preview card already opens the document, not for a create the turn then edits.
- Render the link only once its title query resolves, and hide it when the document is absent.

Fixes review findings on plan document-update-discoverability.md