### PR TITLE
fix(providers): actionable managed-pod credential error messaging

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -1613,7 +1613,7 @@ describe("ConnectionResolutionError classification", () => {
     expect(result.userMessage).toContain('profile "custom-fast"');
   });
 
-  it("classifies platform_unauthenticated with a log-in fix", () => {
+  it("classifies platform_unauthenticated with a log-in fix on a non-platform install", () => {
     const err = new ConnectionResolutionError(
       "vellum",
       "platform_unauthenticated",
@@ -1622,6 +1622,22 @@ describe("ConnectionResolutionError classification", () => {
     const result = classifyConversationError(err, errCtx);
     expect(result.userMessage).toContain("platform login");
     expect(result.userMessage).toContain("Log in");
+  });
+
+  it("classifies platform_unauthenticated as a re-provision hint on a platform-managed assistant", () => {
+    const err = new ConnectionResolutionError(
+      "vellum",
+      "platform_unauthenticated",
+      "unavailable",
+    );
+    process.env.IS_PLATFORM = "true";
+    try {
+      const result = classifyConversationError(err, errCtx);
+      expect(result.userMessage).toContain("re-provisioned");
+      expect(result.userMessage).not.toContain("Log in");
+    } finally {
+      delete process.env.IS_PLATFORM;
+    }
   });
 
   it("is a structured VellumError (ConfigError) for logging/monitoring", () => {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -6,6 +6,7 @@ import type {
   ConversationErrorCode,
   ConversationErrorEvent,
 } from "../api/events/conversation-error.js";
+import { getIsPlatform } from "../config/env-registry.js";
 import {
   isImageDimensionsTooLargeError,
   isImageMediaTypeMismatchError,
@@ -361,6 +362,12 @@ function connectionResolutionUserMessage(
       // doesn't.
       return `${connection}${usedBy} has no stored credential. Add an API key or reconnect it in ${fixPath}.`;
     case "platform_unauthenticated":
+      // A platform-managed assistant cannot log in or switch providers, and
+      // this classifier only sees the reason code, so one honest wording covers
+      // both the transient and the re-provision cases.
+      if (getIsPlatform()) {
+        return `${connection}${usedBy} is unavailable. If this persists, the platform credential may need to be re-provisioned on the Vellum platform.`;
+      }
       return `${connection}${usedBy} requires a Vellum platform login. Log in, or pick a different provider in ${fixPath}.`;
     case "model_incompatible":
       return `${error.model ? `Model "${error.model}"` : "The requested model"} isn't available on ${connectionName ? `connection "${connectionName}"` : "the configured connection"}${usedBy}. Pick a different model or connection in ${fixPath}.`;

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -1,21 +1,46 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realDbConnection from "../../persistence/db-connection.js";
+import * as realLogger from "../../util/logger.js";
+import * as realConnections from "../inference/connections.js";
+import * as realPlatformProxy from "../platform-proxy/context.js";
+import * as realProviderAvailability from "../provider-availability.js";
 
 let connectionsByName: Record<string, unknown> = {};
 let secureKeys: Record<string, string | undefined> = {};
 let cesUnreachable = false;
 let platformLoggedIn = false;
 
+// The daemon reports to Sentry by logging at error level; spy on that call so
+// the managed-absent alert is assertable without a Sentry SDK in the tests.
+// The mocks spread their real modules so the dynamic import below links against
+// complete namespaces, overriding only the functions each test drives.
+const errorLogSpy = mock((..._args: unknown[]) => {});
+const testLogger = {
+  info: () => {},
+  warn: () => {},
+  error: errorLogSpy,
+  debug: () => {},
+};
+mock.module("../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => testLogger,
+}));
+
 mock.module("../../persistence/db-connection.js", () => ({
+  ...realDbConnection,
   getDb: () => ({}),
 }));
 
 mock.module("../inference/connections.js", () => ({
+  ...realConnections,
   getConnection: (_db: unknown, name: string) =>
     connectionsByName[name] ?? null,
   listConnections: () => [],
 }));
 
 mock.module("../provider-availability.js", () => ({
+  ...realProviderAvailability,
   checkCredentialPresence: async (account: string) =>
     cesUnreachable
       ? "indeterminate"
@@ -25,6 +50,7 @@ mock.module("../provider-availability.js", () => ({
 }));
 
 mock.module("../platform-proxy/context.js", () => ({
+  ...realPlatformProxy,
   hasManagedProxyPrereqs: async () => platformLoggedIn,
   resolveManagedProxyContext: async () => ({
     enabled: platformLoggedIn,
@@ -35,10 +61,15 @@ mock.module("../platform-proxy/context.js", () => ({
   }),
 }));
 
-import {
-  ConnectionResolutionError,
+import type { ConnectionResolutionError } from "../connection-resolution.js";
+
+// Imported after the mocks so the module-level logger is the spied one, letting
+// the managed-absent Sentry alert be asserted (module-level `const log` binds at
+// evaluation time, unlike the runtime-called db/context mocks).
+const {
+  ConnectionResolutionError: ConnectionResolutionErrorClass,
   preflightResolvedConfig,
-} from "../connection-resolution.js";
+} = await import("../connection-resolution.js");
 
 const resolved = (overrides: Partial<Record<string, string>> = {}) => ({
   provider: "anthropic",
@@ -54,7 +85,7 @@ async function preflightError(
     await preflightResolvedConfig(config, { profileName: "custom-fast" });
     return undefined;
   } catch (err) {
-    expect(err).toBeInstanceOf(ConnectionResolutionError);
+    expect(err).toBeInstanceOf(ConnectionResolutionErrorClass);
     return err as ConnectionResolutionError;
   }
 }
@@ -74,6 +105,12 @@ beforeEach(() => {
   secureKeys = { "credential/anthropic/api_key": "sk-ant" };
   cesUnreachable = false;
   platformLoggedIn = false;
+  delete process.env.IS_CONTAINERIZED;
+  errorLogSpy.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.IS_CONTAINERIZED;
 });
 
 describe("preflightResolvedConfig", () => {
@@ -298,5 +335,68 @@ describe("preflightResolvedConfig", () => {
       auth: { type: "none" },
     };
     expect(await preflightError(resolved())).toBeUndefined();
+  });
+});
+
+describe("preflightResolvedConfig — managed-pod platform credential messaging", () => {
+  const managedPod = () => {
+    connectionsByName = {
+      vellum: {
+        name: "vellum",
+        provider: "vellum",
+        auth: { type: "platform" },
+      },
+    };
+    process.env.IS_CONTAINERIZED = "true";
+  };
+  const managedRoute = () => resolved({ provider_connection: "vellum" });
+
+  test("store unreachable surfaces a retriable message, no login text, no alert", async () => {
+    managedPod();
+    cesUnreachable = true;
+    const err = await preflightError(managedRoute());
+    expect(err?.reason).toBe("platform_unauthenticated");
+    expect(err?.message).toContain("temporarily unavailable");
+    expect(err?.message).not.toContain("log in");
+    expect(errorLogSpy).not.toHaveBeenCalled();
+  });
+
+  test("credential absent reports platform-side repair and emits a Sentry event", async () => {
+    managedPod();
+    // Logged out with a reachable store means the credential is genuinely absent.
+    const err = await preflightError(managedRoute());
+    expect(err?.reason).toBe("platform_unauthenticated");
+    expect(err?.message).toContain("requires platform-side repair");
+    expect(err?.message).not.toContain("log in");
+    expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    const [context] = errorLogSpy.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(context.connectionName).toBe("vellum");
+    // The alert carries identifiers only — never the credential value.
+    expect(JSON.stringify(context)).not.toContain("sk-");
+  });
+
+  test("a healthy platform login passes silently on a pod, no alert", async () => {
+    managedPod();
+    platformLoggedIn = true;
+    expect(await preflightError(managedRoute())).toBeUndefined();
+    expect(errorLogSpy).not.toHaveBeenCalled();
+  });
+
+  test("local install keeps the log-in-or-switch wording and raises no alert", async () => {
+    connectionsByName = {
+      vellum: {
+        name: "vellum",
+        provider: "vellum",
+        auth: { type: "platform" },
+      },
+    };
+    // IS_CONTAINERIZED left unset: this is a local / self-hosted install.
+    const err = await preflightError(managedRoute());
+    expect(err?.reason).toBe("platform_unauthenticated");
+    expect(err?.message).toContain("log in or pick a different provider");
+    expect(errorLogSpy).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -1,46 +1,21 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import * as realDbConnection from "../../persistence/db-connection.js";
-import * as realLogger from "../../util/logger.js";
-import * as realConnections from "../inference/connections.js";
-import * as realPlatformProxy from "../platform-proxy/context.js";
-import * as realProviderAvailability from "../provider-availability.js";
-
 let connectionsByName: Record<string, unknown> = {};
 let secureKeys: Record<string, string | undefined> = {};
 let cesUnreachable = false;
 let platformLoggedIn = false;
 
-// The daemon reports to Sentry by logging at error level; spy on that call so
-// the managed-absent alert is assertable without a Sentry SDK in the tests.
-// The mocks spread their real modules so the dynamic import below links against
-// complete namespaces, overriding only the functions each test drives.
-const errorLogSpy = mock((..._args: unknown[]) => {});
-const testLogger = {
-  info: () => {},
-  warn: () => {},
-  error: errorLogSpy,
-  debug: () => {},
-};
-mock.module("../../util/logger.js", () => ({
-  ...realLogger,
-  getLogger: () => testLogger,
-}));
-
 mock.module("../../persistence/db-connection.js", () => ({
-  ...realDbConnection,
   getDb: () => ({}),
 }));
 
 mock.module("../inference/connections.js", () => ({
-  ...realConnections,
   getConnection: (_db: unknown, name: string) =>
     connectionsByName[name] ?? null,
   listConnections: () => [],
 }));
 
 mock.module("../provider-availability.js", () => ({
-  ...realProviderAvailability,
   checkCredentialPresence: async (account: string) =>
     cesUnreachable
       ? "indeterminate"
@@ -50,7 +25,6 @@ mock.module("../provider-availability.js", () => ({
 }));
 
 mock.module("../platform-proxy/context.js", () => ({
-  ...realPlatformProxy,
   hasManagedProxyPrereqs: async () => platformLoggedIn,
   resolveManagedProxyContext: async () => ({
     enabled: platformLoggedIn,
@@ -61,15 +35,10 @@ mock.module("../platform-proxy/context.js", () => ({
   }),
 }));
 
-import type { ConnectionResolutionError } from "../connection-resolution.js";
-
-// Imported after the mocks so the module-level logger is the spied one, letting
-// the managed-absent Sentry alert be asserted (module-level `const log` binds at
-// evaluation time, unlike the runtime-called db/context mocks).
-const {
-  ConnectionResolutionError: ConnectionResolutionErrorClass,
+import {
+  ConnectionResolutionError,
   preflightResolvedConfig,
-} = await import("../connection-resolution.js");
+} from "../connection-resolution.js";
 
 const resolved = (overrides: Partial<Record<string, string>> = {}) => ({
   provider: "anthropic",
@@ -85,7 +54,7 @@ async function preflightError(
     await preflightResolvedConfig(config, { profileName: "custom-fast" });
     return undefined;
   } catch (err) {
-    expect(err).toBeInstanceOf(ConnectionResolutionErrorClass);
+    expect(err).toBeInstanceOf(ConnectionResolutionError);
     return err as ConnectionResolutionError;
   }
 }
@@ -105,12 +74,11 @@ beforeEach(() => {
   secureKeys = { "credential/anthropic/api_key": "sk-ant" };
   cesUnreachable = false;
   platformLoggedIn = false;
-  delete process.env.IS_CONTAINERIZED;
-  errorLogSpy.mockClear();
+  delete process.env.IS_PLATFORM;
 });
 
 afterEach(() => {
-  delete process.env.IS_CONTAINERIZED;
+  delete process.env.IS_PLATFORM;
 });
 
 describe("preflightResolvedConfig", () => {
@@ -338,8 +306,8 @@ describe("preflightResolvedConfig", () => {
   });
 });
 
-describe("preflightResolvedConfig — managed-pod platform credential messaging", () => {
-  const managedPod = () => {
+describe("preflightResolvedConfig platform-managed credential messaging", () => {
+  const platformManaged = () => {
     connectionsByName = {
       vellum: {
         name: "vellum",
@@ -347,45 +315,35 @@ describe("preflightResolvedConfig — managed-pod platform credential messaging"
         auth: { type: "platform" },
       },
     };
-    process.env.IS_CONTAINERIZED = "true";
+    process.env.IS_PLATFORM = "true";
   };
   const managedRoute = () => resolved({ provider_connection: "vellum" });
 
-  test("store unreachable surfaces a retriable message, no login text, no alert", async () => {
-    managedPod();
+  test("store unreachable surfaces a retriable message with no login text", async () => {
+    platformManaged();
     cesUnreachable = true;
     const err = await preflightError(managedRoute());
     expect(err?.reason).toBe("platform_unauthenticated");
     expect(err?.message).toContain("temporarily unavailable");
     expect(err?.message).not.toContain("log in");
-    expect(errorLogSpy).not.toHaveBeenCalled();
   });
 
-  test("credential absent reports platform-side repair and emits a Sentry event", async () => {
-    managedPod();
+  test("credential absent asks for platform re-provisioning, not a login", async () => {
+    platformManaged();
     // Logged out with a reachable store means the credential is genuinely absent.
     const err = await preflightError(managedRoute());
     expect(err?.reason).toBe("platform_unauthenticated");
-    expect(err?.message).toContain("requires platform-side repair");
+    expect(err?.message).toContain("must be re-provisioned");
     expect(err?.message).not.toContain("log in");
-    expect(errorLogSpy).toHaveBeenCalledTimes(1);
-    const [context] = errorLogSpy.mock.calls[0] as [
-      Record<string, unknown>,
-      string,
-    ];
-    expect(context.connectionName).toBe("vellum");
-    // The alert carries identifiers only — never the credential value.
-    expect(JSON.stringify(context)).not.toContain("sk-");
   });
 
-  test("a healthy platform login passes silently on a pod, no alert", async () => {
-    managedPod();
+  test("a healthy platform login passes silently", async () => {
+    platformManaged();
     platformLoggedIn = true;
     expect(await preflightError(managedRoute())).toBeUndefined();
-    expect(errorLogSpy).not.toHaveBeenCalled();
   });
 
-  test("local install keeps the log-in-or-switch wording and raises no alert", async () => {
+  test("non-platform install keeps the log-in-or-switch wording", async () => {
     connectionsByName = {
       vellum: {
         name: "vellum",
@@ -393,10 +351,9 @@ describe("preflightResolvedConfig — managed-pod platform credential messaging"
         auth: { type: "platform" },
       },
     };
-    // IS_CONTAINERIZED left unset: this is a local / self-hosted install.
+    // IS_PLATFORM left unset covers both local and self-hosted Docker installs.
     const err = await preflightError(managedRoute());
     expect(err?.reason).toBe("platform_unauthenticated");
     expect(err?.message).toContain("log in or pick a different provider");
-    expect(errorLogSpy).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -27,11 +27,7 @@
  *      a conversation offline.
  */
 
-import {
-  getPlatformAssistantId,
-  getPlatformOrganizationId,
-} from "../config/env.js";
-import { getIsContainerized } from "../config/env-registry.js";
+import { getIsPlatform } from "../config/env-registry.js";
 import {
   resolveCallSiteConfig,
   selectWinningProfile,
@@ -477,12 +473,12 @@ export async function preflightResolvedConfig(
     if (presence === "ok") {
       return;
     }
-    if (getIsContainerized()) {
-      // A managed pod cannot present a login screen or switch providers, so the
-      // login-or-switch wording never fits. An unreachable store is transient
-      // and recovers on its own, so it reads as a retry. A reachable but empty
-      // store needs platform-side reprovisioning, so it raises an alert rather
-      // than blaming the operator.
+    if (getIsPlatform()) {
+      // A platform-managed assistant cannot present a login screen or switch
+      // providers, so the login-or-switch wording never fits. An unreachable
+      // store is transient and recovers on its own, so it reads as a retry. A
+      // reachable but empty store can only be fixed by re-provisioning the
+      // credential platform-side.
       if (presence === "indeterminate") {
         throw new ConnectionResolutionError(
           connectionName,
@@ -491,15 +487,18 @@ export async function preflightResolvedConfig(
           errorOptions,
         );
       }
-      reportMissingManagedCredential(
-        connectionName,
-        resolved.model,
-        attribution.profileName,
+      log.error(
+        {
+          connectionName,
+          model: resolved.model,
+          profileName: attribution.profileName,
+        },
+        "Managed platform credential is missing and must be re-provisioned",
       );
       throw new ConnectionResolutionError(
         connectionName,
         "platform_unauthenticated",
-        "This assistant's platform credential is missing and requires platform-side repair; support has been notified.",
+        "This assistant's platform credential is missing and must be re-provisioned on the Vellum platform.",
         errorOptions,
       );
     }
@@ -579,31 +578,6 @@ async function platformLoginPresence(): Promise<
     return "ok";
   }
   return presence === "indeterminate" ? "indeterminate" : "unauthenticated";
-}
-
-/**
- * Raise the operator-facing alert for a managed pod whose platform credential
- * store is reachable but empty. The user cannot fix this because the credential
- * is reprovisioned by platform staff rather than through any in-app screen, so
- * an error-level log carries it into crash diagnostics as the notification. The
- * context locates the assistant and connection, and the credential value itself
- * is never read or logged.
- */
-function reportMissingManagedCredential(
-  connectionName: string,
-  model: string | undefined,
-  profileName: string | undefined,
-): void {
-  log.error(
-    {
-      connectionName,
-      model,
-      profileName,
-      platformAssistantId: getPlatformAssistantId() || undefined,
-      platformOrganizationId: getPlatformOrganizationId() || undefined,
-    },
-    "Managed platform credential is missing and requires platform-side repair",
-  );
 }
 
 /**

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -28,6 +28,11 @@
  */
 
 import {
+  getPlatformAssistantId,
+  getPlatformOrganizationId,
+} from "../config/env.js";
+import { getIsContainerized } from "../config/env-registry.js";
+import {
   resolveCallSiteConfig,
   selectWinningProfile,
 } from "../config/llm-resolver.js";
@@ -468,7 +473,37 @@ export async function preflightResolvedConfig(
         errorOptions,
       );
     }
-    if ((await platformLoginPresence()) === "unauthenticated") {
+    const presence = await platformLoginPresence();
+    if (presence === "ok") {
+      return;
+    }
+    if (getIsContainerized()) {
+      // A managed pod cannot present a login screen or switch providers, so the
+      // login-or-switch wording never fits. An unreachable store is transient
+      // and recovers on its own, so it reads as a retry. A reachable but empty
+      // store needs platform-side reprovisioning, so it raises an alert rather
+      // than blaming the operator.
+      if (presence === "indeterminate") {
+        throw new ConnectionResolutionError(
+          connectionName,
+          "platform_unauthenticated",
+          "The assistant's platform credentials are temporarily unavailable; retrying automatically.",
+          errorOptions,
+        );
+      }
+      reportMissingManagedCredential(
+        connectionName,
+        resolved.model,
+        attribution.profileName,
+      );
+      throw new ConnectionResolutionError(
+        connectionName,
+        "platform_unauthenticated",
+        "This assistant's platform credential is missing and requires platform-side repair; support has been notified.",
+        errorOptions,
+      );
+    }
+    if (presence === "unauthenticated") {
       throw new ConnectionResolutionError(
         connectionName,
         "platform_unauthenticated",
@@ -544,6 +579,31 @@ async function platformLoginPresence(): Promise<
     return "ok";
   }
   return presence === "indeterminate" ? "indeterminate" : "unauthenticated";
+}
+
+/**
+ * Raise the operator-facing alert for a managed pod whose platform credential
+ * store is reachable but empty. The user cannot fix this because the credential
+ * is reprovisioned by platform staff rather than through any in-app screen, so
+ * an error-level log carries it into crash diagnostics as the notification. The
+ * context locates the assistant and connection, and the credential value itself
+ * is never read or logged.
+ */
+function reportMissingManagedCredential(
+  connectionName: string,
+  model: string | undefined,
+  profileName: string | undefined,
+): void {
+  log.error(
+    {
+      connectionName,
+      model,
+      profileName,
+      platformAssistantId: getPlatformAssistantId() || undefined,
+      platformOrganizationId: getPlatformOrganizationId() || undefined,
+    },
+    "Managed platform credential is missing and requires platform-side repair",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Platform-managed assistants no longer tell the user to log in when a platform credential fails. Unreachable storage surfaces as a retriable "temporarily unavailable; retrying automatically" message; a genuinely missing credential says it must be re-provisioned on the Vellum platform.
- Both user-facing surfaces are covered: the settings/callsite inspector (renders the resolver's own message) and the mid-conversation reply (regenerated by the classifier in `conversation-error.ts` from the reason code).
- Gated on `getIsPlatform()`, so self-hosted Docker and local installs keep the existing "log in or pick a different provider" wording unchanged.
- No Sentry: the missing-credential case writes a plain daemon-log diagnostic, with no alert or notification claim.

Part of plan: atl-1179-remediation.md (PR 5)