### PR TITLE
fix(assistant): keep untrusted plugins out of the auto-upgrade sweep

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24314,8 +24314,9 @@ paths:
         non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or
         the target (`theirs`), or writing git conflict markers into the file and reporting them in
         `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time
-        baseline cannot be reconstructed returns 409. Mirrors the CLI''s `assistant plugins upgrade <name> [--strategy
-        <s>]`.'
+        baseline cannot be reconstructed returns 409. Pass `marketplaceOnly` to refuse the untrusted direct path
+        outright (409), which is what the unattended auto-update sweep does. Mirrors the CLI''s `assistant plugins
+        upgrade <name> [--strategy <s>]`.'
       tags:
         - plugins
       parameters:
@@ -24345,6 +24346,13 @@ paths:
                     - theirs
                     - overwrite
                     - assistant
+                marketplaceOnly:
+                  description:
+                    Refuse the upgrade (409) when the marketplace does not claim this plugin, instead of advancing it to
+                    whatever its recorded GitHub ref now resolves to. Set by unattended callers such as the automatic
+                    update sweep, for which running code no curator reviewed is never an acceptable outcome. Defaults to
+                    false.
+                  type: boolean
       responses:
         "200":
           description: Successful response
@@ -24444,8 +24452,9 @@ paths:
           description: No copy of the plugin is installed, or its source resolves to nothing.
         "409":
           description:
-            The install has neither a marketplace entry nor a recorded GitHub source to advance to, or a merge strategy
-            was requested whose install-time baseline cannot be reconstructed.
+            The install has neither a marketplace entry nor a recorded GitHub source to advance to, a `marketplaceOnly`
+            upgrade was requested for an install the marketplace does not claim, or a merge strategy was requested whose
+            install-time baseline cannot be reconstructed.
         "503":
           description: The plugin source (GitHub) was temporarily unavailable; the upgrade is retryable.
   /v1/plugins/{name}/versions:

--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -32,6 +32,7 @@ import { computeFingerprint } from "../plugin-fingerprint.js";
 import { PluginNotInstalledError } from "../uninstall-plugin.js";
 import {
   PluginMergeBaselineError,
+  PluginNotCuratedError,
   PluginNotUpgradableError,
   upgradePlugin,
 } from "../upgrade-plugin.js";
@@ -572,6 +573,44 @@ describe("upgradePlugin — direct GitHub-URL installs", () => {
     expect(meta.source.ref).toBe("main");
     // AND the drift was resolved without cloning first (ls-remote, then fetch)
     expect(calls[0]?.[0]).toBe("ls-remote");
+  });
+
+  test("marketplaceOnly refuses the direct path instead of following the ref", async () => {
+    // GIVEN a direct install tracking `main` at SHA_A, absent from the
+    // marketplace, whose branch has advanced to SHA_B
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: "main" });
+    const fetch = makeFetch({ manifest: undefined });
+    const calls: string[][] = [];
+    const runGit = directGitRunner({ main: SHA_B }, SHA_B, { calls });
+
+    // WHEN a caller that only accepts a curated pin asks for the upgrade
+    const upgrade = upgradePlugin(
+      { name: "level-up", marketplaceOnly: true },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN it is refused, and the mutable ref is never even resolved
+    await expect(upgrade).rejects.toThrow(PluginNotCuratedError);
+    expect(calls).toEqual([]);
+    // AND the install stays exactly where it was
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_A);
+  });
+
+  test("marketplaceOnly still upgrades a plugin the catalog claims", async () => {
+    // GIVEN an install the marketplace pins at SHA_B
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = fakeGitRunner(SHA_B);
+
+    // WHEN the same curated-only caller asks for the upgrade
+    const result = await upgradePlugin(
+      { name: "level-up", marketplaceOnly: true },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the flag is inert: the curated pin is taken as usual
+    expect(result.outcome).toBe("upgraded");
+    expect(result.toCommit).toBe(SHA_B);
   });
 
   test("is a no-op when the recorded branch still points at the installed commit", async () => {

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -17,6 +17,11 @@
  * verbatim, with no curated adapter overlay, exactly as the original untrusted
  * install was (see {@link directUpgrade}).
  *
+ * Because that target is a mutable ref, taking it means running whatever
+ * upstream pushed since, which is a choice only a human should make. A caller
+ * with nobody in the loop passes `marketplaceOnly` to rule it out: the direct
+ * path then throws {@link PluginNotCuratedError} instead of advancing.
+ *
  * This is deliberately a distinct operation from install: `install` is
  * first-time materialization (and errors on an existing install unless
  * `--force` is passed), whereas `upgrade` moves an existing install forward.
@@ -114,6 +119,20 @@ export interface UpgradePluginOptions {
    * {@link DEFAULT_PLUGIN_UPGRADE_STRATEGY}.
    */
   readonly strategy?: PluginUpgradeStrategy;
+  /**
+   * Refuse to advance an install the marketplace does not claim, instead of
+   * falling back to {@link directUpgrade}.
+   *
+   * A direct install's upgrade target is a mutable upstream ref, so taking it
+   * means fetching and executing whatever was pushed since. Callers with
+   * nobody in the loop (the unattended auto-update sweep) set this so that
+   * outcome is impossible for them, and it is enforced here rather than by the
+   * caller's own pre-check: the catalog is fetched again inside this call, so
+   * an entry that disappears in between would otherwise silently reroute a
+   * curated upgrade into a direct one. Defaults to false, which is what an
+   * interactive `assistant plugins upgrade` wants.
+   */
+  readonly marketplaceOnly?: boolean;
 }
 
 /** Dependencies injected by the caller. */
@@ -209,6 +228,23 @@ export class PluginNotUpgradableError extends Error {
 }
 
 /**
+ * A `marketplaceOnly` upgrade was requested for an install the marketplace does
+ * not claim, so the only revision available is a mutable upstream ref the
+ * caller refuses to take.
+ *
+ * Distinct from {@link PluginNotUpgradableError}: the install *can* be
+ * upgraded, just not without a human choosing to accept unreviewed code.
+ */
+export class PluginNotCuratedError extends Error {
+  constructor(readonly pluginName: string) {
+    super(
+      `Plugin "${pluginName}" cannot be upgraded automatically: it has no marketplace entry, so its only upgrade target is a mutable upstream ref. Run 'assistant plugins upgrade ${pluginName}' to move it deliberately.`,
+    );
+    this.name = "PluginNotCuratedError";
+  }
+}
+
+/**
  * A merge strategy (`ours`/`theirs`) was requested but the install-time
  * baseline needed for a three-way merge cannot be reconstructed.
  */
@@ -244,6 +280,8 @@ function pluginTarget(name: string, deps: UpgradePluginDeps): string {
  * Throws {@link PluginNotInstalledError} when no copy is installed,
  * {@link PluginNotUpgradableError} when the install is neither in the
  * marketplace nor carries a recorded GitHub source to advance,
+ * {@link PluginNotCuratedError} when `marketplaceOnly` was requested for an
+ * install the marketplace does not claim,
  * {@link PluginMergeBaselineError} when a merge strategy is requested but the
  * install-time baseline cannot be reconstructed,
  * {@link PluginSourceUnavailableError} when the marketplace catalog or the
@@ -301,6 +339,10 @@ export async function upgradePlugin(
           name,
           "it has no marketplace entry and no installed copy to upgrade",
         );
+      }
+      if (opts.marketplaceOnly) {
+        // The caller only accepts a curated pin, and this install has none.
+        throw new PluginNotCuratedError(name);
       }
       return directUpgrade({ name, local, dryRun, strategy }, deps);
     }

--- a/assistant/src/config/schemas/plugin-updates.ts
+++ b/assistant/src/config/schemas/plugin-updates.ts
@@ -5,11 +5,15 @@ import { z } from "zod";
  *
  * The resource monitor process runs a periodic sweep (see
  * `monitoring/plugin-auto-update.ts`) that moves every installed, enabled
- * plugin to its source's current revision. The sweep is off by default:
+ * marketplace plugin to the catalog's current pin. The sweep is off by default:
  * `mode: "manual"` means nothing upgrades unless a human runs
  * `assistant plugins upgrade <name>` (or the equivalent route), which is the
  * behavior every workspace had before this block existed. Setting
  * `mode: "auto"` opts the workspace into the hourly sweep.
+ *
+ * Opting in never covers plugins installed straight from a GitHub URL. Those
+ * track a mutable ref rather than a reviewed pin, so the sweep leaves them to
+ * an explicit `assistant plugins upgrade`.
  */
 export const PluginUpdatesConfigSchema = z
   .object({
@@ -19,7 +23,7 @@ export const PluginUpdatesConfigSchema = z
       })
       .default("manual")
       .describe(
-        'How installed plugins move to newer revisions. "manual" (default) never upgrades on its own — upgrades happen only when a human asks for one. "auto" lets the resource monitor upgrade every installed, enabled plugin on the `checkIntervalMs` cadence.',
+        'How installed plugins move to newer revisions. "manual" (default) never upgrades on its own: upgrades happen only when a human asks for one. "auto" lets the resource monitor upgrade every installed, enabled marketplace plugin on the `checkIntervalMs` cadence. Plugins installed directly from a GitHub URL are never upgraded automatically, since they track a mutable ref instead of a reviewed pin.',
       ),
     strategy: z
       // Deliberately narrower than the full `PluginUpgradeStrategy` union: the

--- a/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
@@ -10,6 +10,9 @@
  *     stamp survives restarts;
  *   - only plugins that can actually move reach the daemon — up-to-date and
  *     disabled installs cost it nothing;
+ *   - only curated marketplace installs are swept: a plugin installed straight
+ *     from a GitHub URL, or one whose recorded source disagrees with the
+ *     catalog entry claiming its name, is left for a human to upgrade;
  *   - one plugin's refusal does not stop the sweep, an unreachable daemon
  *     abandons it without stamping (so it retries), and a timed-out upgrade
  *     abandons it *with* a stamp (so the retry cannot race the handler that
@@ -56,6 +59,25 @@ afterAll(() => {
 let inspectStatus = new Map<string, string>();
 let inspectThrowsFor = new Set<string>();
 
+/** GitHub coordinates, as both the provenance sidecar and the catalog carry them. */
+interface Coordinates {
+  /** `owner/repo`. */
+  readonly repo: string;
+  /** Repo-relative plugin root; absent = repo root. */
+  readonly path?: string;
+}
+
+/**
+ * Provenance `inspectPlugin` reports per plugin name: where the installed copy
+ * says it came from, and where the catalog entry claiming that name points.
+ * Absent for a plugin that declares neither, which is what an older install
+ * with no sidecar looks like.
+ */
+let inspectProvenance = new Map<
+  string,
+  { readonly source?: Coordinates; readonly marketplace?: Coordinates }
+>();
+
 type UpgradeReply = {
   ok: boolean;
   result?: { outcome?: string; toCommit?: string };
@@ -78,7 +100,20 @@ mock.module("../../cli/lib/inspect-plugin.js", () => ({
     if (inspectThrowsFor.has(name)) {
       throw new Error("marketplace unreachable");
     }
-    return { name, status: inspectStatus.get(name) ?? "up-to-date" };
+    const provenance = inspectProvenance.get(name);
+    const source = provenance?.source;
+    const marketplace = provenance?.marketplace;
+    const [owner = "", repo = ""] = source?.repo.split("/") ?? [];
+    return {
+      name,
+      status: inspectStatus.get(name) ?? "up-to-date",
+      local: source
+        ? { source: { kind: "github", owner, repo, path: source.path } }
+        : null,
+      remote: marketplace
+        ? { repo: marketplace.repo, path: marketplace.path ?? "" }
+        : null,
+    };
   },
 }));
 
@@ -110,7 +145,14 @@ function writeConfig(pluginUpdates: Record<string, unknown>): void {
 /** Materialize an installed plugin and declare what inspect says about it. */
 function installPlugin(
   name: string,
-  opts: { status?: string; disabled?: boolean } = {},
+  opts: {
+    status?: string;
+    disabled?: boolean;
+    /** Coordinates the install's provenance sidecar records. */
+    source?: Coordinates;
+    /** Coordinates the catalog entry claiming this name points at. */
+    marketplace?: Coordinates;
+  } = {},
 ): void {
   const dir = join(PLUGINS_DIR, name);
   mkdirSync(dir, { recursive: true });
@@ -122,6 +164,12 @@ function installPlugin(
     writeFileSync(join(dir, ".disabled"), "");
   }
   inspectStatus.set(name, opts.status ?? "update-available");
+  if (opts.source || opts.marketplace) {
+    inspectProvenance.set(name, {
+      source: opts.source,
+      marketplace: opts.marketplace,
+    });
+  }
 }
 
 /** Backdate the stamp so the sweep is (or is not) due again. */
@@ -134,6 +182,7 @@ function stampAgedBy(ms: number): void {
 beforeEach(() => {
   inspectStatus = new Map();
   inspectThrowsFor = new Set();
+  inspectProvenance = new Map();
   upgradeReply = () => ({
     ok: true,
     result: { outcome: "upgraded", toCommit: "abc1234" },
@@ -201,6 +250,94 @@ describe("plugin auto-update sweep", () => {
     await runPluginAutoUpdateSweepIfDue();
 
     expect(upgradeCalls.map((c) => c.name)).toEqual(["beta"]);
+  });
+
+  test("a plugin installed straight from a GitHub URL is never swept", async () => {
+    writeConfig({ mode: "auto" });
+    // No catalog entry claims the name, so its only upgrade target is whatever
+    // the recorded upstream ref points at right now. Nobody reviewed that.
+    installPlugin("alpha", { status: "not-in-marketplace" });
+    installPlugin("beta", { status: "update-available" });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["beta"]);
+    expect(result.skippedUntrusted).toEqual(["alpha"]);
+    expect(result.failed).toEqual([]);
+  });
+
+  test("a whole workspace of untrusted installs stamps instead of retrying every minute", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", { status: "not-in-marketplace" });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(result.skipped).toBe("no-candidates");
+    expect(result.skippedUntrusted).toEqual(["alpha"]);
+    expect(upgradeCalls).toEqual([]);
+    expect(await runPluginAutoUpdateSweepIfDue()).toMatchObject({
+      skipped: "not-due",
+    });
+  });
+
+  test("an install whose source disagrees with the catalog is left alone", async () => {
+    writeConfig({ mode: "auto" });
+    // A direct install sitting on a curated plugin's name: only the name lines
+    // up, so the sweep must not swap it for the catalog's code.
+    installPlugin("alpha", {
+      status: "update-available",
+      source: { repo: "someone-else/alpha" },
+      marketplace: { repo: "vellum-ai/alpha" },
+    });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls).toEqual([]);
+    expect(result.skippedUntrusted).toEqual(["alpha"]);
+  });
+
+  test("an install from the catalog's own repo is upgraded", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", {
+      status: "update-available",
+      source: { repo: "vellum-ai/plugins", path: "alpha" },
+      marketplace: { repo: "vellum-ai/plugins", path: "alpha" },
+    });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["alpha"]);
+    expect(result.skippedUntrusted).toEqual([]);
+  });
+
+  test("a matching repo with a different plugin root is left alone", async () => {
+    writeConfig({ mode: "auto" });
+    // Same monorepo, different directory: not the plugin the catalog pins.
+    installPlugin("alpha", {
+      status: "update-available",
+      source: { repo: "vellum-ai/plugins", path: "experimental/alpha" },
+      marketplace: { repo: "vellum-ai/plugins", path: "alpha" },
+    });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls).toEqual([]);
+    expect(result.skippedUntrusted).toEqual(["alpha"]);
+  });
+
+  test("an install with no recorded source is still re-pinned to the curated commit", async () => {
+    writeConfig({ mode: "auto" });
+    // An older or manually-copied copy: nothing about it contradicts the
+    // catalog, and the upgrade is what gives it provenance.
+    installPlugin("alpha", {
+      status: "unknown-provenance",
+      marketplace: { repo: "vellum-ai/alpha" },
+    });
+
+    const result = await runPluginAutoUpdateSweepIfDue();
+
+    expect(upgradeCalls.map((c) => c.name)).toEqual(["alpha"]);
+    expect(result.upgraded).toEqual(["alpha"]);
   });
 
   test("a disabled plugin is left alone", async () => {

--- a/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-auto-update.test.ts
@@ -12,7 +12,9 @@
  *     disabled installs cost it nothing;
  *   - only curated marketplace installs are swept: a plugin installed straight
  *     from a GitHub URL, or one whose recorded source disagrees with the
- *     catalog entry claiming its name, is left for a human to upgrade;
+ *     catalog entry claiming its name, is left for a human to upgrade, and
+ *     every request the daemon does get carries `marketplaceOnly` so it
+ *     enforces that boundary against its own inspection;
  *   - one plugin's refusal does not stop the sweep, an unreachable daemon
  *     abandons it without stamping (so it retries), and a timed-out upgrade
  *     abandons it *with* a stamp (so the retry cannot race the handler that
@@ -90,6 +92,8 @@ let upgradeReply: (name: string) => UpgradeReply = () => ({
   result: { outcome: "upgraded", toCommit: "abc1234" },
 });
 const upgradeCalls: Array<{ name: string; strategy: unknown }> = [];
+/** Full request bodies, for the assertions that care about more than strategy. */
+const upgradeBodies: Array<Record<string, unknown>> = [];
 
 const realInspect = await import("../../cli/lib/inspect-plugin.js");
 const realIpcClient = await import("../../ipc/cli-client.js");
@@ -121,12 +125,16 @@ mock.module("../../ipc/cli-client.js", () => ({
   ...realIpcClient,
   cliIpcCall: async (
     _method: string,
-    params: { pathParams: { name: string }; body: { strategy: unknown } },
+    params: {
+      pathParams: { name: string };
+      body: Record<string, unknown>;
+    },
   ) => {
     upgradeCalls.push({
       name: params.pathParams.name,
       strategy: params.body.strategy,
     });
+    upgradeBodies.push(params.body);
     return upgradeReply(params.pathParams.name);
   },
 }));
@@ -188,6 +196,7 @@ beforeEach(() => {
     result: { outcome: "upgraded", toCommit: "abc1234" },
   });
   upgradeCalls.length = 0;
+  upgradeBodies.length = 0;
   rmSync(STAMP, { force: true });
   rmSync(PLUGINS_DIR, { recursive: true, force: true });
   mkdirSync(PLUGINS_DIR, { recursive: true });
@@ -264,6 +273,23 @@ describe("plugin auto-update sweep", () => {
     expect(upgradeCalls.map((c) => c.name)).toEqual(["beta"]);
     expect(result.skippedUntrusted).toEqual(["alpha"]);
     expect(result.failed).toEqual([]);
+  });
+
+  test("every request asks the daemon to enforce the curated boundary itself", async () => {
+    writeConfig({ mode: "auto" });
+    installPlugin("alpha", { status: "update-available" });
+    installPlugin("beta", { status: "unknown-provenance" });
+
+    await runPluginAutoUpdateSweepIfDue();
+
+    // The daemon re-inspects before it moves anything, so a catalog entry that
+    // disappears after the inspection above would flip it to the direct path.
+    // `marketplaceOnly` makes the daemon refuse instead of following the
+    // install's mutable ref.
+    expect(upgradeBodies).toEqual([
+      { strategy: "theirs", marketplaceOnly: true },
+      { strategy: "theirs", marketplaceOnly: true },
+    ]);
   });
 
   test("a whole workspace of untrusted installs stamps instead of retrying every minute", async () => {

--- a/assistant/src/monitoring/plugin-auto-update.ts
+++ b/assistant/src/monitoring/plugin-auto-update.ts
@@ -8,6 +8,15 @@
  * (default hourly), inspects which ones can actually move, and upgrades those
  * with the configured merge strategy (default `theirs`).
  *
+ * Only plugins that come from the curated marketplace are swept. The catalog
+ * pins every entry to an immutable commit that a curator reviewed, so an
+ * unattended upgrade can only land code that passed that review. A plugin
+ * installed straight from a GitHub URL has no such gate: it tracks a mutable
+ * ref (a branch, a tag, or the repo's default branch), so upgrading it means
+ * fetching and executing whatever upstream pushed since. That is a decision
+ * for a human at a terminal, not for an hourly background sweep, so untrusted
+ * installs are filtered out here and left for `assistant plugins upgrade`.
+ *
  * The monitor drives it — not the daemon — for the same reason it drives the
  * plugin source watch and crash recovery: the work is periodic, network-bound,
  * and must not compete with the daemon's turn loop. Drift detection happens
@@ -30,7 +39,10 @@
 import { statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { inspectPlugin } from "../cli/lib/inspect-plugin.js";
+import {
+  inspectPlugin,
+  type PluginInspection,
+} from "../cli/lib/inspect-plugin.js";
 import { listInstalledPlugins } from "../cli/lib/list-installed-plugins.js";
 import { getConfigReadOnly } from "../config/loader.js";
 import type { PluginUpdatesConfig } from "../config/schemas/plugin-updates.js";
@@ -67,22 +79,20 @@ const STAMP_FILENAME = "plugin-auto-update-last-run-at";
 /**
  * Inspection verdicts worth asking the daemon about.
  *
- * `update-available` is the obvious one. `unknown-provenance` (an older or
- * manually-copied install with no recorded commit) is included because an
- * upgrade re-pins it, which is how it stops being unknown. So is
- * `not-in-marketplace`: a plugin installed straight from a GitHub URL has no
- * catalog entry to compare against, but it still tracks a ref upstream may
- * have moved — only the daemon's upgrade can resolve that, and it no-ops when
- * the ref still points at the installed commit.
+ * Both resolve to a curated marketplace pin, which is the only revision this
+ * sweep is willing to move an install to. `update-available` is the obvious
+ * one. `unknown-provenance` (an older or manually-copied install with no
+ * recorded commit) is included because an upgrade re-pins it to that same
+ * curated commit, which is how it stops being unknown.
  *
- * Everything else is skipped: `up-to-date` has nowhere to move, and
- * `remote-unavailable` means the catalog could not be read, so an upgrade
- * would fail on the same outage a moment later.
+ * Everything else is skipped: `up-to-date` has nowhere to move,
+ * `remote-unavailable` means the catalog could not be read so an upgrade would
+ * fail on the same outage a moment later, and `not-in-marketplace` is the
+ * untrusted direct install whose only upgrade target is a mutable upstream ref.
  */
 const UPGRADABLE_STATUSES: ReadonlySet<string> = new Set([
   "update-available",
   "unknown-provenance",
-  "not-in-marketplace",
 ]);
 
 /** Outcome the daemon reports for one plugin; mirrors `PluginUpgradeResult`. */
@@ -114,30 +124,82 @@ function stampSweep(): void {
 }
 
 /**
+ * Whether an installed copy actually tracks the curated source the sweep would
+ * upgrade it to.
+ *
+ * The provenance sidecar records the owner/repo/path the install was
+ * materialized from. When that names a different repository than the catalog
+ * entry claiming the plugin's name, the install is a direct (untrusted) one
+ * sitting on a curated name, and only its name lines up with the catalog. The
+ * sweep leaves it alone: the user picked that source, and swapping it for
+ * someone else's code is a call for a human running `assistant plugins
+ * upgrade`, not for an unattended hourly pass.
+ *
+ * An install with no recorded source at all (an older or manually-copied copy)
+ * is not disqualified. Nothing about it contradicts the catalog, and re-pinning
+ * it to the curated commit is exactly how it gains provenance.
+ */
+function tracksCuratedSource(inspection: PluginInspection): boolean {
+  const source = inspection.local?.source;
+  if (!source) {
+    return true;
+  }
+  const remote = inspection.remote;
+  if (!remote) {
+    return false;
+  }
+  return (
+    `${source.owner}/${source.repo}`.toLowerCase() ===
+      remote.repo.toLowerCase() && (source.path ?? "") === remote.path
+  );
+}
+
+/** What one pass of inspection concluded about the installed plugins. */
+interface UpgradeCandidates {
+  /** Names the daemon should be asked to upgrade. */
+  readonly candidates: readonly string[];
+  /** Names left alone because they do not come from the curated marketplace. */
+  readonly untrusted: readonly string[];
+}
+
+/**
  * Installed plugins this sweep should ask the daemon to upgrade.
  *
  * Only user-installed plugins are listed (defaults ship with the assistant and
  * have no upstream to advance to). A disabled plugin is deliberately left
- * alone — the user switched it off, and upgrading it would re-materialize code
+ * alone: the user switched it off, and upgrading it would re-materialize code
  * and re-declare schedules for something that isn't running. What survives
  * that is inspected, so the daemon is only asked about plugins that can
- * actually move (see {@link UPGRADABLE_STATUSES}).
+ * actually move (see {@link UPGRADABLE_STATUSES}) and whose move lands on a
+ * curated pin (see {@link tracksCuratedSource}).
  */
-async function listUpgradableNames(): Promise<string[]> {
+async function listUpgradableNames(): Promise<UpgradeCandidates> {
   const installed = listInstalledPlugins()
     .map((plugin) => plugin.name)
     .filter((name) => !isPluginDisabled(name));
 
   const candidates: string[] = [];
+  const untrusted: string[] = [];
   for (const name of installed) {
     try {
       const inspection = await inspectPlugin(
         { name },
         { fetch: globalThis.fetch.bind(globalThis) },
       );
-      if (UPGRADABLE_STATUSES.has(inspection.status)) {
-        candidates.push(name);
+      if (inspection.status === "not-in-marketplace") {
+        // No catalog entry claims the name, so the only thing to upgrade to is
+        // whatever the recorded upstream ref points at right now.
+        untrusted.push(name);
+        continue;
       }
+      if (!UPGRADABLE_STATUSES.has(inspection.status)) {
+        continue;
+      }
+      if (!tracksCuratedSource(inspection)) {
+        untrusted.push(name);
+        continue;
+      }
+      candidates.push(name);
     } catch (err) {
       // An install whose drift cannot be classified (source unreachable,
       // rate-limited) is skipped rather than handed to the daemon, which
@@ -145,7 +207,7 @@ async function listUpgradableNames(): Promise<string[]> {
       log.debug({ err, name }, "Plugin auto-update could not inspect plugin");
     }
   }
-  return candidates;
+  return { candidates, untrusted };
 }
 
 /** Ask the daemon to upgrade one plugin. */
@@ -174,6 +236,12 @@ export interface PluginAutoUpdateSweepResult {
   readonly upgraded: readonly string[];
   readonly unchanged: readonly string[];
   readonly failed: readonly string[];
+  /**
+   * Installs the sweep refused to touch because they do not come from the
+   * curated marketplace. They are not failures: a human can still upgrade them
+   * with `assistant plugins upgrade`.
+   */
+  readonly skippedUntrusted: readonly string[];
   /** True when the daemon could not be reached, so the sweep stays due. */
   readonly daemonUnreachable: boolean;
 }
@@ -182,6 +250,7 @@ const NOTHING: Omit<PluginAutoUpdateSweepResult, "skipped"> = {
   upgraded: [],
   unchanged: [],
   failed: [],
+  skippedUntrusted: [],
   daemonUnreachable: false,
 };
 
@@ -214,18 +283,29 @@ export async function runPluginAutoUpdateSweepIfDue(): Promise<PluginAutoUpdateS
     return { skipped: "not-due", ...NOTHING };
   }
 
-  let names: string[];
+  let inspected: UpgradeCandidates;
   try {
-    names = await listUpgradableNames();
+    inspected = await listUpgradableNames();
   } catch (err) {
     log.warn({ err }, "Plugin auto-update could not list installed plugins");
     return { skipped: "no-candidates", ...NOTHING };
+  }
+  const { candidates: names, untrusted } = inspected;
+  if (untrusted.length > 0) {
+    log.info(
+      { plugins: untrusted },
+      "Plugin auto-update skipped plugins that are not from the curated marketplace",
+    );
   }
   if (names.length === 0) {
     // Stamp anyway: a workspace with nothing to move is a completed sweep, and
     // re-inspecting every plugin a minute later would be pure churn.
     stampSweep();
-    return { skipped: "no-candidates", ...NOTHING };
+    return {
+      skipped: "no-candidates",
+      ...NOTHING,
+      skippedUntrusted: untrusted,
+    };
   }
 
   const upgraded: string[] = [];
@@ -302,13 +382,21 @@ export async function runPluginAutoUpdateSweepIfDue(): Promise<PluginAutoUpdateS
         upgraded: upgraded.length,
         unchanged: unchanged.length,
         failed: failed.length,
+        skippedUntrusted: untrusted.length,
         strategy: config.strategy,
       },
       "Plugin auto-update sweep complete",
     );
   }
 
-  return { skipped: null, upgraded, unchanged, failed, daemonUnreachable };
+  return {
+    skipped: null,
+    upgraded,
+    unchanged,
+    failed,
+    skippedUntrusted: untrusted,
+    daemonUnreachable,
+  };
 }
 
 /** Handle for the running auto-update loop. */

--- a/assistant/src/monitoring/plugin-auto-update.ts
+++ b/assistant/src/monitoring/plugin-auto-update.ts
@@ -17,6 +17,13 @@
  * for a human at a terminal, not for an hourly background sweep, so untrusted
  * installs are filtered out here and left for `assistant plugins upgrade`.
  *
+ * The filter is applied twice, in both processes. Inspecting here keeps the
+ * daemon from being asked about plugins the sweep would never accept, but the
+ * daemon re-inspects before it moves anything, so this side's verdict cannot be
+ * the one that matters: a catalog entry that disappears in between would flip
+ * the daemon to the direct path. Every request therefore carries
+ * `marketplaceOnly`, which the daemon enforces against its own inspection.
+ *
  * The monitor drives it — not the daemon — for the same reason it drives the
  * plugin source watch and crash recovery: the work is periodic, network-bound,
  * and must not compete with the daemon's turn loop. Drift detection happens
@@ -210,7 +217,16 @@ async function listUpgradableNames(): Promise<UpgradeCandidates> {
   return { candidates, untrusted };
 }
 
-/** Ask the daemon to upgrade one plugin. */
+/**
+ * Ask the daemon to upgrade one plugin.
+ *
+ * `marketplaceOnly` restates this sweep's boundary as something the daemon
+ * enforces rather than something it trusts the caller to have checked. The
+ * daemon re-inspects before it moves anything, so a catalog entry that
+ * disappears between the inspection above and the daemon's own would otherwise
+ * turn a curated upgrade into a direct one against the install's mutable ref.
+ * With the flag set the daemon refuses instead.
+ */
 function requestUpgrade(
   name: string,
   strategy: PluginUpdatesConfig["strategy"],
@@ -219,7 +235,7 @@ function requestUpgrade(
     UPGRADE_IPC_METHOD,
     // The target revision is never caller-supplied — the daemon resolves it
     // from the plugin's own source, exactly as an interactive upgrade does.
-    { pathParams: { name }, body: { strategy } },
+    { pathParams: { name }, body: { strategy, marketplaceOnly: true } },
     { timeoutMs: UPGRADE_TIMEOUT_MS },
   );
 }

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -109,6 +109,7 @@ import {
 } from "../../../cli/lib/uninstall-plugin.js";
 import {
   PluginMergeBaselineError,
+  PluginNotCuratedError,
   PluginNotUpgradableError,
   type PluginUpgradeResult,
   type UpgradePluginDeps,
@@ -252,6 +253,7 @@ const upgradeSpy = mock(
 
 mock.module("../../../cli/lib/upgrade-plugin.js", () => ({
   PluginMergeBaselineError,
+  PluginNotCuratedError,
   PluginNotUpgradableError,
   upgradePlugin: upgradeSpy,
 }));
@@ -2127,6 +2129,7 @@ describe("POST /v1/plugins/:name/upgrade", () => {
       name: "level-up",
       dryRun: false,
       strategy: undefined,
+      marketplaceOnly: false,
     });
   });
 
@@ -2148,6 +2151,7 @@ describe("POST /v1/plugins/:name/upgrade", () => {
       name: "level-up",
       dryRun: undefined,
       strategy: "ours",
+      marketplaceOnly: false,
     });
   });
 
@@ -2175,6 +2179,7 @@ describe("POST /v1/plugins/:name/upgrade", () => {
       name: "level-up",
       dryRun: undefined,
       strategy: "assistant",
+      marketplaceOnly: false,
     });
   });
 
@@ -2300,6 +2305,10 @@ describe("POST /v1/plugins/:name/upgrade", () => {
     expect(upgradeSpy.mock.calls[0]?.[0]).toEqual({
       name: "level-up",
       dryRun: undefined,
+      strategy: undefined,
+      // Unlike dryRun, an absent flag here is a definite "no": the untrusted
+      // direct path stays available unless a caller opts out of it.
+      marketplaceOnly: false,
     });
   });
 
@@ -2340,6 +2349,41 @@ describe("POST /v1/plugins/:name/upgrade", () => {
 
     await expect(
       invokeUpgrade({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test("marketplaceOnly is forwarded so the lib enforces it, not the caller", async () => {
+    // The lib re-inspects the catalog inside the call, so the flag has to
+    // travel with the request: a caller's own pre-check cannot bind a decision
+    // the lib makes afterwards.
+    upgradeSpy.mockImplementation(async () => upgradeResult());
+
+    await invokeUpgrade({
+      pathParams: { name: "level-up" },
+      body: { marketplaceOnly: true },
+    });
+
+    expect(upgradeSpy.mock.calls[0]?.[0]).toEqual({
+      name: "level-up",
+      dryRun: undefined,
+      strategy: undefined,
+      marketplaceOnly: true,
+    });
+  });
+
+  test("PluginNotCuratedError → ConflictError (409)", async () => {
+    // A marketplaceOnly caller asked about an install the catalog does not
+    // claim. Retrying changes nothing: only a human upgrading it without the
+    // flag can move it.
+    upgradeSpy.mockImplementation(async () => {
+      throw new PluginNotCuratedError("level-up");
+    });
+
+    await expect(
+      invokeUpgrade({
+        pathParams: { name: "level-up" },
+        body: { marketplaceOnly: true },
+      }),
     ).rejects.toBeInstanceOf(ConflictError);
   });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -85,6 +85,7 @@ import {
 } from "../../cli/lib/uninstall-plugin.js";
 import {
   PluginMergeBaselineError,
+  PluginNotCuratedError,
   PluginNotUpgradableError,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
@@ -605,6 +606,12 @@ const pluginUpgradeRequestSchema = z.object({
     .optional()
     .describe(
       "How to reconcile local edits with the pin. `overwrite` (default) discards local edits and re-installs the pin; `ours`/`theirs` three-way merge, resolving conflicting hunks toward the local edit or the pin respectively; `assistant` is not yet supported.",
+    ),
+  marketplaceOnly: z
+    .boolean()
+    .optional()
+    .describe(
+      "Refuse the upgrade (409) when the marketplace does not claim this plugin, instead of advancing it to whatever its recorded GitHub ref now resolves to. Set by unattended callers such as the automatic update sweep, for which running code no curator reviewed is never an acceptable outcome. Defaults to false.",
     ),
 });
 
@@ -1465,6 +1472,11 @@ async function handleUpgradePlugin({
     typeof body.strategy === "string"
       ? (body.strategy as PluginUpgradeStrategy)
       : undefined;
+  // Enforced here, not just by whoever decided to call: `upgradePlugin` fetches
+  // the catalog itself, so an entry that vanishes between a caller's own check
+  // and this handler would otherwise reroute a curated upgrade onto the
+  // install's mutable recorded ref.
+  const marketplaceOnly = body.marketplaceOnly === true;
 
   // Like install, the upgrade target ref is the curated marketplace pin
   // (resolved inside `upgradePlugin` via `inspectPlugin`), never a
@@ -1498,7 +1510,7 @@ async function handleUpgradePlugin({
     // upgraded revision adds is surfaced to the user by the schedule
     // reconciler's `schedule.declared` notification when it arms.
     const result = await upgradePlugin(
-      { name, dryRun, strategy },
+      { name, dryRun, strategy, marketplaceOnly },
       {
         fetch: globalThis.fetch.bind(globalThis),
         // Tear the old version down BEFORE the staged tree replaces its
@@ -1566,6 +1578,12 @@ async function handleUpgradePlugin({
     // 409 marks the request as well-formed but not actionable in the current
     // state.
     if (err instanceof PluginNotUpgradableError) {
+      throw new ConflictError(err.message);
+    }
+    // A `marketplaceOnly` caller asked about an install the catalog does not
+    // claim. Retrying changes nothing; only a human upgrading it deliberately
+    // (without the flag) can move it, so 409 rather than a retryable 503.
+    if (err instanceof PluginNotCuratedError) {
       throw new ConflictError(err.message);
     }
     // A rate-limited or temporarily-down source (the plugin repo or the
@@ -2039,7 +2057,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Upgrade a plugin to its source's current revision",
     description:
-      'Move an installed plugin to its source\'s current revision, re-materializing it under `<workspaceDir>/plugins/<name>/`. A marketplace plugin advances to the curated pin; a plugin installed directly from a GitHub URL (untrusted, not in the marketplace) advances to whatever its recorded ref now resolves to — a pinned SHA is immutable (a no-op), a branch/tag/HEAD moves as upstream does — re-materialized verbatim with no curated adapter overlay, exactly as the original untrusted install was. The target ref is never taken from the request (no caller-supplied ref), mirroring `plugins install`\'s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed commit already equals the target; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite` (default) discards them and re-installs the target wholesale; `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or the target (`theirs`), or writing git conflict markers into the file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time baseline cannot be reconstructed returns 409. Mirrors the CLI\'s `assistant plugins upgrade <name> [--strategy <s>]`.',
+      'Move an installed plugin to its source\'s current revision, re-materializing it under `<workspaceDir>/plugins/<name>/`. A marketplace plugin advances to the curated pin; a plugin installed directly from a GitHub URL (untrusted, not in the marketplace) advances to whatever its recorded ref now resolves to — a pinned SHA is immutable (a no-op), a branch/tag/HEAD moves as upstream does — re-materialized verbatim with no curated adapter overlay, exactly as the original untrusted install was. The target ref is never taken from the request (no caller-supplied ref), mirroring `plugins install`\'s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed commit already equals the target; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite` (default) discards them and re-installs the target wholesale; `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or the target (`theirs`), or writing git conflict markers into the file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time baseline cannot be reconstructed returns 409. Pass `marketplaceOnly` to refuse the untrusted direct path outright (409), which is what the unattended auto-update sweep does. Mirrors the CLI\'s `assistant plugins upgrade <name> [--strategy <s>]`.',
     tags: ["plugins"],
     pathParams: [
       {
@@ -2062,7 +2080,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "409": {
         description:
-          "The install has neither a marketplace entry nor a recorded GitHub source to advance to, or a merge strategy was requested whose install-time baseline cannot be reconstructed.",
+          "The install has neither a marketplace entry nor a recorded GitHub source to advance to, a `marketplaceOnly` upgrade was requested for an install the marketplace does not claim, or a merge strategy was requested whose install-time baseline cannot be reconstructed.",
       },
       "503": {
         description:

--- a/clients/docs/src/app/docs/_components/extensibility-distribution-content.tsx
+++ b/clients/docs/src/app/docs/_components/extensibility-distribution-content.tsx
@@ -609,8 +609,8 @@ $ assistant plugins install owner/repo`}</code>
             <li>
               <code>mode</code>: <code>manual</code> (the default) never
               upgrades on its own. <code>auto</code> sweeps your installed
