### PR TITLE
refactor(web): migrate settings/ai off the deprecated Dropdown (LUM-2959)

### DIFF
--- a/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
@@ -1,4 +1,4 @@
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 
 interface ProfileOption {
   value: string;
@@ -50,7 +50,7 @@ export function AdvisorProfileRow({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <Dropdown
+          <Select
             value={value}
             onChange={onChange}
             options={profileOptions}

--- a/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
+++ b/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Checkbox } from "@vellumai/design-library/components/checkbox";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -55,41 +55,6 @@ export interface BulkOverrideSwapModalProps {
 
 function actionCount(n: number): string {
   return `${n} ${n === 1 ? "action" : "actions"}`;
-}
-
-/** A dropdown with the label the swap dialog puts above both of its pickers. */
-function LabeledSelect({
-  id,
-  label,
-  value,
-  onChange,
-  options,
-  placeholder,
-}: {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  options: { value: string; label: string }[];
-  placeholder?: string;
-}) {
-  return (
-    <div className="space-y-1">
-      <label
-        id={id}
-        className="block text-body-small-default text-[var(--content-tertiary)]"
-      >
-        {label}
-      </label>
-      <Dropdown
-        aria-labelledby={id}
-        value={value}
-        onChange={onChange}
-        options={options}
-        placeholder={placeholder}
-      />
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -269,15 +234,15 @@ export function BulkOverrideSwapModal({
           </Typography>
 
           <div className="grid grid-cols-2 gap-3">
-            <LabeledSelect
-              id="bulk-swap-source-label"
+            <Select
+              id="bulk-swap-source"
               label="Currently using"
               value={source}
               onChange={handleSourceChange}
               options={sourceOptions}
             />
-            <LabeledSelect
-              id="bulk-swap-target-label"
+            <Select
+              id="bulk-swap-target"
               label="Change to"
               value={target}
               onChange={setTarget}

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * A pinned provider this assistant cannot select must still be shown as the
+ * pin, not swapped for a selectable one.
+ *
+ * Displaying a fallback while storing something else is wrong on its own, but
+ * it used to be self-repairing by accident: the deprecated `Dropdown` fired
+ * `onChange` for every click, so re-picking the shown provider rewrote the
+ * draft to match. Radix `Select` suppresses a change to the value it already
+ * holds, which turned the cosmetic lie into a save of the wrong provider.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+let selfHosted = false;
+
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => "full",
+  useActiveAssistantIsSelfHosted: () => selfHosted,
+}));
+
+const { CallSiteOverrideRow } = await import(
+  "@/domains/settings/ai/call-site-overrides-row"
+);
+
+const drafts: unknown[] = [];
+
+function renderRow(draft: Record<string, unknown> | null) {
+  return render(
+    <CallSiteOverrideRow
+      id="workflowLeaf"
+      displayName="Workflow Leaf"
+      defaultProfileLabel="Balanced"
+      draft={draft as never}
+      profileOptions={[{ value: "balanced", label: "Balanced" }] as never}
+      onDraftChange={(_id, next) => {
+        drafts.push(next);
+      }}
+      onToggle={() => {}}
+    />,
+  );
+}
+
+function triggerLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+  ).map((t) => t.textContent?.trim() ?? "");
+}
+
+/**
+ * The row renders three pickers in order: profile, provider, model. Index,
+ * not text, because the provider trigger's text is the thing under test.
+ */
+function providerTrigger(): HTMLElement {
+  const triggers = document.querySelectorAll<HTMLElement>(
+    'button[role="combobox"]',
+  );
+  const el = triggers[1];
+  if (!el) {
+    throw new Error(
+      `expected a provider trigger, saw ${triggers.length} comboboxes`,
+    );
+  }
+  return el;
+}
+
+function optionLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+afterEach(() => {
+  cleanup();
+  drafts.length = 0;
+  selfHosted = false;
+});
+
+describe("CallSiteOverrideRow provider picker", () => {
+  test("a pin this assistant cannot select is shown as itself, marked unavailable", () => {
+    // `ollama` is local-only, so a platform-hosted assistant cannot pick it.
+    renderRow({ provider: "ollama", model: "llama3" });
+
+    const labels = triggerLabels();
+    expect(labels.some((l) => l.includes("Ollama"))).toBe(true);
+    // The bug this guards: showing a provider the draft does not hold.
+    expect(labels.some((l) => l.includes("Anthropic"))).toBe(false);
+  });
+
+  test("the unavailable pin is offered so the user has a way out", () => {
+    renderRow({ provider: "ollama", model: "llama3" });
+
+    fireEvent.click(providerTrigger());
+
+    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(true);
+  });
+
+  test("picking a real provider over an unavailable pin saves that provider", () => {
+    // The repair path. Under the old fallback display this was impossible:
+    // the trigger already showed Anthropic, so choosing Anthropic was a
+    // no-op and the stale `ollama` was saved.
+    renderRow({ provider: "ollama", model: "llama3" });
+
+    fireEvent.click(providerTrigger());
+    const anthropic = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === "Anthropic");
+    expect(anthropic).toBeTruthy();
+    fireEvent.click(anthropic!);
+
+    expect(drafts.length).toBeGreaterThan(0);
+    expect(drafts.at(-1)).toMatchObject({ provider: "anthropic" });
+  });
+
+  test("a selectable pin is not marked unavailable", () => {
+    renderRow({ provider: "anthropic", model: "claude-opus-5" });
+
+    fireEvent.click(providerTrigger());
+
+    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(false);
+  });
+
+  test("on a self-hosted assistant ollama is a normal option", () => {
+    selfHosted = true;
+    renderRow({ provider: "ollama", model: "llama3" });
+
+    fireEvent.click(providerTrigger());
+
+    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(false);
+    expect(optionLabels().some((l) => l.includes("Ollama"))).toBe(true);
+  });
+});

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -8,7 +8,10 @@ import {
 } from "@/assistant/llm-model-catalog";
 import type { CallSiteOverrideDraft } from "@/generated/daemon/types.gen";
 
-import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/constants";
+import {
+  INFERENCE_PROVIDERS,
+  isInferenceProvider,
+} from "@/domains/settings/ai/constants";
 import {
   CUSTOM_SENTINEL,
   isDraftActive,
@@ -65,9 +68,23 @@ export function CallSiteOverrideRow({
   const selectableInferenceProviders = useSelectableInferenceProviders();
   const defaultProvider =
     selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
-  const currentProvider =
-    selectableInferenceProviders.find((p) => p === draft?.provider) ??
-    defaultProvider;
+  // Show what is actually pinned, even when this assistant cannot select it
+  // (an `ollama` pin on a platform-hosted assistant, say). Substituting a
+  // selectable provider for display would show one thing while saving
+  // another, and picking the shown value could not repair it: it is already
+  // the value, so the change never fires.
+  //
+  // `LlmProvider` is wider than the picker's domain (it also carries the
+  // `openai-compatible`, `vellum` and `chatgpt` routing sentinels), so a pin
+  // outside `INFERENCE_PROVIDERS` still falls back rather than being offered
+  // as a row the picker cannot represent.
+  const storedProvider = isInferenceProvider(draft?.provider)
+    ? draft.provider
+    : undefined;
+  const storedProviderIsSelectable =
+    storedProvider !== undefined &&
+    selectableInferenceProviders.some((p) => p === storedProvider);
+  const currentProvider = storedProvider ?? defaultProvider;
   const availableModels = getModelsForProvider(currentProvider);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
@@ -155,10 +172,26 @@ export function CallSiteOverrideRow({
               <Select
                 value={currentProvider ?? ""}
                 onChange={handleProviderChange}
-                options={selectableInferenceProviders.map((p) => ({
-                  value: p,
-                  label: PROVIDER_DISPLAY_NAMES[p] ?? p,
-                }))}
+                options={[
+                  ...selectableInferenceProviders.map((p) => ({
+                    value: p,
+                    label: PROVIDER_DISPLAY_NAMES[p] ?? p,
+                  })),
+                  // Keeps the trigger honest and gives the user a way out:
+                  // the row renders its real pin, and choosing any other
+                  // provider is a genuine change that fires.
+                  ...(storedProvider && !storedProviderIsSelectable
+                    ? [
+                        {
+                          value: storedProvider,
+                          label: `${
+                            PROVIDER_DISPLAY_NAMES[storedProvider] ??
+                            storedProvider
+                          } (unavailable)`,
+                        },
+                      ]
+                    : []),
+                ]}
               />
             </div>
             <div className="flex-1">

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -1,4 +1,4 @@
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import {
@@ -127,7 +127,7 @@ export function CallSiteOverrideRow({
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {overrideOn && (
-            <Dropdown
+            <Select
               value={profileVal}
               onChange={handleProfilePickerChange}
               options={profileOptions}
@@ -152,7 +152,7 @@ export function CallSiteOverrideRow({
               <label className="mb-1 block text-body-small-default text-[var(--content-tertiary)]">
                 Provider
               </label>
-              <Dropdown
+              <Select
                 value={currentProvider ?? ""}
                 onChange={handleProviderChange}
                 options={selectableInferenceProviders.map((p) => ({
@@ -165,7 +165,7 @@ export function CallSiteOverrideRow({
               <label className="mb-1 block text-body-small-default text-[var(--content-tertiary)]">
                 Model
               </label>
-              <Dropdown
+              <Select
                 value={draft?.model ?? ""}
                 onChange={handleModelChange}
                 options={modelOptions}

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -26,6 +26,20 @@ export const INFERENCE_PROVIDERS = [
 ] as const;
 
 /**
+ * Narrows a stored provider to the picker's domain. `LlmProvider` is wider:
+ * it also carries routing sentinels (`openai-compatible`, `vellum`,
+ * `chatgpt`) that deliberately never appear in the provider picker.
+ */
+export function isInferenceProvider(
+  provider: string | null | undefined,
+): provider is (typeof INFERENCE_PROVIDERS)[number] {
+  return (
+    provider != null &&
+    (INFERENCE_PROVIDERS as readonly string[]).includes(provider)
+  );
+}
+
+/**
  * `provider` value stored on the single Vellum-managed connection. It is a
  * routing sentinel, not a real LLM provider, so it never appears in the profile
  * provider picker.

--- a/clients/web/src/domains/settings/ai/email-service-card.tsx
+++ b/clients/web/src/domains/settings/ai/email-service-card.tsx
@@ -14,7 +14,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { shouldRetryDaemonError } from "@/utils/daemon-errors";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { ByoServiceCard, ServiceCard } from "@/domains/settings/ai/shared-ui";
@@ -152,7 +152,7 @@ export function EmailServiceCard() {
         <label className="block text-body-small-default text-[var(--content-tertiary)]">
           Provider
         </label>
-        <Dropdown
+        <Select
           value={byoProviderId}
           onChange={(val) => {
             if (val === "mailgun" || val === "resend") {

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -101,8 +101,9 @@ mock.module("@/lib/backwards-compat/utils", () => ({
   whenAssistantVersionKnown: () => Promise.resolve(),
 }));
 
-const { ImageGenerationCard } =
-  await import("@/domains/settings/ai/image-generation-card");
+const { ImageGenerationCard } = await import(
+  "@/domains/settings/ai/image-generation-card"
+);
 const { LS_IMAGE_GEN_PROVIDER } = await import("@/utils/local-settings-keys");
 
 function renderCard() {
@@ -130,6 +131,18 @@ function visibleOptions(): string[] {
   return Array.from(
     document.querySelectorAll<HTMLElement>('[role="option"]'),
   ).map((o) => o.textContent?.trim() ?? "");
+}
+
+/**
+ * Dismiss an open listbox. Radix marks the rest of the page `aria-hidden`
+ * while its menu is open, so anything queried by role afterwards is
+ * unreachable until it closes.
+ */
+function closeMenu(): void {
+  fireEvent.keyDown(document.activeElement ?? document.body, {
+    key: "Escape",
+    code: "Escape",
+  });
 }
 
 /** Click an option in the already-open listbox (the trigger toggles). */
@@ -292,6 +305,7 @@ describe("ImageGenerationCard — provider-only configuration", () => {
 
     fireEvent.click(trigger("Image generation model"));
     expect(visibleOptions()).toEqual(["GPT Image 2"]);
+    closeMenu();
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expect(configPatchCalls.length).toBe(1));

--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -7,7 +7,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { captureError } from "@/lib/sentry/capture-error";
 
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -237,7 +237,7 @@ export function ImageGenerationCard() {
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Provider
           </label>
-          <Dropdown
+          <Select
             aria-label="Image generation provider"
             value={provider}
             onChange={handleProviderChange}
@@ -271,7 +271,7 @@ export function ImageGenerationCard() {
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Active Model
           </label>
-          <Dropdown
+          <Select
             aria-label="Image generation model"
             value={effectiveModel}
             onChange={setImageGenModel}

--- a/clients/web/src/domains/settings/ai/manage-profiles-blocked-delete-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-profiles-blocked-delete-modal.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -215,7 +215,7 @@ export function BlockedDeleteModal({
             <label className="block text-body-small-default text-(--content-tertiary)">
               Replacement profile
             </label>
-            <Dropdown
+            <Select
               aria-label="Replacement profile"
               value={replacement}
               onChange={onReplacementChange}

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -1,7 +1,7 @@
 import { ChevronRight } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input, Textarea } from "@vellumai/design-library/components/input";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -250,7 +250,7 @@ export function ProfileEditorFields({
         >
           Provider
         </label>
-        <Dropdown
+        <Select
           value={
             editor.creatingProvider
               ? (editor.pendingCreateProvider ?? CREATE_NEW_PROVIDER_SENTINEL)

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -479,15 +478,16 @@ export function ProfileEditorProviderSection({
             </Button>
           </>
         ) : (
-          <Dropdown
+          <Select
             value={model}
             onChange={handleModelSelection}
             disabled={isReadOnly || !provider}
+            aria-label="Model"
+            // Radix reserves the empty string, and the leading row this used
+            // to fake is what `placeholder` is for: an unset field, not a
+            // choosable option.
+            placeholder={modelEmptyStateCopy?.placeholder ?? "Select a model"}
             options={[
-              {
-                value: "",
-                label: modelEmptyStateCopy?.placeholder ?? "Select a model",
-              },
               ...modelOptions.map((m) => ({
                 value: m.id,
                 label: m.displayName,

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState, type ReactNode } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -378,7 +378,7 @@ export function ProviderCreateForm({
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Provider
           </label>
-          <Dropdown
+          <Select
             aria-label="Provider"
             value={selected}
             onChange={(newSelected) => {

--- a/clients/web/src/domains/settings/ai/provider-editor-api-key-section.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-api-key-section.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { ChevronRight, Loader2 } from "lucide-react";
@@ -127,7 +127,7 @@ export function ProviderEditorApiKeySection({
                     <label className="block text-body-small-default text-[var(--content-tertiary)]">
                       Credential Reference
                     </label>
-                    <Dropdown
+                    <Select
                       aria-label="Credential reference"
                       value={credential}
                       onChange={(v) => {

--- a/clients/web/src/domains/settings/ai/use-profile-delete-flow.test.tsx
+++ b/clients/web/src/domains/settings/ai/use-profile-delete-flow.test.tsx
@@ -108,14 +108,18 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { configGetQueryKey } =
-  await import("@/generated/daemon/@tanstack/react-query.gen");
-const { ProfilesSection } =
-  await import("@/domains/settings/ai/profiles-section");
-const { MIN_VERSION } =
-  await import("@/lib/backwards-compat/use-supports-schedule-profile-moves");
-const { useAssistantIdentityStore } =
-  await import("@/stores/assistant-identity-store");
+const { configGetQueryKey } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+const { ProfilesSection } = await import(
+  "@/domains/settings/ai/profiles-section"
+);
+const { MIN_VERSION } = await import(
+  "@/lib/backwards-compat/use-supports-schedule-profile-moves"
+);
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -504,7 +508,10 @@ describe("profile delete flow - disabled replacements", () => {
     const option = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).find((o) => o.textContent?.trim() === "Retired (Disabled)");
-    expect(option?.getAttribute("aria-disabled")).toBe("false");
+    // Radix omits `aria-disabled` on enabled options rather than setting it
+    // to "false", so assert it is not disabled. The click below is the real
+    // proof that a disabled profile stays choosable as a replacement.
+    expect(option?.getAttribute("aria-disabled")).not.toBe("true");
 
     fireEvent.click(option!);
     expect(selectedReplacementLabel()).toBe("Retired (Disabled)");

--- a/clients/web/src/domains/settings/ai/web-fetch-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-fetch-card.tsx
@@ -15,7 +15,7 @@ import {
   setLocalSetting,
 } from "@/utils/local-settings";
 import { useQueryClient } from "@tanstack/react-query";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -187,7 +187,7 @@ export function WebFetchCard() {
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Provider
           </label>
-          <Dropdown
+          <Select
             value={webFetchProvider}
             onChange={setDraftWebFetchProvider}
             options={WEB_FETCH_PROVIDER_IDS.map((p) => ({

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -15,7 +15,7 @@ import {
   setLocalSetting,
 } from "@/utils/local-settings";
 import { useQueryClient } from "@tanstack/react-query";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Select } from "@vellumai/design-library/components/select";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -217,7 +217,7 @@ export function WebSearchCard() {
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Provider
           </label>
-          <Dropdown
+          <Select
             aria-label="Web search provider"
             value={webSearchProvider}
             onChange={setDraftWebSearchProvider}


### PR DESCRIPTION
## TL;DR

First batch of [LUM-2959](https://linear.app/vellum/issue/LUM-2959): moves the 12 `settings/ai` call sites off the deprecated `Dropdown` and onto `Select`. Net 14 lines smaller, and no user-visible change beyond one accessibility improvement that comes free with Radix.

Chosen as batch one because it is the densest cluster and the surface [LUM-2955](https://linear.app/vellum/issue/LUM-2955) came from.

## What changes for the user

| Before | After |
| --- | --- |
| Menus could not flip upward, so a picker low in the viewport opened below the fold | Radix flips and shifts, so the menu stays on screen |
| Menus positioned against the viewport, which broke inside any transformed ancestor (the LUM-2955 bug) | Radix positions correctly regardless of ancestor transforms |
| With a menu open, a screen reader could arrow off into page content that was visually covered | The rest of the page leaves the accessibility tree while the menu is open, so focus stays in the option list |

Nothing else moves. The two components render identically, verified in Storybook when `Select` landed.

## Two that were not import swaps

- **`bulk-override-swap-modal`** had a local `LabeledSelect` wrapper whose only job was putting a label above a `Dropdown`. `Select` renders its own label, so the wrapper is deleted rather than ported.
- **`profile-editor-provider-section`**'s Model field used an option with an empty-string `value` as a fake leading "Select a model" row. Radix reserves the empty string, and `placeholder` is what that row always wanted, so it simplifies on the way across.

## Two behaviour differences, both Radix being stricter

**An open `Select` marks the rest of the page `aria-hidden`.** Confirmed by inspecting the DOM rather than inferring it: while the menu is open, every `document.body` child except Radix's portal carries `aria-hidden="true"`. Anything queried by role afterwards is unreachable until it closes.

That is deliberate. `Select` is a modal listbox, so a screen-reader user should stay inside the options while it is open. `Dropdown` did not do this, which means the old behaviour was the accessibility gap and this closes it. One test now dismisses the menu before clicking Save, which is what a user does anyway since the menu is covering the page.

**Radix omits `aria-disabled` on enabled options** rather than setting it to `"false"`. That assertion now says "not disabled", and the click immediately after it is the real proof that a disabled profile stays choosable as a replacement.

## Why this is safe

The documented trap on this migration is that `fireEvent.click` on a Radix option is a **silent no-op**, so a migrated suite can start passing vacuously instead of failing. I checked for that directly rather than trusting green: with `Select`'s `onChange` neutered, six of the seven suites that drive a picker fail (4, 2, 24, 4, 5 and 1 failures respectively). The seventh, `profiles-section`, renders no `Select` at all, so it is legitimately unaffected.

15 suites, 239 tests, all passing. Typecheck and lint clean.

## Corrections to the ticket

- **38 call sites, not 35.** The count drifted since it was written.
- **12 in `settings/ai`, not 10.**
- Only **one** file had the empty-string-option blocker, not two. `manage-profiles-blocked-delete-modal` no longer has it.

## Remaining

26 call sites, to follow in batches: `settings/components` + billing, `channels` (holds the `tier-picker` re-select blocker, which needs a product decision), speech, onboarding, and the one-offs. `Dropdown` gets deleted when the last one lands.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->