### PR TITLE
fix(cli): explain which gateway rejected a pairing code and hint at env mismatches

### DIFF
--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -56,9 +56,11 @@ mock.module("../lib/guardian-token.js", () => ({
   loadGuardianToken: loadGuardianTokenMock,
 }));
 
-// Stub the token-refresh helper without importing the real client module
-// (it drags in the interactive chat client's dependency graph). Pass-through
-// by default: the stored token is returned as-is.
+// Stub the token-refresh helper. Pass-through by default: the stored token is
+// returned as-is. Capture the real module first so afterAll can restore it;
+// without the restore this mock leaks into client-tui-refresh.test.ts, whose
+// refresh test then receives the pass-through instead of the real refresher.
+const realClient = { ...(await import("../commands/client.js")) };
 const resolveFreshBearerTokenMock = mock(
   async (
     _runtimeUrl: string,
@@ -68,6 +70,7 @@ const resolveFreshBearerTokenMock = mock(
   ) => bearerToken,
 );
 mock.module("../commands/client.js", () => ({
+  ...realClient,
   resolveFreshBearerToken: resolveFreshBearerTokenMock,
 }));
 
@@ -77,6 +80,7 @@ afterAll(() => {
   mock.module("../lib/process.js", () => realProcess);
   mock.module("../lib/drain.js", () => realDrain);
   mock.module("../lib/guardian-token.js", () => realGuardianToken);
+  mock.module("../commands/client.js", () => realClient);
 });
 
 import { sleep } from "../commands/sleep.js";

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -192,8 +192,11 @@ async function gatewayPostOrExit(
   body: unknown,
   headers?: Record<string, string>,
 ): Promise<Response> {
-  const response = await gatewayPost(gatewayUrl, path, body, headers);
+  return exitOnHttpError(await gatewayPost(gatewayUrl, path, body, headers));
+}
 
+/** Exit with a generic HTTP-error message on non-2xx; pass 2xx through. */
+async function exitOnHttpError(response: Response): Promise<Response> {
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
     console.error(
@@ -201,7 +204,6 @@ async function gatewayPostOrExit(
     );
     process.exit(1);
   }
-
   return response;
 }
 
@@ -223,19 +225,31 @@ async function createRemoteWebPairingChallenge(
 
 /**
  * Approve a pending pairing challenge by its user code, the local-presence
- * proof for the device-code flow. Used by `--qr`, which approves the
- * challenge it just minted so one scan completes pairing. `--web-approve`
- * approves user-supplied codes instead and prints mismatch diagnostics on
- * rejection (see {@link formatWebApproveFailure}).
+ * proof for the device-code flow. Single owner of the pairing-verification
+ * route and request body: `--qr` approves via {@link approveRemoteWebPairing}
+ * (generic exit on non-2xx), while `--web-approve` calls this directly to
+ * inspect rejections and print mismatch diagnostics (see
+ * {@link formatWebApproveFailure}).
+ */
+async function postPairingVerification(
+  gatewayUrl: string,
+  userCode: string,
+): Promise<Response> {
+  return gatewayPost(gatewayUrl, "/v1/remote-web/pairing-verification", {
+    userCode,
+  } satisfies RemoteWebPairingVerificationRequest);
+}
+
+/**
+ * Approve the challenge `--qr` just minted so one scan completes pairing,
+ * exiting with a generic message on non-2xx.
  */
 async function approveRemoteWebPairing(
   gatewayUrl: string,
   userCode: string,
 ): Promise<RemoteWebPairingVerificationResponse> {
-  const response = await gatewayPostOrExit(
-    gatewayUrl,
-    "/v1/remote-web/pairing-verification",
-    { userCode } satisfies RemoteWebPairingVerificationRequest,
+  const response = await exitOnHttpError(
+    await postPairingVerification(gatewayUrl, userCode),
   );
   return (await response.json()) as RemoteWebPairingVerificationResponse;
 }
@@ -417,16 +431,10 @@ export async function pair(): Promise<void> {
   if (webApproveCode) {
     await assertWebRemoteIngressEnabled(entry.assistantId, mintUrl);
 
-    // Rejections are diagnosed here rather than by gatewayPostOrExit: a
+    // Rejections are diagnosed here rather than by exitOnHttpError: a
     // rejected code must name the gateway that was asked, or an
     // assistant/environment mismatch is indistinguishable from a typo.
-    const response = await gatewayPost(
-      mintUrl,
-      "/v1/remote-web/pairing-verification",
-      {
-        userCode: webApproveCode,
-      } satisfies RemoteWebPairingVerificationRequest,
-    );
+    const response = await postPairingVerification(mintUrl, webApproveCode);
     if (!response.ok) {
       const errorBody = await response.text().catch(() => "");
       const diagnostic = formatWebApproveFailure(

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -40,6 +40,7 @@ import {
   getClientRegistrationHeaders,
 } from "../lib/client-identity.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
+import { resolveEnvironmentSource } from "../lib/environments/resolve.js";
 import {
   formatFeatureFlagGateMessage,
   isAssistantFeatureFlagEnabled,
@@ -47,6 +48,7 @@ import {
 } from "../lib/feature-flags.js";
 import { getLocalLanIPv4 } from "../lib/local.js";
 import { isLoopbackUrl, loopbackSafeFetch } from "../lib/loopback-fetch.js";
+import { formatWebApproveFailure, parseGatewayErrorCode } from "../lib/pair.js";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 
 function assistantDisplayName(entry: AssistantEntry): string {
@@ -152,19 +154,18 @@ export function buildAppConnectUrl(
 
 /**
  * POST a JSON body to a loopback gateway route, exiting with a clear message
- * when the gateway is unreachable or answers non-2xx. Every pairing subcommand
- * talks to the gateway this way, so the reachability + HTTP-error handling has
- * a single home.
+ * when the gateway is unreachable. Non-2xx responses are returned to the
+ * caller; use {@link gatewayPostOrExit} unless the call site prints its own
+ * HTTP-error diagnostics.
  */
-async function gatewayPostOrExit(
+async function gatewayPost(
   gatewayUrl: string,
   path: string,
   body: unknown,
   headers?: Record<string, string>,
 ): Promise<Response> {
-  let response: Response;
   try {
-    response = await loopbackSafeFetch(`${gatewayUrl}${path}`, {
+    return await loopbackSafeFetch(`${gatewayUrl}${path}`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: JSON.stringify(body),
@@ -177,6 +178,20 @@ async function gatewayPostOrExit(
     console.error("Is the assistant running? Try `vellum wake`.");
     process.exit(1);
   }
+}
+
+/**
+ * {@link gatewayPost}, but also exiting with a generic message on non-2xx.
+ * Every pairing subcommand talks to the gateway this way, so the reachability
+ * + HTTP-error handling has a single home.
+ */
+async function gatewayPostOrExit(
+  gatewayUrl: string,
+  path: string,
+  body: unknown,
+  headers?: Record<string, string>,
+): Promise<Response> {
+  const response = await gatewayPost(gatewayUrl, path, body, headers);
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
@@ -206,9 +221,11 @@ async function createRemoteWebPairingChallenge(
 }
 
 /**
- * Approve a pending pairing challenge by its user code — the local-presence
- * proof for the device-code flow. Shared by `--web-approve` and `--qr` (which
- * approves the challenge it just minted so one scan completes pairing).
+ * Approve a pending pairing challenge by its user code, the local-presence
+ * proof for the device-code flow. Used by `--qr`, which approves the
+ * challenge it just minted so one scan completes pairing. `--web-approve`
+ * approves user-supplied codes instead and prints mismatch diagnostics on
+ * rejection (see {@link formatWebApproveFailure}).
  */
 async function approveRemoteWebPairing(
   gatewayUrl: string,
@@ -399,7 +416,32 @@ export async function pair(): Promise<void> {
   if (webApproveCode) {
     await assertWebRemoteIngressEnabled(entry.assistantId, mintUrl);
 
-    const result = await approveRemoteWebPairing(mintUrl, webApproveCode);
+    // Rejections are diagnosed here rather than by gatewayPostOrExit: a
+    // rejected code must name the gateway that was asked, or an
+    // assistant/environment mismatch is indistinguishable from a typo.
+    const response = await gatewayPost(
+      mintUrl,
+      "/v1/remote-web/pairing-verification",
+      {
+        userCode: webApproveCode,
+      } satisfies RemoteWebPairingVerificationRequest,
+    );
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      const diagnostic = formatWebApproveFailure(
+        mintUrl,
+        assistantDisplayName(entry),
+        resolveEnvironmentSource().name,
+        parseGatewayErrorCode(errorBody),
+      );
+      console.error(
+        diagnostic ??
+          `Error: HTTP ${response.status}: ${errorBody || response.statusText}`,
+      );
+      process.exit(1);
+    }
+    const result =
+      (await response.json()) as RemoteWebPairingVerificationResponse;
     if (jsonOutput) {
       console.log(JSON.stringify(result, null, 2));
       return;

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -31,6 +31,7 @@ import { extractFlag } from "../lib/arg-utils.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import {
   formatAssistantLookupError,
+  formatAssistantReference,
   lookupAssistantByIdentifier,
   resolveAssistant,
   type AssistantEntry,
@@ -40,7 +41,7 @@ import {
   getClientRegistrationHeaders,
 } from "../lib/client-identity.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
-import { resolveEnvironmentSource } from "../lib/environments/resolve.js";
+import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 import {
   formatFeatureFlagGateMessage,
   isAssistantFeatureFlagEnabled,
@@ -430,8 +431,8 @@ export async function pair(): Promise<void> {
       const errorBody = await response.text().catch(() => "");
       const diagnostic = formatWebApproveFailure(
         mintUrl,
-        assistantDisplayName(entry),
-        resolveEnvironmentSource().name,
+        formatAssistantReference(entry),
+        getCurrentEnvironment().name,
         parseGatewayErrorCode(errorBody),
       );
       console.error(

--- a/cli/src/lib/pair.test.ts
+++ b/cli/src/lib/pair.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatWebApproveFailure, parseGatewayErrorCode } from "./pair.js";
+
+const GATEWAY_URL = "http://127.0.0.1:20100";
+const ASSISTANT_NAME = "example-assistant";
+const ENV_NAME = "local";
+
+describe("formatWebApproveFailure", () => {
+  test("INVALID_USER_CODE names the gateway, assistant, and environment", () => {
+    const message = formatWebApproveFailure(
+      GATEWAY_URL,
+      ASSISTANT_NAME,
+      ENV_NAME,
+      "INVALID_USER_CODE",
+    );
+    expect(message).not.toBeNull();
+    expect(message).toContain(`No such pairing code on ${GATEWAY_URL}`);
+    expect(message).toContain(`assistant "${ASSISTANT_NAME}"`);
+    expect(message).toContain(`environment "${ENV_NAME}"`);
+  });
+
+  test("INVALID_USER_CODE includes the TTL note and the cross-environment hint", () => {
+    const message = formatWebApproveFailure(
+      GATEWAY_URL,
+      ASSISTANT_NAME,
+      ENV_NAME,
+      "INVALID_USER_CODE",
+    );
+    expect(message).toContain("expire after 10 minutes");
+    expect(message).toContain("single-use");
+    expect(message).toContain("different assistant or environment");
+    expect(message).toContain("VELLUM_ENVIRONMENT");
+  });
+
+  test("EXPIRED_USER_CODE gets the same diagnostic with an expiry lead line", () => {
+    const message = formatWebApproveFailure(
+      GATEWAY_URL,
+      ASSISTANT_NAME,
+      ENV_NAME,
+      "EXPIRED_USER_CODE",
+    );
+    expect(message).toContain(`Pairing code expired on ${GATEWAY_URL}`);
+    expect(message).toContain("expire after 10 minutes");
+    expect(message).toContain("VELLUM_ENVIRONMENT");
+  });
+
+  test("unknown error codes return null so callers fall back to the generic HTTP error", () => {
+    for (const code of ["RATE_LIMITED", "BAD_REQUEST", "", null]) {
+      expect(
+        formatWebApproveFailure(GATEWAY_URL, ASSISTANT_NAME, ENV_NAME, code),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("parseGatewayErrorCode", () => {
+  test("extracts the code from a gateway error envelope", () => {
+    const body = JSON.stringify({
+      error: { code: "INVALID_USER_CODE", message: "invalid pairing code" },
+    });
+    expect(parseGatewayErrorCode(body)).toBe("INVALID_USER_CODE");
+  });
+
+  test("returns null for non-JSON bodies", () => {
+    expect(parseGatewayErrorCode("Not Found")).toBeNull();
+    expect(parseGatewayErrorCode("")).toBeNull();
+  });
+
+  test("returns null when the envelope carries no string code", () => {
+    expect(parseGatewayErrorCode(JSON.stringify({ error: {} }))).toBeNull();
+    expect(
+      parseGatewayErrorCode(JSON.stringify({ error: { code: 404 } })),
+    ).toBeNull();
+    expect(parseGatewayErrorCode(JSON.stringify({}))).toBeNull();
+  });
+});

--- a/cli/src/lib/pair.test.ts
+++ b/cli/src/lib/pair.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
+import { REMOTE_WEB_PAIRING_CODE_TTL_MS } from "@vellumai/service-contracts/remote-web-pairing";
+
 import { formatWebApproveFailure, parseGatewayErrorCode } from "./pair.js";
 
 const GATEWAY_URL = "http://127.0.0.1:20100";
 // Callers pass formatAssistantReference() output: display name plus stable ID.
 const ASSISTANT_REFERENCE = "example-assistant (asst_0123456789abcdef)";
 const ENV_NAME = "local";
+const TTL_NOTE = `expire after ${Math.round(REMOTE_WEB_PAIRING_CODE_TTL_MS / 60_000)} minutes`;
 
 describe("formatWebApproveFailure", () => {
   test("INVALID_USER_CODE names the gateway, assistant reference, and environment", () => {
@@ -29,7 +32,7 @@ describe("formatWebApproveFailure", () => {
       ENV_NAME,
       "INVALID_USER_CODE",
     );
-    expect(message).toContain("expire after 10 minutes");
+    expect(message).toContain(TTL_NOTE);
     expect(message).toContain("single-use");
     expect(message).toContain("different assistant or environment");
     expect(message).toContain("VELLUM_ENVIRONMENT");
@@ -43,14 +46,19 @@ describe("formatWebApproveFailure", () => {
       "EXPIRED_USER_CODE",
     );
     expect(message).toContain(`Pairing code expired on ${GATEWAY_URL}`);
-    expect(message).toContain("expire after 10 minutes");
+    expect(message).toContain(TTL_NOTE);
     expect(message).toContain("VELLUM_ENVIRONMENT");
   });
 
   test("unknown error codes return null so callers fall back to the generic HTTP error", () => {
     for (const code of ["RATE_LIMITED", "BAD_REQUEST", "", null]) {
       expect(
-        formatWebApproveFailure(GATEWAY_URL, ASSISTANT_REFERENCE, ENV_NAME, code),
+        formatWebApproveFailure(
+          GATEWAY_URL,
+          ASSISTANT_REFERENCE,
+          ENV_NAME,
+          code,
+        ),
       ).toBeNull();
     }
   });

--- a/cli/src/lib/pair.test.ts
+++ b/cli/src/lib/pair.test.ts
@@ -3,27 +3,29 @@ import { describe, expect, test } from "bun:test";
 import { formatWebApproveFailure, parseGatewayErrorCode } from "./pair.js";
 
 const GATEWAY_URL = "http://127.0.0.1:20100";
-const ASSISTANT_NAME = "example-assistant";
+// Callers pass formatAssistantReference() output: display name plus stable ID.
+const ASSISTANT_REFERENCE = "example-assistant (asst_0123456789abcdef)";
 const ENV_NAME = "local";
 
 describe("formatWebApproveFailure", () => {
-  test("INVALID_USER_CODE names the gateway, assistant, and environment", () => {
+  test("INVALID_USER_CODE names the gateway, assistant reference, and environment", () => {
     const message = formatWebApproveFailure(
       GATEWAY_URL,
-      ASSISTANT_NAME,
+      ASSISTANT_REFERENCE,
       ENV_NAME,
       "INVALID_USER_CODE",
     );
     expect(message).not.toBeNull();
     expect(message).toContain(`No such pairing code on ${GATEWAY_URL}`);
-    expect(message).toContain(`assistant "${ASSISTANT_NAME}"`);
+    expect(message).toContain(`assistant "${ASSISTANT_REFERENCE}"`);
+    expect(message).toContain("asst_0123456789abcdef");
     expect(message).toContain(`environment "${ENV_NAME}"`);
   });
 
   test("INVALID_USER_CODE includes the TTL note and the cross-environment hint", () => {
     const message = formatWebApproveFailure(
       GATEWAY_URL,
-      ASSISTANT_NAME,
+      ASSISTANT_REFERENCE,
       ENV_NAME,
       "INVALID_USER_CODE",
     );
@@ -36,7 +38,7 @@ describe("formatWebApproveFailure", () => {
   test("EXPIRED_USER_CODE gets the same diagnostic with an expiry lead line", () => {
     const message = formatWebApproveFailure(
       GATEWAY_URL,
-      ASSISTANT_NAME,
+      ASSISTANT_REFERENCE,
       ENV_NAME,
       "EXPIRED_USER_CODE",
     );
@@ -48,7 +50,7 @@ describe("formatWebApproveFailure", () => {
   test("unknown error codes return null so callers fall back to the generic HTTP error", () => {
     for (const code of ["RATE_LIMITED", "BAD_REQUEST", "", null]) {
       expect(
-        formatWebApproveFailure(GATEWAY_URL, ASSISTANT_NAME, ENV_NAME, code),
+        formatWebApproveFailure(GATEWAY_URL, ASSISTANT_REFERENCE, ENV_NAME, code),
       ).toBeNull();
     }
   });

--- a/cli/src/lib/pair.ts
+++ b/cli/src/lib/pair.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure helpers for `vellum pair`'s remote-web approval flow.
+ *
+ * Pairing challenge stores are in-memory per gateway process, so approving a
+ * code against a different assistant or environment than the one that served
+ * the pair page looks identical to a typo'd or expired code. These helpers
+ * turn the gateway's error envelope into a diagnostic that names the gateway
+ * actually asked.
+ */
+
+/**
+ * Extract the `error.code` from a gateway JSON error envelope
+ * (`{"error":{"code":...,"message":...}}`). Returns null when the body is not
+ * JSON or carries no string code.
+ */
+export function parseGatewayErrorCode(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as { error?: { code?: unknown } };
+    return typeof parsed.error?.code === "string" ? parsed.error.code : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Diagnostic for a failed `--web-approve`, naming which gateway rejected the
+ * code and hinting at cross-assistant / cross-environment mismatches. Returns
+ * null for error codes this helper doesn't recognize, so the caller falls
+ * back to the generic HTTP error text.
+ */
+export function formatWebApproveFailure(
+  gatewayUrl: string,
+  assistantName: string,
+  envName: string,
+  errorCode: string | null,
+): string | null {
+  if (errorCode !== "INVALID_USER_CODE" && errorCode !== "EXPIRED_USER_CODE") {
+    return null;
+  }
+  const rejection =
+    errorCode === "EXPIRED_USER_CODE"
+      ? "Pairing code expired on"
+      : "No such pairing code on";
+  return [
+    `${rejection} ${gatewayUrl} (assistant "${assistantName}", environment "${envName}").`,
+    "Codes are minted by the gateway that serves the pair page, expire after 10 minutes, and are single-use.",
+    "If the pair page came from a different assistant or environment (e.g. the desktop app's), re-run with that environment's VELLUM_ENVIRONMENT and that assistant's name.",
+  ].join("\n");
+}

--- a/cli/src/lib/pair.ts
+++ b/cli/src/lib/pair.ts
@@ -26,11 +26,13 @@ export function parseGatewayErrorCode(body: string): string | null {
  * Diagnostic for a failed `--web-approve`, naming which gateway rejected the
  * code and hinting at cross-assistant / cross-environment mismatches. Returns
  * null for error codes this helper doesn't recognize, so the caller falls
- * back to the generic HTTP error text.
+ * back to the generic HTTP error text. `assistantReference` should carry the
+ * stable assistant ID (see `formatAssistantReference`); `envName` should be
+ * the effective environment actually used (see `getCurrentEnvironment`).
  */
 export function formatWebApproveFailure(
   gatewayUrl: string,
-  assistantName: string,
+  assistantReference: string,
   envName: string,
   errorCode: string | null,
 ): string | null {
@@ -42,7 +44,7 @@ export function formatWebApproveFailure(
       ? "Pairing code expired on"
       : "No such pairing code on";
   return [
-    `${rejection} ${gatewayUrl} (assistant "${assistantName}", environment "${envName}").`,
+    `${rejection} ${gatewayUrl} (assistant "${assistantReference}", environment "${envName}").`,
     "Codes are minted by the gateway that serves the pair page, expire after 10 minutes, and are single-use.",
     "If the pair page came from a different assistant or environment (e.g. the desktop app's), re-run with that environment's VELLUM_ENVIRONMENT and that assistant's name.",
   ].join("\n");

--- a/cli/src/lib/pair.ts
+++ b/cli/src/lib/pair.ts
@@ -8,6 +8,10 @@
  * actually asked.
  */
 
+import { REMOTE_WEB_PAIRING_CODE_TTL_MS } from "@vellumai/service-contracts/remote-web-pairing";
+
+const CODE_TTL_MINUTES = Math.round(REMOTE_WEB_PAIRING_CODE_TTL_MS / 60_000);
+
 /**
  * Extract the `error.code` from a gateway JSON error envelope
  * (`{"error":{"code":...,"message":...}}`). Returns null when the body is not
@@ -45,7 +49,7 @@ export function formatWebApproveFailure(
       : "No such pairing code on";
   return [
     `${rejection} ${gatewayUrl} (assistant "${assistantReference}", environment "${envName}").`,
-    "Codes are minted by the gateway that serves the pair page, expire after 10 minutes, and are single-use.",
+    `Codes are minted by the gateway that serves the pair page, expire after ${CODE_TTL_MINUTES} minutes, and are single-use.`,
     "If the pair page came from a different assistant or environment (e.g. the desktop app's), re-run with that environment's VELLUM_ENVIRONMENT and that assistant's name.",
   ].join("\n");
 }

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -1,12 +1,13 @@
 import { createHash, randomBytes, randomInt } from "node:crypto";
 
-import type {
-  RemoteWebPairingChallengeResponse,
-  RemoteWebPairingTokenPendingResponse,
-  RemoteWebPairingVerificationResponse,
+import {
+  REMOTE_WEB_PAIRING_CODE_TTL_MS,
+  type RemoteWebPairingChallengeResponse,
+  type RemoteWebPairingTokenPendingResponse,
+  type RemoteWebPairingVerificationResponse,
 } from "@vellumai/service-contracts/remote-web-pairing";
 
-const CODE_TTL_MS = 10 * 60 * 1000;
+const CODE_TTL_MS = REMOTE_WEB_PAIRING_CODE_TTL_MS;
 const MAX_ACTIVE_CHALLENGES = 200;
 const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const USER_CODE_LENGTH = 8;

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -21,6 +21,12 @@
  * `Date#toISOString()`.
  */
 
+/**
+ * Pairing-challenge TTL in milliseconds (10 minutes): the gateway's challenge
+ * store enforces it and the `vellum pair` CLI renders it in user-facing copy.
+ */
+export const REMOTE_WEB_PAIRING_CODE_TTL_MS = 10 * 60 * 1000;
+
 /** `POST /v1/remote-web/pairing-challenge` request body. */
 export interface RemoteWebPairingChallengeRequest {
   /** Public https base URL the scanning device can reach the assistant at. */


### PR DESCRIPTION
## Summary
- `vellum pair --web-approve` failures now say which gateway/assistant/environment rejected the code, note the 10-minute single-use TTL, and hint at cross-environment mismatches
- Unknown error codes keep the generic HTTP error; successful approve output unchanged

Part of plan: pairing-qa-followups.md (PR 4 of 5)