### PR TITLE
fix(skills): show the History tab only when there is history

### DIFF
--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.stories.tsx
@@ -195,8 +195,8 @@ function withShell(client: QueryClient) {
 
 /**
  * Landing on the page: Files is selected and History sits beside it. Click
- * History to see the revision list inside the page's own card. Every story
- * below opens on Files the same way, since the tab is uncontrolled.
+ * History to see the revision list inside the page's own card. The tab is
+ * uncontrolled, so this and the story below both open on Files.
  */
 export const Default: Story = {
   decorators: [withShell(seededClient({ historySupported: true }))],
@@ -211,16 +211,21 @@ export const HistoryTruncated: Story = {
   ],
 };
 
-/** A skill that exists but has never been edited. */
-export const HistoryEmpty: Story = {
+/**
+ * No tab strip at all. A skill with no recorded revisions renders exactly as
+ * the page did before history existed, rather than offering a History tab
+ * that opens onto an empty state.
+ */
+export const NoHistoryYet: Story = {
   decorators: [
     withShell(seededClient({ historySupported: true, revisions: [] })),
   ],
 };
 
 /**
- * An assistant that predates the history route. No tab strip renders at all,
- * so the page looks exactly as it did before this feature.
+ * Also no tab strip, by the same rule: an assistant that predates the history
+ * route reports nothing, which is indistinguishable from having nothing to
+ * report as far as the page is concerned.
  */
 export const HistoryUnsupported: Story = {
   decorators: [withShell(seededClient({ historySupported: false }))],

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -72,19 +72,23 @@ export function SkillDetail({
     isContentLoading,
   } = useSkillDetailFiles(assistantId, skill.id);
 
-  // An assistant without the history route reports `isUnsupported`, which
-  // hides the tab strip entirely so the page renders exactly as it did before
-  // revisions existed. Shares a query key with the panel, so this is one
-  // request, not two.
-  const { isUnsupported: isHistoryUnsupported } = useSkillHistory(
+  // Shares a query key with the panel below, so this is one request, not two.
+  const { revisions, isLoading: isHistoryLoading } = useSkillHistory(
     assistantId,
     skill.id,
   );
 
+  // The tab strip appears only once there is something behind it. A skill with
+  // no recorded revisions, and an assistant too old to report any, both render
+  // the page exactly as it looked before history existed, rather than offering
+  // a tab that opens onto an empty state. Staying hidden while the query is in
+  // flight is what keeps the tabs from appearing and then vanishing.
+  const hasHistory = !isHistoryLoading && revisions.length > 0;
+
   const [selectedTab, setSelectedTab] = useState("files");
-  // Falling back to Files when history turns out to be unsupported keeps the
-  // page coherent if the query answers after a tab was already chosen.
-  const activeTab = isHistoryUnsupported ? "files" : selectedTab;
+  // Pin to Files when there is no history, so a tab chosen before the query
+  // answered cannot leave the page on a panel that is no longer rendered.
+  const activeTab = hasHistory ? selectedTab : "files";
 
   const header = (
     <div className="mb-4 flex items-start gap-3">
@@ -269,7 +273,7 @@ export function SkillDetail({
         onValueChange={setSelectedTab}
         className="flex min-h-0 flex-1 flex-col"
       >
-        {!isHistoryUnsupported && (
+        {hasHistory && (
           <Tabs.List className="mb-3">
             <Tabs.Trigger value="files">Files</Tabs.Trigger>
             <Tabs.Trigger value="history">History</Tabs.Trigger>
@@ -283,7 +287,7 @@ export function SkillDetail({
         >
           {filesCard}
         </Tabs.Panel>
-        {!isHistoryUnsupported && (
+        {hasHistory && (
           <Tabs.Panel value="history" className="flex min-h-0 flex-1 flex-col">
             <Card.Root asChild noPadding>
               <div className="min-h-0 flex-1 overflow-y-auto">

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -27,7 +27,10 @@ import {
 } from "@/domains/intelligence/skills/types";
 import { useWorkspaceWritePostMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useSkillDetailFiles } from "@/hooks/use-skill-detail-files";
-import { useSkillHistory } from "@/hooks/use-skill-history";
+import {
+  shouldShowHistoryTab,
+  useSkillHistory,
+} from "@/hooks/use-skill-history";
 import { captureError } from "@/lib/sentry/capture-error";
 import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { invalidateSkillsList, isRemovableSkill } from "@/utils/skills";
@@ -73,22 +76,22 @@ export function SkillDetail({
   } = useSkillDetailFiles(assistantId, skill.id);
 
   // Shares a query key with the panel below, so this is one request, not two.
-  const { revisions, isLoading: isHistoryLoading } = useSkillHistory(
-    assistantId,
-    skill.id,
-  );
+  const {
+    revisions,
+    isLoading: isHistoryLoading,
+    isError: isHistoryError,
+  } = useSkillHistory(assistantId, skill.id);
 
-  // The tab strip appears only once there is something behind it. A skill with
-  // no recorded revisions, and an assistant too old to report any, both render
-  // the page exactly as it looked before history existed, rather than offering
-  // a tab that opens onto an empty state. Staying hidden while the query is in
-  // flight is what keeps the tabs from appearing and then vanishing.
-  const hasHistory = !isHistoryLoading && revisions.length > 0;
+  const showHistory = shouldShowHistoryTab({
+    isLoading: isHistoryLoading,
+    isError: isHistoryError,
+    revisionCount: revisions.length,
+  });
 
   const [selectedTab, setSelectedTab] = useState("files");
-  // Pin to Files when there is no history, so a tab chosen before the query
-  // answered cannot leave the page on a panel that is no longer rendered.
-  const activeTab = hasHistory ? selectedTab : "files";
+  // Pin to Files whenever the strip is hidden, so the page never rests on an
+  // unrendered panel.
+  const activeTab = showHistory ? selectedTab : "files";
 
   const header = (
     <div className="mb-4 flex items-start gap-3">
@@ -273,7 +276,7 @@ export function SkillDetail({
         onValueChange={setSelectedTab}
         className="flex min-h-0 flex-1 flex-col"
       >
-        {hasHistory && (
+        {showHistory && (
           <Tabs.List className="mb-3">
             <Tabs.Trigger value="files">Files</Tabs.Trigger>
             <Tabs.Trigger value="history">History</Tabs.Trigger>
@@ -287,7 +290,7 @@ export function SkillDetail({
         >
           {filesCard}
         </Tabs.Panel>
-        {hasHistory && (
+        {showHistory && (
           <Tabs.Panel value="history" className="flex min-h-0 flex-1 flex-col">
             <Card.Root asChild noPadding>
               <div className="min-h-0 flex-1 overflow-y-auto">

--- a/clients/web/src/hooks/use-skill-history.test.ts
+++ b/clients/web/src/hooks/use-skill-history.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldShowHistoryTab } from "./use-skill-history";
+
+/**
+ * The History tab's visibility rule. Three inputs collapse into one boolean,
+ * and two of the combinations are the ones reviewers flagged as easy to get
+ * wrong: an in-flight read must not flash the tab, and a failed read must not
+ * be mistaken for an empty one.
+ */
+
+describe("shouldShowHistoryTab", () => {
+  test("shows the tab when there are revisions", () => {
+    expect(
+      shouldShowHistoryTab({
+        isLoading: false,
+        isError: false,
+        revisionCount: 2,
+      }),
+    ).toBe(true);
+  });
+
+  test("hides the tab for a skill with nothing recorded", () => {
+    expect(
+      shouldShowHistoryTab({
+        isLoading: false,
+        isError: false,
+        revisionCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test("shows the tab when the read failed, so the failure is reportable", () => {
+    // An errored query also reports zero revisions. Without this branch the
+    // page would render as though the skill had never been edited, hiding a
+    // transient failure behind a plausible-looking empty state.
+    expect(
+      shouldShowHistoryTab({
+        isLoading: false,
+        isError: true,
+        revisionCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test("hides the tab while the read is in flight", () => {
+    // Gating on the count alone would render the strip, then remove it a
+    // moment later when the empty result landed.
+    expect(
+      shouldShowHistoryTab({
+        isLoading: true,
+        isError: false,
+        revisionCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test("loading wins over a stale error, so a retry does not flicker", () => {
+    expect(
+      shouldShowHistoryTab({
+        isLoading: true,
+        isError: true,
+        revisionCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/hooks/use-skill-history.ts
+++ b/clients/web/src/hooks/use-skill-history.ts
@@ -10,9 +10,12 @@
  * last released version while running unreleased code) get the tab without a
  * debug override.
  *
- * `null` and an empty `revisions` array mean different things and must stay
- * distinct: `null` is "this assistant cannot report history", while `[]` is
- * "history is available and this skill has no recorded edits".
+ * `null` (this assistant cannot report history) and `[]` (it can, and this
+ * skill has no recorded edits) stay distinct in the fetch, because the 404
+ * mapping is what makes the missing route degrade quietly. Callers are free to
+ * treat them the same: the detail page shows the History tab only when there
+ * are revisions to show, which both cases fail for the same reason from a
+ * reader's point of view.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -76,8 +79,6 @@ export function useSkillHistory(assistantId: string | null, skillId: string) {
     history: query.data ?? null,
     revisions: query.data?.revisions ?? [],
     truncatedByCompaction: query.data?.truncatedByCompaction ?? false,
-    /** The connected assistant cannot report history, so hide the surface. */
-    isUnsupported: query.isSuccess && query.data === null,
     isLoading: query.isLoading,
     isError: query.isError,
   };

--- a/clients/web/src/hooks/use-skill-history.ts
+++ b/clients/web/src/hooks/use-skill-history.ts
@@ -3,12 +3,11 @@
  *
  * Deliberately not version-gated. This is a read whose only fallback is "the
  * feature is absent", which is exactly what an assistant without the route
- * produces: `fetchSkillHistory` maps its 404 to `null`, the History tab hides,
- * and the detail page renders the way it did before revisions existed. That is
- * the documented exemption in BACKWARDS_COMPAT.md ("When a gate is
- * unnecessary"), and it lets same-source self-hosted setups (which report the
- * last released version while running unreleased code) get the tab without a
- * debug override.
+ * produces: `fetchSkillHistory` maps its 404 to `null` and the detail page
+ * renders just the files card. That is the documented exemption in
+ * BACKWARDS_COMPAT.md ("When a gate is unnecessary"), and it lets same-source
+ * self-hosted setups (which report the last released version while running
+ * unreleased code) get the tab without a debug override.
  *
  * `null` (this assistant cannot report history) and `[]` (it can, and this
  * skill has no recorded edits) stay distinct in the fetch, because the 404
@@ -57,6 +56,29 @@ export async function fetchSkillHistory(
     throw error ?? new Error("Failed to fetch skill history.");
   }
   return data ?? null;
+}
+
+/**
+ * Whether the skill detail page should offer its History tab.
+ *
+ * A tab is a promise that there is something behind it, so an empty result
+ * hides the strip entirely rather than opening onto an empty state. A FAILED
+ * read is not empty: collapsing it into the same case would make a transient
+ * failure indistinguishable from a skill that has never been edited, leaving
+ * the reader no signal and no way to retry short of reloading.
+ *
+ * Pure and exported so the distinction between "nothing to show" and "could
+ * not find out" is pinned by a test rather than by reading the JSX.
+ */
+export function shouldShowHistoryTab(state: {
+  isLoading: boolean;
+  isError: boolean;
+  revisionCount: number;
+}): boolean {
+  if (state.isLoading) {
+    return false;
+  }
+  return state.isError || state.revisionCount > 0;
 }
 
 export function useSkillHistory(assistantId: string | null, skillId: string) {


### PR DESCRIPTION
## TL;DR

The skill detail page showed a **History** tab for any skill, including ones with no recorded revisions, where clicking it produced "No changes recorded yet." The tab now appears only when there is at least one revision behind it.

## Why

A tab is a promise that there is something there. For a freshly created skill, or any skill the workspace has not committed a change to yet, that promise was empty. Hiding the strip costs nothing: the page then renders exactly as it did before history existed, which was already what happened for an assistant too old to report history at all.

That second case is the useful precedent. `useSkillHistory` already distinguished `null` (this assistant cannot report history) from `[]` (it can, and there is nothing recorded), and hid the strip for `null`. From a reader's point of view those are the same situation, so both now take the same path.

## Before / after

| Skill state | Before | After |
|---|---|---|
| Has revisions | Files / History tabs | Unchanged |
| No revisions recorded | Files / History tabs, History opens onto an empty state | No tab strip; the files card sits directly under the header |
| Assistant predates the route | No tab strip | Unchanged |
| History still loading | Tabs render immediately | No tab strip until the read resolves |

## Why it's safe

- **Purely presentational.** No API, route, or query change. The read, its 404-to-null mapping, and the gateless-degrade contract from #40228 are all untouched.
- **No flicker.** The gate is `!isLoading && revisions.length > 0`, not the count alone, so the strip cannot appear and then vanish mid-read. It stays hidden while in flight and appears once, if warranted.
- **No stranded panel.** The active tab pins to Files whenever the strip is hidden, so a tab selected before the query answered cannot leave the page on a panel that is no longer rendered.
- **The editor still survives.** The files panel keeps its `forceMount` and inline `display`, so an in-progress skill edit is not lost when the strip appears or the tab changes.

## Removed

`isUnsupported` on `useSkillHistory` has no callers left, since `hasHistory` subsumes it, so it is gone rather than left as speculative API. The docstring that claimed the two cases "must stay distinct" now says what is actually true: they stay distinct in the fetch, because the 404 mapping is what makes a missing route quiet, and callers are free to collapse them.

## Verified

`SkillRevisionList`'s "No changes recorded yet" state is kept and still story-covered. It is no longer reachable from the tab, but a refetch that returns an empty list while the panel is already open still lands there, so it is defensive rather than dead.

Storybook, all four states on the real `SkillDetail` page:

| Story | Tabs rendered |
|---|---|
| `Default` | Files, History |
| `HistoryTruncated` | Files, History |
| `NoHistoryYet` | none |
| `HistoryUnsupported` | none |

`NoHistoryYet` replaces the old `HistoryEmpty` story, since what it demonstrates is now the absence of the strip rather than the empty state inside it.

Follow-ups from #40228 are tracked in LUM-3084, JARVIS-1467, and JARVIS-1468; none are affected by this change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->