### PR TITLE
fix(cli): give vellum's ngrok agent its own API port so it coexists with foreign agents

### DIFF
--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -9,11 +9,11 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 import {
   clearIngressUrl,
+  loadNgrokAgent,
   loadNgrokDomain,
-  loadNgrokWebAddrPort,
   saveIngressUrl,
+  saveNgrokAgent,
   saveNgrokDomain,
-  saveNgrokWebAddrPort,
 } from "../lib/ingress-config.js";
 
 function writeLockfile(entry: Record<string, unknown>): void {
@@ -109,7 +109,7 @@ describe("ingress lockfile mirroring", () => {
   });
 });
 
-describe("ngrok web-addr port persistence", () => {
+describe("ngrok dedicated-agent persistence", () => {
   function readNgrokEntry(ws: string): Record<string, unknown> | undefined {
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
@@ -120,38 +120,54 @@ describe("ngrok web-addr port persistence", () => {
   test("save and load round-trip; null clears", () => {
     const ws = makeWorkspace();
 
-    saveNgrokWebAddrPort(ws, 41234);
-    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
 
-    saveNgrokWebAddrPort(ws, null);
-    expect(loadNgrokWebAddrPort(ws)).toBeNull();
+    saveNgrokAgent(ws, null);
+    expect(loadNgrokAgent(ws)).toBeNull();
     // Clearing the last ngrok field drops the entry entirely.
     expect(readNgrokEntry(ws)).toBeUndefined();
   });
 
-  test("loadNgrokWebAddrPort returns null when nothing is saved", () => {
-    expect(loadNgrokWebAddrPort(makeWorkspace())).toBeNull();
+  test("a record without a pid loads with pid null", () => {
+    const ws = makeWorkspace();
+
+    saveNgrokAgent(ws, { webAddrPort: 41234 });
+    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: null });
+    expect(readNgrokEntry(ws)).toEqual({ webAddrPort: 41234 });
   });
 
-  test("saveNgrokDomain preserves the persisted web-addr port", () => {
+  test("re-saving without a pid drops a previously recorded pid", () => {
     const ws = makeWorkspace();
-    saveNgrokWebAddrPort(ws, 41234);
+    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+
+    saveNgrokAgent(ws, { webAddrPort: 42345, pid: null });
+    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 42345, pid: null });
+  });
+
+  test("loadNgrokAgent returns null when nothing is saved", () => {
+    expect(loadNgrokAgent(makeWorkspace())).toBeNull();
+  });
+
+  test("saveNgrokDomain preserves the persisted agent record", () => {
+    const ws = makeWorkspace();
+    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
 
     saveNgrokDomain(ws, "foo.ngrok.app");
     expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
-    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
 
     saveNgrokDomain(ws, null);
     expect(loadNgrokDomain(ws)).toBeNull();
-    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
   });
 
-  test("saveNgrokWebAddrPort preserves the saved domain", () => {
+  test("saveNgrokAgent preserves the saved domain", () => {
     const ws = makeWorkspace();
     saveNgrokDomain(ws, "foo.ngrok.app");
 
-    saveNgrokWebAddrPort(ws, 41234);
-    saveNgrokWebAddrPort(ws, null);
+    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+    saveNgrokAgent(ws, null);
     expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
   });
 });

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 // Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR.
 const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
@@ -9,6 +16,7 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 import {
   clearIngressUrl,
+  getNgrokAgentStatePath,
   loadNgrokAgent,
   loadNgrokDomain,
   saveIngressUrl,
@@ -33,9 +41,13 @@ function readLockfileEntry(): Record<string, unknown> {
 const tempDirs: string[] = [];
 
 function makeWorkspace(): string {
-  const dir = mkdtempSync(join(tmpdir(), "ingress-config-ws-"));
-  tempDirs.push(dir);
-  return dir;
+  // Mirror the real layout (`<parent>/workspace`) so host-local agent state
+  // lands in an isolated parent dir, not the shared tmpdir.
+  const base = mkdtempSync(join(tmpdir(), "ingress-config-ws-"));
+  tempDirs.push(base);
+  const ws = join(base, "workspace");
+  mkdirSync(ws, { recursive: true });
+  return ws;
 }
 
 afterEach(() => {
@@ -111,11 +123,27 @@ describe("ingress lockfile mirroring", () => {
 
 describe("ngrok dedicated-agent persistence", () => {
   function readNgrokEntry(ws: string): Record<string, unknown> | undefined {
-    const config = JSON.parse(
-      readFileSync(join(ws, "config.json"), "utf-8"),
-    ) as { ingress?: { ngrok?: Record<string, unknown> } };
+    const configPath = join(ws, "config.json");
+    if (!existsSync(configPath)) return undefined;
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      ingress?: { ngrok?: Record<string, unknown> };
+    };
     return config.ingress?.ngrok;
   }
+
+  test("the record lives beside the workspace, never inside it", () => {
+    const ws = makeWorkspace();
+
+    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+
+    // Host-local state: a sibling of the workspace dir, beside the pid files.
+    expect(getNgrokAgentStatePath(ws)).toBe(
+      join(dirname(ws), "ngrok-agent.json"),
+    );
+    expect(existsSync(getNgrokAgentStatePath(ws))).toBe(true);
+    // The workspace config, which travels with moves/restores, is untouched.
+    expect(existsSync(join(ws, "config.json"))).toBe(false);
+  });
 
   test("save and load round-trip; null clears", () => {
     const ws = makeWorkspace();
@@ -125,8 +153,7 @@ describe("ngrok dedicated-agent persistence", () => {
 
     saveNgrokAgent(ws, null);
     expect(loadNgrokAgent(ws)).toBeNull();
-    // Clearing the last ngrok field drops the entry entirely.
-    expect(readNgrokEntry(ws)).toBeUndefined();
+    expect(existsSync(getNgrokAgentStatePath(ws))).toBe(false);
   });
 
   test("a record without a pid loads with pid null", () => {
@@ -134,7 +161,9 @@ describe("ngrok dedicated-agent persistence", () => {
 
     saveNgrokAgent(ws, { webAddrPort: 41234 });
     expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: null });
-    expect(readNgrokEntry(ws)).toEqual({ webAddrPort: 41234 });
+    expect(
+      JSON.parse(readFileSync(getNgrokAgentStatePath(ws), "utf-8")),
+    ).toEqual({ webAddrPort: 41234 });
   });
 
   test("re-saving without a pid drops a previously recorded pid", () => {
@@ -147,6 +176,51 @@ describe("ngrok dedicated-agent persistence", () => {
 
   test("loadNgrokAgent returns null when nothing is saved", () => {
     expect(loadNgrokAgent(makeWorkspace())).toBeNull();
+  });
+
+  test("loadNgrokAgent returns null for a corrupt or malformed record", () => {
+    const ws = makeWorkspace();
+
+    writeFileSync(getNgrokAgentStatePath(ws), "not json");
+    expect(loadNgrokAgent(ws)).toBeNull();
+
+    writeFileSync(
+      getNgrokAgentStatePath(ws),
+      JSON.stringify({ webAddrPort: "41234" }),
+    );
+    expect(loadNgrokAgent(ws)).toBeNull();
+  });
+
+  test("loadNgrokAgent ignores legacy agent keys in the workspace config", () => {
+    const ws = makeWorkspace();
+    writeFileSync(
+      join(ws, "config.json"),
+      JSON.stringify({
+        ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
+      }),
+    );
+
+    // A record written by an older CLI is meaningless on another host.
+    expect(loadNgrokAgent(ws)).toBeNull();
+  });
+
+  test("saveNgrokDomain scrubs legacy agent keys from the workspace config", () => {
+    const ws = makeWorkspace();
+    writeFileSync(
+      join(ws, "config.json"),
+      JSON.stringify({
+        ingress: {
+          ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 5 },
+        },
+      }),
+    );
+
+    saveNgrokDomain(ws, "bar.ngrok.app");
+    expect(readNgrokEntry(ws)).toEqual({ domain: "bar.ngrok.app" });
+
+    saveNgrokDomain(ws, null);
+    // Scrubbing the legacy keys and the domain drops the entry entirely.
+    expect(readNgrokEntry(ws)).toBeUndefined();
   });
 
   test("saveNgrokDomain preserves the persisted agent record", () => {

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -16,7 +16,6 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 import {
   clearIngressUrl,
-  getNgrokAgentStatePath,
   loadNgrokAgent,
   loadNgrokDomain,
   saveIngressUrl,
@@ -122,126 +121,113 @@ describe("ingress lockfile mirroring", () => {
 });
 
 describe("ngrok dedicated-agent persistence", () => {
-  function readNgrokEntry(ws: string): Record<string, unknown> | undefined {
-    const configPath = join(ws, "config.json");
-    if (!existsSync(configPath)) return undefined;
-    const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
-      ingress?: { ngrok?: Record<string, unknown> };
-    };
-    return config.ingress?.ngrok;
+  const AGENT_ID = "ingress-test";
+
+  function writeAgentEntry(extra: Record<string, unknown> = {}): void {
+    writeLockfile({
+      assistantId: AGENT_ID,
+      runtimeUrl: "http://192.168.1.50:7830",
+      cloud: "local",
+      ...extra,
+    });
   }
 
-  test("the record lives beside the workspace, never inside it", () => {
+  test("the record lives on the lockfile entry, never in the workspace or beside it", () => {
+    writeAgentEntry();
     const ws = makeWorkspace();
 
-    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 41234, pid: 55555 });
 
-    // Host-local state: a sibling of the workspace dir, beside the pid files.
-    expect(getNgrokAgentStatePath(ws)).toBe(
-      join(dirname(ws), "ngrok-agent.json"),
-    );
-    expect(existsSync(getNgrokAgentStatePath(ws))).toBe(true);
-    // The workspace config, which travels with moves/restores, is untouched.
+    expect(readLockfileEntry().ngrokAgent).toEqual({
+      webAddrPort: 41234,
+      pid: 55555,
+    });
+    // The workspace config, which travels with moves/restores, is untouched,
+    // and no state file appears in the directory containing the workspace
+    // (the forbidden `.vellum` tree in the real layout).
     expect(existsSync(join(ws, "config.json"))).toBe(false);
+    expect(existsSync(join(dirname(ws), "ngrok-agent.json"))).toBe(false);
   });
 
-  test("save and load round-trip; null clears", () => {
-    const ws = makeWorkspace();
+  test("save and load round-trip; null clears the field", () => {
+    writeAgentEntry();
 
-    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
-    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 41234, pid: 55555 });
+    expect(loadNgrokAgent(AGENT_ID)).toEqual({
+      webAddrPort: 41234,
+      pid: 55555,
+    });
 
-    saveNgrokAgent(ws, null);
-    expect(loadNgrokAgent(ws)).toBeNull();
-    expect(existsSync(getNgrokAgentStatePath(ws))).toBe(false);
+    saveNgrokAgent(AGENT_ID, null);
+    expect(loadNgrokAgent(AGENT_ID)).toBeNull();
+    expect(readLockfileEntry().ngrokAgent).toBeUndefined();
   });
 
   test("a record without a pid loads with pid null", () => {
-    const ws = makeWorkspace();
+    writeAgentEntry();
 
-    saveNgrokAgent(ws, { webAddrPort: 41234 });
-    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: null });
-    expect(
-      JSON.parse(readFileSync(getNgrokAgentStatePath(ws), "utf-8")),
-    ).toEqual({ webAddrPort: 41234 });
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 41234 });
+    expect(loadNgrokAgent(AGENT_ID)).toEqual({ webAddrPort: 41234, pid: null });
+    expect(readLockfileEntry().ngrokAgent).toEqual({ webAddrPort: 41234 });
   });
 
   test("re-saving without a pid drops a previously recorded pid", () => {
-    const ws = makeWorkspace();
-    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
+    writeAgentEntry();
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 41234, pid: 55555 });
 
-    saveNgrokAgent(ws, { webAddrPort: 42345, pid: null });
-    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 42345, pid: null });
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 42345, pid: null });
+    expect(loadNgrokAgent(AGENT_ID)).toEqual({ webAddrPort: 42345, pid: null });
   });
 
   test("loadNgrokAgent returns null when nothing is saved", () => {
-    expect(loadNgrokAgent(makeWorkspace())).toBeNull();
+    writeAgentEntry();
+    expect(loadNgrokAgent(AGENT_ID)).toBeNull();
   });
 
-  test("loadNgrokAgent returns null for a corrupt or malformed record", () => {
-    const ws = makeWorkspace();
+  test("loadNgrokAgent returns null for a malformed record on the entry", () => {
+    writeAgentEntry({ ngrokAgent: "not a record" });
+    expect(loadNgrokAgent(AGENT_ID)).toBeNull();
 
-    writeFileSync(getNgrokAgentStatePath(ws), "not json");
-    expect(loadNgrokAgent(ws)).toBeNull();
-
-    writeFileSync(
-      getNgrokAgentStatePath(ws),
-      JSON.stringify({ webAddrPort: "41234" }),
-    );
-    expect(loadNgrokAgent(ws)).toBeNull();
+    writeAgentEntry({ ngrokAgent: { webAddrPort: "41234" } });
+    expect(loadNgrokAgent(AGENT_ID)).toBeNull();
   });
 
-  test("loadNgrokAgent ignores legacy agent keys in the workspace config", () => {
-    const ws = makeWorkspace();
-    writeFileSync(
-      join(ws, "config.json"),
-      JSON.stringify({
-        ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
-      }),
-    );
+  test("saving a record for an unknown assistant throws; clearing is a no-op", () => {
+    writeAgentEntry();
 
-    // A record written by an older CLI is meaningless on another host.
-    expect(loadNgrokAgent(ws)).toBeNull();
+    expect(() => {
+      saveNgrokAgent("no-such-assistant", { webAddrPort: 41234 });
+    }).toThrow("no assistant entry found");
+    expect(() => {
+      saveNgrokAgent("no-such-assistant", null);
+    }).not.toThrow();
+    expect(readLockfileEntry().ngrokAgent).toBeUndefined();
+    expect(loadNgrokAgent("no-such-assistant")).toBeNull();
   });
 
-  test("saveNgrokDomain scrubs legacy agent keys from the workspace config", () => {
+  test("the record and the saved workspace domain are independent", () => {
+    writeAgentEntry();
     const ws = makeWorkspace();
-    writeFileSync(
-      join(ws, "config.json"),
-      JSON.stringify({
-        ingress: {
-          ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 5 },
-        },
-      }),
-    );
-
-    saveNgrokDomain(ws, "bar.ngrok.app");
-    expect(readNgrokEntry(ws)).toEqual({ domain: "bar.ngrok.app" });
-
-    saveNgrokDomain(ws, null);
-    // Scrubbing the legacy keys and the domain drops the entry entirely.
-    expect(readNgrokEntry(ws)).toBeUndefined();
-  });
-
-  test("saveNgrokDomain preserves the persisted agent record", () => {
-    const ws = makeWorkspace();
-    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
 
     saveNgrokDomain(ws, "foo.ngrok.app");
+    saveNgrokAgent(AGENT_ID, { webAddrPort: 41234, pid: 55555 });
+
     expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
-    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
+    expect(loadNgrokAgent(AGENT_ID)).toEqual({
+      webAddrPort: 41234,
+      pid: 55555,
+    });
+    // The domain is the only ngrok state in the workspace config; the agent
+    // record never lands there.
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress?: { ngrok?: Record<string, unknown> } };
+    expect(config.ingress?.ngrok).toEqual({ domain: "foo.ngrok.app" });
+
+    saveNgrokAgent(AGENT_ID, null);
+    expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
 
     saveNgrokDomain(ws, null);
     expect(loadNgrokDomain(ws)).toBeNull();
-    expect(loadNgrokAgent(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
-  });
-
-  test("saveNgrokAgent preserves the saved domain", () => {
-    const ws = makeWorkspace();
-    saveNgrokDomain(ws, "foo.ngrok.app");
-
-    saveNgrokAgent(ws, { webAddrPort: 41234, pid: 55555 });
-    saveNgrokAgent(ws, null);
-    expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
   });
 });

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -7,7 +7,14 @@ import { join } from "node:path";
 const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
-import { clearIngressUrl, saveIngressUrl } from "../lib/ingress-config.js";
+import {
+  clearIngressUrl,
+  loadNgrokDomain,
+  loadNgrokWebAddrPort,
+  saveIngressUrl,
+  saveNgrokDomain,
+  saveNgrokWebAddrPort,
+} from "../lib/ingress-config.js";
 
 function writeLockfile(entry: Record<string, unknown>): void {
   writeFileSync(
@@ -99,5 +106,52 @@ describe("ingress lockfile mirroring", () => {
       saveIngressUrl(ws, "https://tunnel.example.ts.net", "no-such-assistant");
     }).not.toThrow();
     expect(readLockfileEntry().ingressUrl).toBeUndefined();
+  });
+});
+
+describe("ngrok web-addr port persistence", () => {
+  function readNgrokEntry(ws: string): Record<string, unknown> | undefined {
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as { ingress?: { ngrok?: Record<string, unknown> } };
+    return config.ingress?.ngrok;
+  }
+
+  test("save and load round-trip; null clears", () => {
+    const ws = makeWorkspace();
+
+    saveNgrokWebAddrPort(ws, 41234);
+    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+
+    saveNgrokWebAddrPort(ws, null);
+    expect(loadNgrokWebAddrPort(ws)).toBeNull();
+    // Clearing the last ngrok field drops the entry entirely.
+    expect(readNgrokEntry(ws)).toBeUndefined();
+  });
+
+  test("loadNgrokWebAddrPort returns null when nothing is saved", () => {
+    expect(loadNgrokWebAddrPort(makeWorkspace())).toBeNull();
+  });
+
+  test("saveNgrokDomain preserves the persisted web-addr port", () => {
+    const ws = makeWorkspace();
+    saveNgrokWebAddrPort(ws, 41234);
+
+    saveNgrokDomain(ws, "foo.ngrok.app");
+    expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
+    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+
+    saveNgrokDomain(ws, null);
+    expect(loadNgrokDomain(ws)).toBeNull();
+    expect(loadNgrokWebAddrPort(ws)).toBe(41234);
+  });
+
+  test("saveNgrokWebAddrPort preserves the saved domain", () => {
+    const ws = makeWorkspace();
+    saveNgrokDomain(ws, "foo.ngrok.app");
+
+    saveNgrokWebAddrPort(ws, 41234);
+    saveNgrokWebAddrPort(ws, null);
+    expect(loadNgrokDomain(ws)).toBe("foo.ngrok.app");
   });
 });

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -21,7 +21,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import * as cloudflareTunnel from "../lib/cloudflare-tunnel.js";
 import * as ngrok from "../lib/ngrok.js";
@@ -876,11 +876,15 @@ describe("ngrok --domain spawn args", () => {
     mock.module("node:child_process", () => realChildProcess);
   });
 
+  const NGROK_ASSISTANT_ID = "ngrok-agent-test";
+
   beforeEach(() => {
     spawnMock.mockClear();
     lastChild = null;
     delete process.env.IS_CONTAINERIZED;
     mockNgrokApiFetch([{ tunnels: [] }]);
+    // Every direct ngrok call persists its agent record on this entry.
+    seedNgrokLockfile();
   });
 
   afterEach(() => {
@@ -890,14 +894,19 @@ describe("ngrok --domain spawn args", () => {
     } else {
       process.env.IS_CONTAINERIZED = originalContainerized;
     }
+    if (originalLockfileDir === undefined) {
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+    }
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   function makeWorkspace(config: Record<string, unknown>): string {
-    // Mirror the real layout (`<parent>/workspace`) so host-local agent
-    // state lands in an isolated parent dir, not the shared tmpdir.
+    // Mirror the real layout (`<parent>/workspace`) so any stray host-local
+    // state would land in an isolated parent dir, not the shared tmpdir.
     const base = mkdtempSync(join(tmpdir(), "vellum-ngrok-domain-test-"));
     tempDirs.push(base);
     const ws = join(base, "workspace");
@@ -906,26 +915,34 @@ describe("ngrok --domain spawn args", () => {
     return ws;
   }
 
-  /** Seed the host-local dedicated-agent record beside the workspace. */
-  function writeAgentRecord(
-    ws: string,
-    record: { webAddrPort: number; pid?: number },
-  ): void {
-    writeFileSync(
-      join(dirname(ws), "ngrok-agent.json"),
-      JSON.stringify(record),
-    );
+  /** Seed a fresh lockfile whose entry optionally carries an agent record. */
+  function seedNgrokLockfile(record?: {
+    webAddrPort: number;
+    pid?: number;
+  }): void {
+    const entry = makeLocalEntry(NGROK_ASSISTANT_ID);
+    if (record) {
+      entry.ngrokAgent = record;
+    }
+    writeLockfile(entry);
   }
 
-  function readAgentRecord(
-    ws: string,
-  ): { webAddrPort?: number; pid?: number } | null {
-    const statePath = join(dirname(ws), "ngrok-agent.json");
-    if (!existsSync(statePath)) return null;
-    return JSON.parse(readFileSync(statePath, "utf-8")) as {
-      webAddrPort?: number;
-      pid?: number;
+  function readAgentRecord(): { webAddrPort?: number; pid?: number } | null {
+    const lockfilePath = join(
+      process.env.VELLUM_LOCKFILE_DIR ?? "",
+      ".vellum.lock.json",
+    );
+    if (!existsSync(lockfilePath)) return null;
+    const data = JSON.parse(readFileSync(lockfilePath, "utf-8")) as {
+      assistants: Record<string, unknown>[];
     };
+    const entry = data.assistants.find(
+      (e) => e.assistantId === NGROK_ASSISTANT_ID,
+    );
+    return (
+      (entry?.ngrokAgent as { webAddrPort?: number; pid?: number } | null) ??
+      null
+    );
   }
 
   interface StubTunnel {
@@ -972,6 +989,7 @@ describe("ngrok --domain spawn args", () => {
     const run = realNgrok.runNgrokTunnel({
       port: 7831,
       workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
       domain: "foo.ngrok.app",
     });
     // runNgrokTunnel blocks until the ngrok process exits; pump exit events
@@ -1049,6 +1067,7 @@ describe("ngrok --domain spawn args", () => {
     const run = realNgrok.runNgrokTunnel({
       port: 7831,
       workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
       domain: "foo.ngrok.app",
     });
     const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
@@ -1084,6 +1103,7 @@ describe("ngrok --domain spawn args", () => {
     const run = realNgrok.runNgrokTunnel({
       port: 7831,
       workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
       domain: "foo.ngrok.app",
     });
     // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
@@ -1144,7 +1164,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: unknown;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        7830,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       warnSpy.mockRestore();
     }
@@ -1201,7 +1225,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: unknown;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        18080,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       warnSpy.mockRestore();
     }
@@ -1247,7 +1275,11 @@ describe("ngrok --domain spawn args", () => {
       },
     );
 
-    const run = realNgrok.runNgrokTunnel({ port: 18080, workspaceDir: ws });
+    const run = realNgrok.runNgrokTunnel({
+      port: 18080,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
     const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
     try {
       await run;
@@ -1292,7 +1324,11 @@ describe("ngrok --domain spawn args", () => {
       },
     ]);
 
-    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    const child = await realNgrok.maybeStartNgrokTunnel(
+      7830,
+      ws,
+      NGROK_ASSISTANT_ID,
+    );
 
     expect(child).not.toBeNull();
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -1332,7 +1368,11 @@ describe("ngrok --domain spawn args", () => {
       },
     ]);
 
-    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
     const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
     try {
       await run;
@@ -1392,7 +1432,7 @@ describe("ngrok --domain spawn args", () => {
 
   test("maybeStartNgrokTunnel reuses the dedicated agent at the persisted web-addr without spawning", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
-    writeAgentRecord(ws, { webAddrPort: 41234 });
+    seedNgrokLockfile({ webAddrPort: 41234 });
     // The default :4040 API sees nothing; the persisted dedicated agent's
     // API reports the tunnel for the target port.
     mockRoutedNgrokApiFetch((url) =>
@@ -1401,19 +1441,23 @@ describe("ngrok --domain spawn args", () => {
         : { tunnels: [] },
     );
 
-    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    const child = await realNgrok.maybeStartNgrokTunnel(
+      7830,
+      ws,
+      NGROK_ASSISTANT_ID,
+    );
 
     expect(child).toBeNull();
     expect(spawnMock).not.toHaveBeenCalled();
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     // The persisted address stays recorded for the next preflight.
-    expect(readAgentRecord(ws)?.webAddrPort).toBe(41234);
+    expect(readAgentRecord()?.webAddrPort).toBe(41234);
   });
 
   test("maybeStartNgrokTunnel clears a stale persisted web-addr and spawns fresh", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
-    writeAgentRecord(ws, { webAddrPort: 41234 });
+    seedNgrokLockfile({ webAddrPort: 41234 });
     mockRoutedNgrokApiFetch((url) => {
       if (url.includes(":41234")) return "unreachable";
       if (url.includes(":4040")) return { tunnels: [] };
@@ -1421,7 +1465,11 @@ describe("ngrok --domain spawn args", () => {
       return { tunnels: [dedicatedAgentTunnel(7830)] };
     });
 
-    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    const child = await realNgrok.maybeStartNgrokTunnel(
+      7830,
+      ws,
+      NGROK_ASSISTANT_ID,
+    );
 
     expect(child).not.toBeNull();
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -1433,20 +1481,24 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     // The stale record is overwritten with the fresh agent's port, and the
     // workspace config never receives host-local agent state.
-    expect(readAgentRecord(ws)?.webAddrPort).toBe(newPort);
+    expect(readAgentRecord()?.webAddrPort).toBe(newPort);
     expect(config.ingress.ngrok).toBeUndefined();
   });
 
   test("runNgrokTunnel adopts the dedicated agent's tunnel via the persisted web-addr", async () => {
     const ws = makeWorkspace({});
-    writeAgentRecord(ws, { webAddrPort: 41234 });
+    seedNgrokLockfile({ webAddrPort: 41234 });
     mockRoutedNgrokApiFetch((url) =>
       url.includes(":41234")
         ? { tunnels: [dedicatedAgentTunnel(7831)] }
         : { tunnels: [] },
     );
 
-    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
     // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
     // listener is registered. Earlier tests leak SIGINT handlers that call
     // process.exit, so no-op it while pumping.
@@ -1464,12 +1516,12 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).not.toHaveBeenCalled();
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(readAgentRecord(ws)?.webAddrPort).toBe(41234);
+    expect(readAgentRecord()?.webAddrPort).toBe(41234);
   });
 
   test("maybeStartNgrokTunnel stops a stale-target dedicated agent and spawns fresh", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
-    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
+    seedNgrokLockfile({ webAddrPort: 41234, pid: 55555 });
     // The persisted vellum-owned agent still answers on :41234 but tunnels an
     // old target port. It must be stopped (never coexisted with) before the
     // replacement spawns, so the pid recorded for sleep covers every
@@ -1503,7 +1555,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: ChildProcess | null = null;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        18080,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       killSpy.mockRestore();
     }
@@ -1519,12 +1575,12 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     // The stale record is replaced with the fresh agent's port and pid.
-    expect(readAgentRecord(ws)).toEqual({ webAddrPort: newPort, pid: 4242 });
+    expect(readAgentRecord()).toEqual({ webAddrPort: newPort, pid: 4242 });
   });
 
   test("runNgrokTunnel stops a stale-target dedicated agent before spawning", async () => {
     const ws = makeWorkspace({});
-    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
+    seedNgrokLockfile({ webAddrPort: 41234, pid: 55555 });
     let staleAgentUp = true;
     mockRoutedNgrokApiFetch((url) => {
       if (url.includes(":41234")) {
@@ -1551,7 +1607,11 @@ describe("ngrok --domain spawn args", () => {
       return true;
     }) as never);
 
-    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
     const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
     try {
       await run;
@@ -1564,12 +1624,12 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(readAgentRecord(ws)?.pid).toBe(4242);
+    expect(readAgentRecord()?.pid).toBe(4242);
   });
 
   test("maybeStartNgrokTunnel SIGKILLs a stale agent that ignores SIGTERM before replacing it", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
-    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
+    seedNgrokLockfile({ webAddrPort: 41234, pid: 55555 });
     // The stale vellum-owned agent ignores SIGTERM. The stop must escalate
     // to SIGKILL rather than silently fall through, so the replacement never
     // coexists with a live orphan holding the old public tunnel.
@@ -1603,7 +1663,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: ChildProcess | null = null;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        18080,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       killSpy.mockRestore();
     }
@@ -1615,7 +1679,7 @@ describe("ngrok --domain spawn args", () => {
     expect(child?.pid).toBe(4242);
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(readAgentRecord(ws)?.pid).toBe(4242);
+    expect(readAgentRecord()?.pid).toBe(4242);
   }, 15_000);
 
   test("maybeStartNgrokTunnel reuses the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
@@ -1623,7 +1687,7 @@ describe("ngrok --domain spawn args", () => {
       telegram: { botUsername: "example_bot" },
       ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
-    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
+    seedNgrokLockfile({ webAddrPort: 41234, pid: 55555 });
     // A foreign :4040 agent tunnels the same target port under another
     // domain; the dedicated agent's entry matches the reserved domain and
     // must win over the foreign tunnel listed first.
@@ -1657,7 +1721,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: unknown;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        7830,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       killSpy.mockRestore();
     }
@@ -1669,14 +1737,14 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
     // The dedicated agent stays recorded for the next preflight.
-    expect(readAgentRecord(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
+    expect(readAgentRecord()).toEqual({ webAddrPort: 41234, pid: 55555 });
   });
 
   test("runNgrokTunnel adopts the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
     const ws = makeWorkspace({
       ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
-    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
+    seedNgrokLockfile({ webAddrPort: 41234, pid: 55555 });
     mockRoutedNgrokApiFetch((url) =>
       url.includes(":41234")
         ? {
@@ -1697,7 +1765,11 @@ describe("ngrok --domain spawn args", () => {
           },
     );
 
-    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
     // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
     // listener is registered. Earlier tests leak SIGINT handlers that call
     // process.exit, so no-op it while pumping.
@@ -1715,21 +1787,23 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).not.toHaveBeenCalled();
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
-    expect(readAgentRecord(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
+    expect(readAgentRecord()).toEqual({ webAddrPort: 41234, pid: 55555 });
   });
 
-  test("maybeStartNgrokTunnel escalates to SIGKILL when a failed spawn ignores SIGTERM", async () => {
+  test("maybeStartNgrokTunnel escalates to SIGKILL when a failed spawn ignores SIGTERM and commits no ingress URL", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
     // No agents are running, so a fresh dedicated agent spawns and its API
-    // reports the tunnel; persisting the record then fails because a
-    // directory squats on the state path. The failure path must escalate
-    // through stopProcess so the child cannot outlive its discoverability.
+    // reports the tunnel; persisting the record then fails because the
+    // lockfile has no entry for the assistant. The failure path must
+    // escalate through stopProcess so the child cannot outlive its
+    // discoverability, and the ingress URL must never be committed for a
+    // tunnel that was rolled back.
     mockRoutedNgrokApiFetch((url) =>
       url.includes(":4040")
         ? { tunnels: [] }
         : { tunnels: [dedicatedAgentTunnel(7830)] },
     );
-    mkdirSync(join(dirname(ws), "ngrok-agent.json"));
+    writeLockfile(makeLocalEntry("some-other-assistant"));
     // mockRestore clears call history, so record kills out-of-band. Signal 0
     // is stopProcess's liveness probe: the child survives SIGTERM and only
     // dies to SIGKILL.
@@ -1751,7 +1825,11 @@ describe("ngrok --domain spawn args", () => {
     let child: ChildProcess | null = null;
     const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        7830,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       killSpy.mockRestore();
       warnSpy.mockRestore();
@@ -1762,6 +1840,82 @@ describe("ngrok --domain spawn args", () => {
     expect(child).toBeNull();
     expect(kills).toContainEqual([4242, "SIGTERM"]);
     expect(kills).toContainEqual([4242, "SIGKILL"]);
+    // The record persists before the URL commits, so a persistence failure
+    // leaves no dangling public URL in the workspace config.
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress?.publicBaseUrl).toBeUndefined();
+  }, 15_000);
+
+  test("runNgrokTunnel Ctrl+C escalates the agent stop and clears the record only once the agent is gone", async () => {
+    const ws = makeWorkspace({});
+    mockNgrokApiFetch([
+      { tunnels: [] },
+      { tunnels: [dedicatedAgentTunnel(7831)] },
+    ]);
+    // The spawned agent ignores SIGTERM and dies only to SIGKILL. Signal 0
+    // is stopProcess's liveness probe; capture the persisted record at
+    // SIGKILL time to prove it outlives the agent, not the other way round.
+    let childUp = true;
+    const recordsAtSigkill: ({ webAddrPort?: number; pid?: number } | null)[] =
+      [];
+    const kills: [number, string | number][] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal: string | number,
+    ) => {
+      if (pid === 4242 && signal === 0) {
+        if (!childUp) throw new Error("ESRCH");
+        return true;
+      }
+      if (signal !== 0) kills.push([pid, signal]);
+      if (pid === 4242 && signal === "SIGKILL") {
+        recordsAtSigkill.push(readAgentRecord());
+        childUp = false;
+      }
+      return true;
+    }) as never);
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      (() => undefined) as never,
+    );
+
+    async function until(cond: () => boolean): Promise<void> {
+      const start = Date.now();
+      while (!cond()) {
+        if (Date.now() - start > 10_000) throw new Error("condition timeout");
+        await new Promise((r) => setTimeout(r, 20));
+      }
+    }
+
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      assistantId: NGROK_ASSISTANT_ID,
+    });
+    try {
+      // Wait for the spawn to persist the record, then deliver one Ctrl+C.
+      await until(() => readAgentRecord() !== null);
+      process.emit("SIGINT");
+      // The shutdown escalates SIGTERM -> wait -> SIGKILL before the record
+      // and the ingress URL are cleared.
+      await until(() => readAgentRecord() === null);
+    } finally {
+      // Let the blocking wait settle so the run promise resolves.
+      lastChild?.emit("exit", 0);
+      await run;
+      killSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    expect(kills).toContainEqual([4242, "SIGTERM"]);
+    expect(kills).toContainEqual([4242, "SIGKILL"]);
+    // At SIGKILL time the record was still persisted: it is only cleared
+    // after the stop confirms the agent is gone.
+    expect(recordsAtSigkill).toEqual([
+      { webAddrPort: expect.any(Number) as number, pid: 4242 },
+    ]);
+    expect(readAgentRecord()).toBeNull();
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress?.publicBaseUrl).toBeUndefined();
   }, 15_000);
 
   test("maybeStartNgrokTunnel treats a loopback port allocation failure as nonfatal", async () => {
@@ -1784,7 +1938,11 @@ describe("ngrok --domain spawn args", () => {
 
     let child: unknown;
     try {
-      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+      child = await realNgrok.maybeStartNgrokTunnel(
+        7830,
+        ws,
+        NGROK_ASSISTANT_ID,
+      );
     } finally {
       warnSpy.mockRestore();
       mock.module("node:net", () => realNet);

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -962,12 +962,14 @@ describe("ngrok --domain spawn args", () => {
       string[],
     ];
     expect(cmd).toBe("ngrok");
-    expect(args).toEqual([
+    expect(args.slice(0, 4)).toEqual([
       "http",
       "7831",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
+    expect(args[4]).toMatch(/^--web-addr=127\.0\.0\.1:\d+$/);
+    expect(args).toHaveLength(5);
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
@@ -1102,13 +1104,29 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
-  test("maybeStartNgrokTunnel skips when an existing agent tunnels a different port", async () => {
+  const foreignAgentTunnel: StubTunnel = {
+    public_url: "https://foreign.ngrok-free.app",
+    config: { addr: "localhost:7840" },
+  };
+
+  test("maybeStartNgrokTunnel coexists with a foreign agent tunneling a different port", async () => {
     const ws = makeWorkspace({
       telegram: { botUsername: "example_bot" },
     });
-    // A stale pre-upgrade agent still tunnels the raw gateway port; the edge
-    // port (18080) has no tunnel.
-    mockTunnelListFetch("https://stale.ngrok-free.app", "localhost:7830");
+    // A foreign agent holds the default :4040 API and tunnels another local
+    // port; our own agent comes up on a dedicated web-addr and reports the
+    // tunnel for the requested port.
+    mockNgrokApiFetch([
+      { tunnels: [foreignAgentTunnel] },
+      {
+        tunnels: [
+          {
+            public_url: "https://edge.ngrok-free.app",
+            config: { addr: "localhost:18080" },
+          },
+        ],
+      },
+    ]);
 
     const warnings: string[] = [];
     const warnSpy = spyOn(console, "warn").mockImplementation(
@@ -1124,60 +1142,72 @@ describe("ngrok --domain spawn args", () => {
       warnSpy.mockRestore();
     }
 
-    expect(child).toBeNull();
-    expect(spawnMock).not.toHaveBeenCalled();
-    const combined = warnings.join("\n");
-    expect(combined).toContain("different local port");
-    expect(combined).toContain(
-      "https://stale.ngrok-free.app -> localhost:7830",
+    expect(child).not.toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args).toContain("18080");
+    expect(args.some((a) => /^--web-addr=127\.0\.0\.1:\d+$/.test(a))).toBe(
+      true,
     );
-    expect(combined).toContain("not 18080");
-    expect(combined).toContain("vellum tunnel --provider ngrok");
+
+    const combined = warnings.join("\n");
+    expect(combined).toContain("another ngrok agent is running");
+    expect(combined).toContain(
+      "https://foreign.ngrok-free.app -> localhost:7840",
+    );
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
     ) as { ingress?: { publicBaseUrl?: string } };
-    expect(config.ingress?.publicBaseUrl).toBeUndefined();
+    expect(config.ingress?.publicBaseUrl).toBe("https://edge.ngrok-free.app");
   });
 
-  test("runNgrokTunnel fails loudly when an existing agent tunnels a different port", async () => {
+  test("runNgrokTunnel warns and coexists when a foreign agent tunnels a different port", async () => {
     const ws = makeWorkspace({});
-    mockTunnelListFetch("https://stale.ngrok-free.app", "localhost:7830");
+    mockNgrokApiFetch([
+      { tunnels: [foreignAgentTunnel] },
+      {
+        tunnels: [
+          {
+            public_url: "https://edge.ngrok-free.app",
+            config: { addr: "localhost:18080" },
+          },
+        ],
+      },
+    ]);
 
-    const errors: string[] = [];
-    const errSpy = spyOn(console, "error").mockImplementation(
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
       (...a: unknown[]) => {
-        errors.push(a.join(" "));
+        warnings.push(a.join(" "));
       },
     );
-    const exitSpy = spyOn(process, "exit").mockImplementation(((
-      code?: number,
-    ) => {
-      throw new Error(`exit:${code}`);
-    }) as never);
 
+    const run = realNgrok.runNgrokTunnel({ port: 18080, workspaceDir: ws });
+    const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
     try {
-      await expect(
-        realNgrok.runNgrokTunnel({ port: 18080, workspaceDir: ws }),
-      ).rejects.toThrow("exit:1");
+      await run;
     } finally {
-      errSpy.mockRestore();
-      exitSpy.mockRestore();
+      clearInterval(pump);
+      warnSpy.mockRestore();
     }
 
-    const combined = errors.join("\n");
-    expect(combined).toContain("different local port");
+    const combined = warnings.join("\n");
+    expect(combined).toContain("another ngrok agent is running");
     expect(combined).toContain(
-      "https://stale.ngrok-free.app -> localhost:7830",
+      "https://foreign.ngrok-free.app -> localhost:7840",
     );
-    expect(combined).toContain("not 18080");
-    expect(combined).toContain("Stop the existing ngrok agent");
-    expect(spawnMock).not.toHaveBeenCalled();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args.some((a) => /^--web-addr=127\.0\.0\.1:\d+$/.test(a))).toBe(
+      true,
+    );
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
     ) as { ingress?: { publicBaseUrl?: string } };
-    expect(config.ingress?.publicBaseUrl).toBeUndefined();
+    expect(config.ingress?.publicBaseUrl).toBe("https://edge.ngrok-free.app");
   });
 
   test("maybeStartNgrokTunnel passes the saved domain to the spawn args", async () => {
@@ -1207,12 +1237,14 @@ describe("ngrok --domain spawn args", () => {
       string[],
     ];
     expect(cmd).toBe("ngrok");
-    expect(args).toEqual([
+    expect(args.slice(0, 4)).toEqual([
       "http",
       "7830",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
+    expect(args[4]).toMatch(/^--web-addr=127\.0\.0\.1:\d+$/);
+    expect(args).toHaveLength(5);
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
@@ -1246,12 +1278,14 @@ describe("ngrok --domain spawn args", () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
-    expect(args).toEqual([
+    expect(args.slice(0, 4)).toEqual([
       "http",
       "7831",
       "--log=stdout",
       "--domain=foo.ngrok.app",
     ]);
+    expect(args[4]).toMatch(/^--web-addr=127\.0\.0\.1:\d+$/);
+    expect(args).toHaveLength(5);
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -1293,4 +1293,145 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
+
+  interface NgrokIngressConfig {
+    ingress: {
+      publicBaseUrl?: string;
+      ngrok?: { domain?: string; webAddrPort?: number };
+    };
+  }
+
+  function readWorkspaceConfig(ws: string): NgrokIngressConfig {
+    return JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as NgrokIngressConfig;
+  }
+
+  /** ngrok local API stub routing responses by the fetched URL. */
+  function mockRoutedNgrokApiFetch(
+    route: (url: string) => { tunnels: StubTunnel[] } | "unreachable",
+  ): void {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const result = route(String(input));
+      if (result === "unreachable") throw new Error("connect ECONNREFUSED");
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  const dedicatedAgentTunnel = (port: number): StubTunnel => ({
+    public_url: "https://edge.ngrok-free.app",
+    config: { addr: `localhost:${port}` },
+  });
+
+  test("maybeStartNgrokTunnel reuses the dedicated agent at the persisted web-addr without spawning", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { webAddrPort: 41234 } },
+    });
+    // The default :4040 API sees nothing; the persisted dedicated agent's
+    // API reports the tunnel for the target port.
+    mockRoutedNgrokApiFetch((url) =>
+      url.includes(":41234")
+        ? { tunnels: [dedicatedAgentTunnel(7830)] }
+        : { tunnels: [] },
+    );
+
+    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+
+    expect(child).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    // The persisted address stays recorded for the next preflight.
+    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+  });
+
+  test("maybeStartNgrokTunnel clears a stale persisted web-addr and spawns fresh", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { webAddrPort: 41234 } },
+    });
+    mockRoutedNgrokApiFetch((url) => {
+      if (url.includes(":41234")) return "unreachable";
+      if (url.includes(":4040")) return { tunnels: [] };
+      // The freshly spawned agent's dedicated API reports the tunnel.
+      return { tunnels: [dedicatedAgentTunnel(7830)] };
+    });
+
+    const child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+
+    expect(child).not.toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    const webAddrArg = args.find((a) => a.startsWith("--web-addr="));
+    const newPort = Number(/:(\d+)$/.exec(webAddrArg ?? "")?.[1]);
+    expect(Number.isInteger(newPort)).toBe(true);
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    // The stale address is overwritten with the fresh agent's port.
+    expect(config.ingress.ngrok?.webAddrPort).toBe(newPort);
+  });
+
+  test("runNgrokTunnel adopts the dedicated agent's tunnel via the persisted web-addr", async () => {
+    const ws = makeWorkspace({ ingress: { ngrok: { webAddrPort: 41234 } } });
+    mockRoutedNgrokApiFetch((url) =>
+      url.includes(":41234")
+        ? { tunnels: [dedicatedAgentTunnel(7831)] }
+        : { tunnels: [] },
+    );
+
+    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
+    // listener is registered. Earlier tests leak SIGINT handlers that call
+    // process.exit, so no-op it while pumping.
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      (() => undefined) as never,
+    );
+    const pump = setInterval(() => process.emit("SIGINT"), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+      exitSpy.mockRestore();
+    }
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+  });
+
+  test("maybeStartNgrokTunnel treats a loopback port allocation failure as nonfatal", async () => {
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    mockNgrokApiFetch([{ tunnels: [] }]);
+    const realNet = { ...(await import("node:net")) };
+    mock.module("node:net", () => ({
+      ...realNet,
+      createServer: () => {
+        throw new Error("EMFILE: too many open files");
+      },
+    }));
+
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
+      (...a: unknown[]) => {
+        warnings.push(a.join(" "));
+      },
+    );
+
+    let child: unknown;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    } finally {
+      warnSpy.mockRestore();
+      mock.module("node:net", () => realNet);
+    }
+
+    expect(child).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(warnings.join("\n")).toContain("Could not start ngrok tunnel");
+  });
 });

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -1297,7 +1297,7 @@ describe("ngrok --domain spawn args", () => {
   interface NgrokIngressConfig {
     ingress: {
       publicBaseUrl?: string;
-      ngrok?: { domain?: string; webAddrPort?: number };
+      ngrok?: { domain?: string; webAddrPort?: number; agentPid?: number };
     };
   }
 
@@ -1402,6 +1402,204 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+  });
+
+  test("maybeStartNgrokTunnel stops a stale-target dedicated agent and spawns fresh", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
+    });
+    // The persisted vellum-owned agent still answers on :41234 but tunnels an
+    // old target port. It must be stopped (never coexisted with) before the
+    // replacement spawns, so the pid recorded for sleep covers every
+    // vellum-owned agent.
+    let staleAgentUp = true;
+    mockRoutedNgrokApiFetch((url) => {
+      if (url.includes(":41234")) {
+        return staleAgentUp
+          ? { tunnels: [dedicatedAgentTunnel(7830)] }
+          : "unreachable";
+      }
+      if (url.includes(":4040")) return { tunnels: [] };
+      // The freshly spawned agent's dedicated API reports the new tunnel.
+      return { tunnels: [dedicatedAgentTunnel(18080)] };
+    });
+    // mockRestore clears call history, so record kills out-of-band.
+    const kills: [number, string][] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal: string,
+    ) => {
+      kills.push([pid, signal]);
+      if (pid === 55555) staleAgentUp = false;
+      return true;
+    }) as never);
+
+    let child: ChildProcess | null = null;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    expect(kills).toContainEqual([55555, "SIGTERM"]);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    // The returned child is the fresh agent, so wake records only its pid.
+    expect(child?.pid).toBe(4242);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    const webAddrArg = args.find((a) => a.startsWith("--web-addr="));
+    const newPort = Number(/:(\d+)$/.exec(webAddrArg ?? "")?.[1]);
+    expect(Number.isInteger(newPort)).toBe(true);
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    // The stale record is replaced with the fresh agent's port and pid.
+    expect(config.ingress.ngrok?.webAddrPort).toBe(newPort);
+    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+  });
+
+  test("runNgrokTunnel stops a stale-target dedicated agent before spawning", async () => {
+    const ws = makeWorkspace({
+      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
+    });
+    let staleAgentUp = true;
+    mockRoutedNgrokApiFetch((url) => {
+      if (url.includes(":41234")) {
+        return staleAgentUp
+          ? { tunnels: [dedicatedAgentTunnel(7830)] }
+          : "unreachable";
+      }
+      if (url.includes(":4040")) return { tunnels: [] };
+      return { tunnels: [dedicatedAgentTunnel(7831)] };
+    });
+    // mockRestore clears call history, so record kills out-of-band.
+    const kills: [number, string][] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal: string,
+    ) => {
+      kills.push([pid, signal]);
+      if (pid === 55555) staleAgentUp = false;
+      return true;
+    }) as never);
+
+    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+      killSpy.mockRestore();
+    }
+
+    expect(kills).toContainEqual([55555, "SIGTERM"]);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+  });
+
+  test("maybeStartNgrokTunnel reuses the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: {
+        ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 55555 },
+      },
+    });
+    // A foreign :4040 agent tunnels the same target port under another
+    // domain; the dedicated agent's entry matches the reserved domain and
+    // must win over the foreign tunnel listed first.
+    mockRoutedNgrokApiFetch((url) =>
+      url.includes(":41234")
+        ? {
+            tunnels: [
+              {
+                public_url: "https://foo.ngrok.app",
+                config: { addr: "localhost:7830" },
+              },
+            ],
+          }
+        : {
+            tunnels: [
+              {
+                public_url: "https://foreign.ngrok-free.app",
+                config: { addr: "localhost:7830" },
+              },
+            ],
+          },
+    );
+    // mockRestore clears call history, so record kills out-of-band.
+    const kills: number[] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+    ) => {
+      kills.push(pid);
+      return true;
+    }) as never);
+
+    let child: unknown;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    expect(child).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+    // The dedicated agent matches the reserved domain, so it is not stopped.
+    expect(kills).toEqual([]);
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    // The dedicated agent stays recorded for the next preflight.
+    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+    expect(config.ingress.ngrok?.agentPid).toBe(55555);
+  });
+
+  test("runNgrokTunnel adopts the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
+    const ws = makeWorkspace({
+      ingress: {
+        ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 55555 },
+      },
+    });
+    mockRoutedNgrokApiFetch((url) =>
+      url.includes(":41234")
+        ? {
+            tunnels: [
+              {
+                public_url: "https://foo.ngrok.app",
+                config: { addr: "localhost:7831" },
+              },
+            ],
+          }
+        : {
+            tunnels: [
+              {
+                public_url: "https://foreign.ngrok-free.app",
+                config: { addr: "localhost:7831" },
+              },
+            ],
+          },
+    );
+
+    const run = realNgrok.runNgrokTunnel({ port: 7831, workspaceDir: ws });
+    // The adopt path blocks until SIGINT/SIGTERM; pump SIGINT until the
+    // listener is registered. Earlier tests leak SIGINT handlers that call
+    // process.exit, so no-op it while pumping.
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      (() => undefined) as never,
+    );
+    const pump = setInterval(() => process.emit("SIGINT"), 10);
+    try {
+      await run;
+    } finally {
+      clearInterval(pump);
+      exitSpy.mockRestore();
+    }
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+    expect(config.ingress.ngrok?.agentPid).toBe(55555);
   });
 
   test("maybeStartNgrokTunnel treats a loopback port allocation failure as nonfatal", async () => {

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -988,48 +988,66 @@ describe("ngrok --domain spawn args", () => {
       )) as unknown as typeof globalThis.fetch;
   }
 
-  test("runNgrokTunnel rejects an existing tunnel that mismatches the requested domain", async () => {
+  test("runNgrokTunnel coexists with a same-port tunnel under another domain and spawns its own agent", async () => {
     const ws = makeWorkspace({});
-    mockTunnelListFetch("https://other.ngrok-free.app", "localhost:7831");
+    // A foreign agent already tunnels the target port under another domain.
+    // With dedicated web-addrs this is as safe as any coexist: warn and
+    // spawn our own domain-bound agent instead of exiting.
+    mockNgrokApiFetch([
+      {
+        tunnels: [
+          {
+            public_url: "https://other.ngrok-free.app",
+            config: { addr: "localhost:7831" },
+          },
+        ],
+      },
+      {
+        tunnels: [
+          {
+            public_url: "https://foo.ngrok.app",
+            config: { addr: "localhost:7831" },
+          },
+        ],
+      },
+    ]);
 
-    const errors: string[] = [];
-    const errSpy = spyOn(console, "error").mockImplementation(
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
       (...a: unknown[]) => {
-        errors.push(a.join(" "));
+        warnings.push(a.join(" "));
       },
     );
-    const exitSpy = spyOn(process, "exit").mockImplementation(((
-      code?: number,
-    ) => {
-      throw new Error(`exit:${code}`);
-    }) as never);
 
+    const run = realNgrok.runNgrokTunnel({
+      port: 7831,
+      workspaceDir: ws,
+      domain: "foo.ngrok.app",
+    });
+    const pump = setInterval(() => lastChild?.emit("exit", 0), 10);
     try {
-      await expect(
-        realNgrok.runNgrokTunnel({
-          port: 7831,
-          workspaceDir: ws,
-          domain: "foo.ngrok.app",
-        }),
-      ).rejects.toThrow("exit:1");
+      await run;
     } finally {
-      errSpy.mockRestore();
-      exitSpy.mockRestore();
+      clearInterval(pump);
+      warnSpy.mockRestore();
     }
 
-    const combined = errors.join("\n");
-    expect(combined).toContain("https://other.ngrok-free.app");
+    const combined = warnings.join("\n");
+    expect(combined).toContain("another ngrok agent is running");
     expect(combined).toContain(
-      "does not match the requested domain 'foo.ngrok.app'",
+      "https://other.ngrok-free.app -> localhost:7831",
     );
-    expect(combined).toContain("Stop the existing ngrok agent");
-    expect(spawnMock).not.toHaveBeenCalled();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args).toContain("--domain=foo.ngrok.app");
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
     ) as { ingress?: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
-    expect(config.ingress?.publicBaseUrl).toBeUndefined();
-    expect(config.ingress?.ngrok).toBeUndefined();
+    // Only our own domain-matching tunnel is blessed in config.
+    expect(config.ingress?.publicBaseUrl).toBe("https://foo.ngrok.app");
+    expect(config.ingress?.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
   test("runNgrokTunnel adopts an existing tunnel that matches the requested domain", async () => {
@@ -1063,12 +1081,32 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
-  test("maybeStartNgrokTunnel rejects a mismatched existing tunnel without adopting or spawning", async () => {
+  test("maybeStartNgrokTunnel coexists with a same-port tunnel under another domain and spawns its own agent", async () => {
     const ws = makeWorkspace({
       telegram: { botUsername: "example_bot" },
       ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
-    mockTunnelListFetch("https://other.ngrok-free.app", "localhost:7830");
+    // A foreign agent already tunnels the target port under another domain.
+    // With dedicated web-addrs this is as safe as any coexist: warn and
+    // spawn our own domain-bound agent instead of giving up.
+    mockNgrokApiFetch([
+      {
+        tunnels: [
+          {
+            public_url: "https://other.ngrok-free.app",
+            config: { addr: "localhost:7830" },
+          },
+        ],
+      },
+      {
+        tunnels: [
+          {
+            public_url: "https://foo.ngrok.app",
+            config: { addr: "localhost:7830" },
+          },
+        ],
+      },
+    ]);
 
     const warnings: string[] = [];
     const warnSpy = spyOn(console, "warn").mockImplementation(
@@ -1084,23 +1122,22 @@ describe("ngrok --domain spawn args", () => {
       warnSpy.mockRestore();
     }
 
-    expect(child).toBeNull();
-    expect(spawnMock).not.toHaveBeenCalled();
+    expect(child).not.toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args).toContain("--domain=foo.ngrok.app");
     const combined = warnings.join("\n");
-    expect(combined).toContain("https://other.ngrok-free.app");
+    expect(combined).toContain("another ngrok agent is running");
     expect(combined).toContain(
-      "does not match the reserved domain 'foo.ngrok.app'",
-    );
-    expect(combined).toContain(
-      "vellum tunnel --provider ngrok --domain foo.ngrok.app",
+      "https://other.ngrok-free.app -> localhost:7830",
     );
 
     const config = JSON.parse(
       readFileSync(join(ws, "config.json"), "utf-8"),
     ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
-    // The mismatched tunnel is not blessed in config…
-    expect(config.ingress.publicBaseUrl).toBeUndefined();
-    // …and the reserved domain stays saved as standing intent.
+    // Only our own domain-matching tunnel is blessed in config...
+    expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
+    // ...and the reserved domain stays saved as standing intent.
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
   });
 
@@ -1424,14 +1461,19 @@ describe("ngrok --domain spawn args", () => {
       // The freshly spawned agent's dedicated API reports the new tunnel.
       return { tunnels: [dedicatedAgentTunnel(18080)] };
     });
-    // mockRestore clears call history, so record kills out-of-band.
-    const kills: [number, string][] = [];
+    // mockRestore clears call history, so record kills out-of-band. Signal 0
+    // is stopProcess's liveness probe: alive until SIGTERM, then gone.
+    const kills: [number, string | number][] = [];
     const killSpy = spyOn(process, "kill").mockImplementation(((
       pid: number,
-      signal: string,
+      signal: string | number,
     ) => {
-      kills.push([pid, signal]);
-      if (pid === 55555) staleAgentUp = false;
+      if (pid === 55555 && signal === 0) {
+        if (!staleAgentUp) throw new Error("ESRCH");
+        return true;
+      }
+      if (signal !== 0) kills.push([pid, signal]);
+      if (pid === 55555 && signal === "SIGTERM") staleAgentUp = false;
       return true;
     }) as never);
 
@@ -1471,14 +1513,19 @@ describe("ngrok --domain spawn args", () => {
       if (url.includes(":4040")) return { tunnels: [] };
       return { tunnels: [dedicatedAgentTunnel(7831)] };
     });
-    // mockRestore clears call history, so record kills out-of-band.
-    const kills: [number, string][] = [];
+    // mockRestore clears call history, so record kills out-of-band. Signal 0
+    // is stopProcess's liveness probe: alive until SIGTERM, then gone.
+    const kills: [number, string | number][] = [];
     const killSpy = spyOn(process, "kill").mockImplementation(((
       pid: number,
-      signal: string,
+      signal: string | number,
     ) => {
-      kills.push([pid, signal]);
-      if (pid === 55555) staleAgentUp = false;
+      if (pid === 55555 && signal === 0) {
+        if (!staleAgentUp) throw new Error("ESRCH");
+        return true;
+      }
+      if (signal !== 0) kills.push([pid, signal]);
+      if (pid === 55555 && signal === "SIGTERM") staleAgentUp = false;
       return true;
     }) as never);
 
@@ -1497,6 +1544,59 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     expect(config.ingress.ngrok?.agentPid).toBe(4242);
   });
+
+  test("maybeStartNgrokTunnel SIGKILLs a stale agent that ignores SIGTERM before replacing it", async () => {
+    const ws = makeWorkspace({
+      telegram: { botUsername: "example_bot" },
+      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
+    });
+    // The stale vellum-owned agent ignores SIGTERM. The stop must escalate
+    // to SIGKILL rather than silently fall through, so the replacement never
+    // coexists with a live orphan holding the old public tunnel.
+    let staleAgentUp = true;
+    mockRoutedNgrokApiFetch((url) => {
+      if (url.includes(":41234")) {
+        return staleAgentUp
+          ? { tunnels: [dedicatedAgentTunnel(7830)] }
+          : "unreachable";
+      }
+      if (url.includes(":4040")) return { tunnels: [] };
+      // The freshly spawned agent's dedicated API reports the new tunnel.
+      return { tunnels: [dedicatedAgentTunnel(18080)] };
+    });
+    // mockRestore clears call history, so record kills out-of-band. Signal 0
+    // is stopProcess's liveness probe: the agent survives SIGTERM and only
+    // dies to SIGKILL.
+    const kills: [number, string | number][] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal: string | number,
+    ) => {
+      if (pid === 55555 && signal === 0) {
+        if (!staleAgentUp) throw new Error("ESRCH");
+        return true;
+      }
+      if (signal !== 0) kills.push([pid, signal]);
+      if (pid === 55555 && signal === "SIGKILL") staleAgentUp = false;
+      return true;
+    }) as never);
+
+    let child: ChildProcess | null = null;
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(18080, ws);
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    expect(kills).toContainEqual([55555, "SIGTERM"]);
+    expect(kills).toContainEqual([55555, "SIGKILL"]);
+    // The replacement spawns only after the escalated stop finished.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(child?.pid).toBe(4242);
+    const config = readWorkspaceConfig(ws);
+    expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
+    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+  }, 15_000);
 
   test("maybeStartNgrokTunnel reuses the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
     const ws = makeWorkspace({

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -13,6 +13,7 @@ import * as childProcess from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -20,7 +21,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import * as cloudflareTunnel from "../lib/cloudflare-tunnel.js";
 import * as ngrok from "../lib/ngrok.js";
@@ -895,10 +896,36 @@ describe("ngrok --domain spawn args", () => {
   });
 
   function makeWorkspace(config: Record<string, unknown>): string {
-    const ws = mkdtempSync(join(tmpdir(), "vellum-ngrok-domain-test-"));
-    tempDirs.push(ws);
+    // Mirror the real layout (`<parent>/workspace`) so host-local agent
+    // state lands in an isolated parent dir, not the shared tmpdir.
+    const base = mkdtempSync(join(tmpdir(), "vellum-ngrok-domain-test-"));
+    tempDirs.push(base);
+    const ws = join(base, "workspace");
+    mkdirSync(ws, { recursive: true });
     writeFileSync(join(ws, "config.json"), JSON.stringify(config, null, 2));
     return ws;
+  }
+
+  /** Seed the host-local dedicated-agent record beside the workspace. */
+  function writeAgentRecord(
+    ws: string,
+    record: { webAddrPort: number; pid?: number },
+  ): void {
+    writeFileSync(
+      join(dirname(ws), "ngrok-agent.json"),
+      JSON.stringify(record),
+    );
+  }
+
+  function readAgentRecord(
+    ws: string,
+  ): { webAddrPort?: number; pid?: number } | null {
+    const statePath = join(dirname(ws), "ngrok-agent.json");
+    if (!existsSync(statePath)) return null;
+    return JSON.parse(readFileSync(statePath, "utf-8")) as {
+      webAddrPort?: number;
+      pid?: number;
+    };
   }
 
   interface StubTunnel {
@@ -1334,7 +1361,7 @@ describe("ngrok --domain spawn args", () => {
   interface NgrokIngressConfig {
     ingress: {
       publicBaseUrl?: string;
-      ngrok?: { domain?: string; webAddrPort?: number; agentPid?: number };
+      ngrok?: { domain?: string };
     };
   }
 
@@ -1364,10 +1391,8 @@ describe("ngrok --domain spawn args", () => {
   });
 
   test("maybeStartNgrokTunnel reuses the dedicated agent at the persisted web-addr without spawning", async () => {
-    const ws = makeWorkspace({
-      telegram: { botUsername: "example_bot" },
-      ingress: { ngrok: { webAddrPort: 41234 } },
-    });
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    writeAgentRecord(ws, { webAddrPort: 41234 });
     // The default :4040 API sees nothing; the persisted dedicated agent's
     // API reports the tunnel for the target port.
     mockRoutedNgrokApiFetch((url) =>
@@ -1383,14 +1408,12 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     // The persisted address stays recorded for the next preflight.
-    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+    expect(readAgentRecord(ws)?.webAddrPort).toBe(41234);
   });
 
   test("maybeStartNgrokTunnel clears a stale persisted web-addr and spawns fresh", async () => {
-    const ws = makeWorkspace({
-      telegram: { botUsername: "example_bot" },
-      ingress: { ngrok: { webAddrPort: 41234 } },
-    });
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    writeAgentRecord(ws, { webAddrPort: 41234 });
     mockRoutedNgrokApiFetch((url) => {
       if (url.includes(":41234")) return "unreachable";
       if (url.includes(":4040")) return { tunnels: [] };
@@ -1408,12 +1431,15 @@ describe("ngrok --domain spawn args", () => {
     expect(Number.isInteger(newPort)).toBe(true);
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    // The stale address is overwritten with the fresh agent's port.
-    expect(config.ingress.ngrok?.webAddrPort).toBe(newPort);
+    // The stale record is overwritten with the fresh agent's port, and the
+    // workspace config never receives host-local agent state.
+    expect(readAgentRecord(ws)?.webAddrPort).toBe(newPort);
+    expect(config.ingress.ngrok).toBeUndefined();
   });
 
   test("runNgrokTunnel adopts the dedicated agent's tunnel via the persisted web-addr", async () => {
-    const ws = makeWorkspace({ ingress: { ngrok: { webAddrPort: 41234 } } });
+    const ws = makeWorkspace({});
+    writeAgentRecord(ws, { webAddrPort: 41234 });
     mockRoutedNgrokApiFetch((url) =>
       url.includes(":41234")
         ? { tunnels: [dedicatedAgentTunnel(7831)] }
@@ -1438,14 +1464,12 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).not.toHaveBeenCalled();
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
+    expect(readAgentRecord(ws)?.webAddrPort).toBe(41234);
   });
 
   test("maybeStartNgrokTunnel stops a stale-target dedicated agent and spawns fresh", async () => {
-    const ws = makeWorkspace({
-      telegram: { botUsername: "example_bot" },
-      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
-    });
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
     // The persisted vellum-owned agent still answers on :41234 but tunnels an
     // old target port. It must be stopped (never coexisted with) before the
     // replacement spawns, so the pid recorded for sleep covers every
@@ -1495,14 +1519,12 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
     // The stale record is replaced with the fresh agent's port and pid.
-    expect(config.ingress.ngrok?.webAddrPort).toBe(newPort);
-    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+    expect(readAgentRecord(ws)).toEqual({ webAddrPort: newPort, pid: 4242 });
   });
 
   test("runNgrokTunnel stops a stale-target dedicated agent before spawning", async () => {
-    const ws = makeWorkspace({
-      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
-    });
+    const ws = makeWorkspace({});
+    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
     let staleAgentUp = true;
     mockRoutedNgrokApiFetch((url) => {
       if (url.includes(":41234")) {
@@ -1542,14 +1564,12 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+    expect(readAgentRecord(ws)?.pid).toBe(4242);
   });
 
   test("maybeStartNgrokTunnel SIGKILLs a stale agent that ignores SIGTERM before replacing it", async () => {
-    const ws = makeWorkspace({
-      telegram: { botUsername: "example_bot" },
-      ingress: { ngrok: { webAddrPort: 41234, agentPid: 55555 } },
-    });
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
     // The stale vellum-owned agent ignores SIGTERM. The stop must escalate
     // to SIGKILL rather than silently fall through, so the replacement never
     // coexists with a live orphan holding the old public tunnel.
@@ -1595,16 +1615,15 @@ describe("ngrok --domain spawn args", () => {
     expect(child?.pid).toBe(4242);
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://edge.ngrok-free.app");
-    expect(config.ingress.ngrok?.agentPid).toBe(4242);
+    expect(readAgentRecord(ws)?.pid).toBe(4242);
   }, 15_000);
 
   test("maybeStartNgrokTunnel reuses the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
     const ws = makeWorkspace({
       telegram: { botUsername: "example_bot" },
-      ingress: {
-        ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 55555 },
-      },
+      ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
+    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
     // A foreign :4040 agent tunnels the same target port under another
     // domain; the dedicated agent's entry matches the reserved domain and
     // must win over the foreign tunnel listed first.
@@ -1650,16 +1669,14 @@ describe("ngrok --domain spawn args", () => {
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
     // The dedicated agent stays recorded for the next preflight.
-    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
-    expect(config.ingress.ngrok?.agentPid).toBe(55555);
+    expect(readAgentRecord(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
   });
 
   test("runNgrokTunnel adopts the dedicated agent's domain-matching tunnel over a foreign same-port tunnel", async () => {
     const ws = makeWorkspace({
-      ingress: {
-        ngrok: { domain: "foo.ngrok.app", webAddrPort: 41234, agentPid: 55555 },
-      },
+      ingress: { ngrok: { domain: "foo.ngrok.app" } },
     });
+    writeAgentRecord(ws, { webAddrPort: 41234, pid: 55555 });
     mockRoutedNgrokApiFetch((url) =>
       url.includes(":41234")
         ? {
@@ -1698,9 +1715,54 @@ describe("ngrok --domain spawn args", () => {
     expect(spawnMock).not.toHaveBeenCalled();
     const config = readWorkspaceConfig(ws);
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
-    expect(config.ingress.ngrok?.webAddrPort).toBe(41234);
-    expect(config.ingress.ngrok?.agentPid).toBe(55555);
+    expect(readAgentRecord(ws)).toEqual({ webAddrPort: 41234, pid: 55555 });
   });
+
+  test("maybeStartNgrokTunnel escalates to SIGKILL when a failed spawn ignores SIGTERM", async () => {
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    // No agents are running, so a fresh dedicated agent spawns and its API
+    // reports the tunnel; persisting the record then fails because a
+    // directory squats on the state path. The failure path must escalate
+    // through stopProcess so the child cannot outlive its discoverability.
+    mockRoutedNgrokApiFetch((url) =>
+      url.includes(":4040")
+        ? { tunnels: [] }
+        : { tunnels: [dedicatedAgentTunnel(7830)] },
+    );
+    mkdirSync(join(dirname(ws), "ngrok-agent.json"));
+    // mockRestore clears call history, so record kills out-of-band. Signal 0
+    // is stopProcess's liveness probe: the child survives SIGTERM and only
+    // dies to SIGKILL.
+    let childUp = true;
+    const kills: [number, string | number][] = [];
+    const killSpy = spyOn(process, "kill").mockImplementation(((
+      pid: number,
+      signal: string | number,
+    ) => {
+      if (pid === 4242 && signal === 0) {
+        if (!childUp) throw new Error("ESRCH");
+        return true;
+      }
+      if (signal !== 0) kills.push([pid, signal]);
+      if (pid === 4242 && signal === "SIGKILL") childUp = false;
+      return true;
+    }) as never);
+
+    let child: ChildProcess | null = null;
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      child = await realNgrok.maybeStartNgrokTunnel(7830, ws);
+    } finally {
+      killSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+
+    // The startup failure stays nonfatal, but the spawned child was stopped
+    // with the full escalation before the error surfaced.
+    expect(child).toBeNull();
+    expect(kills).toContainEqual([4242, "SIGTERM"]);
+    expect(kills).toContainEqual([4242, "SIGKILL"]);
+  }, 15_000);
 
   test("maybeStartNgrokTunnel treats a loopback port allocation failure as nonfatal", async () => {
     const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });

--- a/cli/src/__tests__/upgrade-local.test.ts
+++ b/cli/src/__tests__/upgrade-local.test.ts
@@ -418,6 +418,7 @@ describe("vellum upgrade local", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       join(tempDir, ".vellum", "workspace"),
+      "local-assistant",
     );
     expect(waitForReadyMock).toHaveBeenCalledWith("http://127.0.0.1:7830");
     expect(commitWorkspaceViaGatewayMock).toHaveBeenCalledWith(

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -404,7 +404,6 @@ describe("vellum wake", () => {
   });
 });
 
-
 describe("vellum wake — tunnel edge restore", () => {
   const webhookConfig = { telegram: { botUsername: "bot" } };
   const enabledConfig = {
@@ -430,6 +429,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -448,6 +448,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -460,6 +461,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -472,6 +474,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -502,6 +505,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7845,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -522,6 +526,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -559,6 +564,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -582,6 +588,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -598,6 +605,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7841,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -620,6 +628,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -126,6 +126,12 @@ export type AssistantEntry = Omit<
   zone?: string;
   /** PID of the file watcher process for docker instances hatched with --watch. */
   watcherPid?: number;
+  /** The vellum-spawned dedicated ngrok agent's web-addr (local API) port and
+   *  pid. Host-local process state like `watcherPid`: kept on the lockfile
+   *  entry (the CLI-owned contract, per the no-`.vellum/`-access boundary in
+   *  cli/AGENTS.md), never in the workspace config, which travels with
+   *  workspace moves and restores. */
+  ngrokAgent?: { webAddrPort: number; pid?: number };
   /** Local bootstrap secret used to lease guardian tokens for Docker assistants after detached hatch. */
   guardianBootstrapSecret?: string;
   /** Docker image metadata for rollback. Only present for docker topology entries. */

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -16,6 +22,10 @@ import {
  * mirrored onto the lockfile entry (`ingressUrl`) — the CLI-owned contract
  * that CLI features (e.g. remote-web pairing defaults) read, per the
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
+ *
+ * The dedicated ngrok agent record is the exception: it is host-local
+ * process state, kept in a file beside the CLI's pid files rather than in
+ * the workspace config (see getNgrokAgentStatePath).
  */
 
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
@@ -93,6 +103,11 @@ function updateNgrokEntry(
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
   const ngrok = (ingress.ngrok ?? {}) as Record<string, unknown>;
+  // Stray agent state written by older CLIs is host-local process state that
+  // is meaningless after a workspace move; drop it whenever the entry is
+  // rewritten. The live record is in the host-local file, never here.
+  delete ngrok.webAddrPort;
+  delete ngrok.agentPid;
   mutate(ngrok);
   if (Object.keys(ngrok).length > 0) {
     ingress.ngrok = ngrok;
@@ -135,40 +150,58 @@ export interface NgrokAgentRecord {
 }
 
 /**
- * Persist the spawned ngrok agent's dedicated web-addr port and pid under
- * `ingress.ngrok` so later runs can query that agent's local API and reuse
- * its tunnel, or stop the agent when it no longer serves the requested
+ * Host-local path for the dedicated-agent record: beside the `ngrok.pid`
+ * file wake/sleep keep in the directory containing the workspace
+ * (`<instanceDir>/.vellum` or `~/.vellum`). The record is process state for
+ * this host, so it must never live in the workspace `config.json`, which
+ * travels with workspace moves and restores and would point another host at
+ * an unrelated process.
+ */
+export function getNgrokAgentStatePath(workspaceDir: string): string {
+  return join(dirname(workspaceDir), "ngrok-agent.json");
+}
+
+/**
+ * Persist the spawned ngrok agent's dedicated web-addr port and pid to the
+ * host-local state file so later runs can query that agent's local API and
+ * reuse its tunnel, or stop the agent when it no longer serves the requested
  * target; null clears a stale record.
  */
 export function saveNgrokAgent(
   workspaceDir: string,
   agent: { webAddrPort: number; pid?: number | null } | null,
 ): void {
-  updateNgrokEntry(workspaceDir, (ngrok) => {
-    if (agent !== null) {
-      ngrok.webAddrPort = agent.webAddrPort;
-      if (agent.pid !== undefined && agent.pid !== null) {
-        ngrok.agentPid = agent.pid;
-      } else {
-        delete ngrok.agentPid;
-      }
-    } else {
-      delete ngrok.webAddrPort;
-      delete ngrok.agentPid;
-    }
-  });
+  const statePath = getNgrokAgentStatePath(workspaceDir);
+  if (agent === null) {
+    rmSync(statePath, { force: true });
+    return;
+  }
+  const record: Record<string, number> = { webAddrPort: agent.webAddrPort };
+  if (agent.pid !== undefined && agent.pid !== null) {
+    record.pid = agent.pid;
+  }
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, JSON.stringify(record, null, 2) + "\n");
 }
 
-/** Read the persisted dedicated-agent record, if saved. */
+/** Read the persisted dedicated-agent record, if saved and well-formed. */
 export function loadNgrokAgent(workspaceDir: string): NgrokAgentRecord | null {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = config.ingress as Record<string, unknown> | undefined;
-  const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
-  const port = ngrok?.webAddrPort;
+  const statePath = getNgrokAgentStatePath(workspaceDir);
+  if (!existsSync(statePath)) return null;
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(readFileSync(statePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+  const port = record.webAddrPort;
   if (typeof port !== "number" || !Number.isInteger(port) || port <= 0) {
     return null;
   }
-  const pid = ngrok?.agentPid;
+  const pid = record.pid;
   const validPid =
     typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : null;
   return { webAddrPort: port, pid: validPid };

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -1,10 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -23,9 +17,11 @@ import {
  * that CLI features (e.g. remote-web pairing defaults) read, per the
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  *
- * The dedicated ngrok agent record is the exception: it is host-local
- * process state, kept in a file beside the CLI's pid files rather than in
- * the workspace config (see getNgrokAgentStatePath).
+ * The dedicated ngrok agent record is host-local process state, so it lives
+ * on the lockfile entry (`ngrokAgent`, like `watcherPid` and
+ * `resources.signingKey`), never in the workspace config, which travels with
+ * workspace moves and restores, and never under the daemon/gateway-owned
+ * `.vellum/` tree (cli/AGENTS.md "No `.vellum/` directory access").
  */
 
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
@@ -103,11 +99,6 @@ function updateNgrokEntry(
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
   const ngrok = (ingress.ngrok ?? {}) as Record<string, unknown>;
-  // Stray agent state written by older CLIs is host-local process state that
-  // is meaningless after a workspace move; drop it whenever the entry is
-  // rewritten. The live record is in the host-local file, never here.
-  delete ngrok.webAddrPort;
-  delete ngrok.agentPid;
   mutate(ngrok);
   if (Object.keys(ngrok).length > 0) {
     ingress.ngrok = ngrok;
@@ -150,53 +141,50 @@ export interface NgrokAgentRecord {
 }
 
 /**
- * Host-local path for the dedicated-agent record: beside the `ngrok.pid`
- * file wake/sleep keep in the directory containing the workspace
- * (`<instanceDir>/.vellum` or `~/.vellum`). The record is process state for
- * this host, so it must never live in the workspace `config.json`, which
- * travels with workspace moves and restores and would point another host at
- * an unrelated process.
- */
-export function getNgrokAgentStatePath(workspaceDir: string): string {
-  return join(dirname(workspaceDir), "ngrok-agent.json");
-}
-
-/**
- * Persist the spawned ngrok agent's dedicated web-addr port and pid to the
- * host-local state file so later runs can query that agent's local API and
- * reuse its tunnel, or stop the agent when it no longer serves the requested
- * target; null clears a stale record.
+ * Persist the spawned ngrok agent's dedicated web-addr port and pid on the
+ * assistant's lockfile entry (`ngrokAgent`) so later runs can query that
+ * agent's local API and reuse its tunnel, or stop the agent when it no
+ * longer serves the requested target; null clears a stale record. The record
+ * is process state for this host, so it lives in the CLI-owned lockfile and
+ * must never touch the workspace `config.json`, which travels with workspace
+ * moves and restores and would point another host at an unrelated process.
+ *
+ * Saving a record for an unknown assistant throws: an unrecordable agent
+ * must be rolled back by the caller, not left running undiscoverable.
+ * Clearing (null) for an unknown assistant is a no-op.
  */
 export function saveNgrokAgent(
-  workspaceDir: string,
+  assistantId: string,
   agent: { webAddrPort: number; pid?: number | null } | null,
 ): void {
-  const statePath = getNgrokAgentStatePath(workspaceDir);
+  const result = lookupAssistantByIdentifier(assistantId);
+  if (result.status !== "found") {
+    if (agent === null) return;
+    throw new Error(
+      `cannot record the ngrok agent: no assistant entry found for '${assistantId}'`,
+    );
+  }
+  const entry = result.entry;
   if (agent === null) {
-    rmSync(statePath, { force: true });
-    return;
+    delete entry.ngrokAgent;
+  } else {
+    const record: { webAddrPort: number; pid?: number } = {
+      webAddrPort: agent.webAddrPort,
+    };
+    if (agent.pid !== undefined && agent.pid !== null) {
+      record.pid = agent.pid;
+    }
+    entry.ngrokAgent = record;
   }
-  const record: Record<string, number> = { webAddrPort: agent.webAddrPort };
-  if (agent.pid !== undefined && agent.pid !== null) {
-    record.pid = agent.pid;
-  }
-  mkdirSync(dirname(statePath), { recursive: true });
-  writeFileSync(statePath, JSON.stringify(record, null, 2) + "\n");
+  saveAssistantEntry(entry);
 }
 
 /** Read the persisted dedicated-agent record, if saved and well-formed. */
-export function loadNgrokAgent(workspaceDir: string): NgrokAgentRecord | null {
-  const statePath = getNgrokAgentStatePath(workspaceDir);
-  if (!existsSync(statePath)) return null;
-  let record: Record<string, unknown>;
-  try {
-    record = JSON.parse(readFileSync(statePath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-  } catch {
-    return null;
-  }
+export function loadNgrokAgent(assistantId: string): NgrokAgentRecord | null {
+  const result = lookupAssistantByIdentifier(assistantId);
+  if (result.status !== "found") return null;
+  const record = result.entry.ngrokAgent as Record<string, unknown> | undefined;
+  if (typeof record !== "object" || record === null) return null;
   const port = record.webAddrPort;
   if (typeof port !== "number" || !Number.isInteger(port) || port <= 0) {
     return null;

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -85,20 +85,36 @@ export function saveIngressUrl(
   }
 }
 
-/** Persist a reserved ngrok domain under `ingress.ngrok.domain`; null clears it. */
-export function saveNgrokDomain(
+/** Update the `ingress.ngrok` entry in place, dropping it when it empties. */
+function updateNgrokEntry(
   workspaceDir: string,
-  domain: string | null,
+  mutate: (ngrok: Record<string, unknown>) => void,
 ): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  if (domain) {
-    ingress.ngrok = { domain };
+  const ngrok = (ingress.ngrok ?? {}) as Record<string, unknown>;
+  mutate(ngrok);
+  if (Object.keys(ngrok).length > 0) {
+    ingress.ngrok = ngrok;
   } else {
     delete ingress.ngrok;
   }
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
+}
+
+/** Persist a reserved ngrok domain under `ingress.ngrok.domain`; null clears it. */
+export function saveNgrokDomain(
+  workspaceDir: string,
+  domain: string | null,
+): void {
+  updateNgrokEntry(workspaceDir, (ngrok) => {
+    if (domain) {
+      ngrok.domain = domain;
+    } else {
+      delete ngrok.domain;
+    }
+  });
 }
 
 /** Read the reserved ngrok domain from the workspace config, if saved. */
@@ -108,6 +124,36 @@ export function loadNgrokDomain(workspaceDir: string): string | null {
   const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
   const domain = ngrok?.domain;
   return typeof domain === "string" && domain.trim() ? domain : null;
+}
+
+/**
+ * Persist the spawned ngrok agent's dedicated web-addr port under
+ * `ingress.ngrok.webAddrPort` so later runs can query that agent's local API
+ * and reuse its tunnel instead of spawning a second agent; null clears a
+ * stale entry.
+ */
+export function saveNgrokWebAddrPort(
+  workspaceDir: string,
+  port: number | null,
+): void {
+  updateNgrokEntry(workspaceDir, (ngrok) => {
+    if (port !== null) {
+      ngrok.webAddrPort = port;
+    } else {
+      delete ngrok.webAddrPort;
+    }
+  });
+}
+
+/** Read the persisted dedicated-agent web-addr port, if saved. */
+export function loadNgrokWebAddrPort(workspaceDir: string): number | null {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = config.ingress as Record<string, unknown> | undefined;
+  const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
+  const port = ngrok?.webAddrPort;
+  return typeof port === "number" && Number.isInteger(port) && port > 0
+    ? port
+    : null;
 }
 
 /** Clear the ingress public base URL from the workspace config. */

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -126,34 +126,52 @@ export function loadNgrokDomain(workspaceDir: string): string | null {
   return typeof domain === "string" && domain.trim() ? domain : null;
 }
 
+/** Persisted record of the vellum-spawned dedicated ngrok agent. */
+export interface NgrokAgentRecord {
+  /** The agent's dedicated web-addr (local API) port. */
+  webAddrPort: number;
+  /** The agent's process id, when the spawning run recorded one. */
+  pid: number | null;
+}
+
 /**
- * Persist the spawned ngrok agent's dedicated web-addr port under
- * `ingress.ngrok.webAddrPort` so later runs can query that agent's local API
- * and reuse its tunnel instead of spawning a second agent; null clears a
- * stale entry.
+ * Persist the spawned ngrok agent's dedicated web-addr port and pid under
+ * `ingress.ngrok` so later runs can query that agent's local API and reuse
+ * its tunnel, or stop the agent when it no longer serves the requested
+ * target; null clears a stale record.
  */
-export function saveNgrokWebAddrPort(
+export function saveNgrokAgent(
   workspaceDir: string,
-  port: number | null,
+  agent: { webAddrPort: number; pid?: number | null } | null,
 ): void {
   updateNgrokEntry(workspaceDir, (ngrok) => {
-    if (port !== null) {
-      ngrok.webAddrPort = port;
+    if (agent !== null) {
+      ngrok.webAddrPort = agent.webAddrPort;
+      if (agent.pid !== undefined && agent.pid !== null) {
+        ngrok.agentPid = agent.pid;
+      } else {
+        delete ngrok.agentPid;
+      }
     } else {
       delete ngrok.webAddrPort;
+      delete ngrok.agentPid;
     }
   });
 }
 
-/** Read the persisted dedicated-agent web-addr port, if saved. */
-export function loadNgrokWebAddrPort(workspaceDir: string): number | null {
+/** Read the persisted dedicated-agent record, if saved. */
+export function loadNgrokAgent(workspaceDir: string): NgrokAgentRecord | null {
   const config = loadRawConfig(workspaceDir);
   const ingress = config.ingress as Record<string, unknown> | undefined;
   const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
   const port = ngrok?.webAddrPort;
-  return typeof port === "number" && Number.isInteger(port) && port > 0
-    ? port
-    : null;
+  if (typeof port !== "number" || !Number.isInteger(port) || port <= 0) {
+    return null;
+  }
+  const pid = ngrok?.agentPid;
+  const validPid =
+    typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : null;
+  return { webAddrPort: port, pid: validPid };
 }
 
 /** Clear the ingress public base URL from the workspace config. */

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -32,6 +32,7 @@ import {
 } from "./http-client.js";
 import { stopIngressNginx } from "./nginx-ingress.js";
 import {
+  isNgrokProcess,
   type ProcessState,
   resolveProcessState,
   stopProcess,
@@ -1721,20 +1722,6 @@ export async function startGateway(
 
   console.log("✅ Gateway started\n");
   return gatewayUrl;
-}
-
-/** Check whether a PID belongs to an ngrok process via its command line. */
-function isNgrokProcess(pid: number): boolean {
-  try {
-    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return /ngrok/.test(output);
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/cli/src/lib/ngrok.test.ts
+++ b/cli/src/lib/ngrok.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:net";
+
+import {
+  buildNgrokArgs,
+  classifyExistingAgent,
+  pickFreeLoopbackPort,
+  pickMatchingTunnel,
+  waitForNgrokUrl,
+  type NgrokTunnel,
+} from "./ngrok.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function tunnel(publicUrl: string, addr: string): NgrokTunnel {
+  return { public_url: publicUrl, config: { addr } };
+}
+
+const foreignTunnel = tunnel("https://foreign.example.app", "localhost:7840");
+
+describe("pickMatchingTunnel", () => {
+  test("returns null when no tunnel targets the port", () => {
+    expect(pickMatchingTunnel([foreignTunnel], 18080)).toBeNull();
+  });
+
+  test("picks the tunnel for the target port among foreign tunnels", () => {
+    const tunnels = [
+      foreignTunnel,
+      tunnel("https://edge.example.app", "localhost:18080"),
+    ];
+    expect(pickMatchingTunnel(tunnels, 18080)).toBe("https://edge.example.app");
+  });
+
+  test("prefers HTTPS over HTTP for the same port", () => {
+    const tunnels = [
+      tunnel("http://edge.example.app", "127.0.0.1:18080"),
+      tunnel("https://edge.example.app", "127.0.0.1:18080"),
+    ];
+    expect(pickMatchingTunnel(tunnels, 18080)).toBe("https://edge.example.app");
+  });
+
+  test("matches every supported addr spelling", () => {
+    for (const addr of [
+      "localhost:18080",
+      "127.0.0.1:18080",
+      "http://localhost:18080",
+      "http://127.0.0.1:18080",
+    ]) {
+      expect(
+        pickMatchingTunnel([tunnel("https://edge.example.app", addr)], 18080),
+      ).toBe("https://edge.example.app");
+    }
+  });
+
+  test("filters by domain when one is requested", () => {
+    const tunnels = [
+      tunnel("https://other.example.app", "localhost:18080"),
+      tunnel("https://reserved.example.app", "localhost:18080"),
+    ];
+    expect(pickMatchingTunnel(tunnels, 18080, "reserved.example.app")).toBe(
+      "https://reserved.example.app",
+    );
+    expect(pickMatchingTunnel(tunnels, 18080, "absent.example.app")).toBeNull();
+  });
+});
+
+describe("classifyExistingAgent", () => {
+  test("returns none for an empty tunnel list", () => {
+    expect(classifyExistingAgent([], 18080)).toBe("none");
+  });
+
+  test("returns reuse when a tunnel targets the port", () => {
+    const tunnels = [
+      foreignTunnel,
+      tunnel("https://edge.example.app", "localhost:18080"),
+    ];
+    expect(classifyExistingAgent(tunnels, 18080)).toBe("reuse");
+  });
+
+  test("returns coexist when only foreign tunnels are listed", () => {
+    expect(classifyExistingAgent([foreignTunnel], 18080)).toBe("coexist");
+  });
+
+  test("returns coexist when the port matches but the domain does not", () => {
+    const tunnels = [tunnel("https://other.example.app", "localhost:18080")];
+    expect(classifyExistingAgent(tunnels, 18080, "reserved.example.app")).toBe(
+      "coexist",
+    );
+  });
+});
+
+describe("buildNgrokArgs", () => {
+  test("builds base args without domain or web-addr", () => {
+    expect(buildNgrokArgs(18080)).toEqual(["http", "18080", "--log=stdout"]);
+  });
+
+  test("appends --domain when a domain is given", () => {
+    expect(buildNgrokArgs(18080, "reserved.example.app")).toEqual([
+      "http",
+      "18080",
+      "--log=stdout",
+      "--domain=reserved.example.app",
+    ]);
+  });
+
+  test("appends --web-addr iff a web-addr port is given", () => {
+    expect(buildNgrokArgs(18080, undefined, 41234)).toEqual([
+      "http",
+      "18080",
+      "--log=stdout",
+      "--web-addr=127.0.0.1:41234",
+    ]);
+    expect(buildNgrokArgs(18080, "reserved.example.app", 41234)).toEqual([
+      "http",
+      "18080",
+      "--log=stdout",
+      "--domain=reserved.example.app",
+      "--web-addr=127.0.0.1:41234",
+    ]);
+  });
+});
+
+describe("pickFreeLoopbackPort", () => {
+  test("returns a bindable loopback port", async () => {
+    const port = await pickFreeLoopbackPort();
+    expect(Number.isInteger(port)).toBe(true);
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThan(65536);
+
+    // The port is released and can be bound again.
+    await new Promise<void>((resolve, reject) => {
+      const server = createServer();
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    });
+  });
+});
+
+describe("waitForNgrokUrl", () => {
+  /** Stub the agent API, recording each fetched URL. */
+  function mockTunnelsFetch(tunnels: NgrokTunnel[]): string[] {
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      fetchedUrls.push(String(input));
+      return new Response(JSON.stringify({ tunnels }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    return fetchedUrls;
+  }
+
+  test("polls the default :4040 API when no apiUrl is given", async () => {
+    const fetchedUrls = mockTunnelsFetch([
+      tunnel("https://edge.example.app", "localhost:18080"),
+    ]);
+
+    const url = await waitForNgrokUrl(18080);
+
+    expect(url).toBe("https://edge.example.app");
+    expect(fetchedUrls).toEqual(["http://127.0.0.1:4040/api/tunnels"]);
+  });
+
+  test("polls the provided agent API and ignores foreign tunnels", async () => {
+    const fetchedUrls = mockTunnelsFetch([
+      foreignTunnel,
+      tunnel("https://edge.example.app", "localhost:18080"),
+    ]);
+
+    const url = await waitForNgrokUrl(
+      18080,
+      undefined,
+      "http://127.0.0.1:41234/api/tunnels",
+    );
+
+    expect(url).toBe("https://edge.example.app");
+    expect(fetchedUrls).toEqual(["http://127.0.0.1:41234/api/tunnels"]);
+  });
+
+  test("times out when the agent never reports a matching tunnel", async () => {
+    mockTunnelsFetch([foreignTunnel]);
+
+    await expect(
+      waitForNgrokUrl(18080, undefined, undefined, 1),
+    ).rejects.toThrow("did not become available");
+  });
+});

--- a/cli/src/lib/ngrok.test.ts
+++ b/cli/src/lib/ngrok.test.ts
@@ -66,6 +66,19 @@ describe("pickMatchingTunnel", () => {
     );
     expect(pickMatchingTunnel(tunnels, 18080, "absent.example.app")).toBeNull();
   });
+
+  test("a later domain match beats an earlier HTTPS tunnel on the same port", () => {
+    // A foreign agent's tunnel is listed before the dedicated agent's entry;
+    // with a reserved domain the domain match must be selected, not the
+    // first HTTPS tunnel.
+    const tunnels = [
+      tunnel("https://foreign.example.app", "localhost:18080"),
+      tunnel("https://reserved.example.app", "localhost:18080"),
+    ];
+    expect(pickMatchingTunnel(tunnels, 18080, "reserved.example.app")).toBe(
+      "https://reserved.example.app",
+    );
+  });
 });
 
 describe("classifyExistingAgent", () => {
@@ -89,6 +102,16 @@ describe("classifyExistingAgent", () => {
     const tunnels = [tunnel("https://other.example.app", "localhost:18080")];
     expect(classifyExistingAgent(tunnels, 18080, "reserved.example.app")).toBe(
       "coexist",
+    );
+  });
+
+  test("returns reuse when a later tunnel matches the reserved domain", () => {
+    const tunnels = [
+      tunnel("https://foreign.example.app", "localhost:18080"),
+      tunnel("https://reserved.example.app", "localhost:18080"),
+    ];
+    expect(classifyExistingAgent(tunnels, 18080, "reserved.example.app")).toBe(
+      "reuse",
     );
   });
 });

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -7,12 +7,12 @@ import { GATEWAY_PORT } from "./constants.js";
 import {
   clearIngressUrl,
   getDefaultWorkspaceDir,
+  loadNgrokAgent,
   loadNgrokDomain,
-  loadNgrokWebAddrPort,
   loadRawConfig,
   saveIngressUrl,
+  saveNgrokAgent,
   saveNgrokDomain,
-  saveNgrokWebAddrPort,
 } from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 
@@ -91,26 +91,89 @@ async function queryNgrokTunnels(
 }
 
 /**
- * List tunnels visible to the spawn preflight: the default :4040 agent
- * (foreign or legacy reuse) plus our previously spawned dedicated agent at
- * its persisted web-addr port. A persisted address that no longer answers is
- * stale (the agent died or was stopped), so it is cleared and the caller
- * falls through to spawning fresh.
+ * Agents visible to the spawn preflight: the default :4040 agent (foreign or
+ * legacy reuse, never ours to stop) and our previously spawned dedicated
+ * agent at its persisted web-addr port. A persisted record whose API no
+ * longer answers is stale (the agent died or was stopped), so it is cleared
+ * and reported absent.
  */
-async function queryPreflightTunnels(
+interface PreflightAgents {
+  /** Tunnels listed by the default :4040 agent. */
+  defaultAgentTunnels: NgrokTunnel[];
+  /** The persisted vellum-owned agent, when its API still answers. */
+  dedicatedAgent: {
+    webAddrPort: number;
+    pid: number | null;
+    tunnels: NgrokTunnel[];
+  } | null;
+}
+
+async function queryPreflightAgents(
   workspaceDir: string,
-): Promise<NgrokTunnel[]> {
-  const tunnels = (await queryNgrokTunnels()) ?? [];
-  const savedWebAddrPort = loadNgrokWebAddrPort(workspaceDir);
-  if (savedWebAddrPort !== null) {
-    const dedicated = await queryNgrokTunnels(ngrokApiUrl(savedWebAddrPort));
-    if (dedicated === null) {
-      saveNgrokWebAddrPort(workspaceDir, null);
+): Promise<PreflightAgents> {
+  const defaultAgentTunnels = (await queryNgrokTunnels()) ?? [];
+  let dedicatedAgent: PreflightAgents["dedicatedAgent"] = null;
+  const saved = loadNgrokAgent(workspaceDir);
+  if (saved !== null) {
+    const tunnels = await queryNgrokTunnels(ngrokApiUrl(saved.webAddrPort));
+    if (tunnels === null) {
+      saveNgrokAgent(workspaceDir, null);
     } else {
-      tunnels.push(...dedicated);
+      dedicatedAgent = {
+        webAddrPort: saved.webAddrPort,
+        pid: saved.pid,
+        tunnels,
+      };
     }
   }
-  return tunnels;
+  return { defaultAgentTunnels, dedicatedAgent };
+}
+
+/** Whether the PID belongs to an ngrok process, guarding against pid reuse. */
+function isNgrokPid(pid: number): boolean {
+  try {
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      timeout: 3_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return /ngrok/.test(output);
+  } catch {
+    return false;
+  }
+}
+
+/** Poll the agent's API until it stops answering, bounded by timeoutMs. */
+async function waitForAgentExit(
+  apiUrl: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if ((await queryNgrokTunnels(apiUrl)) === null) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
+/**
+ * Stop our persisted dedicated agent and clear its record. Called when the
+ * agent no longer serves the requested target/domain: it is vellum-owned, so
+ * it must be replaced rather than coexisted with, otherwise the recorded pid
+ * handoff would orphan its tunnel at sleep. Foreign agents are never stopped.
+ * A missing or reused pid skips the kill but still clears the record so the
+ * caller spawns fresh.
+ */
+async function stopDedicatedAgent(
+  workspaceDir: string,
+  agent: { webAddrPort: number; pid: number | null },
+): Promise<void> {
+  if (agent.pid !== null && isNgrokPid(agent.pid)) {
+    try {
+      process.kill(agent.pid, "SIGTERM");
+      await waitForAgentExit(ngrokApiUrl(agent.webAddrPort));
+    } catch {}
+  }
+  saveNgrokAgent(workspaceDir, null);
 }
 
 /** Whether a tunnel targets the given local port, under any addr spelling. */
@@ -347,21 +410,54 @@ export async function maybeStartNgrokTunnel(
 
   // Reuse an existing tunnel if one is already running, from the default
   // :4040 agent or our own previously spawned dedicated agent.
-  const runningTunnels = await queryPreflightTunnels(workspaceDir);
-  const existingUrl = pickMatchingTunnel(runningTunnels, targetPort);
+  const preflight = await queryPreflightAgents(workspaceDir);
+  let runningTunnels = [
+    ...preflight.defaultAgentTunnels,
+    ...(preflight.dedicatedAgent?.tunnels ?? []),
+  ];
+
+  // Our dedicated agent no longer serves the requested target or domain
+  // (e.g. an earlier wake tunneled a different edge port): stop it before
+  // spawning a replacement, so the pid recorded for sleep never orphans its
+  // tunnel. Foreign agents on :4040 are never stopped.
+  if (
+    preflight.dedicatedAgent !== null &&
+    pickMatchingTunnel(
+      preflight.dedicatedAgent.tunnels,
+      targetPort,
+      savedDomain,
+    ) === null
+  ) {
+    console.log(
+      `   Stopping the previously started ngrok agent; it no longer matches the requested target.`,
+    );
+    await stopDedicatedAgent(workspaceDir, preflight.dedicatedAgent);
+    runningTunnels = preflight.defaultAgentTunnels;
+  }
+
+  // Prefer a domain-matching tunnel when a domain is reserved, so a foreign
+  // tunnel on the same port cannot shadow our dedicated agent's tunnel.
+  const existingUrl = pickMatchingTunnel(
+    runningTunnels,
+    targetPort,
+    savedDomain,
+  );
   if (existingUrl) {
-    if (savedDomain && !urlMatchesDomain(existingUrl, savedDomain)) {
+    console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
+    saveIngressUrl(workspaceDir, existingUrl);
+    return null;
+  }
+  if (savedDomain) {
+    const mismatchedUrl = pickMatchingTunnel(runningTunnels, targetPort);
+    if (mismatchedUrl) {
       // Spawning a second agent would collide (ERR_NGROK_334), and saving the
       // mismatched URL would clobber the reserved-domain intent. Leave the
       // tunnel running but refuse to bless it in config.
       console.warn(
-        `   ⚠ Existing ngrok tunnel ${existingUrl} does not match the reserved domain '${savedDomain}'. Ignoring it. Stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
+        `   ⚠ Existing ngrok tunnel ${mismatchedUrl} does not match the reserved domain '${savedDomain}'. Ignoring it. Stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
       );
       return null;
     }
-    console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl);
-    return null;
   }
   if (classifyExistingAgent(runningTunnels, targetPort) === "coexist") {
     // An agent is up but only tunnels other local targets (e.g. a foreign
@@ -401,9 +497,12 @@ export async function maybeStartNgrokTunnel(
       ngrokApiUrl(webAddrPort),
     );
     saveIngressUrl(workspaceDir, publicUrl);
-    // Record the agent's API address so the next run's preflight can find
-    // and reuse this agent instead of spawning a second one.
-    saveNgrokWebAddrPort(workspaceDir, webAddrPort);
+    // Record the agent's API address and pid so the next run's preflight can
+    // find and reuse this agent, or stop it when its target goes stale.
+    saveNgrokAgent(workspaceDir, {
+      webAddrPort,
+      pid: ngrokProcess.pid ?? null,
+    });
     console.log(`   Tunnel established: ${publicUrl}`);
 
     return ngrokProcess;
@@ -469,24 +568,48 @@ export async function runNgrokTunnel(
 
   // Check for an existing ngrok tunnel pointing at the local edge, from the
   // default :4040 agent or our own previously spawned dedicated agent.
-  const runningTunnels = await queryPreflightTunnels(workspaceDir);
-  const existingUrl = pickMatchingTunnel(runningTunnels, port);
+  const preflight = await queryPreflightAgents(workspaceDir);
+  let runningTunnels = [
+    ...preflight.defaultAgentTunnels,
+    ...(preflight.dedicatedAgent?.tunnels ?? []),
+  ];
+
+  // Our dedicated agent no longer serves the requested target or domain:
+  // stop it before spawning a replacement so its tunnel is not orphaned.
+  // Foreign agents on :4040 are never stopped.
+  if (
+    preflight.dedicatedAgent !== null &&
+    pickMatchingTunnel(preflight.dedicatedAgent.tunnels, port, domain) === null
+  ) {
+    console.log(
+      "Stopping the previously started ngrok agent; it no longer matches the requested target.",
+    );
+    await stopDedicatedAgent(workspaceDir, preflight.dedicatedAgent);
+    runningTunnels = preflight.defaultAgentTunnels;
+  }
+
+  // Prefer a domain-matching tunnel when a domain is set, so a foreign
+  // tunnel on the same port cannot shadow our dedicated agent's tunnel.
+  const existingUrl = pickMatchingTunnel(runningTunnels, port, domain);
   if (classifyExistingAgent(runningTunnels, port) === "coexist") {
     // An agent is up but only tunnels other local targets (e.g. a foreign
     // agent holding :4040). Spawn our own agent on a dedicated web-addr; a
     // single-agent plan limit still surfaces via ngrok's own exit error.
     console.warn(`Warning: ${coexistNotice(runningTunnels)}`);
   }
-  if (existingUrl) {
-    if (domain && !urlMatchesDomain(existingUrl, domain)) {
+  if (!existingUrl && domain) {
+    const mismatchedUrl = pickMatchingTunnel(runningTunnels, port);
+    if (mismatchedUrl) {
       console.error(
-        `Error: an ngrok tunnel is already running on port ${port} at ${existingUrl}, which does not match the ${opts.domain ? "requested" : "saved"} domain '${domain}'.`,
+        `Error: an ngrok tunnel is already running on port ${port} at ${mismatchedUrl}, which does not match the ${opts.domain ? "requested" : "saved"} domain '${domain}'.`,
       );
       console.error(
         "Stop the existing ngrok agent first, then re-run this command to bind the reserved domain.",
       );
       process.exit(1);
     }
+  }
+  if (existingUrl) {
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
     if (opts.domain) {
@@ -522,7 +645,7 @@ export async function runNgrokTunnel(
     if (publicUrl) {
       console.log("\nClearing ingress URL from config...");
       clearIngressUrl(workspaceDir, opts.assistantId);
-      saveNgrokWebAddrPort(workspaceDir, null);
+      saveNgrokAgent(workspaceDir, null);
     }
   };
 
@@ -577,9 +700,12 @@ export async function runNgrokTunnel(
   // The domain is standing intent, not tunnel state: cleanup clears the
   // ingress URL but leaves the domain saved for wake/daemon restores.
   saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
-  // Record the agent's API address so a later wake preflight can find and
-  // reuse this agent instead of spawning a second one.
-  saveNgrokWebAddrPort(workspaceDir, webAddrPort);
+  // Record the agent's API address and pid so a later wake preflight can
+  // find and reuse this agent, or stop it when its target goes stale.
+  saveNgrokAgent(workspaceDir, {
+    webAddrPort,
+    pid: ngrokProcess.pid ?? null,
+  });
   if (opts.domain) {
     saveNgrokDomain(workspaceDir, opts.domain);
   }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -8,9 +8,11 @@ import {
   clearIngressUrl,
   getDefaultWorkspaceDir,
   loadNgrokDomain,
+  loadNgrokWebAddrPort,
   loadRawConfig,
   saveIngressUrl,
   saveNgrokDomain,
+  saveNgrokWebAddrPort,
 } from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 
@@ -86,6 +88,29 @@ async function queryNgrokTunnels(
   } catch {
     return null;
   }
+}
+
+/**
+ * List tunnels visible to the spawn preflight: the default :4040 agent
+ * (foreign or legacy reuse) plus our previously spawned dedicated agent at
+ * its persisted web-addr port. A persisted address that no longer answers is
+ * stale (the agent died or was stopped), so it is cleared and the caller
+ * falls through to spawning fresh.
+ */
+async function queryPreflightTunnels(
+  workspaceDir: string,
+): Promise<NgrokTunnel[]> {
+  const tunnels = (await queryNgrokTunnels()) ?? [];
+  const savedWebAddrPort = loadNgrokWebAddrPort(workspaceDir);
+  if (savedWebAddrPort !== null) {
+    const dedicated = await queryNgrokTunnels(ngrokApiUrl(savedWebAddrPort));
+    if (dedicated === null) {
+      saveNgrokWebAddrPort(workspaceDir, null);
+    } else {
+      tunnels.push(...dedicated);
+    }
+  }
+  return tunnels;
 }
 
 /** Whether a tunnel targets the given local port, under any addr spelling. */
@@ -320,8 +345,9 @@ export async function maybeStartNgrokTunnel(
 
   const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
 
-  // Reuse an existing tunnel if one is already running
-  const runningTunnels = (await queryNgrokTunnels()) ?? [];
+  // Reuse an existing tunnel if one is already running, from the default
+  // :4040 agent or our own previously spawned dedicated agent.
+  const runningTunnels = await queryPreflightTunnels(workspaceDir);
   const existingUrl = pickMatchingTunnel(runningTunnels, targetPort);
   if (existingUrl) {
     if (savedDomain && !urlMatchesDomain(existingUrl, savedDomain)) {
@@ -353,24 +379,31 @@ export async function maybeStartNgrokTunnel(
   // Writing to a log file sidesteps both issues — the file descriptor is
   // inherited by the detached ngrok process and remains valid after CLI exit.
   const ngrokLogPath = join(workspaceDir, "data", "logs", "ngrok.log");
-  // A dedicated web-addr keeps this agent's local API separate from any
-  // other agent's, so discovery below polls our own agent's tunnels.
-  const webAddrPort = await pickFreeLoopbackPort();
-  const ngrokProcess = startNgrokProcess(
-    targetPort,
-    ngrokLogPath,
-    savedDomain,
-    webAddrPort,
-  );
-  ngrokProcess.unref();
+  let ngrokProcess: ChildProcess | undefined;
 
   try {
+    // A dedicated web-addr keeps this agent's local API separate from any
+    // other agent's, so discovery below polls our own agent's tunnels. The
+    // allocation lives inside this guarded path so a loopback bind failure
+    // stays nonfatal like any other ngrok startup failure.
+    const webAddrPort = await pickFreeLoopbackPort();
+    ngrokProcess = startNgrokProcess(
+      targetPort,
+      ngrokLogPath,
+      savedDomain,
+      webAddrPort,
+    );
+    ngrokProcess.unref();
+
     const publicUrl = await waitForNgrokUrl(
       targetPort,
       savedDomain,
       ngrokApiUrl(webAddrPort),
     );
     saveIngressUrl(workspaceDir, publicUrl);
+    // Record the agent's API address so the next run's preflight can find
+    // and reuse this agent instead of spawning a second one.
+    saveNgrokWebAddrPort(workspaceDir, webAddrPort);
     console.log(`   Tunnel established: ${publicUrl}`);
 
     return ngrokProcess;
@@ -381,7 +414,7 @@ export async function maybeStartNgrokTunnel(
     if (savedDomain) {
       console.warn(`   ⚠ ${savedDomainRecoveryHint(savedDomain)}`);
     }
-    if (!ngrokProcess.killed) ngrokProcess.kill("SIGTERM");
+    if (ngrokProcess && !ngrokProcess.killed) ngrokProcess.kill("SIGTERM");
     return null;
   }
 }
@@ -434,8 +467,9 @@ export async function runNgrokTunnel(
     console.log(`Using saved ngrok domain: ${domain}`);
   }
 
-  // Check for an existing ngrok tunnel pointing at the local edge
-  const runningTunnels = (await queryNgrokTunnels()) ?? [];
+  // Check for an existing ngrok tunnel pointing at the local edge, from the
+  // default :4040 agent or our own previously spawned dedicated agent.
+  const runningTunnels = await queryPreflightTunnels(workspaceDir);
   const existingUrl = pickMatchingTunnel(runningTunnels, port);
   if (classifyExistingAgent(runningTunnels, port) === "coexist") {
     // An agent is up but only tunnels other local targets (e.g. a foreign
@@ -488,6 +522,7 @@ export async function runNgrokTunnel(
     if (publicUrl) {
       console.log("\nClearing ingress URL from config...");
       clearIngressUrl(workspaceDir, opts.assistantId);
+      saveNgrokWebAddrPort(workspaceDir, null);
     }
   };
 
@@ -542,6 +577,9 @@ export async function runNgrokTunnel(
   // The domain is standing intent, not tunnel state: cleanup clears the
   // ingress URL but leaves the domain saved for wake/daemon restores.
   saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
+  // Record the agent's API address so a later wake preflight can find and
+  // reuse this agent instead of spawning a second one.
+  saveNgrokWebAddrPort(workspaceDir, webAddrPort);
   if (opts.domain) {
     saveNgrokDomain(workspaceDir, opts.domain);
   }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -15,6 +15,7 @@ import {
   saveNgrokDomain,
 } from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
+import { isNgrokProcess, stopProcess } from "./process.js";
 
 const NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels";
 const NGROK_POLL_INTERVAL_MS = 500;
@@ -129,49 +130,22 @@ async function queryPreflightAgents(
   return { defaultAgentTunnels, dedicatedAgent };
 }
 
-/** Whether the PID belongs to an ngrok process, guarding against pid reuse. */
-function isNgrokPid(pid: number): boolean {
-  try {
-    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-      encoding: "utf-8",
-      timeout: 3_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return /ngrok/.test(output);
-  } catch {
-    return false;
-  }
-}
-
-/** Poll the agent's API until it stops answering, bounded by timeoutMs. */
-async function waitForAgentExit(
-  apiUrl: string,
-  timeoutMs = 5_000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if ((await queryNgrokTunnels(apiUrl)) === null) return;
-    await new Promise((r) => setTimeout(r, 200));
-  }
-}
-
 /**
  * Stop our persisted dedicated agent and clear its record. Called when the
  * agent no longer serves the requested target/domain: it is vellum-owned, so
  * it must be replaced rather than coexisted with, otherwise the recorded pid
  * handoff would orphan its tunnel at sleep. Foreign agents are never stopped.
  * A missing or reused pid skips the kill but still clears the record so the
- * caller spawns fresh.
+ * caller spawns fresh. stopProcess escalates SIGTERM to SIGKILL, so the old
+ * agent is gone (or unkillably dying) before the record is cleared and a
+ * replacement spawns.
  */
 async function stopDedicatedAgent(
   workspaceDir: string,
   agent: { webAddrPort: number; pid: number | null },
 ): Promise<void> {
-  if (agent.pid !== null && isNgrokPid(agent.pid)) {
-    try {
-      process.kill(agent.pid, "SIGTERM");
-      await waitForAgentExit(ngrokApiUrl(agent.webAddrPort));
-    } catch {}
+  if (agent.pid !== null && isNgrokProcess(agent.pid)) {
+    await stopProcess(agent.pid, "ngrok agent");
   }
   saveNgrokAgent(workspaceDir, null);
 }
@@ -340,6 +314,100 @@ export async function waitForNgrokUrl(
   );
 }
 
+/** What the spawn preflight found, shared by both tunnel entry points. */
+interface NgrokPreflight {
+  /** Tunnels from every visible agent, after any stale-agent stop. */
+  runningTunnels: NgrokTunnel[];
+  /** Reusable tunnel URL for the target port (and domain, when set). */
+  existingUrl: string | null;
+  /** Agents are running but only serve other targets or domains. */
+  coexist: boolean;
+}
+
+/**
+ * Shared spawn preflight: query the default :4040 agent and our persisted
+ * dedicated agent, stop the dedicated agent when it no longer serves the
+ * requested target or domain (so the pid recorded for sleep never orphans
+ * its tunnel; foreign agents are never stopped), and pick a reusable tunnel,
+ * preferring a domain match when a domain is set. `onStopStaleAgent` lets
+ * each caller keep its own messaging for the stop.
+ */
+async function preflightNgrok(
+  workspaceDir: string,
+  targetPort: number,
+  domain: string | undefined,
+  onStopStaleAgent: () => void,
+): Promise<NgrokPreflight> {
+  const agents = await queryPreflightAgents(workspaceDir);
+  let runningTunnels = [
+    ...agents.defaultAgentTunnels,
+    ...(agents.dedicatedAgent?.tunnels ?? []),
+  ];
+
+  if (
+    agents.dedicatedAgent !== null &&
+    pickMatchingTunnel(agents.dedicatedAgent.tunnels, targetPort, domain) ===
+      null
+  ) {
+    onStopStaleAgent();
+    await stopDedicatedAgent(workspaceDir, agents.dedicatedAgent);
+    runningTunnels = agents.defaultAgentTunnels;
+  }
+
+  return {
+    runningTunnels,
+    existingUrl: pickMatchingTunnel(runningTunnels, targetPort, domain),
+    coexist:
+      classifyExistingAgent(runningTunnels, targetPort, domain) === "coexist",
+  };
+}
+
+/**
+ * Spawn our dedicated agent: pick a free web-addr port so its local API
+ * stays separate from any other agent's, start ngrok, wait for the tunnel
+ * on our own agent's API, and persist the ingress URL plus the agent record
+ * so the next preflight can reuse or stop this agent. `configure` runs right
+ * after the spawn, before the tunnel wait (unref, event handlers). On any
+ * failure the spawned process is killed and the error rethrown; warn-vs-exit
+ * policy stays with the caller.
+ */
+async function spawnDedicatedAgent(opts: {
+  targetPort: number;
+  workspaceDir: string;
+  domain?: string;
+  logFilePath?: string;
+  assistantId?: string;
+  configure?: (child: ChildProcess) => void;
+}): Promise<{ ngrokProcess: ChildProcess; publicUrl: string }> {
+  const webAddrPort = await pickFreeLoopbackPort();
+  const ngrokProcess = startNgrokProcess(
+    opts.targetPort,
+    opts.logFilePath,
+    opts.domain,
+    webAddrPort,
+  );
+  opts.configure?.(ngrokProcess);
+
+  try {
+    const publicUrl = await waitForNgrokUrl(
+      opts.targetPort,
+      opts.domain,
+      ngrokApiUrl(webAddrPort),
+    );
+    saveIngressUrl(opts.workspaceDir, publicUrl, opts.assistantId);
+    saveNgrokAgent(opts.workspaceDir, {
+      webAddrPort,
+      pid: ngrokProcess.pid ?? null,
+    });
+    return { ngrokProcess, publicUrl };
+  } catch (err) {
+    if (!ngrokProcess.killed) {
+      ngrokProcess.kill("SIGTERM");
+    }
+    throw err;
+  }
+}
+
 /**
  * Check whether an already-loaded workspace config has webhook-based
  * integrations (e.g. Telegram, Twilio) that require a public ingress URL.
@@ -409,60 +477,27 @@ export async function maybeStartNgrokTunnel(
   const savedDomain = loadNgrokDomain(workspaceDir) ?? undefined;
 
   // Reuse an existing tunnel if one is already running, from the default
-  // :4040 agent or our own previously spawned dedicated agent.
-  const preflight = await queryPreflightAgents(workspaceDir);
-  let runningTunnels = [
-    ...preflight.defaultAgentTunnels,
-    ...(preflight.dedicatedAgent?.tunnels ?? []),
-  ];
-
-  // Our dedicated agent no longer serves the requested target or domain
-  // (e.g. an earlier wake tunneled a different edge port): stop it before
-  // spawning a replacement, so the pid recorded for sleep never orphans its
-  // tunnel. Foreign agents on :4040 are never stopped.
-  if (
-    preflight.dedicatedAgent !== null &&
-    pickMatchingTunnel(
-      preflight.dedicatedAgent.tunnels,
-      targetPort,
-      savedDomain,
-    ) === null
-  ) {
-    console.log(
-      `   Stopping the previously started ngrok agent; it no longer matches the requested target.`,
-    );
-    await stopDedicatedAgent(workspaceDir, preflight.dedicatedAgent);
-    runningTunnels = preflight.defaultAgentTunnels;
-  }
-
-  // Prefer a domain-matching tunnel when a domain is reserved, so a foreign
-  // tunnel on the same port cannot shadow our dedicated agent's tunnel.
-  const existingUrl = pickMatchingTunnel(
-    runningTunnels,
+  // :4040 agent or our own previously spawned dedicated agent; a stale
+  // dedicated agent is stopped before it can be replaced.
+  const { runningTunnels, existingUrl, coexist } = await preflightNgrok(
+    workspaceDir,
     targetPort,
     savedDomain,
+    () =>
+      console.log(
+        `   Stopping the previously started ngrok agent; it no longer matches the requested target.`,
+      ),
   );
   if (existingUrl) {
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
     saveIngressUrl(workspaceDir, existingUrl);
     return null;
   }
-  if (savedDomain) {
-    const mismatchedUrl = pickMatchingTunnel(runningTunnels, targetPort);
-    if (mismatchedUrl) {
-      // Spawning a second agent would collide (ERR_NGROK_334), and saving the
-      // mismatched URL would clobber the reserved-domain intent. Leave the
-      // tunnel running but refuse to bless it in config.
-      console.warn(
-        `   ⚠ Existing ngrok tunnel ${mismatchedUrl} does not match the reserved domain '${savedDomain}'. Ignoring it. Stop the running ngrok agent and run \`vellum tunnel --provider ngrok --domain ${savedDomain}\` to bind the reserved domain.`,
-      );
-      return null;
-    }
-  }
-  if (classifyExistingAgent(runningTunnels, targetPort) === "coexist") {
-    // An agent is up but only tunnels other local targets (e.g. a foreign
-    // agent holding :4040). Spawn our own agent on a dedicated web-addr; a
-    // single-agent plan limit still surfaces via ngrok's own exit error.
+  if (coexist) {
+    // An agent is up but only tunnels other local targets or domains (e.g. a
+    // foreign agent holding :4040, or a same-port tunnel under another
+    // domain). Spawn our own agent on a dedicated web-addr; a clash on the
+    // same reserved domain still surfaces via ngrok's own ERR_NGROK_334 exit.
     console.warn(`   ⚠ ${coexistNotice(runningTunnels)}`);
   }
 
@@ -472,36 +507,19 @@ export async function maybeStartNgrokTunnel(
   // This avoids two problems that occur with piped stdio:
   //   1. If pipe handles are left open, the CLI process hangs after hatch/wake.
   //   2. If pipe handles are destroyed, SIGPIPE kills ngrok on its next write.
-  // Writing to a log file sidesteps both issues — the file descriptor is
+  // Writing to a log file sidesteps both issues: the file descriptor is
   // inherited by the detached ngrok process and remains valid after CLI exit.
   const ngrokLogPath = join(workspaceDir, "data", "logs", "ngrok.log");
-  let ngrokProcess: ChildProcess | undefined;
 
   try {
-    // A dedicated web-addr keeps this agent's local API separate from any
-    // other agent's, so discovery below polls our own agent's tunnels. The
-    // allocation lives inside this guarded path so a loopback bind failure
-    // stays nonfatal like any other ngrok startup failure.
-    const webAddrPort = await pickFreeLoopbackPort();
-    ngrokProcess = startNgrokProcess(
+    // The whole spawn sequence (including the loopback web-addr allocation)
+    // lives inside this guarded path so any failure stays nonfatal.
+    const { ngrokProcess, publicUrl } = await spawnDedicatedAgent({
       targetPort,
-      ngrokLogPath,
-      savedDomain,
-      webAddrPort,
-    );
-    ngrokProcess.unref();
-
-    const publicUrl = await waitForNgrokUrl(
-      targetPort,
-      savedDomain,
-      ngrokApiUrl(webAddrPort),
-    );
-    saveIngressUrl(workspaceDir, publicUrl);
-    // Record the agent's API address and pid so the next run's preflight can
-    // find and reuse this agent, or stop it when its target goes stale.
-    saveNgrokAgent(workspaceDir, {
-      webAddrPort,
-      pid: ngrokProcess.pid ?? null,
+      workspaceDir,
+      domain: savedDomain,
+      logFilePath: ngrokLogPath,
+      configure: (child) => child.unref(),
     });
     console.log(`   Tunnel established: ${publicUrl}`);
 
@@ -513,7 +531,6 @@ export async function maybeStartNgrokTunnel(
     if (savedDomain) {
       console.warn(`   ⚠ ${savedDomainRecoveryHint(savedDomain)}`);
     }
-    if (ngrokProcess && !ngrokProcess.killed) ngrokProcess.kill("SIGTERM");
     return null;
   }
 }
@@ -567,47 +584,23 @@ export async function runNgrokTunnel(
   }
 
   // Check for an existing ngrok tunnel pointing at the local edge, from the
-  // default :4040 agent or our own previously spawned dedicated agent.
-  const preflight = await queryPreflightAgents(workspaceDir);
-  let runningTunnels = [
-    ...preflight.defaultAgentTunnels,
-    ...(preflight.dedicatedAgent?.tunnels ?? []),
-  ];
-
-  // Our dedicated agent no longer serves the requested target or domain:
-  // stop it before spawning a replacement so its tunnel is not orphaned.
-  // Foreign agents on :4040 are never stopped.
-  if (
-    preflight.dedicatedAgent !== null &&
-    pickMatchingTunnel(preflight.dedicatedAgent.tunnels, port, domain) === null
-  ) {
-    console.log(
-      "Stopping the previously started ngrok agent; it no longer matches the requested target.",
-    );
-    await stopDedicatedAgent(workspaceDir, preflight.dedicatedAgent);
-    runningTunnels = preflight.defaultAgentTunnels;
-  }
-
-  // Prefer a domain-matching tunnel when a domain is set, so a foreign
-  // tunnel on the same port cannot shadow our dedicated agent's tunnel.
-  const existingUrl = pickMatchingTunnel(runningTunnels, port, domain);
-  if (classifyExistingAgent(runningTunnels, port) === "coexist") {
-    // An agent is up but only tunnels other local targets (e.g. a foreign
-    // agent holding :4040). Spawn our own agent on a dedicated web-addr; a
-    // single-agent plan limit still surfaces via ngrok's own exit error.
+  // default :4040 agent or our own previously spawned dedicated agent; a
+  // stale dedicated agent is stopped before it can be replaced.
+  const { runningTunnels, existingUrl, coexist } = await preflightNgrok(
+    workspaceDir,
+    port,
+    domain,
+    () =>
+      console.log(
+        "Stopping the previously started ngrok agent; it no longer matches the requested target.",
+      ),
+  );
+  if (coexist) {
+    // An agent is up but only tunnels other local targets or domains (e.g. a
+    // foreign agent holding :4040, or a same-port tunnel under another
+    // domain). Spawn our own agent on a dedicated web-addr; a clash on the
+    // same reserved domain still surfaces via ngrok's own ERR_NGROK_334 exit.
     console.warn(`Warning: ${coexistNotice(runningTunnels)}`);
-  }
-  if (!existingUrl && domain) {
-    const mismatchedUrl = pickMatchingTunnel(runningTunnels, port);
-    if (mismatchedUrl) {
-      console.error(
-        `Error: an ngrok tunnel is already running on port ${port} at ${mismatchedUrl}, which does not match the ${opts.domain ? "requested" : "saved"} domain '${domain}'.`,
-      );
-      console.error(
-        "Stop the existing ngrok agent first, then re-run this command to bind the reserved domain.",
-      );
-      process.exit(1);
-    }
   }
   if (existingUrl) {
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
@@ -632,14 +625,10 @@ export async function runNgrokTunnel(
   console.log(`Starting ngrok tunnel to localhost:${port}...`);
 
   let publicUrl: string | undefined;
-
-  // A dedicated web-addr keeps this agent's local API separate from any
-  // other agent's, so discovery below polls our own agent's tunnels.
-  const webAddrPort = await pickFreeLoopbackPort();
-  const ngrokProcess = startNgrokProcess(port, undefined, domain, webAddrPort);
+  let ngrokProcess: ChildProcess | undefined;
 
   const cleanup = () => {
-    if (!ngrokProcess.killed) {
+    if (ngrokProcess && !ngrokProcess.killed) {
       ngrokProcess.kill("SIGTERM");
     }
     if (publicUrl) {
@@ -658,33 +647,46 @@ export async function runNgrokTunnel(
     process.exit(0);
   });
 
-  ngrokProcess.on("error", (err: Error) => {
-    console.error(`ngrok process error: ${err.message}`);
-    process.exit(1);
-  });
+  const configure = (child: ChildProcess) => {
+    ngrokProcess = child;
 
-  ngrokProcess.on("exit", (code: number | null) => {
-    if (code !== null && code !== 0) {
-      console.error(`ngrok exited with code ${code}.`);
-      console.error(
-        "Check that ngrok is authenticated: ngrok config add-authtoken <token>",
-      );
+    child.on("error", (err: Error) => {
+      console.error(`ngrok process error: ${err.message}`);
       process.exit(1);
-    }
-  });
+    });
 
-  // Pipe ngrok stdout/stderr to console for visibility
-  ngrokProcess.stdout?.on("data", (data: Buffer) => {
-    const line = data.toString().trim();
-    if (line) console.log(`[ngrok] ${line}`);
-  });
-  ngrokProcess.stderr?.on("data", (data: Buffer) => {
-    const line = data.toString().trim();
-    if (line) console.error(`[ngrok] ${line}`);
-  });
+    child.on("exit", (code: number | null) => {
+      if (code !== null && code !== 0) {
+        console.error(`ngrok exited with code ${code}.`);
+        console.error(
+          "Check that ngrok is authenticated: ngrok config add-authtoken <token>",
+        );
+        process.exit(1);
+      }
+    });
+
+    // Pipe ngrok stdout/stderr to console for visibility
+    child.stdout?.on("data", (data: Buffer) => {
+      const line = data.toString().trim();
+      if (line) console.log(`[ngrok] ${line}`);
+    });
+    child.stderr?.on("data", (data: Buffer) => {
+      const line = data.toString().trim();
+      if (line) console.error(`[ngrok] ${line}`);
+    });
+  };
 
   try {
-    publicUrl = await waitForNgrokUrl(port, domain, ngrokApiUrl(webAddrPort));
+    // The domain is standing intent, not tunnel state: cleanup clears the
+    // ingress URL and the agent record but leaves the domain saved for
+    // wake/daemon restores.
+    ({ ngrokProcess, publicUrl } = await spawnDedicatedAgent({
+      targetPort: port,
+      workspaceDir,
+      domain,
+      assistantId: opts.assistantId,
+      configure,
+    }));
   } catch (err) {
     cleanup();
     if (domain && !opts.domain) {
@@ -697,15 +699,6 @@ export async function runNgrokTunnel(
   console.log(`Tunnel established: ${publicUrl}`);
   console.log(`Forwarding to:     localhost:${port}`);
 
-  // The domain is standing intent, not tunnel state: cleanup clears the
-  // ingress URL but leaves the domain saved for wake/daemon restores.
-  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
-  // Record the agent's API address and pid so a later wake preflight can
-  // find and reuse this agent, or stop it when its target goes stale.
-  saveNgrokAgent(workspaceDir, {
-    webAddrPort,
-    pid: ngrokProcess.pid ?? null,
-  });
   if (opts.domain) {
     saveNgrokDomain(workspaceDir, opts.domain);
   }
@@ -715,6 +708,6 @@ export async function runNgrokTunnel(
 
   // Keep running until the ngrok process exits or we receive a signal
   await new Promise<void>((resolve) => {
-    ngrokProcess.on("exit", () => resolve());
+    ngrokProcess?.on("exit", () => resolve());
   });
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -368,7 +368,9 @@ async function preflightNgrok(
  * on our own agent's API, and persist the ingress URL plus the agent record
  * so the next preflight can reuse or stop this agent. `configure` runs right
  * after the spawn, before the tunnel wait (unref, event handlers). On any
- * failure the spawned process is killed and the error rethrown; warn-vs-exit
+ * failure the spawned process is stopped via the stopProcess escalation
+ * (SIGTERM, wait, SIGKILL) before the error is rethrown, so a failed spawn
+ * cannot orphan a live tunnel that is invisible to later runs; warn-vs-exit
  * policy stays with the caller.
  */
 async function spawnDedicatedAgent(opts: {
@@ -401,8 +403,12 @@ async function spawnDedicatedAgent(opts: {
     });
     return { ngrokProcess, publicUrl };
   } catch (err) {
-    if (!ngrokProcess.killed) {
-      ngrokProcess.kill("SIGTERM");
+    // This agent is invisible on :4040 and its record is only written on
+    // success, so a child that survives a bare SIGTERM would be
+    // undiscoverable. Escalate and wait for it to exit before rethrowing.
+    const pid = ngrokProcess.pid;
+    if (pid !== undefined && isNgrokProcess(pid)) {
+      await stopProcess(pid, "ngrok agent");
     }
     throw err;
   }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
+import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
@@ -17,7 +18,7 @@ const NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels";
 const NGROK_POLL_INTERVAL_MS = 500;
 const NGROK_POLL_TIMEOUT_MS = 15_000;
 
-interface NgrokTunnel {
+export interface NgrokTunnel {
   public_url: string;
   config?: { addr?: string };
 }
@@ -43,13 +44,40 @@ export function getNgrokVersion(): string | null {
   }
 }
 
+/** Local API URL for an ngrok agent bound to a dedicated web-addr port. */
+function ngrokApiUrl(webAddrPort: number): string {
+  return `http://127.0.0.1:${webAddrPort}/api/tunnels`;
+}
+
+/** Bind to an OS-assigned loopback port, release it, and return its number. */
+export function pickFreeLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((err) => {
+        if (err) {
+          reject(err);
+        } else if (address && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("could not determine a free loopback port"));
+        }
+      });
+    });
+  });
+}
+
 /**
- * Query the ngrok local API for running tunnels.
+ * Query an ngrok agent's local API for running tunnels.
  * Returns the list of tunnels, or null if the API is unreachable.
  */
-async function queryNgrokTunnels(): Promise<NgrokTunnel[] | null> {
+async function queryNgrokTunnels(
+  apiUrl: string = NGROK_API_URL,
+): Promise<NgrokTunnel[] | null> {
   try {
-    const res = await loopbackSafeFetch(NGROK_API_URL, {
+    const res = await loopbackSafeFetch(apiUrl, {
       signal: AbortSignal.timeout(2_000),
     });
     if (!res.ok) return null;
@@ -72,7 +100,7 @@ function tunnelTargetsPort(tunnel: NgrokTunnel, targetPort: number): boolean {
 }
 
 /** Pick the tunnel for the target port (and domain, when set), HTTPS first. */
-function pickMatchingTunnel(
+export function pickMatchingTunnel(
   tunnels: NgrokTunnel[],
   targetPort: number,
   domain?: string,
@@ -94,9 +122,26 @@ function describeTunnels(tunnels: NgrokTunnel[]): string {
     .join(", ");
 }
 
-/** Diagnostic for a running ngrok agent whose tunnels all miss the target port. */
-function staleAgentDiagnostic(tunnels: NgrokTunnel[], port: number): string {
-  return `an ngrok agent is already running but tunnels a different local port (${describeTunnels(tunnels)}), not ${port}. It was likely started before the tunnel edge unification or by an external process.`;
+/**
+ * How a running agent's tunnel list relates to the requested target port:
+ * `reuse` when it already tunnels the port (and domain, when set), `coexist`
+ * when it only serves other targets (e.g. a foreign agent on :4040), `none`
+ * when no tunnels are listed.
+ */
+export function classifyExistingAgent(
+  tunnels: NgrokTunnel[],
+  targetPort: number,
+  domain?: string,
+): "reuse" | "coexist" | "none" {
+  if (tunnels.length === 0) {
+    return "none";
+  }
+  return pickMatchingTunnel(tunnels, targetPort, domain) ? "reuse" : "coexist";
+}
+
+/** Notice for a running agent that does not tunnel the target port. */
+function coexistNotice(tunnels: NgrokTunnel[]): string {
+  return `another ngrok agent is running (${describeTunnels(tunnels)}); starting a separate ngrok agent for the local edge.`;
 }
 
 /** Recovery copy for a saved domain whose reservation may have lapsed. */
@@ -115,6 +160,22 @@ function urlMatchesDomain(publicUrl: string, domain: string): boolean {
   }
 }
 
+/** Build the ngrok CLI argument list for an HTTP tunnel. */
+export function buildNgrokArgs(
+  targetPort: number,
+  domain?: string,
+  webAddrPort?: number,
+): string[] {
+  const args = ["http", String(targetPort), "--log=stdout"];
+  if (domain) {
+    args.push(`--domain=${domain}`);
+  }
+  if (webAddrPort !== undefined) {
+    args.push(`--web-addr=127.0.0.1:${webAddrPort}`);
+  }
+  return args;
+}
+
 /**
  * Start an ngrok process tunneling HTTP traffic to the given local port.
  *
@@ -126,12 +187,17 @@ function urlMatchesDomain(publicUrl: string, domain: string): boolean {
  * When `domain` is set, the tunnel binds that reserved ngrok domain via
  * `--domain=<domain>`.
  *
+ * When `webAddrPort` is set, the agent's local web UI/API binds
+ * `127.0.0.1:<webAddrPort>` instead of the default :4040, so this agent can
+ * coexist with a foreign agent that already holds the default address.
+ *
  * Returns the spawned child process.
  */
 export function startNgrokProcess(
   targetPort: number,
   logFilePath?: string,
   domain?: string,
+  webAddrPort?: number,
 ): ChildProcess {
   let stdio: ("ignore" | "pipe" | number)[] = ["ignore", "pipe", "pipe"];
   let fd: number | undefined;
@@ -142,15 +208,14 @@ export function startNgrokProcess(
     stdio = ["ignore", fd, fd];
   }
 
-  const args = ["http", String(targetPort), "--log=stdout"];
-  if (domain) {
-    args.push(`--domain=${domain}`);
-  }
-
-  const child = spawn("ngrok", args, {
-    detached: true,
-    stdio,
-  });
+  const child = spawn(
+    "ngrok",
+    buildNgrokArgs(targetPort, domain, webAddrPort),
+    {
+      detached: true,
+      stdio,
+    },
+  );
 
   // The child process inherits a duplicate of the fd via dup2, so the
   // parent's copy is no longer needed. Close it to avoid leaking the
@@ -163,18 +228,19 @@ export function startNgrokProcess(
 }
 
 /**
- * Poll the ngrok local API until a tunnel appears for the target port (and
- * reserved domain, when one is requested), preferring HTTPS.
+ * Poll an ngrok agent's local API until a tunnel appears for the target port
+ * (and reserved domain, when one is requested), preferring HTTPS.
  * Returns the public URL, or throws if the timeout is exceeded.
  */
 export async function waitForNgrokUrl(
   targetPort: number,
   domain?: string,
+  apiUrl: string = NGROK_API_URL,
   timeoutMs: number = NGROK_POLL_TIMEOUT_MS,
 ): Promise<string> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const tunnels = await queryNgrokTunnels();
+    const tunnels = await queryNgrokTunnels(apiUrl);
     if (tunnels && tunnels.length > 0) {
       const url = pickMatchingTunnel(tunnels, targetPort, domain);
       if (url) return url;
@@ -271,14 +337,11 @@ export async function maybeStartNgrokTunnel(
     saveIngressUrl(workspaceDir, existingUrl);
     return null;
   }
-  if (runningTunnels.length > 0) {
-    // An agent is up but tunnels some other local port (likely started before
-    // the edge unification, or by an external process). Spawning a second
-    // agent would collide (ERR_NGROK_334) on single-agent plans, so skip.
-    console.warn(
-      `   ⚠ ${staleAgentDiagnostic(runningTunnels, targetPort)} Stop that ngrok agent, then run \`vellum tunnel --provider ngrok\` to tunnel the local edge.`,
-    );
-    return null;
+  if (classifyExistingAgent(runningTunnels, targetPort) === "coexist") {
+    // An agent is up but only tunnels other local targets (e.g. a foreign
+    // agent holding :4040). Spawn our own agent on a dedicated web-addr; a
+    // single-agent plan limit still surfaces via ngrok's own exit error.
+    console.warn(`   ⚠ ${coexistNotice(runningTunnels)}`);
   }
 
   console.log(`   Starting ngrok tunnel for webhook integrations...`);
@@ -290,11 +353,23 @@ export async function maybeStartNgrokTunnel(
   // Writing to a log file sidesteps both issues — the file descriptor is
   // inherited by the detached ngrok process and remains valid after CLI exit.
   const ngrokLogPath = join(workspaceDir, "data", "logs", "ngrok.log");
-  const ngrokProcess = startNgrokProcess(targetPort, ngrokLogPath, savedDomain);
+  // A dedicated web-addr keeps this agent's local API separate from any
+  // other agent's, so discovery below polls our own agent's tunnels.
+  const webAddrPort = await pickFreeLoopbackPort();
+  const ngrokProcess = startNgrokProcess(
+    targetPort,
+    ngrokLogPath,
+    savedDomain,
+    webAddrPort,
+  );
   ngrokProcess.unref();
 
   try {
-    const publicUrl = await waitForNgrokUrl(targetPort, savedDomain);
+    const publicUrl = await waitForNgrokUrl(
+      targetPort,
+      savedDomain,
+      ngrokApiUrl(webAddrPort),
+    );
     saveIngressUrl(workspaceDir, publicUrl);
     console.log(`   Tunnel established: ${publicUrl}`);
 
@@ -362,14 +437,11 @@ export async function runNgrokTunnel(
   // Check for an existing ngrok tunnel pointing at the local edge
   const runningTunnels = (await queryNgrokTunnels()) ?? [];
   const existingUrl = pickMatchingTunnel(runningTunnels, port);
-  if (!existingUrl && runningTunnels.length > 0) {
-    // Spawning a second agent would collide (ERR_NGROK_334) on single-agent
-    // plans; fail loudly instead, matching the domain-mismatch path.
-    console.error(`Error: ${staleAgentDiagnostic(runningTunnels, port)}`);
-    console.error(
-      "Stop the existing ngrok agent first, then re-run this command to tunnel the local edge.",
-    );
-    process.exit(1);
+  if (classifyExistingAgent(runningTunnels, port) === "coexist") {
+    // An agent is up but only tunnels other local targets (e.g. a foreign
+    // agent holding :4040). Spawn our own agent on a dedicated web-addr; a
+    // single-agent plan limit still surfaces via ngrok's own exit error.
+    console.warn(`Warning: ${coexistNotice(runningTunnels)}`);
   }
   if (existingUrl) {
     if (domain && !urlMatchesDomain(existingUrl, domain)) {
@@ -404,7 +476,10 @@ export async function runNgrokTunnel(
 
   let publicUrl: string | undefined;
 
-  const ngrokProcess = startNgrokProcess(port, undefined, domain);
+  // A dedicated web-addr keeps this agent's local API separate from any
+  // other agent's, so discovery below polls our own agent's tunnels.
+  const webAddrPort = await pickFreeLoopbackPort();
+  const ngrokProcess = startNgrokProcess(port, undefined, domain, webAddrPort);
 
   const cleanup = () => {
     if (!ngrokProcess.killed) {
@@ -451,7 +526,7 @@ export async function runNgrokTunnel(
   });
 
   try {
-    publicUrl = await waitForNgrokUrl(port, domain);
+    publicUrl = await waitForNgrokUrl(port, domain, ngrokApiUrl(webAddrPort));
   } catch (err) {
     cleanup();
     if (domain && !opts.domain) {

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -110,15 +110,15 @@ interface PreflightAgents {
 }
 
 async function queryPreflightAgents(
-  workspaceDir: string,
+  assistantId: string,
 ): Promise<PreflightAgents> {
   const defaultAgentTunnels = (await queryNgrokTunnels()) ?? [];
   let dedicatedAgent: PreflightAgents["dedicatedAgent"] = null;
-  const saved = loadNgrokAgent(workspaceDir);
+  const saved = loadNgrokAgent(assistantId);
   if (saved !== null) {
     const tunnels = await queryNgrokTunnels(ngrokApiUrl(saved.webAddrPort));
     if (tunnels === null) {
-      saveNgrokAgent(workspaceDir, null);
+      saveNgrokAgent(assistantId, null);
     } else {
       dedicatedAgent = {
         webAddrPort: saved.webAddrPort,
@@ -141,13 +141,13 @@ async function queryPreflightAgents(
  * replacement spawns.
  */
 async function stopDedicatedAgent(
-  workspaceDir: string,
+  assistantId: string,
   agent: { webAddrPort: number; pid: number | null },
 ): Promise<void> {
   if (agent.pid !== null && isNgrokProcess(agent.pid)) {
     await stopProcess(agent.pid, "ngrok agent");
   }
-  saveNgrokAgent(workspaceDir, null);
+  saveNgrokAgent(assistantId, null);
 }
 
 /** Whether a tunnel targets the given local port, under any addr spelling. */
@@ -333,12 +333,12 @@ interface NgrokPreflight {
  * each caller keep its own messaging for the stop.
  */
 async function preflightNgrok(
-  workspaceDir: string,
+  assistantId: string,
   targetPort: number,
   domain: string | undefined,
   onStopStaleAgent: () => void,
 ): Promise<NgrokPreflight> {
-  const agents = await queryPreflightAgents(workspaceDir);
+  const agents = await queryPreflightAgents(assistantId);
   let runningTunnels = [
     ...agents.defaultAgentTunnels,
     ...(agents.dedicatedAgent?.tunnels ?? []),
@@ -350,7 +350,7 @@ async function preflightNgrok(
       null
   ) {
     onStopStaleAgent();
-    await stopDedicatedAgent(workspaceDir, agents.dedicatedAgent);
+    await stopDedicatedAgent(assistantId, agents.dedicatedAgent);
     runningTunnels = agents.defaultAgentTunnels;
   }
 
@@ -365,20 +365,25 @@ async function preflightNgrok(
 /**
  * Spawn our dedicated agent: pick a free web-addr port so its local API
  * stays separate from any other agent's, start ngrok, wait for the tunnel
- * on our own agent's API, and persist the ingress URL plus the agent record
+ * on our own agent's API, and persist the agent record plus the ingress URL
  * so the next preflight can reuse or stop this agent. `configure` runs right
- * after the spawn, before the tunnel wait (unref, event handlers). On any
- * failure the spawned process is stopped via the stopProcess escalation
- * (SIGTERM, wait, SIGKILL) before the error is rethrown, so a failed spawn
+ * after the spawn, before the tunnel wait (unref, event handlers).
+ *
+ * The agent record is persisted before the ingress URL is committed: if the
+ * record cannot be written, the failure path rolls the spawn back with no
+ * URL committed anywhere, so clients are never left pointing at a public
+ * URL whose agent the CLI cannot rediscover. On any failure the spawned
+ * process is stopped via the stopProcess escalation (SIGTERM, wait,
+ * SIGKILL) and the record is cleared only after the stop, so a failed spawn
  * cannot orphan a live tunnel that is invisible to later runs; warn-vs-exit
  * policy stays with the caller.
  */
 async function spawnDedicatedAgent(opts: {
   targetPort: number;
   workspaceDir: string;
+  assistantId: string;
   domain?: string;
   logFilePath?: string;
-  assistantId?: string;
   configure?: (child: ChildProcess) => void;
 }): Promise<{ ngrokProcess: ChildProcess; publicUrl: string }> {
   const webAddrPort = await pickFreeLoopbackPort();
@@ -396,19 +401,25 @@ async function spawnDedicatedAgent(opts: {
       opts.domain,
       ngrokApiUrl(webAddrPort),
     );
-    saveIngressUrl(opts.workspaceDir, publicUrl, opts.assistantId);
-    saveNgrokAgent(opts.workspaceDir, {
+    saveNgrokAgent(opts.assistantId, {
       webAddrPort,
       pid: ngrokProcess.pid ?? null,
     });
+    saveIngressUrl(opts.workspaceDir, publicUrl, opts.assistantId);
     return { ngrokProcess, publicUrl };
   } catch (err) {
-    // This agent is invisible on :4040 and its record is only written on
-    // success, so a child that survives a bare SIGTERM would be
-    // undiscoverable. Escalate and wait for it to exit before rethrowing.
+    // This agent is invisible on :4040, so a child that survives a bare
+    // SIGTERM would be undiscoverable. Escalate and wait for it to exit,
+    // then drop any record written above; the original error is the one
+    // worth surfacing if the best-effort clear fails too.
     const pid = ngrokProcess.pid;
     if (pid !== undefined && isNgrokProcess(pid)) {
       await stopProcess(pid, "ngrok agent");
+    }
+    try {
+      saveNgrokAgent(opts.assistantId, null);
+    } catch {
+      // Keep the original error.
     }
     throw err;
   }
@@ -460,12 +471,15 @@ function hasNonNgrokIngressUrl(workspaceDir: string): boolean {
  * Auto-start an ngrok tunnel if webhook integrations are configured and no
  * non-ngrok ingress URL is present. Designed to be called during daemon/gateway
  * startup. Non-fatal: if ngrok is unavailable or fails, startup continues.
+ * `assistantId` names the lockfile entry the dedicated-agent record (and the
+ * ingress URL mirror) are persisted on.
  *
  * Returns the spawned ngrok child process (for PID tracking) or null.
  */
 export async function maybeStartNgrokTunnel(
   targetPort: number,
   workspaceDir: string,
+  assistantId: string,
 ): Promise<ChildProcess | null> {
   // Managed/containerized deployments route webhooks through the platform's
   // callback proxy. ngrok is not needed and would not be reachable from the
@@ -486,7 +500,7 @@ export async function maybeStartNgrokTunnel(
   // :4040 agent or our own previously spawned dedicated agent; a stale
   // dedicated agent is stopped before it can be replaced.
   const { runningTunnels, existingUrl, coexist } = await preflightNgrok(
-    workspaceDir,
+    assistantId,
     targetPort,
     savedDomain,
     () =>
@@ -496,7 +510,7 @@ export async function maybeStartNgrokTunnel(
   );
   if (existingUrl) {
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl);
+    saveIngressUrl(workspaceDir, existingUrl, assistantId);
     return null;
   }
   if (coexist) {
@@ -523,6 +537,7 @@ export async function maybeStartNgrokTunnel(
     const { ngrokProcess, publicUrl } = await spawnDedicatedAgent({
       targetPort,
       workspaceDir,
+      assistantId,
       domain: savedDomain,
       logFilePath: ngrokLogPath,
       configure: (child) => child.unref(),
@@ -546,8 +561,9 @@ export interface RunNgrokTunnelOptions {
   port?: number;
   /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
   workspaceDir?: string;
-  /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
-  assistantId?: string;
+  /** Lockfile entry the dedicated-agent record (`ngrokAgent`) and the ingress
+   *  URL mirror (`ingressUrl`) are persisted on. */
+  assistantId: string;
   /**
    * Reserved ngrok domain to bind. Persisted so wake restores reuse it.
    * When omitted, a previously saved domain is reused without being rewritten.
@@ -560,7 +576,7 @@ export interface RunNgrokTunnelOptions {
  * save the public URL to config, and block until exit or signal.
  */
 export async function runNgrokTunnel(
-  opts: RunNgrokTunnelOptions = {},
+  opts: RunNgrokTunnelOptions,
 ): Promise<void> {
   const version = getNgrokVersion();
   if (!version) {
@@ -593,7 +609,7 @@ export async function runNgrokTunnel(
   // default :4040 agent or our own previously spawned dedicated agent; a
   // stale dedicated agent is stopped before it can be replaced.
   const { runningTunnels, existingUrl, coexist } = await preflightNgrok(
-    workspaceDir,
+    opts.assistantId,
     port,
     domain,
     () =>
@@ -632,26 +648,34 @@ export async function runNgrokTunnel(
 
   let publicUrl: string | undefined;
   let ngrokProcess: ChildProcess | undefined;
+  let cleanedUp = false;
 
-  const cleanup = () => {
-    if (ngrokProcess && !ngrokProcess.killed) {
-      ngrokProcess.kill("SIGTERM");
+  // Shutdown teardown (Ctrl+C or a failed spawn): stop the agent through the
+  // stopProcess escalation (SIGTERM, wait, SIGKILL, guarded by
+  // isNgrokProcess against pid reuse) and only then clear the persisted
+  // state, so a slow or SIGTERM-ignoring agent never outlives the only
+  // record of its dedicated API port.
+  const cleanup = async () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    const pid = ngrokProcess?.pid;
+    if (pid !== undefined && isNgrokProcess(pid)) {
+      await stopProcess(pid, "ngrok agent");
     }
     if (publicUrl) {
       console.log("\nClearing ingress URL from config...");
       clearIngressUrl(workspaceDir, opts.assistantId);
-      saveNgrokAgent(workspaceDir, null);
+      saveNgrokAgent(opts.assistantId, null);
     }
   };
 
-  process.on("SIGINT", () => {
-    cleanup();
-    process.exit(0);
-  });
-  process.on("SIGTERM", () => {
-    cleanup();
-    process.exit(0);
-  });
+  const onShutdownSignal = () => {
+    cleanup()
+      .catch(() => {})
+      .finally(() => process.exit(0));
+  };
+  process.on("SIGINT", onShutdownSignal);
+  process.on("SIGTERM", onShutdownSignal);
 
   const configure = (child: ChildProcess) => {
     ngrokProcess = child;
@@ -683,37 +707,42 @@ export async function runNgrokTunnel(
   };
 
   try {
-    // The domain is standing intent, not tunnel state: cleanup clears the
-    // ingress URL and the agent record but leaves the domain saved for
-    // wake/daemon restores.
-    ({ ngrokProcess, publicUrl } = await spawnDedicatedAgent({
-      targetPort: port,
-      workspaceDir,
-      domain,
-      assistantId: opts.assistantId,
-      configure,
-    }));
-  } catch (err) {
-    cleanup();
-    if (domain && !opts.domain) {
-      console.error(savedDomainRecoveryHint(domain));
+    try {
+      // The domain is standing intent, not tunnel state: cleanup clears the
+      // ingress URL and the agent record but leaves the domain saved for
+      // wake/daemon restores.
+      ({ ngrokProcess, publicUrl } = await spawnDedicatedAgent({
+        targetPort: port,
+        workspaceDir,
+        assistantId: opts.assistantId,
+        domain,
+        configure,
+      }));
+    } catch (err) {
+      await cleanup();
+      if (domain && !opts.domain) {
+        console.error(savedDomainRecoveryHint(domain));
+      }
+      throw err;
     }
-    throw err;
+
+    console.log("");
+    console.log(`Tunnel established: ${publicUrl}`);
+    console.log(`Forwarding to:     localhost:${port}`);
+
+    if (opts.domain) {
+      saveNgrokDomain(workspaceDir, opts.domain);
+    }
+    console.log("Ingress URL saved to config.");
+    console.log("");
+    console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");
+
+    // Keep running until the ngrok process exits or we receive a signal
+    await new Promise<void>((resolve) => {
+      ngrokProcess?.on("exit", () => resolve());
+    });
+  } finally {
+    process.off("SIGINT", onShutdownSignal);
+    process.off("SIGTERM", onShutdownSignal);
   }
-
-  console.log("");
-  console.log(`Tunnel established: ${publicUrl}`);
-  console.log(`Forwarding to:     localhost:${port}`);
-
-  if (opts.domain) {
-    saveNgrokDomain(workspaceDir, opts.domain);
-  }
-  console.log("Ingress URL saved to config.");
-  console.log("");
-  console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");
-
-  // Keep running until the ngrok process exits or we receive a signal
-  await new Promise<void>((resolve) => {
-    ngrokProcess?.on("exit", () => resolve());
-  });
 }

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -1,5 +1,5 @@
-import { execFileSync } from "child_process";
-import { existsSync, readFileSync, unlinkSync } from "fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 
 import {
   httpHealthCheck,
@@ -23,6 +23,24 @@ export function isVellumProcess(pid: number): boolean {
     return /vellum-daemon|vellum-cli|vellum-gateway|credential-executor|@vellumai|\/\.?vellum\/|\/daemon\/main|\/\.vellum\/.*qdrant\/bin\/qdrant/.test(
       output,
     );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify that a PID belongs to an ngrok process by inspecting its command
+ * line via `ps`. Prevents killing unrelated processes when a recorded ngrok
+ * PID is stale and the OS has reused it.
+ */
+export function isNgrokProcess(pid: number): boolean {
+  try {
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return /ngrok/.test(output);
   } catch {
     return false;
   }

--- a/cli/src/lib/tunnel-edge.ts
+++ b/cli/src/lib/tunnel-edge.ts
@@ -27,7 +27,8 @@ export const WEB_INGRESS_FLAG_RETRY = {
  */
 function wantsWebIngress(config: Record<string, unknown>): boolean {
   const ingress = config.ingress as
-    { enabled?: unknown; publicBaseUrl?: unknown } | undefined;
+    | { enabled?: unknown; publicBaseUrl?: unknown }
+    | undefined;
   return (
     ingress?.enabled === true &&
     typeof ingress.publicBaseUrl === "string" &&
@@ -108,5 +109,5 @@ export async function restoreTunnelEdgeAndAutoTunnel(
       );
     }
   }
-  return maybeStartNgrokTunnel(tunnelTargetPort, workspaceDir);
+  return maybeStartNgrokTunnel(tunnelTargetPort, workspaceDir, assistantId);
 }


### PR DESCRIPTION
## Summary
- vellum's spawned ngrok agent now gets a dedicated `--web-addr` on a free loopback port, and tunnel discovery polls that agent's own API instead of assuming :4040
- A foreign ngrok agent on :4040 no longer causes a hard exit (or a misreported foreign URL): vellum warns and coexists; the matching-tunnel reuse path is unchanged

Part of plan: pairing-qa-followups.md (PR 3 of 5)
