### PR TITLE
feat(plugins): opt-in hourly plugin auto-updates driven by the monitoring worker

### DIFF
--- a/assistant/src/config/__tests__/plugin-updates-schema.test.ts
+++ b/assistant/src/config/__tests__/plugin-updates-schema.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Guards over the `pluginUpdates` config block — the opt-in that decides
+ * whether installed plugins move on their own.
+ *
+ * The defaults are the contract: a workspace that says nothing must behave
+ * exactly as it did before the block existed (manual, nothing upgrades), and
+ * an opted-in workspace must land on the `theirs` merge strategy.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PluginUpdatesConfigSchema } from "../schemas/plugin-updates.js";
+
+describe("pluginUpdates config schema", () => {
+  test("defaults are manual / theirs / hourly", () => {
+    expect(PluginUpdatesConfigSchema.parse({})).toEqual({
+      mode: "manual",
+      strategy: "theirs",
+      checkIntervalMs: 3_600_000,
+    });
+  });
+
+  test("mode accepts only manual and auto", () => {
+    expect(PluginUpdatesConfigSchema.parse({ mode: "auto" }).mode).toBe("auto");
+    expect(
+      PluginUpdatesConfigSchema.safeParse({ mode: "sometimes" }).success,
+    ).toBe(false);
+  });
+
+  test("the unattended-hostile `assistant` strategy is not selectable", () => {
+    // It resolves conflicts by writing git conflict markers into the plugin's
+    // files, which unattended would leave broken code on disk.
+    expect(
+      PluginUpdatesConfigSchema.safeParse({ strategy: "assistant" }).success,
+    ).toBe(false);
+  });
+
+  test("sub-5-minute sweep intervals are rejected", () => {
+    expect(
+      PluginUpdatesConfigSchema.safeParse({ checkIntervalMs: 1_000 }).success,
+    ).toBe(false);
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -50,6 +50,7 @@ import {
   PlatformConfigSchema,
   UiConfigSchema,
 } from "./schemas/platform.js";
+import { PluginUpdatesConfigSchema } from "./schemas/plugin-updates.js";
 import { SecretDetectionConfigSchema } from "./schemas/security.js";
 import { ServicesSchema } from "./schemas/services.js";
 import { SkillsConfigSchema } from "./schemas/skills.js";
@@ -142,6 +143,9 @@ export const AssistantConfigSchema = z.object({
     .describe(
       "Per-plugin configuration keyed by plugin name. Validated downstream by each plugin's manifest.config validator at bootstrap.",
     ),
+  pluginUpdates: PluginUpdatesConfigSchema.default(
+    PluginUpdatesConfigSchema.parse({}),
+  ),
   legacyTelemetryOptOut: z
     .boolean()
     .optional()

--- a/assistant/src/config/schemas/plugin-updates.ts
+++ b/assistant/src/config/schemas/plugin-updates.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+/**
+ * Unattended plugin upgrade configuration.
+ *
+ * The resource monitor process runs a periodic sweep (see
+ * `monitoring/plugin-auto-update.ts`) that moves every installed, enabled
+ * plugin to its source's current revision. The sweep is off by default:
+ * `mode: "manual"` means nothing upgrades unless a human runs
+ * `assistant plugins upgrade <name>` (or the equivalent route), which is the
+ * behavior every workspace had before this block existed. Setting
+ * `mode: "auto"` opts the workspace into the hourly sweep.
+ */
+export const PluginUpdatesConfigSchema = z
+  .object({
+    mode: z
+      .enum(["manual", "auto"], {
+        error: 'pluginUpdates.mode must be "manual" or "auto"',
+      })
+      .default("manual")
+      .describe(
+        'How installed plugins move to newer revisions. "manual" (default) never upgrades on its own — upgrades happen only when a human asks for one. "auto" lets the resource monitor upgrade every installed, enabled plugin on the `checkIntervalMs` cadence.',
+      ),
+    strategy: z
+      // Deliberately narrower than the full `PluginUpgradeStrategy` union: the
+      // `assistant` strategy resolves conflicts by writing git conflict
+      // markers into the plugin's files and expecting someone to resolve
+      // them. Unattended, that would leave a syntactically broken plugin on
+      // disk with nobody in the loop, so it is not selectable here. It stays
+      // available for interactive `assistant plugins upgrade --strategy
+      // assistant`.
+      .enum(["theirs", "ours", "overwrite"], {
+        error:
+          'pluginUpdates.strategy must be "theirs", "ours", or "overwrite"',
+      })
+      .default("theirs")
+      .describe(
+        'How an automatic upgrade reconciles local edits to a plugin with the incoming revision. "theirs" (default) three-way merges and resolves conflicting hunks toward the incoming revision, keeping non-conflicting local edits; "ours" merges the same way but resolves conflicts toward the local edit; "overwrite" discards local edits and re-installs the revision wholesale. Only consulted when `mode` is "auto".',
+      ),
+    checkIntervalMs: z
+      .number({ error: "pluginUpdates.checkIntervalMs must be a number" })
+      .int("pluginUpdates.checkIntervalMs must be an integer")
+      .min(300_000, "pluginUpdates.checkIntervalMs must be at least 300000ms")
+      .max(
+        604_800_000,
+        "pluginUpdates.checkIntervalMs must be <= 604800000ms (7 days)",
+      )
+      .default(3_600_000)
+      .describe(
+        'Minimum interval between automatic upgrade sweeps, in milliseconds (default 1 hour). The last sweep is stamped on disk, so restarting the daemon does not re-run a sweep that already ran within the interval. Only consulted when `mode` is "auto".',
+      ),
+  })
+  .describe("Unattended plugin upgrade configuration");
+
+export type PluginUpdatesConfig = z.infer<typeof PluginUpdatesConfigSchema>;

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -58,6 +58,15 @@ export interface CliIpcCallResult<T = unknown> {
    * when the originating daemon-side error carried a `details` field.
    */
   errorDetails?: unknown;
+  /**
+   * Set when the call was abandoned because `timeoutMs` elapsed with no
+   * response. Distinct from every other `ok: false` shape: the request WAS
+   * delivered and the daemon may still be executing it — closing the client
+   * socket does not abort the handler. Callers that would otherwise retry a
+   * transport failure must not retry this one until the original can no
+   * longer be in flight.
+   */
+  timedOut?: boolean;
 }
 
 /**
@@ -178,7 +187,7 @@ export async function cliIpcCall<T = unknown>(
           { method, socketPath, timeoutMs: callTimeoutMs },
           "CLI IPC call timed out waiting for response",
         );
-        finish({ ok: false, error: "Request timed out" });
+        finish({ ok: false, error: "Request timed out", timedOut: true });
       }, callTimeoutMs);
 
       socket.on("data", (chunk) => {

--- a/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the unattended plugin upgrade sweep, driven one pass at a time
+ * (no timers) with every seam injected.
+ *
+ * The contract under test:
+ *   - a `manual` workspace (the default) never asks the daemon for anything;
+ *   - an `auto` workspace sweeps at most once per `checkIntervalMs`, and the
+ *     stamp survives restarts;
+ *   - one plugin's refusal does not stop the sweep, but an unreachable daemon
+ *     abandons it without stamping, so it retries;
+ *   - the configured strategy is what the daemon is asked for.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PluginUpdatesConfigSchema } from "../../config/schemas/plugin-updates.js";
+import {
+  type PluginAutoUpdateDeps,
+  runPluginAutoUpdatePassIfDue,
+} from "../plugin-auto-update.js";
+
+type UpgradeCall = { name: string; strategy: string };
+
+function makeDeps(
+  overrides: {
+    config?: Partial<{
+      mode: "manual" | "auto";
+      strategy: "theirs" | "ours" | "overwrite";
+      checkIntervalMs: number;
+    }>;
+    names?: string[];
+    now?: number;
+    lastRunAt?: number | null;
+    upgrade?: PluginAutoUpdateDeps["requestUpgrade"];
+  } = {},
+): {
+  deps: PluginAutoUpdateDeps;
+  calls: UpgradeCall[];
+  stamps: number[];
+} {
+  const calls: UpgradeCall[] = [];
+  const stamps: number[] = [];
+  const config = PluginUpdatesConfigSchema.parse(overrides.config ?? {});
+  const now = overrides.now ?? 1_000_000_000;
+  const upgrade: PluginAutoUpdateDeps["requestUpgrade"] =
+    overrides.upgrade ??
+    (async () => ({
+      ok: true,
+      result: { outcome: "upgraded", toCommit: "abc" },
+    }));
+  const deps: PluginAutoUpdateDeps = {
+    readConfig: () => config,
+    listUpgradableNames: () => overrides.names ?? ["alpha"],
+    requestUpgrade: async (name, strategy) => {
+      calls.push({ name, strategy });
+      return upgrade(name, strategy);
+    },
+    readLastRunAt: () => overrides.lastRunAt ?? null,
+    writeLastRunAt: () => stamps.push(now),
+    now: () => now,
+  };
+  return { deps, calls, stamps };
+}
+
+describe("plugin auto-update pass", () => {
+  test("defaults to manual: nothing is upgraded and nothing is stamped", async () => {
+    const { deps, calls, stamps } = makeDeps();
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.skipped).toBe("manual");
+    expect(calls).toEqual([]);
+    expect(stamps).toEqual([]);
+  });
+
+  test("auto mode upgrades every listed plugin with the configured strategy", async () => {
+    const { deps, calls, stamps } = makeDeps({
+      config: { mode: "auto" },
+      names: ["alpha", "beta"],
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.skipped).toBeNull();
+    expect(result.upgraded).toEqual(["alpha", "beta"]);
+    expect(calls).toEqual([
+      { name: "alpha", strategy: "theirs" },
+      { name: "beta", strategy: "theirs" },
+    ]);
+    expect(stamps.length).toBe(1);
+  });
+
+  test("a non-default strategy is what the daemon is asked for", async () => {
+    const { deps, calls } = makeDeps({
+      config: { mode: "auto", strategy: "overwrite" },
+    });
+    await runPluginAutoUpdatePassIfDue(deps);
+    expect(calls).toEqual([{ name: "alpha", strategy: "overwrite" }]);
+  });
+
+  test("an up-to-date plugin counts as unchanged, not upgraded", async () => {
+    const { deps } = makeDeps({
+      config: { mode: "auto" },
+      upgrade: async () => ({
+        ok: true,
+        result: { outcome: "already-up-to-date" },
+      }),
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.upgraded).toEqual([]);
+    expect(result.unchanged).toEqual(["alpha"]);
+  });
+
+  test("a sweep inside the interval is skipped", async () => {
+    const now = 5_000_000;
+    const { deps, calls } = makeDeps({
+      config: { mode: "auto", checkIntervalMs: 3_600_000 },
+      now,
+      lastRunAt: now - 3_599_999,
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.skipped).toBe("not-due");
+    expect(calls).toEqual([]);
+  });
+
+  test("a sweep at exactly one interval is due", async () => {
+    const now = 5_000_000;
+    const { deps, calls } = makeDeps({
+      config: { mode: "auto", checkIntervalMs: 3_600_000 },
+      now,
+      lastRunAt: now - 3_600_000,
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.skipped).toBeNull();
+    expect(calls.length).toBe(1);
+  });
+
+  test("one plugin's refusal does not stop the rest, and the sweep stamps", async () => {
+    const { deps, stamps } = makeDeps({
+      config: { mode: "auto" },
+      names: ["alpha", "beta"],
+      upgrade: async (name) =>
+        name === "alpha"
+          ? { ok: false, statusCode: 409, error: "not upgradable" }
+          : { ok: true, result: { outcome: "upgraded" } },
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.failed).toEqual(["alpha"]);
+    expect(result.upgraded).toEqual(["beta"]);
+    expect(result.daemonUnreachable).toBe(false);
+    expect(stamps.length).toBe(1);
+  });
+
+  test("an unreachable daemon abandons the sweep and stays due", async () => {
+    const { deps, calls, stamps } = makeDeps({
+      config: { mode: "auto" },
+      names: ["alpha", "beta"],
+      upgrade: async () => ({ ok: false, error: "connect ENOENT" }),
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.daemonUnreachable).toBe(true);
+    // Abandoned after the first plugin — the rest would fail identically.
+    expect(calls).toEqual([{ name: "alpha", strategy: "theirs" }]);
+    expect(stamps).toEqual([]);
+  });
+
+  test("a thrown upgrade is contained and counted as a failure", async () => {
+    const { deps, stamps } = makeDeps({
+      config: { mode: "auto" },
+      upgrade: async () => {
+        throw new Error("boom");
+      },
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.failed).toEqual(["alpha"]);
+    expect(stamps.length).toBe(1);
+  });
+
+  test("an empty workspace stamps instead of re-listing every minute", async () => {
+    const { deps, calls, stamps } = makeDeps({
+      config: { mode: "auto" },
+      names: [],
+    });
+    const result = await runPluginAutoUpdatePassIfDue(deps);
+    expect(result.skipped).toBe("no-plugins");
+    expect(calls).toEqual([]);
+    expect(stamps.length).toBe(1);
+  });
+
+  test("an unreadable config upgrades nothing", async () => {
+    const { deps, calls } = makeDeps({ config: { mode: "auto" } });
+    const broken: PluginAutoUpdateDeps = {
+      ...deps,
+      readConfig: () => {
+        throw new Error("config.json is corrupt");
+      },
+    };
+    const result = await runPluginAutoUpdatePassIfDue(broken);
+    expect(result.skipped).toBe("config-unreadable");
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("pluginUpdates config schema", () => {
+  test("defaults are manual / theirs / hourly", () => {
+    expect(PluginUpdatesConfigSchema.parse({})).toEqual({
+      mode: "manual",
+      strategy: "theirs",
+      checkIntervalMs: 3_600_000,
+    });
+  });
+
+  test("the unattended-hostile `assistant` strategy is not selectable", () => {
+    expect(
+      PluginUpdatesConfigSchema.safeParse({ strategy: "assistant" }).success,
+    ).toBe(false);
+  });
+
+  test("sub-5-minute intervals are rejected", () => {
+    expect(
+      PluginUpdatesConfigSchema.safeParse({ checkIntervalMs: 1_000 }).success,
+    ).toBe(false);
+  });
+});

--- a/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
@@ -1,220 +1,332 @@
 /**
  * Tests for the unattended plugin upgrade sweep, driven one pass at a time
- * (no timers) with every seam injected.
+ * (no timers) against a temp workspace: a real `config.json`, real plugin
+ * directories, and a real on-disk sweep stamp. Only the two network-bound
+ * seams are mocked — the marketplace drift check and the daemon IPC call.
  *
  * The contract under test:
  *   - a `manual` workspace (the default) never asks the daemon for anything;
  *   - an `auto` workspace sweeps at most once per `checkIntervalMs`, and the
  *     stamp survives restarts;
- *   - one plugin's refusal does not stop the sweep, but an unreachable daemon
- *     abandons it without stamping, so it retries;
+ *   - only plugins that can actually move reach the daemon — up-to-date and
+ *     disabled installs cost it nothing;
+ *   - one plugin's refusal does not stop the sweep, an unreachable daemon
+ *     abandons it without stamping (so it retries), and a timed-out upgrade
+ *     abandons it *with* a stamp (so the retry cannot race the handler that
+ *     is still running);
  *   - the configured strategy is what the daemon is asked for.
  */
 
-import { describe, expect, test } from "bun:test";
-
-import { PluginUpdatesConfigSchema } from "../../config/schemas/plugin-updates.js";
 import {
-  type PluginAutoUpdateDeps,
-  runPluginAutoUpdatePassIfDue,
-} from "../plugin-auto-update.js";
+  existsSync,
+  mkdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-type UpgradeCall = { name: string; strategy: string };
+const ROOT = join(
+  tmpdir(),
+  `plugin-auto-update-test-${process.pid}-${Date.now()}`,
+);
+const PLUGINS_DIR = join(ROOT, "plugins");
+const MONITORING_DIR = join(ROOT, "data", "monitoring");
+const STAMP = join(MONITORING_DIR, "plugin-auto-update-last-run-at");
+const CONFIG_PATH = join(ROOT, "config.json");
 
-function makeDeps(
-  overrides: {
-    config?: Partial<{
-      mode: "manual" | "auto";
-      strategy: "theirs" | "ours" | "overwrite";
-      checkIntervalMs: number;
-    }>;
-    names?: string[];
-    now?: number;
-    lastRunAt?: number | null;
-    upgrade?: PluginAutoUpdateDeps["requestUpgrade"];
-  } = {},
-): {
-  deps: PluginAutoUpdateDeps;
-  calls: UpgradeCall[];
-  stamps: number[];
-} {
-  const calls: UpgradeCall[] = [];
-  const stamps: number[] = [];
-  const config = PluginUpdatesConfigSchema.parse(overrides.config ?? {});
-  const now = overrides.now ?? 1_000_000_000;
-  const upgrade: PluginAutoUpdateDeps["requestUpgrade"] =
-    overrides.upgrade ??
-    (async () => ({
-      ok: true,
-      result: { outcome: "upgraded", toCommit: "abc" },
-    }));
-  const deps: PluginAutoUpdateDeps = {
-    readConfig: () => config,
-    listUpgradableNames: () => overrides.names ?? ["alpha"],
-    requestUpgrade: async (name, strategy) => {
-      calls.push({ name, strategy });
-      return upgrade(name, strategy);
-    },
-    readLastRunAt: () => overrides.lastRunAt ?? null,
-    writeLastRunAt: () => stamps.push(now),
-    now: () => now,
-  };
-  return { deps, calls, stamps };
+process.env.VELLUM_WORKSPACE_DIR = ROOT;
+mkdirSync(MONITORING_DIR, { recursive: true });
+mkdirSync(PLUGINS_DIR, { recursive: true });
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+// ── Mocked seams: the marketplace drift check and the daemon call ───────────
+//
+// `mock.module` replaces the module for the whole test process, so each
+// factory spreads the real module and overrides only the one export this
+// file drives. Replacing either wholesale would strip the other exports out
+// from under any test file running alongside this one.
+
+/** Drift status `inspectPlugin` reports per plugin name. */
+let inspectStatus = new Map<string, string>();
+let inspectThrowsFor = new Set<string>();
+
+type UpgradeReply = {
+  ok: boolean;
+  result?: { outcome?: string; toCommit?: string };
+  error?: string;
+  statusCode?: number;
+  timedOut?: boolean;
+};
+let upgradeReply: (name: string) => UpgradeReply = () => ({
+  ok: true,
+  result: { outcome: "upgraded", toCommit: "abc1234" },
+});
+const upgradeCalls: Array<{ name: string; strategy: unknown }> = [];
+
+const realInspect = await import("../../cli/lib/inspect-plugin.js");
+const realIpcClient = await import("../../ipc/cli-client.js");
+
+mock.module("../../cli/lib/inspect-plugin.js", () => ({
+  ...realInspect,
+  inspectPlugin: async ({ name }: { name: string }) => {
+    if (inspectThrowsFor.has(name)) {
+      throw new Error("marketplace unreachable");
+    }
+    return { name, status: inspectStatus.get(name) ?? "up-to-date" };
+  },
+}));
+
+mock.module("../../ipc/cli-client.js", () => ({
+  ...realIpcClient,
+  cliIpcCall: async (
+    _method: string,
+    params: { pathParams: { name: string }; body: { strategy: unknown } },
+  ) => {
+    upgradeCalls.push({
+      name: params.pathParams.name,
+      strategy: params.body.strategy,
+    });
+    return upgradeReply(params.pathParams.name);
+  },
+}));
+
+const { invalidateConfigCache } = await import("../../config/loader.js");
+const { runPluginAutoUpdateSweepIfDue } =
+  await import("../plugin-auto-update.js");
+
+// ── Workspace fixtures ──────────────────────────────────────────────────────
+
+function writeConfig(pluginUpdates: Record<string, unknown>): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify({ pluginUpdates }, null, 2));
+  invalidateConfigCache();
 }
 
-describe("plugin auto-update pass", () => {
+/** Materialize an installed plugin and declare what inspect says about it. */
+function installPlugin(
+  name: string,
+  opts: { status?: string; disabled?: boolean } = {},
+): void {
+  const dir = join(PLUGINS_DIR, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  if (opts.disabled) {
+    writeFileSync(join(dir, ".disabled"), "");
+  }
+  inspectStatus.set(name, opts.status ?? "update-available");
+}
+
+/** Backdate the stamp so the sweep is (or is not) due again. */
+function stampAgedBy(ms: number): void {
+  writeFileSync(STAMP, "");
+  const when = new Date(Date.now() - ms);
+  utimesSync(STAMP, when, when);
+}
+
+beforeEach(() => {
+  inspectStatus = new Map();
+  inspectThrowsFor = new Set();
+  upgradeReply = () => ({
+    ok: true,
+    result: { outcome: "upgraded", toCommit: "abc1234" },
+  });
+  upgradeCalls.length = 0;
+  rmSync(STAMP, { force: true });
+  rmSync(PLUGINS_DIR, { recursive: true, force: true });
+  mkdirSync(PLUGINS_DIR, { recursive: true });
+  writeConfig({});
+});
+
+describe("plugin auto-update sweep", () => {
   test("defaults to manual: nothing is upgraded and nothing is stamped", async () => {
-    const { deps, calls, stamps } = makeDeps();
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+    installPlugin("alpha");
+    const result = await runPluginAutoUpdateSweepIfDue();
     expect(result.skipped).toBe("manual");
-    expect(calls).toEqual([]);
-    expect(stamps).toEqual([]);
+    expect(upgradeCalls).toEqual([]);
+    expect(existsSync(STAMP)).toBe(false);
   });
 
-  test("auto mode upgrades every listed plugin with the configured strategy", async () => {
-    const { deps, calls, stamps } = makeDeps({
-      config: { mode: "auto" },
-      names: ["alpha", "beta"],
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+  test("auto mode upgrades every candidate with the configured strategy", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", { status: "update-available" });
+    installPlugin("beta", { status: "unknown-provenance" });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.skipped).toBeNull();
     expect(result.upgraded).toEqual(["alpha", "beta"]);
-    expect(calls).toEqual([
+    expect(upgradeCalls).toEqual([
       { name: "alpha", strategy: "theirs" },
       { name: "beta", strategy: "theirs" },
     ]);
-    expect(stamps.length).toBe(1);
   });
 
   test("a non-default strategy is what the daemon is asked for", async () => {
-    const { deps, calls } = makeDeps({
-      config: { mode: "auto", strategy: "overwrite" },
-    });
-    await runPluginAutoUpdatePassIfDue(deps);
-    expect(calls).toEqual([{ name: "alpha", strategy: "overwrite" }]);
+    writeConfig({ mode: "auto", strategy: "overwrite" });
+    installPlugin("alpha");
+
+    await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls).toEqual([{ name: "alpha", strategy: "overwrite" }]);
   });
 
-  test("an up-to-date plugin counts as unchanged, not upgraded", async () => {
-    const { deps } = makeDeps({
-      config: { mode: "auto" },
-      upgrade: async () => ({
-        ok: true,
-        result: { outcome: "already-up-to-date" },
-      }),
+  test("up-to-date plugins never reach the daemon", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", { status: "up-to-date" });
+    installPlugin("beta", { status: "update-available" });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls).toEqual([{ name: "beta", strategy: "theirs" }]);
+    expect(result.upgraded).toEqual(["beta"]);
+  });
+
+  test("a plugin whose drift cannot be resolved is skipped, not attempted", async () => {
+    writeConfig({ mode: "auto" });
+    // The catalog was unreachable for one, and the inspect call itself blew
+    // up for the other; an upgrade would hit the same failure.
+    installPlugin("alpha", { status: "remote-unavailable" });
+    installPlugin("gamma", { status: "update-available" });
+    inspectThrowsFor = new Set(["gamma"]);
+    installPlugin("beta", { status: "update-available" });
+
+    await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["beta"]);
+  });
+
+  test("a disabled plugin is left alone", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    installPlugin("beta", { disabled: true });
+
+    await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["alpha"]);
+  });
+
+  test("an up-to-date daemon verdict counts as unchanged, not upgraded", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    upgradeReply = () => ({
+      ok: true,
+      result: { outcome: "already-up-to-date" },
     });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.upgraded).toEqual([]);
     expect(result.unchanged).toEqual(["alpha"]);
   });
 
   test("a sweep inside the interval is skipped", async () => {
-    const now = 5_000_000;
-    const { deps, calls } = makeDeps({
-      config: { mode: "auto", checkIntervalMs: 3_600_000 },
-      now,
-      lastRunAt: now - 3_599_999,
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    stampAgedBy(60_000);
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.skipped).toBe("not-due");
-    expect(calls).toEqual([]);
+    expect(upgradeCalls).toEqual([]);
   });
 
-  test("a sweep at exactly one interval is due", async () => {
-    const now = 5_000_000;
-    const { deps, calls } = makeDeps({
-      config: { mode: "auto", checkIntervalMs: 3_600_000 },
-      now,
-      lastRunAt: now - 3_600_000,
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+  test("a sweep past the interval runs again", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    stampAgedBy(3_600_001);
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.skipped).toBeNull();
-    expect(calls.length).toBe(1);
+    expect(upgradeCalls.length).toBe(1);
+  });
+
+  test("a shortened interval is honored", async () => {
+    writeConfig({ mode: "auto", checkIntervalMs: 300_000 });
+    installPlugin("alpha");
+    stampAgedBy(400_000);
+
+    expect((await runPluginAutoUpdateSweepIfDue()).skipped).toBeNull();
   });
 
   test("one plugin's refusal does not stop the rest, and the sweep stamps", async () => {
-    const { deps, stamps } = makeDeps({
-      config: { mode: "auto" },
-      names: ["alpha", "beta"],
-      upgrade: async (name) =>
-        name === "alpha"
-          ? { ok: false, statusCode: 409, error: "not upgradable" }
-          : { ok: true, result: { outcome: "upgraded" } },
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    installPlugin("beta");
+    upgradeReply = (name) =>
+      name === "alpha"
+        ? { ok: false, statusCode: 409, error: "not upgradable" }
+        : { ok: true, result: { outcome: "upgraded" } };
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.failed).toEqual(["alpha"]);
     expect(result.upgraded).toEqual(["beta"]);
     expect(result.daemonUnreachable).toBe(false);
-    expect(stamps.length).toBe(1);
+    // Stamped: the next attempt is an interval away.
+    expect(await runPluginAutoUpdateSweepIfDue()).toMatchObject({
+      skipped: "not-due",
+    });
   });
 
   test("an unreachable daemon abandons the sweep and stays due", async () => {
-    const { deps, calls, stamps } = makeDeps({
-      config: { mode: "auto" },
-      names: ["alpha", "beta"],
-      upgrade: async () => ({ ok: false, error: "connect ENOENT" }),
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    installPlugin("beta");
+    upgradeReply = () => ({ ok: false, error: "connect ENOENT" });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.daemonUnreachable).toBe(true);
     // Abandoned after the first plugin — the rest would fail identically.
-    expect(calls).toEqual([{ name: "alpha", strategy: "theirs" }]);
-    expect(stamps).toEqual([]);
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["alpha"]);
+
+    // Unstamped, so the next poll retries immediately.
+    upgradeCalls.length = 0;
+    upgradeReply = () => ({ ok: true, result: { outcome: "upgraded" } });
+    const retry = await runPluginAutoUpdateSweepIfDue();
+    expect(retry.skipped).toBeNull();
+    expect(retry.upgraded).toEqual(["alpha", "beta"]);
   });
 
-  test("a thrown upgrade is contained and counted as a failure", async () => {
-    const { deps, stamps } = makeDeps({
-      config: { mode: "auto" },
-      upgrade: async () => {
-        throw new Error("boom");
-      },
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
+  test("a timed-out upgrade stamps, so the retry cannot race the daemon handler", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha");
+    installPlugin("beta");
+    upgradeReply = (name) =>
+      name === "alpha"
+        ? { ok: false, error: "Request timed out", timedOut: true }
+        : { ok: true, result: { outcome: "upgraded" } };
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
     expect(result.failed).toEqual(["alpha"]);
-    expect(stamps.length).toBe(1);
-  });
-
-  test("an empty workspace stamps instead of re-listing every minute", async () => {
-    const { deps, calls, stamps } = makeDeps({
-      config: { mode: "auto" },
-      names: [],
-    });
-    const result = await runPluginAutoUpdatePassIfDue(deps);
-    expect(result.skipped).toBe("no-plugins");
-    expect(calls).toEqual([]);
-    expect(stamps.length).toBe(1);
-  });
-
-  test("an unreadable config upgrades nothing", async () => {
-    const { deps, calls } = makeDeps({ config: { mode: "auto" } });
-    const broken: PluginAutoUpdateDeps = {
-      ...deps,
-      readConfig: () => {
-        throw new Error("config.json is corrupt");
-      },
-    };
-    const result = await runPluginAutoUpdatePassIfDue(broken);
-    expect(result.skipped).toBe("config-unreadable");
-    expect(calls).toEqual([]);
-  });
-});
-
-describe("pluginUpdates config schema", () => {
-  test("defaults are manual / theirs / hourly", () => {
-    expect(PluginUpdatesConfigSchema.parse({})).toEqual({
-      mode: "manual",
-      strategy: "theirs",
-      checkIntervalMs: 3_600_000,
+    // The daemon may still be swapping `alpha`; nothing is queued behind it.
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["alpha"]);
+    expect(result.daemonUnreachable).toBe(false);
+    expect(await runPluginAutoUpdateSweepIfDue()).toMatchObject({
+      skipped: "not-due",
     });
   });
 
-  test("the unattended-hostile `assistant` strategy is not selectable", () => {
-    expect(
-      PluginUpdatesConfigSchema.safeParse({ strategy: "assistant" }).success,
-    ).toBe(false);
-  });
+  test("a workspace with nothing to move stamps instead of re-inspecting every minute", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", { status: "up-to-date" });
 
-  test("sub-5-minute intervals are rejected", () => {
-    expect(
-      PluginUpdatesConfigSchema.safeParse({ checkIntervalMs: 1_000 }).success,
-    ).toBe(false);
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(result.skipped).toBe("no-candidates");
+    expect(upgradeCalls).toEqual([]);
+    expect(await runPluginAutoUpdateSweepIfDue()).toMatchObject({
+      skipped: "not-due",
+    });
   });
 });

--- a/assistant/src/monitoring/plugin-auto-update.ts
+++ b/assistant/src/monitoring/plugin-auto-update.ts
@@ -1,0 +1,333 @@
+/**
+ * Unattended plugin upgrades, driven from the resource monitor process.
+ *
+ * A workspace opts in with `pluginUpdates.mode: "auto"`; the default,
+ * `"manual"`, keeps the pre-existing behavior where a plugin only ever moves
+ * when a human runs `assistant plugins upgrade`. When opted in, this sweep
+ * walks every installed, enabled plugin once per `pluginUpdates.checkIntervalMs`
+ * (default hourly) and moves each one to its source's current revision using
+ * the configured merge strategy (default `theirs`).
+ *
+ * The monitor drives it — not the daemon — for the same reason it drives the
+ * plugin source watch and crash recovery: the work is periodic, network-bound,
+ * and must not compete with the daemon's turn loop. But the monitor does *not*
+ * perform the upgrade itself. It asks the daemon to, over the CLI IPC socket
+ * (`plugins_upgrade`), because the upgrade has in-process lifecycle: the old
+ * version's `shutdown` must run at the swap boundary and the new version's
+ * `init` must run right after, both inside the process that loaded the plugin.
+ * A monitor-local upgrade would swap files under a daemon that never tore the
+ * old version down. When the daemon is unreachable nothing is attempted and
+ * the sweep stays due, so it retries on the next poll rather than skipping the
+ * window.
+ *
+ * The last completed sweep is stamped in the monitoring data dir, so a daemon
+ * that restarts every few minutes still upgrades at most once per interval
+ * instead of re-sweeping (and re-cloning) on every boot.
+ */
+
+import { statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { listInstalledPlugins } from "../cli/lib/list-installed-plugins.js";
+import { getConfigReadOnly } from "../config/loader.js";
+import type { PluginUpdatesConfig } from "../config/schemas/plugin-updates.js";
+import { cliIpcCall } from "../ipc/cli-client.js";
+import { isPluginDisabled } from "../plugins/disabled-state.js";
+import { getLogger } from "../util/logger.js";
+import { getMonitoringDataDir } from "../util/platform.js";
+
+const log = getLogger("plugin-auto-update");
+
+/** IPC method backing `POST /v1/plugins/:name/upgrade` on the daemon. */
+const UPGRADE_IPC_METHOD = "plugins_upgrade";
+
+/**
+ * Per-plugin ceiling for the daemon call. An upgrade clones the source, may
+ * install dependencies, and runs the plugin's `shutdown`/`init` hooks, so it
+ * is far slower than the IPC client's default 60s — but it must still be
+ * bounded, or one wedged upgrade stalls every later plugin in the sweep.
+ */
+const UPGRADE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** How often the loop re-tests whether a sweep is due. */
+const DUE_POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Delay before the first due-check. The monitor starts alongside the daemon,
+ * which is still migrating and loading plugins; there is nothing to upgrade
+ * into until it is up.
+ */
+const BOOT_DELAY_MS = 60_000;
+
+const STAMP_FILENAME = "plugin-auto-update-last-run-at";
+
+/** Outcome the daemon reports for one plugin; mirrors `PluginUpgradeResult`. */
+interface UpgradeCallResult {
+  readonly outcome?: string;
+  readonly fromCommit?: string | null;
+  readonly toCommit?: string;
+}
+
+/** Injectable seams. Production callers take every default. */
+export interface PluginAutoUpdateDeps {
+  /** Effective `pluginUpdates` block. Re-read each pass so a config edit takes effect without a restart. */
+  readonly readConfig: () => PluginUpdatesConfig;
+  /** Names of installed plugins eligible for an unattended upgrade. */
+  readonly listUpgradableNames: () => string[];
+  /** Ask the daemon to upgrade one plugin. */
+  readonly requestUpgrade: (
+    name: string,
+    strategy: PluginUpdatesConfig["strategy"],
+  ) => Promise<{
+    readonly ok: boolean;
+    readonly result?: UpgradeCallResult;
+    readonly error?: string;
+    /** Absent when the call never reached the daemon (transport failure). */
+    readonly statusCode?: number;
+  }>;
+  /** Epoch millis of the last completed sweep, or null when never swept. */
+  readonly readLastRunAt: () => number | null;
+  /** Stamp a completed sweep. */
+  readonly writeLastRunAt: () => void;
+  readonly now: () => number;
+}
+
+function stampPath(): string {
+  return join(getMonitoringDataDir(), STAMP_FILENAME);
+}
+
+/**
+ * Installed plugins the sweep may move: user-installed (defaults ship with the
+ * assistant and have no upstream to advance to) and not disabled. A disabled
+ * plugin is deliberately left alone — the user switched it off, and upgrading
+ * it would re-materialize code and re-declare schedules for something that
+ * isn't running.
+ */
+function defaultListUpgradableNames(): string[] {
+  return listInstalledPlugins()
+    .map((plugin) => plugin.name)
+    .filter((name) => !isPluginDisabled(name));
+}
+
+async function defaultRequestUpgrade(
+  name: string,
+  strategy: PluginUpdatesConfig["strategy"],
+): Promise<{
+  ok: boolean;
+  result?: UpgradeCallResult;
+  error?: string;
+  statusCode?: number;
+}> {
+  return cliIpcCall<UpgradeCallResult>(
+    UPGRADE_IPC_METHOD,
+    // The target revision is never caller-supplied — the daemon resolves it
+    // from the plugin's own source, exactly as an interactive upgrade does.
+    { pathParams: { name }, body: { strategy } },
+    { timeoutMs: UPGRADE_TIMEOUT_MS },
+  );
+}
+
+const PRODUCTION_DEPS: PluginAutoUpdateDeps = {
+  // `getConfigReadOnly` never creates directories or writes config.json —
+  // the monitor must not repair the daemon's config file behind its back.
+  readConfig: () => getConfigReadOnly().pluginUpdates,
+  listUpgradableNames: defaultListUpgradableNames,
+  requestUpgrade: defaultRequestUpgrade,
+  readLastRunAt: () => {
+    try {
+      return statSync(stampPath()).mtimeMs;
+    } catch {
+      return null; // never swept, or an unreadable stamp — treat as due
+    }
+  },
+  writeLastRunAt: () => {
+    try {
+      writeFileSync(stampPath(), "");
+    } catch (err) {
+      log.warn({ err }, "Could not stamp the plugin auto-update sweep");
+    }
+  },
+  now: () => Date.now(),
+};
+
+/** What one pass did, for logging and tests. */
+export interface PluginAutoUpdatePassResult {
+  /** Why the pass did no work, or `null` when a sweep ran. */
+  readonly skipped:
+    | "manual"
+    | "not-due"
+    | "no-plugins"
+    | "config-unreadable"
+    | null;
+  readonly upgraded: readonly string[];
+  readonly unchanged: readonly string[];
+  readonly failed: readonly string[];
+  /** True when the daemon could not be reached, so the sweep stays due. */
+  readonly daemonUnreachable: boolean;
+}
+
+const NOTHING: Omit<PluginAutoUpdatePassResult, "skipped"> = {
+  upgraded: [],
+  unchanged: [],
+  failed: [],
+  daemonUnreachable: false,
+};
+
+/**
+ * Run one sweep if the workspace is opted in and the interval has elapsed.
+ *
+ * Never throws: a plugin whose upgrade fails (source unreachable, no upstream
+ * to advance to, an unreconstructable merge baseline) is logged and skipped so
+ * one bad plugin cannot block the rest, and the sweep is stamped regardless —
+ * a failure retries on the next interval, not on the next minute.
+ */
+export async function runPluginAutoUpdatePassIfDue(
+  deps: PluginAutoUpdateDeps = PRODUCTION_DEPS,
+): Promise<PluginAutoUpdatePassResult> {
+  let config: PluginUpdatesConfig;
+  try {
+    config = deps.readConfig();
+  } catch (err) {
+    // A config that cannot be read is not an invitation to upgrade anything.
+    log.warn({ err }, "Plugin auto-update could not read config — skipping");
+    return { skipped: "config-unreadable", ...NOTHING };
+  }
+  if (config.mode !== "auto") {
+    return { skipped: "manual", ...NOTHING };
+  }
+
+  const lastRunAt = deps.readLastRunAt();
+  if (lastRunAt !== null && deps.now() - lastRunAt < config.checkIntervalMs) {
+    return { skipped: "not-due", ...NOTHING };
+  }
+
+  let names: string[];
+  try {
+    names = deps.listUpgradableNames();
+  } catch (err) {
+    log.warn({ err }, "Plugin auto-update could not list installed plugins");
+    return { skipped: "no-plugins", ...NOTHING };
+  }
+  if (names.length === 0) {
+    // Stamp anyway: an empty workspace is a completed sweep, and re-listing an
+    // empty directory every minute is pointless.
+    deps.writeLastRunAt();
+    return { skipped: "no-plugins", ...NOTHING };
+  }
+
+  const upgraded: string[] = [];
+  const unchanged: string[] = [];
+  const failed: string[] = [];
+  let daemonUnreachable = false;
+
+  // Sequential on purpose: each upgrade clones a repository and may install
+  // dependencies, and the daemon runs the swapped plugin's lifecycle hooks.
+  // Running them one at a time keeps the monitor's network and the daemon's
+  // event loop from being flooded by a workspace with many plugins.
+  for (const name of names) {
+    let call: Awaited<ReturnType<PluginAutoUpdateDeps["requestUpgrade"]>>;
+    try {
+      call = await deps.requestUpgrade(name, config.strategy);
+    } catch (err) {
+      failed.push(name);
+      log.warn({ err, name }, "Plugin auto-update call failed");
+      continue;
+    }
+    if (call.ok) {
+      const outcome = call.result?.outcome;
+      if (outcome === "upgraded") {
+        upgraded.push(name);
+        log.info(
+          {
+            name,
+            strategy: config.strategy,
+            from: call.result?.fromCommit,
+            to: call.result?.toCommit,
+          },
+          "Plugin auto-upgraded",
+        );
+      } else {
+        unchanged.push(name);
+      }
+      continue;
+    }
+    if (call.statusCode === undefined) {
+      // Transport failure: the daemon is down, restarting, or still gated on
+      // migrations. Nothing after this would fare better, so abandon the
+      // sweep without stamping and retry on the next poll.
+      daemonUnreachable = true;
+      log.debug(
+        { name, error: call.error },
+        "Plugin auto-update could not reach the daemon — staying due",
+      );
+      break;
+    }
+    failed.push(name);
+    log.warn(
+      { name, statusCode: call.statusCode, error: call.error },
+      "Plugin auto-upgrade was refused",
+    );
+  }
+
+  if (!daemonUnreachable) {
+    deps.writeLastRunAt();
+    log.info(
+      {
+        upgraded: upgraded.length,
+        unchanged: unchanged.length,
+        failed: failed.length,
+        strategy: config.strategy,
+      },
+      "Plugin auto-update sweep complete",
+    );
+  }
+
+  return { skipped: null, upgraded, unchanged, failed, daemonUnreachable };
+}
+
+/** Handle for the running auto-update loop. */
+export interface PluginAutoUpdateHandle {
+  stop(): void;
+}
+
+let inFlight = false;
+
+/**
+ * Guarded pass: a sweep can outlive the poll interval (each plugin gets up to
+ * {@link UPGRADE_TIMEOUT_MS}), and two concurrent sweeps would ask the daemon
+ * to upgrade the same plugin twice.
+ */
+async function tick(): Promise<void> {
+  if (inFlight) {
+    return;
+  }
+  inFlight = true;
+  try {
+    await runPluginAutoUpdatePassIfDue();
+  } catch (err) {
+    log.warn({ err }, "Plugin auto-update pass failed (non-fatal)");
+  } finally {
+    inFlight = false;
+  }
+}
+
+/**
+ * Start the auto-update loop in the monitor process.
+ *
+ * The timer runs regardless of the current mode — it is the pass that reads
+ * `pluginUpdates.mode`, so switching a workspace to `auto` takes effect within
+ * one poll instead of at the next daemon restart. Timers are unref'd so the
+ * loop never keeps the process alive.
+ */
+export function startPluginAutoUpdate(): PluginAutoUpdateHandle {
+  const bootTimer = setTimeout(() => void tick(), BOOT_DELAY_MS);
+  bootTimer.unref?.();
+  const pollTimer = setInterval(() => void tick(), DUE_POLL_INTERVAL_MS);
+  pollTimer.unref?.();
+  return {
+    stop() {
+      clearTimeout(bootTimer);
+      clearInterval(pollTimer);
+    },
+  };
+}

--- a/assistant/src/monitoring/plugin-auto-update.ts
+++ b/assistant/src/monitoring/plugin-auto-update.ts
@@ -5,12 +5,14 @@
  * `"manual"`, keeps the pre-existing behavior where a plugin only ever moves
  * when a human runs `assistant plugins upgrade`. When opted in, this sweep
  * walks every installed, enabled plugin once per `pluginUpdates.checkIntervalMs`
- * (default hourly) and moves each one to its source's current revision using
- * the configured merge strategy (default `theirs`).
+ * (default hourly), inspects which ones can actually move, and upgrades those
+ * with the configured merge strategy (default `theirs`).
  *
  * The monitor drives it — not the daemon — for the same reason it drives the
  * plugin source watch and crash recovery: the work is periodic, network-bound,
- * and must not compete with the daemon's turn loop. But the monitor does *not*
+ * and must not compete with the daemon's turn loop. Drift detection happens
+ * here too (`inspectPlugin` reads the catalog; no clone), so a workspace whose
+ * plugins are all current costs the daemon nothing. But the monitor does *not*
  * perform the upgrade itself. It asks the daemon to, over the CLI IPC socket
  * (`plugins_upgrade`), because the upgrade has in-process lifecycle: the old
  * version's `shutdown` must run at the swap boundary and the new version's
@@ -22,12 +24,13 @@
  *
  * The last completed sweep is stamped in the monitoring data dir, so a daemon
  * that restarts every few minutes still upgrades at most once per interval
- * instead of re-sweeping (and re-cloning) on every boot.
+ * instead of re-cloning on every boot.
  */
 
 import { statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { inspectPlugin } from "../cli/lib/inspect-plugin.js";
 import { listInstalledPlugins } from "../cli/lib/list-installed-plugins.js";
 import { getConfigReadOnly } from "../config/loader.js";
 import type { PluginUpdatesConfig } from "../config/schemas/plugin-updates.js";
@@ -45,7 +48,7 @@ const UPGRADE_IPC_METHOD = "plugins_upgrade";
  * Per-plugin ceiling for the daemon call. An upgrade clones the source, may
  * install dependencies, and runs the plugin's `shutdown`/`init` hooks, so it
  * is far slower than the IPC client's default 60s — but it must still be
- * bounded, or one wedged upgrade stalls every later plugin in the sweep.
+ * bounded, or one wedged upgrade stalls the sweep forever.
  */
 const UPGRADE_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -61,6 +64,27 @@ const BOOT_DELAY_MS = 60_000;
 
 const STAMP_FILENAME = "plugin-auto-update-last-run-at";
 
+/**
+ * Inspection verdicts worth asking the daemon about.
+ *
+ * `update-available` is the obvious one. `unknown-provenance` (an older or
+ * manually-copied install with no recorded commit) is included because an
+ * upgrade re-pins it, which is how it stops being unknown. So is
+ * `not-in-marketplace`: a plugin installed straight from a GitHub URL has no
+ * catalog entry to compare against, but it still tracks a ref upstream may
+ * have moved — only the daemon's upgrade can resolve that, and it no-ops when
+ * the ref still points at the installed commit.
+ *
+ * Everything else is skipped: `up-to-date` has nowhere to move, and
+ * `remote-unavailable` means the catalog could not be read, so an upgrade
+ * would fail on the same outage a moment later.
+ */
+const UPGRADABLE_STATUSES: ReadonlySet<string> = new Set([
+  "update-available",
+  "unknown-provenance",
+  "not-in-marketplace",
+]);
+
 /** Outcome the daemon reports for one plugin; mirrors `PluginUpgradeResult`. */
 interface UpgradeCallResult {
   readonly outcome?: string;
@@ -68,56 +92,67 @@ interface UpgradeCallResult {
   readonly toCommit?: string;
 }
 
-/** Injectable seams. Production callers take every default. */
-export interface PluginAutoUpdateDeps {
-  /** Effective `pluginUpdates` block. Re-read each pass so a config edit takes effect without a restart. */
-  readonly readConfig: () => PluginUpdatesConfig;
-  /** Names of installed plugins eligible for an unattended upgrade. */
-  readonly listUpgradableNames: () => string[];
-  /** Ask the daemon to upgrade one plugin. */
-  readonly requestUpgrade: (
-    name: string,
-    strategy: PluginUpdatesConfig["strategy"],
-  ) => Promise<{
-    readonly ok: boolean;
-    readonly result?: UpgradeCallResult;
-    readonly error?: string;
-    /** Absent when the call never reached the daemon (transport failure). */
-    readonly statusCode?: number;
-  }>;
-  /** Epoch millis of the last completed sweep, or null when never swept. */
-  readonly readLastRunAt: () => number | null;
-  /** Stamp a completed sweep. */
-  readonly writeLastRunAt: () => void;
-  readonly now: () => number;
-}
-
 function stampPath(): string {
   return join(getMonitoringDataDir(), STAMP_FILENAME);
 }
 
-/**
- * Installed plugins the sweep may move: user-installed (defaults ship with the
- * assistant and have no upstream to advance to) and not disabled. A disabled
- * plugin is deliberately left alone — the user switched it off, and upgrading
- * it would re-materialize code and re-declare schedules for something that
- * isn't running.
- */
-function defaultListUpgradableNames(): string[] {
-  return listInstalledPlugins()
-    .map((plugin) => plugin.name)
-    .filter((name) => !isPluginDisabled(name));
+/** Epoch millis of the last completed sweep, or `null` when never swept. */
+function lastSweepAt(): number | null {
+  try {
+    return statSync(stampPath()).mtimeMs;
+  } catch {
+    return null; // never swept, or an unreadable stamp — treat as due
+  }
 }
 
-async function defaultRequestUpgrade(
+function stampSweep(): void {
+  try {
+    writeFileSync(stampPath(), "");
+  } catch (err) {
+    log.warn({ err }, "Could not stamp the plugin auto-update sweep");
+  }
+}
+
+/**
+ * Installed plugins this sweep should ask the daemon to upgrade.
+ *
+ * Only user-installed plugins are listed (defaults ship with the assistant and
+ * have no upstream to advance to). A disabled plugin is deliberately left
+ * alone — the user switched it off, and upgrading it would re-materialize code
+ * and re-declare schedules for something that isn't running. What survives
+ * that is inspected, so the daemon is only asked about plugins that can
+ * actually move (see {@link UPGRADABLE_STATUSES}).
+ */
+async function listUpgradableNames(): Promise<string[]> {
+  const installed = listInstalledPlugins()
+    .map((plugin) => plugin.name)
+    .filter((name) => !isPluginDisabled(name));
+
+  const candidates: string[] = [];
+  for (const name of installed) {
+    try {
+      const inspection = await inspectPlugin(
+        { name },
+        { fetch: globalThis.fetch.bind(globalThis) },
+      );
+      if (UPGRADABLE_STATUSES.has(inspection.status)) {
+        candidates.push(name);
+      }
+    } catch (err) {
+      // An install whose drift cannot be classified (source unreachable,
+      // rate-limited) is skipped rather than handed to the daemon, which
+      // would hit the same failure a moment later.
+      log.debug({ err, name }, "Plugin auto-update could not inspect plugin");
+    }
+  }
+  return candidates;
+}
+
+/** Ask the daemon to upgrade one plugin. */
+function requestUpgrade(
   name: string,
   strategy: PluginUpdatesConfig["strategy"],
-): Promise<{
-  ok: boolean;
-  result?: UpgradeCallResult;
-  error?: string;
-  statusCode?: number;
-}> {
+) {
   return cliIpcCall<UpgradeCallResult>(
     UPGRADE_IPC_METHOD,
     // The target revision is never caller-supplied — the daemon resolves it
@@ -127,36 +162,13 @@ async function defaultRequestUpgrade(
   );
 }
 
-const PRODUCTION_DEPS: PluginAutoUpdateDeps = {
-  // `getConfigReadOnly` never creates directories or writes config.json —
-  // the monitor must not repair the daemon's config file behind its back.
-  readConfig: () => getConfigReadOnly().pluginUpdates,
-  listUpgradableNames: defaultListUpgradableNames,
-  requestUpgrade: defaultRequestUpgrade,
-  readLastRunAt: () => {
-    try {
-      return statSync(stampPath()).mtimeMs;
-    } catch {
-      return null; // never swept, or an unreadable stamp — treat as due
-    }
-  },
-  writeLastRunAt: () => {
-    try {
-      writeFileSync(stampPath(), "");
-    } catch (err) {
-      log.warn({ err }, "Could not stamp the plugin auto-update sweep");
-    }
-  },
-  now: () => Date.now(),
-};
-
-/** What one pass did, for logging and tests. */
-export interface PluginAutoUpdatePassResult {
-  /** Why the pass did no work, or `null` when a sweep ran. */
+/** What one sweep did, for logging and tests. */
+export interface PluginAutoUpdateSweepResult {
+  /** Why the sweep did no work, or `null` when it ran. */
   readonly skipped:
     | "manual"
     | "not-due"
-    | "no-plugins"
+    | "no-candidates"
     | "config-unreadable"
     | null;
   readonly upgraded: readonly string[];
@@ -166,7 +178,7 @@ export interface PluginAutoUpdatePassResult {
   readonly daemonUnreachable: boolean;
 }
 
-const NOTHING: Omit<PluginAutoUpdatePassResult, "skipped"> = {
+const NOTHING: Omit<PluginAutoUpdateSweepResult, "skipped"> = {
   upgraded: [],
   unchanged: [],
   failed: [],
@@ -181,12 +193,13 @@ const NOTHING: Omit<PluginAutoUpdatePassResult, "skipped"> = {
  * one bad plugin cannot block the rest, and the sweep is stamped regardless —
  * a failure retries on the next interval, not on the next minute.
  */
-export async function runPluginAutoUpdatePassIfDue(
-  deps: PluginAutoUpdateDeps = PRODUCTION_DEPS,
-): Promise<PluginAutoUpdatePassResult> {
+export async function runPluginAutoUpdateSweepIfDue(): Promise<PluginAutoUpdateSweepResult> {
   let config: PluginUpdatesConfig;
   try {
-    config = deps.readConfig();
+    // `getConfigReadOnly` never creates directories or writes config.json —
+    // the monitor must not repair the daemon's config file behind its back.
+    // It re-reads on change, so flipping the mode needs no restart.
+    config = getConfigReadOnly().pluginUpdates;
   } catch (err) {
     // A config that cannot be read is not an invitation to upgrade anything.
     log.warn({ err }, "Plugin auto-update could not read config — skipping");
@@ -196,23 +209,23 @@ export async function runPluginAutoUpdatePassIfDue(
     return { skipped: "manual", ...NOTHING };
   }
 
-  const lastRunAt = deps.readLastRunAt();
-  if (lastRunAt !== null && deps.now() - lastRunAt < config.checkIntervalMs) {
+  const lastRunAt = lastSweepAt();
+  if (lastRunAt !== null && Date.now() - lastRunAt < config.checkIntervalMs) {
     return { skipped: "not-due", ...NOTHING };
   }
 
   let names: string[];
   try {
-    names = deps.listUpgradableNames();
+    names = await listUpgradableNames();
   } catch (err) {
     log.warn({ err }, "Plugin auto-update could not list installed plugins");
-    return { skipped: "no-plugins", ...NOTHING };
+    return { skipped: "no-candidates", ...NOTHING };
   }
   if (names.length === 0) {
-    // Stamp anyway: an empty workspace is a completed sweep, and re-listing an
-    // empty directory every minute is pointless.
-    deps.writeLastRunAt();
-    return { skipped: "no-plugins", ...NOTHING };
+    // Stamp anyway: a workspace with nothing to move is a completed sweep, and
+    // re-inspecting every plugin a minute later would be pure churn.
+    stampSweep();
+    return { skipped: "no-candidates", ...NOTHING };
   }
 
   const upgraded: string[] = [];
@@ -225,9 +238,9 @@ export async function runPluginAutoUpdatePassIfDue(
   // Running them one at a time keeps the monitor's network and the daemon's
   // event loop from being flooded by a workspace with many plugins.
   for (const name of names) {
-    let call: Awaited<ReturnType<PluginAutoUpdateDeps["requestUpgrade"]>>;
+    let call: Awaited<ReturnType<typeof requestUpgrade>>;
     try {
-      call = await deps.requestUpgrade(name, config.strategy);
+      call = await requestUpgrade(name, config.strategy);
     } catch (err) {
       failed.push(name);
       log.warn({ err, name }, "Plugin auto-update call failed");
@@ -251,6 +264,19 @@ export async function runPluginAutoUpdatePassIfDue(
       }
       continue;
     }
+    if (call.timedOut) {
+      // The request was delivered and the daemon may still be swapping this
+      // plugin — closing our socket does not abort its handler. Stop the sweep
+      // and stamp it: retrying in a minute would pile work onto an upgrade
+      // that is still running (the daemon refuses a second upgrade of the same
+      // plugin anyway). The next attempt is a full interval away.
+      failed.push(name);
+      log.warn(
+        { name, timeoutMs: UPGRADE_TIMEOUT_MS },
+        "Plugin auto-upgrade timed out — abandoning the sweep until the next interval",
+      );
+      break;
+    }
     if (call.statusCode === undefined) {
       // Transport failure: the daemon is down, restarting, or still gated on
       // migrations. Nothing after this would fare better, so abandon the
@@ -270,7 +296,7 @@ export async function runPluginAutoUpdatePassIfDue(
   }
 
   if (!daemonUnreachable) {
-    deps.writeLastRunAt();
+    stampSweep();
     log.info(
       {
         upgraded: upgraded.length,
@@ -293,7 +319,7 @@ export interface PluginAutoUpdateHandle {
 let inFlight = false;
 
 /**
- * Guarded pass: a sweep can outlive the poll interval (each plugin gets up to
+ * Guarded sweep: a sweep can outlive the poll interval (each plugin gets up to
  * {@link UPGRADE_TIMEOUT_MS}), and two concurrent sweeps would ask the daemon
  * to upgrade the same plugin twice.
  */
@@ -303,9 +329,9 @@ async function tick(): Promise<void> {
   }
   inFlight = true;
   try {
-    await runPluginAutoUpdatePassIfDue();
+    await runPluginAutoUpdateSweepIfDue();
   } catch (err) {
-    log.warn({ err }, "Plugin auto-update pass failed (non-fatal)");
+    log.warn({ err }, "Plugin auto-update sweep failed (non-fatal)");
   } finally {
     inFlight = false;
   }
@@ -314,7 +340,7 @@ async function tick(): Promise<void> {
 /**
  * Start the auto-update loop in the monitor process.
  *
- * The timer runs regardless of the current mode — it is the pass that reads
+ * The timer runs regardless of the current mode — it is the sweep that reads
  * `pluginUpdates.mode`, so switching a workspace to `auto` takes effect within
  * one poll instead of at the next daemon restart. Timers are unref'd so the
  * loop never keeps the process alive.

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -48,6 +48,10 @@ import {
   startFileDescriptorMonitor,
 } from "./file-descriptors.js";
 import {
+  type PluginAutoUpdateHandle,
+  startPluginAutoUpdate,
+} from "./plugin-auto-update.js";
+import {
   type PluginSourceWatchHandle,
   startPluginSourceWatch,
 } from "./plugin-source-watch.js";
@@ -90,6 +94,7 @@ async function main(): Promise<void> {
   let sampler: ResourceSamplerHandle | null = null;
   let fdMonitor: FileDescriptorMonitorHandle | null = null;
   let sourceWatch: PluginSourceWatchHandle | null = null;
+  let autoUpdate: PluginAutoUpdateHandle | null = null;
   let recovery: RecoveryHandle | null = null;
 
   let shuttingDown = false;
@@ -104,6 +109,7 @@ async function main(): Promise<void> {
     stopConfigSnapshotReporter();
     stopMemoryTierReporter();
     stopDbIntegritySampler();
+    autoUpdate?.stop();
     sourceWatch?.stop();
     fdMonitor?.stop();
     sampler?.stop();
@@ -153,6 +159,10 @@ async function main(): Promise<void> {
   sourceWatch = startPluginSourceWatch(
     config.monitoring.pluginSourceScanIntervalMs,
   );
+  // Unattended plugin upgrades, when the workspace opted in
+  // (`pluginUpdates.mode: "auto"`). The loop starts either way — the pass
+  // reads the mode, so flipping it takes effect without a restart.
+  autoUpdate = startPluginAutoUpdate();
   // Crash recovery runs here, off the daemon's boot path and event loop.
   recovery = startRecovery();
 
@@ -181,6 +191,7 @@ async function main(): Promise<void> {
   process.on("uncaughtException", (err) => {
     log.error({ err }, "Uncaught exception in resource monitor process");
     recovery?.stop();
+    autoUpdate?.stop();
     sourceWatch?.stop();
     fdMonitor?.stop();
     sampler?.stop();
@@ -192,6 +203,7 @@ async function main(): Promise<void> {
   process.on("unhandledRejection", (reason) => {
     log.error({ reason }, "Unhandled rejection in resource monitor process");
     recovery?.stop();
+    autoUpdate?.stop();
     sourceWatch?.stop();
     fdMonitor?.stop();
     sampler?.stop();
@@ -202,6 +214,7 @@ async function main(): Promise<void> {
 
   process.on("exit", () => {
     recovery?.stop();
+    autoUpdate?.stop();
     sourceWatch?.stop();
     fdMonitor?.stop();
     sampler?.stop();

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -2178,6 +2178,90 @@ describe("POST /v1/plugins/:name/upgrade", () => {
     });
   });
 
+  test("refuses a concurrent upgrade of the same plugin with ConflictError (409)", async () => {
+    // Two upgrades of one plugin derive the same staging path in this
+    // process, so the second would delete the first's tree mid-swap. It is
+    // refused instead \u2014 the monitor's auto-update sweep and a user clicking
+    // Upgrade can now land at the same moment.
+    let releaseFirst: () => void = () => {};
+    const firstStarted = Promise.withResolvers<void>();
+    upgradeSpy.mockImplementation(async () => {
+      firstStarted.resolve();
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return upgradeResult();
+    });
+
+    const first = invokeUpgrade({ pathParams: { name: "level-up" } });
+    await firstStarted.promise;
+
+    await expect(
+      invokeUpgrade({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    releaseFirst();
+    await expect(first).resolves.toMatchObject({ outcome: "upgraded" });
+
+    // The guard is released once the first settles, so the next one runs.
+    upgradeSpy.mockImplementation(async () => upgradeResult());
+    await expect(
+      invokeUpgrade({ pathParams: { name: "level-up" } }),
+    ).resolves.toMatchObject({ outcome: "upgraded" });
+  });
+
+  test("a different plugin is not blocked by an in-flight upgrade", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstStarted = Promise.withResolvers<void>();
+    upgradeSpy.mockImplementation(async (opts) => {
+      if (opts.name === "level-up") {
+        firstStarted.resolve();
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return upgradeResult({ name: opts.name });
+    });
+
+    const first = invokeUpgrade({ pathParams: { name: "level-up" } });
+    await firstStarted.promise;
+
+    await expect(
+      invokeUpgrade({ pathParams: { name: "other-plugin" } }),
+    ).resolves.toMatchObject({ name: "other-plugin" });
+
+    releaseFirst();
+    await first;
+  });
+
+  test("a dry run neither takes nor respects the in-flight guard", async () => {
+    // Dry runs return before the swap boundary, so they never stage.
+    let releaseFirst: () => void = () => {};
+    const firstStarted = Promise.withResolvers<void>();
+    upgradeSpy.mockImplementation(async (opts) => {
+      if (!opts.dryRun) {
+        firstStarted.resolve();
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return upgradeResult();
+    });
+
+    const first = invokeUpgrade({ pathParams: { name: "level-up" } });
+    await firstStarted.promise;
+
+    await expect(
+      invokeUpgrade({
+        pathParams: { name: "level-up" },
+        body: { dryRun: true },
+      }),
+    ).resolves.toMatchObject({ outcome: "upgraded" });
+
+    releaseFirst();
+    await first;
+  });
+
   test("PluginMergeBaselineError \u2192 ConflictError (409)", async () => {
     // A merge strategy whose install-time baseline can't be reconstructed: a
     // well-formed request that isn't actionable in the current state.

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1426,6 +1426,34 @@ async function handleDiffPlugin({ pathParams = {} }: RouteHandlerArgs) {
 // Handler — upgrade
 // ---------------------------------------------------------------------------
 
+/**
+ * Install names with an upgrade past the staging boundary right now.
+ *
+ * An upgrade stages into `<plugins>/../.plugins-staging/<name>.upgrading.<pid>`
+ * and finishes with an `rm -rf` + rename over the live install. Two concurrent
+ * upgrades of the same plugin in this process derive the same staging path, so
+ * the second would delete the first's tree mid-flight and leave the install
+ * half-swapped. The upgrade is per-plugin mutable state with more than one
+ * caller (CLI, the web Upgrade button, and the monitor's auto-update sweep),
+ * so it is serialized per name: the second caller is refused rather than
+ * queued, since by the time it could run, the revision it wanted is already
+ * what the first caller installed.
+ *
+ * Dry runs never stage — they return before the swap boundary — so they
+ * neither take nor respect the guard.
+ */
+const upgradesInFlight = new Set<string>();
+
+/** An upgrade for this plugin is already running in this process. */
+class PluginUpgradeInProgressError extends Error {
+  constructor(pluginName: string) {
+    super(
+      `An upgrade for plugin "${pluginName}" is already in progress. Wait for it to finish before starting another.`,
+    );
+    this.name = "PluginUpgradeInProgressError";
+  }
+}
+
 async function handleUpgradePlugin({
   pathParams = {},
   body = {},
@@ -1453,8 +1481,18 @@ async function handleUpgradePlugin({
   // brings the on-disk version up, so the reconcile below must run even when
   // the swap itself failed (re-initializing the untouched old install).
   let deactivated = false;
+  // Name held by this request in `upgradesInFlight`, so `finally` releases
+  // exactly what it claimed (and nothing when the claim was refused).
+  let claimed: string | null = null;
   try {
     const name = sanitizePluginName(rawName);
+    if (!dryRun) {
+      if (upgradesInFlight.has(name)) {
+        throw new PluginUpgradeInProgressError(name);
+      }
+      upgradesInFlight.add(name);
+      claimed = name;
+    }
     // No `confirmStaged` consent gate here: the daemon route is unattended by
     // design (there is no interactive surface to prompt on). A schedule the
     // upgraded revision adds is surfaced to the user by the schedule
@@ -1506,6 +1544,11 @@ async function handleUpgradePlugin({
     if (err instanceof InvalidPluginNameError) {
       throw new BadRequestError(err.message);
     }
+    // A concurrent upgrade of the same plugin owns the staging path — a
+    // well-formed request that is not actionable until the first one lands.
+    if (err instanceof PluginUpgradeInProgressError) {
+      throw new ConflictError(err.message);
+    }
     if (err instanceof PluginNotInstalledError) {
       throw new NotFoundError(err.message);
     }
@@ -1544,6 +1587,13 @@ async function handleUpgradePlugin({
     // changed is a cheap no-op.)
     if (deactivated) {
       await reconcilePluginSourcesNow();
+    }
+    // Released after the reconcile, not before: until the new version's
+    // `init` has run the plugin is still mid-swap, and a second upgrade
+    // starting there would stage against a tree this request is still
+    // bringing up.
+    if (claimed !== null) {
+      upgradesInFlight.delete(claimed);
     }
   }
 }

--- a/clients/docs/src/app/docs/_components/extensibility-distribution-content.tsx
+++ b/clients/docs/src/app/docs/_components/extensibility-distribution-content.tsx
@@ -11,8 +11,13 @@ const TOC_ITEMS = [
   { id: "publishing", label: "Publishing your plugin", level: 2 },
   { id: "installing", label: "Installing a plugin", level: 2 },
   { id: "the-cli", label: "The plugins CLI", level: 3 },
-  { id: "untrusted-install", label: "Installing from a GitHub URL (untrusted)", level: 2 },
+  {
+    id: "untrusted-install",
+    label: "Installing from a GitHub URL (untrusted)",
+    level: 2,
+  },
   { id: "updating", label: "Updating a plugin", level: 2 },
+  { id: "automatic-updates", label: "Automatic updates", level: 3 },
   { id: "drift", label: "Drift and local edits", level: 3 },
   { id: "in-product", label: "Upgrading from the Plugins tab", level: 3 },
   { id: "the-manifest", label: "The marketplace manifest", level: 2 },
@@ -252,10 +257,9 @@ export function ExtensibilityDistributionContent() {
           A plugin does not have to live in your workspace to be installed.
           Vellum keeps a curated catalog of external plugins, and the CLI
           installs any of them by name. The catalog is a single manifest the
-          Vellum team reviews and approves, so installing a catalog plugin
-          only ever pulls code that has been vetted into that list. For
-          plugins not yet in the catalog, the CLI also accepts a GitHub URL
-          directly, see{" "}
+          Vellum team reviews and approves, so installing a catalog plugin only
+          ever pulls code that has been vetted into that list. For plugins not
+          yet in the catalog, the CLI also accepts a GitHub URL directly, see{" "}
           <Link href="#untrusted-install" className={linkClass}>
             Installing from a GitHub URL (untrusted)
           </Link>
@@ -406,8 +410,8 @@ e83c5163316f89bfbde7d9ab23ca2e25604af290`}</code>
               import errors at boot).
             </li>
             <li>
-              The surfaces the plugin claims contribute something on boot
-              rather than silently failing.
+              The surfaces the plugin claims contribute something on boot rather
+              than silently failing.
             </li>
           </ul>
           <p className="mb-0 text-zinc-600 dark:text-zinc-400">
@@ -506,9 +510,9 @@ simple-memory  0.1.0    ok`}</code>
           </SectionHeading>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
             While a plugin is still under development, before it is whitelisted
-            in the catalog, you can install it directly from its GitHub repo
-            by passing a URL (anything containing a slash) instead of a
-            marketplace name:
+            in the catalog, you can install it directly from its GitHub repo by
+            passing a URL (anything containing a slash) instead of a marketplace
+            name:
           </p>
           <pre className="mb-4 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-100">
             <code>{`# Install from a repo URL (default branch)
@@ -528,15 +532,14 @@ $ assistant plugins install owner/repo --name my-plugin --force
 $ assistant plugins install owner/repo`}</code>
           </pre>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
-            The ref comes from the URL&apos;s{" "}
-            <code>/tree/&lt;ref&gt;/</code> segment, or defaults to the
-            repository&apos;s default branch. The install directory name is
-            derived from the repo (or sub-path leaf) and can be overridden with{" "}
-            <code>--name</code>.
+            The ref comes from the URL&apos;s <code>/tree/&lt;ref&gt;/</code>{" "}
+            segment, or defaults to the repository&apos;s default branch. The
+            install directory name is derived from the repo (or sub-path leaf)
+            and can be overridden with <code>--name</code>.
           </p>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
-            A direct install <strong>bypasses marketplace curation
-            entirely</strong>:
+            A direct install{" "}
+            <strong>bypasses marketplace curation entirely</strong>:
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
             <li>
@@ -550,26 +553,26 @@ $ assistant plugins install owner/repo`}</code>
             <li>
               The source is <strong>untrusted</strong>. It has not been
               reviewed, and its hooks and tools run inside the assistant with
-              full access. The CLI prints a yellow warning naming the source
-              so the choice to trust it is explicit.
+              full access. The CLI prints a yellow warning naming the source so
+              the choice to trust it is explicit.
             </li>
             <li>
               Unlike marketplace installs, which pin an immutable, reviewed
-              commit SHA, a branch or <code>HEAD</code> ref is mutable. A
-              direct install is a development convenience, not a reproducible
-              pin. If you pin a full commit SHA in the URL, the integrity
-              check still enforces it.
+              commit SHA, a branch or <code>HEAD</code> ref is mutable. A direct
+              install is a development convenience, not a reproducible pin. If
+              you pin a full commit SHA in the URL, the integrity check still
+              enforces it.
             </li>
             <li>
-              The marketplace-only flags (<code>--ref</code>,{" "}
-              <code>--pin</code>, <code>--allow-unreviewed</code>) do not
-              apply to a direct install. The ref lives in the URL.
+              The marketplace-only flags (<code>--ref</code>, <code>--pin</code>
+              , <code>--allow-unreviewed</code>) do not apply to a direct
+              install. The ref lives in the URL.
             </li>
           </ul>
           <p className="mb-0 text-zinc-600 dark:text-zinc-400">
             Once the plugin is ready for broader distribution, add it to{" "}
-            <code>marketplace.json</code> so others can install it by name
-            with a reviewed, reproducible pin.
+            <code>marketplace.json</code> so others can install it by name with
+            a reviewed, reproducible pin.
           </p>
         </section>
 
@@ -580,9 +583,56 @@ $ assistant plugins install owner/repo`}</code>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
             Installs are pinned. Because the catalog pins each plugin to an
             immutable commit, an install never changes on its own. It stays on
-            the commit it was installed at until you explicitly move it.
+            the commit it was installed at until you explicitly move it &mdash;
+            or until an opted-in workspace&apos;s automatic sweep moves it.
             Curators advance a plugin by bumping its <code>source.ref</code> in
             the manifest; your local copy only catches up when you upgrade it.
+          </p>
+
+          <SectionHeading id="automatic-updates" level={3}>
+            Automatic updates
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+            Upgrades are manual by default. A workspace can opt into unattended
+            upgrades with the <code>pluginUpdates</code> block in its{" "}
+            <code>config.json</code>:
+          </p>
+          <pre className="mb-4 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-100">
+            <code>{`{
+  "pluginUpdates": {
+    "mode": "auto",
+    "strategy": "theirs"
+  }
+}`}</code>
+          </pre>
+          <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
+            <li>
+              <code>mode</code>: <code>manual</code> (the default) never
+              upgrades on its own. <code>auto</code> sweeps your installed
+              plugins hourly and moves each one to its source&apos;s current
+              revision.
+            </li>
+            <li>
+              <code>strategy</code>: how an automatic upgrade reconciles your
+              local edits with the incoming revision. <code>theirs</code> (the
+              default) three-way merges and resolves conflicting hunks toward
+              the incoming revision; <code>ours</code> resolves them toward your
+              edit; <code>overwrite</code> discards local edits and re-installs
+              wholesale.
+            </li>
+            <li>
+              <code>checkIntervalMs</code>: minimum spacing between sweeps,
+              default <code>3600000</code> (1 hour). The last sweep is recorded
+              on disk, so restarting the assistant does not re-run a sweep that
+              already ran within the interval.
+            </li>
+          </ul>
+          <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+            Disabled plugins are skipped, and so is anything already on its
+            latest revision &mdash; the sweep checks for drift before it moves
+            anything. A plugin that cannot be upgraded (its source is
+            unreachable, or it has no upstream to advance to) is skipped and the
+            rest of the sweep continues.
           </p>
 
           <SectionHeading id="drift" level={3}>
@@ -595,8 +645,9 @@ $ assistant plugins install owner/repo`}</code>
             the plugin root. The fingerprint excludes four preserved entries (
             <code>install-meta.json</code>, <code>config.json</code>,{" "}
             <code>data/</code>, <code>.disabled</code>) so user config edits and
-            runtime data never show as drift. <code>assistant plugins inspect &lt;name&gt;</code>{" "}
-            reads that sidecar, compares the installed commit against the
+            runtime data never show as drift.{" "}
+            <code>assistant plugins inspect &lt;name&gt;</code> reads that
+            sidecar, compares the installed commit against the
             marketplace&apos;s current pin, and reports one of six states:
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
@@ -758,14 +809,15 @@ e83c5163316f89bfbde7d9ab23ca2e25604af290  refs/tags/v1.2.0^{}`}</code>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
             The adapter is a single JavaScript file referenced from the
             marketplace entry&apos;s <code>adapter</code> field. It runs after
-            the plugin is cloned but before the loader scans for surfaces, so
-            it can move files, generate a manifest, or rename entry points. The
+            the plugin is cloned but before the loader scans for surfaces, so it
+            can move files, generate a manifest, or rename entry points. The
             transform receives the cloned directory path and the marketplace
             entry, and is expected to leave the tree in Vellum&apos;s plugin
             layout:
           </p>
           <pre className="mb-4 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-100">
-            <code>{`// adapter.js — reshapes a Claude Code skill into Vellum layout
+            <code>
+              {`// adapter.js — reshapes a Claude Code skill into Vellum layout
 export default function adapt({ dir, entry }) {
   // The source repo ships instructions in SKILL.md at the root.
   // Vellum expects them under skills/<name>/SKILL.md.
@@ -792,10 +844,9 @@ export default function adapt({ dir, entry }) {
             </code>
           </pre>
           <p className="mb-0 text-zinc-600 dark:text-zinc-400">
-            The adapter runs in the assistant&apos;s sandbox alongside the
-            rest of the plugin install, with filesystem access limited to the
-            plugin directory. Network access is not available during the
-            adapt step.
+            The adapter runs in the assistant&apos;s sandbox alongside the rest
+            of the plugin install, with filesystem access limited to the plugin
+            directory. Network access is not available during the adapt step.
           </p>
         </section>
       </DocsContent>

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -756,7 +756,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-31T11:59:40.000Z"
+      "updatedAt": "2026-08-06T12:32:09.000Z"
     },
     {
       "id": "public-ingress",
@@ -1146,7 +1146,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-05T00:51:26.000Z"
+      "updatedAt": "2026-08-05T01:40:48.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/plugin-builder/references/distribution.md
+++ b/skills/plugin-builder/references/distribution.md
@@ -185,7 +185,26 @@ Note: The plugin is dropped immediately.
 
 ## Updating a plugin
 
-Installs are pinned. Because the catalog pins each plugin to an immutable commit, an install never changes on its own. It stays on the commit it was installed at until you explicitly move it. Curators advance a plugin by bumping its `source.ref` in the manifest; your local copy only catches up when you upgrade it.
+Installs are pinned. Because the catalog pins each plugin to an immutable commit, an install never changes on its own. It stays on the commit it was installed at until you explicitly move it — or until an opted-in workspace's automatic sweep moves it (see [Automatic updates](#automatic-updates)). Curators advance a plugin by bumping its `source.ref` in the manifest; your local copy only catches up when you upgrade it.
+
+### Automatic updates
+
+Upgrades are manual by default. A workspace can opt into unattended upgrades through the `pluginUpdates` block in its `config.json`:
+
+```json
+{
+  "pluginUpdates": {
+    "mode": "auto",
+    "strategy": "theirs"
+  }
+}
+```
+
+- `mode`: `manual` (default) never upgrades on its own — every workspace behaves exactly as described above. `auto` lets the resource monitor sweep installed plugins hourly and move each one to its source's current revision.
+- `strategy`: how an automatic upgrade reconciles local edits with the incoming revision — `theirs` (default) three-way merges and resolves conflicting hunks toward the incoming revision, `ours` resolves them toward the local edit, `overwrite` discards local edits and re-installs wholesale. The interactive `--strategy assistant` (which leaves conflict markers for someone to resolve) is deliberately not selectable here: nobody is in the loop to resolve them.
+- `checkIntervalMs`: minimum spacing between sweeps, default `3600000` (1 hour). The last sweep is stamped on disk, so restarting the daemon does not re-run a sweep that already ran within the interval.
+
+Disabled plugins are skipped. The sweep runs in the resource monitor process but asks the daemon to perform each upgrade, so the plugin's `shutdown`/`init` hooks run in the process that loaded it, exactly as they do for a manual upgrade. A plugin that cannot be upgraded (source unreachable, no upstream to advance to) is logged and skipped; the rest of the sweep continues.
 
 ### Drift and local edits
 


### PR DESCRIPTION
## Prompt / plan

> we want to use the monitoring worker to drive auto-updates of plugins. it should run once per hour. by default, the workspace config should be set to 'manual' upgrades, which means plugins _don't_ upgrade (existing behavior today). this config should be able to be set to 'auto' where we also need to define a strategy, which should default to 'theirs'

**Why:** plugin installs are pinned and only ever move when a human runs `assistant plugins upgrade`. A workspace that wants its plugins to stay current has to babysit them. This adds the opt-in.

**Approach:**

- New `pluginUpdates` block in the workspace config (`assistant/src/config/schemas/plugin-updates.ts`):
  - `mode`: `manual` (default) — nothing upgrades unattended, byte-for-byte today's behavior; `auto` — opt into the sweep.
  - `strategy`: `theirs` (default) / `ours` / `overwrite`, only consulted in `auto`.
  - `checkIntervalMs`: default `3600000` (1 hour), min 5 min, max 7 days.
- New sweep in the resource monitor process (`assistant/src/monitoring/plugin-auto-update.ts`), started from `monitoring/worker.ts` alongside the plugin source watch and crash recovery. It polls once a minute and sweeps when the interval has elapsed, so flipping `mode` takes effect without a restart.
- **The monitor does not upgrade in-process.** It calls the daemon's `plugins_upgrade` IPC route, because the swap has to run the outgoing version's `shutdown` and the incoming version's `init` inside the process that loaded the plugin. A monitor-local upgrade would swap files under a daemon that never tore the old version down. Same route the CLI and web Upgrade button use, so declared-schedule consent notifications still fire.
- The last completed sweep is stamped in the monitoring data dir, so a daemon that restarts every few minutes still upgrades at most once per interval instead of re-cloning every boot. When the daemon is unreachable nothing is attempted and the sweep stays due (retries next poll) rather than burning the window.
- Disabled plugins are skipped — the user switched them off, so re-materializing their code and re-declaring their schedules would be surprising. One plugin's failure (unreachable source, no upstream to advance to, unreconstructable merge baseline) is logged and skipped without stopping the rest.

**One judgment call worth flagging:** the `assistant` upgrade strategy is deliberately *not* selectable in this config. It resolves conflicts by writing git conflict markers into the plugin's source files and expecting someone to resolve them — unattended that leaves syntactically broken code on disk with nobody in the loop. It stays available for interactive `plugins upgrade --strategy assistant`. Easy to widen the enum if you disagree.

## Test plan

- New `assistant/src/monitoring/__tests__/plugin-auto-update.test.ts` (14 tests, timer-free, every seam injected): manual default asks the daemon for nothing; `auto` sweeps every listed plugin with the configured strategy; interval boundary (not due at `interval - 1ms`, due at exactly `interval`); a 4xx refusal on one plugin doesn't stop the rest and still stamps; an unreachable daemon abandons the sweep without stamping; a thrown call is contained; empty workspace stamps; unreadable config upgrades nothing; plus schema defaults (`manual` / `theirs` / hourly) and the rejected `assistant` strategy.
- `bun test src/monitoring/__tests__/ src/config/__tests__/loader-last-known-good.test.ts src/__tests__/worker-entrypoint-guards.test.ts src/__tests__/config-schema-cmd.test.ts` — all green.
- `bun run typecheck:fast`, `eslint`, `prettier --check` clean; `bun run generate:openapi` produces no diff (no route changes).
- Not exercised end-to-end against a live daemon — the sweep's daemon call is the same `plugins_upgrade` IPC method the CLI already drives.

Docs: `skills/plugin-builder/references/distribution.md` gains an "Automatic updates" section, and the "an install never changes on its own" claim is now correctly conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmGELweX5EKr588B5FwVEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmGELweX5EKr588B5FwVEJ)_