### PR TITLE
fix(assistant): make document change broadcasts reach every client

### DIFF
--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -15,6 +15,11 @@ import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as DOCUMENT_ROUTES } from "../runtime/routes/documents-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
+import {
+  DOCUMENTS_CHANGED_COALESCE_MS,
+  DOCUMENTS_CHANGED_MAX_DEFER_MS,
+  publishDocumentsChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
 await initializeDb();
@@ -35,15 +40,27 @@ function getRoute(operationId: string): RouteDefinition {
 }
 
 /**
+ * Wait past the documents coalescing window plus a few ticks of async hub
+ * dispatch, so a publish scheduled before the wait has certainly landed.
+ */
+async function settlePublishes(): Promise<void> {
+  await new Promise((resolve) =>
+    setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS + 50),
+  );
+}
+
+/**
  * Run `action` and return every `sync_changed` event it produced.
  *
- * The hub dispatches asynchronously, so the capture window stays open for a
- * few ticks past the action. That window is what lets a "publishes nothing"
+ * Publishes coalesce and the hub dispatches asynchronously, so the window is
+ * drained before the capture starts (setup writes must not leak into it) and
+ * held open past the action. That window is what lets a "publishes nothing"
  * assertion be meaningful and what catches a stray second publish.
  */
 async function captureSyncEvents(
   action: () => unknown | Promise<unknown>,
 ): Promise<AssistantEventEnvelope[]> {
+  await settlePublishes();
   const received: AssistantEventEnvelope[] = [];
   const subscription = assistantEventHub.subscribe({
     type: "process",
@@ -55,7 +72,7 @@ async function captureSyncEvents(
   });
   try {
     await action();
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await settlePublishes();
     return received;
   } finally {
     subscription.dispose();
@@ -134,11 +151,11 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
-  test("an upsert over an existing document publishes again", async () => {
+  test("retitling an existing document publishes", async () => {
     await saveViaRoute();
 
     const events = await captureSyncEvents(() =>
-      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+      saveViaRoute({ title: "Renamed notes" }),
     );
     expectDocumentsChanged(events);
   });
@@ -174,6 +191,40 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
+  test("the link publishes without an origin so the caller is not suppressed", async () => {
+    // `document-viewer-page` links, then navigates to the conversation whose
+    // assets pill must now list the document, and invalidates nothing itself.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      invoke("linkDocumentConversation", {
+        pathParams: { id: "doc-sync" },
+        body: { conversationId: OTHER_CONVERSATION_ID },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
+  test("binding a workspace file publishes without an origin so the caller is not suppressed", async () => {
+    // `viewer-store.loadWorkspaceFileDocument` creates the row and invalidates
+    // nothing, so the client that opened the file is the one that most needs
+    // the invalidation.
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+
+    const events = await captureSyncEvents(() =>
+      invoke("documentForWorkspaceFile", {
+        body: { path: "sync-notes/plan.md", conversationId: CONVERSATION_ID },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
   test("binding a workspace file to a new document publishes", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
 
@@ -206,7 +257,19 @@ describe("document write routes publish documents:list", () => {
   });
 });
 
-describe("document routes that write nothing stay silent", () => {
+describe("document routes that change nothing the list shows stay silent", () => {
+  test("a content-only autosave publishes nothing", async () => {
+    // The web editor autosaves about once a second while the user types and
+    // always resends the same title, so a content-only save must not make every
+    // other client drain its document queries.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expect(events).toEqual([]);
+  });
+
   test("reopening an unchanged, already-linked file publishes nothing", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
     await openWorkspaceFile("sync-notes/plan.md");
@@ -260,5 +323,56 @@ describe("document routes that write nothing stay silent", () => {
       invoke("getDocument", { pathParams: { id: "doc-sync" } }),
     );
     expect(events).toEqual([]);
+  });
+});
+
+describe("documents-changed publishes coalesce", () => {
+  test("a burst of writes collapses into a single broadcast", async () => {
+    // The document-editor skill streams a document as many `document_update`
+    // calls, each of which publishes. Without coalescing each one drains three
+    // documentsGet queries on every connected client.
+    const events = await captureSyncEvents(() => {
+      for (let i = 0; i < 10; i++) {
+        publishDocumentsChanged();
+      }
+    });
+
+    expectDocumentsChanged(events);
+  });
+
+  test("a burst spanning two clients drops the origin so neither suppresses it", async () => {
+    const events = await captureSyncEvents(() => {
+      publishDocumentsChanged("client-a");
+      publishDocumentsChanged("client-b");
+    });
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
+  test("a burst from one client keeps that client's origin", async () => {
+    const events = await captureSyncEvents(() => {
+      publishDocumentsChanged("client-a");
+      publishDocumentsChanged("client-a");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({ originClientId: "client-a" });
+  });
+
+  test("an unbroken run of writes still publishes before the turn ends", async () => {
+    // A document streamed in sub-window chunks would otherwise keep pushing the
+    // timer out and never refresh the list while it is being written.
+    const events = await captureSyncEvents(async () => {
+      const deadline = Date.now() + DOCUMENTS_CHANGED_MAX_DEFER_MS + 100;
+      while (Date.now() < deadline) {
+        publishDocumentsChanged();
+        await new Promise((resolve) =>
+          setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS / 3),
+        );
+      }
+    });
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/assistant/src/__tests__/document-update-default-surface.test.ts
+++ b/assistant/src/__tests__/document-update-default-surface.test.ts
@@ -187,6 +187,34 @@ describe("executeDocumentUpdate — default surface_id resolution", () => {
     expect(result.content).toContain("document_create");
   });
 
+  test("reports success when no client is connected to render the edit", () => {
+    // A headless turn (a schedule, or an SMS or Telegram channel) has no
+    // client, but the row is written all the same. Reporting an error would
+    // skip the post-execution hooks, so the documents-changed broadcast that
+    // tells clients about the edit would never fire, and the model would be
+    // told to retry a write that already succeeded.
+    seedDocument({
+      surfaceId: "doc-headless",
+      conversationId: "conv-current",
+      title: "X",
+      content: "start",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentUpdate(
+      { content: "appended", mode: "append" },
+      makeContext({ sendToClient: undefined }),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ success: boolean; surface_id: string }>(result);
+    expect(body.success).toBe(true);
+    // Web anchors its changed-document chip on this id, so a headless write
+    // that omitted it would surface nothing.
+    expect(body.surface_id).toBe("doc-headless");
+    expect(getDocumentById("doc-headless")?.content).toBe("start\n\nappended");
+  });
+
   test("still requires content", () => {
     seedDocument({
       surfaceId: "doc-only",

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -187,6 +187,13 @@ registerAppSurfaceRefreshHook("app_update");
 // after an edit, and a deleted document lingers as a ghost row. `skill_execute`
 // calls reach the runner already unwrapped to the inner tool name, so the
 // bundled document-editor skill needs no separate registration.
+//
+// A second copy of this list lives in web's `DOCUMENT_MUTATION_TOOLS`
+// (`clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx`),
+// which anchors the changed-document chips. It deliberately omits
+// `document_delete` (a deleted document has nothing to open), so the two lists
+// differ by that one entry and nothing else. Add a new mutating document tool
+// to both.
 registerHook(
   [
     "document_create",

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -60,6 +60,7 @@ import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js"
 import { CONTACTS_MIRROR_IPC_METHODS } from "./routes/contacts-mirror-ipc-routes.js";
 import { CONVERSATION_SYNC_IPC_METHODS } from "./routes/conversation-sync-ipc-routes.js";
 import { type DbProxyParams, handleDbProxy } from "./routes/db-proxy.js";
+import { DOCUMENTS_SYNC_IPC_METHODS } from "./routes/documents-sync-ipc-routes.js";
 import { EVENTS_IPC_METHODS } from "./routes/events-ipc-routes.js";
 import { GUARDIAN_LABEL_IPC_METHODS } from "./routes/guardian-label-ipc-routes.js";
 import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
@@ -215,6 +216,7 @@ export class AssistantIpcServer {
       CONTACTS_MIRROR_IPC_METHODS,
       GUARDIAN_LABEL_IPC_METHODS,
       CONVERSATION_SYNC_IPC_METHODS,
+      DOCUMENTS_SYNC_IPC_METHODS,
       EVENTS_IPC_METHODS,
     ]) {
       for (const [operationId, handler] of Object.entries(methodMap)) {

--- a/assistant/src/ipc/routes/__tests__/documents-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/documents-sync-ipc-routes.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The daemon-side handler for the worker → daemon documents-changed hand-off.
+ * A sidecar worker's own hub has no SSE subscriber, so it asks the daemon to
+ * republish the invalidation where clients actually observe it.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const publishCalls: Array<string | undefined> = [];
+
+mock.module("../../../runtime/sync/resource-sync-events.js", () => ({
+  publishDocumentsChanged: (originClientId?: string) => {
+    publishCalls.push(originClientId);
+  },
+}));
+
+import { DB_MIGRATION_READINESS_EXEMPT_OPERATIONS } from "../../../daemon/daemon-readiness.js";
+import { NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD } from "../../../runtime/sync/worker-daemon-notify.js";
+import {
+  DOCUMENTS_SYNC_IPC_METHODS,
+  handleNotifyDocumentsChanged,
+} from "../documents-sync-ipc-routes.js";
+
+describe("documents-sync IPC route", () => {
+  beforeEach(() => {
+    publishCalls.length = 0;
+  });
+
+  test("republishes the documents-changed invalidation on the daemon", () => {
+    const result = handleNotifyDocumentsChanged({ body: {} });
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCalls).toEqual([undefined]);
+  });
+
+  test("carries no origin client id, so no client suppresses it", () => {
+    // The hand-off comes from a background turn with no originating client.
+    handleNotifyDocumentsChanged({ body: {} });
+
+    expect(publishCalls[0]).toBeUndefined();
+  });
+
+  test("is reachable on the IPC surface under the shared method name", () => {
+    expect(
+      typeof DOCUMENTS_SYNC_IPC_METHODS[NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD],
+    ).toBe("function");
+  });
+
+  test("is DB-migration readiness gated (absent from the exempt set)", () => {
+    expect(
+      DB_MIGRATION_READINESS_EXEMPT_OPERATIONS.has(
+        NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
+      ),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/ipc/routes/documents-sync-ipc-routes.ts
+++ b/assistant/src/ipc/routes/documents-sync-ipc-routes.ts
@@ -1,0 +1,42 @@
+/**
+ * IPC-only route the sidecar workers (schedule, memory) call after a turn
+ * changed a document.
+ *
+ * Workers disable SSE seq stamping (`disableStreamSeqStamping`) so the daemon
+ * is the sole seq authority, and the SSE subscribers live in the daemon too. A
+ * worker that published `documents:list` on its own hub would reach nobody, so
+ * a scheduled or background turn's document edit would stay invisible: the
+ * conversation assets pill and the Library would keep serving their cached
+ * list. That is precisely the case the changed-document surfacing exists for.
+ *
+ * This route runs the publish on the daemon instead, where real subscribers
+ * observe it. The hand-off carries no originating client, so nothing suppresses
+ * the broadcast as its own echo.
+ *
+ * IPC-only: registered directly on the assistant IPC server (see
+ * `assistant-server.ts`), never in the shared `ROUTES` array. The handler
+ * touches no database, but the IPC server's uniform DB-migration gate still
+ * applies (the method is not exempt); the worker's call is best-effort and
+ * tolerates that.
+ */
+
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+import { publishDocumentsChanged } from "../../runtime/sync/resource-sync-events.js";
+import { NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD } from "../../runtime/sync/worker-daemon-notify.js";
+
+/** Republish a worker's documents-changed invalidation to daemon subscribers. */
+export function handleNotifyDocumentsChanged(_args: RouteHandlerArgs) {
+  publishDocumentsChanged();
+  return { ok: true };
+}
+
+/**
+ * IPC-only documents-sync methods, keyed by operationId. Registered directly on
+ * the assistant IPC server (see `assistant-server.ts`).
+ */
+export const DOCUMENTS_SYNC_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  [NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD]: handleNotifyDocumentsChanged,
+};

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -164,10 +164,15 @@ function loadDocumentPayload(surfaceId: string): Record<string, unknown> {
  * content has drifted from the bytes on disk (the file was edited outside the
  * editor), the row is refreshed from the file before it is returned. Writes go
  * the other way — the document store writes through to the file.
+ *
+ * The publishes here carry no origin client id on purpose. The only caller,
+ * `viewer-store.loadWorkspaceFileDocument`, opens the file and never
+ * invalidates its own document queries, so the client that creates the row is
+ * the one that most needs to hear about it: suppressing its own echo would
+ * leave its assets pill and Library without the document it just opened.
  */
 function handleDocumentForWorkspaceFile({
   body,
-  headers,
 }: RouteHandlerArgs): Record<string, unknown> {
   const { path, conversationId } = (body ?? {}) as {
     path?: string;
@@ -225,7 +230,7 @@ function handleDocumentForWorkspaceFile({
     // Reopening an unchanged, already-linked file writes nothing, so it must
     // not invalidate every client's document list on each open.
     if (!alreadyLinked || refreshed) {
-      publishDocumentsChanged(getOriginClientId(headers));
+      publishDocumentsChanged();
     }
     return loadDocumentPayload(existing.surfaceId);
   }
@@ -251,7 +256,7 @@ function handleDocumentForWorkspaceFile({
     );
     addDocumentConversation(raced.surfaceId, conversationId);
     if (!racedAlreadyLinked) {
-      publishDocumentsChanged(getOriginClientId(headers));
+      publishDocumentsChanged();
     }
     return loadDocumentPayload(raced.surfaceId);
   }
@@ -260,7 +265,7 @@ function handleDocumentForWorkspaceFile({
     { surfaceId, workspacePath: relativePath, conversationId },
     "Bound workspace file to a new document",
   );
-  publishDocumentsChanged(getOriginClientId(headers));
+  publishDocumentsChanged();
   return loadDocumentPayload(surfaceId);
 }
 
@@ -377,6 +382,8 @@ export const ROUTES: RouteDefinition[] = [
         throw new BadRequestError("wordCount is required");
       }
 
+      const before = getDocumentById(surfaceId);
+
       const result = saveDocument({
         surfaceId,
         conversationId,
@@ -388,7 +395,15 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
-      publishDocumentsChanged(getOriginClientId(headers));
+      // This is the web editor's autosave, which fires roughly once a second
+      // while the user types and always resends the title it opened with. The
+      // list surfaces render title and surface id, so a content-only save
+      // changes nothing they show, and broadcasting it would make every other
+      // client drain its document queries on each keystroke burst. A new row or
+      // a retitled one does change the list, so those still publish.
+      if (!before || before.title !== title) {
+        publishDocumentsChanged(getOriginClientId(headers));
+      }
       return result;
     },
   },
@@ -439,7 +454,7 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string().describe("Conversation to link"),
     }),
     responseBody: z.object({ success: z.literal(true) }),
-    handler: ({ pathParams, body, headers }) => {
+    handler: ({ pathParams, body }) => {
       const { conversationId } = (body ?? {}) as { conversationId?: string };
       if (!conversationId) {
         throw new BadRequestError("conversationId is required");
@@ -453,7 +468,12 @@ export const ROUTES: RouteDefinition[] = [
         { surfaceId: pathParams!.id, conversationId },
         "Linked document to conversation",
       );
-      publishDocumentsChanged(getOriginClientId(headers));
+      // No origin client id: the only caller, `document-viewer-page`, links the
+      // document and then navigates to the conversation whose assets pill must
+      // now list it, without invalidating anything itself. Suppressing its own
+      // echo would land it on a conversation whose pill is missing the document
+      // it just linked.
+      publishDocumentsChanged();
       return { success: true as const };
     },
   },

--- a/assistant/src/runtime/sync/documents-sidecar-publish.test.ts
+++ b/assistant/src/runtime/sync/documents-sidecar-publish.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A scheduled, heartbeat, or background turn runs its document tools in a
+ * sidecar worker, whose local hub has no SSE subscriber. The documents-changed
+ * broadcast has to be handed to the daemon there, or the document edited while
+ * the user was not looking stays invisible on every client.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let notifyCount = 0;
+
+mock.module("./worker-daemon-notify.js", () => ({
+  NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD:
+    "notify_conversation_persisted_externally",
+  NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD: "notify_documents_changed_externally",
+  notifyDaemonConversationPersisted: async () => {},
+  notifyDaemonDocumentsChanged: async () => {
+    notifyCount++;
+  },
+}));
+
+import type { AssistantEventEnvelope } from "../../api/index.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  _resetStreamStateForTesting,
+  disableStreamSeqStamping,
+} from "../assistant-stream-state.js";
+import {
+  DOCUMENTS_CHANGED_COALESCE_MS,
+  publishDocumentsChanged,
+} from "./resource-sync-events.js";
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) =>
+    setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS + 50),
+  );
+}
+
+/** Run `publish`, then return the `sync_changed` events it put on the hub. */
+async function captureLocalPublishes(
+  publish: () => void,
+): Promise<AssistantEventEnvelope[]> {
+  await settle();
+  const received: AssistantEventEnvelope[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      if (event.message.type === "sync_changed") {
+        received.push(event);
+      }
+    },
+  });
+  try {
+    publish();
+    await settle();
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+describe("publishDocumentsChanged in a sidecar worker", () => {
+  beforeEach(async () => {
+    await settle();
+    notifyCount = 0;
+    _resetStreamStateForTesting();
+  });
+
+  test("hands the broadcast to the daemon instead of publishing into a void", async () => {
+    disableStreamSeqStamping();
+
+    const events = await captureLocalPublishes(() => {
+      publishDocumentsChanged();
+    });
+
+    expect(notifyCount).toBe(1);
+    expect(events).toEqual([]);
+  });
+
+  test("coalesces a burst of worker writes into one hand-off", async () => {
+    disableStreamSeqStamping();
+
+    await captureLocalPublishes(() => {
+      for (let i = 0; i < 10; i++) {
+        publishDocumentsChanged();
+      }
+    });
+
+    expect(notifyCount).toBe(1);
+  });
+
+  test("publishes on the local hub in the daemon, where subscribers live", async () => {
+    const events = await captureLocalPublishes(() => {
+      publishDocumentsChanged();
+    });
+
+    expect(notifyCount).toBe(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({ type: "sync_changed" });
+  });
+});

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -9,7 +9,10 @@ import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { isStreamSeqStampingDisabled } from "../assistant-stream-state.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
-import { notifyDaemonConversationPersisted } from "./worker-daemon-notify.js";
+import {
+  notifyDaemonConversationPersisted,
+  notifyDaemonDocumentsChanged,
+} from "./worker-daemon-notify.js";
 
 /**
  * Derive the initiating client's id from request headers so a sync publish can
@@ -67,8 +70,79 @@ export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
 }
 
-export function publishDocumentsChanged(originClientId?: string): void {
+/**
+ * How long a documents-list invalidation waits for the writes around it to
+ * settle before it is broadcast.
+ *
+ * Document writes arrive in bursts: the document-editor skill is instructed to
+ * stream a document as many small `document_update` calls, and the web editor
+ * autosaves as the user types. Every burst member publishes, and every publish
+ * makes each client drain its `documentsGet` queries (the per-conversation
+ * assets pill, the Library, the intelligence stats), during an SSE stream that
+ * is already saturated. Open editors track each individual write through
+ * `document_editor_update`, so the list-level invalidation only has to land
+ * once the burst settles.
+ */
+export const DOCUMENTS_CHANGED_COALESCE_MS = 150;
+
+/**
+ * Ceiling on how long an unbroken run of writes can defer the invalidation, so
+ * a document streamed in sub-window chunks still refreshes the list while it is
+ * being written instead of only when the turn ends.
+ */
+export const DOCUMENTS_CHANGED_MAX_DEFER_MS = 1_000;
+
+let documentsPublishTimer: ReturnType<typeof setTimeout> | undefined;
+let documentsPublishDeadline = 0;
+let documentsPublishOrigin: string | undefined;
+let documentsPublishOriginSeen = false;
+
+function flushDocumentsChanged(): void {
+  documentsPublishTimer = undefined;
+  documentsPublishDeadline = 0;
+  const originClientId = documentsPublishOrigin;
+  documentsPublishOrigin = undefined;
+  documentsPublishOriginSeen = false;
+
+  // In a sidecar worker (seq stamping disabled) the local hub has no SSE
+  // subscribers, so a local publish reaches no client and a document edited by
+  // a scheduled or background turn stays invisible. Hand off to the daemon,
+  // which republishes the invalidation where subscribers observe it. Such a
+  // turn has no originating client, so no `originClientId` is forwarded.
+  if (isStreamSeqStampingDisabled()) {
+    void notifyDaemonDocumentsChanged();
+    return;
+  }
   void publishSyncInvalidation([SYNC_TAGS.documentsList], originClientId);
+}
+
+/**
+ * Invalidate the document list on every client, coalescing a burst of writes
+ * into a single broadcast (see {@link DOCUMENTS_CHANGED_COALESCE_MS}).
+ */
+export function publishDocumentsChanged(originClientId?: string): void {
+  if (!documentsPublishOriginSeen) {
+    documentsPublishOrigin = originClientId;
+    documentsPublishOriginSeen = true;
+  } else if (documentsPublishOrigin !== originClientId) {
+    // Writes from more than one client merged into this broadcast, so no single
+    // client may suppress it as its own echo.
+    documentsPublishOrigin = undefined;
+  }
+
+  const now = Date.now();
+  if (documentsPublishTimer) {
+    clearTimeout(documentsPublishTimer);
+  } else {
+    documentsPublishDeadline = now + DOCUMENTS_CHANGED_MAX_DEFER_MS;
+  }
+  documentsPublishTimer = setTimeout(
+    flushDocumentsChanged,
+    Math.max(
+      0,
+      Math.min(DOCUMENTS_CHANGED_COALESCE_MS, documentsPublishDeadline - now),
+    ),
+  );
 }
 
 export function publishPluginsChanged(originClientId?: string): void {

--- a/assistant/src/runtime/sync/worker-daemon-notify.test.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.test.ts
@@ -33,7 +33,9 @@ mock.module("../../ipc/cli-client.js", () => ({
 
 import {
   NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD,
+  NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
   notifyDaemonConversationPersisted,
+  notifyDaemonDocumentsChanged,
 } from "./worker-daemon-notify.js";
 
 describe("notifyDaemonConversationPersisted", () => {
@@ -63,6 +65,38 @@ describe("notifyDaemonConversationPersisted", () => {
     shouldThrow = true;
 
     const result = await notifyDaemonConversationPersisted("conv-1");
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("notifyDaemonDocumentsChanged", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    nextResult = { ok: true };
+    shouldThrow = false;
+  });
+
+  test("asks the daemon to republish over the shared IPC method", async () => {
+    await notifyDaemonDocumentsChanged();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe(NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD);
+    expect(calls[0]!.params).toEqual({ body: {} });
+  });
+
+  test("swallows a failed IPC result (best-effort, no throw)", async () => {
+    nextResult = { ok: false, error: "daemon unreachable" };
+
+    const result = await notifyDaemonDocumentsChanged();
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("swallows a thrown IPC error (best-effort, no throw)", async () => {
+    shouldThrow = true;
+
+    const result = await notifyDaemonDocumentsChanged();
     expect(result).toBeUndefined();
     expect(calls).toHaveLength(1);
   });

--- a/assistant/src/runtime/sync/worker-daemon-notify.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.ts
@@ -1,13 +1,13 @@
 /**
- * Worker → daemon hand-off for conversation message-persist notifications.
+ * Worker → daemon hand-off for sync notifications a sidecar cannot deliver.
  *
  * Sidecar worker processes (schedule, memory) disable SSE seq stamping — the
  * daemon is the sole seq authority — so a worker's own `getCurrentSeq()`
- * reports `0` and its `publishConversationMessagesChanged` broadcast reaches no
- * SSE subscriber (those live in the daemon). After a worker persists a turn's
- * rows it hands the notification here; the daemon records an honest snapshot
- * anchor at its own seq and republishes the invalidation to real subscribers
- * (see `ipc/routes/conversation-sync-ipc-routes.ts`).
+ * reports `0` and its `sync_changed` broadcasts reach no SSE subscriber (those
+ * live in the daemon). A worker hands the notification here instead and the
+ * daemon republishes it to real subscribers (see
+ * `ipc/routes/conversation-sync-ipc-routes.ts`,
+ * `ipc/routes/documents-sync-ipc-routes.ts`).
  */
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
@@ -21,6 +21,14 @@ const log = getLogger("worker-daemon-notify");
  */
 export const NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD =
   "notify_conversation_persisted_externally";
+
+/**
+ * IPC method the daemon exposes for the documents-changed hand-off. Shared by
+ * the worker caller and the daemon route registration so the wire name cannot
+ * drift.
+ */
+export const NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD =
+  "notify_documents_changed_externally";
 
 /**
  * Short timeout: this is a fire-and-forget invalidation, not a request whose
@@ -59,5 +67,35 @@ export async function notifyDaemonConversationPersisted(
       { err, conversationId },
       "daemon conversation-persisted notify failed",
     );
+  }
+}
+
+/**
+ * Ask the daemon to republish the documents-list invalidation.
+ *
+ * A scheduled or background turn runs its document tools in a sidecar worker,
+ * so the edit is real but the worker's own broadcast reaches nobody. This is
+ * the path that lets the user learn a document changed while they were not
+ * looking.
+ *
+ * Best-effort by design, like the conversation hand-off: an unreachable daemon
+ * is logged at debug and swallowed, and the client picks the change up on its
+ * next document-list fetch.
+ */
+export async function notifyDaemonDocumentsChanged(): Promise<void> {
+  try {
+    const result = await cliIpcCall(
+      NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
+      { body: {} },
+      { timeoutMs: NOTIFY_TIMEOUT_MS },
+    );
+    if (!result.ok) {
+      log.debug(
+        { error: result.error },
+        "daemon documents-changed notify was not acknowledged",
+      );
+    }
+  } catch (err) {
+    log.debug({ err }, "daemon documents-changed notify failed");
   }
 }

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -447,13 +447,20 @@ export function executeDocumentUpdate(
     };
   }
 
-  // Fallback if no client is connected
+  // No client is connected to render the edit, but the write landed, so this is
+  // a success. Reporting it as an error would strand a headless turn (a
+  // schedule, SMS, or Telegram channel): post-execution hooks are skipped for
+  // errored tools, so the documents-changed broadcast that tells clients about
+  // the edit would never fire, and the model would be told to retry a write
+  // that already succeeded.
   return {
     content: JSON.stringify({
-      success: false,
-      error: "No client connected to update document",
+      success: true,
+      surface_id: surfaceId,
+      mode,
+      message: "Document content updated (no client connected to render it)",
     }),
-    isError: true,
+    isError: false,
   };
 }
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -424,7 +424,15 @@ export function resolveBackgroundTaskIds(
   return ids;
 }
 
-/** The document tools that change a document's content. */
+/**
+ * The document tools that change a document's content.
+ *
+ * The daemon keeps its own copy of this list, in the documents-changed hook in
+ * `assistant/src/daemon/tool-side-effects.ts`. That one also carries
+ * `document_delete`, which is left out here on purpose: a deleted document has
+ * nothing to reopen, so it must not anchor a changed-document chip. Add a new
+ * mutating document tool to both.
+ */
 const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
   "document_create",
   "document_update",


### PR DESCRIPTION
## Summary
- Deliver the documents-changed broadcast from sidecar worker turns, so background edits are not silent.
- Stop reporting a successful headless document update as an error, which skipped the broadcast hook.
- Coalesce chunked-update broadcasts instead of firing one per chunk.
- Publish unconditionally from the routes whose callers do not invalidate locally.

Fixes review findings on plan document-update-discoverability.md