### PR TITLE
fix(security): stop skill history executing repo-controlled diff helpers

### DIFF
--- a/assistant/src/skills/skill-history.test.ts
+++ b/assistant/src/skills/skill-history.test.ts
@@ -212,6 +212,32 @@ describe("getSkillHistory", () => {
     expect(history.skillId).toBe("never-committed");
   });
 
+  test("a repository-controlled textconv driver is never executed", async () => {
+    // `.gitattributes` selects a diff driver and git config names the program
+    // for it. Both are writable through ordinary workspace paths, so rendering
+    // a patch must not hand control to them (ATL-1238).
+    write("skills/alpha/SKILL.md", "# Alpha\n");
+    write(".gitattributes", "*.md diff=evil\n");
+    commit("initial");
+    write("skills/alpha/SKILL.md", "# Alpha\n\nEdited.\n");
+    commit("auto-commit: heartbeat safety net (1 file)");
+
+    const sentinel = join(repoDir, "textconv-executed");
+    git("config", "diff.evil.textconv", `sh -c "touch ${sentinel}; cat"`);
+
+    const history = await getSkillHistory("alpha");
+
+    // The driver stays unrun...
+    expect(existsSync(sentinel)).toBe(false);
+    // ...and the diff still renders, so the hardening did not cost the feature.
+    expect(history.revisions[0]!.diff).toContain("Edited.");
+  });
+
+  // `--no-ext-diff` guards the sibling vector, `diff.<driver>.command`, but has
+  // no test here: an external diff driver does not fire in this environment
+  // even without the flag, so an assertion about it would pass whether or not
+  // the guard were present.
+
   test("a traversal-shaped id is rejected before it reaches a pathspec", async () => {
     write("skills/alpha/SKILL.md", "# Alpha\n");
     commit("initial");

--- a/assistant/src/skills/skill-history.ts
+++ b/assistant/src/skills/skill-history.ts
@@ -84,6 +84,38 @@ export interface SkillHistory {
 const FIELD = "\u001f";
 
 /**
+ * Diff options that must accompany EVERY git read here.
+ *
+ * `git show` and `git diff` honour repository-controlled helpers by default:
+ * a `.gitattributes` entry can select a diff driver, and a `diff.<driver>.
+ * textconv` or `diff.<driver>.command` setting names a program git then
+ * EXECUTES while rendering the patch. Workspace files and git metadata are
+ * writable by model and tool paths, so without these flags merely viewing a
+ * skill's history would run whatever the workspace asked for, inside the
+ * daemon, on behalf of any caller holding `settings.read` (ATL-1238).
+ *
+ * Applied through `readGit` rather than at each call site, so a future reader
+ * cannot add a git invocation that quietly omits them.
+ */
+const DIFF_HARDENING = ["--no-textconv", "--no-ext-diff"];
+
+/**
+ * Run one hardened, non-initializing git read. The subcommand is passed
+ * separately because the hardening flags have to follow it.
+ */
+async function readGit(
+  git: ReturnType<typeof getWorkspaceGitService>,
+  subcommand: "log" | "show",
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  return git.runReadOnlyGitWithoutInit([
+    subcommand,
+    ...DIFF_HARDENING,
+    ...args,
+  ]);
+}
+
+/**
  * Read a skill's recent revisions from workspace git.
  *
  * Returns an empty history rather than throwing when git is unavailable, the
@@ -127,8 +159,7 @@ export async function getSkillHistory(
 
   let shas: Array<{ sha: string; changedAt: string }>;
   try {
-    const { stdout } = await git.runReadOnlyGitWithoutInit([
-      "log",
+    const { stdout } = await readGit(git, "log", [
       // Committer date, not author date. `git log` orders by commit date, so
       // reporting the author date could label the list newest-first while its
       // displayed dates disagree with that order.
@@ -163,15 +194,8 @@ export async function getSkillHistory(
     let files: string[];
     try {
       const [diffResult, nameResult] = await Promise.all([
-        git.runReadOnlyGitWithoutInit([
-          "show",
-          "--format=",
-          sha,
-          "--",
-          ...pathspec,
-        ]),
-        git.runReadOnlyGitWithoutInit([
-          "show",
+        readGit(git, "show", ["--format=", sha, "--", ...pathspec]),
+        readGit(git, "show", [
           "--format=",
           "--name-only",
           sha,
@@ -214,8 +238,7 @@ async function hasCompactedHistory(
   git: ReturnType<typeof getWorkspaceGitService>,
 ): Promise<boolean> {
   try {
-    const { stdout } = await git.runReadOnlyGitWithoutInit([
-      "log",
+    const { stdout } = await readGit(git, "log", [
       "--format=%s",
       "--max-count=1",
       "--grep=Compacted workspace history",


### PR DESCRIPTION
Fixes ATL-1238 (High).

## TL;DR

`GET /skills/:id/history` could execute arbitrary commands named by the workspace repository. Every git read in the history module now runs with `--no-textconv --no-ext-diff`.

## The vector

`git show` honours repository-controlled diff helpers by default:

1. A `.gitattributes` entry selects a diff driver for a path: `*.md diff=evil`.
2. Git config defines the driver: `diff.evil.textconv = <command>`.
3. Rendering a patch for a matching file **executes that command**.

Both inputs sit in the workspace, which model and tool write paths can reach. So viewing a skill's history in the UI ran whatever the workspace asked for, in the daemon process, on behalf of any caller holding `settings.read` — a read-only-looking GET as a command execution sink.

Reproduced before fixing, on a scratch repo with a driver whose textconv was `sh -c "echo PWNED >&2; cat"`:

| Invocation | Times the command ran |
|---|---|
| `git show --format= HEAD -- skills/t/` | 2 |
| `git show --no-textconv --no-ext-diff --format= HEAD -- skills/t/` | 0 |

## The fix

Both flags on every git read in `skill-history.ts`, applied through a single `readGit(git, subcommand, args)` helper that all four call sites go through.

Putting them in a helper rather than repeating them per call is the point: the failure mode this class of bug has is a fifth invocation added later that omits the flag, and a per-call-site convention does not survive that. `git log` accepts both flags as well as `git show`, so one helper covers every read here.

## Why it's safe

- **No behaviour change for the feature.** The regression test asserts the diff still renders with the flags on. `--no-textconv` only suppresses running a converter before diffing; `--no-ext-diff` only suppresses handing the diff to an external program. Neither is wanted for a programmatic read.
- **No API, route, schema, or client change.** `openapi.yaml --check` is clean.
- **Surrounding suites unaffected:** 93 `workspace-git-service` tests, 5 route tests, 10 history tests.

## Test coverage, and its limit

The added test plants a real `.gitattributes` driver plus a textconv command that would `touch` a sentinel file, then asserts the sentinel is absent **and** the diff still contains the expected content. Sensitivity-checked: with `DIFF_HARDENING` emptied, it fails.

`--no-ext-diff` guards the sibling `diff.<driver>.command` vector and is **deliberately untested**. I wrote a test for it, found it passed with the flag removed, and confirmed with a standalone repo that an external diff driver does not fire in this environment at all — so any assertion about it would pass whether or not the guard existed. The flag is correct hardening and the ticket asks for it, but I would rather state that it is unverified than ship a test that looks like coverage and is not.

## Not addressed here

The ticket's broader ask, that "git execution should be hardened against repository-controlled helpers where possible," is wider than this endpoint. Other repo-config-driven execution hooks (`core.fsmonitor`, filter drivers on checkout paths) reach different call sites and deserve their own pass rather than being bundled into a targeted fix for the reported sink.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->