### PR TITLE
feat(web): give the bell notification detail a fixed frame and a pinned footer

### DIFF
--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -7,9 +7,13 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { formatFullLocalDate, formatRelativeDate } from "@/utils/format-date";
+import {
+  formatCompactLocalDate,
+  formatFullLocalDate,
+  formatRelativeDate,
+} from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
-import { Button, Tag, Typography } from "@vellumai/design-library";
+import { Button, Typography } from "@vellumai/design-library";
 
 import { HomeGenericDetail } from "../detail-panel/home-generic-detail";
 import { HomeToolPermissionCard } from "../detail-panel/home-tool-permission-card";
@@ -23,13 +27,22 @@ import { getFeedItemScheduleId, resolveFeedItemTitle } from "../utils";
 export const NOTIFICATIONS_PANEL_HEADER_CLASS =
   "mb-[var(--app-spacing-sm)] flex min-h-8 items-center gap-[var(--app-spacing-xs)]";
 
+/**
+ * Notification bodies read as prose here, so paragraphs and list items take a
+ * 1.5 ratio in place of the 18px line height the body token pairs with its
+ * 14px text. Scoped to this panel, leaving the Activity page's detail on the
+ * token default.
+ */
+const BODY_LEADING_CLASS = "[&_p]:leading-normal [&_li]:leading-normal";
+
 export interface NotificationsBellDetailProps {
   item: FeedItem;
   /**
-   * Max-height class for the scrollable body. The bell passes the cap it uses
-   * for the list, so the panel never jumps height between the two views.
+   * Height of the scrollable content region. The bell passes the budget the
+   * list is capped at, and the detail takes it as a fixed height so every
+   * notification renders in an identically sized frame.
    */
-  bodyMaxHeightClass: string;
+  contentHeight: string;
   /**
    * Ids of the conversations that still exist, merged from the foreground,
    * background, and scheduled lists exactly as the Activity page merges them.
@@ -58,7 +71,7 @@ export interface NotificationsBellDetailProps {
  */
 export function NotificationsBellDetail({
   item,
-  bodyMaxHeightClass,
+  contentHeight,
   validConversationIds,
   areConversationListsPending,
   validScheduleIds,
@@ -86,10 +99,9 @@ export function NotificationsBellDetail({
     (conversationId !== null && areConversationListsPending) ||
     (scheduleId !== null && isScheduleListPending);
 
-  // A link the lists have yet to vouch for still renders, holding the row it
-  // will occupy so the panel keeps its height once validation resolves. One
-  // whose target turns out to be gone drops out, and a footer left with none
-  // of them collapses away rather than holding empty space.
+  // A link the lists have yet to vouch for still renders, holding the box it
+  // will occupy so the footer keeps its shape once validation resolves. One
+  // whose target turns out to be gone drops out.
   const linkedConversationId =
     conversationId !== null &&
     (isValidationPending || validConversationIds.has(conversationId))
@@ -162,19 +174,21 @@ export function NotificationsBellDetail({
         </div>
       </div>
 
+      {/*
+        A fixed frame rather than a cap: a short notification leaves empty
+        space below it and a long one scrolls inside, so the panel is the same
+        size whichever notification is open.
+      */}
       <div
-        className={`overflow-y-auto px-[var(--app-spacing-md)] ${bodyMaxHeightClass}`}
+        data-testid="notifications-bell-detail-content"
+        style={{ height: contentHeight }}
+        className="overflow-y-auto px-[var(--app-spacing-md)]"
       >
         {item.detailPanel?.kind === "toolPermission" ? (
           <HomeToolPermissionCard item={item} />
         ) : (
-          <HomeGenericDetail item={item} />
+          <HomeGenericDetail item={item} className={BODY_LEADING_CLASS} />
         )}
-        <div className="mt-[var(--app-spacing-md)]">
-          <Tag tone="neutral" title={formatFullLocalDate(item.timestamp)}>
-            {formatRelativeDate(item.timestamp)}
-          </Tag>
-        </div>
 
         {/*
           The assistant's own offers on this notification, so they sit with the
@@ -208,14 +222,29 @@ export function NotificationsBellDetail({
         ) : null}
       </div>
 
-      {linkedScheduleId || linkedConversationId ? (
-        // Both links can be offered at once. They sit on one right-aligned row
-        // at the popover's width and wrap onto a second one below it in the
-        // narrowest bottom sheets, so neither ever overflows the panel.
-        <div
-          data-testid="notifications-bell-detail-footer"
-          className="mt-[var(--app-spacing-sm)] flex flex-wrap items-center justify-end gap-[var(--app-spacing-sm)] border-t border-[var(--border-base)] pt-[var(--app-spacing-sm)]"
+      {/*
+        A pinned strip closing the frame: the timestamp on the left, the links
+        out on the right. Every notification has a timestamp, so the strip is
+        always there. Both links can be offered at once, and they wrap under
+        the timestamp in the narrowest bottom sheets rather than overflowing.
+      */}
+      <div
+        data-testid="notifications-bell-detail-footer"
+        className="mt-[var(--app-spacing-sm)] flex flex-wrap items-center justify-between gap-[var(--app-spacing-sm)] border-t border-[var(--border-base)] pt-[var(--app-spacing-sm)]"
+      >
+        <Typography
+          variant="body-small-lighter"
+          className="min-w-0 truncate text-[var(--content-tertiary)]"
+          title={formatFullLocalDate(item.timestamp)}
         >
+          {`${formatRelativeDate(item.timestamp)} · ${formatCompactLocalDate(
+            item.timestamp,
+          )}`}
+        </Typography>
+
+        {/* `ml-auto` keeps the links against the right edge on the second row
+            too, once a narrow sheet has wrapped them off the timestamp's. */}
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-[var(--app-spacing-sm)]">
           {linkedScheduleId ? (
             <Button
               variant="outlined"
@@ -244,7 +273,7 @@ export function NotificationsBellDetail({
             </Button>
           ) : null}
         </div>
-      ) : null}
+      </div>
     </>
   );
 }

--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -44,6 +44,13 @@ export interface NotificationsBellDetailProps {
    */
   contentHeight: string;
   /**
+   * Ceiling on that frame, expressed against the viewport rather than the
+   * content, so a viewport too short to seat the budget shrinks the frame
+   * instead of overflowing. Together with `contentHeight` this is the minimum
+   * of the two. Omitted where an ancestor already scrolls.
+   */
+  contentMaxHeight?: string;
+  /**
    * Ids of the conversations that still exist, merged from the foreground,
    * background, and scheduled lists exactly as the Activity page merges them.
    */
@@ -72,6 +79,7 @@ export interface NotificationsBellDetailProps {
 export function NotificationsBellDetail({
   item,
   contentHeight,
+  contentMaxHeight,
   validConversationIds,
   areConversationListsPending,
   validScheduleIds,
@@ -177,11 +185,14 @@ export function NotificationsBellDetail({
       {/*
         A fixed frame rather than a cap: a short notification leaves empty
         space below it and a long one scrolls inside, so the panel is the same
-        size whichever notification is open.
+        size whichever notification is open. The `max-height` is measured
+        against the viewport, never the content, so it clamps the frame on a
+        screen too short to seat it without ever letting the notification's
+        own length move it.
       */}
       <div
         data-testid="notifications-bell-detail-content"
-        style={{ height: contentHeight }}
+        style={{ height: contentHeight, maxHeight: contentMaxHeight }}
         className="overflow-y-auto px-[var(--app-spacing-md)]"
       >
         {item.detailPanel?.kind === "toolPermission" ? (

--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -10,7 +10,6 @@ import {
 import {
   formatCompactLocalDate,
   formatFullLocalDate,
-  formatRelativeDate,
 } from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { Button, Typography } from "@vellumai/design-library";
@@ -248,9 +247,7 @@ export function NotificationsBellDetail({
           className="min-w-0 truncate text-[var(--content-tertiary)]"
           title={formatFullLocalDate(item.timestamp)}
         >
-          {`${formatRelativeDate(item.timestamp)} · ${formatCompactLocalDate(
-            item.timestamp,
-          )}`}
+          {formatCompactLocalDate(item.timestamp)}
         </Typography>
 
         {/* `ml-auto` keeps the links against the right edge on the second row

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -22,6 +22,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { Conversation } from "@/types/conversation-types";
+import { formatCompactLocalDate } from "@/utils/format-date";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 
 import { feedItem } from "../feed-test-fixtures";
@@ -268,6 +269,16 @@ function footerLinkLabels(footer: HTMLElement): (string | null)[] {
   );
 }
 
+/** The detail's fixed-height content region. */
+function detailContent(): HTMLElement {
+  return screen.getByTestId("notifications-bell-detail-content");
+}
+
+/** The detail's pinned footer strip. */
+function detailFooter(): HTMLElement {
+  return screen.getByTestId("notifications-bell-detail-footer");
+}
+
 beforeEach(() => {
   isMobileRef.value = false;
   feedRef.items = [];
@@ -418,6 +429,19 @@ describe("NotificationsBell detail", () => {
   });
   const SECOND = feedItem({ id: "second", title: "Backup finished" });
 
+  /**
+   * Opens the detail on a body of the given length and reports the height its
+   * content region resolved to, tearing the tree down so the next call starts
+   * from one bell.
+   */
+  async function detailFrameHeight(summary: string): Promise<string> {
+    feedRef.items = [{ ...FIRST, summary }];
+    await openDetail("Watcher job failed");
+    const height = detailContent().style.height;
+    cleanup();
+    return height;
+  }
+
   test("selecting a row opens that item's detail in place", async () => {
     feedRef.items = [FIRST, SECOND];
 
@@ -429,7 +453,7 @@ describe("NotificationsBell detail", () => {
     expect(
       screen.getByText("The watcher job could not reach the upstream service."),
     ).toBeTruthy();
-    expect(screen.getByText("3h ago")).toBeTruthy();
+    expect(detailFooter().textContent).toContain("3h ago");
     // The list is gone, so its other row went with it.
     expect(screen.queryByText("Backup finished")).toBeNull();
     expect(screen.queryByRole("heading", { name: "Notifications" })).toBeNull();
@@ -687,7 +711,7 @@ describe("NotificationsBell detail", () => {
     ).toBeTruthy();
   });
 
-  test("drops the footer once the lists resolve without either target", async () => {
+  test("keeps the footer once the lists resolve without either target", async () => {
     feedRef.items = [
       {
         ...FIRST,
@@ -700,12 +724,58 @@ describe("NotificationsBell detail", () => {
 
     await openDetail("Watcher job failed");
 
-    // No links survived validation, so the reserved strip goes with them.
-    expect(screen.queryByTestId("notifications-bell-detail-footer")).toBeNull();
+    // No links survived validation, but the strip carries the timestamp, so
+    // it stays and only the links go.
+    const footer = detailFooter();
+    expect(footerLinkLabels(footer)).toEqual([]);
+    expect(footer.textContent).toContain("3h ago");
     expect(
       screen.queryByRole("button", { name: "Go to Conversation" }),
     ).toBeNull();
     expect(screen.queryByRole("button", { name: "View schedule" })).toBeNull();
+  });
+
+  test("keeps the footer for an item with neither a conversation nor a schedule", async () => {
+    feedRef.items = [FIRST];
+
+    await openDetail("Watcher job failed");
+
+    const footer = detailFooter();
+    expect(footerLinkLabels(footer)).toEqual([]);
+    expect(footer.textContent).toContain("3h ago");
+  });
+
+  test("the timestamp rides in the footer rather than the body", async () => {
+    feedRef.items = [FIRST];
+
+    await openDetail("Watcher job failed");
+
+    const footer = detailFooter();
+    expect(footer.textContent).toContain("3h ago");
+    expect(footer.textContent).toContain(
+      formatCompactLocalDate(FIRST.timestamp),
+    );
+    expect(detailContent().textContent).not.toContain("3h ago");
+  });
+
+  test("the content region is a fixed frame rather than a cap", async () => {
+    feedRef.items = [FIRST];
+
+    await openDetail("Watcher job failed");
+
+    const content = detailContent();
+    expect(content.style.height).not.toBe("");
+    expect(content.style.maxHeight).toBe("");
+  });
+
+  test("a long body and a short body render in the same frame", async () => {
+    const shortHeight = await detailFrameHeight("Done.");
+    const longHeight = await detailFrameHeight(
+      "The watcher job could not reach the upstream service. ".repeat(80),
+    );
+
+    expect(shortHeight).not.toBe("");
+    expect(shortHeight).toBe(longHeight);
   });
 
   test("loads the conversation and schedule lists only once a detail is open", async () => {
@@ -754,6 +824,12 @@ describe("NotificationsBell detail", () => {
     expect(
       screen.getByText("The watcher job could not reach the upstream service."),
     ).toBeTruthy();
+    // The sheet gets the same treatment as the popover: a content region with
+    // no cap on it, closed by a footer carrying the timestamp. The sheet's
+    // budget is a `dvh` length, which happy-dom drops from the CSSOM, so the
+    // height value itself is only observable on the popover path above.
+    expect(detailContent().style.maxHeight).toBe("");
+    expect(detailFooter().textContent).toContain("3h ago");
   });
 });
 

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -763,9 +763,30 @@ describe("NotificationsBell detail", () => {
 
     await openDetail("Watcher job failed");
 
+    // A `height` in bare pixels, so the frame is drawn at the budget whatever
+    // the notification is. The `max-height` riding alongside it is the
+    // viewport clamp below, which carries no content term either.
+    expect(detailContent().style.height).toMatch(/^\d+px$/);
+  });
+
+  test("the frame is clamped to the available viewport height", async () => {
+    feedRef.items = [FIRST];
+
+    await openDetail("Watcher job failed");
+
+    // A phone in landscape is roughly 844x390: wide enough to take the
+    // popover path (the mobile query is on width alone) but far too short for
+    // the budget, which a fixed height on its own would overflow. `dvh` over
+    // `vh` so the term stays honest under mobile browser chrome.
     const content = detailContent();
-    expect(content.style.height).not.toBe("");
-    expect(content.style.maxHeight).toBe("");
+    const clamp = /^calc\(100dvh - (\d+)px\)$/.exec(content.style.maxHeight);
+    expect(clamp).not.toBeNull();
+
+    // The clamp may only engage on a viewport shorter than any ordinary
+    // desktop window, so the frame there is still exactly the budget.
+    const budget = Number.parseInt(content.style.height, 10);
+    const chromeAllowance = Number.parseInt(clamp?.[1] ?? "", 10);
+    expect(budget + chromeAllowance).toBeLessThan(600);
   });
 
   test("a long body and a short body render in the same frame", async () => {
@@ -824,10 +845,11 @@ describe("NotificationsBell detail", () => {
     expect(
       screen.getByText("The watcher job could not reach the upstream service."),
     ).toBeTruthy();
-    // The sheet gets the same treatment as the popover: a content region with
-    // no cap on it, closed by a footer carrying the timestamp. The sheet's
-    // budget is a `dvh` length, which happy-dom drops from the CSSOM, so the
-    // height value itself is only observable on the popover path above.
+    // No viewport clamp on this path: the sheet is capped at 85dvh and its
+    // body scrolls, so an oversized frame scrolls inside the sheet rather
+    // than escaping the viewport the way the popover would. The sheet's own
+    // budget is a bare `dvh` length, which happy-dom drops from the CSSOM, so
+    // the height value itself is only observable on the popover path above.
     expect(detailContent().style.maxHeight).toBe("");
     expect(detailFooter().textContent).toContain("3h ago");
   });

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -453,7 +453,9 @@ describe("NotificationsBell detail", () => {
     expect(
       screen.getByText("The watcher job could not reach the upstream service."),
     ).toBeTruthy();
-    expect(detailFooter().textContent).toContain("3h ago");
+    expect(detailFooter().textContent).toContain(
+      formatCompactLocalDate(FIRST.timestamp),
+    );
     // The list is gone, so its other row went with it.
     expect(screen.queryByText("Backup finished")).toBeNull();
     expect(screen.queryByRole("heading", { name: "Notifications" })).toBeNull();
@@ -728,7 +730,9 @@ describe("NotificationsBell detail", () => {
     // it stays and only the links go.
     const footer = detailFooter();
     expect(footerLinkLabels(footer)).toEqual([]);
-    expect(footer.textContent).toContain("3h ago");
+    expect(footer.textContent).toContain(
+      formatCompactLocalDate(FIRST.timestamp),
+    );
     expect(
       screen.queryByRole("button", { name: "Go to Conversation" }),
     ).toBeNull();
@@ -742,7 +746,9 @@ describe("NotificationsBell detail", () => {
 
     const footer = detailFooter();
     expect(footerLinkLabels(footer)).toEqual([]);
-    expect(footer.textContent).toContain("3h ago");
+    expect(footer.textContent).toContain(
+      formatCompactLocalDate(FIRST.timestamp),
+    );
   });
 
   test("the timestamp rides in the footer rather than the body", async () => {
@@ -751,11 +757,12 @@ describe("NotificationsBell detail", () => {
     await openDetail("Watcher job failed");
 
     const footer = detailFooter();
-    expect(footer.textContent).toContain("3h ago");
-    expect(footer.textContent).toContain(
-      formatCompactLocalDate(FIRST.timestamp),
-    );
-    expect(detailContent().textContent).not.toContain("3h ago");
+    const absolute = formatCompactLocalDate(FIRST.timestamp);
+    expect(footer.textContent).toContain(absolute);
+    // The absolute form only. The relative label is the list row's treatment,
+    // and repeating it here crowds the strip the links share.
+    expect(footer.textContent).not.toContain("3h ago");
+    expect(detailContent().textContent).not.toContain(absolute);
   });
 
   test("the content region is a fixed frame rather than a cap", async () => {
@@ -851,7 +858,9 @@ describe("NotificationsBell detail", () => {
     // budget is a bare `dvh` length, which happy-dom drops from the CSSOM, so
     // the height value itself is only observable on the popover path above.
     expect(detailContent().style.maxHeight).toBe("");
-    expect(detailFooter().textContent).toContain("3h ago");
+    expect(detailFooter().textContent).toContain(
+      formatCompactLocalDate(FIRST.timestamp),
+    );
   });
 });
 

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -47,13 +47,18 @@ export interface ActivityLocationState {
   feedItemId?: string;
 }
 
-// Caps the visible list at five compact cards plus the four 8px gaps between
-// them. A compact card is 73px tall: 2px borders, 16px padding, a 32px title
-// line (sized by the h-8 hover actions that share it with the timestamp), a 2px
-// gap, and a 21px preview line. 5 * 73 + 4 * 8 = 397. Older notifications stay
-// reachable by scrolling. The detail view's body takes the same cap, so the
-// panel keeps its height across the swap.
-const SCROLL_MAX_HEIGHT_CLASS = "max-h-[397px]";
+// The height budget the panel's content region is drawn against: five compact
+// cards plus the four 8px gaps between them. A compact card is 73px tall: 2px
+// borders, 16px padding, a 32px title line (sized by the h-8 hover actions that
+// share it with the timestamp), a 2px gap, and a 21px preview line.
+// 5 * 73 + 4 * 8 = 397. The list takes it as a cap, so a short feed draws a
+// short panel and older notifications stay reachable by scrolling. The detail
+// takes it as a fixed height, so every notification renders in the same frame.
+const PANEL_CONTENT_HEIGHT = "397px";
+
+// The same budget on a bottom sheet, where the content region is measured
+// against the viewport rather than the popover.
+const MOBILE_PANEL_CONTENT_HEIGHT = "60dvh";
 
 /**
  * Notification bell for the top nav: a ghost icon button with an unread dot
@@ -259,9 +264,9 @@ export function NotificationsBell() {
     />
   );
 
-  const scrollMaxHeightClass = isMobile
-    ? "max-h-[60dvh]"
-    : SCROLL_MAX_HEIGHT_CLASS;
+  const contentHeight = isMobile
+    ? MOBILE_PANEL_CONTENT_HEIGHT
+    : PANEL_CONTENT_HEIGHT;
 
   const list =
     visibleItems.length === 0 ? (
@@ -279,7 +284,8 @@ export function NotificationsBell() {
         onScroll={(event) => {
           listScrollTopRef.current = event.currentTarget.scrollTop;
         }}
-        className={`flex flex-col gap-[var(--app-spacing-sm)] overflow-y-auto ${scrollMaxHeightClass}`}
+        style={{ maxHeight: contentHeight }}
+        className="flex flex-col gap-[var(--app-spacing-sm)] overflow-y-auto"
       >
         {visibleItems.map((item) => (
           <HomeRecapRow
@@ -311,7 +317,7 @@ export function NotificationsBell() {
       {selectedItem ? (
         <NotificationsBellDetail
           item={selectedItem}
-          bodyMaxHeightClass={scrollMaxHeightClass}
+          contentHeight={contentHeight}
           validConversationIds={validConversationIds}
           areConversationListsPending={areConversationListsPending}
           validScheduleIds={validScheduleIds}

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -56,8 +56,32 @@ export interface ActivityLocationState {
 // takes it as a fixed height, so every notification renders in the same frame.
 const PANEL_CONTENT_HEIGHT = "397px";
 
+// Ceiling on that budget, so a viewport too short to seat it shrinks the
+// content region instead of running the popover off the bottom edge. The
+// popover path is taken on width alone (`useIsMobile` is a 767px width query),
+// and a phone in landscape is around 844x390: wide enough for the popover,
+// 390px tall.
+//
+// The subtracted allowance is the chrome the content region shares the
+// viewport with, on the 8px spacing grid: 48px of top bar (16px of padding
+// over a 32px icon button) plus the popover's 8px sideOffset, 16px of popover
+// padding, a 40px header row (a 32px control row plus its 8px margin), a 49px
+// footer strip (8px margin, a 1px rule, 8px padding, a 32px button row), and
+// 8px of clearance at the bottom edge. 48 + 8 + 16 + 40 + 49 + 8 = 169,
+// rounded up to 176. The clamp therefore only engages below a 573px viewport,
+// leaving every ordinary desktop window on the budget exactly.
+const PANEL_VIEWPORT_MAX_HEIGHT = "calc(100dvh - 176px)";
+
+// The list caps rather than fixes, so its one `max-height` has to carry both
+// terms; the detail splits them across `height` and `max-height`, which is the
+// same minimum.
+const PANEL_LIST_MAX_HEIGHT = `min(${PANEL_CONTENT_HEIGHT}, ${PANEL_VIEWPORT_MAX_HEIGHT})`;
+
 // The same budget on a bottom sheet, where the content region is measured
-// against the viewport rather than the popover.
+// against the viewport rather than the popover. No viewport ceiling of its
+// own: the sheet is capped at 85dvh and its body scrolls, so an oversized
+// frame scrolls inside the sheet rather than escaping the viewport. The
+// popover has no such scrolling ancestor, which is why only it needs one.
 const MOBILE_PANEL_CONTENT_HEIGHT = "60dvh";
 
 /**
@@ -267,6 +291,10 @@ export function NotificationsBell() {
   const contentHeight = isMobile
     ? MOBILE_PANEL_CONTENT_HEIGHT
     : PANEL_CONTENT_HEIGHT;
+  const contentMaxHeight = isMobile ? undefined : PANEL_VIEWPORT_MAX_HEIGHT;
+  const listMaxHeight = isMobile
+    ? MOBILE_PANEL_CONTENT_HEIGHT
+    : PANEL_LIST_MAX_HEIGHT;
 
   const list =
     visibleItems.length === 0 ? (
@@ -284,7 +312,7 @@ export function NotificationsBell() {
         onScroll={(event) => {
           listScrollTopRef.current = event.currentTarget.scrollTop;
         }}
-        style={{ maxHeight: contentHeight }}
+        style={{ maxHeight: listMaxHeight }}
         className="flex flex-col gap-[var(--app-spacing-sm)] overflow-y-auto"
       >
         {visibleItems.map((item) => (
@@ -318,6 +346,7 @@ export function NotificationsBell() {
         <NotificationsBellDetail
           item={selectedItem}
           contentHeight={contentHeight}
+          contentMaxHeight={contentMaxHeight}
           validConversationIds={validConversationIds}
           areConversationListsPending={areConversationListsPending}
           validScheduleIds={validScheduleIds}

--- a/clients/web/src/domains/home/detail-panel/home-generic-detail.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-generic-detail.tsx
@@ -3,12 +3,14 @@ import type { FeedItem } from "@vellumai/assistant-api";
 
 export interface HomeGenericDetailProps {
   item: FeedItem;
+  /** Extra classes for the markdown body, e.g. a looser line height. */
+  className?: string;
 }
 
 /**
  * Fallback renderer for feed items that don't have a specialized
  * detail panel. Renders the item summary as markdown.
  */
-export function HomeGenericDetail({ item }: HomeGenericDetailProps) {
-  return <HomeMarkdownContent content={item.summary} />;
+export function HomeGenericDetail({ item, className }: HomeGenericDetailProps) {
+  return <HomeMarkdownContent content={item.summary} className={className} />;
 }

--- a/clients/web/src/utils/format-date.test.ts
+++ b/clients/web/src/utils/format-date.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatCompactLocalDate,
+  formatFriendlyDate,
+  formatFullLocalDate,
+} from "@/utils/format-date";
+
+/**
+ * Assertions are written against the runtime's own locale data rather than a
+ * hardcoded "Aug 5, 11:42 AM", so they hold wherever the suite runs. What they
+ * pin is the composition: the friendly date, a comma, and the local time.
+ */
+function localTime(date: Date): string {
+  return date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+describe("formatCompactLocalDate", () => {
+  test("pairs the friendly date with the local time", () => {
+    const date = new Date(2026, 7, 5, 11, 42);
+
+    expect(formatCompactLocalDate(date.toISOString())).toBe(
+      `${formatFriendlyDate(date)}, ${localTime(date)}`,
+    );
+  });
+
+  test("leaves the year off a date inside the current one", () => {
+    const currentYear = new Date().getFullYear();
+    const date = new Date(currentYear, 0, 15, 9, 14);
+
+    expect(formatCompactLocalDate(date.toISOString())).not.toContain(
+      String(currentYear),
+    );
+  });
+
+  test("carries the year once the date falls outside the current one", () => {
+    const date = new Date(2001, 0, 15, 9, 14);
+
+    expect(formatCompactLocalDate(date.toISOString())).toContain("2001");
+  });
+
+  test("stays shorter than the full local date it condenses", () => {
+    const iso = new Date(2026, 7, 5, 11, 42).toISOString();
+
+    expect(formatCompactLocalDate(iso).length).toBeLessThan(
+      formatFullLocalDate(iso).length,
+    );
+  });
+
+  test("renders nothing for a missing timestamp", () => {
+    expect(formatCompactLocalDate(null)).toBe("");
+    expect(formatCompactLocalDate(undefined)).toBe("");
+    expect(formatCompactLocalDate("")).toBe("");
+  });
+});

--- a/clients/web/src/utils/format-date.ts
+++ b/clients/web/src/utils/format-date.ts
@@ -69,6 +69,25 @@ export function formatRelativeDate(dateStr: string | null | undefined): string {
 }
 
 /**
+ * Compact absolute timestamp for inline metadata, e.g. "Aug 5, 11:42 AM".
+ * Pairs the friendly date (short month, year only outside the current one)
+ * with the local time, short enough to sit beside a relative label.
+ */
+export function formatCompactLocalDate(
+  dateStr: string | null | undefined,
+): string {
+  if (!dateStr) {
+    return "";
+  }
+  const date = new Date(dateStr);
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${formatFriendlyDate(date)}, ${time}`;
+}
+
+/**
  * Full local timestamp with timezone abbreviation for tooltip display.
  * e.g. "May 29, 2026, 10:36 AM EDT"
  */


### PR DESCRIPTION
## Summary
- The detail view now renders in a fixed frame matching the list's height, so the popover no longer resizes per notification. Long bodies scroll inside it.
- The timestamp moves out of the body into the footer's left slot, which is now a permanent pinned strip: metadata left, action right.
- Loosens the body's line height, which was inheriting a 1.29 ratio.