### PR TITLE
fix(credentials): report the secure prompt as closed once it is answered

### DIFF
--- a/assistant/src/__tests__/credential-prompt-route.test.ts
+++ b/assistant/src/__tests__/credential-prompt-route.test.ts
@@ -206,11 +206,12 @@ describe("credentials/prompt route", () => {
     expect(capturedMetadata?.usageDescription).toBeUndefined();
   });
 
-  test("stores a non-slack credential to secure storage without a message", async () => {
+  test("stores a non-slack credential to secure storage and reports the value as received", async () => {
     /**
      * The default delivery persists the value to secure storage and runs the
-     * manual-token connection sync, returning no message so the CLI prints its
-     * generic "Stored credential" line.
+     * manual-token connection sync. The message must name the outcome — the
+     * value is in hand — so a bare `ok: true` cannot be misread as "the prompt
+     * opened".
      */
     // GIVEN a standard store-delivery prompt for a non-slack credential
     // WHEN the route handles it
@@ -227,8 +228,55 @@ describe("credentials/prompt route", () => {
     // AND the manual token connection is synced for the service
     expect(syncedServices).toEqual(["stripe"]);
 
-    // AND no message is returned (the CLI falls back to its default line)
-    expect(result.message).toBeUndefined();
+    // AND the message reports the credential as received and stored
+    expect(result.message).toContain(
+      "Credential received from the user and stored as stripe/api_key.",
+    );
+  });
+
+  test("every successful outcome states that the prompt has closed", async () => {
+    /**
+     * The prompt blocks until answered, so a caller reads the result only after
+     * the secure input is gone. Without an explicit close signal a model
+     * follows up with "the prompt is open, paste it there" and the user
+     * re-submits into a surface that never reappears — the loop reported in
+     * the Aug 2026 Claude Code auth feedback. Every success path must say so,
+     * not just the plain vault write.
+     */
+    const closed =
+      "The secure prompt has closed — do not ask the user to enter this value again.";
+
+    // GIVEN a plain vault write
+    const stored = (await promptRoute!.handler({
+      body: { service: "stripe", field: "api_key", label: "Stripe API Key" },
+    })) as PromptResponse;
+
+    // THEN it reports the prompt as closed
+    expect(stored.message).toContain(closed);
+
+    // GIVEN a one-time send instead
+    secretResult = { value: "secret-value", delivery: "transient_send" };
+    const transient = (await promptRoute!.handler({
+      body: { service: "stripe", field: "api_key", label: "Stripe API Key" },
+    })) as PromptResponse;
+
+    // THEN it reports the prompt as closed too
+    expect(transient.message).toContain(closed);
+
+    // GIVEN a Slack channel token, whose status line owns the outcome summary
+    secretResult = { value: "secret-value", delivery: "store" };
+    slackConfigResult = slackResult({ connected: true, teamName: "Acme" });
+    const slack = (await promptRoute!.handler({
+      body: {
+        service: "slack_channel",
+        field: "bot_token",
+        label: "Slack Bot Token",
+      },
+    })) as PromptResponse;
+
+    // THEN the close notice rides along with the connection status
+    expect(slack.message).toContain("Slack channel connected to Acme.");
+    expect(slack.message).toContain(closed);
   });
 
   test("connects the channel when a slack_channel token is provided", async () => {
@@ -259,7 +307,9 @@ describe("credentials/prompt route", () => {
 
     // AND the connection status is surfaced as the response message
     expect(result.ok).toBe(true);
-    expect(result.message).toBe("Slack channel connected to Acme (@acmebot).");
+    expect(result.message).toContain(
+      "Slack channel connected to Acme (@acmebot).",
+    );
   });
 
   test("surfaces the warning when a slack_channel connection is incomplete", async () => {
@@ -284,7 +334,7 @@ describe("credentials/prompt route", () => {
 
     // THEN the warning is surfaced as the response message
     expect(result.ok).toBe(true);
-    expect(result.message).toBe(
+    expect(result.message).toContain(
       "Slack channel connection incomplete; provide the app token.",
     );
   });

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -292,6 +292,13 @@ encrypted vault with the specified metadata.
 
 Requires the assistant to be running with at least one connected client.
 
+This command BLOCKS until the user answers the prompt, so it returns only once
+the prompt has already closed. Tell the user what to paste BEFORE running it —
+anything said afterwards reaches them after the input is gone, and pointing
+them at a closed prompt makes them re-submit a value that was already received.
+The --label and --description text renders inside the prompt itself, so put the
+instructions there rather than in a follow-up message.
+
 Examples:
   $ assistant credentials prompt --service sentry --field auth_token \\
       --label "Sentry Auth Token" --placeholder "sntrys_..." \\

--- a/assistant/src/runtime/routes/credential-prompt-routes.ts
+++ b/assistant/src/runtime/routes/credential-prompt-routes.ts
@@ -50,6 +50,20 @@ const CredentialPromptParams = z.object({
 // Response type (shared with CLI consumer)
 // ---------------------------------------------------------------------------
 
+/**
+ * Appended to every terminal success message.
+ *
+ * The prompt blocks until the user answers, so by the time a caller reads the
+ * result the secure input is already gone from the UI. A bare `ok: true` reads
+ * as "the prompt opened successfully", which leads a model to follow up with
+ * "the prompt is open, paste your value there" — pointing the user at a surface
+ * that has already closed. The user, having just submitted, re-answers a prompt
+ * that never reappears, and the flow loops. State the close explicitly so the
+ * only available reading is the correct one.
+ */
+const PROMPT_CLOSED_NOTICE =
+  "The secure prompt has closed — do not ask the user to enter this value again.";
+
 export type CredentialPromptResult = {
   ok: boolean;
   /**
@@ -204,19 +218,26 @@ async function handleCredentialPrompt({ body = {} }: RouteHandlerArgs) {
       ok: true,
       service: validated.service,
       field: validated.field,
-      message: `One-time credential provided for ${validated.service}/${validated.field}. The value was not saved and will be consumed by the next operation.`,
+      message: `One-time credential provided for ${validated.service}/${validated.field}. The value was not saved and will be consumed by the next operation. ${PROMPT_CLOSED_NOTICE}`,
     };
   }
 
+  // A Slack channel token is routed through the channel config rather than the
+  // vault, so its connection status is what describes the outcome; every other
+  // credential reports the vault write.
   const slackStatus = persisted.slackChannel
     ? formatSlackChannelStatus(persisted.slackChannel).trim()
     : "";
+  const outcomeSummary =
+    slackStatus.length > 0
+      ? slackStatus
+      : `Credential received from the user and stored as ${validated.service}/${validated.field}.`;
 
   return {
     ok: true,
     service: validated.service,
     field: validated.field,
-    message: slackStatus.length > 0 ? slackStatus : undefined,
+    message: `${outcomeSummary} ${PROMPT_CLOSED_NOTICE}`,
   };
 }
 


### PR DESCRIPTION
## Prompt / plan

Triaged a user feedback bundle reporting: *"Its giving me the credential prompt, I paste it in, and then the next message tells me the credential prompt is open (even though its not open).. if i tell it i already provided it, it just runs through the same loop. so no way to get claude skill to work"*

The daemon log timed the loop exactly:

| Time | Event |
|---|---|
| 13:09:05.570 | `assistant credentials prompt --service claude_code --field oauth_code` starts (bash tool, blocking) |
| 13:09:08.841 | `[pending-interactions] Pending interaction resolved … state: "answered"` — the user pasted the code |
| 13:09:08.946 | shell command exits, `durationMs: 3373` |
| 13:09:08.986 | assistant message: *"The secure credential prompt is open. Paste the **short authorization code only** into that prompt, then submit it."* |

The prompt was open for 3.3 seconds and was already consumed 145ms before the message describing it as open. The same pattern repeated at 13:10:43 and 13:14:26; the user answered the prompt five times (`POST /v1/secret -> 200` at 12:48:57, 12:52:16, 13:09:08, 13:10:43, 13:14:26), each time being told afterwards that the prompt was open.

The cause is the shape of the success result. `handleCredentialPrompt` returned a bare `{ok: true, service, field}` on the stored-credential path — `message` was set only for Slack channel tokens. `ok: true` reads as "the prompt opened successfully" rather than "the value is in hand", so the model narrates an instruction that only makes sense before the call. Since the command blocks until the user answers, that narration always lands after the prompt has closed.

Two changes:

- **Route** (`credential-prompt-routes.ts`) — every successful outcome now states what happened and that the prompt has closed. The Slack channel status line keeps ownership of its own outcome summary, since that token routes through the channel config rather than the vault. Failure outcomes (cancel / timeout / superseded) are deliberately untouched: after those, re-prompting *is* the correct next step, and saying "closed, don't re-ask" would be wrong.
- **Command help** (`credentials.help.ts`) — the preventive half: the command blocks, so announce the prompt *before* calling it, and put instructions in `--label`/`--description` where they render inside the prompt itself.

This addresses the narration loop only. The same session also failed because `claude setup-token`'s output was scraped off an 80-column tmux pane and the token appears to have been truncated (two independently minted tokens both landed at exactly 79 chars, and every call 401'd while `claude auth status` reported `loggedIn: true`). That is a separate fix, not in this PR.

## Test plan

- `bun test src/__tests__/credential-prompt-route.test.ts` — 21 pass. Updated three assertions that encoded the old shape (the stored path asserted `message` was `undefined`; two Slack tests used exact-match `toBe`). Added `every successful outcome states that the prompt has closed`, covering the vault write, one-time send, and Slack channel paths.
- `bun test src/cli/commands/__tests__/credentials.test.ts src/__tests__/request-secret-standalone-channel-gate.test.ts src/__tests__/approval-routes-http.test.ts` — 29 pass.
- `bun run typecheck:fast` and `bun run lint` — clean.

<!-- No new routes added; the CLI verb for this route already exists. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyxaUrBnc99tvQYsPyFrTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxaUrBnc99tvQYsPyFrTD)_