### PR TITLE
fix(cli): stop `vellum clean` from killing live tunnel/log/terminal CLI sessions

### DIFF
--- a/cli/src/lib/orphan-detection.test.ts
+++ b/cli/src/lib/orphan-detection.test.ts
@@ -1,40 +1,93 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 
-import { classifyProcess } from "./orphan-detection.js";
+import {
+  classifyProcess,
+  detectOrphanedProcesses,
+  isInteractiveCliSession,
+} from "./orphan-detection.js";
 
-describe("classifyProcess", () => {
-  test("spares a live tunnel session launched via a script path", () => {
+// `mock.restore()` does not undo `mock.module()`; keep the real module so it
+// can be restored in afterAll for later test files in the same run.
+const realStepRunner = { ...(await import("./step-runner")) };
+
+describe("isInteractiveCliSession", () => {
+  test("matches a live tunnel session launched via a script path", () => {
     expect(
-      classifyProcess(
+      isInteractiveCliSession(
         "bun /Users/x/.nvm/versions/node/v22.14.0/bin/vellum tunnel --provider ngrok",
       ),
-    ).toBe("unknown");
+    ).toBe(true);
   });
 
-  test("spares interactive subcommands like logs and terminal", () => {
-    expect(classifyProcess("vellum logs foo")).toBe("unknown");
-    expect(classifyProcess("vellum terminal")).toBe("unknown");
+  test("matches interactive subcommands like logs and terminal", () => {
+    expect(isInteractiveCliSession("vellum logs foo")).toBe(true);
+    expect(isInteractiveCliSession("vellum terminal")).toBe(true);
   });
 
-  test("spares the other long-running interactive subcommands", () => {
-    expect(classifyProcess("vellum events")).toBe("unknown");
-    expect(classifyProcess("vellum client")).toBe("unknown");
-    expect(classifyProcess("vellum ssh quiet-finch")).toBe("unknown");
-    expect(classifyProcess("vellum exec quiet-finch ls")).toBe("unknown");
-    expect(classifyProcess("vellum message quiet-finch hi")).toBe("unknown");
-    expect(classifyProcess("vellum workflows")).toBe("unknown");
-    expect(classifyProcess("vellum-cli tunnel --provider ngrok")).toBe(
-      "unknown",
+  test("matches the other long-running interactive subcommands", () => {
+    expect(isInteractiveCliSession("vellum events")).toBe(true);
+    expect(isInteractiveCliSession("vellum client")).toBe(true);
+    expect(isInteractiveCliSession("vellum ssh quiet-finch")).toBe(true);
+    expect(isInteractiveCliSession("vellum message quiet-finch hi")).toBe(true);
+    expect(isInteractiveCliSession("vellum workflows")).toBe(true);
+    expect(isInteractiveCliSession("vellum-cli tunnel --provider ngrok")).toBe(
+      true,
     );
   });
 
-  test("still classifies non-interactive CLI wrappers as vellum", () => {
+  test("allows the known global flags before the subcommand", () => {
+    expect(isInteractiveCliSession("vellum --plain tunnel")).toBe(true);
+    expect(isInteractiveCliSession("vellum --no-color logs foo")).toBe(true);
+    expect(isInteractiveCliSession("vellum --no-color --plain events")).toBe(
+      true,
+    );
+  });
+
+  test("matches exec sessions even when argv mentions a service name", () => {
+    expect(
+      isInteractiveCliSession(
+        "vellum exec -it --service vellum-gateway -- /bin/sh",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match non-interactive CLI wrappers", () => {
+    expect(isInteractiveCliSession("vellum hatch")).toBe(false);
+    expect(isInteractiveCliSession("vellum")).toBe(false);
+    expect(isInteractiveCliSession("/usr/bin/vellum sleep")).toBe(false);
+  });
+
+  test("interactive names in later argv tokens do not match", () => {
+    expect(isInteractiveCliSession("vellum hatch --name logs")).toBe(false);
+    expect(isInteractiveCliSession("vellum sleep logs")).toBe(false);
+  });
+
+  test("unknown flags before the subcommand do not match", () => {
+    expect(isInteractiveCliSession("vellum --verbose tunnel")).toBe(false);
+  });
+
+  test("repo paths containing vellum do not match", () => {
+    expect(
+      isInteractiveCliSession(
+        "node /Users/runner/work/vellum-assistant/vellum-assistant/scripts/build.js",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("classifyProcess", () => {
+  test("labels interactive CLI sessions as vellum like any other wrapper", () => {
+    expect(classifyProcess("vellum tunnel --provider ngrok")).toBe("vellum");
+    expect(classifyProcess("vellum logs foo")).toBe("vellum");
+    expect(classifyProcess("vellum-cli tunnel --provider ngrok")).toBe(
+      "vellum",
+    );
+  });
+
+  test("classifies non-interactive CLI wrappers as vellum", () => {
     expect(classifyProcess("vellum hatch")).toBe("vellum");
     expect(classifyProcess("vellum")).toBe("vellum");
     expect(classifyProcess("/usr/bin/vellum sleep")).toBe("vellum");
-  });
-
-  test("interactive names in later argv tokens do not trigger the exemption", () => {
     expect(classifyProcess("vellum hatch --name logs")).toBe("vellum");
     expect(classifyProcess("vellum sleep logs")).toBe("vellum");
   });
@@ -65,5 +118,33 @@ describe("classifyProcess", () => {
         "node /Users/runner/work/vellum-assistant/vellum-assistant/scripts/build.js",
       ),
     ).toBe("unknown");
+  });
+});
+
+describe("detectOrphanedProcesses", () => {
+  afterAll(() => {
+    mock.module("./step-runner", () => realStepRunner);
+  });
+
+  test("skips live interactive sessions but still reports orphaned services", async () => {
+    const psOutput = [
+      "101 1 bun /Users/x/bin/vellum tunnel --provider ngrok",
+      "102 1 vellum exec -it --service vellum-gateway -- /bin/sh",
+      "103 1 vellum --plain logs foo",
+      "104 1 bun /x/bin/vellum-gateway --port 7830",
+      "105 1 vellum hatch",
+    ].join("\n");
+    mock.module("./step-runner", () => ({
+      ...realStepRunner,
+      execOutput: async () => psOutput,
+    }));
+
+    const orphans = await detectOrphanedProcesses({
+      excludePids: new Set<string>(),
+    });
+
+    expect(orphans.map((o) => o.pid).sort()).toEqual(["104", "105"]);
+    expect(orphans.find((o) => o.pid === "104")?.name).toBe("gateway");
+    expect(orphans.find((o) => o.pid === "105")?.name).toBe("vellum");
   });
 });

--- a/cli/src/lib/orphan-detection.test.ts
+++ b/cli/src/lib/orphan-detection.test.ts
@@ -34,6 +34,11 @@ describe("classifyProcess", () => {
     expect(classifyProcess("/usr/bin/vellum sleep")).toBe("vellum");
   });
 
+  test("interactive names in later argv tokens do not trigger the exemption", () => {
+    expect(classifyProcess("vellum hatch --name logs")).toBe("vellum");
+    expect(classifyProcess("vellum sleep logs")).toBe("vellum");
+  });
+
   test("service process classifications are unchanged", () => {
     expect(classifyProcess("/opt/homebrew/bin/qdrant --config foo")).toBe(
       "qdrant",

--- a/cli/src/lib/orphan-detection.test.ts
+++ b/cli/src/lib/orphan-detection.test.ts
@@ -53,8 +53,25 @@ describe("isInteractiveCliSession", () => {
 
   test("does not match non-interactive CLI wrappers", () => {
     expect(isInteractiveCliSession("vellum hatch")).toBe(false);
-    expect(isInteractiveCliSession("vellum")).toBe(false);
     expect(isInteractiveCliSession("/usr/bin/vellum sleep")).toBe(false);
+    expect(isInteractiveCliSession("vellum wake")).toBe(false);
+    expect(isInteractiveCliSession("vellum wake --watch")).toBe(false);
+  });
+
+  test("matches the implicit TUI client (bare vellum)", () => {
+    expect(isInteractiveCliSession("vellum")).toBe(true);
+    expect(isInteractiveCliSession("bun /Users/x/.nvm/bin/vellum")).toBe(true);
+    expect(isInteractiveCliSession("vellum --plain")).toBe(true);
+  });
+
+  test("matches a foreground wake session", () => {
+    expect(isInteractiveCliSession("vellum wake --foreground")).toBe(true);
+    expect(isInteractiveCliSession("vellum wake --watch --foreground")).toBe(
+      true,
+    );
+    expect(
+      isInteractiveCliSession("bun /Users/x/bin/vellum wake --foreground"),
+    ).toBe(true);
   });
 
   test("interactive names in later argv tokens do not match", () => {

--- a/cli/src/lib/orphan-detection.test.ts
+++ b/cli/src/lib/orphan-detection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyProcess } from "./orphan-detection.js";
+
+describe("classifyProcess", () => {
+  test("spares a live tunnel session launched via a script path", () => {
+    expect(
+      classifyProcess(
+        "bun /Users/x/.nvm/versions/node/v22.14.0/bin/vellum tunnel --provider ngrok",
+      ),
+    ).toBe("unknown");
+  });
+
+  test("spares interactive subcommands like logs and terminal", () => {
+    expect(classifyProcess("vellum logs foo")).toBe("unknown");
+    expect(classifyProcess("vellum terminal")).toBe("unknown");
+  });
+
+  test("spares the other long-running interactive subcommands", () => {
+    expect(classifyProcess("vellum events")).toBe("unknown");
+    expect(classifyProcess("vellum client")).toBe("unknown");
+    expect(classifyProcess("vellum ssh quiet-finch")).toBe("unknown");
+    expect(classifyProcess("vellum exec quiet-finch ls")).toBe("unknown");
+    expect(classifyProcess("vellum message quiet-finch hi")).toBe("unknown");
+    expect(classifyProcess("vellum workflows")).toBe("unknown");
+    expect(classifyProcess("vellum-cli tunnel --provider ngrok")).toBe(
+      "unknown",
+    );
+  });
+
+  test("still classifies non-interactive CLI wrappers as vellum", () => {
+    expect(classifyProcess("vellum hatch")).toBe("vellum");
+    expect(classifyProcess("vellum")).toBe("vellum");
+    expect(classifyProcess("/usr/bin/vellum sleep")).toBe("vellum");
+  });
+
+  test("service process classifications are unchanged", () => {
+    expect(classifyProcess("/opt/homebrew/bin/qdrant --config foo")).toBe(
+      "qdrant",
+    );
+    expect(classifyProcess("bun /x/bin/vellum-gateway --port 7830")).toBe(
+      "gateway",
+    );
+    expect(classifyProcess("bun /x/bin/vellum-daemon start")).toBe("assistant");
+    expect(classifyProcess("node daemon start")).toBe("assistant");
+    expect(
+      classifyProcess("bun /x/bin/vellum-openclaw-adapter --port 9000"),
+    ).toBe("openclaw-adapter");
+  });
+
+  test("macOS desktop app processes stay excluded", () => {
+    expect(
+      classifyProcess("/Applications/Vellum.app/Contents/MacOS/Vellum"),
+    ).toBe("unknown");
+  });
+
+  test("repo paths containing vellum do not match", () => {
+    expect(
+      classifyProcess(
+        "node /Users/runner/work/vellum-assistant/vellum-assistant/scripts/build.js",
+      ),
+    ).toBe("unknown");
+  });
+});

--- a/cli/src/lib/orphan-detection.ts
+++ b/cli/src/lib/orphan-detection.ts
@@ -29,13 +29,15 @@ export function classifyProcess(command: string): string {
   // `vellum tunnel` in someone's terminal): they have no PID-file
   // registration, so `vellum clean` would otherwise kill them mid-session.
   // The command line may be "bun /path/to/bin/vellum tunnel ...", so match
-  // the subcommand after the script path, not just argv[0].
+  // the first argument after the vellum binary/script path — later argv
+  // tokens (e.g. "vellum hatch --name logs") must not trigger the exemption.
   if (
-    /(?:^|\/)vellum(?:-cli)?(?:\s+\S+)*?\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
+    /(?:^|\/)vellum(?:-cli)?\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
       command,
     )
-  )
+  ) {
     return "unknown";
+  }
   if (/vellum-cli/.test(command)) return "vellum";
   // Exclude macOS desktop app processes — their path contains .app/Contents/MacOS/
   // but they are not background service processes.

--- a/cli/src/lib/orphan-detection.ts
+++ b/cli/src/lib/orphan-detection.ts
@@ -50,10 +50,25 @@ export function classifyProcess(command: string): string {
  * service-like substrings in later argv (e.g. `vellum exec -it --service
  * vellum-gateway -- /bin/sh`) cannot re-flag a live session, while
  * `classifyProcess` stays a pure display label for `vellum ps`.
+ *
+ * Also spared: bare `vellum` (no subcommand launches the implicit TUI client
+ * via tryLaunchClient) and `vellum wake --foreground` (stays attached with
+ * logs in the terminal).
  */
 export function isInteractiveCliSession(command: string): boolean {
-  return /(?:^|\/)vellum(?:-cli)?(?:\s+--(?:no-color|plain))*\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
-    command,
+  const vellumToken = /(?:^|\/)vellum(?:-cli)?(?:\s+--(?:no-color|plain))*/;
+  const interactiveSubcommand = new RegExp(
+    vellumToken.source +
+      String.raw`\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b`,
+  );
+  const implicitTuiClient = new RegExp(vellumToken.source + String.raw`\s*$`);
+  const foregroundWake = new RegExp(
+    vellumToken.source + String.raw`\s+wake\b(?:\s+\S+)*\s--foreground\b`,
+  );
+  return (
+    interactiveSubcommand.test(command) ||
+    implicitTuiClient.test(command) ||
+    foregroundWake.test(command)
   );
 }
 

--- a/cli/src/lib/orphan-detection.ts
+++ b/cli/src/lib/orphan-detection.ts
@@ -25,6 +25,17 @@ export function classifyProcess(command: string): string {
     return "openclaw-adapter";
   if (/vellum-daemon/.test(command)) return "assistant";
   if (/daemon\s+(start|restart)/.test(command)) return "assistant";
+  // Spare deliberate long-running interactive CLI sessions (e.g. a live
+  // `vellum tunnel` in someone's terminal): they have no PID-file
+  // registration, so `vellum clean` would otherwise kill them mid-session.
+  // The command line may be "bun /path/to/bin/vellum tunnel ...", so match
+  // the subcommand after the script path, not just argv[0].
+  if (
+    /(?:^|\/)vellum(?:-cli)?(?:\s+\S+)*?\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
+      command,
+    )
+  )
+    return "unknown";
   if (/vellum-cli/.test(command)) return "vellum";
   // Exclude macOS desktop app processes — their path contains .app/Contents/MacOS/
   // but they are not background service processes.

--- a/cli/src/lib/orphan-detection.ts
+++ b/cli/src/lib/orphan-detection.ts
@@ -25,19 +25,6 @@ export function classifyProcess(command: string): string {
     return "openclaw-adapter";
   if (/vellum-daemon/.test(command)) return "assistant";
   if (/daemon\s+(start|restart)/.test(command)) return "assistant";
-  // Spare deliberate long-running interactive CLI sessions (e.g. a live
-  // `vellum tunnel` in someone's terminal): they have no PID-file
-  // registration, so `vellum clean` would otherwise kill them mid-session.
-  // The command line may be "bun /path/to/bin/vellum tunnel ...", so match
-  // the first argument after the vellum binary/script path — later argv
-  // tokens (e.g. "vellum hatch --name logs") must not trigger the exemption.
-  if (
-    /(?:^|\/)vellum(?:-cli)?\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
-      command,
-    )
-  ) {
-    return "unknown";
-  }
   if (/vellum-cli/.test(command)) return "vellum";
   // Exclude macOS desktop app processes — their path contains .app/Contents/MacOS/
   // but they are not background service processes.
@@ -48,6 +35,26 @@ export function classifyProcess(command: string): string {
   // We require a word boundary before "vellum" to avoid matching repo paths.
   if (/(?:^|\/)vellum(?:\s|$)/.test(command)) return "vellum";
   return "unknown";
+}
+
+/**
+ * True when the command line is a deliberate long-running interactive CLI
+ * session (e.g. a live `vellum tunnel` in someone's terminal). Such sessions
+ * have no PID-file registration, so `vellum clean` would otherwise kill them
+ * mid-session. The command line may be "bun /path/to/bin/vellum tunnel ...",
+ * so match the subcommand right after the vellum binary/script path (allowing
+ * only the known global flags in between; see GLOBAL_FLAGS in cli/src/index.ts).
+ * Later argv tokens (e.g. "vellum hatch --name logs") must not match.
+ *
+ * `detectOrphanedProcesses` consults this before classification so that
+ * service-like substrings in later argv (e.g. `vellum exec -it --service
+ * vellum-gateway -- /bin/sh`) cannot re-flag a live session, while
+ * `classifyProcess` stays a pure display label for `vellum ps`.
+ */
+export function isInteractiveCliSession(command: string): boolean {
+  return /(?:^|\/)vellum(?:-cli)?(?:\s+--(?:no-color|plain))*\s+(?:tunnel|events|logs|client|terminal|ssh|exec|message|workflows)\b/.test(
+    command,
+  );
 }
 
 export function parseRemotePs(output: string): RemoteProcess[] {
@@ -165,6 +172,11 @@ export async function detectOrphanedProcesses(
     for (const p of procs) {
       if (p.pid === ownPid || seenPids.has(p.pid)) continue;
       if (knownPids.has(p.pid)) continue;
+      // Live interactive sessions are spared before classification so that
+      // service substrings in their argv cannot mark them as orphans.
+      if (isInteractiveCliSession(p.command)) {
+        continue;
+      }
       const type = classifyProcess(p.command);
       if (type === "unknown") continue;
       results.push({ name: type, pid: p.pid, source: "process table" });


### PR DESCRIPTION
## Summary
- `classifyProcess` now returns "unknown" for deliberate long-running interactive CLI subcommands (tunnel, events, logs, client, terminal, ssh, exec, message, workflows) so `vellum clean` spares them
- Stale `vellum hatch`/`vellum sleep` wrappers and gateway/daemon/qdrant service processes are cleaned exactly as before

Part of plan: pairing-qa-followups.md (PR 5 of 5)