-              plugins hourly and moves each one to its source&apos;s current
-              revision.
+              marketplace plugins hourly and moves each one to the
+              catalog&apos;s current pin.
             </li>
             <li>
               <code>strategy</code>: how an automatic upgrade reconciles your
@@ -628,8 +628,17 @@ $ assistant plugins install owner/repo`}</code>
             </li>
           </ul>
           <p className="mb-4 text-zinc-600 dark:text-zinc-400">
-            Disabled plugins are skipped, and so is anything already on its
-            latest revision &mdash; the sweep checks for drift before it moves
+            Only curated marketplace installs are swept. The catalog pins every
+            entry to a commit a curator reviewed, so an automatic upgrade can
+            only land reviewed code. A plugin you installed straight from a
+            GitHub URL tracks a mutable ref instead (a branch, a tag, or the
+            repo&apos;s default branch), so upgrading it means running whatever
+            upstream pushed since. Those stay put until you upgrade them
+            yourself with <code>assistant plugins upgrade &lt;name&gt;</code>.
+          </p>
+          <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+            Disabled plugins are skipped too, and so is anything already on its
+            latest revision: the sweep checks for drift before it moves
             anything. A plugin that cannot be upgraded (its source is
             unreachable, or it has no upstream to advance to) is skipped and the
             rest of the sweep continues.

--- a/skills/plugin-builder/references/distribution.md
+++ b/skills/plugin-builder/references/distribution.md
@@ -206,6 +206,8 @@ Upgrades are manual by default. A workspace can opt into unattended upgrades thr
 
 **Only curated marketplace installs are swept.** The catalog pins every entry to a commit a curator reviewed, so an unattended upgrade can only land reviewed code. A plugin installed straight from a GitHub URL has no such gate: it tracks a mutable ref (a branch, a tag, or the repo's default branch), so upgrading it means fetching and running whatever upstream pushed since. The sweep skips those, and so it skips any install whose recorded `install-meta.json` source names a different repository (or plugin root) than the catalog entry claiming its name. Upgrade them deliberately with `assistant plugins upgrade <name>`.
 
+The boundary is enforced where the upgrade happens, not only where it is decided. Every sweep request carries `marketplaceOnly`, and the upgrade refuses (409) if its own catalog read finds no entry, so a catalog entry that disappears mid-sweep cannot reroute a curated upgrade onto an install's mutable ref.
+
 Disabled plugins are skipped too. The sweep runs in the resource monitor process but asks the daemon to perform each upgrade, so the plugin's `shutdown`/`init` hooks run in the process that loaded it, exactly as they do for a manual upgrade. A plugin that cannot be upgraded (source unreachable, no upstream to advance to) is logged and skipped; the rest of the sweep continues.
 
 ### Drift and local edits

--- a/skills/plugin-builder/references/distribution.md
+++ b/skills/plugin-builder/references/distribution.md
@@ -200,11 +200,13 @@ Upgrades are manual by default. A workspace can opt into unattended upgrades thr
 }
 ```
 
