### PR TITLE
fix: keep the reopen link for cross-conversation edits and publish content-only saves

### DIFF
--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -160,6 +160,19 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
+  test("a content-only save publishes", async () => {
+    // The save moves `updated_at` and the word count, which order and fill the
+    // Library and the assets list on every other client. The saving client
+    // suppresses its own echo, and the publish coalesces, so an autosave run
+    // costs the others at most one broadcast per second.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expectDocumentsChanged(events);
+  });
+
   test("the save carries the caller's client id so it can suppress its own echo", async () => {
     const events = await captureSyncEvents(() =>
       invoke("saveDocument", {
@@ -258,18 +271,6 @@ describe("document write routes publish documents:list", () => {
 });
 
 describe("document routes that change nothing the list shows stay silent", () => {
-  test("a content-only autosave publishes nothing", async () => {
-    // The web editor autosaves about once a second while the user types and
-    // always resends the same title, so a content-only save must not make every
-    // other client drain its document queries.
-    await saveViaRoute();
-
-    const events = await captureSyncEvents(() =>
-      saveViaRoute({ content: "hello world again", wordCount: 3 }),
-    );
-    expect(events).toEqual([]);
-  });
-
   test("reopening an unchanged, already-linked file publishes nothing", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
     await openWorkspaceFile("sync-notes/plan.md");

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -382,8 +382,6 @@ export const ROUTES: RouteDefinition[] = [
         throw new BadRequestError("wordCount is required");
       }
 
-      const before = getDocumentById(surfaceId);
-
       const result = saveDocument({
         surfaceId,
         conversationId,
@@ -395,15 +393,12 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
-      // This is the web editor's autosave, which fires roughly once a second
-      // while the user types and always resends the title it opened with. The
-      // list surfaces render title and surface id, so a content-only save
-      // changes nothing they show, and broadcasting it would make every other
-      // client drain its document queries on each keystroke burst. A new row or
-      // a retitled one does change the list, so those still publish.
-      if (!before || before.title !== title) {
-        publishDocumentsChanged(getOriginClientId(headers));
-      }
+      // Every save moves `updated_at`, which both document lists order by and
+      // the Library renders next to the word count, so a content-only save
+      // changes what the list surfaces show. The publish coalesces, which
+      // bounds the web editor's per-keystroke autosave to one broadcast per
+      // second, and the saving client suppresses its own echo by origin id.
+      publishDocumentsChanged(getOriginClientId(headers));
       return result;
     },
   },

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -2,9 +2,9 @@
  * Tests for the end-of-turn link back to a document the assistant changed.
  *
  * Covers the two things the link owes its caller: it names the document from
- * the documents query, rendering only once that query resolves with the
- * document in it, and it is present exactly when its own document is not the
- * one open in the viewer.
+ * the documents query, rendering only once a resolved list carries the
+ * document, and it is present exactly when its own document is not the one
+ * open in the viewer.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -18,17 +18,22 @@ import { useViewerStore } from "@/stores/viewer-store";
 
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
+const OTHER_CONVERSATION_ID = "conv-2";
 const SURFACE_ID = "surf-notes";
 
 const onOpenDocument = mock((_surfaceId: string) => {});
 
-type SeededDocument = { surfaceId: string; title: string };
+type SeededDocument = {
+  surfaceId: string;
+  title: string;
+  conversationId?: string;
+};
 
 function seededPayload(documents: SeededDocument[]) {
   return {
     documents: documents.map((doc) => ({
       surfaceId: doc.surfaceId,
-      conversationId: CONVERSATION_ID,
+      conversationId: doc.conversationId ?? CONVERSATION_ID,
       title: doc.title,
       wordCount: 0,
       createdAt: 0,
@@ -59,8 +64,14 @@ function renderWithClient(
   render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
-/** Render the link with the conversation-scoped documents query answered. */
-function renderLink(documents: SeededDocument[]): void {
+/**
+ * Render the link with the conversation-scoped documents query answered, and
+ * the assistant-wide fallback answered too when `assistantWide` is given.
+ */
+function renderLink(
+  documents: SeededDocument[],
+  assistantWide?: SeededDocument[],
+): void {
   const queryClient = makeQueryClient();
   queryClient.setQueryData(
     documentsGetQueryKey({
@@ -69,6 +80,12 @@ function renderLink(documents: SeededDocument[]): void {
     }),
     seededPayload(documents),
   );
+  if (assistantWide) {
+    queryClient.setQueryData(
+      documentsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+      seededPayload(assistantWide),
+    );
+  }
   renderWithClient(queryClient, CONVERSATION_ID);
 }
 
@@ -118,7 +135,35 @@ describe("DocumentReopenLink", () => {
     expect(screen.queryByText("Untitled document")).toBeNull();
   });
 
-  test("renders nothing for a document the resolved list does not carry", () => {
+  test("names a document edited from another conversation", () => {
+    // The assistant can edit any document it reaches, and the edit does not
+    // link that document to the conversation it was made from, so this
+    // conversation's list misses it while the assistant-wide list carries it.
+    renderLink(
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+      [
+        {
+          surfaceId: SURFACE_ID,
+          title: "Quarterly notes",
+          conversationId: OTHER_CONVERSATION_ID,
+        },
+      ],
+    );
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("renders nothing for a document neither resolved list carries", () => {
+    renderLink(
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+    );
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("renders nothing while the assistant-wide fallback is unresolved", () => {
     renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
 
     expect(screen.queryByTestId("document-reopen-link")).toBeNull();

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -11,8 +11,8 @@
  * The name comes from the documents query rather than the tool result, so the
  * link reads the same title the assets list and the Library show, including
  * after a rename. The link waits for that query and stays away from a document
- * the resolved list does not carry, so it never offers to open something that
- * has been deleted.
+ * no resolved list carries, so it never offers to open something that has been
+ * deleted.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -22,41 +22,86 @@ import { Button } from "@vellumai/design-library/components/button";
 
 import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { DocumentsGetResponse } from "@/generated/daemon/types.gen";
 
 /** Label for a document the documents query lists under an empty title. */
 const FALLBACK_DOCUMENT_NAME = "Untitled document";
 
 /**
- * Title of the document `surfaceId`: `undefined` until the documents query
- * resolves, `null` once a resolved list does not carry the document, and
- * otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when that title is empty).
+ * Title of `surfaceId` within one documents response: `null` when the response
+ * does not carry it, otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when
+ * that title is empty).
+ */
+function selectDocumentTitle(
+  response: DocumentsGetResponse,
+  surfaceId: string,
+): string | null {
+  const found = response.documents.find((doc) => doc.surfaceId === surfaceId);
+  if (!found) {
+    return null;
+  }
+  return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
+}
+
+/**
+ * Title of `surfaceId` in one documents list: `undefined` until that list
+ * resolves and `null` once a resolved list does not carry the document.
  *
  * With a conversation the key matches the assets pill's, so both read one cache
  * entry and one invalidation refreshes both. Without one the key drops the
  * filter and reads the assistant-wide list, which no pill shares.
  */
-function useDocumentDisplayName(
+function useDocumentTitle(
   surfaceId: string,
-  assistantId?: string | null,
-  conversationId?: string | null,
+  assistantId: string | null | undefined,
+  conversationId: string | null | undefined,
+  enabled: boolean,
 ): string | null | undefined {
   const { data: title } = useQuery({
     ...documentsGetOptions({
       path: { assistant_id: assistantId ?? "" },
       ...(conversationId ? { query: { conversationId } } : {}),
     }),
-    enabled: Boolean(assistantId),
-    select: (response) => {
-      const found = response.documents.find(
-        (doc) => doc.surfaceId === surfaceId,
-      );
-      if (!found) {
-        return null;
-      }
-      return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
-    },
+    enabled,
+    select: (response) => selectDocumentTitle(response, surfaceId),
   });
   return title;
+}
+
+/**
+ * Title to render for `surfaceId`: `undefined` while it is still being
+ * resolved, `null` once no list carries the document.
+ *
+ * The conversation-scoped list is asked first so the link reads the same cache
+ * entry as the assets pill. A miss there is not an absence: the assistant can
+ * edit any document it can reach, and an edit does not link the document to the
+ * conversation it was made from, so a document reached from an older
+ * conversation is missing from this one's list while still existing. The
+ * assistant-wide list settles that, and only a miss in both hides the link.
+ */
+function useDocumentDisplayName(
+  surfaceId: string,
+  assistantId?: string | null,
+  conversationId?: string | null,
+): string | null | undefined {
+  const hasAssistant = Boolean(assistantId);
+  const scopedTitle = useDocumentTitle(
+    surfaceId,
+    assistantId,
+    conversationId,
+    hasAssistant,
+  );
+  const assistantWideTitle = useDocumentTitle(
+    surfaceId,
+    assistantId,
+    null,
+    hasAssistant && Boolean(conversationId) && scopedTitle === null,
+  );
+
+  if (conversationId && scopedTitle === null) {
+    return assistantWideTitle;
+  }
+  return scopedTitle;
 }
 
 export interface DocumentReopenLinkProps {


### PR DESCRIPTION
## Summary
- Fall back to the assistant-wide document lookup so a document edited from another conversation still gets a reopen link, hiding it only when the document is genuinely gone.
- Publish a documents change for content-only saves, which alter word count, updated-at and Library ordering on other clients. The coalescer already bounds the broadcast rate.

Fixes round-2 review findings on plan document-update-discoverability.md