### PR TITLE
Keep document-editor updates discoverable after the assistant changes a document

### DIFF
--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Client-initiated document writes must invalidate the `documents:list` tag so
+ * the Library and the per-conversation assets list converge on every surface.
+ * Read routes and rejected writes must stay silent.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import type { AssistantEventEnvelope } from "../api/index.js";
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { createConversation } from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { ROUTES as DOCUMENT_ROUTES } from "../runtime/routes/documents-routes.js";
+import type { RouteDefinition } from "../runtime/routes/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+await initializeDb();
+
+const workspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+const notesDir = join(workspaceDir, "sync-notes");
+
+const CONVERSATION_ID = "conv-doc-sync";
+const OTHER_CONVERSATION_ID = "conv-doc-sync-other";
+const MISSING_CONVERSATION_ID = "conv-doc-sync-missing";
+
+function getRoute(operationId: string): RouteDefinition {
+  const route = DOCUMENT_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`No document route found for operationId: ${operationId}`);
+  }
+  return route;
+}
+
+/**
+ * Run `action` and return every `sync_changed` event it produced.
+ *
+ * The hub dispatches asynchronously, so the capture window stays open for a
+ * few ticks past the action. That window is what lets a "publishes nothing"
+ * assertion be meaningful and what catches a stray second publish.
+ */
+async function captureSyncEvents(
+  action: () => unknown | Promise<unknown>,
+): Promise<AssistantEventEnvelope[]> {
+  const received: AssistantEventEnvelope[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      if (event.message.type === "sync_changed") {
+        received.push(event);
+      }
+    },
+  });
+  try {
+    await action();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+function expectDocumentsChanged(events: AssistantEventEnvelope[]): void {
+  expect(events).toHaveLength(1);
+  expect(events[0].message).toMatchObject({
+    type: "sync_changed",
+    tags: [SYNC_TAGS.documentsList],
+  });
+}
+
+/** Run a route handler so its synchronous throws surface as rejections. */
+async function invoke(
+  operationId: string,
+  args: Parameters<RouteDefinition["handler"]>[0],
+): Promise<unknown> {
+  return await getRoute(operationId).handler(args);
+}
+
+async function saveViaRoute(
+  overrides: Record<string, unknown> = {},
+): Promise<unknown> {
+  return await invoke("saveDocument", {
+    body: {
+      surfaceId: "doc-sync",
+      conversationId: CONVERSATION_ID,
+      title: "Notes",
+      content: "hello world",
+      wordCount: 2,
+      ...overrides,
+    },
+  });
+}
+
+async function openWorkspaceFile(
+  path: string,
+  conversationId = CONVERSATION_ID,
+): Promise<unknown> {
+  return await invoke("documentForWorkspaceFile", {
+    body: { path, conversationId },
+  });
+}
+
+async function linkViaRoute(
+  surfaceId: string,
+  conversationId: string,
+): Promise<unknown> {
+  return await invoke("linkDocumentConversation", {
+    pathParams: { id: surfaceId },
+    body: { conversationId },
+  });
+}
+
+beforeEach(() => {
+  const db = getDb();
+  db.run("DELETE FROM document_conversations");
+  db.run("DELETE FROM documents");
+  db.run("DELETE FROM conversations");
+  createConversation({ id: CONVERSATION_ID });
+  createConversation({ id: OTHER_CONVERSATION_ID });
+  rmSync(notesDir, { recursive: true, force: true });
+  mkdirSync(notesDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(notesDir, { recursive: true, force: true });
+  resetDbForTesting();
+});
+
+describe("document write routes publish documents:list", () => {
+  test("a successful save publishes exactly one documents-changed event", async () => {
+    const events = await captureSyncEvents(() => saveViaRoute());
+    expectDocumentsChanged(events);
+  });
+
+  test("an upsert over an existing document publishes again", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("the save carries the caller's client id so it can suppress its own echo", async () => {
+    const events = await captureSyncEvents(() =>
+      invoke("saveDocument", {
+        body: {
+          surfaceId: "doc-sync-origin",
+          conversationId: CONVERSATION_ID,
+          title: "Notes",
+          content: "hello world",
+          wordCount: 2,
+        },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({
+      type: "sync_changed",
+      tags: [SYNC_TAGS.documentsList],
+      originClientId: "client-abc",
+    });
+  });
+
+  test("linking a document to a conversation publishes", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      linkViaRoute("doc-sync", OTHER_CONVERSATION_ID),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("binding a workspace file to a new document publishes", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("reopening the file from another conversation publishes the new link", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md", OTHER_CONVERSATION_ID),
+    );
+    expectDocumentsChanged(events);
+  });
+
+  test("refreshing a document whose file changed on disk publishes", async () => {
+    const filePath = join(notesDir, "plan.md");
+    writeFileSync(filePath, "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+    writeFileSync(filePath, "# Plan\n\nedited outside the editor");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expectDocumentsChanged(events);
+  });
+});
+
+describe("document routes that write nothing stay silent", () => {
+  test("reopening an unchanged, already-linked file publishes nothing", async () => {
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+    await openWorkspaceFile("sync-notes/plan.md");
+
+    const events = await captureSyncEvents(() =>
+      openWorkspaceFile("sync-notes/plan.md"),
+    );
+    expect(events).toEqual([]);
+  });
+
+  test("a save rejected by validation publishes nothing", async () => {
+    const events = await captureSyncEvents(async () => {
+      await expect(saveViaRoute({ title: undefined })).rejects.toThrow(
+        /title is required/,
+      );
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("a save the store refuses publishes nothing", async () => {
+    // The conversation row is absent, so the insert trips the foreign key and
+    // the store reports failure instead of persisting.
+    const events = await captureSyncEvents(async () => {
+      await expect(
+        saveViaRoute({ conversationId: MISSING_CONVERSATION_ID }),
+      ).rejects.toThrow();
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("a link to a document that does not exist publishes nothing", async () => {
+    const events = await captureSyncEvents(async () => {
+      await expect(
+        linkViaRoute("doc-missing", OTHER_CONVERSATION_ID),
+      ).rejects.toThrow(/Document not found/);
+    });
+    expect(events).toEqual([]);
+  });
+
+  test("listing documents publishes nothing", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() => invoke("listDocuments", {}));
+    expect(events).toEqual([]);
+  });
+
+  test("reading a single document publishes nothing", async () => {
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      invoke("getDocument", { pathParams: { id: "doc-sync" } }),
+    );
+    expect(events).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -160,6 +160,19 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
+  test("a content-only save publishes", async () => {
+    // The save moves `updated_at` and the word count, which order and fill the
+    // Library and the assets list on every other client. The saving client
+    // suppresses its own echo, and the publish coalesces, so an autosave run
+    // costs the others at most one broadcast per second.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expectDocumentsChanged(events);
+  });
+
   test("the save carries the caller's client id so it can suppress its own echo", async () => {
     const events = await captureSyncEvents(() =>
       invoke("saveDocument", {
@@ -258,18 +271,6 @@ describe("document write routes publish documents:list", () => {
 });
 
 describe("document routes that change nothing the list shows stay silent", () => {
-  test("a content-only autosave publishes nothing", async () => {
-    // The web editor autosaves about once a second while the user types and
-    // always resends the same title, so a content-only save must not make every
-    // other client drain its document queries.
-    await saveViaRoute();
-
-    const events = await captureSyncEvents(() =>
-      saveViaRoute({ content: "hello world again", wordCount: 3 }),
-    );
-    expect(events).toEqual([]);
-  });
-
   test("reopening an unchanged, already-linked file publishes nothing", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
     await openWorkspaceFile("sync-notes/plan.md");

--- a/assistant/src/__tests__/document-sync-tags.test.ts
+++ b/assistant/src/__tests__/document-sync-tags.test.ts
@@ -15,6 +15,11 @@ import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as DOCUMENT_ROUTES } from "../runtime/routes/documents-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
+import {
+  DOCUMENTS_CHANGED_COALESCE_MS,
+  DOCUMENTS_CHANGED_MAX_DEFER_MS,
+  publishDocumentsChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
 await initializeDb();
@@ -35,15 +40,27 @@ function getRoute(operationId: string): RouteDefinition {
 }
 
 /**
+ * Wait past the documents coalescing window plus a few ticks of async hub
+ * dispatch, so a publish scheduled before the wait has certainly landed.
+ */
+async function settlePublishes(): Promise<void> {
+  await new Promise((resolve) =>
+    setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS + 50),
+  );
+}
+
+/**
  * Run `action` and return every `sync_changed` event it produced.
  *
- * The hub dispatches asynchronously, so the capture window stays open for a
- * few ticks past the action. That window is what lets a "publishes nothing"
+ * Publishes coalesce and the hub dispatches asynchronously, so the window is
+ * drained before the capture starts (setup writes must not leak into it) and
+ * held open past the action. That window is what lets a "publishes nothing"
  * assertion be meaningful and what catches a stray second publish.
  */
 async function captureSyncEvents(
   action: () => unknown | Promise<unknown>,
 ): Promise<AssistantEventEnvelope[]> {
+  await settlePublishes();
   const received: AssistantEventEnvelope[] = [];
   const subscription = assistantEventHub.subscribe({
     type: "process",
@@ -55,7 +72,7 @@ async function captureSyncEvents(
   });
   try {
     await action();
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await settlePublishes();
     return received;
   } finally {
     subscription.dispose();
@@ -134,11 +151,11 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
-  test("an upsert over an existing document publishes again", async () => {
+  test("retitling an existing document publishes", async () => {
     await saveViaRoute();
 
     const events = await captureSyncEvents(() =>
-      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+      saveViaRoute({ title: "Renamed notes" }),
     );
     expectDocumentsChanged(events);
   });
@@ -174,6 +191,40 @@ describe("document write routes publish documents:list", () => {
     expectDocumentsChanged(events);
   });
 
+  test("the link publishes without an origin so the caller is not suppressed", async () => {
+    // `document-viewer-page` links, then navigates to the conversation whose
+    // assets pill must now list the document, and invalidates nothing itself.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      invoke("linkDocumentConversation", {
+        pathParams: { id: "doc-sync" },
+        body: { conversationId: OTHER_CONVERSATION_ID },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
+  test("binding a workspace file publishes without an origin so the caller is not suppressed", async () => {
+    // `viewer-store.loadWorkspaceFileDocument` creates the row and invalidates
+    // nothing, so the client that opened the file is the one that most needs
+    // the invalidation.
+    writeFileSync(join(notesDir, "plan.md"), "# Plan");
+
+    const events = await captureSyncEvents(() =>
+      invoke("documentForWorkspaceFile", {
+        body: { path: "sync-notes/plan.md", conversationId: CONVERSATION_ID },
+        headers: { "x-vellum-client-id": "client-abc" },
+      }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
   test("binding a workspace file to a new document publishes", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
 
@@ -206,7 +257,19 @@ describe("document write routes publish documents:list", () => {
   });
 });
 
-describe("document routes that write nothing stay silent", () => {
+describe("document routes that change nothing the list shows stay silent", () => {
+  test("a content-only autosave publishes nothing", async () => {
+    // The web editor autosaves about once a second while the user types and
+    // always resends the same title, so a content-only save must not make every
+    // other client drain its document queries.
+    await saveViaRoute();
+
+    const events = await captureSyncEvents(() =>
+      saveViaRoute({ content: "hello world again", wordCount: 3 }),
+    );
+    expect(events).toEqual([]);
+  });
+
   test("reopening an unchanged, already-linked file publishes nothing", async () => {
     writeFileSync(join(notesDir, "plan.md"), "# Plan");
     await openWorkspaceFile("sync-notes/plan.md");
@@ -260,5 +323,56 @@ describe("document routes that write nothing stay silent", () => {
       invoke("getDocument", { pathParams: { id: "doc-sync" } }),
     );
     expect(events).toEqual([]);
+  });
+});
+
+describe("documents-changed publishes coalesce", () => {
+  test("a burst of writes collapses into a single broadcast", async () => {
+    // The document-editor skill streams a document as many `document_update`
+    // calls, each of which publishes. Without coalescing each one drains three
+    // documentsGet queries on every connected client.
+    const events = await captureSyncEvents(() => {
+      for (let i = 0; i < 10; i++) {
+        publishDocumentsChanged();
+      }
+    });
+
+    expectDocumentsChanged(events);
+  });
+
+  test("a burst spanning two clients drops the origin so neither suppresses it", async () => {
+    const events = await captureSyncEvents(() => {
+      publishDocumentsChanged("client-a");
+      publishDocumentsChanged("client-b");
+    });
+
+    expect(events).toHaveLength(1);
+    expect("originClientId" in events[0].message).toBe(false);
+  });
+
+  test("a burst from one client keeps that client's origin", async () => {
+    const events = await captureSyncEvents(() => {
+      publishDocumentsChanged("client-a");
+      publishDocumentsChanged("client-a");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({ originClientId: "client-a" });
+  });
+
+  test("an unbroken run of writes still publishes before the turn ends", async () => {
+    // A document streamed in sub-window chunks would otherwise keep pushing the
+    // timer out and never refresh the list while it is being written.
+    const events = await captureSyncEvents(async () => {
+      const deadline = Date.now() + DOCUMENTS_CHANGED_MAX_DEFER_MS + 100;
+      while (Date.now() < deadline) {
+        publishDocumentsChanged();
+        await new Promise((resolve) =>
+          setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS / 3),
+        );
+      }
+    });
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/assistant/src/__tests__/document-update-default-surface.test.ts
+++ b/assistant/src/__tests__/document-update-default-surface.test.ts
@@ -187,6 +187,34 @@ describe("executeDocumentUpdate — default surface_id resolution", () => {
     expect(result.content).toContain("document_create");
   });
 
+  test("reports success when no client is connected to render the edit", () => {
+    // A headless turn (a schedule, or an SMS or Telegram channel) has no
+    // client, but the row is written all the same. Reporting an error would
+    // skip the post-execution hooks, so the documents-changed broadcast that
+    // tells clients about the edit would never fire, and the model would be
+    // told to retry a write that already succeeded.
+    seedDocument({
+      surfaceId: "doc-headless",
+      conversationId: "conv-current",
+      title: "X",
+      content: "start",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentUpdate(
+      { content: "appended", mode: "append" },
+      makeContext({ sendToClient: undefined }),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ success: boolean; surface_id: string }>(result);
+    expect(body.success).toBe(true);
+    // Web anchors its changed-document chip on this id, so a headless write
+    // that omitted it would surface nothing.
+    expect(body.surface_id).toBe("doc-headless");
+    expect(getDocumentById("doc-headless")?.content).toBe("start\n\nappended");
+  });
+
   test("still requires content", () => {
     seedDocument({
       surfaceId: "doc-only",

--- a/assistant/src/__tests__/tool-side-effects-documents.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-documents.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the document post-execution hooks that publish a documents-changed
+ * broadcast so client asset lists and the Library refresh after a mutation.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { createMockLoggerModule } from "./helpers/mock-logger.js";
+
+// ---------------------------------------------------------------------------
+// Mocks. Must be set up before importing the module under test.
+// ---------------------------------------------------------------------------
+
+const mockPublishDocumentsChanged = mock(() => {});
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishAppsChanged: mock(() => {}),
+  publishDocumentsChanged: mockPublishDocumentsChanged,
+}));
+
+mock.module("../util/logger.js", () => createMockLoggerModule());
+
+// Stub the transitive imports so the module graph under test stops at
+// tool-side-effects.ts and never reaches the real sync publisher.
+mock.module("../channels/gateway-verification-sessions.js", () => ({
+  findActiveSession: mock(() => Promise.resolve(null)),
+}));
+mock.module("../runtime/verification-outbound-actions.js", () => ({
+  deliverVerificationSlack: mock(() => {}),
+}));
+mock.module("../media/app-icon-generator.js", () => ({
+  generateAppIcon: mock(() => Promise.resolve()),
+}));
+mock.module("../apps/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => ""),
+  getAppsDir: mock(() => ""),
+  resolveAppIdFromPath: mock(() => null),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppDir: mock(() => ({ dirName: "", dirPath: "" })),
+  slugify: mock((s: string) => s),
+  validateDirName: mock(() => {}),
+  generateAppDirName: mock(() => ""),
+  listApps: mock(() => []),
+  createApp: mock(() => ({})),
+  updateApp: mock(() => {}),
+  deleteApp: mock(() => {}),
+  getAppPreview: mock(() => null),
+  createAppRecord: mock(() => ({})),
+  getAppRecord: mock(() => null),
+  queryAppRecords: mock(() => []),
+  updateAppRecord: mock(() => {}),
+  deleteAppRecord: mock(() => {}),
+  listAppFiles: mock(() => []),
+  appFileExists: mock(() => false),
+  readAppFile: mock(() => ""),
+  writeAppFile: mock(() => {}),
+  editAppFile: mock(() => ({})),
+  inlineDistAssets: mock((_: unknown, html: string) => html),
+  addAppConversationId: mock(() => false),
+  linkAppToConversationLineage: mock(() => {}),
+}));
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: mock(() => Promise.resolve({ ok: true })),
+}));
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+}));
+mock.module("../daemon/doordash-steps.js", () => ({
+  isDoordashCommand: mock(() => false),
+  updateDoordashProgress: mock(() => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks. The dynamic import ensures the mock.module() calls above
+// are registered before tool-side-effects.ts evaluates its top-level imports.
+// ---------------------------------------------------------------------------
+
+import type { SideEffectContext } from "../daemon/tool-side-effects.js";
+
+const { runPostExecutionSideEffects } =
+  await import("../daemon/tool-side-effects.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummySideEffectCtx = {
+  ctx: {} as SideEffectContext["ctx"],
+} satisfies SideEffectContext;
+
+const MUTATING_TOOLS = [
+  "document_create",
+  "document_update",
+  "document_replace_text",
+  "document_delete",
+];
+
+const READ_ONLY_TOOLS = [
+  "document_read",
+  "document_list",
+  "document_find",
+  "document_open",
+];
+
+// The content is deliberately not JSON: the hook fires on the executed tool
+// name alone and must never depend on the shape of the LLM-facing result.
+async function runTool(name: string, isError = false): Promise<void> {
+  await runPostExecutionSideEffects(
+    name,
+    { surface_id: "doc-1" },
+    { content: "Document saved.", isError },
+    dummySideEffectCtx,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("document hooks: documents-changed broadcast", () => {
+  beforeEach(() => {
+    mockPublishDocumentsChanged.mockReset();
+  });
+
+  for (const toolName of MUTATING_TOOLS) {
+    test(`${toolName} publishes exactly one documents change`, async () => {
+      await runTool(toolName);
+      expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  for (const toolName of READ_ONLY_TOOLS) {
+    test(`${toolName} publishes no documents change`, async () => {
+      await runTool(toolName);
+      expect(mockPublishDocumentsChanged).not.toHaveBeenCalled();
+    });
+  }
+
+  test("a failed mutation publishes no documents change", async () => {
+    await runTool("document_update", true);
+    expect(mockPublishDocumentsChanged).not.toHaveBeenCalled();
+  });
+
+  test("two mutations in one turn publish once each", async () => {
+    await runTool("document_update");
+    await runTool("document_replace_text");
+    expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/__tests__/tool-side-effects-documents.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-documents.test.ts
@@ -5,6 +5,11 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  DOCUMENT_EDIT_TOOL_NAMES,
+  DOCUMENT_MUTATION_TOOL_NAMES,
+  REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES,
+} from "../api/constants/document-tools.js";
 import { createMockLoggerModule } from "./helpers/mock-logger.js";
 
 // ---------------------------------------------------------------------------
@@ -91,13 +96,6 @@ const dummySideEffectCtx = {
   ctx: {} as SideEffectContext["ctx"],
 } satisfies SideEffectContext;
 
-const MUTATING_TOOLS = [
-  "document_create",
-  "document_update",
-  "document_replace_text",
-  "document_delete",
-];
-
 const READ_ONLY_TOOLS = [
   "document_read",
   "document_list",
@@ -125,7 +123,7 @@ describe("document hooks: documents-changed broadcast", () => {
     mockPublishDocumentsChanged.mockReset();
   });
 
-  for (const toolName of MUTATING_TOOLS) {
+  for (const toolName of DOCUMENT_MUTATION_TOOL_NAMES) {
     test(`${toolName} publishes exactly one documents change`, async () => {
       await runTool(toolName);
       expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(1);
@@ -148,5 +146,35 @@ describe("document hooks: documents-changed broadcast", () => {
     await runTool("document_update");
     await runTool("document_replace_text");
     expect(mockPublishDocumentsChanged).toHaveBeenCalledTimes(2);
+  });
+});
+
+// The daemon hooks every mutating tool, while the web transcript anchors its
+// changed-document chips on the reopenable subset and its inline-preview
+// bookkeeping on the edit subset. Pinning all three keeps a new entry in
+// `DOCUMENT_MUTATION_TOOLS` from silently landing in the wrong subsets.
+describe("document mutation tool metadata", () => {
+  test("the daemon hooks every mutating document tool", () => {
+    expect([...DOCUMENT_MUTATION_TOOL_NAMES]).toEqual([
+      "document_create",
+      "document_update",
+      "document_replace_text",
+      "document_delete",
+    ]);
+  });
+
+  test("the reopenable subset drops document_delete and keeps the rest", () => {
+    expect([...REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES]).toEqual([
+      "document_create",
+      "document_update",
+      "document_replace_text",
+    ]);
+  });
+
+  test("the edit subset is exactly the two write-into-existing tools", () => {
+    expect([...DOCUMENT_EDIT_TOOL_NAMES]).toEqual([
+      "document_update",
+      "document_replace_text",
+    ]);
   });
 });

--- a/assistant/src/api/constants/document-tools.ts
+++ b/assistant/src/api/constants/document-tools.ts
@@ -1,0 +1,55 @@
+/**
+ * The document tools that mutate the stored document set, and what each one
+ * leaves behind. This is the single declaration both the daemon and the web
+ * client derive their tool sets from, so a new mutating document tool is added
+ * here once and every consumer picks it up.
+ *
+ * Tool names are the ones the runner sees. Calls arriving through the bundled
+ * `document-editor` skill reach the daemon already unwrapped to the inner tool
+ * name, and the web client unwraps the `skill_execute` envelope itself.
+ */
+
+export interface DocumentMutationTool {
+  /** The executed tool name. */
+  readonly name: string;
+  /**
+   * Whether the document is still openable once the tool has run. A deleted
+   * document has nothing to open, so it cannot anchor a link back to itself.
+   */
+  readonly reopenable: boolean;
+  /**
+   * Whether the tool writes into an already-created document, as opposed to
+   * the create that opened it.
+   */
+  readonly edit: boolean;
+}
+
+export const DOCUMENT_MUTATION_TOOLS: readonly DocumentMutationTool[] = [
+  { name: "document_create", reopenable: true, edit: false },
+  { name: "document_update", reopenable: true, edit: true },
+  { name: "document_replace_text", reopenable: true, edit: true },
+  { name: "document_delete", reopenable: false, edit: false },
+];
+
+/**
+ * Every tool that changes the document list. The daemon hooks these to publish
+ * a documents-changed broadcast, because they carry no list-level change signal
+ * of their own and client asset lists would otherwise keep serving a cached
+ * list after an edit and a deleted document would linger as a ghost row.
+ */
+export const DOCUMENT_MUTATION_TOOL_NAMES: readonly string[] =
+  DOCUMENT_MUTATION_TOOLS.map((tool) => tool.name);
+
+/**
+ * The mutating tools that leave the document openable. The web transcript
+ * anchors its changed-document chips on these, so a delete never produces a
+ * chip pointing at a document that is gone.
+ */
+export const REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES: readonly string[] =
+  DOCUMENT_MUTATION_TOOLS.filter((tool) => tool.reopenable).map(
+    (tool) => tool.name,
+  );
+
+/** The mutating tools that write into an already-created document. */
+export const DOCUMENT_EDIT_TOOL_NAMES: readonly string[] =
+  DOCUMENT_MUTATION_TOOLS.filter((tool) => tool.edit).map((tool) => tool.name);

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -138,6 +138,13 @@ export {
   CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
 } from "./constants/call-sites.js";
 export {
+  DOCUMENT_EDIT_TOOL_NAMES,
+  DOCUMENT_MUTATION_TOOL_NAMES,
+  DOCUMENT_MUTATION_TOOLS,
+  type DocumentMutationTool,
+  REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES,
+} from "./constants/document-tools.js";
+export {
   SSE_REPLAY_RING_AGE_LIMIT_MS,
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "./constants/sse-replay.js";

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -15,6 +15,7 @@ export const SYNC_TAGS = {
   assistantSchedules: "assistant:self:schedules",
   assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
+  documentsList: "documents:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -187,6 +187,13 @@ registerAppSurfaceRefreshHook("app_update");
 // after an edit, and a deleted document lingers as a ghost row. `skill_execute`
 // calls reach the runner already unwrapped to the inner tool name, so the
 // bundled document-editor skill needs no separate registration.
+//
+// A second copy of this list lives in web's `DOCUMENT_MUTATION_TOOLS`
+// (`clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx`),
+// which anchors the changed-document chips. It deliberately omits
+// `document_delete` (a deleted document has nothing to open), so the two lists
+// differ by that one entry and nothing else. Add a new mutating document tool
+// to both.
 registerHook(
   [
     "document_create",

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,6 +9,7 @@
 
 import { isAbsolute, resolve, sep } from "node:path";
 
+import { DOCUMENT_MUTATION_TOOL_NAMES } from "../api/constants/document-tools.js";
 import type { AssistantEvent } from "../api/index.js";
 import { getApp, linkAppToConversationLineage } from "../apps/app-store.js";
 import { findActiveSession } from "../channels/gateway-verification-sessions.js";
@@ -187,24 +188,9 @@ registerAppSurfaceRefreshHook("app_update");
 // after an edit, and a deleted document lingers as a ghost row. `skill_execute`
 // calls reach the runner already unwrapped to the inner tool name, so the
 // bundled document-editor skill needs no separate registration.
-//
-// A second copy of this list lives in web's `DOCUMENT_MUTATION_TOOLS`
-// (`clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx`),
-// which anchors the changed-document chips. It deliberately omits
-// `document_delete` (a deleted document has nothing to open), so the two lists
-// differ by that one entry and nothing else. Add a new mutating document tool
-// to both.
-registerHook(
-  [
-    "document_create",
-    "document_update",
-    "document_replace_text",
-    "document_delete",
-  ],
-  () => {
-    publishDocumentsChanged();
-  },
-);
+registerHook([...DOCUMENT_MUTATION_TOOL_NAMES], () => {
+  publishDocumentsChanged();
+});
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -18,7 +18,10 @@ import { invalidateEdgeIndex } from "../plugins/defaults/memory/substrate/edge-i
 import { invalidatePageIndex } from "../plugins/defaults/memory/substrate/page-index.js";
 import { getConceptsDir } from "../plugins/defaults/memory/substrate/page-store.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
-import { publishAppsChanged } from "../runtime/sync/resource-sync-events.js";
+import {
+  publishAppsChanged,
+  publishDocumentsChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -178,6 +181,23 @@ function registerAppSurfaceRefreshHook(toolName: string): void {
 }
 registerAppSurfaceRefreshHook("app_refresh");
 registerAppSurfaceRefreshHook("app_update");
+
+// The mutating document tools carry no list-level change signal of their own,
+// so the conversation assets pill and the Library keep serving a cached list
+// after an edit, and a deleted document lingers as a ghost row. `skill_execute`
+// calls reach the runner already unwrapped to the inner tool name, so the
+// bundled document-editor skill needs no separate registration.
+registerHook(
+  [
+    "document_create",
+    "document_update",
+    "document_replace_text",
+    "document_delete",
+  ],
+  () => {
+    publishDocumentsChanged();
+  },
+);
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -60,6 +60,7 @@ import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js"
 import { CONTACTS_MIRROR_IPC_METHODS } from "./routes/contacts-mirror-ipc-routes.js";
 import { CONVERSATION_SYNC_IPC_METHODS } from "./routes/conversation-sync-ipc-routes.js";
 import { type DbProxyParams, handleDbProxy } from "./routes/db-proxy.js";
+import { DOCUMENTS_SYNC_IPC_METHODS } from "./routes/documents-sync-ipc-routes.js";
 import { EVENTS_IPC_METHODS } from "./routes/events-ipc-routes.js";
 import { GUARDIAN_LABEL_IPC_METHODS } from "./routes/guardian-label-ipc-routes.js";
 import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
@@ -215,6 +216,7 @@ export class AssistantIpcServer {
       CONTACTS_MIRROR_IPC_METHODS,
       GUARDIAN_LABEL_IPC_METHODS,
       CONVERSATION_SYNC_IPC_METHODS,
+      DOCUMENTS_SYNC_IPC_METHODS,
       EVENTS_IPC_METHODS,
     ]) {
       for (const [operationId, handler] of Object.entries(methodMap)) {

--- a/assistant/src/ipc/routes/__tests__/documents-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/documents-sync-ipc-routes.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The daemon-side handler for the worker → daemon documents-changed hand-off.
+ * A sidecar worker's own hub has no SSE subscriber, so it asks the daemon to
+ * republish the invalidation where clients actually observe it.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const publishCalls: Array<string | undefined> = [];
+
+mock.module("../../../runtime/sync/resource-sync-events.js", () => ({
+  publishDocumentsChanged: (originClientId?: string) => {
+    publishCalls.push(originClientId);
+  },
+}));
+
+import { DB_MIGRATION_READINESS_EXEMPT_OPERATIONS } from "../../../daemon/daemon-readiness.js";
+import { NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD } from "../../../runtime/sync/worker-daemon-notify.js";
+import {
+  DOCUMENTS_SYNC_IPC_METHODS,
+  handleNotifyDocumentsChanged,
+} from "../documents-sync-ipc-routes.js";
+
+describe("documents-sync IPC route", () => {
+  beforeEach(() => {
+    publishCalls.length = 0;
+  });
+
+  test("republishes the documents-changed invalidation on the daemon", () => {
+    const result = handleNotifyDocumentsChanged({ body: {} });
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCalls).toEqual([undefined]);
+  });
+
+  test("carries no origin client id, so no client suppresses it", () => {
+    // The hand-off comes from a background turn with no originating client.
+    handleNotifyDocumentsChanged({ body: {} });
+
+    expect(publishCalls[0]).toBeUndefined();
+  });
+
+  test("is reachable on the IPC surface under the shared method name", () => {
+    expect(
+      typeof DOCUMENTS_SYNC_IPC_METHODS[NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD],
+    ).toBe("function");
+  });
+
+  test("is DB-migration readiness gated (absent from the exempt set)", () => {
+    expect(
+      DB_MIGRATION_READINESS_EXEMPT_OPERATIONS.has(
+        NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
+      ),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/ipc/routes/documents-sync-ipc-routes.ts
+++ b/assistant/src/ipc/routes/documents-sync-ipc-routes.ts
@@ -1,0 +1,42 @@
+/**
+ * IPC-only route the sidecar workers (schedule, memory) call after a turn
+ * changed a document.
+ *
+ * Workers disable SSE seq stamping (`disableStreamSeqStamping`) so the daemon
+ * is the sole seq authority, and the SSE subscribers live in the daemon too. A
+ * worker that published `documents:list` on its own hub would reach nobody, so
+ * a scheduled or background turn's document edit would stay invisible: the
+ * conversation assets pill and the Library would keep serving their cached
+ * list. That is precisely the case the changed-document surfacing exists for.
+ *
+ * This route runs the publish on the daemon instead, where real subscribers
+ * observe it. The hand-off carries no originating client, so nothing suppresses
+ * the broadcast as its own echo.
+ *
+ * IPC-only: registered directly on the assistant IPC server (see
+ * `assistant-server.ts`), never in the shared `ROUTES` array. The handler
+ * touches no database, but the IPC server's uniform DB-migration gate still
+ * applies (the method is not exempt); the worker's call is best-effort and
+ * tolerates that.
+ */
+
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+import { publishDocumentsChanged } from "../../runtime/sync/resource-sync-events.js";
+import { NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD } from "../../runtime/sync/worker-daemon-notify.js";
+
+/** Republish a worker's documents-changed invalidation to daemon subscribers. */
+export function handleNotifyDocumentsChanged(_args: RouteHandlerArgs) {
+  publishDocumentsChanged();
+  return { ok: true };
+}
+
+/**
+ * IPC-only documents-sync methods, keyed by operationId. Registered directly on
+ * the assistant IPC server (see `assistant-server.ts`).
+ */
+export const DOCUMENTS_SYNC_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  [NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD]: handleNotifyDocumentsChanged,
+};

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -16,12 +16,17 @@ import {
   getDocumentById,
   getDocumentByWorkspacePath,
   getDocumentsForConversation,
+  isDocumentAssociatedWithConversation,
   refreshDocumentContentFromFile,
   saveDocument,
 } from "../../documents/document-store.js";
 import { rawAll } from "../../persistence/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  getOriginClientId,
+  publishDocumentsChanged,
+} from "../sync/resource-sync-events.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import {
   BadRequestError,
@@ -162,6 +167,7 @@ function loadDocumentPayload(surfaceId: string): Record<string, unknown> {
  */
 function handleDocumentForWorkspaceFile({
   body,
+  headers,
 }: RouteHandlerArgs): Record<string, unknown> {
   const { path, conversationId } = (body ?? {}) as {
     path?: string;
@@ -194,8 +200,13 @@ function handleDocumentForWorkspaceFile({
   if (existing) {
     // Opening the file from another conversation grants that conversation
     // access, the same association the link route writes.
+    const alreadyLinked = isDocumentAssociatedWithConversation(
+      existing.surfaceId,
+      conversationId,
+    );
     addDocumentConversation(existing.surfaceId, conversationId);
 
+    let refreshed = false;
     if (existing.content !== fileText) {
       const refresh = refreshDocumentContentFromFile(
         existing.surfaceId,
@@ -204,10 +215,17 @@ function handleDocumentForWorkspaceFile({
       if (!refresh.success) {
         throw new InternalError(refresh.error);
       }
+      refreshed = true;
       log.info(
         { surfaceId: existing.surfaceId, workspacePath: relativePath },
         "Refreshed file-backed document from disk",
       );
+    }
+
+    // Reopening an unchanged, already-linked file writes nothing, so it must
+    // not invalidate every client's document list on each open.
+    if (!alreadyLinked || refreshed) {
+      publishDocumentsChanged(getOriginClientId(headers));
     }
     return loadDocumentPayload(existing.surfaceId);
   }
@@ -227,7 +245,14 @@ function handleDocumentForWorkspaceFile({
     if (!raced) {
       throw new InternalError(created.error);
     }
+    const racedAlreadyLinked = isDocumentAssociatedWithConversation(
+      raced.surfaceId,
+      conversationId,
+    );
     addDocumentConversation(raced.surfaceId, conversationId);
+    if (!racedAlreadyLinked) {
+      publishDocumentsChanged(getOriginClientId(headers));
+    }
     return loadDocumentPayload(raced.surfaceId);
   }
 
@@ -235,6 +260,7 @@ function handleDocumentForWorkspaceFile({
     { surfaceId, workspacePath: relativePath, conversationId },
     "Bound workspace file to a new document",
   );
+  publishDocumentsChanged(getOriginClientId(headers));
   return loadDocumentPayload(surfaceId);
 }
 
@@ -325,7 +351,7 @@ export const ROUTES: RouteDefinition[] = [
       success: z.literal(true),
       surfaceId: z.string(),
     }),
-    handler: ({ body }) => {
+    handler: ({ body, headers }) => {
       const { surfaceId, conversationId, title, content, wordCount } = (body ??
         {}) as {
         surfaceId?: string;
@@ -362,6 +388,7 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
+      publishDocumentsChanged(getOriginClientId(headers));
       return result;
     },
   },
@@ -412,7 +439,7 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string().describe("Conversation to link"),
     }),
     responseBody: z.object({ success: z.literal(true) }),
-    handler: ({ pathParams, body }) => {
+    handler: ({ pathParams, body, headers }) => {
       const { conversationId } = (body ?? {}) as { conversationId?: string };
       if (!conversationId) {
         throw new BadRequestError("conversationId is required");
@@ -426,6 +453,7 @@ export const ROUTES: RouteDefinition[] = [
         { surfaceId: pathParams!.id, conversationId },
         "Linked document to conversation",
       );
+      publishDocumentsChanged(getOriginClientId(headers));
       return { success: true as const };
     },
   },

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -164,10 +164,15 @@ function loadDocumentPayload(surfaceId: string): Record<string, unknown> {
  * content has drifted from the bytes on disk (the file was edited outside the
  * editor), the row is refreshed from the file before it is returned. Writes go
  * the other way — the document store writes through to the file.
+ *
+ * The publishes here carry no origin client id on purpose. The only caller,
+ * `viewer-store.loadWorkspaceFileDocument`, opens the file and never
+ * invalidates its own document queries, so the client that creates the row is
+ * the one that most needs to hear about it: suppressing its own echo would
+ * leave its assets pill and Library without the document it just opened.
  */
 function handleDocumentForWorkspaceFile({
   body,
-  headers,
 }: RouteHandlerArgs): Record<string, unknown> {
   const { path, conversationId } = (body ?? {}) as {
     path?: string;
@@ -225,7 +230,7 @@ function handleDocumentForWorkspaceFile({
     // Reopening an unchanged, already-linked file writes nothing, so it must
     // not invalidate every client's document list on each open.
     if (!alreadyLinked || refreshed) {
-      publishDocumentsChanged(getOriginClientId(headers));
+      publishDocumentsChanged();
     }
     return loadDocumentPayload(existing.surfaceId);
   }
@@ -251,7 +256,7 @@ function handleDocumentForWorkspaceFile({
     );
     addDocumentConversation(raced.surfaceId, conversationId);
     if (!racedAlreadyLinked) {
-      publishDocumentsChanged(getOriginClientId(headers));
+      publishDocumentsChanged();
     }
     return loadDocumentPayload(raced.surfaceId);
   }
@@ -260,7 +265,7 @@ function handleDocumentForWorkspaceFile({
     { surfaceId, workspacePath: relativePath, conversationId },
     "Bound workspace file to a new document",
   );
-  publishDocumentsChanged(getOriginClientId(headers));
+  publishDocumentsChanged();
   return loadDocumentPayload(surfaceId);
 }
 
@@ -377,6 +382,8 @@ export const ROUTES: RouteDefinition[] = [
         throw new BadRequestError("wordCount is required");
       }
 
+      const before = getDocumentById(surfaceId);
+
       const result = saveDocument({
         surfaceId,
         conversationId,
@@ -388,7 +395,15 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
-      publishDocumentsChanged(getOriginClientId(headers));
+      // This is the web editor's autosave, which fires roughly once a second
+      // while the user types and always resends the title it opened with. The
+      // list surfaces render title and surface id, so a content-only save
+      // changes nothing they show, and broadcasting it would make every other
+      // client drain its document queries on each keystroke burst. A new row or
+      // a retitled one does change the list, so those still publish.
+      if (!before || before.title !== title) {
+        publishDocumentsChanged(getOriginClientId(headers));
+      }
       return result;
     },
   },
@@ -439,7 +454,7 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string().describe("Conversation to link"),
     }),
     responseBody: z.object({ success: z.literal(true) }),
-    handler: ({ pathParams, body, headers }) => {
+    handler: ({ pathParams, body }) => {
       const { conversationId } = (body ?? {}) as { conversationId?: string };
       if (!conversationId) {
         throw new BadRequestError("conversationId is required");
@@ -453,7 +468,12 @@ export const ROUTES: RouteDefinition[] = [
         { surfaceId: pathParams!.id, conversationId },
         "Linked document to conversation",
       );
-      publishDocumentsChanged(getOriginClientId(headers));
+      // No origin client id: the only caller, `document-viewer-page`, links the
+      // document and then navigates to the conversation whose assets pill must
+      // now list it, without invalidating anything itself. Suppressing its own
+      // echo would land it on a conversation whose pill is missing the document
+      // it just linked.
+      publishDocumentsChanged();
       return { success: true as const };
     },
   },

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -382,8 +382,6 @@ export const ROUTES: RouteDefinition[] = [
         throw new BadRequestError("wordCount is required");
       }
 
-      const before = getDocumentById(surfaceId);
-
       const result = saveDocument({
         surfaceId,
         conversationId,
@@ -395,15 +393,12 @@ export const ROUTES: RouteDefinition[] = [
       if (!result.success) {
         throw new InternalError(result.error);
       }
-      // This is the web editor's autosave, which fires roughly once a second
-      // while the user types and always resends the title it opened with. The
-      // list surfaces render title and surface id, so a content-only save
-      // changes nothing they show, and broadcasting it would make every other
-      // client drain its document queries on each keystroke burst. A new row or
-      // a retitled one does change the list, so those still publish.
-      if (!before || before.title !== title) {
-        publishDocumentsChanged(getOriginClientId(headers));
-      }
+      // Every save moves `updated_at`, which both document lists order by and
+      // the Library renders next to the word count, so a content-only save
+      // changes what the list surfaces show. The publish coalesces, which
+      // bounds the web editor's per-keystroke autosave to one broadcast per
+      // second, and the saving client suppresses its own echo by origin id.
+      publishDocumentsChanged(getOriginClientId(headers));
       return result;
     },
   },

--- a/assistant/src/runtime/sync/documents-sidecar-publish.test.ts
+++ b/assistant/src/runtime/sync/documents-sidecar-publish.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A scheduled, heartbeat, or background turn runs its document tools in a
+ * sidecar worker, whose local hub has no SSE subscriber. The documents-changed
+ * broadcast has to be handed to the daemon there, or the document edited while
+ * the user was not looking stays invisible on every client.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let notifyCount = 0;
+
+mock.module("./worker-daemon-notify.js", () => ({
+  NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD:
+    "notify_conversation_persisted_externally",
+  NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD: "notify_documents_changed_externally",
+  notifyDaemonConversationPersisted: async () => {},
+  notifyDaemonDocumentsChanged: async () => {
+    notifyCount++;
+  },
+}));
+
+import type { AssistantEventEnvelope } from "../../api/index.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  _resetStreamStateForTesting,
+  disableStreamSeqStamping,
+} from "../assistant-stream-state.js";
+import {
+  DOCUMENTS_CHANGED_COALESCE_MS,
+  publishDocumentsChanged,
+} from "./resource-sync-events.js";
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) =>
+    setTimeout(resolve, DOCUMENTS_CHANGED_COALESCE_MS + 50),
+  );
+}
+
+/** Run `publish`, then return the `sync_changed` events it put on the hub. */
+async function captureLocalPublishes(
+  publish: () => void,
+): Promise<AssistantEventEnvelope[]> {
+  await settle();
+  const received: AssistantEventEnvelope[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      if (event.message.type === "sync_changed") {
+        received.push(event);
+      }
+    },
+  });
+  try {
+    publish();
+    await settle();
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+describe("publishDocumentsChanged in a sidecar worker", () => {
+  beforeEach(async () => {
+    await settle();
+    notifyCount = 0;
+    _resetStreamStateForTesting();
+  });
+
+  test("hands the broadcast to the daemon instead of publishing into a void", async () => {
+    disableStreamSeqStamping();
+
+    const events = await captureLocalPublishes(() => {
+      publishDocumentsChanged();
+    });
+
+    expect(notifyCount).toBe(1);
+    expect(events).toEqual([]);
+  });
+
+  test("coalesces a burst of worker writes into one hand-off", async () => {
+    disableStreamSeqStamping();
+
+    await captureLocalPublishes(() => {
+      for (let i = 0; i < 10; i++) {
+        publishDocumentsChanged();
+      }
+    });
+
+    expect(notifyCount).toBe(1);
+  });
+
+  test("publishes on the local hub in the daemon, where subscribers live", async () => {
+    const events = await captureLocalPublishes(() => {
+      publishDocumentsChanged();
+    });
+
+    expect(notifyCount).toBe(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].message).toMatchObject({ type: "sync_changed" });
+  });
+});

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -9,7 +9,10 @@ import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { isStreamSeqStampingDisabled } from "../assistant-stream-state.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
-import { notifyDaemonConversationPersisted } from "./worker-daemon-notify.js";
+import {
+  notifyDaemonConversationPersisted,
+  notifyDaemonDocumentsChanged,
+} from "./worker-daemon-notify.js";
 
 /**
  * Derive the initiating client's id from request headers so a sync publish can
@@ -67,8 +70,79 @@ export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
 }
 
-export function publishDocumentsChanged(originClientId?: string): void {
+/**
+ * How long a documents-list invalidation waits for the writes around it to
+ * settle before it is broadcast.
+ *
+ * Document writes arrive in bursts: the document-editor skill is instructed to
+ * stream a document as many small `document_update` calls, and the web editor
+ * autosaves as the user types. Every burst member publishes, and every publish
+ * makes each client drain its `documentsGet` queries (the per-conversation
+ * assets pill, the Library, the intelligence stats), during an SSE stream that
+ * is already saturated. Open editors track each individual write through
+ * `document_editor_update`, so the list-level invalidation only has to land
+ * once the burst settles.
+ */
+export const DOCUMENTS_CHANGED_COALESCE_MS = 150;
+
+/**
+ * Ceiling on how long an unbroken run of writes can defer the invalidation, so
+ * a document streamed in sub-window chunks still refreshes the list while it is
+ * being written instead of only when the turn ends.
+ */
+export const DOCUMENTS_CHANGED_MAX_DEFER_MS = 1_000;
+
+let documentsPublishTimer: ReturnType<typeof setTimeout> | undefined;
+let documentsPublishDeadline = 0;
+let documentsPublishOrigin: string | undefined;
+let documentsPublishOriginSeen = false;
+
+function flushDocumentsChanged(): void {
+  documentsPublishTimer = undefined;
+  documentsPublishDeadline = 0;
+  const originClientId = documentsPublishOrigin;
+  documentsPublishOrigin = undefined;
+  documentsPublishOriginSeen = false;
+
+  // In a sidecar worker (seq stamping disabled) the local hub has no SSE
+  // subscribers, so a local publish reaches no client and a document edited by
+  // a scheduled or background turn stays invisible. Hand off to the daemon,
+  // which republishes the invalidation where subscribers observe it. Such a
+  // turn has no originating client, so no `originClientId` is forwarded.
+  if (isStreamSeqStampingDisabled()) {
+    void notifyDaemonDocumentsChanged();
+    return;
+  }
   void publishSyncInvalidation([SYNC_TAGS.documentsList], originClientId);
+}
+
+/**
+ * Invalidate the document list on every client, coalescing a burst of writes
+ * into a single broadcast (see {@link DOCUMENTS_CHANGED_COALESCE_MS}).
+ */
+export function publishDocumentsChanged(originClientId?: string): void {
+  if (!documentsPublishOriginSeen) {
+    documentsPublishOrigin = originClientId;
+    documentsPublishOriginSeen = true;
+  } else if (documentsPublishOrigin !== originClientId) {
+    // Writes from more than one client merged into this broadcast, so no single
+    // client may suppress it as its own echo.
+    documentsPublishOrigin = undefined;
+  }
+
+  const now = Date.now();
+  if (documentsPublishTimer) {
+    clearTimeout(documentsPublishTimer);
+  } else {
+    documentsPublishDeadline = now + DOCUMENTS_CHANGED_MAX_DEFER_MS;
+  }
+  documentsPublishTimer = setTimeout(
+    flushDocumentsChanged,
+    Math.max(
+      0,
+      Math.min(DOCUMENTS_CHANGED_COALESCE_MS, documentsPublishDeadline - now),
+    ),
+  );
 }
 
 export function publishPluginsChanged(originClientId?: string): void {

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -67,6 +67,10 @@ export function publishAppsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.appsList], originClientId);
 }
 
+export function publishDocumentsChanged(originClientId?: string): void {
+  void publishSyncInvalidation([SYNC_TAGS.documentsList], originClientId);
+}
+
 export function publishPluginsChanged(originClientId?: string): void {
   void publishSyncInvalidation([SYNC_TAGS.pluginsList], originClientId);
 }

--- a/assistant/src/runtime/sync/worker-daemon-notify.test.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.test.ts
@@ -33,7 +33,9 @@ mock.module("../../ipc/cli-client.js", () => ({
 
 import {
   NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD,
+  NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
   notifyDaemonConversationPersisted,
+  notifyDaemonDocumentsChanged,
 } from "./worker-daemon-notify.js";
 
 describe("notifyDaemonConversationPersisted", () => {
@@ -63,6 +65,38 @@ describe("notifyDaemonConversationPersisted", () => {
     shouldThrow = true;
 
     const result = await notifyDaemonConversationPersisted("conv-1");
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("notifyDaemonDocumentsChanged", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    nextResult = { ok: true };
+    shouldThrow = false;
+  });
+
+  test("asks the daemon to republish over the shared IPC method", async () => {
+    await notifyDaemonDocumentsChanged();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe(NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD);
+    expect(calls[0]!.params).toEqual({ body: {} });
+  });
+
+  test("swallows a failed IPC result (best-effort, no throw)", async () => {
+    nextResult = { ok: false, error: "daemon unreachable" };
+
+    const result = await notifyDaemonDocumentsChanged();
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("swallows a thrown IPC error (best-effort, no throw)", async () => {
+    shouldThrow = true;
+
+    const result = await notifyDaemonDocumentsChanged();
     expect(result).toBeUndefined();
     expect(calls).toHaveLength(1);
   });

--- a/assistant/src/runtime/sync/worker-daemon-notify.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.ts
@@ -1,13 +1,13 @@
 /**
- * Worker → daemon hand-off for conversation message-persist notifications.
+ * Worker → daemon hand-off for sync notifications a sidecar cannot deliver.
  *
  * Sidecar worker processes (schedule, memory) disable SSE seq stamping — the
  * daemon is the sole seq authority — so a worker's own `getCurrentSeq()`
- * reports `0` and its `publishConversationMessagesChanged` broadcast reaches no
- * SSE subscriber (those live in the daemon). After a worker persists a turn's
- * rows it hands the notification here; the daemon records an honest snapshot
- * anchor at its own seq and republishes the invalidation to real subscribers
- * (see `ipc/routes/conversation-sync-ipc-routes.ts`).
+ * reports `0` and its `sync_changed` broadcasts reach no SSE subscriber (those
+ * live in the daemon). A worker hands the notification here instead and the
+ * daemon republishes it to real subscribers (see
+ * `ipc/routes/conversation-sync-ipc-routes.ts`,
+ * `ipc/routes/documents-sync-ipc-routes.ts`).
  */
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
@@ -21,6 +21,14 @@ const log = getLogger("worker-daemon-notify");
  */
 export const NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD =
   "notify_conversation_persisted_externally";
+
+/**
+ * IPC method the daemon exposes for the documents-changed hand-off. Shared by
+ * the worker caller and the daemon route registration so the wire name cannot
+ * drift.
+ */
+export const NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD =
+  "notify_documents_changed_externally";
 
 /**
  * Short timeout: this is a fire-and-forget invalidation, not a request whose
@@ -59,5 +67,35 @@ export async function notifyDaemonConversationPersisted(
       { err, conversationId },
       "daemon conversation-persisted notify failed",
     );
+  }
+}
+
+/**
+ * Ask the daemon to republish the documents-list invalidation.
+ *
+ * A scheduled or background turn runs its document tools in a sidecar worker,
+ * so the edit is real but the worker's own broadcast reaches nobody. This is
+ * the path that lets the user learn a document changed while they were not
+ * looking.
+ *
+ * Best-effort by design, like the conversation hand-off: an unreachable daemon
+ * is logged at debug and swallowed, and the client picks the change up on its
+ * next document-list fetch.
+ */
+export async function notifyDaemonDocumentsChanged(): Promise<void> {
+  try {
+    const result = await cliIpcCall(
+      NOTIFY_DOCUMENTS_CHANGED_IPC_METHOD,
+      { body: {} },
+      { timeoutMs: NOTIFY_TIMEOUT_MS },
+    );
+    if (!result.ok) {
+      log.debug(
+        { error: result.error },
+        "daemon documents-changed notify was not acknowledged",
+      );
+    }
+  } catch (err) {
+    log.debug({ err }, "daemon documents-changed notify failed");
   }
 }

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -447,13 +447,20 @@ export function executeDocumentUpdate(
     };
   }
 
-  // Fallback if no client is connected
+  // No client is connected to render the edit, but the write landed, so this is
+  // a success. Reporting it as an error would strand a headless turn (a
+  // schedule, SMS, or Telegram channel): post-execution hooks are skipped for
+  // errored tools, so the documents-changed broadcast that tells clients about
+  // the edit would never fire, and the model would be told to retry a write
+  // that already succeeded.
   return {
     content: JSON.stringify({
-      success: false,
-      error: "No client connected to update document",
+      success: true,
+      surface_id: surfaceId,
+      mode,
+      message: "Document content updated (no client connected to render it)",
     }),
-    isError: true,
+    isError: false,
   };
 }
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -7,12 +7,15 @@
  *
  * Class strings are deliberately not asserted (happy-dom makes those brittle);
  * the dot is located by its `data-testid` and the state it communicates is
- * asserted through the trigger's accessible name.
+ * asserted through the trigger's accessible name. The one exception is the
+ * appearance pulse, which has no accessible surface at all: those tests check
+ * for the single animation class token on the dot and nothing else.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as motionReact from "motion/react";
 
 import type { DocumentSummary } from "@/types/document-types";
 
@@ -23,8 +26,20 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
-const { ConversationAssetsPill, ASSETS_PILL_UNSEEN_DOT_TESTID } =
-  await import("@/domains/chat/components/conversation-assets-pill");
+// `useReducedMotion` reads a cached media-query singleton, so a per-test
+// `matchMedia` stub can't flip it. Override just that export and drive it
+// through this toggle instead.
+let reducedMotion = false;
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
+const {
+  ConversationAssetsPill,
+  ASSETS_PILL_UNSEEN_DOT_TESTID,
+  ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS,
+} = await import("@/domains/chat/components/conversation-assets-pill");
 const { useUnseenDocumentChangesStore } =
   await import("@/domains/chat/unseen-document-changes-store");
 const { appsGetOptions, documentsGetOptions } =
@@ -127,8 +142,15 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   isMobileRef.value = false;
+  reducedMotion = false;
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
+
+function dotHasPulse(): boolean {
+  return screen
+    .getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)
+    .classList.contains(ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS);
+}
 
 describe("desktop pill", () => {
   test("shows the dot and names the state when a change is unseen", () => {
@@ -225,6 +247,26 @@ describe("conversation switch while the disclosure is open", () => {
     expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
     expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
     expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+});
+
+describe("appearance pulse", () => {
+  // One `layersIcon` node feeds both the mobile trigger and the desktop pill,
+  // so the pulse has a single render site and needs no per-platform case.
+  test("pulses the dot when a change lands", () => {
+    markUnseen();
+    renderPill();
+
+    expect(dotHasPulse()).toBe(true);
+  });
+
+  test("appears without animating when reduced motion is preferred", () => {
+    reducedMotion = true;
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(dotHasPulse()).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests for `ConversationAssetsPill`'s unseen-document-changes affordance.
+ *
+ * The pill's asset list comes from two TanStack queries, so the suite seeds
+ * the cache with `staleTime: Infinity` instead of mocking the SDK: nothing
+ * refetches on mount and the rendered list is exactly what a test asks for.
+ *
+ * Class strings are deliberately not asserted (happy-dom makes those brittle);
+ * the dot is located by its `data-testid` and the state it communicates is
+ * asserted through the trigger's accessible name.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DocumentSummary } from "@/types/document-types";
+
+const isMobileRef = { value: false };
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const { ConversationAssetsPill, ASSETS_PILL_UNSEEN_DOT_TESTID } =
+  await import("@/domains/chat/components/conversation-assets-pill");
+const { useUnseenDocumentChangesStore } =
+  await import("@/domains/chat/unseen-document-changes-store");
+const { appsGetOptions, documentsGetOptions } =
+  await import("@/generated/daemon/@tanstack/react-query.gen");
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+const SURFACE_ID = "surface-1";
+const OTHER_CONVERSATION_ID = "conv-2";
+const OTHER_SURFACE_ID = "surface-2";
+
+const DOC_TITLE = "Roadmap";
+const OTHER_DOC_TITLE = "Backlog";
+
+const SEEN_LABEL = "Conversation assets, 1 items";
+const UNSEEN_LABEL = "Conversation assets, 1 items (unseen changes)";
+
+function makeDocument(
+  conversationId = CONVERSATION_ID,
+  surfaceId = SURFACE_ID,
+  title = DOC_TITLE,
+): DocumentSummary {
+  return {
+    surfaceId,
+    conversationId,
+    title,
+    wordCount: 12,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_001,
+  };
+}
+
+/**
+ * `staleTime: Infinity` keeps the seeded entries fresh, so the queries resolve
+ * from cache and never reach the generated SDK.
+ */
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+    },
+  });
+}
+
+function seedConversation(
+  client: QueryClient,
+  documents: DocumentSummary[],
+  conversationId: string,
+) {
+  const queryArgs = {
+    path: { assistant_id: ASSISTANT_ID },
+    query: { conversationId },
+  };
+  client.setQueryData(appsGetOptions(queryArgs).queryKey, { apps: [] });
+  client.setQueryData(documentsGetOptions(queryArgs).queryKey, { documents });
+}
+
+function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
+  const client = makeQueryClient();
+  seedConversation(client, withAssets ? [makeDocument()] : [], CONVERSATION_ID);
+  seedConversation(
+    client,
+    [makeDocument(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID, OTHER_DOC_TITLE)],
+    OTHER_CONVERSATION_ID,
+  );
+
+  const pill = (conversationId: string) => (
+    <QueryClientProvider client={client}>
+      <ConversationAssetsPill
+        assistantId={ASSISTANT_ID}
+        conversationId={conversationId}
+      />
+    </QueryClientProvider>
+  );
+
+  const view = render(pill(CONVERSATION_ID));
+
+  return {
+    /** Swap the prop on the already-mounted pill, as the chat header does. */
+    switchConversation: (conversationId: string) => {
+      view.rerender(pill(conversationId));
+    },
+  };
+}
+
+function markUnseen(conversationId = CONVERSATION_ID, surfaceId = SURFACE_ID) {
+  useUnseenDocumentChangesStore
+    .getState()
+    .markDocumentChanged(conversationId, surfaceId);
+}
+
+function unseenConversations(): string[] {
+  return Object.keys(useUnseenDocumentChangesStore.getState().changedDocuments);
+}
+
+beforeEach(() => {
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  isMobileRef.value = false;
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+describe("desktop pill", () => {
+  test("shows the dot and names the state when a change is unseen", () => {
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+  });
+
+  test("shows no dot and the plain name when nothing is unseen", () => {
+    renderPill();
+
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
+  });
+
+  test("opening the popover clears the conversation", () => {
+    markUnseen();
+    renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
+
+    expect(unseenConversations()).toEqual([]);
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+});
+
+describe("mobile trigger", () => {
+  beforeEach(() => {
+    isMobileRef.value = true;
+  });
+
+  test("shows the dot and names the state when a change is unseen", () => {
+    markUnseen();
+    renderPill();
+
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+  });
+
+  test("shows no dot and the plain name when nothing is unseen", () => {
+    renderPill();
+
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
+  });
+
+  test("opening the sheet clears the conversation", () => {
+    markUnseen();
+    renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
+
+    expect(unseenConversations()).toEqual([]);
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+});
+
+describe("conversation switch while the disclosure is open", () => {
+  /**
+   * The chat header renders one unkeyed pill and swaps `conversationId` on it,
+   * so `open` survives the switch and `onOpenChange` never fires for it. The
+   * pill closes its own disclosure on that swap: the incoming conversation's
+   * assets are never put on screen unasked, and its changes stay marked unseen
+   * until the user opens the list.
+   */
+  test("closes the popover and keeps the incoming dot", () => {
+    markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
+    const { switchConversation } = renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
+
+    switchConversation(OTHER_CONVERSATION_ID);
+
+    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+    expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+
+  test("closes the sheet and keeps the incoming dot on mobile", () => {
+    isMobileRef.value = true;
+    markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
+    const { switchConversation } = renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
+
+    switchConversation(OTHER_CONVERSATION_ID);
+
+    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
+    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
+    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
+    expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+});
+
+describe("empty asset list", () => {
+  /**
+   * Pins the deliberate trade-off: the pill renders nothing at all without
+   * assets, so there is no Layers icon to carry a dot. An unseen change in
+   * that window stays recorded in the store and the dot appears as soon as
+   * the documents query reports the asset, rather than the pill being forced
+   * to render an empty disclosure.
+   */
+  test("renders nothing even when a change is unseen", () => {
+    markUnseen();
+    renderPill({ withAssets: false });
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(unseenConversations()).toEqual([CONVERSATION_ID]);
+  });
+});

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AppWindow, FileText, Layers } from "lucide-react";
+import { useReducedMotion } from "motion/react";
 import {
   useCallback,
   useEffect,
@@ -35,8 +36,12 @@ import { useAppDelete } from "@/hooks/use-app-delete";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
+import { cn } from "@/utils/misc";
 
 export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
+
+/** Bounded attention pulse defined in `src/index.css`. */
+export const ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS = "unseen-dot-pulse";
 
 interface ConversationAsset {
   id: string;
@@ -142,6 +147,7 @@ export function ConversationAssetsPill({
   }, [conversationId]);
 
   const isMobile = useIsMobile();
+  const reduceMotion = useReducedMotion();
   const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
   const clearConversation =
     useUnseenDocumentChangesStore.use.clearConversation();
@@ -183,14 +189,18 @@ export function ConversationAssetsPill({
 
   // Same dot as the notifications bell in this header cluster: ringed in the
   // color of the surface behind it so the ring reads as a gap carved out of
-  // the icon.
+  // the icon. The dot mounts only while changes are unseen, so the CSS pulse
+  // runs on appearance and needs no restart bookkeeping.
   const layersIcon = (
     <span className="relative flex" aria-hidden>
       <Layers />
       {hasUnseenChanges ? (
         <span
           data-testid={ASSETS_PILL_UNSEEN_DOT_TESTID}
-          className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+          className={cn(
+            "absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]",
+            !reduceMotion && ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS,
+          )}
         />
       ) : null}
     </span>

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -1,6 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AppWindow, FileText, Layers } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   BottomSheet,
@@ -21,10 +27,16 @@ import {
   AppAssetActions,
   DocumentAssetActions,
 } from "@/domains/chat/components/conversation-asset-actions";
+import {
+  useHasUnseenDocumentChanges,
+  useUnseenDocumentChangesStore,
+} from "@/domains/chat/unseen-document-changes-store";
 import { useAppDelete } from "@/hooks/use-app-delete";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
+
+export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
 
 interface ConversationAsset {
   id: string;
@@ -118,7 +130,33 @@ export function ConversationAssetsPill({
   const assets = useMemo(() => toAssets(apps, docs), [apps, docs]);
 
   const [open, setOpen] = useState(false);
+
+  // The chat header swaps `conversationId` on this same mounted pill, so an
+  // open disclosure would otherwise carry over and list the incoming
+  // conversation's assets without the user asking to see them, leaving that
+  // conversation's changes marked unseen behind a sheet that is already open.
+  // Layout effect: the outgoing conversation's disclosure must never paint
+  // over the incoming conversation, not even for one frame.
+  useLayoutEffect(() => {
+    setOpen(false);
+  }, [conversationId]);
+
   const isMobile = useIsMobile();
+  const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
+  const clearConversation =
+    useUnseenDocumentChangesStore.use.clearConversation();
+
+  // Opening the disclosure is the user looking at the asset list, so whatever
+  // changed is no longer unseen.
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        clearConversation(conversationId);
+      }
+    },
+    [clearConversation, conversationId],
+  );
 
   const handleSelect = useCallback(
     (asset: ConversationAsset) => {
@@ -139,7 +177,24 @@ export function ConversationAssetsPill({
   }
 
   const label = assets.length === 1 ? "1 asset" : `${assets.length} assets`;
-  const ariaLabel = `Conversation assets, ${assets.length} items`;
+  const ariaLabel = hasUnseenChanges
+    ? `Conversation assets, ${assets.length} items (unseen changes)`
+    : `Conversation assets, ${assets.length} items`;
+
+  // Same dot as the notifications bell in this header cluster: ringed in the
+  // color of the surface behind it so the ring reads as a gap carved out of
+  // the icon.
+  const layersIcon = (
+    <span className="relative flex" aria-hidden>
+      <Layers />
+      {hasUnseenChanges ? (
+        <span
+          data-testid={ASSETS_PILL_UNSEEN_DOT_TESTID}
+          className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)] touch-mobile:border-[var(--surface-lift)]"
+        />
+      ) : null}
+    </span>
+  );
 
   const assetItems = assets.map((asset) => (
     <PanelItem
@@ -170,12 +225,12 @@ export function ConversationAssetsPill({
   if (isMobile) {
     return (
       <>
-        <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Root open={open} onOpenChange={handleOpenChange}>
           <BottomSheet.Trigger asChild>
             <Button
               variant="ghost"
               active
-              iconOnly={<Layers />}
+              iconOnly={layersIcon}
               tintColor="var(--content-default)"
               aria-label={ariaLabel}
             />
@@ -199,12 +254,12 @@ export function ConversationAssetsPill({
 
   return (
     <>
-      <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Root open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
           <Button
             variant="ghost"
             active
-            leftIcon={<Layers />}
+            leftIcon={layersIcon}
             className="rounded-full"
             tintColor="var(--content-default)"
             aria-label={ariaLabel}

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -191,8 +191,20 @@ export function ConversationAssetsPill({
   // color of the surface behind it so the ring reads as a gap carved out of
   // the icon. The dot mounts only while changes are unseen, so the CSS pulse
   // runs on appearance and needs no restart bookkeeping.
+  //
+  // This wrapper is the dot's positioning context and the element the Button
+  // sizes in place of the glyph. `iconOnly` sizes the glyph with its own
+  // `[&_svg]` rule, which reaches through the wrapper, so a size rule here
+  // would only compete with it. `leftIcon` sizes just the box it provides, so
+  // there the wrapper fills that box and hands the size down to the glyph.
   const layersIcon = (
-    <span className="relative flex" aria-hidden>
+    <span
+      className={cn(
+        "relative flex",
+        !isMobile && "size-full [&_svg]:size-full",
+      )}
+      aria-hidden
+    >
       <Layers />
       {hasUnseenChanges ? (
         <span

--- a/clients/web/src/domains/chat/components/local-file/open-local-file.test.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
 
 import type { WorkspaceFilePreviewKind } from "@/stores/viewer-store";
 
@@ -6,11 +7,13 @@ const openWorkspaceFile = mock(async (_path: string) => {});
 mock.module("@/utils/open-workspace-file", () => ({ openWorkspaceFile }));
 
 const {
+  isDocumentOpen,
   isWorkspaceFileOpen,
   openLocalFile,
   opensInDocumentDrawer,
   previewKindFor,
   toggleLocalFile,
+  useIsDocumentOpen,
   usesDocumentDrawer,
 } = await import("@/domains/chat/components/local-file/open-local-file");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -325,6 +328,66 @@ describe("isWorkspaceFileOpen", () => {
         "data/rows.csv",
       ),
     ).toBe(true);
+  });
+});
+
+describe("isDocumentOpen", () => {
+  const drawer = openDrawerState("drafts/notes.md");
+  const preview = openPreviewState("data/rows.csv");
+
+  /** What the reactive hook reports for the store state currently set. */
+  function renderIsDocumentOpen(surfaceId: string): boolean {
+    const { result, unmount } = renderHook(() => useIsDocumentOpen(surfaceId));
+    const answer = result.current;
+    unmount();
+    return answer;
+  }
+
+  test("matches the document the viewer is showing", () => {
+    useViewerStore.setState(drawer);
+
+    expect(
+      isDocumentOpen("document", drawer.openedDocumentState, "surf-file"),
+    ).toBe(true);
+    expect(renderIsDocumentOpen("surf-file")).toBe(true);
+  });
+
+  test("does not match a different document", () => {
+    useViewerStore.setState(drawer);
+
+    expect(
+      isDocumentOpen("document", drawer.openedDocumentState, "surf-other"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-other")).toBe(false);
+  });
+
+  test("does not match while another view is on top", () => {
+    const behind = { ...drawer, mainView: "chat" as const };
+    useViewerStore.setState(behind);
+
+    expect(
+      isDocumentOpen("chat", behind.openedDocumentState, "surf-file"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
+  });
+
+  test("does not match while nothing is loaded", () => {
+    useViewerStore.setState({
+      mainView: "document",
+      openedDocumentState: null,
+    });
+
+    expect(isDocumentOpen("document", null, "surf-file")).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
+  });
+
+  test("does not match a preview, which is not a document surface", () => {
+    useViewerStore.setState(preview);
+
+    expect(
+      isDocumentOpen("document", preview.openedDocumentState, "surf-file"),
+    ).toBe(false);
+    expect(renderIsDocumentOpen("surf-file")).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/components/local-file/open-local-file.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.ts
@@ -193,6 +193,42 @@ export function useIsWorkspaceFileOpen(workspacePath: string | null): boolean {
 }
 
 /**
+ * Whether the document drawer is currently showing the document surface
+ * `surfaceId`. Pure predicate so an affordance that hides itself while its own
+ * document is visible and anything acting on that document can never disagree
+ * about what "open" means.
+ *
+ * A read-only preview carries no surface id, so it matches nothing.
+ *
+ * This answers for the in-chat viewer only. The standalone
+ * `/assistant/documents/:surfaceId` route is a separate surface that does not
+ * set `mainView`, so a consumer that needs "open anywhere" also matches the
+ * route.
+ */
+export function isDocumentOpen(
+  mainView: MainView,
+  openedDocument: OpenedDocumentState | null,
+  surfaceId: string,
+): boolean {
+  return (
+    mainView === "document" &&
+    openedDocument !== null &&
+    openedDocument.source === "document" &&
+    openedDocument.surfaceId === surfaceId
+  );
+}
+
+/**
+ * Reactive form of {@link isDocumentOpen}, composed over atomic selectors so a
+ * consumer only re-renders when the view or the opened document changes.
+ */
+export function useIsDocumentOpen(surfaceId: string): boolean {
+  const mainView = useViewerStore.use.mainView();
+  const openedDocument = useViewerStore.use.openedDocumentState();
+  return isDocumentOpen(mainView, openedDocument, surfaceId);
+}
+
+/**
  * Open a workspace file the assistant referenced: a document bound to the file
  * for markdown, the drawer's read-only preview for everything else.
  *

--- a/clients/web/src/domains/chat/components/local-file/open-local-file.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.ts
@@ -210,12 +210,22 @@ export function isDocumentOpen(
   openedDocument: OpenedDocumentState | null,
   surfaceId: string,
 ): boolean {
-  return (
-    mainView === "document" &&
-    openedDocument !== null &&
-    openedDocument.source === "document" &&
-    openedDocument.surfaceId === surfaceId
-  );
+  return openedDocumentSurfaceId(mainView, openedDocument) === surfaceId;
+}
+
+/**
+ * The document surface the drawer is showing, or `null` when it shows nothing
+ * or a read-only preview. The identity behind {@link isDocumentOpen}, for
+ * callers that need to know *which* document rather than ask about one.
+ */
+export function openedDocumentSurfaceId(
+  mainView: MainView,
+  openedDocument: OpenedDocumentState | null,
+): string | null {
+  if (mainView !== "document" || openedDocument?.source !== "document") {
+    return null;
+  }
+  return openedDocument.surfaceId;
 }
 
 /**

--- a/clients/web/src/domains/chat/document-viewer-page.test.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * The standalone `/assistant/documents/:surfaceId` route is a second way into
+ * a document, so opening one there clears its unseen-change record just as the
+ * in-chat viewer does.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import type { DocumentsByIdGetResponse } from "@/generated/daemon/types.gen";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
+
+const daemonSdk = await import("@/generated/daemon/sdk.gen");
+
+type DocumentResult = { data: DocumentsByIdGetResponse | null };
+
+let documentResult: () => Promise<DocumentResult> = () =>
+  Promise.reject(new Error("not stubbed"));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  documentsByIdGet: () => documentResult(),
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: { use: { activeAssistantId: () => "asst-1" } },
+}));
+
+// The editor is a heavy Tiptap tree with nothing to say about the record.
+mock.module("./components/document-viewer-container", () => ({
+  DocumentViewerContainer: () => <div data-testid="viewer" />,
+}));
+
+const { DocumentViewerPage } = await import(
+  "@/domains/chat/document-viewer-page"
+);
+
+function documentSurface(
+  overrides: Partial<DocumentsByIdGetResponse> = {},
+): DocumentsByIdGetResponse {
+  return {
+    success: true,
+    surfaceId: "surf-1",
+    conversationId: "conv-1",
+    title: "Notes",
+    content: "# Notes",
+    wordCount: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    workspacePath: null,
+    ...overrides,
+  };
+}
+
+function renderPage(surfaceId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/assistant/documents/${surfaceId}`]}>
+      <Routes>
+        <Route
+          path="/assistant/documents/:surfaceId"
+          element={<DocumentViewerPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
+beforeEach(() => {
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DocumentViewerPage", () => {
+  test("clears the unseen change for the document it loaded", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("leaves the conversation's other unseen documents alone", async () => {
+    const unseen = useUnseenDocumentChangesStore.getState();
+    unseen.markDocumentChanged("conv-1", "surf-1");
+    unseen.markDocumentChanged("conv-1", "surf-2");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("keeps the unseen change when the load fails", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.reject(new Error("boom"));
+
+    renderPage("surf-1");
+    await waitFor(() => {
+      expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+    });
+  });
+});

--- a/clients/web/src/domains/chat/document-viewer-page.test.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.test.tsx
@@ -105,6 +105,19 @@ describe("DocumentViewerPage", () => {
     expect(unseenFor("conv-1")).toEqual(["surf-2"]);
   });
 
+  test("clears a change recorded against a conversation other than the document's", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-1");
+    documentResult = () =>
+      Promise.resolve({ data: documentSurface({ conversationId: "conv-1" }) });
+
+    const { findByTestId } = renderPage("surf-1");
+    await findByTestId("viewer");
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
   test("keeps the unseen change when the load fails", async () => {
     useUnseenDocumentChangesStore
       .getState()

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -33,6 +33,7 @@ import {
   type DocumentViewerContainerHandle,
 } from "./components/document-viewer-container";
 import { useDocumentCommentEvents } from "./hooks/use-document-comment-events";
+import { useUnseenDocumentChangesStore } from "./unseen-document-changes-store";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -75,6 +76,11 @@ export function DocumentViewerPage() {
           return;
         }
         setDoc(result);
+        // This route is a second way into a document, separate from the
+        // in-chat viewer, so it clears the unseen record itself.
+        useUnseenDocumentChangesStore
+          .getState()
+          .clearDocument(result.conversationId, surfaceId);
       } catch {
         if (!cancelled) {
           setError("Failed to load document.");

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -80,7 +80,7 @@ export function DocumentViewerPage() {
         // in-chat viewer, so it clears the unseen record itself.
         useUnseenDocumentChangesStore
           .getState()
-          .clearDocument(result.conversationId, surfaceId);
+          .clearDocumentEverywhere(surfaceId);
       } catch {
         if (!cancelled) {
           setError("Failed to load document.");

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -2,9 +2,9 @@
  * Tests for the end-of-turn link back to a document the assistant changed.
  *
  * Covers the two things the link owes its caller: it names the document from
- * the documents query, rendering only once that query resolves with the
- * document in it, and it is present exactly when its own document is not the
- * one open in the viewer.
+ * the documents query, rendering only once a resolved list carries the
+ * document, and it is present exactly when its own document is not the one
+ * open in the viewer.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -18,17 +18,22 @@ import { useViewerStore } from "@/stores/viewer-store";
 
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
+const OTHER_CONVERSATION_ID = "conv-2";
 const SURFACE_ID = "surf-notes";
 
 const onOpenDocument = mock((_surfaceId: string) => {});
 
-type SeededDocument = { surfaceId: string; title: string };
+type SeededDocument = {
+  surfaceId: string;
+  title: string;
+  conversationId?: string;
+};
 
 function seededPayload(documents: SeededDocument[]) {
   return {
     documents: documents.map((doc) => ({
       surfaceId: doc.surfaceId,
-      conversationId: CONVERSATION_ID,
+      conversationId: doc.conversationId ?? CONVERSATION_ID,
       title: doc.title,
       wordCount: 0,
       createdAt: 0,
@@ -59,8 +64,14 @@ function renderWithClient(
   render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
-/** Render the link with the conversation-scoped documents query answered. */
-function renderLink(documents: SeededDocument[]): void {
+/**
+ * Render the link with the conversation-scoped documents query answered, and
+ * the assistant-wide fallback answered too when `assistantWide` is given.
+ */
+function renderLink(
+  documents: SeededDocument[],
+  assistantWide?: SeededDocument[],
+): void {
   const queryClient = makeQueryClient();
   queryClient.setQueryData(
     documentsGetQueryKey({
@@ -69,6 +80,12 @@ function renderLink(documents: SeededDocument[]): void {
     }),
     seededPayload(documents),
   );
+  if (assistantWide) {
+    queryClient.setQueryData(
+      documentsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+      seededPayload(assistantWide),
+    );
+  }
   renderWithClient(queryClient, CONVERSATION_ID);
 }
 
@@ -118,7 +135,35 @@ describe("DocumentReopenLink", () => {
     expect(screen.queryByText("Untitled document")).toBeNull();
   });
 
-  test("renders nothing for a document the resolved list does not carry", () => {
+  test("names a document edited from another conversation", () => {
+    // The assistant can edit any document it reaches, and the edit does not
+    // link that document to the conversation it was made from, so this
+    // conversation's list misses it while the assistant-wide list carries it.
+    renderLink(
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+      [
+        {
+          surfaceId: SURFACE_ID,
+          title: "Quarterly notes",
+          conversationId: OTHER_CONVERSATION_ID,
+        },
+      ],
+    );
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("renders nothing for a document neither resolved list carries", () => {
+    renderLink(
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+      [{ surfaceId: "surf-other", title: "Some other doc" }],
+    );
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("renders nothing while the assistant-wide fallback is unresolved", () => {
     renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
 
     expect(screen.queryByTestId("document-reopen-link")).toBeNull();

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for the end-of-turn link back to a document the assistant changed.
+ *
+ * Covers the two things the link owes its caller: it names the document from
+ * the documents query (with a neutral label when the query has no title for
+ * it), and it is present exactly when its own document is not the one open in
+ * the viewer.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { DocumentReopenLink } from "@/domains/chat/transcript/document-reopen-link";
+import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useViewerStore } from "@/stores/viewer-store";
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+const SURFACE_ID = "surf-notes";
+
+const onOpenDocument = mock((_surfaceId: string) => {});
+
+type SeededDocument = { surfaceId: string; title: string };
+
+/**
+ * Render the link with the documents query already answered. `staleTime` is
+ * infinite so the seeded entry is never refetched and the test needs no network.
+ */
+function renderLink(documents: SeededDocument[]): void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(
+    documentsGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID },
+      query: { conversationId: CONVERSATION_ID },
+    }),
+    {
+      documents: documents.map((doc) => ({
+        surfaceId: doc.surfaceId,
+        conversationId: CONVERSATION_ID,
+        title: doc.title,
+        wordCount: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      })),
+    },
+  );
+  const ui: ReactNode = (
+    <DocumentReopenLink
+      surfaceId={SURFACE_ID}
+      assistantId={ASSISTANT_ID}
+      conversationId={CONVERSATION_ID}
+      onOpenDocument={onOpenDocument}
+    />
+  );
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+/** Put the viewer store where it would be with `surfaceId` open in the drawer. */
+function openDocument(surfaceId: string): void {
+  useViewerStore.setState({
+    mainView: "document",
+    openedDocumentState: {
+      source: "document",
+      surfaceId,
+      conversationId: CONVERSATION_ID,
+      documentName: "Quarterly notes",
+      content: "# notes",
+    },
+  });
+}
+
+beforeEach(() => {
+  onOpenDocument.mockClear();
+  useViewerStore.setState({ mainView: "chat", openedDocumentState: null });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DocumentReopenLink", () => {
+  test("names the document from the documents query", () => {
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("falls back to a neutral label when the query has no title", () => {
+    renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
+
+    expect(screen.getByText("Untitled document")).toBeTruthy();
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("hides itself while its own document is open", () => {
+    openDocument(SURFACE_ID);
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("stays visible while a different document is open", () => {
+    openDocument("surf-other");
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
+  });
+
+  test("clicking opens the document it names", () => {
+    renderLink([
+      { surfaceId: "surf-other", title: "Some other doc" },
+      { surfaceId: SURFACE_ID, title: "Quarterly notes" },
+    ]);
+
+    fireEvent.click(screen.getByTestId("document-reopen-link"));
+
+    expect(onOpenDocument).toHaveBeenCalledTimes(1);
+    expect(onOpenDocument.mock.calls[0]).toEqual([SURFACE_ID]);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -2,9 +2,9 @@
  * Tests for the end-of-turn link back to a document the assistant changed.
  *
  * Covers the two things the link owes its caller: it names the document from
- * the documents query (with a neutral label when the query has no title for
- * it), and it is present exactly when its own document is not the one open in
- * the viewer.
+ * the documents query, rendering only once that query resolves with the
+ * document in it, and it is present exactly when its own document is not the
+ * one open in the viewer.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -24,39 +24,52 @@ const onOpenDocument = mock((_surfaceId: string) => {});
 
 type SeededDocument = { surfaceId: string; title: string };
 
-/**
- * Render the link with the documents query already answered. `staleTime` is
- * infinite so the seeded entry is never refetched and the test needs no network.
- */
-function renderLink(documents: SeededDocument[]): void {
-  const queryClient = new QueryClient({
+function seededPayload(documents: SeededDocument[]) {
+  return {
+    documents: documents.map((doc) => ({
+      surfaceId: doc.surfaceId,
+      conversationId: CONVERSATION_ID,
+      title: doc.title,
+      wordCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    })),
+  };
+}
+
+/** A client that never refetches, so a seeded entry needs no network. */
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   });
+}
+
+function renderWithClient(
+  queryClient: QueryClient,
+  conversationId: string | null,
+): void {
+  const ui: ReactNode = (
+    <DocumentReopenLink
+      surfaceId={SURFACE_ID}
+      assistantId={ASSISTANT_ID}
+      conversationId={conversationId}
+      onOpenDocument={onOpenDocument}
+    />
+  );
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+/** Render the link with the conversation-scoped documents query answered. */
+function renderLink(documents: SeededDocument[]): void {
+  const queryClient = makeQueryClient();
   queryClient.setQueryData(
     documentsGetQueryKey({
       path: { assistant_id: ASSISTANT_ID },
       query: { conversationId: CONVERSATION_ID },
     }),
-    {
-      documents: documents.map((doc) => ({
-        surfaceId: doc.surfaceId,
-        conversationId: CONVERSATION_ID,
-        title: doc.title,
-        wordCount: 0,
-        createdAt: 0,
-        updatedAt: 0,
-      })),
-    },
+    seededPayload(documents),
   );
-  const ui: ReactNode = (
-    <DocumentReopenLink
-      surfaceId={SURFACE_ID}
-      assistantId={ASSISTANT_ID}
-      conversationId={CONVERSATION_ID}
-      onOpenDocument={onOpenDocument}
-    />
-  );
-  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  renderWithClient(queryClient, CONVERSATION_ID);
 }
 
 /** Put the viewer store where it would be with `surfaceId` open in the drawer. */
@@ -73,12 +86,20 @@ function openDocument(surfaceId: string): void {
   });
 }
 
+const realFetch = globalThis.fetch;
+
 beforeEach(() => {
   onOpenDocument.mockClear();
   useViewerStore.setState({ mainView: "chat", openedDocumentState: null });
+  // An unseeded query leaves the link in its loading state for the whole test
+  // instead of reaching the network.
+  globalThis.fetch = Object.assign(() => new Promise<Response>(() => {}), {
+    preconnect: () => {},
+  }) as typeof globalThis.fetch;
 });
 
 afterEach(() => {
+  globalThis.fetch = realFetch;
   cleanup();
 });
 
@@ -90,11 +111,35 @@ describe("DocumentReopenLink", () => {
     expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
   });
 
-  test("falls back to a neutral label when the query has no title", () => {
+  test("renders nothing until the documents query resolves", () => {
+    renderWithClient(makeQueryClient(), CONVERSATION_ID);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+    expect(screen.queryByText("Untitled document")).toBeNull();
+  });
+
+  test("renders nothing for a document the resolved list does not carry", () => {
     renderLink([{ surfaceId: "surf-other", title: "Some other doc" }]);
+
+    expect(screen.queryByTestId("document-reopen-link")).toBeNull();
+  });
+
+  test("falls back to a neutral label for a document with an empty title", () => {
+    renderLink([{ surfaceId: SURFACE_ID, title: "  " }]);
 
     expect(screen.getByText("Untitled document")).toBeTruthy();
     expect(screen.getByTestId("document-reopen-link")).toBeTruthy();
+  });
+
+  test("reads the assistant-wide list when there is no conversation", () => {
+    const queryClient = makeQueryClient();
+    queryClient.setQueryData(
+      documentsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+      seededPayload([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]),
+    );
+    renderWithClient(queryClient, null);
+
+    expect(screen.getByText("Quarterly notes")).toBeTruthy();
   });
 
   test("hides itself while its own document is open", () => {

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -11,8 +11,8 @@
  * The name comes from the documents query rather than the tool result, so the
  * link reads the same title the assets list and the Library show, including
  * after a rename. The link waits for that query and stays away from a document
- * the resolved list does not carry, so it never offers to open something that
- * has been deleted.
+ * no resolved list carries, so it never offers to open something that has been
+ * deleted.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -22,41 +22,86 @@ import { Button } from "@vellumai/design-library/components/button";
 
 import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { DocumentsGetResponse } from "@/generated/daemon/types.gen";
 
 /** Label for a document the documents query lists under an empty title. */
 const FALLBACK_DOCUMENT_NAME = "Untitled document";
 
 /**
- * Title of the document `surfaceId`: `undefined` until the documents query
- * resolves, `null` once a resolved list does not carry the document, and
- * otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when that title is empty).
+ * Title of `surfaceId` within one documents response: `null` when the response
+ * does not carry it, otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when
+ * that title is empty).
+ */
+function selectDocumentTitle(
+  response: DocumentsGetResponse,
+  surfaceId: string,
+): string | null {
+  const found = response.documents.find((doc) => doc.surfaceId === surfaceId);
+  if (!found) {
+    return null;
+  }
+  return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
+}
+
+/**
+ * Title of `surfaceId` in one documents list: `undefined` until that list
+ * resolves and `null` once a resolved list does not carry the document.
  *
  * With a conversation the key matches the assets pill's, so both read one cache
  * entry and one invalidation refreshes both. Without one the key drops the
  * filter and reads the assistant-wide list, which no pill shares.
  */
-function useDocumentDisplayName(
+function useDocumentTitle(
   surfaceId: string,
-  assistantId?: string | null,
-  conversationId?: string | null,
+  assistantId: string | null | undefined,
+  conversationId: string | null | undefined,
+  enabled: boolean,
 ): string | null | undefined {
   const { data: title } = useQuery({
     ...documentsGetOptions({
       path: { assistant_id: assistantId ?? "" },
       ...(conversationId ? { query: { conversationId } } : {}),
     }),
-    enabled: Boolean(assistantId),
-    select: (response) => {
-      const found = response.documents.find(
-        (doc) => doc.surfaceId === surfaceId,
-      );
-      if (!found) {
-        return null;
-      }
-      return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
-    },
+    enabled,
+    select: (response) => selectDocumentTitle(response, surfaceId),
   });
   return title;
+}
+
+/**
+ * Title to render for `surfaceId`: `undefined` while it is still being
+ * resolved, `null` once no list carries the document.
+ *
+ * The conversation-scoped list is asked first so the link reads the same cache
+ * entry as the assets pill. A miss there is not an absence: the assistant can
+ * edit any document it can reach, and an edit does not link the document to the
+ * conversation it was made from, so a document reached from an older
+ * conversation is missing from this one's list while still existing. The
+ * assistant-wide list settles that, and only a miss in both hides the link.
+ */
+function useDocumentDisplayName(
+  surfaceId: string,
+  assistantId?: string | null,
+  conversationId?: string | null,
+): string | null | undefined {
+  const hasAssistant = Boolean(assistantId);
+  const scopedTitle = useDocumentTitle(
+    surfaceId,
+    assistantId,
+    conversationId,
+    hasAssistant,
+  );
+  const assistantWideTitle = useDocumentTitle(
+    surfaceId,
+    assistantId,
+    null,
+    hasAssistant && Boolean(conversationId) && scopedTitle === null,
+  );
+
+  if (conversationId && scopedTitle === null) {
+    return assistantWideTitle;
+  }
+  return scopedTitle;
 }
 
 export interface DocumentReopenLinkProps {

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -10,8 +10,9 @@
  *
  * The name comes from the documents query rather than the tool result, so the
  * link reads the same title the assets list and the Library show, including
- * after a rename. A document the query cannot name still gets a link, under a
- * neutral label.
+ * after a rename. The link waits for that query and stays away from a document
+ * the resolved list does not carry, so it never offers to open something that
+ * has been deleted.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -22,31 +23,39 @@ import { Button } from "@vellumai/design-library/components/button";
 import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 
-/** Label for a document the documents query has no title for. */
+/** Label for a document the documents query lists under an empty title. */
 const FALLBACK_DOCUMENT_NAME = "Untitled document";
 
 /**
- * Title of the document `surfaceId`, or {@link FALLBACK_DOCUMENT_NAME} when the
- * documents query has not named it. Keyed the same way the assets pill keys its
- * list, so both read one cache entry and one invalidation refreshes both.
+ * Title of the document `surfaceId`: `undefined` until the documents query
+ * resolves, `null` once a resolved list does not carry the document, and
+ * otherwise its title ({@link FALLBACK_DOCUMENT_NAME} when that title is empty).
+ *
+ * With a conversation the key matches the assets pill's, so both read one cache
+ * entry and one invalidation refreshes both. Without one the key drops the
+ * filter and reads the assistant-wide list, which no pill shares.
  */
 function useDocumentDisplayName(
   surfaceId: string,
   assistantId?: string | null,
   conversationId?: string | null,
-): string {
+): string | null | undefined {
   const { data: title } = useQuery({
     ...documentsGetOptions({
       path: { assistant_id: assistantId ?? "" },
-      query: { conversationId: conversationId ?? undefined },
+      ...(conversationId ? { query: { conversationId } } : {}),
     }),
     enabled: Boolean(assistantId),
-    select: (response) =>
-      response.documents.find((doc) => doc.surfaceId === surfaceId)?.title,
+    select: (response) => {
+      const found = response.documents.find(
+        (doc) => doc.surfaceId === surfaceId,
+      );
+      if (!found) {
+        return null;
+      }
+      return found.title.trim() === "" ? FALLBACK_DOCUMENT_NAME : found.title;
+    },
   });
-  if (title === undefined || title.trim() === "") {
-    return FALLBACK_DOCUMENT_NAME;
-  }
   return title;
 }
 
@@ -73,7 +82,7 @@ export function DocumentReopenLink({
     conversationId,
   );
 
-  if (isOpen) {
+  if (isOpen || displayName == null) {
     return null;
   }
 

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -1,0 +1,96 @@
+/**
+ * A link back to a document the assistant changed during a turn, rendered at
+ * the end of that turn's response.
+ *
+ * The link is derived durably from the turn's tool calls, which persist on the
+ * message, and is hidden reactively while the document is visible. It does not
+ * depend on point-in-time closed-ness captured when the turn finished: that
+ * does not survive a reload, and on mobile the editor is a full-screen overlay,
+ * so a visible transcript already means the editor is closed.
+ *
+ * The name comes from the documents query rather than the tool result, so the
+ * link reads the same title the assets list and the Library show, including
+ * after a rename. A document the query cannot name still gets a link, under a
+ * neutral label.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { ArrowUpRight, FileText } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+
+/** Label for a document the documents query has no title for. */
+const FALLBACK_DOCUMENT_NAME = "Untitled document";
+
+/**
+ * Title of the document `surfaceId`, or {@link FALLBACK_DOCUMENT_NAME} when the
+ * documents query has not named it. Keyed the same way the assets pill keys its
+ * list, so both read one cache entry and one invalidation refreshes both.
+ */
+function useDocumentDisplayName(
+  surfaceId: string,
+  assistantId?: string | null,
+  conversationId?: string | null,
+): string {
+  const { data: title } = useQuery({
+    ...documentsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+      query: { conversationId: conversationId ?? undefined },
+    }),
+    enabled: Boolean(assistantId),
+    select: (response) =>
+      response.documents.find((doc) => doc.surfaceId === surfaceId)?.title,
+  });
+  if (title === undefined || title.trim() === "") {
+    return FALLBACK_DOCUMENT_NAME;
+  }
+  return title;
+}
+
+export interface DocumentReopenLinkProps {
+  /** Surface id of the document the turn changed. */
+  surfaceId: string;
+  /** Assistant the documents query reads through. */
+  assistantId?: string | null;
+  /** Conversation the document belongs to. */
+  conversationId?: string | null;
+  onOpenDocument: (surfaceId: string) => void;
+}
+
+export function DocumentReopenLink({
+  surfaceId,
+  assistantId,
+  conversationId,
+  onOpenDocument,
+}: DocumentReopenLinkProps) {
+  const isOpen = useIsDocumentOpen(surfaceId);
+  const displayName = useDocumentDisplayName(
+    surfaceId,
+    assistantId,
+    conversationId,
+  );
+
+  if (isOpen) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="compact"
+      className="mt-2 max-w-full gap-2 rounded-lg"
+      aria-label={`Open ${displayName}`}
+      data-testid="document-reopen-link"
+      onClick={() => onOpenDocument(surfaceId)}
+    >
+      <FileText className="h-4 w-4 shrink-0 text-[var(--content-quiet)]" />
+      <span className="min-w-0 truncate text-title-small text-[var(--content-strong)]">
+        {displayName}
+      </span>
+      <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-[var(--content-faint)]" />
+    </Button>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -69,6 +69,10 @@ export interface LatestTurnRowProps {
   onWorkflowClick?: (runId: string) => void;
   /** Callback to abort/stop a running workflow from an inline card. */
   onStopWorkflow?: (runId: string) => void;
+  /** Changed-document ids per transcript item key, resolved across whole
+   *  responses by `Transcript`. Only the message that ends a completed response
+   *  has an entry, and the in-flight response has none. */
+  changedDocumentIdsByKey?: ReadonlyMap<string, string[]>;
 }
 
 export const LatestTurnRow = memo(function LatestTurnRow({
@@ -94,6 +98,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   onStopSubagent,
   onWorkflowClick,
   onStopWorkflow,
+  changedDocumentIdsByKey,
 }: LatestTurnRowProps) {
   // The response cluster is "streaming" whenever the turn is in flight. This
   // keeps each response message's last tool-call group expanded for the whole
@@ -159,6 +164,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             onStopSubagent={onStopSubagent}
             onWorkflowClick={onWorkflowClick}
             onStopWorkflow={onStopWorkflow}
+            changedDocumentIds={changedDocumentIdsByKey?.get(response.key)}
             isStreaming={isStreaming}
             isLatestMessage={response === lastMessageItem}
           />

--- a/clients/web/src/domains/chat/transcript/resolve-response-documents.test.ts
+++ b/clients/web/src/domains/chat/transcript/resolve-response-documents.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { ConversationContentBlock } from "@vellumai/assistant-api";
+import type { TranscriptItem } from "@/domains/chat/transcript/types";
+
+import { resolveResponseDocumentIds } from "@/domains/chat/transcript/resolve-response-documents";
+
+/** A settled `document_update` whose result carries the surface it wrote. */
+function updateCall(id: string, surfaceId: string): ChatMessageToolCall {
+  return {
+    id,
+    name: "document_update",
+    input: { surface_id: surfaceId, content: "notes" },
+    result: JSON.stringify({ success: true, surface_id: surfaceId }),
+    completedAt: 1,
+  };
+}
+
+/** A settled `document_create` whose result names the document it opened. */
+function createCall(id: string, surfaceId: string): ChatMessageToolCall {
+  return {
+    id,
+    name: "document_create",
+    input: { title: "Notes" },
+    result: JSON.stringify({ surface_id: surfaceId, opened: true }),
+    completedAt: 1,
+  };
+}
+
+/**
+ * The inline `document_preview` surface `document_create` emits alongside its
+ * result. The card carries its own `preview-` surface id; the document it
+ * opens rides in `data.surfaceId`.
+ */
+function previewBlock(surfaceId: string): ConversationContentBlock {
+  return {
+    type: "surface",
+    surface: {
+      surfaceId: `preview-${surfaceId}`,
+      surfaceType: "document_preview",
+      data: { title: "Notes", surfaceId },
+    },
+  } as ConversationContentBlock;
+}
+
+function assistant(
+  key: string,
+  toolCalls: ChatMessageToolCall[] = [],
+  extraBlocks: ConversationContentBlock[] = [],
+): TranscriptItem {
+  return {
+    kind: "message",
+    key,
+    message: {
+      id: key,
+      role: "assistant",
+      toolCalls,
+      contentBlocks: [
+        ...toolCalls.map(
+          (toolCall) =>
+            ({ type: "tool_use", toolCall }) as ConversationContentBlock,
+        ),
+        ...extraBlocks,
+      ],
+    },
+  };
+}
+
+function user(key: string): TranscriptItem {
+  return {
+    kind: "message",
+    key,
+    message: {
+      id: key,
+      role: "user",
+      contentBlocks: [{ type: "text", text: "do it" }],
+    },
+  };
+}
+
+describe("resolveResponseDocumentIds", () => {
+  test("collapses one document changed by several messages into one entry", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      assistant("a2", [updateCall("tc-2", "surf-notes")]),
+      assistant("a3", [updateCall("tc-3", "surf-notes")]),
+    ];
+
+    const byKey = resolveResponseDocumentIds(items);
+
+    expect([...byKey]).toEqual([["a3", ["surf-notes"]]]);
+  });
+
+  test("keeps one entry per distinct document of a response", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      assistant("a2", [updateCall("tc-2", "surf-plan")]),
+    ];
+
+    const byKey = resolveResponseDocumentIds(items);
+
+    expect(byKey.get("a2")).toEqual(["surf-notes", "surf-plan"]);
+    expect(byKey.has("a1")).toBe(false);
+  });
+
+  test("anchors each response on its own final message", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      assistant("a2"),
+      user("u2"),
+      assistant("a3", [updateCall("tc-2", "surf-plan")]),
+      assistant("a4"),
+    ];
+
+    const byKey = resolveResponseDocumentIds(items);
+
+    expect(byKey.get("a2")).toEqual(["surf-notes"]);
+    expect(byKey.get("a4")).toEqual(["surf-plan"]);
+    expect(byKey.size).toBe(2);
+  });
+
+  test("withholds the in-flight response while the turn is active", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-2", "surf-plan")]),
+    ];
+
+    const byKey = resolveResponseDocumentIds(items, { turnActive: true });
+
+    expect(byKey.get("a1")).toEqual(["surf-notes"]);
+    expect(byKey.has("a2")).toBe(false);
+  });
+
+  test("keeps an earlier response's entry when the newest turn has no message yet", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      user("u2"),
+    ];
+
+    const byKey = resolveResponseDocumentIds(items, { turnActive: true });
+
+    expect(byKey.get("a1")).toEqual(["surf-notes"]);
+  });
+
+  test("skips a document a preview card in the same response already opens", () => {
+    const items = [
+      user("u1"),
+      assistant(
+        "a1",
+        [createCall("tc-1", "surf-notes")],
+        [previewBlock("surf-notes")],
+      ),
+      assistant("a2"),
+    ];
+
+    expect(resolveResponseDocumentIds(items).size).toBe(0);
+  });
+
+  test("keeps a previewed document a later message of the response edits", () => {
+    const items = [
+      user("u1"),
+      assistant(
+        "a1",
+        [createCall("tc-1", "surf-notes")],
+        [previewBlock("surf-notes")],
+      ),
+      assistant("a2", [updateCall("tc-2", "surf-notes")]),
+    ];
+
+    expect(resolveResponseDocumentIds(items).get("a2")).toEqual(["surf-notes"]);
+  });
+
+  test("keeps a document previewed by a later response", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [], [previewBlock("surf-notes")]),
+    ];
+
+    expect(resolveResponseDocumentIds(items).get("a1")).toEqual(["surf-notes"]);
+  });
+
+  test("keeps a document a non-preview surface names", () => {
+    const card = {
+      type: "surface",
+      surface: {
+        surfaceId: "card-1",
+        surfaceType: "card",
+        data: { surfaceId: "surf-notes" },
+      },
+    } as ConversationContentBlock;
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")], [card]),
+    ];
+
+    expect(resolveResponseDocumentIds(items).get("a1")).toEqual(["surf-notes"]);
+  });
+
+  test("ignores a tool call that is not a document mutation", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [
+        {
+          id: "tc-read",
+          name: "file_read",
+          input: { path: "/tmp/notes.md" },
+          result: JSON.stringify({ surface_id: "surf-notes" }),
+          completedAt: 1,
+        },
+      ]),
+    ];
+
+    expect(resolveResponseDocumentIds(items).size).toBe(0);
+  });
+
+  test("skips a failed document call", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [{ ...updateCall("tc-1", "surf-notes"), isError: true }]),
+    ];
+
+    expect(resolveResponseDocumentIds(items).size).toBe(0);
+  });
+
+  test("anchors on the last ordinary message when a system card ends the response", () => {
+    const card: TranscriptItem = {
+      kind: "message",
+      key: "a2",
+      message: {
+        id: "a2",
+        role: "assistant",
+        isSystemCard: true,
+        contentBlocks: [{ type: "text", text: "Context compacted." }],
+      },
+    };
+    const items = [
+      user("u1"),
+      assistant("a1", [updateCall("tc-1", "surf-notes")]),
+      card,
+    ];
+
+    const byKey = resolveResponseDocumentIds(items);
+
+    expect(byKey.get("a1")).toEqual(["surf-notes"]);
+    expect(byKey.has("a2")).toBe(false);
+  });
+
+  test("reuses the previous array when a response resolves the same ids", () => {
+    const items = [user("u1"), assistant("a1", [updateCall("tc-1", "surf-a")])];
+
+    const first = resolveResponseDocumentIds(items).get("a1");
+    const second = resolveResponseDocumentIds(items).get("a1");
+
+    expect(second).toBe(first!);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/resolve-response-documents.ts
+++ b/clients/web/src/domains/chat/transcript/resolve-response-documents.ts
@@ -1,0 +1,180 @@
+// Assign the documents a response changed to the message that ends it, so a
+// response closes with one reopen link per document rather than repeating the
+// same link on every message that wrote to it.
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type {
+  MessageItem,
+  TranscriptItem,
+} from "@/domains/chat/transcript/types";
+
+import {
+  resolveChangedDocuments,
+  resolveEditedDocuments,
+} from "@/domains/chat/transcript/transcript-message-body-shared";
+
+/**
+ * Split `items` into responses on the same boundary `partitionLatestTurn`
+ * uses: every user message opens a new one. Assistant messages before the
+ * first user message form the leading response, and the trailing entry is the
+ * response to the newest user message, empty until it produces a message.
+ *
+ * Non-message items (the thinking slot, pending prompts, ephemeral meta) carry
+ * no tool calls and no link slot, so they are skipped rather than split on.
+ */
+function splitResponses(items: TranscriptItem[]): MessageItem[][] {
+  const responses: MessageItem[][] = [[]];
+
+  for (const item of items) {
+    if (item.kind !== "message") {
+      continue;
+    }
+    if (item.message.role === "user") {
+      responses.push([]);
+      continue;
+    }
+    responses[responses.length - 1]!.push(item);
+  }
+
+  return responses;
+}
+
+/**
+ * The documents `message` opens with an inline `document_preview` card. The
+ * card's own `surfaceId` is the surface (`preview-<doc id>`); the document it
+ * opens rides in `data.surfaceId`, which is what a document tool call reports
+ * in its result.
+ */
+function previewedDocumentIds(message: DisplayMessage): string[] {
+  const surfaceIds: string[] = [];
+
+  for (const block of message.contentBlocks ?? []) {
+    if (
+      block.type !== "surface" ||
+      block.surface.surfaceType !== "document_preview"
+    ) {
+      continue;
+    }
+    const surfaceId = block.surface.data?.surfaceId;
+    if (typeof surfaceId === "string" && surfaceId !== "") {
+      surfaceIds.push(surfaceId);
+    }
+  }
+
+  return surfaceIds;
+}
+
+/**
+ * The ids of the documents `response` changed, in first-changed order.
+ *
+ * A `document_preview` card opens its own document, so a document the response
+ * only previews is claimed up front and owes no link beside its card. A
+ * document the response also writes to is changed below that card, so it stays
+ * unclaimed and still ends the response with a link.
+ *
+ * The claim set spans the whole response, so repeated edits of one document
+ * collapse into a single id, whether they ran in one message or several.
+ */
+function changedDocumentIds(response: MessageItem[]): string[] {
+  const edited = new Set<string>();
+  for (const item of response) {
+    for (const surfaceId of resolveEditedDocuments(
+      item.message.toolCalls ?? [],
+    )) {
+      edited.add(surfaceId);
+    }
+  }
+
+  const claimed = new Set<string>();
+  for (const item of response) {
+    for (const surfaceId of previewedDocumentIds(item.message)) {
+      if (!edited.has(surfaceId)) {
+        claimed.add(surfaceId);
+      }
+    }
+  }
+
+  const surfaceIds: string[] = [];
+  for (const item of response) {
+    surfaceIds.push(
+      ...resolveChangedDocuments(item.message.toolCalls ?? [], claimed),
+    );
+  }
+
+  return surfaceIds;
+}
+
+/**
+ * Whether `item` can carry its response's reopen links. System cards render
+ * through `SystemCardRow`, which has no link slot, so a response that ends on
+ * one anchors its links on the last ordinary message instead.
+ */
+function canAnchorLinks(item: MessageItem): boolean {
+  return !item.message.isSystemCard;
+}
+
+/** Previously returned ids, keyed by the message that anchored them. */
+const idsByAnchor = new WeakMap<DisplayMessage, string[]>();
+
+/**
+ * Reuse the previous array for an anchor whose ids are unchanged, so the row
+ * carrying the links keeps its `memo()` across the re-render every streaming
+ * token triggers.
+ */
+function stableIds(anchor: DisplayMessage, surfaceIds: string[]): string[] {
+  const cached = idsByAnchor.get(anchor);
+  if (
+    cached &&
+    cached.length === surfaceIds.length &&
+    cached.every((id, i) => id === surfaceIds[i])
+  ) {
+    return cached;
+  }
+  idsByAnchor.set(anchor, surfaceIds);
+  return surfaceIds;
+}
+
+export interface ResolveResponseDocumentsOptions {
+  /**
+   * Whether a turn is in flight. The trailing response is the one being
+   * generated, so it is left out until the turn settles and its closing
+   * affordance is honest.
+   */
+  turnActive?: boolean;
+}
+
+/**
+ * The documents each completed response changed, keyed by the transcript item
+ * key of the message that ends that response.
+ *
+ * Each id rides on its tool call's persisted `result`, so a response reseeded
+ * from `/messages` resolves the same ids as the streamed one.
+ *
+ * Rows read their own entry, so every row without links keeps a stable
+ * `undefined` and every row with them keeps a stable array.
+ */
+export function resolveResponseDocumentIds(
+  items: TranscriptItem[],
+  options?: ResolveResponseDocumentsOptions,
+): Map<string, string[]> {
+  const byItemKey = new Map<string, string[]>();
+  const responses = splitResponses(items);
+  const inFlightIndex = options?.turnActive ? responses.length - 1 : -1;
+
+  responses.forEach((response, index) => {
+    if (index === inFlightIndex) {
+      return;
+    }
+    const anchor = response.findLast(canAnchorLinks);
+    if (!anchor) {
+      return;
+    }
+    const surfaceIds = changedDocumentIds(response);
+    if (surfaceIds.length === 0) {
+      return;
+    }
+    byItemKey.set(anchor.key, stableIds(anchor.message, surfaceIds));
+  });
+
+  return byItemKey;
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import {
   computeCardBackedWorkflowRunIds,
+  resolveChangedDocuments,
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -126,5 +127,168 @@ describe("computeCardBackedWorkflowRunIds", () => {
       result: "Failed to start workflow: agent cap exceeded",
     });
     expect(computeCardBackedWorkflowRunIds([tc], backingState()).size).toBe(0);
+  });
+});
+
+/** A document tool call whose surface id is recoverable from its result. */
+function docCall(
+  id: string,
+  tool: string,
+  surfaceId: string,
+  overrides: Partial<ChatMessageToolCall> = {},
+): ChatMessageToolCall {
+  return call({
+    id,
+    name: tool,
+    input: { surface_id: surfaceId },
+    result: JSON.stringify({ success: true, surface_id: surfaceId }),
+    ...overrides,
+  });
+}
+
+describe("resolveChangedDocuments", () => {
+  test("resolves the surface id a single update wrote to", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1");
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("resolves a call delivered inside a skill_execute envelope", () => {
+    const tc = call({
+      id: "tc-a",
+      name: "skill_execute",
+      input: { tool: "document_update", surface_id: "doc-1" },
+      result: JSON.stringify({ success: true, surface_id: "doc-1" }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("collapses a create then an update of the same document to one entry", () => {
+    const calls = [
+      docCall("tc-a", "document_create", "doc-1"),
+      docCall("tc-b", "document_update", "doc-1"),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual(["doc-1"]);
+  });
+
+  test("returns two different documents in first-changed order", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-2"),
+      docCall("tc-b", "document_replace_text", "doc-1"),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([
+      "doc-2",
+      "doc-1",
+    ]);
+  });
+
+  test("a shared claimed Set stops a second group anchoring the same document", () => {
+    const claimed = new Set<string>();
+    const first = docCall("tc-a", "document_update", "doc-1");
+    const second = docCall("tc-b", "document_update", "doc-1");
+    expect(resolveChangedDocuments([first], claimed)).toEqual(["doc-1"]);
+    expect(resolveChangedDocuments([second], claimed)).toEqual([]);
+  });
+
+  test("ignores a malformed, non-JSON result without throwing", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: "Failed to update document: no document is open",
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores a result whose JSON carries no surface_id", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: JSON.stringify({ success: true }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores a call whose result has not landed yet", () => {
+    const tc = docCall("tc-a", "document_update", "doc-1", {
+      result: undefined,
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores non-document tool calls", () => {
+    const calls = [
+      call({ id: "tc-a", name: "document_read", result: "{}" }),
+      call({
+        id: "tc-b",
+        name: "file_write",
+        result: JSON.stringify({ surface_id: "doc-1" }),
+      }),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([]);
+  });
+
+  test("ignores an errored call even when its result carries a surface id", () => {
+    // A failed document_replace_text still echoes the surface id it targeted,
+    // but nothing changed, so there is no document to reopen.
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      isError: true,
+      result: JSON.stringify({
+        success: false,
+        surface_id: "doc-1",
+        error: "text not found",
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("ignores a replace that succeeded without changing content", () => {
+    // document_replace_text succeeds with content_changed: false when `find`
+    // matched nothing, so the document is unchanged.
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      result: JSON.stringify({
+        success: true,
+        surface_id: "doc-1",
+        replacements_made: 0,
+        content_changed: false,
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual([]);
+  });
+
+  test("resolves a replace that reports content_changed", () => {
+    const tc = docCall("tc-a", "document_replace_text", "doc-1", {
+      result: JSON.stringify({
+        success: true,
+        surface_id: "doc-1",
+        replacements_made: 2,
+        content_changed: true,
+      }),
+    });
+    expect(resolveChangedDocuments([tc], new Set())).toEqual(["doc-1"]);
+  });
+
+  test("resolves create and update results, which omit content_changed", () => {
+    const calls = [
+      call({
+        id: "tc-a",
+        name: "document_create",
+        input: { title: "Notes" },
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-1",
+          message: "Document created",
+        }),
+      }),
+      call({
+        id: "tc-b",
+        name: "document_update",
+        input: { surface_id: "doc-2" },
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          mode: "append",
+          message: "Document content updated",
+        }),
+      }),
+    ];
+    expect(resolveChangedDocuments(calls, new Set())).toEqual([
+      "doc-1",
+      "doc-2",
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import {
   computeCardBackedWorkflowRunIds,
   resolveChangedDocuments,
+  resolveEditedDocuments,
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -290,5 +291,58 @@ describe("resolveChangedDocuments", () => {
       "doc-1",
       "doc-2",
     ]);
+  });
+});
+
+describe("resolveEditedDocuments", () => {
+  test("returns the documents an update and a replace wrote to", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-1"),
+      docCall("tc-b", "document_replace_text", "doc-2", {
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          content_changed: true,
+        }),
+      }),
+    ];
+    expect([...resolveEditedDocuments(calls)]).toEqual(["doc-1", "doc-2"]);
+  });
+
+  test("omits a document the turn only created", () => {
+    const calls = [docCall("tc-a", "document_create", "doc-1")];
+    expect(resolveEditedDocuments(calls).size).toBe(0);
+  });
+
+  test("includes a created document the turn goes on to write into", () => {
+    const calls = [
+      docCall("tc-a", "document_create", "doc-1"),
+      docCall("tc-b", "document_update", "doc-1"),
+    ];
+    expect([...resolveEditedDocuments(calls)]).toEqual(["doc-1"]);
+  });
+
+  test("resolves an edit delivered inside a skill_execute envelope", () => {
+    const tc = call({
+      id: "tc-a",
+      name: "skill_execute",
+      input: { tool: "document_update", surface_id: "doc-1" },
+      result: JSON.stringify({ success: true, surface_id: "doc-1" }),
+    });
+    expect([...resolveEditedDocuments([tc])]).toEqual(["doc-1"]);
+  });
+
+  test("omits an errored edit and a replace that changed nothing", () => {
+    const calls = [
+      docCall("tc-a", "document_update", "doc-1", { isError: true }),
+      docCall("tc-b", "document_replace_text", "doc-2", {
+        result: JSON.stringify({
+          success: true,
+          surface_id: "doc-2",
+          content_changed: false,
+        }),
+      }),
+    ];
+    expect(resolveEditedDocuments(calls).size).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -85,6 +85,14 @@ export interface TranscriptMessageBodyProps {
   /** Callback to abort/stop a running workflow from an inline card. */
   onStopWorkflow?: (runId: string) => void;
   /**
+   * Ids of the documents this message's whole response changed, resolved by
+   * `Transcript` (see `resolveResponseDocumentIds`) and set only on the message
+   * that ends a completed response. Each one renders a reopen link below the
+   * message body, so a response closes with one link per document however many
+   * of its messages wrote to it.
+   */
+  changedDocumentIds?: string[];
+  /**
    * True when this message belongs to the turn that is actively streaming.
    * Set by `LatestTurnRow` for the in-progress response cluster; history
    * rows leave it `false`. Keeps the message's last tool-call group expanded
@@ -507,9 +515,8 @@ function extractDocumentSurfaceIdFromResult(
  * reseed, unlike the ephemeral `document_editor_update` event.
  *
  * The caller owns the `claimed` Set so it persists across every invocation
- * within a single message. That collapses repeated edits of one document into a
- * single entry and stops two non-consecutive tool-call groups from both
- * anchoring the same document.
+ * within a single response. That collapses repeated edits of one document into
+ * a single entry, whether they ran in one message or spread across several.
  */
 export function resolveChangedDocuments(
   toolCalls: ChatMessageToolCall[],
@@ -536,9 +543,9 @@ export function resolveChangedDocuments(
  * `document_replace_text`, ignoring the create that opened them.
  *
  * An inline `document_preview` card renders where its tool ran, so it stands in
- * for the end-of-response reopen link only on a document the turn leaves alone
- * afterwards. A document the turn keeps writing to is changed below its card
- * and still owes a link at the end.
+ * for the end-of-response reopen link only on a document the response leaves
+ * alone afterwards. A document the response keeps writing to is changed below
+ * its card and still owes a link at the end.
  */
 export function resolveEditedDocuments(
   toolCalls: ChatMessageToolCall[],

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -424,7 +424,15 @@ export function resolveBackgroundTaskIds(
   return ids;
 }
 
-/** The document tools that change a document's content. */
+/**
+ * The document tools that change a document's content.
+ *
+ * The daemon keeps its own copy of this list, in the documents-changed hook in
+ * `assistant/src/daemon/tool-side-effects.ts`. That one also carries
+ * `document_delete`, which is left out here on purpose: a deleted document has
+ * nothing to reopen, so it must not anchor a changed-document chip. Add a new
+ * mutating document tool to both.
+ */
 const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
   "document_create",
   "document_update",

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -1,4 +1,8 @@
 import {
+  DOCUMENT_EDIT_TOOL_NAMES,
+  REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES,
+} from "@vellumai/assistant-api";
+import {
   isAcpSpawnCall,
   isBackgroundBashCall,
   isRunWorkflowCall,
@@ -424,26 +428,15 @@ export function resolveBackgroundTaskIds(
   return ids;
 }
 
-/**
- * The document tools that change a document's content.
- *
- * The daemon keeps its own copy of this list, in the documents-changed hook in
- * `assistant/src/daemon/tool-side-effects.ts`. That one also carries
- * `document_delete`, which is left out here on purpose: a deleted document has
- * nothing to reopen, so it must not anchor a changed-document chip. Add a new
- * mutating document tool to both.
- */
-const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
-  "document_create",
-  "document_update",
-  "document_replace_text",
-]);
+/** The mutating document tools that leave the document openable. */
+const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set(
+  REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES,
+);
 
 /** The mutating document tools that write into an already-created document. */
-const DOCUMENT_EDIT_TOOLS: ReadonlySet<string> = new Set([
-  "document_update",
-  "document_replace_text",
-]);
+const DOCUMENT_EDIT_TOOLS: ReadonlySet<string> = new Set(
+  DOCUMENT_EDIT_TOOL_NAMES,
+);
 
 /**
  * Detect a call to one of `tools`. Document tools ship in the bundled

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -431,13 +431,22 @@ const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
   "document_replace_text",
 ]);
 
+/** The mutating document tools that write into an already-created document. */
+const DOCUMENT_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  "document_update",
+  "document_replace_text",
+]);
+
 /**
- * Detect a call to a document tool that changes content. Document tools ship in
- * the bundled `document-editor` skill, so a call arrives either under its raw
- * tool name or inside a `skill_execute` envelope whose `input.tool` names it.
+ * Detect a call to one of `tools`. Document tools ship in the bundled
+ * `document-editor` skill, so a call arrives either under its raw tool name or
+ * inside a `skill_execute` envelope whose `input.tool` names it.
  */
-function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
-  if (DOCUMENT_MUTATION_TOOLS.has(toolCall.name)) {
+function isDocumentToolCall(
+  toolCall: ChatMessageToolCall,
+  tools: ReadonlySet<string>,
+): boolean {
+  if (tools.has(toolCall.name)) {
     return true;
   }
   if (toolCall.name !== "skill_execute") {
@@ -448,15 +457,15 @@ function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
     return false;
   }
   const tool = (input as Record<string, unknown>).tool;
-  return typeof tool === "string" && DOCUMENT_MUTATION_TOOLS.has(tool);
+  return typeof tool === "string" && tools.has(tool);
 }
 
 /**
- * Extract the `surface_id` a mutating document tool call wrote to. The
- * executors return `JSON.stringify({ ..., surface_id })` (see
+ * Extract the `surface_id` a call to one of `tools` wrote to. The executors
+ * return `JSON.stringify({ ..., surface_id })` (see
  * `assistant/src/tools/document/document-tool.ts`). Returns `undefined` for a
- * non-document call, a call that failed, a replace that matched nothing, or a
- * non-JSON/malformed result, so callers anchor only on documents that really
+ * call outside `tools`, a call that failed, a replace that matched nothing, or
+ * a non-JSON/malformed result, so callers anchor only on documents that really
  * changed.
  *
  * Only `document_replace_text` reports `content_changed`, and it succeeds with
@@ -467,8 +476,9 @@ function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
  */
 function extractDocumentSurfaceIdFromResult(
   toolCall: ChatMessageToolCall,
+  tools: ReadonlySet<string>,
 ): string | undefined {
-  if (!isDocumentMutationCall(toolCall) || toolCall.isError === true) {
+  if (!isDocumentToolCall(toolCall, tools) || toolCall.isError === true) {
     return undefined;
   }
   if (typeof toolCall.result !== "string" || !toolCall.result) {
@@ -507,10 +517,40 @@ export function resolveChangedDocuments(
   const surfaceIds: string[] = [];
 
   for (const tc of toolCalls) {
-    const surfaceId = extractDocumentSurfaceIdFromResult(tc);
+    const surfaceId = extractDocumentSurfaceIdFromResult(
+      tc,
+      DOCUMENT_MUTATION_TOOLS,
+    );
     if (surfaceId && !claimed.has(surfaceId)) {
       surfaceIds.push(surfaceId);
       claimed.add(surfaceId);
+    }
+  }
+
+  return surfaceIds;
+}
+
+/**
+ * The ids of the documents `toolCalls` wrote into with `document_update` or
+ * `document_replace_text`, ignoring the create that opened them.
+ *
+ * An inline `document_preview` card renders where its tool ran, so it stands in
+ * for the end-of-response reopen link only on a document the turn leaves alone
+ * afterwards. A document the turn keeps writing to is changed below its card
+ * and still owes a link at the end.
+ */
+export function resolveEditedDocuments(
+  toolCalls: ChatMessageToolCall[],
+): Set<string> {
+  const surfaceIds = new Set<string>();
+
+  for (const tc of toolCalls) {
+    const surfaceId = extractDocumentSurfaceIdFromResult(
+      tc,
+      DOCUMENT_EDIT_TOOLS,
+    );
+    if (surfaceId) {
+      surfaceIds.add(surfaceId);
     }
   }
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -424,6 +424,99 @@ export function resolveBackgroundTaskIds(
   return ids;
 }
 
+/** The document tools that change a document's content. */
+const DOCUMENT_MUTATION_TOOLS: ReadonlySet<string> = new Set([
+  "document_create",
+  "document_update",
+  "document_replace_text",
+]);
+
+/**
+ * Detect a call to a document tool that changes content. Document tools ship in
+ * the bundled `document-editor` skill, so a call arrives either under its raw
+ * tool name or inside a `skill_execute` envelope whose `input.tool` names it.
+ */
+function isDocumentMutationCall(toolCall: ChatMessageToolCall): boolean {
+  if (DOCUMENT_MUTATION_TOOLS.has(toolCall.name)) {
+    return true;
+  }
+  if (toolCall.name !== "skill_execute") {
+    return false;
+  }
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") {
+    return false;
+  }
+  const tool = (input as Record<string, unknown>).tool;
+  return typeof tool === "string" && DOCUMENT_MUTATION_TOOLS.has(tool);
+}
+
+/**
+ * Extract the `surface_id` a mutating document tool call wrote to. The
+ * executors return `JSON.stringify({ ..., surface_id })` (see
+ * `assistant/src/tools/document/document-tool.ts`). Returns `undefined` for a
+ * non-document call, a call that failed, a replace that matched nothing, or a
+ * non-JSON/malformed result, so callers anchor only on documents that really
+ * changed.
+ *
+ * Only `document_replace_text` reports `content_changed`, and it succeeds with
+ * `content_changed: false` when `find` matched nothing. `document_create` and
+ * `document_update` omit the field and always write, so an absent field reads
+ * as changed and only an explicit `false` rejects the call. That matches the
+ * daemon, which emits `document_editor_update` on the same condition.
+ */
+function extractDocumentSurfaceIdFromResult(
+  toolCall: ChatMessageToolCall,
+): string | undefined {
+  if (!isDocumentMutationCall(toolCall) || toolCall.isError === true) {
+    return undefined;
+  }
+  if (typeof toolCall.result !== "string" || !toolCall.result) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(toolCall.result) as {
+      surface_id?: unknown;
+      content_changed?: unknown;
+    };
+    if (parsed.content_changed === false) {
+      return undefined;
+    }
+    return typeof parsed.surface_id === "string" && parsed.surface_id !== ""
+      ? parsed.surface_id
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the ids of the documents `toolCalls` changed, in first-changed order.
+ * Each id rides on its call's persisted `result`, so it survives a history
+ * reseed, unlike the ephemeral `document_editor_update` event.
+ *
+ * The caller owns the `claimed` Set so it persists across every invocation
+ * within a single message. That collapses repeated edits of one document into a
+ * single entry and stops two non-consecutive tool-call groups from both
+ * anchoring the same document.
+ */
+export function resolveChangedDocuments(
+  toolCalls: ChatMessageToolCall[],
+  claimed: Set<string>,
+): string[] {
+  const surfaceIds: string[] = [];
+
+  for (const tc of toolCalls) {
+    const surfaceId = extractDocumentSurfaceIdFromResult(tc);
+    if (surfaceId && !claimed.has(surfaceId)) {
+      surfaceIds.push(surfaceId);
+      claimed.add(surfaceId);
+    }
+  }
+
+  return surfaceIds;
+}
+
 /**
  * The `acpSessionId` a single `acp_spawn` tool call resolves to — its
  * `byToolUseId` anchor (from the `acp_session_spawned` event), else the id

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -2227,6 +2227,13 @@ describe("TranscriptMessageBody — redacted-credential chip version gate", () =
   });
 });
 
+/**
+ * The links themselves are resolved across a whole response by `Transcript`
+ * (see `resolve-response-documents.test` for which documents a response
+ * anchors, and `transcript.test` for which message ends up carrying them).
+ * What the body owns is the slot: it renders exactly the ids it is handed,
+ * below the response body and above the footer, and nothing without a handler.
+ */
 describe("TranscriptMessageBody: changed-document reopen links", () => {
   const DOC_ASSISTANT_ID = "asst-doc";
   const DOC_CONVERSATION_ID = "conv-doc";
@@ -2247,14 +2254,15 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
   }
 
   /**
-   * A turn that narrates, runs `toolCalls`, then answers. The lead-in and the
-   * tool run collapse into "Earlier activity", so any reopen link that renders
-   * has to sit outside that disclosure to still be visible.
+   * A message that narrates, runs `document_update`, then answers. The lead-in
+   * and the tool run collapse into "Earlier activity", so any reopen link that
+   * renders has to sit outside that disclosure to still be visible.
    */
   function turnElement(
-    toolCalls: ChatMessageToolCall[],
+    changedDocumentIds: string[] | undefined,
     onOpenDocument: ((surfaceId: string) => void) | undefined,
   ) {
+    const toolCalls = [documentUpdateCall("tc-doc", "surf-notes")];
     return (
       <TranscriptMessageBody
         message={{
@@ -2270,14 +2278,15 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
         }}
         conversationId={DOC_CONVERSATION_ID}
         assistantId={DOC_ASSISTANT_ID}
+        changedDocumentIds={changedDocumentIds}
         onOpenDocument={onOpenDocument}
         onSurfaceAction={noop}
       />
     );
   }
 
-  function renderTurn(toolCalls: ChatMessageToolCall[]) {
-    return render(turnElement(toolCalls, onOpenDocumentMock));
+  function renderTurn(changedDocumentIds: string[] | undefined) {
+    return render(turnElement(changedDocumentIds, onOpenDocumentMock));
   }
 
   function reopenLinks(container: HTMLElement): HTMLElement[] {
@@ -2298,10 +2307,8 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     onOpenDocumentMock.mockClear();
   });
 
-  test("renders one reopen link for a turn that changed a document", () => {
-    const { container } = renderTurn([
-      documentUpdateCall("tc-doc", "surf-notes"),
-    ]);
+  test("renders one reopen link per id its response resolved", () => {
+    const { container } = renderTurn(["surf-notes"]);
 
     const links = reopenLinks(container);
     expect(links.length).toBe(1);
@@ -2312,10 +2319,14 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     );
   });
 
+  test("renders the ids in the order the response resolved them", () => {
+    const { container } = renderTurn(["surf-notes", "surf-plan"]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
+  });
+
   test("places the reopen link after the response body and above the footer", () => {
-    const { container, getByText } = renderTurn([
-      documentUpdateCall("tc-doc", "surf-notes"),
-    ]);
+    const { container, getByText } = renderTurn(["surf-notes"]);
 
     const link = reopenLinks(container)[0]!;
     // A direct child of the message column, so it is a sibling of the
@@ -2338,42 +2349,17 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     ).not.toBe(0);
   });
 
-  test("renders a reopen link for each document a turn changed", () => {
-    const { container } = renderTurn([
-      documentUpdateCall("tc-doc-a", "surf-notes"),
-      documentUpdateCall("tc-doc-b", "surf-plan"),
-    ]);
-
-    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
-  });
-
-  test("collapses repeated edits of one document into a single reopen link", () => {
-    const { container } = renderTurn([
-      documentUpdateCall("tc-doc-a", "surf-notes"),
-      documentUpdateCall("tc-doc-b", "surf-notes"),
-    ]);
-
-    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
-  });
-
-  test("renders no reopen link for a turn that changed no document", () => {
-    const { container } = renderTurn([
-      {
-        id: "tc-read",
-        name: "file_read",
-        input: { path: "/tmp/notes.md" },
-        result: JSON.stringify({ surface_id: "surf-notes" }),
-        completedAt: 1,
-      },
-    ]);
+  test("renders no reopen link for its own document tool calls", () => {
+    // The message writes a document, but the response anchored the link on a
+    // later message. Resolution belongs to the response, not to each message
+    // that wrote.
+    const { container } = renderTurn(undefined);
 
     expect(reopenLinks(container).length).toBe(0);
   });
 
   test("clicking the reopen link opens that document", () => {
-    const { container } = renderTurn([
-      documentUpdateCall("tc-doc", "surf-notes"),
-    ]);
+    const { container } = renderTurn(["surf-notes"]);
 
     fireEvent.click(reopenLinks(container)[0]!);
 
@@ -2381,143 +2367,9 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     expect(onOpenDocumentMock).toHaveBeenCalledWith("surf-notes");
   });
 
-  test("keeps the reopen link when the transcript reseeds from history", () => {
-    const toolCall = documentUpdateCall("tc-doc", "surf-notes");
-    const { container, rerender } = renderTurn([toolCall]);
-    expect(reopenLinks(container).length).toBe(1);
-
-    // A reseed from `/messages` rebuilds the row out of the persisted wire
-    // payload: fresh object identities, none of the live stream state.
-    const reseeded = JSON.parse(
-      JSON.stringify(toolCall),
-    ) as ChatMessageToolCall;
-    rerender(turnElement([reseeded], onOpenDocumentMock));
-
-    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
-  });
-
   test("renders no reopen link without a handler to open the document", () => {
-    const { container } = render(
-      turnElement([documentUpdateCall("tc-doc", "surf-notes")], undefined),
-    );
+    const { container } = render(turnElement(["surf-notes"], undefined));
 
     expect(reopenLinks(container).length).toBe(0);
-  });
-
-  /** A settled `document_create` whose result names the document it opened. */
-  function documentCreateCall(
-    id: string,
-    surfaceId: string,
-  ): ChatMessageToolCall {
-    return {
-      id,
-      name: "document_create",
-      input: { title: "Notes" },
-      result: JSON.stringify({ surface_id: surfaceId, opened: true }),
-      completedAt: 1,
-    };
-  }
-
-  /**
-   * The inline `document_preview` surface `document_create` emits alongside its
-   * result. The card carries its own `preview-` surface id; the document it
-   * opens rides in `data.surfaceId`.
-   */
-  function documentPreviewBlock(surfaceId: string): ConversationContentBlock {
-    return {
-      type: "surface",
-      surface: {
-        surfaceId: `preview-${surfaceId}`,
-        surfaceType: "document_preview",
-        title: "Notes",
-        data: { title: "Notes", surfaceId, subtitle: "Document" },
-      },
-    };
-  }
-
-  /** A turn that runs `toolCalls` and renders `surfaceBlocks` between them. */
-  function surfaceTurn(
-    toolCalls: ChatMessageToolCall[],
-    surfaceBlocks: ConversationContentBlock[],
-  ) {
-    return render(
-      <TranscriptMessageBody
-        message={{
-          id: "m-doc-surface-turn",
-          role: "assistant",
-          contentBlocks: [
-            textBlock("Writing your notes."),
-            ...toolCalls.map(toolUseBlock),
-            ...surfaceBlocks,
-            textBlock("Done."),
-          ],
-          toolCalls,
-          timestamp: 1_000,
-        }}
-        conversationId={DOC_CONVERSATION_ID}
-        assistantId={DOC_ASSISTANT_ID}
-        onOpenDocument={onOpenDocumentMock}
-        onSurfaceAction={noop}
-      />,
-    );
-  }
-
-  test("renders no reopen link for a document its inline preview card already opens", () => {
-    const { container } = surfaceTurn(
-      [documentCreateCall("tc-doc", "surf-notes")],
-      [documentPreviewBlock("surf-notes")],
-    );
-
-    // The card is the turn's only affordance for this document.
-    expect(
-      container.querySelector("[data-surface-id='preview-surf-notes']"),
-    ).not.toBeNull();
-    expect(reopenLinks(container).length).toBe(0);
-  });
-
-  test("renders a reopen link for a created document the turn then edits", () => {
-    const { container } = surfaceTurn(
-      [
-        documentCreateCall("tc-doc-a", "surf-notes"),
-        documentUpdateCall("tc-doc-b", "surf-notes"),
-      ],
-      [documentPreviewBlock("surf-notes")],
-    );
-
-    // The card renders where the create ran, above the writes that followed.
-    expect(
-      container.querySelector("[data-surface-id='preview-surf-notes']"),
-    ).not.toBeNull();
-    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
-  });
-
-  test("renders a reopen link for a changed document no preview card covers", () => {
-    const { container } = surfaceTurn(
-      [
-        documentCreateCall("tc-doc-a", "surf-notes"),
-        documentUpdateCall("tc-doc-b", "surf-plan"),
-      ],
-      [documentPreviewBlock("surf-notes")],
-    );
-
-    expect(reopenSurfaceIds(container)).toEqual(["surf-plan"]);
-  });
-
-  test("keeps the reopen link when a non-preview surface names the same id", () => {
-    const { container } = surfaceTurn(
-      [documentUpdateCall("tc-doc", "surf-notes")],
-      [
-        {
-          type: "surface",
-          surface: {
-            surfaceId: "card-1",
-            surfaceType: "card",
-            data: { surfaceId: "surf-notes" },
-          },
-        },
-      ],
-    );
-
-    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -2475,6 +2475,22 @@ describe("TranscriptMessageBody: changed-document reopen links", () => {
     expect(reopenLinks(container).length).toBe(0);
   });
 
+  test("renders a reopen link for a created document the turn then edits", () => {
+    const { container } = surfaceTurn(
+      [
+        documentCreateCall("tc-doc-a", "surf-notes"),
+        documentUpdateCall("tc-doc-b", "surf-notes"),
+      ],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    // The card renders where the create ran, above the writes that followed.
+    expect(
+      container.querySelector("[data-surface-id='preview-surf-notes']"),
+    ).not.toBeNull();
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
   test("renders a reopen link for a changed document no preview card covers", () => {
     const { container } = surfaceTurn(
       [

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -34,6 +34,34 @@ mock.module(
   }),
 );
 
+// The reopen link names its own document from the documents query and hides
+// itself while that document is open; both are covered by
+// `document-reopen-link.test`. Stub it to a bare button so these tests assert
+// what the transcript owns: which documents a turn anchors, in what order,
+// where in the message the links land, and what the click reaches.
+mock.module("@/domains/chat/transcript/document-reopen-link", () => ({
+  DocumentReopenLink: ({
+    surfaceId,
+    assistantId,
+    conversationId,
+    onOpenDocument,
+  }: {
+    surfaceId: string;
+    assistantId?: string | null;
+    conversationId?: string | null;
+    onOpenDocument: (surfaceId: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="document-reopen-link"
+      data-surface-id={surfaceId}
+      data-assistant-id={assistantId ?? ""}
+      data-conversation-id={conversationId ?? ""}
+      onClick={() => onOpenDocument(surfaceId)}
+    />
+  ),
+}));
+
 // The ACP-run and background-task rows wire their transcript stop button to
 // these standalone actions; stub them so clicking Stop records the call without
 // pulling in the daemon SDK / store wiring.
@@ -2196,5 +2224,284 @@ describe("TranscriptMessageBody — redacted-credential chip version gate", () =
   test("user messages never enable chips, even at the gated version", () => {
     hydrateIdentity(REDACTED_CHIPS_MIN_VERSION);
     expect(chipFlag("user")).toBe("false");
+  });
+});
+
+describe("TranscriptMessageBody: changed-document reopen links", () => {
+  const DOC_ASSISTANT_ID = "asst-doc";
+  const DOC_CONVERSATION_ID = "conv-doc";
+  const onOpenDocumentMock = mock((_surfaceId: string) => {});
+
+  /** A settled `document_update` whose result carries the surface it wrote. */
+  function documentUpdateCall(
+    id: string,
+    surfaceId: string,
+  ): ChatMessageToolCall {
+    return {
+      id,
+      name: "document_update",
+      input: { surface_id: surfaceId, content: "notes" },
+      result: JSON.stringify({ success: true, surface_id: surfaceId }),
+      completedAt: 1,
+    };
+  }
+
+  /**
+   * A turn that narrates, runs `toolCalls`, then answers. The lead-in and the
+   * tool run collapse into "Earlier activity", so any reopen link that renders
+   * has to sit outside that disclosure to still be visible.
+   */
+  function turnElement(
+    toolCalls: ChatMessageToolCall[],
+    onOpenDocument: ((surfaceId: string) => void) | undefined,
+  ) {
+    return (
+      <TranscriptMessageBody
+        message={{
+          id: "m-doc-turn",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Updating your notes."),
+            ...toolCalls.map(toolUseBlock),
+            textBlock("Done."),
+          ],
+          toolCalls,
+          timestamp: 1_000,
+        }}
+        conversationId={DOC_CONVERSATION_ID}
+        assistantId={DOC_ASSISTANT_ID}
+        onOpenDocument={onOpenDocument}
+        onSurfaceAction={noop}
+      />
+    );
+  }
+
+  function renderTurn(toolCalls: ChatMessageToolCall[]) {
+    return render(turnElement(toolCalls, onOpenDocumentMock));
+  }
+
+  function reopenLinks(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+      container.querySelectorAll<HTMLElement>(
+        "[data-testid='document-reopen-link']",
+      ),
+    );
+  }
+
+  function reopenSurfaceIds(container: HTMLElement): (string | null)[] {
+    return reopenLinks(container).map((link) =>
+      link.getAttribute("data-surface-id"),
+    );
+  }
+
+  beforeEach(() => {
+    onOpenDocumentMock.mockClear();
+  });
+
+  test("renders one reopen link for a turn that changed a document", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    const links = reopenLinks(container);
+    expect(links.length).toBe(1);
+    expect(links[0]!.getAttribute("data-surface-id")).toBe("surf-notes");
+    expect(links[0]!.getAttribute("data-assistant-id")).toBe(DOC_ASSISTANT_ID);
+    expect(links[0]!.getAttribute("data-conversation-id")).toBe(
+      DOC_CONVERSATION_ID,
+    );
+  });
+
+  test("places the reopen link after the response body and above the footer", () => {
+    const { container, getByText } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    const link = reopenLinks(container)[0]!;
+    // A direct child of the message column, so it is a sibling of the
+    // "Earlier activity" disclosure rather than something inside it.
+    const column = link.parentElement!;
+    expect(column.parentElement!.getAttribute("data-message-id")).toBe(
+      "m-doc-turn",
+    );
+    expect(
+      screen.getByRole("button", { name: "Earlier activity" }).contains(link),
+    ).toBe(false);
+    expect(
+      getByText("Done.").compareDocumentPosition(link) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+    // The hover-action footer is the column's last row.
+    expect(
+      link.compareDocumentPosition(column.lastElementChild!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
+  test("renders a reopen link for each document a turn changed", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc-a", "surf-notes"),
+      documentUpdateCall("tc-doc-b", "surf-plan"),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
+  });
+
+  test("collapses repeated edits of one document into a single reopen link", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc-a", "surf-notes"),
+      documentUpdateCall("tc-doc-b", "surf-notes"),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("renders no reopen link for a turn that changed no document", () => {
+    const { container } = renderTurn([
+      {
+        id: "tc-read",
+        name: "file_read",
+        input: { path: "/tmp/notes.md" },
+        result: JSON.stringify({ surface_id: "surf-notes" }),
+        completedAt: 1,
+      },
+    ]);
+
+    expect(reopenLinks(container).length).toBe(0);
+  });
+
+  test("clicking the reopen link opens that document", () => {
+    const { container } = renderTurn([
+      documentUpdateCall("tc-doc", "surf-notes"),
+    ]);
+
+    fireEvent.click(reopenLinks(container)[0]!);
+
+    expect(onOpenDocumentMock).toHaveBeenCalledTimes(1);
+    expect(onOpenDocumentMock).toHaveBeenCalledWith("surf-notes");
+  });
+
+  test("keeps the reopen link when the transcript reseeds from history", () => {
+    const toolCall = documentUpdateCall("tc-doc", "surf-notes");
+    const { container, rerender } = renderTurn([toolCall]);
+    expect(reopenLinks(container).length).toBe(1);
+
+    // A reseed from `/messages` rebuilds the row out of the persisted wire
+    // payload: fresh object identities, none of the live stream state.
+    const reseeded = JSON.parse(
+      JSON.stringify(toolCall),
+    ) as ChatMessageToolCall;
+    rerender(turnElement([reseeded], onOpenDocumentMock));
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("renders no reopen link without a handler to open the document", () => {
+    const { container } = render(
+      turnElement([documentUpdateCall("tc-doc", "surf-notes")], undefined),
+    );
+
+    expect(reopenLinks(container).length).toBe(0);
+  });
+
+  /** A settled `document_create` whose result names the document it opened. */
+  function documentCreateCall(
+    id: string,
+    surfaceId: string,
+  ): ChatMessageToolCall {
+    return {
+      id,
+      name: "document_create",
+      input: { title: "Notes" },
+      result: JSON.stringify({ surface_id: surfaceId, opened: true }),
+      completedAt: 1,
+    };
+  }
+
+  /**
+   * The inline `document_preview` surface `document_create` emits alongside its
+   * result. The card carries its own `preview-` surface id; the document it
+   * opens rides in `data.surfaceId`.
+   */
+  function documentPreviewBlock(surfaceId: string): ConversationContentBlock {
+    return {
+      type: "surface",
+      surface: {
+        surfaceId: `preview-${surfaceId}`,
+        surfaceType: "document_preview",
+        title: "Notes",
+        data: { title: "Notes", surfaceId, subtitle: "Document" },
+      },
+    };
+  }
+
+  /** A turn that runs `toolCalls` and renders `surfaceBlocks` between them. */
+  function surfaceTurn(
+    toolCalls: ChatMessageToolCall[],
+    surfaceBlocks: ConversationContentBlock[],
+  ) {
+    return render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-doc-surface-turn",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Writing your notes."),
+            ...toolCalls.map(toolUseBlock),
+            ...surfaceBlocks,
+            textBlock("Done."),
+          ],
+          toolCalls,
+          timestamp: 1_000,
+        }}
+        conversationId={DOC_CONVERSATION_ID}
+        assistantId={DOC_ASSISTANT_ID}
+        onOpenDocument={onOpenDocumentMock}
+        onSurfaceAction={noop}
+      />,
+    );
+  }
+
+  test("renders no reopen link for a document its inline preview card already opens", () => {
+    const { container } = surfaceTurn(
+      [documentCreateCall("tc-doc", "surf-notes")],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    // The card is the turn's only affordance for this document.
+    expect(
+      container.querySelector("[data-surface-id='preview-surf-notes']"),
+    ).not.toBeNull();
+    expect(reopenLinks(container).length).toBe(0);
+  });
+
+  test("renders a reopen link for a changed document no preview card covers", () => {
+    const { container } = surfaceTurn(
+      [
+        documentCreateCall("tc-doc-a", "surf-notes"),
+        documentUpdateCall("tc-doc-b", "surf-plan"),
+      ],
+      [documentPreviewBlock("surf-notes")],
+    );
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-plan"]);
+  });
+
+  test("keeps the reopen link when a non-preview surface names the same id", () => {
+    const { container } = surfaceTurn(
+      [documentUpdateCall("tc-doc", "surf-notes")],
+      [
+        {
+          type: "surface",
+          surface: {
+            surfaceId: "card-1",
+            surfaceType: "card",
+            data: { surfaceId: "surf-notes" },
+          },
+        },
+      ],
+    );
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -78,6 +78,7 @@ import {
   resolveAcpRunIds,
   resolveBackgroundTaskIds,
   resolveChangedDocuments,
+  resolveEditedDocuments,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -379,6 +380,12 @@ export function TranscriptMessageBody({
   // Document surface ids claim in their own namespace. Sharing a Set with the
   // process kinds above would let an unrelated id suppress a reopen link.
   const claimedDocumentIds = new Set<string>();
+  // Resolved before the render pass so a `document_preview` card knows whether
+  // the turn writes to its document past the point where the card renders.
+  const editedDocumentIds = useMemo(
+    () => resolveEditedDocuments(message.toolCalls ?? []),
+    [message.toolCalls],
+  );
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -746,13 +753,19 @@ export function TranscriptMessageBody({
   ): ReactNode => {
     // A `document_preview` card opens its own document, so claim that document
     // before the end-of-message resolution runs and the reopen link would
-    // otherwise repeat the same affordance right beside the card. The preview's
-    // own `surfaceId` is the surface (`preview-<doc id>`); the document it
-    // opens rides in `data.surfaceId`, which is what a document tool call
-    // reports in its result.
+    // otherwise repeat the same affordance right beside the card. A document
+    // the turn also edits is left unclaimed: the card sits where its tool ran,
+    // above the edits, so that turn still ends with a link. The preview's own
+    // `surfaceId` is the surface (`preview-<doc id>`); the document it opens
+    // rides in `data.surfaceId`, which is what a document tool call reports in
+    // its result.
     if (surface.surfaceType === "document_preview") {
       const documentSurfaceId = surface.data?.surfaceId;
-      if (typeof documentSurfaceId === "string" && documentSurfaceId !== "") {
+      if (
+        typeof documentSurfaceId === "string" &&
+        documentSurfaceId !== "" &&
+        !editedDocumentIds.has(documentSurfaceId)
+      ) {
         claimedDocumentIds.add(documentSurfaceId);
       }
     }

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -77,8 +77,6 @@ import {
   acpRunIdForCall,
   resolveAcpRunIds,
   resolveBackgroundTaskIds,
-  resolveChangedDocuments,
-  resolveEditedDocuments,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -141,6 +139,7 @@ export function TranscriptMessageBody({
   onStopSubagent,
   onWorkflowClick,
   onStopWorkflow,
+  changedDocumentIds,
   isStreaming = false,
   isLatestMessage = false,
 }: TranscriptMessageBodyProps) {
@@ -377,15 +376,6 @@ export function TranscriptMessageBody({
   const claimedWorkflowIds = new Set<string>();
   const claimedAcpIds = new Set<string>();
   const claimedBackgroundTaskIds = new Set<string>();
-  // Document surface ids claim in their own namespace. Sharing a Set with the
-  // process kinds above would let an unrelated id suppress a reopen link.
-  const claimedDocumentIds = new Set<string>();
-  // Resolved before the render pass so a `document_preview` card knows whether
-  // the turn writes to its document past the point where the card renders.
-  const editedDocumentIds = useMemo(
-    () => resolveEditedDocuments(message.toolCalls ?? []),
-    [message.toolCalls],
-  );
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -751,24 +741,6 @@ export function TranscriptMessageBody({
     surface: ConversationMessageSurface,
     key: string,
   ): ReactNode => {
-    // A `document_preview` card opens its own document, so claim that document
-    // before the end-of-message resolution runs and the reopen link would
-    // otherwise repeat the same affordance right beside the card. A document
-    // the turn also edits is left unclaimed: the card sits where its tool ran,
-    // above the edits, so that turn still ends with a link. The preview's own
-    // `surfaceId` is the surface (`preview-<doc id>`); the document it opens
-    // rides in `data.surfaceId`, which is what a document tool call reports in
-    // its result.
-    if (surface.surfaceType === "document_preview") {
-      const documentSurfaceId = surface.data?.surfaceId;
-      if (
-        typeof documentSurfaceId === "string" &&
-        documentSurfaceId !== "" &&
-        !editedDocumentIds.has(documentSurfaceId)
-      ) {
-        claimedDocumentIds.add(documentSurfaceId);
-      }
-    }
     return (
       <div key={key} className="w-full">
         <SurfaceRouter
@@ -1134,15 +1106,12 @@ export function TranscriptMessageBody({
         })
       : renderedGroups;
 
-  // Resolved after the group render pass, so every inline affordance has taken
-  // its claims first. Without a handler the link opens nothing, so it does not
-  // render.
+  // Resolved across the whole response by `Transcript` and handed only to the
+  // message that ends it. Without a handler the link opens nothing, so it does
+  // not render.
   const documentReopenLinks =
     isAssistant && onOpenDocument
-      ? resolveChangedDocuments(
-          message.toolCalls ?? [],
-          claimedDocumentIds,
-        ).map((surfaceId) => (
+      ? changedDocumentIds?.map((surfaceId) => (
           <DocumentReopenLink
             key={`document-reopen-${surfaceId}`}
             surfaceId={surfaceId}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -42,6 +42,7 @@ import {
   isSubagentSpawnCall,
 } from "@/domains/chat/transcript/message-content";
 import { AcpConnectAffordance } from "@/domains/chat/transcript/acp-connect-affordance";
+import { DocumentReopenLink } from "@/domains/chat/transcript/document-reopen-link";
 import { hasRenderableAnswer } from "@/domains/chat/answered-question";
 import { AnsweredQuestionCard } from "@/domains/chat/components/answered-question-card";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
@@ -76,6 +77,7 @@ import {
   acpRunIdForCall,
   resolveAcpRunIds,
   resolveBackgroundTaskIds,
+  resolveChangedDocuments,
   resolveSpawnedSubagentIds,
   resolveWorkflowRunIds,
   SlackMessageAttribution,
@@ -374,6 +376,9 @@ export function TranscriptMessageBody({
   const claimedWorkflowIds = new Set<string>();
   const claimedAcpIds = new Set<string>();
   const claimedBackgroundTaskIds = new Set<string>();
+  // Document surface ids claim in their own namespace. Sharing a Set with the
+  // process kinds above would let an unrelated id suppress a reopen link.
+  const claimedDocumentIds = new Set<string>();
   const cardBackedWorkflowRunId = (tc: ChatMessageToolCall): string | null => {
     const rid = workflowRunIdForCall(tc, byToolUseIdWf);
     return rid !== null && cardBackedWorkflowRunIds.has(rid) ? rid : null;
@@ -738,19 +743,33 @@ export function TranscriptMessageBody({
   const renderSurfaceNode = (
     surface: ConversationMessageSurface,
     key: string,
-  ): ReactNode => (
-    <div key={key} className="w-full">
-      <SurfaceRouter
-        surface={wireSurfaceToDisplay(surface)}
-        onAction={onSurfaceAction}
-        onOpenApp={onOpenApp}
-        onOpenDocument={onOpenDocument}
-        assistantId={assistantId}
-        toolCalls={message.toolCalls}
-        onVellumLinkClick={handleVellumLinkClick}
-      />
-    </div>
-  );
+  ): ReactNode => {
+    // A `document_preview` card opens its own document, so claim that document
+    // before the end-of-message resolution runs and the reopen link would
+    // otherwise repeat the same affordance right beside the card. The preview's
+    // own `surfaceId` is the surface (`preview-<doc id>`); the document it
+    // opens rides in `data.surfaceId`, which is what a document tool call
+    // reports in its result.
+    if (surface.surfaceType === "document_preview") {
+      const documentSurfaceId = surface.data?.surfaceId;
+      if (typeof documentSurfaceId === "string" && documentSurfaceId !== "") {
+        claimedDocumentIds.add(documentSurfaceId);
+      }
+    }
+    return (
+      <div key={key} className="w-full">
+        <SurfaceRouter
+          surface={wireSurfaceToDisplay(surface)}
+          onAction={onSurfaceAction}
+          onOpenApp={onOpenApp}
+          onOpenDocument={onOpenDocument}
+          assistantId={assistantId}
+          toolCalls={message.toolCalls}
+          onVellumLinkClick={handleVellumLinkClick}
+        />
+      </div>
+    );
+  };
 
   // Render one `activity` group (a contiguous thinking + tool run) into its
   // combined `MultiActivityGroup`, a lone inline link, or a bare thinking
@@ -1102,6 +1121,25 @@ export function TranscriptMessageBody({
         })
       : renderedGroups;
 
+  // Resolved after the group render pass, so every inline affordance has taken
+  // its claims first. Without a handler the link opens nothing, so it does not
+  // render.
+  const documentReopenLinks =
+    isAssistant && onOpenDocument
+      ? resolveChangedDocuments(
+          message.toolCalls ?? [],
+          claimedDocumentIds,
+        ).map((surfaceId) => (
+          <DocumentReopenLink
+            key={`document-reopen-${surfaceId}`}
+            surfaceId={surfaceId}
+            assistantId={assistantId}
+            conversationId={conversationId}
+            onOpenDocument={onOpenDocument}
+          />
+        ))
+      : null;
+
   return (
     <div
       ref={wrapperRef}
@@ -1128,6 +1166,9 @@ export function TranscriptMessageBody({
             messageId={message.id}
           />
         )}
+        {/* Outside the `AssistantContentDisclosure` collapse, so a turn whose
+            document edit lands in "Earlier activity" still ends with the link. */}
+        {documentReopenLinks}
         {trailer}
       </div>
       {vellumFileModal}

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -86,6 +86,10 @@ export interface TranscriptRowProps {
   onWorkflowClick?: (runId: string) => void;
   /** Callback to abort/stop a running workflow from an inline card. */
   onStopWorkflow?: (runId: string) => void;
+  /** Ids of the documents this message's whole response changed. Set only on
+   *  the message that ends a completed response, so the response closes with
+   *  one reopen link per document (see `resolveResponseDocumentIds`). */
+  changedDocumentIds?: string[];
   /** True when this row belongs to the actively-streaming turn. Forwarded to
    *  `TranscriptMessageBody` so the streaming message's last tool-call group
    *  defaults open. History rows leave it `false`. */
@@ -178,6 +182,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   onStopSubagent,
   onWorkflowClick,
   onStopWorkflow,
+  changedDocumentIds,
   isStreaming,
   isLatestMessage,
 }: TranscriptRowProps) {
@@ -212,6 +217,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           onStopSubagent={onStopSubagent}
           onWorkflowClick={onWorkflowClick}
           onStopWorkflow={onStopWorkflow}
+          changedDocumentIds={changedDocumentIds}
           isStreaming={isStreaming}
           isLatestMessage={isLatestMessage}
         />

--- a/clients/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.test.tsx
@@ -51,16 +51,28 @@ mock.module(
   }),
 );
 
+// The reopen link names its own document from the documents query; that is
+// covered by `document-reopen-link.test`. Stub it to a bare marker so these
+// tests assert what the transcript owns: how many links a response ends with
+// and which message carries them.
+mock.module("@/domains/chat/transcript/document-reopen-link", () => ({
+  DocumentReopenLink: ({ surfaceId }: { surfaceId: string }) => (
+    <span data-testid="document-reopen-link" data-surface-id={surfaceId} />
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Subjects under test — imported AFTER mocks are registered.
 // ---------------------------------------------------------------------------
 
 import { renderToStaticMarkup } from "react-dom/server";
 
+import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 
 import { Transcript } from "@/domains/chat/transcript/transcript";
+import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 function userMessage(id: string, content: string): TranscriptItem {
@@ -456,5 +468,162 @@ describe("Transcript no-anchor → anchor transition preserves avatar DOM identi
     });
     expect(avatarMountCount).toBe(1);
     expect(avatarUnmountCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A response is many messages (thinking, tool runs, document edits, more
+// text), and several of them commonly write the same document. The reopen link
+// belongs to the response, not to each message that wrote: one link per
+// document, on the message that ends the response, once the turn has settled.
+// ---------------------------------------------------------------------------
+describe("Transcript changed-document reopen links", () => {
+  afterEach(() => {
+    cleanup();
+    useTurnStore.setState(INITIAL_TURN_STATE);
+  });
+
+  /** A settled `document_update` whose result carries the surface it wrote. */
+  function updateCall(id: string, surfaceId: string): ChatMessageToolCall {
+    return {
+      id,
+      name: "document_update",
+      input: { surface_id: surfaceId, content: "notes" },
+      result: JSON.stringify({ success: true, surface_id: surfaceId }),
+      completedAt: 1,
+    };
+  }
+
+  function editingMessage(
+    id: string,
+    toolCalls: ChatMessageToolCall[],
+  ): TranscriptItem {
+    const msg: DisplayMessage = {
+      id,
+      role: "assistant",
+      toolCalls,
+      contentBlocks: toolCalls.map((toolCall) => ({
+        type: "tool_use",
+        toolCall,
+      })),
+    };
+    return { kind: "message", key: id, message: msg };
+  }
+
+  function renderTranscript(items: TranscriptItem[]) {
+    return render(
+      <Transcript
+        items={items}
+        conversationId="conv-doc"
+        assistantId="asst-doc"
+        onSurfaceAction={noop}
+        onOpenDocument={noop}
+      />,
+    );
+  }
+
+  function reopenSurfaceIds(container: HTMLElement): (string | null)[] {
+    return Array.from(
+      container.querySelectorAll<HTMLElement>(
+        "[data-testid='document-reopen-link']",
+      ),
+    ).map((link) => link.getAttribute("data-surface-id"));
+  }
+
+  /** The response's three messages, all writing the same document. */
+  const threeEditsOfOneDocument: TranscriptItem[] = [
+    userMessage("u1", "update my notes"),
+    editingMessage("a1", [updateCall("tc-1", "surf-notes")]),
+    editingMessage("a2", [updateCall("tc-2", "surf-notes")]),
+    editingMessage("a3", [updateCall("tc-3", "surf-notes")]),
+  ];
+
+  test("renders exactly one link for a document three messages of the response changed", () => {
+    const { container } = renderTranscript(threeEditsOfOneDocument);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("renders one link per distinct document the response changed", () => {
+    const { container } = renderTranscript([
+      userMessage("u1", "update both"),
+      editingMessage("a1", [updateCall("tc-1", "surf-notes")]),
+      editingMessage("a2", [updateCall("tc-2", "surf-plan")]),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
+  });
+
+  test("puts the link on the final message of the response, not the earlier ones", () => {
+    const { container } = renderTranscript(threeEditsOfOneDocument);
+
+    const link = container.querySelector<HTMLElement>(
+      "[data-testid='document-reopen-link']",
+    )!;
+    expect(
+      link.closest("[data-message-id]")!.getAttribute("data-message-id"),
+    ).toBe("a3");
+  });
+
+  test("renders no link while the response is still streaming", () => {
+    useTurnStore.setState({ phase: "streaming" });
+
+    const { container } = renderTranscript(threeEditsOfOneDocument);
+
+    expect(reopenSurfaceIds(container)).toEqual([]);
+  });
+
+  test("renders no link while the response waits on the user", () => {
+    useTurnStore.setState({ phase: "awaiting_user_input" });
+
+    const { container } = renderTranscript(threeEditsOfOneDocument);
+
+    expect(reopenSurfaceIds(container)).toEqual([]);
+  });
+
+  test("renders the link once the streaming response settles", async () => {
+    useTurnStore.setState({ phase: "streaming" });
+    const { container } = renderTranscript(threeEditsOfOneDocument);
+    expect(reopenSurfaceIds(container)).toEqual([]);
+
+    await act(async () => {
+      useTurnStore.setState({ phase: "idle" });
+    });
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("keeps the link on a completed response reseeded from history", () => {
+    const { container, rerender } = renderTranscript(threeEditsOfOneDocument);
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+
+    // A reseed from `/messages` rebuilds every row out of the persisted wire
+    // payload: fresh object identities, none of the live stream state.
+    const reseeded = JSON.parse(
+      JSON.stringify(threeEditsOfOneDocument),
+    ) as TranscriptItem[];
+    rerender(
+      <Transcript
+        items={reseeded}
+        conversationId="conv-doc"
+        assistantId="asst-doc"
+        onSurfaceAction={noop}
+        onOpenDocument={noop}
+      />,
+    );
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes"]);
+  });
+
+  test("ends each earlier response with its own link", () => {
+    const { container } = renderTranscript([
+      userMessage("u1", "update my notes"),
+      editingMessage("a1", [updateCall("tc-1", "surf-notes")]),
+      editingMessage("a2", [updateCall("tc-2", "surf-notes")]),
+      userMessage("u2", "now the plan"),
+      editingMessage("a3", [updateCall("tc-3", "surf-plan")]),
+    ]);
+
+    expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -10,7 +10,9 @@ import {
 } from "react";
 
 import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn";
+import { resolveResponseDocumentIds } from "@/domains/chat/transcript/resolve-response-documents";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
+import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 
 import { LatestTurnRow } from "@/domains/chat/transcript/latest-turn-row";
 import { PullRefreshSpinner } from "@/domains/chat/transcript/pull-refresh-spinner";
@@ -197,6 +199,18 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       ? -1
       : partition.historyItems.findLastIndex((item) => item.kind === "message");
 
+    // A document a response changed earns one reopen link at the end of that
+    // response, not one per message that wrote to it. Resolved here because
+    // this is where the flat item list is read as turns; the in-flight response
+    // is withheld until the turn settles, `awaiting_user_input` included, so a
+    // paused turn never reads as finished.
+    const turnPhase = useTurnStore.use.phase();
+    const turnActive = isSending(turnPhase);
+    const changedDocumentIdsByKey = useMemo(
+      () => resolveResponseDocumentIds(items, { turnActive }),
+      [items, turnActive],
+    );
+
     useImperativeHandle(
       ref,
       (): TranscriptHandle => ({
@@ -316,6 +330,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
                 <TranscriptRow
                   item={item}
                   {...rowProps}
+                  changedDocumentIds={changedDocumentIdsByKey.get(item.key)}
                   isLatestMessage={i === latestHistoryMessageIndex}
                 />
               </div>
@@ -365,6 +380,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
                   anchorMessage={partition.anchorMessage}
                   responseItems={partition.responseItems}
                   {...rowProps}
+                  changedDocumentIdsByKey={changedDocumentIdsByKey}
                 />
               )}
               {rest.renderAvatar && (

--- a/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
@@ -152,6 +152,66 @@ describe("unseen document changes", () => {
     expect(unseen("conv-1")).toBe(false);
   });
 
+  test("clearing everywhere clears a conversation the reader never opened", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-2", "doc-a");
+      useUnseenDocumentChangesStore.getState().clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-2")).toBe(false);
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
+  });
+
+  test("clearing everywhere clears the surface from every conversation", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-2", "doc-a");
+      store.markDocumentChanged("conv-3", "doc-b");
+      store.clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(unseen("conv-2")).toBe(false);
+    expect(unseen("conv-3")).toBe(true);
+  });
+
+  test("clearing everywhere leaves the conversation's other documents unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearDocumentEverywhere("doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toEqual(new Set(["doc-b"]));
+  });
+
+  test("clearing everywhere for an unmarked surface is a no-op", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    const before = useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocumentEverywhere("doc-b");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      before,
+    );
+    expect(unseen("conv-1")).toBe(true);
+  });
+
   test("a null conversation id is never unseen", () => {
     act(() => {
       useUnseenDocumentChangesStore

--- a/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the unseen-document-changes store.
+ *
+ * Every case asserts the pure predicate and the reactive hook together, since
+ * the point of the pairing is that a badge and the clearing logic can never
+ * disagree about what "unseen" means.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import {
+  hasUnseenChanges,
+  useHasUnseenDocumentChanges,
+  useUnseenDocumentChangesStore,
+} from "@/domains/chat/unseen-document-changes-store";
+
+afterEach(() => {
+  cleanup();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+/** Assert the predicate and the hook agree, and return what they both say. */
+function unseen(conversationId: string | null): boolean {
+  const fromPredicate = hasUnseenChanges(
+    useUnseenDocumentChangesStore.getState(),
+    conversationId,
+  );
+  const { result } = renderHook(() =>
+    useHasUnseenDocumentChanges(conversationId),
+  );
+  expect(result.current).toBe(fromPredicate);
+  return fromPredicate;
+}
+
+describe("unseen document changes", () => {
+  test("starts with nothing unseen", () => {
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("marking a document makes its conversation unseen", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+  });
+
+  test("clearing the marked document clears the conversation", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toBeUndefined();
+  });
+
+  test("clearing one document leaves the other unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(
+      useUnseenDocumentChangesStore.getState().changedDocuments["conv-1"],
+    ).toEqual(new Set(["doc-b"]));
+  });
+
+  test("clearing a document that was never marked is a no-op", () => {
+    const before = useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      before,
+    );
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("conversations are isolated from each other", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(true);
+    expect(unseen("conv-2")).toBe(false);
+  });
+
+  test("clearing one conversation leaves the other unseen", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-2", "doc-b");
+      store.clearConversation("conv-1");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(unseen("conv-2")).toBe(true);
+  });
+
+  test("clearing a conversation clears all of its documents", () => {
+    act(() => {
+      const store = useUnseenDocumentChangesStore.getState();
+      store.markDocumentChanged("conv-1", "doc-a");
+      store.markDocumentChanged("conv-1", "doc-b");
+      store.clearConversation("conv-1");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
+  });
+
+  test("marking the same document twice is idempotent", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    const afterFirst =
+      useUnseenDocumentChangesStore.getState().changedDocuments;
+
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toBe(
+      afterFirst,
+    );
+    expect(unseen("conv-1")).toBe(true);
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearDocument("conv-1", "doc-a");
+    });
+
+    expect(unseen("conv-1")).toBe(false);
+  });
+
+  test("a null conversation id is never unseen", () => {
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+
+    expect(unseen(null)).toBe(false);
+  });
+
+  test("the hook reacts to a mark and a clear while mounted", () => {
+    const { result } = renderHook(() => useHasUnseenDocumentChanges("conv-1"));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged("conv-1", "doc-a");
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useUnseenDocumentChangesStore.getState().clearConversation("conv-1");
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/unseen-document-changes-store.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.ts
@@ -7,6 +7,12 @@
  * Entries are keyed by conversation so a change in a background conversation
  * cannot light the affordance on the conversation currently on screen.
  *
+ * A document is reachable from every conversation it is linked to, and an edit
+ * is recorded against the conversation the assistant made it from, which need
+ * not be the one the reader opens it from. Opening a document therefore clears
+ * it from every conversation, which surface ids being globally unique makes
+ * unambiguous.
+ *
  * Wrapped with `createSelectors` for auto-generated per-field hooks.
  *
  * @see {@link https://zustand.docs.pmnd.rs/}
@@ -29,8 +35,14 @@ export interface UnseenDocumentChangesState {
 export interface UnseenDocumentChangesActions {
   /** Record that a document changed while the user was not looking at it. */
   markDocumentChanged: (conversationId: string, surfaceId: string) => void;
-  /** Clear one document, for "the user opened that document". */
+  /** Clear one document within one conversation. */
   clearDocument: (conversationId: string, surfaceId: string) => void;
+  /**
+   * Clear one document from every conversation, for "the user opened that
+   * document". The reader may have opened it from a conversation other than
+   * the one the edit was recorded against.
+   */
+  clearDocumentEverywhere: (surfaceId: string) => void;
   /** Clear a whole conversation, for "the user opened the assets sheet". */
   clearConversation: (conversationId: string) => void;
 }
@@ -69,6 +81,31 @@ const useUnseenDocumentChangesStoreBase = create<UnseenDocumentChangesStore>()(
           delete changedDocuments[conversationId];
         } else {
           changedDocuments[conversationId] = next;
+        }
+        return { changedDocuments };
+      });
+    },
+
+    clearDocumentEverywhere: (surfaceId) => {
+      set((s) => {
+        const changedDocuments: Record<string, ReadonlySet<string>> = {};
+        let found = false;
+        for (const [conversationId, surfaces] of Object.entries(
+          s.changedDocuments,
+        )) {
+          if (!surfaces.has(surfaceId)) {
+            changedDocuments[conversationId] = surfaces;
+            continue;
+          }
+          found = true;
+          const next = new Set(surfaces);
+          next.delete(surfaceId);
+          if (next.size > 0) {
+            changedDocuments[conversationId] = next;
+          }
+        }
+        if (!found) {
+          return s;
         }
         return { changedDocuments };
       });

--- a/clients/web/src/domains/chat/unseen-document-changes-store.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Documents the assistant changed since the user last looked at them.
+ *
+ * Session-ephemeral: the flag lives only for the life of the tab, so a reload
+ * starts clean. There is no server-side "unseen" record to reconcile against.
+ *
+ * Entries are keyed by conversation so a change in a background conversation
+ * cannot light the affordance on the conversation currently on screen.
+ *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+export interface UnseenDocumentChangesState {
+  /**
+   * Conversation id to the surface ids of its documents with unseen changes.
+   *
+   * A conversation with nothing unseen carries no entry at all, so an empty
+   * set is never left behind for a predicate to have to interpret.
+   */
+  changedDocuments: Record<string, ReadonlySet<string>>;
+}
+
+export interface UnseenDocumentChangesActions {
+  /** Record that a document changed while the user was not looking at it. */
+  markDocumentChanged: (conversationId: string, surfaceId: string) => void;
+  /** Clear one document, for "the user opened that document". */
+  clearDocument: (conversationId: string, surfaceId: string) => void;
+  /** Clear a whole conversation, for "the user opened the assets sheet". */
+  clearConversation: (conversationId: string) => void;
+}
+
+export type UnseenDocumentChangesStore = UnseenDocumentChangesState &
+  UnseenDocumentChangesActions;
+
+const useUnseenDocumentChangesStoreBase = create<UnseenDocumentChangesStore>()(
+  (set) => ({
+    changedDocuments: {},
+
+    markDocumentChanged: (conversationId, surfaceId) => {
+      set((s) => {
+        const current = s.changedDocuments[conversationId];
+        if (current?.has(surfaceId)) {
+          return s;
+        }
+        const next = new Set(current);
+        next.add(surfaceId);
+        return {
+          changedDocuments: { ...s.changedDocuments, [conversationId]: next },
+        };
+      });
+    },
+
+    clearDocument: (conversationId, surfaceId) => {
+      set((s) => {
+        const current = s.changedDocuments[conversationId];
+        if (!current?.has(surfaceId)) {
+          return s;
+        }
+        const next = new Set(current);
+        next.delete(surfaceId);
+        const changedDocuments = { ...s.changedDocuments };
+        if (next.size === 0) {
+          delete changedDocuments[conversationId];
+        } else {
+          changedDocuments[conversationId] = next;
+        }
+        return { changedDocuments };
+      });
+    },
+
+    clearConversation: (conversationId) => {
+      set((s) => {
+        if (s.changedDocuments[conversationId] === undefined) {
+          return s;
+        }
+        const changedDocuments = { ...s.changedDocuments };
+        delete changedDocuments[conversationId];
+        return { changedDocuments };
+      });
+    },
+  }),
+);
+
+export const useUnseenDocumentChangesStore = createSelectors(
+  useUnseenDocumentChangesStoreBase,
+);
+
+/**
+ * Whether a conversation has any document changed since the user last looked.
+ *
+ * Pure predicate so the reactive affordance and the imperative clearing paths
+ * can never disagree about what "unseen" means. Takes the store state, so an
+ * event handler can pass `useUnseenDocumentChangesStore.getState()` directly.
+ */
+export function hasUnseenChanges(
+  state: UnseenDocumentChangesState,
+  conversationId: string | null,
+): boolean {
+  if (conversationId === null) {
+    return false;
+  }
+  return (state.changedDocuments[conversationId]?.size ?? 0) > 0;
+}
+
+/**
+ * Reactive form of {@link hasUnseenChanges}, composed over the atomic selector
+ * so a consumer only re-renders when the unseen map changes.
+ */
+export function useHasUnseenDocumentChanges(
+  conversationId: string | null,
+): boolean {
+  const changedDocuments = useUnseenDocumentChangesStore.use.changedDocuments();
+  return hasUnseenChanges({ changedDocuments }, conversationId);
+}

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -9,6 +9,7 @@ import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memo
 import {
   appsGetQueryKey,
   configGetQueryKey,
+  documentsGetQueryKey,
   homeFeedGetQueryKey,
   homeStateGetQueryKey,
   inferenceProfilesGetQueryKey,
@@ -39,6 +40,35 @@ function freshQueryClient(): QueryClient {
     defaultOptions: { queries: { retry: false } },
   });
 }
+
+type QueryPredicate = (query: { queryKey: readonly unknown[] }) => boolean;
+
+/**
+ * Swaps `invalidateQueries` for a capture that records every predicate handed
+ * to it, so a test can ask which query keys the hook claimed.
+ */
+function capturePredicates(queryClient: QueryClient): QueryPredicate[] {
+  const predicates: QueryPredicate[] = [];
+  queryClient.invalidateQueries = ((arg: unknown) => {
+    const predicate = (arg as { predicate?: QueryPredicate }).predicate;
+    if (predicate) {
+      predicates.push(predicate);
+    }
+    return Promise.resolve();
+  }) as never;
+  return predicates;
+}
+
+/** The shape `domains/library/use-library-data.ts` reads documents under. */
+const LIBRARY_DOCUMENTS_KEY = documentsGetQueryKey({
+  path: { assistant_id: "asst-1" },
+});
+
+/** The shape `domains/chat/components/conversation-assets-pill.tsx` reads under. */
+const CONVERSATION_DOCUMENTS_KEY = documentsGetQueryKey({
+  path: { assistant_id: "asst-1" },
+  query: { conversationId: "convo-1" },
+});
 
 function syncEvent(tags: string[]): SyncChangedEvent {
   return { type: "sync_changed", tags };
@@ -296,6 +326,46 @@ describe("useAssistantResourceSync", () => {
       }),
     ).toBe(true);
     expect(predicate!({ queryKey: avatarQueryKey("asst-1") })).toBe(false);
+  });
+
+  // The Library keys the documents read by assistant alone while the
+  // conversation assets pill adds `query.conversationId`. Covering only the
+  // conversation-scoped key leaves the Library serving a pre-edit list.
+  test("invalidates both documents key shapes on documents:list sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const predicates = capturePredicates(queryClient);
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit(syncEvent([SYNC_TAGS.documentsList]) as unknown as AssistantEvent);
+
+    const claims = (queryKey: readonly unknown[]) =>
+      predicates.some((p) => p({ queryKey }));
+    await waitFor(() => {
+      expect(claims(LIBRARY_DOCUMENTS_KEY)).toBe(true);
+    });
+    expect(claims(CONVERSATION_DOCUMENTS_KEY)).toBe(true);
+    expect(claims(appsGetQueryKey({ path: { assistant_id: "asst-1" } }))).toBe(
+      false,
+    );
+  });
+
+  test("reconciles both documents key shapes on non-fresh sse.opened reconnect", async () => {
+    const queryClient = freshQueryClient();
+    const predicates = capturePredicates(queryClient);
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+
+    const claims = (queryKey: readonly unknown[]) =>
+      predicates.some((p) => p({ queryKey }));
+    await waitFor(() => {
+      expect(claims(LIBRARY_DOCUMENTS_KEY)).toBe(true);
+    });
+    expect(claims(CONVERSATION_DOCUMENTS_KEY)).toBe(true);
   });
 
   test("invalidates plugin list / catalog / open-detail queries on plugins:list sync tag", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -2,7 +2,7 @@
  * Bus consumer for assistant-level resource cache invalidation.
  *
  * Routes `sync_changed` tags (avatar, identity, config, sounds, schedules,
- * apps, plugins) and discrete SSE events (`home_feed_updated`,
+ * apps, documents, plugins) and discrete SSE events (`home_feed_updated`,
  * `relationship_state_updated`, `identity_changed`, `avatar_updated`) into
  * TanStack Query cache invalidations.
  *
@@ -133,6 +133,15 @@ export function useAssistantResourceSync(
                   isGeneratedQueryKey(query.queryKey, "appsGet"),
               });
               break;
+            case SYNC_TAGS.documentsList:
+              // The assets pill keys by `query.conversationId` and the Library
+              // by the assistant path alone, so match on the operation id to
+              // cover both key shapes.
+              void queryClient.invalidateQueries({
+                predicate: (query) =>
+                  isGeneratedQueryKey(query.queryKey, "documentsGet"),
+              });
+              break;
             case SYNC_TAGS.pluginsList:
               invalidatePluginQueries(queryClient, assistantId);
               break;
@@ -215,6 +224,9 @@ export function useAssistantResourceSync(
     });
     void queryClient.invalidateQueries({
       predicate: (query) => isGeneratedQueryKey(query.queryKey, "appsGet"),
+    });
+    void queryClient.invalidateQueries({
+      predicate: (query) => isGeneratedQueryKey(query.queryKey, "documentsGet"),
     });
     invalidatePluginQueries(queryClient, assistantId);
     void queryClient.invalidateQueries({

--- a/clients/web/src/hooks/use-document-editor-sync.test.tsx
+++ b/clients/web/src/hooks/use-document-editor-sync.test.tsx
@@ -8,8 +8,8 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router";
+import { useEffect, type ReactNode } from "react";
+import { MemoryRouter, useNavigate, type NavigateFunction } from "react-router";
 
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
@@ -17,12 +17,33 @@ import { __resetForTesting, publish } from "@/lib/event-bus";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
+/** Drives the router from a test, since `MemoryRouter` ignores entry changes. */
+let navigate: NavigateFunction | null = null;
+
+function NavigationProbe() {
+  const navigateFn = useNavigate();
+  useEffect(() => {
+    navigate = navigateFn;
+  }, [navigateFn]);
+  return null;
+}
+
 /** Mount the hook on `pathname`, defaulting to the conversation chat route. */
 function renderSyncAt(pathname: string = routes.conversation("conv-1")) {
   return renderHook(() => useDocumentEditorSync(), {
     wrapper: ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={[pathname]}>{children}</MemoryRouter>
+      <MemoryRouter initialEntries={[pathname]}>
+        <NavigationProbe />
+        {children}
+      </MemoryRouter>
     ),
+  });
+}
+
+/** Navigate the mounted router, the way a click in the sidebar would. */
+function navigateTo(pathname: string) {
+  act(() => {
+    navigate?.(pathname);
   });
 }
 
@@ -66,6 +87,7 @@ function unseenFor(conversationId: string): string[] {
 
 beforeEach(() => {
   __resetForTesting();
+  navigate = null;
   useViewerStore.getState().reset();
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
@@ -137,6 +159,49 @@ describe("useDocumentEditorSync", () => {
     renderSyncAt(routes.document("surf-1"));
 
     publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("clears the record when the user returns to chat with the document open", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("returning to chat clears a record made from another conversation", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ conversationId: "conv-2", surfaceId: "surf-1" });
+    expect(unseenFor("conv-2")).toEqual(["surf-1"]);
+
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
+  test("returning to chat leaves a document other than the open one unseen", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-2" });
+    navigateTo(routes.conversation("conv-1"));
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("returning to chat with no document open clears nothing", () => {
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+    navigateTo(routes.conversation("conv-1"));
 
     expect(unseenFor("conv-1")).toEqual(["surf-1"]);
   });

--- a/clients/web/src/hooks/use-document-editor-sync.test.tsx
+++ b/clients/web/src/hooks/use-document-editor-sync.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * `useDocumentEditorSync` applies a streamed document edit to the viewer and
+ * records the change as unseen unless the user is watching that very document.
+ *
+ * "Watching" is the route as well as the viewer store, so these render the
+ * hook under a router positioned on the route being exercised.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
+import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
+import { __resetForTesting, publish } from "@/lib/event-bus";
+import { useViewerStore } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
+
+/** Mount the hook on `pathname`, defaulting to the conversation chat route. */
+function renderSyncAt(pathname: string = routes.conversation("conv-1")) {
+  return renderHook(() => useDocumentEditorSync(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={[pathname]}>{children}</MemoryRouter>
+    ),
+  });
+}
+
+function publishDocumentEdit(options: {
+  conversationId?: string;
+  surfaceId: string;
+  markdown?: string;
+}) {
+  act(() => {
+    publish("sse.event", {
+      id: "evt-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: "document_editor_update",
+        conversationId: options.conversationId ?? "conv-1",
+        surfaceId: options.surfaceId,
+        markdown: options.markdown ?? "# Edited",
+        mode: "replace",
+      },
+    });
+  });
+}
+
+/** Put the in-chat viewer on `surfaceId`, the way `loadDocument` leaves it. */
+function openInViewer(surfaceId: string) {
+  useViewerStore.getState().openDocument();
+  useViewerStore.getState().setLoadedDocument({
+    source: "document",
+    surfaceId,
+    conversationId: "conv-1",
+    documentName: "Notes",
+    content: "# Notes",
+  });
+}
+
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
+beforeEach(() => {
+  __resetForTesting();
+  useViewerStore.getState().reset();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetForTesting();
+});
+
+describe("useDocumentEditorSync", () => {
+  test("records an unseen change when the document is not open", () => {
+    renderSyncAt();
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("records nothing when that document is the one on screen", () => {
+    openInViewer("surf-1");
+    renderSyncAt();
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  test("records an unseen change when a different document is on screen", () => {
+    openInViewer("surf-1");
+    renderSyncAt();
+
+    publishDocumentEdit({ surfaceId: "surf-2" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  test("records against the conversation the edit came from", () => {
+    renderSyncAt();
+
+    publishDocumentEdit({ conversationId: "conv-2", surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual([]);
+    expect(unseenFor("conv-2")).toEqual(["surf-1"]);
+  });
+
+  test("applies the streamed content to the open document", () => {
+    openInViewer("surf-1");
+    renderSyncAt();
+
+    publishDocumentEdit({ surfaceId: "surf-1", markdown: "# Rewritten" });
+
+    expect(useViewerStore.getState().openedDocumentState).toMatchObject({
+      surfaceId: "surf-1",
+      content: "# Rewritten",
+    });
+  });
+
+  test("records an unseen change when the drawer is open but the route is not chat", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.library.root);
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("records an unseen change on the standalone document route", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.document("surf-1"));
+
+    publishDocumentEdit({ surfaceId: "surf-1" });
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+
+  test("still applies the streamed content off the chat route", () => {
+    openInViewer("surf-1");
+    renderSyncAt(routes.settings.general);
+
+    publishDocumentEdit({ surfaceId: "surf-1", markdown: "# Rewritten" });
+
+    expect(useViewerStore.getState().openedDocumentState).toMatchObject({
+      surfaceId: "surf-1",
+      content: "# Rewritten",
+    });
+  });
+});

--- a/clients/web/src/hooks/use-document-editor-sync.ts
+++ b/clients/web/src/hooks/use-document-editor-sync.ts
@@ -5,13 +5,37 @@
  * The daemon sends incremental markdown content (append or replace
  * mode) as the assistant edits a document surface.
  *
+ * The same event is also the only signal that a document changed at all, so an
+ * edit that lands while the user is not looking at that document is recorded
+ * as unseen here. An edit to the document already on screen is not: the user
+ * is watching it happen.
+ *
+ * "On screen" is the route as well as the viewer store. The store keeps
+ * `mainView === "document"` and its opened document while the user is away on
+ * Library or Settings, but both surfaces that render a document beside the
+ * chat (the desktop drawer in `chat-content-layout.tsx` and the mobile
+ * overlay in `mobile-chat-overlays.tsx`) mount under `ActiveChatView`, which
+ * only the conversation chat route renders. Off that route the document is
+ * not visible, so its edit is unseen.
+ *
+ * The standalone `/assistant/documents/:surfaceId` route is not a live surface
+ * either: it renders the content it fetched on mount and never applies these
+ * updates, so an edit arriving while it is open is unseen there too. That page
+ * clears its own record when the user next loads it.
+ *
  * References:
- * - EVENT_BUS.md — bus subscription contract
- * - stores/viewer-store.ts — document editor state
+ * - EVENT_BUS.md: bus subscription contract
+ * - stores/viewer-store.ts: document editor state
+ * - domains/chat/unseen-document-changes-store.ts: unseen-change records
  */
 
+import { useLocation } from "react-router";
+
+import { isDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useViewerStore } from "@/stores/viewer-store";
+import { isConversationChatPath } from "@/utils/routes";
 
 /**
  * Subscribes to `document_editor_update` SSE events via the event bus
@@ -21,13 +45,27 @@ import { useViewerStore } from "@/stores/viewer-store";
  * store is global and document surface ids are globally unique.
  */
 export function useDocumentEditorSync(): void {
+  const location = useLocation();
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "document_editor_update") {
       return;
     }
-    useViewerStore
+    // An event handler, so the viewer is read rather than subscribed to.
+    const viewer = useViewerStore.getState();
+    const watchingLive =
+      isConversationChatPath(location.pathname) &&
+      isDocumentOpen(
+        viewer.mainView,
+        viewer.openedDocumentState,
+        event.surfaceId,
+      );
+    viewer.updateDocumentContent(event.surfaceId, event.markdown, event.mode);
+    if (watchingLive) {
+      return;
+    }
+    useUnseenDocumentChangesStore
       .getState()
-      .updateDocumentContent(event.surfaceId, event.markdown, event.mode);
+      .markDocumentChanged(event.conversationId, event.surfaceId);
   });
 }

--- a/clients/web/src/hooks/use-document-editor-sync.ts
+++ b/clients/web/src/hooks/use-document-editor-sync.ts
@@ -23,15 +23,23 @@
  * updates, so an edit arriving while it is open is unseen there too. That page
  * clears its own record when the user next loads it.
  *
+ * Returning to the chat route puts a still-open document back on screen with
+ * no load of its own to clear the record it collected while away, so that
+ * clearing happens here too.
+ *
  * References:
  * - EVENT_BUS.md: bus subscription contract
  * - stores/viewer-store.ts: document editor state
  * - domains/chat/unseen-document-changes-store.ts: unseen-change records
  */
 
+import { useEffect } from "react";
 import { useLocation } from "react-router";
 
-import { isDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
+import {
+  isDocumentOpen,
+  openedDocumentSurfaceId,
+} from "@/domains/chat/components/local-file/open-local-file";
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -46,6 +54,23 @@ import { isConversationChatPath } from "@/utils/routes";
  */
 export function useDocumentEditorSync(): void {
   const location = useLocation();
+  const chatVisible = isConversationChatPath(location.pathname);
+
+  useEffect(() => {
+    if (!chatVisible) {
+      return;
+    }
+    const viewer = useViewerStore.getState();
+    const surfaceId = openedDocumentSurfaceId(
+      viewer.mainView,
+      viewer.openedDocumentState,
+    );
+    if (surfaceId === null) {
+      return;
+    }
+    useUnseenDocumentChangesStore.getState().clearDocumentEverywhere(surfaceId);
+  }, [chatVisible]);
+
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "document_editor_update") {
@@ -54,7 +79,7 @@ export function useDocumentEditorSync(): void {
     // An event handler, so the viewer is read rather than subscribed to.
     const viewer = useViewerStore.getState();
     const watchingLive =
-      isConversationChatPath(location.pathname) &&
+      chatVisible &&
       isDocumentOpen(
         viewer.mainView,
         viewer.openedDocumentState,

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -185,6 +185,28 @@ body {
   border-radius: var(--radius-lg);
 }
 
+/* Unseen-changes dot attention pulse, applied when the dot appears so a
+ * change landing while the user reads the transcript is noticeable. Bounded
+ * on purpose: this dot lives in a persistent header, where anything looping
+ * forever reads as noise. It needs no fill mode because the last keyframe is
+ * already the resting style. The consumer also holds it static via
+ * useReducedMotion; the media query is defense-in-depth for callers that
+ * don't. */
+@keyframes unseen-dot-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.35); }
+}
+
+.unseen-dot-pulse {
+  animation: unseen-dot-pulse 0.6s ease-in-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .unseen-dot-pulse {
+    animation: none;
+  }
+}
+
 /* Streamed word fade — applied by `rehypeStreamWordFade` to each word of the
  * actively-streaming assistant message's trailing text. The plugin grades the
  * words nearest the reveal edge with inline opacities; this transition is

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -6,6 +6,7 @@ export const SYNC_TAGS = {
   assistantSchedules: "assistant:self:schedules",
   assistantTheme: "assistant:self:theme",
   appsList: "apps:list",
+  documentsList: "documents:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",
   featureFlagsClient: "feature-flags:client",

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -1107,6 +1107,20 @@ describe("loadDocument", () => {
     expect(unseenFor("conv-1")).toEqual(["surf-2"]);
   });
 
+  it("clears a change recorded against a conversation other than the document's", async () => {
+    // The daemon records the edit against the conversation the tool ran in,
+    // while the document row keeps the conversation that created it.
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-1");
+    documentResult = () =>
+      Promise.resolve({ data: documentSurface({ conversationId: "conv-1" }) });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-2")).toEqual([]);
+  });
+
   it("keeps the unseen change when the open fails", async () => {
     useUnseenDocumentChangesStore
       .getState()
@@ -1188,6 +1202,24 @@ describe("loadWorkspaceFileDocument", () => {
     );
 
     expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  it("clears a change recorded against a conversation other than the document's", async () => {
+    // Opening the file from another conversation still answers with the
+    // conversation that created the document.
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-2", "surf-file");
+    fileDocumentResult = () =>
+      Promise.resolve({ data: fileDocument({ conversationId: "conv-1" }) });
+
+    await getState().loadWorkspaceFileDocument(
+      "asst-1",
+      "drafts/notes.md",
+      "conv-2",
+    );
+
+    expect(unseenFor("conv-2")).toEqual([]);
   });
 
   it("names an untitled document rather than showing an empty navbar", async () => {

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -5,9 +5,13 @@ import type {
   MessageFilesPayload,
   ToolDetailPayload,
 } from "@/stores/viewer-store";
-import type { DocumentsForworkspacefilePostResponse } from "@/generated/daemon/types.gen";
+import type {
+  DocumentsByIdGetResponse,
+  DocumentsForworkspacefilePostResponse,
+} from "@/generated/daemon/types.gen";
 import { ApiError } from "@/utils/api-errors";
 import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 
 // The store opens file-backed documents through the daemon SDK. Spread the
 // real module so the actions this file does not exercise keep their real
@@ -18,12 +22,20 @@ type FileDocumentResult = {
   data: DocumentsForworkspacefilePostResponse | null;
 };
 
+type DocumentResult = {
+  data: DocumentsByIdGetResponse | null;
+};
+
 let fileDocumentResult: () => Promise<FileDocumentResult> = () =>
   Promise.reject(new Error("not stubbed"));
 const fileDocumentCalls: unknown[] = [];
 
+let documentResult: () => Promise<DocumentResult> = () =>
+  Promise.reject(new Error("not stubbed"));
+
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...daemonSdk,
+  documentsByIdGet: () => documentResult(),
   documentsForworkspacefilePost: (options: unknown) => {
     fileDocumentCalls.push(options);
     return fileDocumentResult();
@@ -54,11 +66,19 @@ function getState() {
   return useViewerStore.getState();
 }
 
+/** The surface ids a conversation currently holds unseen changes for. */
+function unseenFor(conversationId: string): string[] {
+  const changed =
+    useUnseenDocumentChangesStore.getState().changedDocuments[conversationId];
+  return [...(changed ?? [])];
+}
+
 beforeEach(() => {
   getState().reset();
   fileDocumentCalls.length = 0;
   toastError.mockClear();
   openWorkspaceFile.mockClear();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
 
 const SAMPLE_APP = {
@@ -1042,6 +1062,64 @@ describe("openWorkspaceFilePreview", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Document viewer: document surfaces
+// ---------------------------------------------------------------------------
+
+/** The daemon's answer for a document surface fetched by id. */
+function documentSurface(
+  overrides: Partial<DocumentsByIdGetResponse> = {},
+): DocumentsByIdGetResponse {
+  return {
+    success: true,
+    surfaceId: "surf-1",
+    conversationId: "conv-1",
+    title: "Notes",
+    content: "# Notes",
+    wordCount: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    workspacePath: null,
+    ...overrides,
+  };
+}
+
+describe("loadDocument", () => {
+  it("clears the unseen change for the document it opened", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(getState().mainView).toBe("document");
+    expect(unseenFor("conv-1")).toEqual([]);
+  });
+
+  it("leaves the conversation's other unseen documents alone", async () => {
+    const unseen = useUnseenDocumentChangesStore.getState();
+    unseen.markDocumentChanged("conv-1", "surf-1");
+    unseen.markDocumentChanged("conv-1", "surf-2");
+    documentResult = () => Promise.resolve({ data: documentSurface() });
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-2"]);
+  });
+
+  it("keeps the unseen change when the open fails", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-1");
+    documentResult = () => Promise.reject(new ApiError(404, "Not found"));
+
+    await getState().loadDocument("asst-1", "surf-1");
+
+    expect(unseenFor("conv-1")).toEqual(["surf-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Document viewer: workspace files
 // ---------------------------------------------------------------------------
 
@@ -1095,6 +1173,21 @@ describe("loadWorkspaceFileDocument", () => {
       body: { path: "drafts/notes.md", conversationId: "conv-1" },
     });
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("clears the unseen change for the document it opened", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged("conv-1", "surf-file");
+    fileDocumentResult = () => Promise.resolve({ data: fileDocument() });
+
+    await getState().loadWorkspaceFileDocument(
+      "asst-1",
+      "drafts/notes.md",
+      "conv-1",
+    );
+
+    expect(unseenFor("conv-1")).toEqual([]);
   });
 
   it("names an untitled document rather than showing an empty navbar", async () => {

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -1242,18 +1242,6 @@ describe("loadWorkspaceFileDocument", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Assets
-// ---------------------------------------------------------------------------
-
-describe("refreshAssets", () => {
-  it("increments the refresh key", () => {
-    useViewerStore.setState({ assetsRefreshKey: 5 });
-    getState().refreshAssets();
-    expect(getState().assetsRefreshKey).toBe(6);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Reset
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -12,7 +12,6 @@
  *   read-only preview of a workspace file the editor cannot round-trip
  * - `isAppMinimized` — mobile-only: app viewer minimized
  * - `intelligenceTab` — sub-tab inside the intelligence panel
- * - `assetsRefreshKey` — counter bumped to force asset re-fetches
  * - `viewBeforeDocument` / `viewBeforeSubagentDetail` / `viewBeforeToolDetail` / `viewBeforeWorkflowDetail` / `viewBeforeAcpRunDetail` — previous view for restoration
  * - `activeSubagentId` — subagent detail panel
  * - `activeToolDetail` — tool-call detail drawer payload
@@ -491,7 +490,6 @@ export interface ViewerState {
   openedDocumentState: OpenedDocumentState | null;
   isAppMinimized: boolean;
   intelligenceTab: IntelligenceTab;
-  assetsRefreshKey: number;
   viewBeforeDocument: Exclude<MainView, OverlayView>;
   activeSubagentId: string | null;
   viewBeforeSubagentDetail: Exclude<MainView, OverlayView>;
@@ -664,9 +662,6 @@ export interface ViewerActions {
   handleDocumentLoadFailed: () => void;
   closeDocument: () => void;
 
-  // --- Assets ---
-  refreshAssets: () => void;
-
   // --- Reset ---
   reset: () => void;
 }
@@ -685,7 +680,6 @@ const INITIAL_STATE: ViewerState = {
   openedDocumentState: null,
   isAppMinimized: false,
   intelligenceTab: "identity",
-  assetsRefreshKey: 0,
   viewBeforeDocument: "chat",
   activeSubagentId: null,
   viewBeforeSubagentDetail: "chat",
@@ -1298,12 +1292,6 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeDocumentTarget: null,
       openedDocumentState: null,
     });
-  },
-
-  // --- Assets ---
-
-  refreshAssets: () => {
-    set({ assetsRefreshKey: get().assetsRefreshKey + 1 });
   },
 
   // --- Reset ---

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -46,6 +46,7 @@ import { ApiError } from "@/utils/api-errors";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { workspaceBasenameOf } from "@/domains/chat/utils/workspace-path-links";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import { createSelectors } from "@/utils/create-selectors";
@@ -1170,6 +1171,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
           workspacePath: result.workspacePath,
         },
       });
+      useUnseenDocumentChangesStore
+        .getState()
+        .clearDocument(result.conversationId, result.surfaceId);
     } catch {
       if (!sameDocumentTarget(get().activeDocumentTarget, target)) {
         return;
@@ -1244,6 +1248,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
           workspacePath: result.workspacePath,
         },
       });
+      useUnseenDocumentChangesStore
+        .getState()
+        .clearDocument(result.conversationId, result.surfaceId);
     } catch (err) {
       giveUp(err);
     }

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -1173,7 +1173,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       });
       useUnseenDocumentChangesStore
         .getState()
-        .clearDocument(result.conversationId, result.surfaceId);
+        .clearDocumentEverywhere(result.surfaceId);
     } catch {
       if (!sameDocumentTarget(get().activeDocumentTarget, target)) {
         return;
@@ -1250,7 +1250,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       });
       useUnseenDocumentChangesStore
         .getState()
-        .clearDocument(result.conversationId, result.surfaceId);
+        .clearDocumentEverywhere(result.surfaceId);
     } catch (err) {
       giveUp(err);
     }

--- a/clients/web/src/utils/sandbox-sync-filter.test.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.test.ts
@@ -23,6 +23,7 @@ describe("forwardableSyncTags", () => {
       "conversation:conv-1:messages",
       "conversations:list",
       "apps:list",
+      "documents:list",
       "plugins:list",
       "feature-flags:client",
     ];
@@ -37,6 +38,15 @@ describe("forwardableSyncTags", () => {
       forwardableSyncTags(
         ["show:state", "apps:list"],
         ["show:state", "apps:list"],
+      ),
+    ).toEqual(["show:state"]);
+  });
+
+  test("drops the documents list tag while keeping a custom tag alongside it", () => {
+    expect(
+      forwardableSyncTags(
+        ["show:state", "documents:list"],
+        ["show:state", "documents:list"],
       ),
     ).toEqual(["show:state"]);
   });

--- a/clients/web/src/utils/sandbox-sync-filter.ts
+++ b/clients/web/src/utils/sandbox-sync-filter.ts
@@ -5,10 +5,10 @@
  * A sandboxed app may only receive `sync_changed` invalidations for the tags
  * it explicitly subscribed to, and never for the host's reserved sync
  * namespaces — forwarding those would leak host activity (conversation
- * traffic, config/theme/schedule changes, the apps/plugins lists) into
- * untrusted app code. Custom tags an app's own routes emit pass through, so an
- * app can drive live refreshes off its own `publishSyncInvalidation` without
- * polling.
+ * traffic, config/theme/schedule changes, the apps/documents/plugins lists)
+ * into untrusted app code. Custom tags an app's own routes emit pass through,
+ * so an app can drive live refreshes off its own `publishSyncInvalidation`
+ * without polling.
  *
  * `sync_changed` carries no payload — only which resource went stale — and the
  * authenticated fetch proxy remains the real access gate; this filter is
@@ -21,6 +21,7 @@ export const RESERVED_SYNC_TAG_PREFIXES = [
   "conversation:",
   "conversations:",
   "apps:",
+  "documents:",
   "plugins:",
   "feature-flags:",
 ] as const;


### PR DESCRIPTION
## Summary

When the assistant edits a document while the editor is closed, the user currently gets no signal at all. `document_update` and `document_replace_text` emit only `document_editor_update`, which is a no-op in the chat handler and otherwise writes straight into the viewer store, so it does nothing unless that exact document is already open.

This adds the missing documents change channel and two affordances on top of it:

- **A dot on the Layers assets icon** when a conversation has document changes the user has not seen, with a brief bounded pulse (reduced-motion aware). Clears when the document or the assets sheet is opened.
- **A reopen link at the end of an assistant response** for each document that turn changed, derived from persisted tool results so it survives a page reload.

Supporting work: a `documents:list` sync tag, daemon broadcasts on every document mutation (including `document_delete`, which previously emitted nothing and left ghost rows), and web-side query invalidation covering all three documents query-key shapes.

## Self-review result

GAPS FOUND, then fixed. Four fresh-eyes review passes plus a regression re-review produced 4 fix PRs. Codex additionally caught 6 real bugs during the per-PR review gate. Every fix carries a regression test verified to fail without it.

Notable bugs caught and fixed:
- The `documents:` sync namespace was not reserved, so the new tag would have leaked to untrusted sandboxed app code.
- The dot could never clear: marks keyed on the conversation the tool ran in, clears keyed on the conversation that owns the document row. Those diverge for any document linked to a second conversation.
- A no-op `document_replace_text` reported a change, offering a reopen link for a document that did not change.
- `document_update` returned `isError: true` on a successful headless write, skipping the broadcast hook entirely.
- `publishDocumentsChanged` had no sidecar-worker guard, so scheduled and background turns published into a void.
- Chunked `document_update` calls (which `SKILL.md` explicitly instructs the model to make per chunk) fired one uncoalesced broadcast each.

## PRs merged into this branch

Implementation: #40245, #40246, #40247, #40248, #40249, #40251, #40254, #40255, #40256, #40257, #40262, #40264
Review fixes: #40270, #40271, #40272, #40274

## Known limitations

Stated plainly rather than buried:

1. **The dot does not light for scheduled or background turns.** `getOrCreateConversation` installs a no-op `sendToClient` that only an HTTP turn replaces, so a background turn emits no `document_editor_update` and nothing marks the change. The documents list still refreshes via the sync tag; only the dot is affected. Pre-existing, not introduced here, but it limits the headline scenario and needs `sendToClient` plumbing for background turns to fix properly.
2. **A `document_update` followed by `document_open` of the same document in one turn can render both a preview card and a reopen link.** The claim that prevents duplication is set-based, not positional. Low frequency; a positional fix was judged disproportionate.
3. **Deliberately deferred:** the duplicate `refreshKey` invalidation path (now redundant with the sync tag, but unwinding it touches 7 files across stream handlers), the desktop dot ring color (`--surface-base` ring on a `--surface-lift` filled pill), deleted-document dot reconciliation, comment-density trim, and registering `documents:list` in the platform repo's tag doc.
4. **No device QA.** Everything here is unit-tested and CI-green, but nothing was exercised in a real iOS or Android shell, where the document editor is a full-screen overlay rather than a drawer.

Part of plan: document-update-discoverability.md