### PR TITLE
fix(pairing): carry --label in the pair bundle and stop embedding the host in the default name

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -11,9 +11,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR.
+// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR. The
+// XDG redirect keeps a developer's `~/.config/vellum/environment` selection
+// from repointing the lockfile name away from the one written below.
 const testDir = mkdtempSync(join(tmpdir(), "pair-command-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+process.env.XDG_CONFIG_HOME = testDir;
 
 import { buildAppConnectUrl, pair } from "../commands/pair.js";
 
@@ -55,6 +59,11 @@ describe("pair command", () => {
   afterAll(() => {
     rmSync(testDir, { recursive: true, force: true });
     delete process.env.VELLUM_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+    }
   });
 
   test("POSTs a cli device-bound pair request and prints a decodable bundle", async () => {
@@ -111,6 +120,40 @@ describe("pair command", () => {
     expect(out.assistantId).toBe("self");
     expect(out.token).toBe("test-access-token");
     expect(out.deviceId).toBe(body.deviceId);
+    // No --label, so the bundle carries no label key at all.
+    expect("label" in out).toBe(false);
+  });
+
+  test("--label is carried in the bundle for the importer's display name", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          token: "t",
+          expiresAt: "2026-06-04T00:00:00.000Z",
+          guardianId: "g",
+          assistantId: "self",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    process.argv = ["bun", "vellum", "pair", "--label", "Office Mac", "--json"];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.label).toBe("Office Mac");
   });
 
   test("resolves an unquoted multi-word display name", async () => {

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -156,6 +156,123 @@ describe("pair command", () => {
     expect(out.label).toBe("Office Mac");
   });
 
+  test("--label with surrounding whitespace is trimmed in the minted bundle", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          token: "t",
+          expiresAt: "2026-06-04T00:00:00.000Z",
+          guardianId: "g",
+          assistantId: "self",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "pair",
+      "--label",
+      "  Office Mac  ",
+      "--json",
+    ];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.label).toBe("Office Mac");
+  });
+
+  test("whitespace-only --label exits 1 with the constraint, before any network call", async () => {
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = ["bun", "vellum", "pair", "--label", "   ", "--json"];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // The importer would drop a whitespace-only label, so the producer refuses
+    // to mint the bundle at all rather than report a label that won't survive.
+    expect(exited).toBe(true);
+    expect(errors.join("\n")).toContain(
+      "--label must be 1-64 characters after trimming",
+    );
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("over-64-character --label exits 1 with the constraint, before any network call", async () => {
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = ["bun", "vellum", "pair", "--label", "x".repeat(65)];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    expect(exited).toBe(true);
+    expect(errors.join("\n")).toContain(
+      "--label must be 1-64 characters after trimming",
+    );
+    expect(fetchCalled).toBe(false);
+  });
+
   test("resolves an unquoted multi-word display name", async () => {
     // Assistant whose display name has a space; passed as separate argv tokens.
     writeFileSync(

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -56,9 +56,11 @@ mock.module("../lib/guardian-token.js", () => ({
   loadGuardianToken: loadGuardianTokenMock,
 }));
 
-// Stub the token-refresh helper without importing the real client module
-// (it drags in the interactive chat client's dependency graph). Pass-through
-// by default: the stored token is returned as-is.
+// Stub the token-refresh helper. Pass-through by default: the stored token is
+// returned as-is. Capture the real module first so afterAll can restore it;
+// without the restore this mock leaks into client-tui-refresh.test.ts, whose
+// refresh test then receives the pass-through instead of the real refresher.
+const realClient = { ...(await import("../commands/client.js")) };
 const resolveFreshBearerTokenMock = mock(
   async (
     _runtimeUrl: string,
@@ -68,6 +70,7 @@ const resolveFreshBearerTokenMock = mock(
   ) => bearerToken,
 );
 mock.module("../commands/client.js", () => ({
+  ...realClient,
   resolveFreshBearerToken: resolveFreshBearerTokenMock,
 }));
 
@@ -77,6 +80,7 @@ afterAll(() => {
   mock.module("../lib/process.js", () => realProcess);
   mock.module("../lib/drain.js", () => realDrain);
   mock.module("../lib/guardian-token.js", () => realGuardianToken);
+  mock.module("../commands/client.js", () => realClient);
 });
 
 import { sleep } from "../commands/sleep.js";

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -89,7 +89,8 @@ ARGUMENTS:
 OPTIONS:
     --url <url>      Reachable gateway URL to advertise in the bundle
                     (default: the assistant's runtime URL, not loopback)
-    --label <name>   Human label for this pairing (echoed in the output)
+    --label <name>   Human label for this pairing, carried in the bundle and
+                    used as the imported assistant's display name
     --web            Create a browser pairing URL for remote web access
     --web-approve <code>
                     Approve a browser pairing code shown by /assistant/pair
@@ -567,6 +568,9 @@ export async function pair(): Promise<void> {
     assistantId: result.assistantId,
     token: result.token,
     deviceId,
+    // The importer uses the label as the entry's display name when no
+    // explicit name is given at import time.
+    ...(label ? { label } : {}),
     // Carry the refresh credential through when the gateway issued one, so the
     // imported client can renew without re-pairing. Omitted entirely for an
     // access-only (older gateway) response so the bundle stays clean.

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -15,6 +15,7 @@ import { nanoid } from "nanoid";
 // error-correction level off `this`, so a destructured import renders nothing.
 import qrcodeTerminal from "qrcode-terminal";
 
+import { MAX_PAIR_LABEL_LENGTH } from "@vellumai/local-mode";
 import {
   buildRemoteWebPairingUrl,
   normalizePairingBaseUrl,
@@ -90,7 +91,8 @@ OPTIONS:
     --url <url>      Reachable gateway URL to advertise in the bundle
                     (default: the assistant's runtime URL, not loopback)
     --label <name>   Human label for this pairing, carried in the bundle and
-                    used as the imported assistant's display name
+                    used as the imported assistant's display name (1-64
+                    characters after trimming whitespace)
     --web            Create a browser pairing URL for remote web access
     --web-approve <code>
                     Approve a browser pairing code shown by /assistant/pair
@@ -268,7 +270,7 @@ export async function pair(): Promise<void> {
     (a) => a !== "--json" && a !== "--web" && a !== "--qr" && a !== "--app",
   );
 
-  const [label, afterLabel] = extractFlag(args, "--label");
+  const [rawLabel, afterLabel] = extractFlag(args, "--label");
   const [webApproveCode, afterWebApprove] = extractFlag(
     afterLabel,
     "--web-approve",
@@ -310,6 +312,20 @@ export async function pair(): Promise<void> {
   }
   if ((appVariant || appSchemeOverride) && !qrPairing) {
     console.error("Error: --app and --app-scheme only apply to --qr pairing.");
+    process.exit(1);
+  }
+
+  // Enforce the importer's label constraint here: decodePairBundle() trims and
+  // silently drops empty or oversized labels, so an invalid --label would mint
+  // a bundle that never delivers the promised display name.
+  const label = rawLabel?.trim();
+  if (
+    rawLabel !== undefined &&
+    (!label || label.length > MAX_PAIR_LABEL_LENGTH)
+  ) {
+    console.error(
+      `Error: --label must be 1-${MAX_PAIR_LABEL_LENGTH} characters after trimming.`,
+    );
     process.exit(1);
   }
 

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -15,7 +15,10 @@ import { nanoid } from "nanoid";
 // error-correction level off `this`, so a destructured import renders nothing.
 import qrcodeTerminal from "qrcode-terminal";
 
-import { MAX_PAIR_LABEL_LENGTH } from "@vellumai/local-mode";
+import {
+  MAX_PAIR_LABEL_LENGTH,
+  normalizePairLabel,
+} from "@vellumai/local-mode";
 import {
   buildRemoteWebPairingUrl,
   normalizePairingBaseUrl,
@@ -315,14 +318,11 @@ export async function pair(): Promise<void> {
     process.exit(1);
   }
 
-  // Enforce the importer's label constraint here: decodePairBundle() trims and
-  // silently drops empty or oversized labels, so an invalid --label would mint
-  // a bundle that never delivers the promised display name.
-  const label = rawLabel?.trim();
-  if (
-    rawLabel !== undefined &&
-    (!label || label.length > MAX_PAIR_LABEL_LENGTH)
-  ) {
+  // Same normalization as the importer: decodePairBundle() silently drops a
+  // label normalizePairLabel() rejects, so an invalid --label would mint a
+  // bundle that never delivers the promised display name. Fail loud instead.
+  const label = normalizePairLabel(rawLabel);
+  if (rawLabel !== undefined && label === undefined) {
     console.error(
       `Error: --label must be 1-${MAX_PAIR_LABEL_LENGTH} characters after trimming.`,
     );

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -179,6 +179,14 @@ describe("normalizePairLabel", () => {
     expect(normalizePairLabel(null)).toBeUndefined();
     expect(normalizePairLabel(42)).toBeUndefined();
   });
+
+  test("counts code points, not UTF-16 units", () => {
+    const emojiLabel = "😀".repeat(MAX_PAIR_LABEL_LENGTH);
+    expect(normalizePairLabel(emojiLabel)).toBe(emojiLabel);
+    expect(
+      normalizePairLabel("😀".repeat(MAX_PAIR_LABEL_LENGTH + 1)),
+    ).toBeUndefined();
+  });
 });
 
 describe("pairAssistant", () => {

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -9,6 +9,7 @@ import {
   decodePairBundle,
   MAX_PAIR_BUNDLE_LENGTH,
   MAX_PAIR_LABEL_LENGTH,
+  normalizePairLabel,
   pairAssistant,
   type PairBundle,
 } from "../pair";
@@ -157,6 +158,26 @@ describe("decodePairBundle", () => {
       decodePairBundle(encodeBundle({ gatewayUrl: "/relative", token: "t" }))
         .ok,
     ).toBe(false);
+  });
+});
+
+describe("normalizePairLabel", () => {
+  test("returns a valid label trimmed", () => {
+    const longest = "a".repeat(MAX_PAIR_LABEL_LENGTH);
+    expect(normalizePairLabel("Office Mac")).toBe("Office Mac");
+    expect(normalizePairLabel("  Office Mac  ")).toBe("Office Mac");
+    expect(normalizePairLabel(longest)).toBe(longest);
+  });
+
+  test("returns undefined for empty, oversized, or non-string values", () => {
+    expect(normalizePairLabel("")).toBeUndefined();
+    expect(normalizePairLabel("   ")).toBeUndefined();
+    expect(
+      normalizePairLabel("a".repeat(MAX_PAIR_LABEL_LENGTH + 1)),
+    ).toBeUndefined();
+    expect(normalizePairLabel(undefined)).toBeUndefined();
+    expect(normalizePairLabel(null)).toBeUndefined();
+    expect(normalizePairLabel(42)).toBeUndefined();
   });
 });
 

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -8,6 +8,7 @@ import {
   connectImport,
   decodePairBundle,
   MAX_PAIR_BUNDLE_LENGTH,
+  MAX_PAIR_LABEL_LENGTH,
   pairAssistant,
   type PairBundle,
 } from "../pair";
@@ -59,6 +60,7 @@ describe("decodePairBundle", () => {
         refreshToken: "refresh",
         refreshTokenExpiresAt: 1893456000000,
         refreshAfter: "2026-07-01T00:00:00.000Z",
+        label: "Office Mac",
       }),
     );
 
@@ -72,8 +74,31 @@ describe("decodePairBundle", () => {
         refreshToken: "refresh",
         refreshTokenExpiresAt: 1893456000000,
         refreshAfter: "2026-07-01T00:00:00.000Z",
+        label: "Office Mac",
       },
     });
+  });
+
+  test("trims the label and drops an empty, oversized, or non-string one", () => {
+    const decode = (label: unknown): string | undefined => {
+      const result = decodePairBundle(
+        encodeBundle({
+          gatewayUrl: "http://10.0.0.5:7830",
+          token: "tok",
+          label,
+        }),
+      );
+      expect(result.ok).toBe(true);
+      return result.ok ? result.bundle.label : undefined;
+    };
+
+    const longest = "a".repeat(MAX_PAIR_LABEL_LENGTH);
+    expect(decode("  Office Mac  ")).toBe("Office Mac");
+    expect(decode(longest)).toBe(longest);
+    expect(decode("")).toBeUndefined();
+    expect(decode("   ")).toBeUndefined();
+    expect(decode(`${longest}a`)).toBeUndefined();
+    expect(decode(42)).toBeUndefined();
   });
 
   test("drops malformed optional fields instead of failing", () => {
@@ -155,7 +180,7 @@ describe("pairAssistant", () => {
     const entry = (onDisk.assistants as Array<Record<string, unknown>>)[0]!;
     expect(entry).toEqual({
       assistantId: "paired-dev-aaa",
-      name: "paired (10.0.0.5:7830)",
+      name: "Paired assistant",
       runtimeUrl: "http://10.0.0.5:7830",
       cloud: "paired",
       paired: true,
@@ -306,6 +331,40 @@ describe("pairAssistant", () => {
       return;
     }
     expect(result.accessOnly).toBe(true);
+  });
+
+  test("a bundle label becomes the display name without touching the id", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ label: "Office Mac", deviceId: "dev-lbl" }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    // The label never feeds the id slug; only an explicit name does.
+    expect(result.assistantId).toBe("paired-dev-lbl");
+    const entry = (
+      readLockfileFromDisk().assistants as Array<Record<string, unknown>>
+    )[0]!;
+    expect(entry.name).toBe("Office Mac");
+  });
+
+  test("an explicit name wins over the bundle label and drives the id slug", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      bundle: bundle({ label: "Office Mac" }),
+      name: "Desk Box",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).toBe("desk-box");
+    const entry = (
+      readLockfileFromDisk().assistants as Array<Record<string, unknown>>
+    )[0]!;
+    expect(entry.name).toBe("Desk Box");
   });
 
   test("a name is slugified into the id while the entry keeps the raw name", () => {
@@ -514,6 +573,36 @@ describe("connectImport", () => {
       paired: true,
       runtimeUrl: "https://gw.example.com",
     });
+  });
+
+  test("a bundle label names the entry; an oversized one still imports", () => {
+    const labeled = connectImport([lockfilePath], configDir, {
+      bundle: encodeBundle({
+        gatewayUrl: "https://gw.example.com",
+        token: "tok",
+        deviceId: "dev-lbl",
+        label: "Office Mac",
+      }),
+    });
+    expect(labeled.ok).toBe(true);
+
+    const oversized = connectImport([lockfilePath], configDir, {
+      bundle: encodeBundle({
+        gatewayUrl: "https://gw.example.com",
+        token: "tok",
+        deviceId: "dev-big",
+        label: "a".repeat(MAX_PAIR_LABEL_LENGTH + 1),
+      }),
+    });
+    expect(oversized.ok).toBe(true);
+
+    const names = (
+      readLockfileFromDisk().assistants as Array<Record<string, unknown>>
+    ).map((a) => [a.assistantId, a.name]);
+    expect(names).toEqual([
+      ["paired-dev-lbl", "Office Mac"],
+      ["paired-dev-big", "Paired assistant"],
+    ]);
   });
 
   test("a missing, empty, or non-string bundle is a 400", () => {

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -49,7 +49,12 @@ export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireOptions, RetireResult } from "./retire";
 export { unpairAssistant } from "./unpair";
-export { decodePairBundle, pairAssistant, connectImport } from "./pair";
+export {
+  decodePairBundle,
+  pairAssistant,
+  connectImport,
+  MAX_PAIR_LABEL_LENGTH,
+} from "./pair";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";
 export { runWake } from "./wake";

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -54,6 +54,7 @@ export {
   pairAssistant,
   connectImport,
   MAX_PAIR_LABEL_LENGTH,
+  normalizePairLabel,
 } from "./pair";
 export { runSleep } from "./sleep";
 export type { SleepResult } from "./sleep";

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -48,7 +48,9 @@ export const MAX_PAIR_LABEL_LENGTH = 64;
  * than {@link MAX_PAIR_LABEL_LENGTH}.
  */
 export function normalizePairLabel(raw: unknown): string | undefined {
-  if (typeof raw !== "string") return undefined;
+  if (typeof raw !== "string") {
+    return undefined;
+  }
   const label = raw.trim();
   return label && label.length <= MAX_PAIR_LABEL_LENGTH ? label : undefined;
 }

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -42,6 +42,18 @@ export type DecodePairBundleResult =
 export const MAX_PAIR_LABEL_LENGTH = 64;
 
 /**
+ * The single label normalization shared by the producer (`vellum pair
+ * --label`) and the importer ({@link decodePairBundle}): trimmed label when
+ * valid, undefined when absent, non-string, empty after trimming, or longer
+ * than {@link MAX_PAIR_LABEL_LENGTH}.
+ */
+export function normalizePairLabel(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const label = raw.trim();
+  return label && label.length <= MAX_PAIR_LABEL_LENGTH ? label : undefined;
+}
+
+/**
  * Decode and validate a base64 pairing bundle. Total and non-throwing:
  * malformed input yields a typed failure. `gatewayUrl` is persisted as
  * `runtimeUrl` and used to build fetch URLs, so it must be an absolute http(s)
@@ -71,10 +83,6 @@ export function decodePairBundle(encoded: string): DecodePairBundleResult {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return { ok: false, error: "Bundle gatewayUrl is not an http(s) URL" };
   }
-  // Dropped (not a bundle failure) when empty or oversized: the label is
-  // cosmetic, so a bad one degrades to the default name rather than refusing
-  // an otherwise valid pairing.
-  const label = typeof b.label === "string" ? b.label.trim() : "";
   return {
     ok: true,
     bundle: {
@@ -92,7 +100,10 @@ export function decodePairBundle(encoded: string): DecodePairBundleResult {
           : undefined,
       refreshAfter:
         typeof b.refreshAfter === "string" ? b.refreshAfter : undefined,
-      label: label && label.length <= MAX_PAIR_LABEL_LENGTH ? label : undefined,
+      // Dropped (not a bundle failure) when invalid: the label is cosmetic,
+      // so a bad one degrades to the default name rather than refusing an
+      // otherwise valid pairing.
+      label: normalizePairLabel(b.label),
     },
   };
 }

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -52,7 +52,11 @@ export function normalizePairLabel(raw: unknown): string | undefined {
     return undefined;
   }
   const label = raw.trim();
-  return label && label.length <= MAX_PAIR_LABEL_LENGTH ? label : undefined;
+  // Count code points, not UTF-16 units, so emoji-heavy labels get the
+  // documented 64-character budget.
+  return label && [...label].length <= MAX_PAIR_LABEL_LENGTH
+    ? label
+    : undefined;
 }
 
 /**

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -28,11 +28,18 @@ export interface PairBundle {
   refreshToken?: string;
   refreshTokenExpiresAt?: string | number;
   refreshAfter?: string;
+  // Optional display name from `vellum pair --label`, used as the imported
+  // entry's name when the importer doesn't supply one. Never feeds the local
+  // id derivation.
+  label?: string;
 }
 
 export type DecodePairBundleResult =
   | { ok: true; bundle: PairBundle }
   | { ok: false; error: string };
+
+/** Longest bundle label kept on import; longer ones are dropped, not fatal. */
+export const MAX_PAIR_LABEL_LENGTH = 64;
 
 /**
  * Decode and validate a base64 pairing bundle. Total and non-throwing:
@@ -64,6 +71,10 @@ export function decodePairBundle(encoded: string): DecodePairBundleResult {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return { ok: false, error: "Bundle gatewayUrl is not an http(s) URL" };
   }
+  // Dropped (not a bundle failure) when empty or oversized: the label is
+  // cosmetic, so a bad one degrades to the default name rather than refusing
+  // an otherwise valid pairing.
+  const label = typeof b.label === "string" ? b.label.trim() : "";
   return {
     ok: true,
     bundle: {
@@ -81,6 +92,7 @@ export function decodePairBundle(encoded: string): DecodePairBundleResult {
           : undefined,
       refreshAfter:
         typeof b.refreshAfter === "string" ? b.refreshAfter : undefined,
+      label: label && label.length <= MAX_PAIR_LABEL_LENGTH ? label : undefined,
     },
   };
 }
@@ -148,9 +160,8 @@ export function pairAssistant(
   configDir: string,
   { bundle, name }: PairOptions,
 ): PairResult {
-  let gatewayHost: string;
   try {
-    gatewayHost = new URL(bundle.gatewayUrl).host;
+    new URL(bundle.gatewayUrl);
   } catch {
     return {
       ok: false,
@@ -251,7 +262,9 @@ export function pairAssistant(
     lockfilePaths,
     {
       assistantId: localId,
-      name: name ?? `paired (${gatewayHost})`,
+      // Host-free display name: renderers append their own `Paired · <host>`
+      // suffix (pairedHostLabel), so the host must not appear here too.
+      name: name ?? bundle.label ?? "Paired assistant",
       runtimeUrl: bundle.gatewayUrl,
       // Paired entries are reached by bearer token at the remote runtimeUrl
       // (a non-"vellum" cloud selects the bearer-token auth path in client.ts).


### PR DESCRIPTION
## Summary
- Pair bundles now carry an optional `label` (from `vellum pair --label`), used as the imported entry's display name
- Unnamed, unlabeled imports default to "Paired assistant" instead of `paired (<host>)`; the host now appears exactly once, via the renderers' `Paired · <host>` suffix
- Old bundles without the field remain valid; entry ids stable across re-import

Part of plan: pairing-qa-followups.md (PR 2 of 5)