### PR TITLE
feat(memory): add memory.retrospective.enabled and forkStrategy config

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25219,8 +25219,9 @@ paths:
         per conversation after activity (time/message thresholds, pre-compaction) — there is no global schedule, so
         `nextRunAt` is always null and no run-now endpoint exists. `intervalMs` is the per-conversation time threshold
         (`memory.retrospective.timeThresholdMs`), `lastRunAt` is the `createdAt` of the most recent retrospective
-        conversation across both legacy and fork sources, and `available` gates on `memory.enabled` (not
-        `memory.v2.enabled`).
+        conversation across both legacy and fork sources, `available` gates on `memory.enabled` (not
+        `memory.v2.enabled`), and `enabled` narrows that by `memory.retrospective.enabled` — the per-pass kill switch
+        that stops retrospectives without disabling the rest of memory.
       tags:
         - retrospective
       responses:

--- a/assistant/src/config/__tests__/memory-retrospective-schema.test.ts
+++ b/assistant/src/config/__tests__/memory-retrospective-schema.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Guards over the `memory.retrospective` switches that decide whether the
+ * retrospective pass runs at all, and how its fork is materialized.
+ *
+ * The defaults are the contract: a workspace that says nothing must behave
+ * exactly as it did before the fields existed — retrospectives on, forks
+ * cloned.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { MemoryRetrospectiveConfigSchema } from "../schemas/memory-retrospective.js";
+
+describe("memory.retrospective config schema", () => {
+  test("an empty block leaves retrospectives on and forks cloning", () => {
+    const parsed = MemoryRetrospectiveConfigSchema.parse({});
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.forkStrategy).toBe("cloning");
+  });
+
+  test("enabled is a boolean-only kill switch", () => {
+    expect(
+      MemoryRetrospectiveConfigSchema.parse({ enabled: false }).enabled,
+    ).toBe(false);
+    expect(
+      MemoryRetrospectiveConfigSchema.safeParse({ enabled: "false" }).success,
+    ).toBe(false);
+  });
+
+  test("forkStrategy accepts only cloning and reference", () => {
+    expect(
+      MemoryRetrospectiveConfigSchema.parse({ forkStrategy: "reference" })
+        .forkStrategy,
+    ).toBe("reference");
+    expect(
+      MemoryRetrospectiveConfigSchema.safeParse({ forkStrategy: "referential" })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -2,6 +2,28 @@ import { z } from "zod";
 
 export const MemoryRetrospectiveConfigSchema = z
   .object({
+    // This kill switch exists only because conversation forking is expensive:
+    // a fork full-copies the source conversation (messages + attachments), so
+    // on a large conversation the retrospective's write burst can lock the
+    // SQLite table against other writers. Until forking is referential, an
+    // operator needs a way to stop retrospectives without turning off memory.
+    enabled: z
+      .boolean({ error: "memory.retrospective.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the memory-retrospective background pass runs. When false, no retrospective is enqueued by any trigger (interval, message count, pre-compaction, scheduled sweep), the scheduled sweep job stops being queued, and any row already queued completes as a no-op. The rest of the memory system (extraction, retrieval, embeddings, `<memory>` injection) is unaffected — use `memory.enabled` to disable memory as a whole.",
+      ),
+
+    forkStrategy: z
+      .enum(["cloning", "reference"], {
+        error:
+          "memory.retrospective.forkStrategy must be 'cloning' or 'reference'",
+      })
+      .default("cloning")
+      .describe(
+        "How a retrospective's fork of the source conversation is materialized. `cloning` (default) full-copies the source conversation's messages and attachments into the fork. `reference` is reserved for the referential fork — the fork holds only its own messages and reads the source's through `fork_parent_message_id` — and is NOT yet implemented; it currently behaves as `cloning`.",
+      ),
+
     timeThresholdMs: z
       .number({
         error: "memory.retrospective.timeThresholdMs must be a number",

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-retrospective-sweep.test.ts
@@ -39,11 +39,14 @@ getMemoryDb();
 const SWEEP_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h default
 
 function buildConfig(
-  overrides: { memoryEnabled?: boolean } = {},
+  overrides: { memoryEnabled?: boolean; retrospectiveEnabled?: boolean } = {},
 ): AssistantConfig {
   const config = applyNestedDefaults({}) as unknown as AssistantConfig;
   if (overrides.memoryEnabled !== undefined) {
     config.memory.enabled = overrides.memoryEnabled;
+  }
+  if (overrides.retrospectiveEnabled !== undefined) {
+    config.memory.retrospective.enabled = overrides.retrospectiveEnabled;
   }
   return config;
 }
@@ -116,6 +119,26 @@ describe("maybeEnqueueRetrospectiveSweepJob", () => {
 
     expect(enqueued).toBe(false);
     expect(countSweepJobs()).toBe(0);
+  });
+
+  test("does not enqueue when retrospectives are disabled, and leaves the checkpoint alone", () => {
+    const now = Date.now();
+    const stale = staleCheckpoint(now);
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, stale);
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(
+      buildConfig({ retrospectiveEnabled: false }),
+      now,
+    );
+
+    expect(enqueued).toBe(false);
+    expect(countSweepJobs()).toBe(0);
+    // Checkpoint untouched, so re-enabling sweeps on the next tick rather
+    // than waiting out another full interval.
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBe(stale);
+
+    expect(maybeEnqueueRetrospectiveSweepJob(buildConfig(), now)).toBe(true);
+    expect(countSweepJobs()).toBe(1);
   });
 
   test("does not stack a second sweep while one is still in flight, but advances the checkpoint", () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -12,6 +12,8 @@ const upsertCalls: Array<{
   runAfter: number;
 }> = [];
 let cfgRequireUserActivity = true;
+let cfgRetrospectiveEnabled = true;
+let cfgThrows = false;
 let mockStateRow: {
   conversationId: string;
   lastProcessedMessageId: string;
@@ -44,9 +46,19 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
 }));
 
 mock.module("../../../../config/loader.js", () => ({
-  getConfig: () => ({
-    memory: { retrospective: { requireUserActivity: cfgRequireUserActivity } },
-  }),
+  getConfig: () => {
+    if (cfgThrows) {
+      throw new Error("config unavailable");
+    }
+    return {
+      memory: {
+        retrospective: {
+          enabled: cfgRetrospectiveEnabled,
+          requireUserActivity: cfgRequireUserActivity,
+        },
+      },
+    };
+  },
 }));
 
 mock.module("../memory-retrospective-state.js", () => ({
@@ -79,6 +91,8 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     convSource = "user";
     upsertCalls.length = 0;
     cfgRequireUserActivity = true;
+    cfgRetrospectiveEnabled = true;
+    cfgThrows = false;
     mockStateRow = null;
     tailQualifies = true;
     gateProbeThrows = false;
@@ -99,6 +113,37 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     expect(call.payload).toEqual({ conversationId: "c1" });
     expect(call.runAfter).toBeGreaterThanOrEqual(before);
     expect(call.runAfter).toBeLessThanOrEqual(after);
+  });
+
+  test("enabled=false — every trigger is declined before any other gate", () => {
+    cfgRetrospectiveEnabled = false;
+
+    for (const trigger of [
+      "interval",
+      "message_count",
+      "compaction",
+      "sweep",
+    ] as const) {
+      expect(
+        enqueueMemoryRetrospectiveIfEnabled({ conversationId: "c1", trigger }),
+      ).toBe(false);
+    }
+
+    expect(upsertCalls).toHaveLength(0);
+    // The kill switch short-circuits ahead of the user-activity probe, so a
+    // disabled retrospective costs no per-conversation message scan.
+    expect(gateProbeCalls).toHaveLength(0);
+  });
+
+  test("unreadable config — the kill switch fails closed", () => {
+    cfgThrows = true;
+    const result = enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+
+    expect(result).toBe(false);
+    expect(upsertCalls).toHaveLength(0);
   });
 
   test("assistant-only tail — user-activity gate skips the enqueue", () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -355,12 +355,14 @@ function makeConfig(
     matchConversationProfile?: boolean;
     promptPath?: string;
     requireUserActivity?: boolean;
+    enabled?: boolean;
   } = {},
 ): Parameters<typeof memoryRetrospectiveJob>[1] {
   return {
     memory: {
       v2: { enabled: true },
       retrospective: {
+        enabled: overrides.enabled ?? true,
         keepSupersededRuns: overrides.keepSupersededRuns ?? false,
         matchConversationProfile: overrides.matchConversationProfile ?? false,
         promptPath: overrides.promptPath ?? null,
@@ -511,6 +513,21 @@ describe("memoryRetrospectiveJob", () => {
     // findMostRecentRetrospectiveFor.
     expect(forkCalls).toHaveLength(1);
     expect(forkCalls[0]!.conversationId).toBe("src-conv-1");
+  });
+
+  test("retrospectives disabled: queued row drains as a no-op without forking", async () => {
+    const outcome = await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ enabled: false }),
+    );
+
+    expect(outcome.kind).toBe("disabled");
+    // The whole point of the switch: no fork, no wake, no pointer movement,
+    // so re-enabling reviews the same window the row was queued for.
+    expect(forkCalls).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(0);
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(0);
   });
 
   test("dormant source beyond the sweep lookback: completed as a no-op, both pointers untouched", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -372,6 +372,7 @@ function makeConfig(): Parameters<typeof memoryRetrospectiveJob>[1] {
     memory: {
       v2: { enabled: true },
       retrospective: {
+        enabled: true,
         keepSupersededRuns: false,
         matchConversationProfile: false,
         promptPath: null,

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -923,6 +923,12 @@ export const RETROSPECTIVE_SWEEP_CHECKPOINT = "retro_sweep:last_run";
  * Deduped against an in-flight sweep so a slow scan can't stack copies; the
  * checkpoint still advances in that case to hold the cadence steady.
  *
+ * `memory.retrospective.enabled` is checked here as well as inside the
+ * enqueue funnel, so a disabled retrospective costs no scan at all rather
+ * than a full conversation scan whose every enqueue is then declined. The
+ * checkpoint is left untouched while disabled — re-enabling then fires the
+ * first sweep on the next tick, which is the desired catch-up.
+ *
  * Exported for tests; the worker calls it on every idle/drain tick. Returns
  * true if a sweep job was enqueued this call.
  */
@@ -931,6 +937,10 @@ export function maybeEnqueueRetrospectiveSweepJob(
   nowMs = Date.now(),
 ): boolean {
   if (!isMemoryEnabled(config)) {
+    return false;
+  }
+
+  if (!config.memory.retrospective.enabled) {
     return false;
   }
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -3,6 +3,8 @@
 // ---------------------------------------------------------------------------
 //
 // Enqueue a `memory_retrospective` job for the given conversation. Gates on:
+//   - `memory.enabled` (the whole memory system) and
+//     `memory.retrospective.enabled` (this pass alone).
 //   - Source conversation isn't a memory-retrospective conversation itself
 //     (recursion guard — we never run a retrospective over reflective
 //     musings from the retrospective agent's own writes).
@@ -72,6 +74,14 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     return false;
   }
 
+  if (!isRetrospectiveEnabled()) {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping memory-retrospective enqueue: memory.retrospective.enabled is false",
+    );
+    return false;
+  }
+
   if (isMemoryRetrospectiveConversation(conversationId)) {
     log.debug(
       { conversationId, trigger },
@@ -105,6 +115,25 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     return false;
   }
   return true;
+}
+
+/**
+ * The `memory.retrospective.enabled` kill switch. Deliberately fails CLOSED,
+ * unlike the heuristic gates around it: this flag exists to stop a
+ * fork-driven write burst from locking the DB, so an unreadable config must
+ * not resurrect the very work an operator turned off. A read that throws is
+ * logged rather than swallowed silently.
+ */
+function isRetrospectiveEnabled(): boolean {
+  try {
+    return getConfig().memory.retrospective.enabled;
+  } catch (err) {
+    log.warn(
+      { err },
+      "Could not read memory.retrospective.enabled; treating retrospectives as disabled",
+    );
+    return false;
+  }
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -154,6 +154,20 @@ export async function memoryRetrospectiveJob(
     return { kind: "no_new_messages" };
   }
 
+  // Execution-time twin of the enqueue funnel's `memory.retrospective.enabled`
+  // gate: rows queued before the flag was turned off drain as no-ops instead
+  // of forking. The CLI's manual `memory retrospective run` calls
+  // `runForkBasedRetrospective` directly and so is unaffected — an operator's
+  // explicit request overrides the flag, matching the lookback and
+  // user-activity gates.
+  if (!config.memory.retrospective.enabled) {
+    log.info(
+      { jobId: job.id, sourceConversationId },
+      "Skipping job: memory.retrospective.enabled is false",
+    );
+    return { kind: "disabled" };
+  }
+
   // Central health counter (admin analytics groups on the watchdog
   // check_name): one event per run with its outcome kind. A run that
   // throws records outcome "error" before the exception continues to the

--- a/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
@@ -413,6 +413,26 @@ describe("getRetrospectiveConfig handler", () => {
     expect(result.success).toBe(true);
   });
 
+  test("available but not enabled when only the retrospective switch is off", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        { memory: { retrospective: { enabled: false } } },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const handler = findHandler("getRetrospectiveConfig");
+    const result = (await handler({})) as ConfigResponse;
+
+    // `available` stays true so the Settings row still renders — it reads
+    // "Paused" rather than disappearing as it would with memory off.
+    expect(result.available).toBe(true);
+    expect(result.enabled).toBe(false);
+    expect(result.success).toBe(true);
+  });
+
   test("stays available when memory v2 is disabled (retrospectives do not gate on v2)", async () => {
     writeFileSync(
       configPath,

--- a/assistant/src/runtime/routes/retrospective-routes.ts
+++ b/assistant/src/runtime/routes/retrospective-routes.ts
@@ -12,6 +12,10 @@
  *
  * `available` gates on `memory.enabled` alone (matching `isMemoryEnabled` in
  * the enqueue path). Retrospectives do NOT depend on `memory.v2.enabled`.
+ * `enabled` narrows `available` by `memory.retrospective.enabled`, the
+ * per-pass kill switch — so a memory-on assistant with retrospectives turned
+ * off reports `available: true, enabled: false` and the Settings row reads
+ * "Paused" rather than implying memory itself is off.
  */
 
 import { z } from "zod";
@@ -71,7 +75,7 @@ function listRetrospectiveConversations(
 function readRetrospectiveConfigResponse() {
   const config = getConfig();
   const available = isMemoryEnabled();
-  const enabled = available;
+  const enabled = available && config.memory.retrospective.enabled;
   const intervalMs = config.memory.retrospective.timeThresholdMs;
   // Retrospectives have no global schedule — runs are triggered per
   // conversation after activity, so a future run time is never known.
@@ -109,8 +113,10 @@ export const ROUTES: RouteDefinition[] = [
       "endpoint exists. `intervalMs` is the per-conversation time threshold " +
       "(`memory.retrospective.timeThresholdMs`), `lastRunAt` is the " +
       "`createdAt` of the most recent retrospective conversation across " +
-      "both legacy and fork sources, and `available` gates on " +
-      "`memory.enabled` (not `memory.v2.enabled`).",
+      "both legacy and fork sources, `available` gates on `memory.enabled` " +
+      "(not `memory.v2.enabled`), and `enabled` narrows that by " +
+      "`memory.retrospective.enabled` — the per-pass kill switch that stops " +
+      "retrospectives without disabling the rest of memory.",
     tags: ["retrospective"],
     responseBody: z.object({
       available: z.boolean(),

--- a/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/system-task-detail-panel.tsx
@@ -118,9 +118,11 @@ export function SystemTaskDetailPanel({
     onRunNow = undefined;
   }
 
-  // Consolidation and retrospective are owned by Memory: no toggle of their
-  // own, paused when Memory is off. Retrospective additionally has no global
-  // schedule, so it hides Next run.
+  // Consolidation and retrospective are owned by Memory: no toggle in this
+  // panel, paused when Memory is off. Retrospective additionally has no global
+  // schedule (so it hides Next run) and its own config switch
+  // (`memory.retrospective.enabled`), which pauses it while Memory stays on —
+  // `available` is what tells the two pauses apart.
   const isMemoryManaged = kind !== "heartbeat";
   const isRetrospective = kind === "retrospective";
   const isMemoryPaused = isMemoryManaged && !enabled;
@@ -133,7 +135,9 @@ export function SystemTaskDetailPanel({
       ? "Enabled"
       : "Disabled";
   const pausedNotice = isRetrospective
-    ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
+    ? retrospectiveConfig?.available === true
+      ? "Retrospectives are turned off in this assistant's memory settings. Turn them back on to resume them."
+      : "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
     : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
   const showMemorySettings =
     isMemoryManaged && enabled && canOpenMemorySettings;

--- a/clients/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/clients/web/src/domains/settings/components/system-tasks-section.tsx
@@ -209,7 +209,10 @@ export function SystemTasksSection({
           helperText={
             retrospectiveConfig.enabled
               ? undefined
-              : "Memory is off, so retrospectives are paused."
+              : // The row only renders when `available` is true (memory is on),
+                // so a false `enabled` here means the retrospective's own
+                // switch — `memory.retrospective.enabled` — is off.
+                "Retrospectives are turned off in this assistant's memory settings."
           }
           // Always null — retrospectives are event-driven, not scheduled;
           // the row simply omits the "Next:" timestamp.


### PR DESCRIPTION
## Prompt / plan

Asked whether there is a way to disable **only** memory retrospectives. There wasn't: every trigger funnels through `enqueueMemoryRetrospectiveIfEnabled`, whose sole config gate was `memory.enabled` — so stopping retrospectives meant disabling the whole memory system (extraction, retrieval, embeddings, `<memory>` injection). Tuning the thresholds is not a substitute either: a conversation with no state row returns the `interval` trigger unconditionally (`memory-retrospective-trigger-check.ts`), and the compaction trigger bypasses `minCooldownMs` by design.

The reason to want the switch is fork cost. A retrospective forks its source conversation, and forking full-copies that conversation's messages and attachments; on a large conversation the write burst can lock the SQLite table against other writers. Until forking is referential, an operator needs a way to stop retrospectives without giving up memory.

This PR adds two config fields and wires the first one:

**`memory.retrospective.enabled`** (boolean, default `true`) — checked in three places:

- **the enqueue funnel** (`memory-retrospective-enqueue.ts`), ahead of the user-activity probe, so all four triggers (interval, message count, compaction, sweep) decline without paying for a per-conversation message scan;
- **the sweep scheduler** (`jobs-worker.ts`), so a disabled retrospective queues no scan job at all. The checkpoint is deliberately left untouched while disabled, so re-enabling sweeps on the next tick instead of waiting out another full interval;
- **the queue handler** (`memory-retrospective-job.ts`), so rows queued before the flag was flipped drain as the pre-existing `disabled` outcome (which resolves as `completed`) instead of forking — both state pointers untouched, so re-enabling reviews the same window.

The config read fails **closed**, unlike the heuristic gates beside it: this flag exists to stop a write burst that locks the DB, so an unreadable config must not resurrect the work an operator turned off. The CLI's manual `assistant memory retrospective run` calls `runForkBasedRetrospective` directly and is unaffected — an operator's explicit request overrides the flag, matching how the lookback and user-activity gates already behave.

`GET /v1/retrospective/config` now reports `enabled` as `available && memory.retrospective.enabled`. `available` still gates on `memory.enabled` alone, so a memory-on assistant with retrospectives off keeps rendering the Settings row and shows "Paused" rather than hiding it. Both client surfaces (the settings row and the schedules detail panel) get copy that names the actual cause — the old "Memory is off, so retrospectives are paused" text was previously unreachable, since `enabled` could not differ from `available`.

**`memory.retrospective.forkStrategy`** (`"cloning"` default, `"reference"`) — declared only. `reference` is reserved for the referential fork (a fork holding just its own messages and reading the source's through `fork_parent_message_id`) and is **not implemented**; it behaves as `cloning` today, which its schema description states. It lands now so the referential-fork work has a config surface to build against.

## Test plan

- New: `assistant/src/config/__tests__/memory-retrospective-schema.test.ts` — defaults (`enabled: true`, `forkStrategy: "cloning"`) and rejection of non-boolean / unknown-variant values.
- New cases in `memory-retrospective-enqueue.test.ts` — all four triggers decline when disabled and the user-activity probe is never reached; an unreadable config fails closed.
- New case in `jobs-worker-retrospective-sweep.test.ts` — no sweep job enqueued when disabled, checkpoint untouched, and the very next enabled tick enqueues.
- New case in `memory-retrospective-job.test.ts` — a queued row returns `disabled` with no fork, no wake, and no pointer movement.
- New case in `retrospective-routes.test.ts` — `available: true, enabled: false` when only the retrospective switch is off.
- Existing stub configs in `memory-retrospective-job.test.ts` and `memory-retrospective-provider-path.test.ts` updated for the new field.
- `assistant/openapi.yaml` regenerated via `bun run generate:openapi`; `bun run typecheck` green in `assistant/` and `clients/web/`; prettier + eslint clean; the memory, config, and route test files above pass individually (this repo runs each test file in its own process — `scripts/test.ts` — because `mock.module` is process-global).

## CLI verb checklist

No new routes — this changes the existing `getRetrospectiveConfig` handler's response only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCQm4gtVzomviYhiw5qyd8)_