### PR TITLE
fix(web): say "can't be reached", not "asleep", for unreachable paired assistants

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -891,7 +891,7 @@ describe("StatusBanner", () => {
     });
 
     test("shows can't-be-reached copy with no wake action for a sleeping paired assistant", () => {
-      // A paired entry has no meaningful sleeping/unreachable distinction —
+      // A paired entry has no meaningful sleeping/unreachable distinction;
       // a failed health probe only proves the link is down.
       localHealthMock = "sleeping";
       assistantsMock = [

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -937,6 +937,48 @@ describe("StatusBanner", () => {
       expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
     });
 
+    test("keeps can't-be-reached for a paired assistant while a local wake is in flight", async () => {
+      // Wake state is not keyed by assistant: a wake started for a local
+      // assistant must not rewrite an unreachable paired entry to "waking up".
+      localHealthMock = "sleeping";
+      assistantsMock = [
+        {
+          id: "assistant-123",
+          isLocal: true,
+          isPlatformHosted: false,
+          isPaired: false,
+        },
+        {
+          id: "assistant-paired",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+        },
+      ];
+      wakeLocalAssistantHostMock = mock(
+        () => new Promise<{ ok: true }>(() => {}),
+      );
+
+      const { rerender } = render(<StatusBanner />);
+      fireEvent.click(screen.getByRole("button", { name: "Wake up" }));
+
+      await waitFor(() => {
+        expect(wakeLocalAssistantHostMock).toHaveBeenCalledWith(
+          "assistant-123",
+        );
+      });
+
+      activeAssistantIdMock = "assistant-paired";
+      localHealthMock = "unreachable";
+      rerender(<StatusBanner />);
+
+      expect(
+        screen.getByText("Your assistant can't be reached"),
+      ).toBeTruthy();
+      expect(screen.queryByText("Your assistant is waking up")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
+    });
+
     test("keeps the asleep copy and wake action for a non-paired local assistant", () => {
       localHealthMock = "unreachable";
       assistantsMock = [

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -32,6 +32,7 @@ let assistantsMock: Array<{
   id: string;
   isLocal: boolean;
   isPlatformHosted: boolean;
+  isPaired?: boolean;
   organizationId?: string | null;
 }> = [];
 let currentOrganizationIdMock: string | null = "org-1";
@@ -858,6 +859,100 @@ describe("StatusBanner", () => {
       expect(html).toContain("Open the Vellum desktop app");
       expect(html).not.toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
+    });
+
+    test("shows can't-be-reached copy with no wake action for an unreachable paired assistant", () => {
+      // A paired entry is reached over a tunnel: the remote host isn't
+      // asleep, the link is down, and Wake can't help.
+      localHealthMock = "unreachable";
+      assistantsMock = [
+        {
+          id: "assistant-123",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+        },
+      ];
+
+      const { container } = render(<StatusBanner />);
+
+      expect(
+        screen.getByText("Your assistant can't be reached"),
+      ).toBeTruthy();
+      expect(
+        screen.getByText(
+          "The connection to the paired assistant's host is down. Check the host machine and its tunnel.",
+        ),
+      ).toBeTruthy();
+      expect(container.innerHTML).toContain("lucide-cloud-off");
+      expect(container.innerHTML).toContain('data-tone="neutral"');
+      expect(screen.queryByText("Your assistant is asleep")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
+    });
+
+    test("shows can't-be-reached copy with no wake action for a sleeping paired assistant", () => {
+      // A paired entry has no meaningful sleeping/unreachable distinction —
+      // a failed health probe only proves the link is down.
+      localHealthMock = "sleeping";
+      assistantsMock = [
+        {
+          id: "assistant-123",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+        },
+      ];
+
+      const { container } = render(<StatusBanner />);
+
+      expect(
+        screen.getByText("Your assistant can't be reached"),
+      ).toBeTruthy();
+      expect(container.innerHTML).toContain("lucide-cloud-off");
+      expect(container.innerHTML).toContain('data-tone="neutral"');
+      expect(screen.queryByText("Your assistant is asleep")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
+    });
+
+    test("prefers can't-be-reached over the runs-locally banner for a paired assistant", () => {
+      // Even where local-mode operations aren't available, a paired entry
+      // must not claim it "runs locally" or suggest `vellum wake`.
+      localHealthMock = "unreachable";
+      isLocalModeHostAvailableMock = false;
+      assistantsMock = [
+        {
+          id: "assistant-123",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+        },
+      ];
+
+      render(<StatusBanner />);
+
+      expect(
+        screen.getByText("Your assistant can't be reached"),
+      ).toBeTruthy();
+      expect(screen.queryByText("Your assistant runs locally")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
+    });
+
+    test("keeps the asleep copy and wake action for a non-paired local assistant", () => {
+      localHealthMock = "unreachable";
+      assistantsMock = [
+        {
+          id: "assistant-123",
+          isLocal: true,
+          isPlatformHosted: false,
+          isPaired: false,
+        },
+      ];
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toContain("Your assistant is asleep");
+      expect(html).toContain("Wake up");
+      expect(html).not.toContain("lucide-cloud-off");
     });
 
     test("hides the Wake up button for an assistant vellum wake can't start (e.g. Docker)", () => {

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -887,8 +887,11 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
+  // Wake state is not keyed by assistant, so an in-flight wake started for a
+  // local assistant must not rewrite a paired entry's health to "starting".
   const effectiveLocalHealth =
     (isWakingLocalAssistant || isLocalWakeSettling) &&
+    !isPairedActiveAssistant &&
     canWakeLocalHealth(localHealth)
       ? "starting"
       : localHealth;

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -410,7 +410,7 @@ function localHealthBannerConfig(
   wakeError?: ReactNode,
 ): BannerConfig | null {
   // A paired entry is reached over a tunnel to a remote host, so a failed
-  // health probe only proves the link is down — there is no meaningful
+  // health probe only proves the link is down; there is no meaningful
   // sleeping/unreachable distinction, and Wake can't help from here.
   if (isPaired && (health === "sleeping" || health === "unreachable")) {
     return {

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -411,10 +411,12 @@ function localHealthBannerConfig(
 ): BannerConfig | null {
   // A paired entry is reached over a tunnel to a remote host, so a failed
   // health probe only proves the link is down; there is no meaningful
-  // sleeping/unreachable distinction, and Wake can't help from here.
+  // sleeping/unreachable distinction, and Wake can't help from here. Wake is
+  // never offered for paired entries, so any wakeError belongs to a
+  // previously-viewed local assistant and must not color this banner.
   if (isPaired && (health === "sleeping" || health === "unreachable")) {
     return {
-      tone: wakeError ? "error" : "neutral",
+      tone: "neutral",
       title: "Your assistant can't be reached",
       icon: <CloudOff className="h-4 w-4" aria-hidden="true" />,
       children:

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -405,9 +405,22 @@ function operationalStatusBannerConfig(
 
 function localHealthBannerConfig(
   health: LocalAssistantHealth | null,
+  isPaired: boolean,
   wakeAction?: ReactNode,
   wakeError?: ReactNode,
 ): BannerConfig | null {
+  // A paired entry is reached over a tunnel to a remote host, so a failed
+  // health probe only proves the link is down — there is no meaningful
+  // sleeping/unreachable distinction, and Wake can't help from here.
+  if (isPaired && (health === "sleeping" || health === "unreachable")) {
+    return {
+      tone: wakeError ? "error" : "neutral",
+      title: "Your assistant can't be reached",
+      icon: <CloudOff className="h-4 w-4" aria-hidden="true" />,
+      children:
+        "The connection to the paired assistant's host is down. Check the host machine and its tunnel.",
+    };
+  }
   switch (health) {
     case "sleeping":
       return {
@@ -550,6 +563,16 @@ function useAssistantBannerConfig(): BannerConfig | null {
     operationalStatusAssistantId ??
     activeAssistantId ??
     selectedOperationalStatusAssistantId;
+  // Paired entries (`cloud: "paired"`) are reached over a tunnel to a remote
+  // host; their local-health banners get link-down copy and no wake action.
+  const isPairedActiveAssistant = useMemo(
+    () =>
+      assistants.some(
+        (assistant) =>
+          assistant.id === activeAssistantId && assistant.isPaired === true,
+      ),
+    [assistants, activeAssistantId],
+  );
   const showDoctorAction =
     assistantState.kind === "active" &&
     !assistantState.isLocal &&
@@ -846,8 +869,13 @@ function useAssistantBannerConfig(): BannerConfig | null {
 
   // A local / self-hosted assistant can surface where local-mode operations
   // aren't available (managed web, remote-web tunnel). There's no transport to
-  // wake it from here, so the banner is informative and action-free.
-  if (!isLocalModeHostAvailable() && canWakeLocalHealth(localHealth)) {
+  // wake it from here, so the banner is informative and action-free. Paired
+  // entries fall through to their own "can't be reached" banner instead.
+  if (
+    !isPairedActiveAssistant &&
+    !isLocalModeHostAvailable() &&
+    canWakeLocalHealth(localHealth)
+  ) {
     return {
       tone: "neutral",
       title: "Your assistant runs locally",
@@ -863,8 +891,10 @@ function useAssistantBannerConfig(): BannerConfig | null {
       ? "starting"
       : localHealth;
   // Only offer "Wake up" when the CLI can actually start this assistant —
-  // `vellum wake` works on plain local entries, not Docker/apple-container.
+  // `vellum wake` works on plain local entries, not Docker/apple-container,
+  // and never a paired entry (the remote host isn't ours to start).
   const localWakeAction =
+    !isPairedActiveAssistant &&
     canWakeLocalHealth(effectiveLocalHealth) &&
     !!activeAssistantId &&
     isCliWakeableAssistant(activeAssistantId) ? (
@@ -886,6 +916,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
     ) : undefined;
   const localHealthBanner = localHealthBannerConfig(
     effectiveLocalHealth,
+    isPairedActiveAssistant,
     localWakeAction,
     wakeLocalAssistantError,
   );


### PR DESCRIPTION
## Summary
- Paired assistants with a failed health probe now show "Your assistant can't be reached" (CloudOff icon, no Wake action) instead of the misleading "asleep" copy
- Non-paired local assistant banners unchanged

Part of plan: pairing-qa-followups.md (PR 1 of 5)