-- `mode`: `manual` (default) never upgrades on its own — every workspace behaves exactly as described above. `auto` lets the resource monitor sweep installed plugins hourly and move each one to its source's current revision.
+- `mode`: `manual` (default) never upgrades on its own, so every workspace behaves exactly as described above. `auto` lets the resource monitor sweep installed marketplace plugins hourly and move each one to the catalog's current pin.
 - `strategy`: how an automatic upgrade reconciles local edits with the incoming revision — `theirs` (default) three-way merges and resolves conflicting hunks toward the incoming revision, `ours` resolves them toward the local edit, `overwrite` discards local edits and re-installs wholesale. The interactive `--strategy assistant` (which leaves conflict markers for someone to resolve) is deliberately not selectable here: nobody is in the loop to resolve them.
 - `checkIntervalMs`: minimum spacing between sweeps, default `3600000` (1 hour). The last sweep is stamped on disk, so restarting the daemon does not re-run a sweep that already ran within the interval.
 
-Disabled plugins are skipped. The sweep runs in the resource monitor process but asks the daemon to perform each upgrade, so the plugin's `shutdown`/`init` hooks run in the process that loaded it, exactly as they do for a manual upgrade. A plugin that cannot be upgraded (source unreachable, no upstream to advance to) is logged and skipped; the rest of the sweep continues.
+**Only curated marketplace installs are swept.** The catalog pins every entry to a commit a curator reviewed, so an unattended upgrade can only land reviewed code. A plugin installed straight from a GitHub URL has no such gate: it tracks a mutable ref (a branch, a tag, or the repo's default branch), so upgrading it means fetching and running whatever upstream pushed since. The sweep skips those, and so it skips any install whose recorded `install-meta.json` source names a different repository (or plugin root) than the catalog entry claiming its name. Upgrade them deliberately with `assistant plugins upgrade <name>`.
+
+Disabled plugins are skipped too. The sweep runs in the resource monitor process but asks the daemon to perform each upgrade, so the plugin's `shutdown`/`init` hooks run in the process that loaded it, exactly as they do for a manual upgrade. A plugin that cannot be upgraded (source unreachable, no upstream to advance to) is logged and skipped; the rest of the sweep continues.
 
 ### Drift and local edits
 


### PR DESCRIPTION
Related to [ATL-1239](https://linear.app/vellum/issue/ATL-1239/security-auto-updates-move-uncurated-plugins-to-mutable-code)

## Prompt / plan

> we should filter out the untrusted source plugins from our auto upgrade loop

**Why.** A workspace on `pluginUpdates.mode: "auto"` had the resource monitor sweep *every* installed, enabled plugin hourly, including ones installed straight from a GitHub URL. Those carry no curated pin. `directUpgrade` in `upgrade-plugin.ts` resolves whatever ref the install recorded, and an install pinned to a full SHA deliberately falls back to the repo's default branch rather than freezing. So for an uncurated plugin the sweep fetched and executed whatever upstream had pushed since, with nobody in the loop. That is the "move uncurated plugins to mutable code" failure mode in the ticket.

Marketplace plugins do not have this problem: the catalog pins each entry to an immutable commit that a curator reviewed, so an unattended upgrade can only land reviewed code.

**What changed.** `monitoring/plugin-auto-update.ts` now only asks the daemon about installs whose upgrade target is a curated pin:

- `not-in-marketplace` is dropped from `UPGRADABLE_STATUSES`. That status *is* the untrusted direct install, and its only upgrade target is a mutable upstream ref.
- New `tracksCuratedSource()` also skips an install whose `install-meta.json` source names a different repository (or plugin root) than the catalog entry claiming its name, so a direct install sitting on a curated plugin's name is not silently swapped for someone else's code.
- An install with **no** recorded source (older or manually copied) is still swept. Nothing about it contradicts the catalog, and re-pinning it to the curated commit is how it gains provenance, which is the reason `unknown-provenance` was included in the first place.
- Skipped names are reported as `skippedUntrusted` on `PluginAutoUpdateSweepResult` and logged once per sweep, so a plugin that stops moving is explainable rather than mysterious.

`assistant plugins upgrade <name>` is untouched. A human can still move any install, including a direct one, which is where that decision belongs. Config schema descriptions, `skills/plugin-builder/references/distribution.md`, and the public extensibility docs page are updated to state the new boundary.

## Test plan

- `bun test src/monitoring/__tests__/plugin-auto-update.test.ts` — 20 pass. Six new cases: a `not-in-marketplace` install is never swept; a workspace of only untrusted installs still stamps instead of retrying every minute; a source/catalog repo mismatch is skipped; a matching repo with a different plugin root is skipped; an install from the catalog's own repo is upgraded; an install with no recorded source is still re-pinned. The test's `inspectPlugin` mock grew `local.source` / `remote` so provenance can be driven per plugin.
- `bun test src/config/__tests__/plugin-updates-schema.test.ts` — 4 pass.
- Neighbours re-run clean in isolation: `upgrade-plugin.test.ts` (33), `plugins.test.ts` (21), `install-from-github.test.ts` (53). Running `plugin-auto-update.test.ts` in the *same process* as `upgrade-plugin.test.ts` fails 32 tests, but that reproduces identically on unmodified `main` — it is the pre-existing process-wide `mock.module` leak the test file's own header documents, not a regression here.
- `bun run typecheck:fast` (assistant) and `tsc --noEmit` (clients/docs) clean; eslint and prettier clean on all changed files.

<!-- No new routes, so the CLI verb checklist does not apply. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ubax5VN3jLXKXKP5L6QND

---
_Generated by [Claude Code](https://claude.ai/code/session_019ubax5VN3jLXKXKP5L6QND)_